### PR TITLE
Add quicksight-to-sigma plugin (converter + assessment), parity-validated on 20 dashboards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace-manifest.json",
   "name": "sigma-migration-skills",
-  "description": "Claude Code skills for migrating BI tools (Tableau, Power BI, Qlik, ThoughtSpot) to Sigma — converters + assessments, validated end-to-end with warehouse parity.",
+  "description": "Skills for migrating BI tools (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight) to Sigma — converters + assessments, validated end-to-end with warehouse parity.",
   "version": "1.0.0",
   "owner": { "name": "Thomas Wells" },
   "metadata": { "pluginRoot": "./plugins" },
@@ -33,6 +33,13 @@
       "description": "ThoughtSpot models/worksheets + Liveboards → Sigma, TML conversion + Liveboard rebuild (KPI/bar/line/pie/pivot/table, search-query filters) + layout, with parity verification. Bundles thoughtspot-to-sigma + thoughtspot-assessment.",
       "category": "migration",
       "keywords": ["thoughtspot", "tml", "migration", "bi"]
+    },
+    {
+      "name": "quicksight-to-sigma",
+      "source": "./quicksight-to-sigma",
+      "description": "Amazon QuickSight analyses/dashboards → Sigma data model + workbook (KPI/bar/line/pie/donut/combo/scatter/table/pivot), with parity verification. Bundles quicksight-to-sigma + quicksight-assessment.",
+      "category": "migration",
+      "keywords": ["quicksight", "amazon", "aws", "migration", "bi"]
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ reading the relevant `SKILL.md` and executing its scripts.
 | Scope/assess a Qlik Cloud tenant | `qlik-assessment` | `plugins/qlik-to-sigma/skills/qlik-assessment/` |
 | Convert a ThoughtSpot model + Liveboards → Sigma (TML) | `thoughtspot-to-sigma` | `plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/` |
 | Scope/assess a ThoughtSpot instance | `thoughtspot-assessment` | `plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/` |
+| Convert an Amazon QuickSight analysis/dashboard → Sigma | `quicksight-to-sigma` | `plugins/quicksight-to-sigma/skills/quicksight-to-sigma/` |
+| Scope/assess a QuickSight instance | `quicksight-assessment` | `plugins/quicksight-to-sigma/skills/quicksight-assessment/` |
 
 Assessments are read-only (never write to the source or post to Sigma); run one
 to pick what to convert, then hand off to the matching converter.

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "quicksight-to-sigma",
+  "displayName": "QuickSight → Sigma",
+  "version": "1.0.0",
+  "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma — analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
+  "author": { "name": "Thomas Wells" },
+  "license": "MIT",
+  "keywords": ["quicksight", "amazon-quicksight", "aws", "sigma", "migration", "bi", "converter"],
+  "skills": "./skills/"
+}

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: quicksight-assessment
+description: Take inventory of an Amazon QuickSight account and produce a migration-readiness readout — environment counts, per-analysis visual-type mix, calc-field complexity (mechanical / restructuring / window-table-calc buckets), parameter + FilterGroup + layout-shape signals, per-dataset source types / custom-sql / joins / RLS, and a value/cost-ranked migration shortlist. Use when a user wants to scope a QuickSight→Sigma migration, audit BI sprawl, or pick which analyses to convert first. READ-ONLY — never writes to QuickSight or posts to Sigma. AWS-CLI auth (no boto3). Enterprise edition required for full complexity. Feeds the quicksight-to-sigma conversion skill.
+---
+
+# Amazon QuickSight Assessment
+
+Surveys an Amazon QuickSight account — **what the configured AWS credentials can
+reach** — via the AWS CLI (`aws quicksight ...`, shelled out via subprocess; no
+boto3). Emits a markdown readout + JSON inventory + a value/cost-ranked migration
+shortlist the user can hand to a Sigma rep or directly to the
+`quicksight-to-sigma` conversion skill.
+
+This is the QuickSight sibling of `powerbi-assessment` and `tableau-assessment` —
+same file layout, same readout sections, same privacy discipline, same
+value/cost shortlist scoring — adapted to QuickSight's two-artifact world
+(analysis + datasets).
+
+> **READ-ONLY.** Every call is a `list-*` or `describe-*` GET-equivalent. The
+> skill **never** writes to QuickSight and **never** posts to Sigma. It does not
+> edit anything outside its output directory.
+
+> **Enterprise edition required for complexity.** The `describe-analysis-definition`,
+> `describe-dashboard-definition`, and `describe-data-set` APIs are
+> **Enterprise-only** — a Standard-edition account rejects them. The skill
+> detects that, flags the account as Standard, and degrades to a counts-only
+> readout (it never crashes on a Standard account, but it also can't score
+> complexity there).
+
+> **Warehouse-agnostic.** QuickSight datasets source from many places
+> (Snowflake, Redshift, Athena, BigQuery, Databricks, Postgres, S3, SaaS). The
+> skill reports each dataset's physical source kind; the downstream
+> `quicksight-to-sigma` converter re-points Sigma at the same tables (S3/SaaS
+> are a known gap). Worked examples use Snowflake because that's where the dev
+> fixtures live.
+
+---
+
+## Privacy posture (READ FIRST, surface to the customer)
+
+**This skill reads analysis / dataset metadata, not warehouse data.** What
+crosses Anthropic's API on its way through Claude:
+
+| Crosses Anthropic API | Stays local |
+|---|---|
+| Aggregate counts (analysis / dataset / data-source counts) | Warehouse / SPICE rows (never queried) |
+| Analysis, dataset, data-source names | AWS credentials |
+| **Analysis definitions** — visual config + **calc-field expressions** | Actual visual cell values |
+| Dataset metadata — physical source kinds, custom-sql, RLS/CLS flags | |
+
+> If calc-field expressions encode business-sensitive logic, that text crosses
+> the API. Tell the customer before running.
+
+---
+
+## When to use this skill
+
+- A QuickSight customer wants a fast scoping view before a deeper migration engagement
+- A Sigma SE preparing for a discovery call wants a pre-built migration shortlist
+- A customer is deciding which QuickSight analyses to retire vs. migrate
+- A `quicksight-to-sigma` invocation needs a Phase 0 inventory of the source account
+
+---
+
+## Setup (one-time)
+
+No Python packages required — the inventory script shells out to the **AWS CLI
+v2** (which you install + authenticate separately). See `scripts/requirements.txt`.
+
+```bash
+# SSO orgs:
+aws sso login --profile <profile>
+# Okta-fronted orgs: gimme-aws-creds writes a usable profile
+gimme-aws-creds --profile <profile>
+# confirm + grab the account id:
+aws sts get-caller-identity --profile <profile>
+```
+
+QuickSight's **identity region is often `us-east-1`** even when data lives
+elsewhere — analyses/datasets/data-sources are read from the identity region.
+Pass `--region us-east-1` unless you know the account is regionalized
+differently.
+
+---
+
+## Scripts overview
+
+| Script | Lang | Purpose | Reused from powerbi-assessment? |
+|---|---|---|---|
+| `scripts/quicksight-inventory.py` | Python | Phase 1-3: analyses + dashboards + datasets + data sources, per-analysis definition complexity (visual mix, calc-field buckets, params, FilterGroups, layout shape) + per-dataset source/prep/RLS → `inventory.json`, `raw-defs/`, `raw-datasets/` | **New** (AWS CLI + AnalysisDefinition parsing has no PBI analog) |
+| `scripts/score-quicksight-complexity.rb` | Ruby | Derive per-analysis convertibility (easy/medium/hard → auto/manual/unhandled) → `complexity.json` | **New** (calc/visual-bucket logic), but emits the shared `n_auto/n_hint/n_manual/n_unhandled` shape |
+| `scripts/build-shortlist.rb` | Ruby | Cross-tab usage × complexity; `score = value/(1+cost)` → `shortlist.json` | **Adapted** — same scoring formula & tag rules; QS value-source + complexity-only fallback |
+| `scripts/render-readout.rb` | Ruby | Compose `readout.md` from the JSON files | **Adapted** — `md_table`/`section_block`/`md_cell` helpers reused verbatim; gather-body is QS-specific |
+| `scripts/migration-plan.rb` | Ruby | Per-analysis `recommended_path` + DM clusters (by shared dataset) → `migration-plan.json` | **Adapted** — same contract shape; clustering keyed on shared dataset instead of shared semantic model |
+
+> **What was reused vs rewritten:** the renderer's templating helpers and the
+> shortlist's value/cost scoring + tag vocabulary are lifted from
+> `powerbi-assessment` (which lifted them from `tableau-assessment`). The auth
+> layer (AWS CLI), AnalysisDefinition parsing, calc-field classification, and the
+> dataset-centric clustering are new because QuickSight's data shape has no
+> direct PBI/Tableau equivalent.
+
+---
+
+## Modes
+
+| Mode | Setup | Coverage | Use when |
+|---|---|---|---|
+| **Complexity-only** *(default)* | AWS CLI + Enterprise | Environment + per-analysis visual/calc complexity + per-dataset sources + **complexity-only** shortlist | Any user; the common case |
+| **Usage-weighted** | Supply `usage.json` (CloudTrail/CloudWatch-derived views) | Adds view/user weighting → usage-weighted shortlist + cold-analysis detection | When you have audit-trail usage data |
+
+QuickSight has no per-analysis view-count API on the standard surface, so the
+default is complexity-only; the readout says so.
+
+---
+
+## Phase 0 — Probe access + edition
+
+```bash
+aws sts get-caller-identity --profile <profile>            # account id + creds OK?
+aws quicksight list-analyses --aws-account-id <ID> --region us-east-1 --profile <profile> | head
+```
+
+If `list-analyses` works but `describe-analysis-definition` later 4xx's with a
+Standard/Enterprise/AccessDenied message, the inventory flags the account
+`enterprise: false` and degrades to counts-only.
+
+---
+
+## Phase 1-3 — Inventory + complexity (always runs)
+
+```bash
+python3 scripts/quicksight-inventory.py \
+  --account-id <ID> --region us-east-1 --profile <profile> \
+  --out /tmp/qs-assessment-<acct>
+ruby scripts/score-quicksight-complexity.rb --out /tmp/qs-assessment-<acct>
+```
+
+`quicksight-inventory.py` does:
+- `list-analyses` / `list-data-sets` / `list-data-sources` (+ `list-dashboards`
+  with `--dashboards-too`) → environment counts.
+- Per analysis: `describe-analysis-definition` → sheet/visual counts, visual-kind
+  histogram (bucketed built / mid-catalog / unhandled per `refs/migration-test-slate.md`),
+  calc-field a/b/c classification (window/table-calc funcs → `c`), parameter +
+  FilterGroup counts, free-form / section-based layout detection. Decoded def
+  saved to `raw-defs/<id>.json`.
+- Per referenced dataset (once): `describe-data-set` → physical source kind(s),
+  import mode, custom-sql, joins, transform count, RLS/CLS. Saved to
+  `raw-datasets/<id>.json`.
+
+`score-quicksight-complexity.rb` maps easy/medium/hard onto the shared
+`auto/manual/unhandled` tiers and folds in dataset joins, transforms, RLS, and
+layout/visual gaps.
+
+### Convertibility scoring
+
+Grounded in `refs/migration-test-slate.md`:
+- **easy → auto**: built visuals (KPI/bar/line/pie) + mechanical calc fields +
+  RelationalTable/CustomSql sources.
+- **medium → manual**: mid-catalog visuals (table/pivot/combo/scatter/gauge/…),
+  restructuring calc fields, dataset joins + data-prep transforms, parameters, RLS/CLS.
+- **hard → unhandled**: window / table-calc functions (no Sigma equivalent →
+  `/* TODO */`), exotic visuals (maps, sankey, insight ML, custom content,
+  plugin), free-form / section-based layout, analysis-level FilterGroups, S3/SaaS sources.
+
+Per-analysis `cost = 10·unhandled + 3·manual` in the shortlist.
+
+---
+
+## Phase 4 — Shortlist
+
+```bash
+ruby scripts/build-shortlist.rb --out /tmp/qs-assessment-<acct>
+```
+
+Scores each analysis:
+- `value = views × √(distinct_users)` *(if `usage.json` supplied)* — or
+  `10 × (sheets + visuals/4)` *(complexity-only fallback)*
+- `cost  = 10·unhandled + 3·manual + 1·hint`
+- `score = value / (1 + cost)`
+
+Same tag vocabulary as the other assessment skills: `migrate-first` / `easy-win`
+/ `moderate` / `needs-gap-scout` / `retire`.
+
+---
+
+## Phase 5 — Render the readout
+
+```bash
+ruby scripts/render-readout.rb --out /tmp/qs-assessment-<acct>
+```
+
+Composes the markdown report (template at `refs/readout-template.md`). Sections:
+environment, visual-type mix, analysis complexity, datasets/sources, priority,
+shortlist, per-analysis complexity, found-vs-not, privacy, hand-off, next steps.
+Carries a Standard-edition banner when the definition APIs were rejected and a
+limited-mode banner when usage data is absent.
+
+---
+
+## Phase 6 — Migration plan (always run)
+
+```bash
+ruby scripts/migration-plan.rb --out /tmp/qs-assessment-<acct>
+```
+
+Composes `migration-plan.json` — the hand-off contract for `quicksight-to-sigma`.
+Each analysis gets a `recommended_path`:
+
+| `recommended_path` | Means |
+|---|---|
+| `quicksight-to-sigma` | Ready for conversion. ≤5 manual/unhandled features. |
+| `quicksight-to-sigma-with-scout` | Has window calcs / exotic visuals / free-form layout — needs a design decision first. |
+| `retire` | Zero views (usage-supplied mode only); recommend not migrating. |
+| `blocked` | >5 manual/unhandled features; needs human rework first. |
+
+**DM clusters** are keyed on the **shared dataset** — analyses that reference the
+same QuickSight dataset (or transitively overlap) share a Sigma data model by
+construction. Cleaner than Tableau's `.twb`-table Jaccard; like Power BI's
+shared-model clustering.
+
+---
+
+## Phase 7 — Hand off to `quicksight-to-sigma`
+
+Present the migration-plan summary and let the user pick the next step (single
+analysis, top-N batch, or just keep the readout). Invoke the converter in the
+same conversation:
+
+```
+Skill(
+  skill: "quicksight-to-sigma",
+  args:  "Convert analysis <id> (<name>) from the just-finished assessment at
+          /tmp/qs-assessment-<acct>. Read migration-plan.json for the
+          recommended_path, blockers, dataset_source_types, and the cluster's
+          shared datasets. The decoded analysis definition is in raw-defs/ and
+          the dataset describes in raw-datasets/ — reuse them instead of
+          re-extracting."
+)
+```
+
+The decoded `raw-defs/` and `raw-datasets/` overlap the converter's Phase-2
+discovery output; the converter can reuse them rather than re-calling the AWS
+CLI.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `list-analyses FAILED` | AWS creds not configured / wrong region | `aws sso login` (or `gimme-aws-creds`); confirm `aws sts get-caller-identity`; try `--region us-east-1` |
+| All analyses show `def_error` + `enterprise: false` | Standard-edition account | Expected — definition APIs are Enterprise-only; readout degrades to counts-only |
+| `def_error: AccessDenied` on an Enterprise account | IAM/QuickSight permissions missing the `quicksight:DescribeAnalysisDefinition` action | Grant the describe-definition + describe-data-set permissions |
+| Empty visual histogram on an analysis you know is rich | Visual union node name not in the built/mid/unhandled sets | Check `VISUAL_*` sets in `quicksight-inventory.py`; unknown nodes default to mid |
+| Datasets section empty | Datasets describe failed or analysis uses dataset-of-datasets | Check `raw-datasets/`; dataset-of-datasets is out of scope (a known converter gap) |
+| `region` wrong / resources missing | Identity region ≠ data region | QuickSight reads from the identity region — almost always `us-east-1` |
+
+See `refs/migration-test-slate.md` (in the `quicksight-to-sigma` skill) for the
+complexity taxonomy + 20-dashboard test slate the buckets are grounded in.

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/README.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/README.md
@@ -1,0 +1,39 @@
+# Sample readout — synthetic QuickSight account fixture
+
+A committed end-to-end run of `quicksight-assessment` against a **synthetic**
+`inventory.json` (account `153722385948`), so the skill's output shape is
+reviewable without an AWS account. The `inventory.json` here is hand-authored to
+exercise the three complexity profiles; the four downstream artifacts
+(`complexity.json`, `shortlist.json`, `migration-plan.json`, `readout.md`) are
+the **real** output of the Ruby pipeline run over it.
+
+Regenerate with:
+
+```bash
+ruby scripts/score-quicksight-complexity.rb --out fixtures/sample-readout
+ruby scripts/build-shortlist.rb            --out fixtures/sample-readout
+ruby scripts/migration-plan.rb             --out fixtures/sample-readout
+ruby scripts/render-readout.rb             --out fixtures/sample-readout
+```
+
+## What this run shows
+
+- **3 analyses, 2 datasets, 1 Snowflake data source.** Enterprise edition (the
+  definition APIs succeeded), so complexity is fully scored.
+- **`Orders Overview`** — the happy path: 5 built visuals (KPI/bar/line/pie), 3
+  mechanical calc fields, no window funcs → ranks highest, `recommended_path:
+  quicksight-to-sigma`.
+- **`Sales Deep Dive`** — mid-catalog visuals (table, pivot, combo), a join +
+  transforms, 1 window calc, RLS dataset → `needs-gap-scout`.
+- **`Exec ML Board`** — the hard case: InsightVisual (ML) + geospatial map +
+  sankey + 3 window calcs + free-form layout → mostly unhandled,
+  `needs-gap-scout`.
+- **Complexity-only mode** (no `usage.json`), so the readout carries the
+  limited-mode banner and the value basis is the `sheets + visuals/4` proxy.
+- **DM clustering** unions all three analyses into one cluster: they transitively
+  share `ds-orders-enriched` (Orders Overview + Exec ML Board reference it
+  directly; Sales Deep Dive references it alongside Customers), so they belong on
+  one Sigma data model.
+
+This validates the shared scoring + tag vocabulary, the Standard-edition /
+limited-mode banner logic, and the shared-dataset clustering.

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/complexity.json
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/complexity.json
@@ -1,0 +1,213 @@
+{
+  "orders-overview": {
+    "name": "Orders Overview",
+    "sheets": 1,
+    "visuals": 5,
+    "visual_kinds": {
+      "KPIVisual": 2,
+      "BarChartVisual": 1,
+      "LineChartVisual": 1,
+      "PieChartVisual": 1
+    },
+    "calc_field_count": 3,
+    "window_calc_count": 0,
+    "parameter_count": 1,
+    "filter_group_count": 0,
+    "dataset_count": 1,
+    "dataset_source_types": [
+      "CustomSql"
+    ],
+    "has_custom_sql": true,
+    "has_joins": false,
+    "rls_role_count": 0,
+    "cls_count": 0,
+    "calc_buckets": {
+      "a": 3,
+      "b": 0,
+      "c": 0
+    },
+    "twb_size_kb": 0,
+    "n_features": 10,
+    "n_auto": 8,
+    "n_hint": 0,
+    "n_manual": 2,
+    "n_unhandled": 0,
+    "features": [
+      {
+        "name": "calc_mechanical",
+        "status": "auto",
+        "count": 3
+      },
+      {
+        "name": "visuals_built",
+        "status": "auto",
+        "count": 5
+      },
+      {
+        "name": "dataset_transforms",
+        "status": "manual",
+        "count": 2
+      },
+      {
+        "name": "parameters",
+        "status": "manual",
+        "count": 1
+      }
+    ]
+  },
+  "sales-deep-dive": {
+    "name": "Sales Deep Dive",
+    "sheets": 2,
+    "visuals": 8,
+    "visual_kinds": {
+      "KPIVisual": 1,
+      "BarChartVisual": 2,
+      "TableVisual": 1,
+      "PivotTableVisual": 1,
+      "ComboChartVisual": 1,
+      "LineChartVisual": 2
+    },
+    "calc_field_count": 6,
+    "window_calc_count": 1,
+    "parameter_count": 2,
+    "filter_group_count": 1,
+    "dataset_count": 2,
+    "dataset_source_types": [
+      "CustomSql",
+      "RelationalTable"
+    ],
+    "has_custom_sql": true,
+    "has_joins": true,
+    "rls_role_count": 1,
+    "cls_count": 0,
+    "calc_buckets": {
+      "a": 4,
+      "b": 1,
+      "c": 1
+    },
+    "twb_size_kb": 0,
+    "n_features": 19,
+    "n_auto": 9,
+    "n_hint": 0,
+    "n_manual": 8,
+    "n_unhandled": 2,
+    "features": [
+      {
+        "name": "calc_mechanical",
+        "status": "auto",
+        "count": 4
+      },
+      {
+        "name": "calc_restructure",
+        "status": "manual",
+        "count": 1
+      },
+      {
+        "name": "calc_window",
+        "status": "unhandled",
+        "count": 1
+      },
+      {
+        "name": "visuals_built",
+        "status": "auto",
+        "count": 5
+      },
+      {
+        "name": "visuals_rebuild",
+        "status": "manual",
+        "count": 3
+      },
+      {
+        "name": "dataset_joins",
+        "status": "manual",
+        "count": 1
+      },
+      {
+        "name": "dataset_transforms",
+        "status": "manual",
+        "count": 3
+      },
+      {
+        "name": "parameters",
+        "status": "manual",
+        "count": 2
+      },
+      {
+        "name": "filter_groups",
+        "status": "unhandled",
+        "count": 1
+      },
+      {
+        "name": "rls_cls",
+        "status": "manual",
+        "count": 1
+      }
+    ]
+  },
+  "exec-ml-board": {
+    "name": "Exec ML Board",
+    "sheets": 1,
+    "visuals": 4,
+    "visual_kinds": {
+      "InsightVisual": 1,
+      "GeospatialMapVisual": 1,
+      "SankeyDiagramVisual": 1,
+      "KPIVisual": 1
+    },
+    "calc_field_count": 4,
+    "window_calc_count": 3,
+    "parameter_count": 0,
+    "filter_group_count": 0,
+    "dataset_count": 1,
+    "dataset_source_types": [
+      "CustomSql"
+    ],
+    "has_custom_sql": true,
+    "has_joins": false,
+    "rls_role_count": 0,
+    "cls_count": 0,
+    "calc_buckets": {
+      "a": 1,
+      "b": 0,
+      "c": 3
+    },
+    "twb_size_kb": 0,
+    "n_features": 10,
+    "n_auto": 2,
+    "n_hint": 0,
+    "n_manual": 1,
+    "n_unhandled": 7,
+    "features": [
+      {
+        "name": "calc_mechanical",
+        "status": "auto",
+        "count": 1
+      },
+      {
+        "name": "calc_window",
+        "status": "unhandled",
+        "count": 3
+      },
+      {
+        "name": "visuals_built",
+        "status": "auto",
+        "count": 1
+      },
+      {
+        "name": "visuals_exotic",
+        "status": "unhandled",
+        "count": 3
+      },
+      {
+        "name": "dataset_transforms",
+        "status": "manual",
+        "count": 2
+      },
+      {
+        "name": "free_form_layout",
+        "status": "unhandled",
+        "count": 1
+      }
+    ]
+  }
+}

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/inventory.json
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/inventory.json
@@ -1,0 +1,83 @@
+{
+  "account": {
+    "account_id": "153722385948",
+    "region": "us-east-1",
+    "generated_at": "2026-06-06",
+    "edition": "Enterprise",
+    "enterprise": true
+  },
+  "analyses": [
+    {
+      "id": "orders-overview",
+      "name": "Orders Overview",
+      "last_updated": "2026-05-20T00:00:00Z",
+      "sheet_count": 1,
+      "visual_count": 5,
+      "visual_kinds": { "KPIVisual": 2, "BarChartVisual": 1, "LineChartVisual": 1, "PieChartVisual": 1 },
+      "visuals_built": 5, "visuals_mid": 0, "visuals_unhandled": 0,
+      "calc_field_count": 3,
+      "calc_buckets": { "a": 3, "b": 0, "c": 0 },
+      "window_calc_count": 0,
+      "parameter_count": 1, "filter_group_count": 0,
+      "free_form_sheets": 0, "section_based_sheets": 0,
+      "dataset_identifiers": ["orders"],
+      "dataset_ids": ["ds-orders-enriched"]
+    },
+    {
+      "id": "sales-deep-dive",
+      "name": "Sales Deep Dive",
+      "last_updated": "2026-05-18T00:00:00Z",
+      "sheet_count": 2,
+      "visual_count": 8,
+      "visual_kinds": { "KPIVisual": 1, "BarChartVisual": 2, "TableVisual": 1, "PivotTableVisual": 1, "ComboChartVisual": 1, "LineChartVisual": 2 },
+      "visuals_built": 5, "visuals_mid": 3, "visuals_unhandled": 0,
+      "calc_field_count": 6,
+      "calc_buckets": { "a": 4, "b": 1, "c": 1 },
+      "window_calc_count": 1,
+      "parameter_count": 2, "filter_group_count": 1,
+      "free_form_sheets": 0, "section_based_sheets": 0,
+      "dataset_identifiers": ["orders", "customers"],
+      "dataset_ids": ["ds-orders-enriched", "ds-customers"]
+    },
+    {
+      "id": "exec-ml-board",
+      "name": "Exec ML Board",
+      "last_updated": "2026-05-10T00:00:00Z",
+      "sheet_count": 1,
+      "visual_count": 4,
+      "visual_kinds": { "InsightVisual": 1, "GeospatialMapVisual": 1, "SankeyDiagramVisual": 1, "KPIVisual": 1 },
+      "visuals_built": 1, "visuals_mid": 0, "visuals_unhandled": 3,
+      "calc_field_count": 4,
+      "calc_buckets": { "a": 1, "b": 0, "c": 3 },
+      "window_calc_count": 3,
+      "parameter_count": 0, "filter_group_count": 0,
+      "free_form_sheets": 1, "section_based_sheets": 0,
+      "dataset_identifiers": ["orders"],
+      "dataset_ids": ["ds-orders-enriched"]
+    }
+  ],
+  "datasets": [
+    {
+      "id": "ds-orders-enriched",
+      "name": "Orders Enriched",
+      "import_mode": "DIRECT_QUERY",
+      "physical_kinds": ["CustomSql"],
+      "has_custom_sql": true, "has_joins": false, "transform_count": 2,
+      "rls_enabled": false, "cls_enabled": false, "column_count": 14
+    },
+    {
+      "id": "ds-customers",
+      "name": "Customers",
+      "import_mode": "SPICE",
+      "physical_kinds": ["RelationalTable"],
+      "has_custom_sql": false, "has_joins": true, "transform_count": 1,
+      "rls_enabled": true, "cls_enabled": false, "column_count": 9
+    }
+  ],
+  "data_sources": [
+    { "id": "src-snow", "name": "Snowflake Prod", "type": "SNOWFLAKE" }
+  ],
+  "environment_overview": {
+    "analyses": 3, "dashboards": 2, "datasets": 2, "data_sources": 1
+  }
+}

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/migration-plan.json
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/migration-plan.json
@@ -1,0 +1,121 @@
+{
+  "analyses": [
+    {
+      "analysisId": "orders-overview",
+      "name": "Orders Overview",
+      "dataset_ids": [
+        "ds-orders-enriched"
+      ],
+      "dataset_source_types": [
+        "CustomSql"
+      ],
+      "recommended_path": "quicksight-to-sigma",
+      "priority_tier": "moderate",
+      "score": 3.21,
+      "views": null,
+      "calc_buckets": {
+        "a": 3,
+        "b": 0,
+        "c": 0
+      },
+      "blockers": [
+        "2 restructuring/join/transform/RLS/param feature(s)"
+      ],
+      "cluster_id": "cluster-01-customers"
+    },
+    {
+      "analysisId": "sales-deep-dive",
+      "name": "Sales Deep Dive",
+      "dataset_ids": [
+        "ds-orders-enriched",
+        "ds-customers"
+      ],
+      "dataset_source_types": [
+        "CustomSql",
+        "RelationalTable"
+      ],
+      "recommended_path": "quicksight-to-sigma-with-scout",
+      "priority_tier": "needs-gap-scout",
+      "score": 0.89,
+      "views": null,
+      "calc_buckets": {
+        "a": 4,
+        "b": 1,
+        "c": 1
+      },
+      "blockers": [
+        "2 unhandled feature(s) (window calc / exotic visual / free-form layout / FilterGroups)",
+        "8 restructuring/join/transform/RLS/param feature(s)"
+      ],
+      "cluster_id": "cluster-01-customers"
+    },
+    {
+      "analysisId": "exec-ml-board",
+      "name": "Exec ML Board",
+      "dataset_ids": [
+        "ds-orders-enriched"
+      ],
+      "dataset_source_types": [
+        "CustomSql"
+      ],
+      "recommended_path": "quicksight-to-sigma-with-scout",
+      "priority_tier": "needs-gap-scout",
+      "score": 0.27,
+      "views": null,
+      "calc_buckets": {
+        "a": 1,
+        "b": 0,
+        "c": 3
+      },
+      "blockers": [
+        "7 unhandled feature(s) (window calc / exotic visual / free-form layout / FilterGroups)",
+        "1 restructuring/join/transform/RLS/param feature(s)"
+      ],
+      "cluster_id": "cluster-01-customers"
+    }
+  ],
+  "dm_clusters": [
+    {
+      "id": "cluster-01-customers",
+      "dataset_ids": [
+        "ds-customers",
+        "ds-orders-enriched"
+      ],
+      "dataset_names": [
+        "Customers",
+        "Orders Enriched"
+      ],
+      "analysisIds": [
+        "orders-overview",
+        "sales-deep-dive",
+        "exec-ml-board"
+      ],
+      "analysis_names": [
+        "Orders Overview",
+        "Sales Deep Dive",
+        "Exec ML Board"
+      ],
+      "shared_source_types": [
+        "CustomSql",
+        "RelationalTable"
+      ],
+      "cluster_size": 3
+    }
+  ],
+  "summary": {
+    "analyses_total": 3,
+    "analyses_ready": 1,
+    "analyses_need_scout": 2,
+    "analyses_blocked": 0,
+    "analyses_retire": 0,
+    "cluster_count": 1,
+    "usage_available": false,
+    "suggested_batch": [
+      {
+        "analysisId": "orders-overview",
+        "name": "Orders Overview",
+        "cluster_id": "cluster-01-customers"
+      }
+    ]
+  }
+}

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/readout.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/readout.md
@@ -1,0 +1,216 @@
+# Amazon QuickSight Assessment — 153722385948
+
+**Account:** `153722385948` | **Region:** us-east-1 | **Edition:** Enterprise | **Mode:** Complexity-only | **Generated:** 2026-06-06
+
+> Lightweight pre-scoping readout produced by the `quicksight-assessment` skill.
+> READ-ONLY — nothing was written to QuickSight or posted to Sigma. The migration
+> shortlist below feeds directly into the `quicksight-to-sigma` conversion skill.
+
+
+
+---
+
+## 1. Environment overview
+
+| | |
+|---|---|
+| Analyses | **3** |
+| Dashboards | 2 |
+| Datasets | **2** |
+| Data sources | 1 |
+
+
+> ⚠️ Running WITHOUT per-analysis usage data. QuickSight has no per-analysis
+> view-count API on the standard surface, so the shortlist below is
+> **complexity-only**: it ranks analyses by size/richness, not by who actually
+> uses them. Supply a `usage.json` (CloudTrail/CloudWatch-derived) to add the
+> usage axis. Everything else (visual mix, calc-field buckets, dataset sources)
+> is accurate.
+
+
+---
+
+## 2. Visual-type mix (account-wide)
+
+QuickSight visuals the workbook builder reproduces directly: KPI, bar, line,
+pie/donut. Everything else is a manual rebuild (mid catalog: table, pivot,
+combo, scatter, gauge, funnel, treemap, …) or has no Sigma equivalent (maps,
+sankey, insight ML, custom content, plugin).
+
+| Visual type | Count |
+|---|---|
+| KPIVisual | 4 |
+| BarChartVisual | 3 |
+| LineChartVisual | 3 |
+| PivotTableVisual | 1 |
+| ComboChartVisual | 1 |
+| InsightVisual | 1 |
+| GeospatialMapVisual | 1 |
+| SankeyDiagramVisual | 1 |
+| PieChartVisual | 1 |
+| TableVisual | 1 |
+
+
+---
+
+## 3. Analysis complexity
+
+Each analysis's conversion burden = its visual mix + calc fields + parameters,
+plus its datasets' source/prep/RLS burden (inherited via dataset references).
+
+| Analysis | Sheets | Visuals | CalcFields | Window | Params | Calc a/b/c |
+|---|---|---|---|---|---|---|
+| Exec ML Board | 1 | 4 | 4 | 3 | 0 | 1/0/3 |
+| Sales Deep Dive | 2 | 8 | 6 | 1 | 2 | 4/1/1 |
+| Orders Overview | 1 | 5 | 3 | 0 | 1 | 3/0/0 |
+
+
+Calc-field convertibility buckets (from `refs/migration-test-slate.md`):
+- **a — mechanical** (~most calc fields): direct Sigma-formula rewrite
+  (`ifelse`→`If`, `switch`→nested `If`, arithmetic, string, date funcs).
+- **b — restructuring**: needs a grouped element or pre-aggregation.
+- **c — no Sigma equivalent**: window / table-calc functions (`sumOver`,
+  `runningSum`, `rank`, `percentOfTotal`, `periodOverPeriod*`, …) — the converter
+  degrades these to a `/* TODO */` placeholder.
+
+Across all scanned analyses: **8 mechanical / 1
+restructuring / 4 no-equivalent** calc fields.
+
+---
+
+## 4. Datasets & sources
+
+Physical source kinds parsed from each dataset's `PhysicalTableMap`:
+
+| Physical source kind | Datasets |
+|---|---|
+| CustomSql | 1 |
+| RelationalTable | 1 |
+
+
+- **1** dataset(s) use **CustomSql** (converted via the
+  `[Custom SQL/<ALIAS>]` fixup — see `quicksight-to-sigma`).
+- **1** dataset(s) have **row-level security** enabled.
+
+Migration signal: datasets on a cloud warehouse Sigma already supports
+(Snowflake, Redshift, Athena, BigQuery, Databricks, Postgres) are **drop-in** —
+Sigma reads the same tables directly. **S3 / SaaS** physical sources are a
+converter gap (placeholder) and surface as unhandled.
+
+---
+
+## 5. Analysis priority — by complexity proxy
+
+| Analysis | Sheets | Visuals | Views | Users |
+|---|---|---|---|---|
+| Orders Overview | 1 | 5 | — | — |
+| Sales Deep Dive | 2 | 8 | — | — |
+| Exec ML Board | 1 | 4 | — | — |
+
+
+
+
+> Usage data unavailable. Analyses above are ranked by a complexity proxy
+> (sheet + visual count), not real view counts.
+
+
+---
+
+## 6. Migration shortlist (complexity-only proxy (sheets + visuals/4))
+
+`cost = 10·unhandled + 3·manual + 1·hint`, ranked by `value / (1 + cost)`.
+Higher score = better first-migration candidate. For QuickSight, `manual` =
+restructuring calc + mid-catalog visuals + dataset joins/transforms + parameters
++ RLS/CLS; `unhandled` = window/table-calc + exotic visuals + free-form/section
+layout + FilterGroups + S3/SaaS source.
+
+| Analysis | Views | Calc a/b/c | Auto/Hint/Man/Unh | Value | Score | Tag |
+|---|---|---|---|---|---|---|
+| Orders Overview | — | 3/0/0 | 8/0/2/0 | 22.5 | 3.21 | moderate |
+| Sales Deep Dive | — | 4/1/1 | 9/0/8/2 | 40.0 | 0.89 | ⚠️ needs-gap-scout |
+| Exec ML Board | — | 1/0/3 | 2/0/1/7 | 20.0 | 0.27 | ⚠️ needs-gap-scout |
+
+
+The top 3 analyses have **9
+unhandled features between them**.
+
+---
+
+## 7. Per-analysis complexity
+
+| Analysis | Sheets | Visuals | CalcFields | Window | RLS | Manual | Unhandled |
+|---|---|---|---|---|---|---|---|
+| Exec ML Board | 1 | 4 | 4 | 3 | 0 | 1 | **7** |
+| Sales Deep Dive | 2 | 8 | 6 | 1 | 1 | 8 | **2** |
+| Orders Overview | 1 | 5 | 3 | 0 | 0 | 2 | 0 |
+
+
+**Total unhandled features across the account: 9** spanning
+2 analyses. Each gets a `gap-scout`-style triage at conversion
+time.
+
+---
+
+## 8. What this skill found vs. what it didn't
+
+**Found (read-only, AWS-CLI delegated):**
+- Environment counts (analyses, dashboards, datasets, data sources)
+- Per-analysis: sheet count, visual count, visual-kind histogram
+- Per-analysis: calc-field count + a/b/c convertibility buckets, window-function detection
+- Per-analysis: parameter count, FilterGroup count, layout shape (free-form / section-based)
+- Per-dataset: source type(s), import mode (SPICE/DirectQuery), custom-sql, joins, transform count, RLS/CLS
+
+
+
+**Not gathered (out of scope):**
+- Per-visual field-level bindings (the converter re-derives these from the analysis definition at conversion time)
+
+- Usage / adoption — QuickSight has no per-analysis view-count API on the
+  standard surface; supply a CloudTrail/CloudWatch-derived `usage.json` to add it.
+
+
+---
+
+## 9. Privacy
+
+What crossed Anthropic's API on its way through Claude during this assessment:
+
+- Aggregate counts (analysis / dataset / data-source counts)
+- Analysis, dataset, and data-source names
+- **Analysis definitions** — visual configuration + **calc-field expressions**
+- Dataset metadata — physical source kinds, custom-sql presence, RLS/CLS flags
+
+What did NOT cross:
+- Warehouse / SPICE rows (this skill never queries the underlying data)
+- AWS credentials (handled by the AWS CLI, not surfaced)
+- Actual visual cell values
+
+---
+
+## 10. Hand-off package
+
+This directory contains:
+
+- `readout.md` — this report
+- `inventory.json` — raw environment + per-analysis + per-dataset metadata
+- `complexity.json` — per-analysis convertibility scoring
+- `shortlist.json` — value/cost-ranked migration shortlist
+- `migration-plan.json` — per-analysis `recommended_path` + DM clusters (by shared dataset)
+- `raw-defs/` — decoded analysis definitions (delete after review if you'd rather not retain calc-field text)
+- `raw-datasets/` — decoded dataset describes
+
+Nothing is uploaded automatically. To share, zip and send deliberately.
+
+---
+
+## 11. Next steps
+
+1. **Pilot the top 3 analyses** with the
+   `quicksight-to-sigma` skill — the migration-plan groups them into DM clusters
+   that share a Sigma data model (by shared dataset).
+2. **Triage the `needs-gap-scout` queue** (2 analyses):
+   window/table-calc functions, exotic visuals, or free-form layout that need a
+   design decision first.
+
+4. **Supply usage data** (CloudTrail/CloudWatch) to get a usage-weighted (not
+   complexity-only) shortlist.

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/shortlist.json
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/fixtures/sample-readout/shortlist.json
@@ -1,0 +1,79 @@
+{
+  "usage_available": false,
+  "value_basis": "complexity-only proxy (sheets + visuals/4)",
+  "analyses": [
+    {
+      "name": "Orders Overview",
+      "id": "orders-overview",
+      "sheets": 1,
+      "visuals": 5,
+      "views": null,
+      "users": null,
+      "auto": 8,
+      "hint": 0,
+      "manual": 2,
+      "unhandled": 0,
+      "calc_buckets": {
+        "a": 3,
+        "b": 0,
+        "c": 0
+      },
+      "dataset_source_types": [
+        "CustomSql"
+      ],
+      "value": 22.5,
+      "cost": 6,
+      "score": 3.21,
+      "tag": "moderate"
+    },
+    {
+      "name": "Sales Deep Dive",
+      "id": "sales-deep-dive",
+      "sheets": 2,
+      "visuals": 8,
+      "views": null,
+      "users": null,
+      "auto": 9,
+      "hint": 0,
+      "manual": 8,
+      "unhandled": 2,
+      "calc_buckets": {
+        "a": 4,
+        "b": 1,
+        "c": 1
+      },
+      "dataset_source_types": [
+        "CustomSql",
+        "RelationalTable"
+      ],
+      "value": 40.0,
+      "cost": 44,
+      "score": 0.89,
+      "tag": "needs-gap-scout"
+    },
+    {
+      "name": "Exec ML Board",
+      "id": "exec-ml-board",
+      "sheets": 1,
+      "visuals": 4,
+      "views": null,
+      "users": null,
+      "auto": 2,
+      "hint": 0,
+      "manual": 1,
+      "unhandled": 7,
+      "calc_buckets": {
+        "a": 1,
+        "b": 0,
+        "c": 3
+      },
+      "dataset_source_types": [
+        "CustomSql"
+      ],
+      "value": 20.0,
+      "cost": 73,
+      "score": 0.27,
+      "tag": "needs-gap-scout"
+    }
+  ]
+}

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/output-shapes.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/output-shapes.md
@@ -1,0 +1,137 @@
+# Output shapes
+
+Three JSON files + one markdown emitted to `<out>/`, plus decoded `raw-defs/`
+and `raw-datasets/`. `render-readout.rb` reads the JSON to produce `readout.md`;
+`quicksight-to-sigma` reads `migration-plan.json`.
+
+Parallel to `powerbi-assessment/refs/output-shapes.md` — the renderer and
+shortlist scoring share that skill's vocabulary so the markdown sections line
+up. The key difference: QuickSight splits complexity across the **analysis**
+(visuals, calc fields, parameters, layout) and its **datasets** (source type,
+custom-sql, joins, data-prep, RLS/CLS).
+
+## `inventory.json` (written by `quicksight-inventory.py`)
+
+```json
+{
+  "account": {
+    "account_id": "...", "region": "us-east-1",
+    "generated_at": "YYYY-MM-DD",
+    "edition": "Enterprise" | "Standard? (definition API rejected)" | null,
+    "enterprise": true | false | null
+  },
+  "analyses": [
+    {
+      "id": "...", "name": "...", "last_updated": "...",
+      "sheet_count": <int>, "visual_count": <int>,
+      "visual_kinds": { "BarChartVisual": N, "KPIVisual": N, ... },
+      "visuals_built": <int>, "visuals_mid": <int>, "visuals_unhandled": <int>,
+      "calc_field_count": <int>,
+      "calc_buckets": { "a": <int>, "b": <int>, "c": <int> },
+      "window_calc_count": <int>,
+      "parameter_count": <int>, "filter_group_count": <int>,
+      "free_form_sheets": <int>, "section_based_sheets": <int>,
+      "dataset_identifiers": [...], "dataset_ids": ["<dataSetId>", ...]
+      // OR, on a Standard account / no perms:  "def_error": "..."
+    }
+  ],
+  "datasets": [
+    {
+      "id": "...", "name": "...",
+      "import_mode": "SPICE" | "DIRECT_QUERY",
+      "physical_kinds": ["RelationalTable" | "CustomSql" | "S3Source", ...],
+      "has_custom_sql": <bool>, "has_joins": <bool>, "transform_count": <int>,
+      "rls_enabled": <bool>, "cls_enabled": <bool>, "column_count": <int>
+    }
+  ],
+  "data_sources": [ { "id": "...", "name": "...", "type": "SNOWFLAKE" | "REDSHIFT" | "ATHENA" | "S3" | ... } ],
+  "environment_overview": {
+    "analyses": <int>, "dashboards": <int>, "datasets": <int>, "data_sources": <int>
+  }
+}
+```
+
+`calc_buckets` semantics (from `refs/migration-test-slate.md`): `a` = mechanical
+rewrite, `b` = needs restructuring, `c` = window / table-calc function with no
+clean Sigma equivalent (converter degrades to a `/* TODO */` placeholder).
+
+## `complexity.json` (written by `score-quicksight-complexity.rb`)
+
+Keyed by **analysis id**. The analysis inherits its datasets' burden via
+`dataset_ids`. The four `n_*` tiers map onto the shared vocabulary: easy → auto,
+medium → manual, hard → unhandled, no `hint` tier.
+
+```json
+{
+  "<analysis-id>": {
+    "name": "...", "sheets": <int>, "visuals": <int>, "visual_kinds": {...},
+    "calc_field_count": <int>, "window_calc_count": <int>,
+    "parameter_count": <int>, "filter_group_count": <int>,
+    "dataset_count": <int>, "dataset_source_types": [...],
+    "has_custom_sql": <bool>, "has_joins": <bool>,
+    "rls_role_count": <int>, "cls_count": <int>,
+    "calc_buckets": { "a": <int>, "b": <int>, "c": <int> },
+    "twb_size_kb": 0,                       // n/a; renderer-compat
+    "n_features": <int>, "n_auto": <int>, "n_hint": 0,
+    "n_manual": <int>,                      // restructure calc + mid visuals + joins + transforms + params + RLS/CLS
+    "n_unhandled": <int>,                   // window calc + exotic visuals + free-form/section layout + FilterGroups + S3 source
+    "features": [{ "name": "...", "status": "auto|manual|unhandled", "count": <int> }]
+  }
+}
+```
+
+## `usage.json` (optional — only if the agent supplies it)
+
+QuickSight has no per-analysis view-count API on the standard surface. If the
+agent derives views from CloudTrail / CloudWatch (optional, out of scope for the
+default run) it can drop a file in this shape and `build-shortlist.rb` will use
+the usage-weighted value formula:
+
+```json
+{
+  "available": true,
+  "by_analysis": { "<analysis-id>": { "views": <int>, "users": <int> } }
+}
+```
+
+If absent, `build-shortlist.rb` falls back to the complexity-only proxy.
+
+## `shortlist.json` (written by `build-shortlist.rb`)
+
+```json
+{
+  "usage_available": <bool>,
+  "value_basis": "usage (views × √users)" | "complexity-only proxy (sheets + visuals/4)",
+  "analyses": [
+    {
+      "name": "...", "id": "...", "sheets": <int>, "visuals": <int>,
+      "views": <int>|null, "users": <int>|null,
+      "auto": <int>, "hint": <int>, "manual": <int>, "unhandled": <int>,
+      "calc_buckets": {...}, "dataset_source_types": [...],
+      "value": <float>, "cost": <int>, "score": <float>,
+      "tag": "migrate-first"|"easy-win"|"moderate"|"needs-gap-scout"|"retire"
+    }
+  ]
+}
+```
+
+Tag rules (mirror powerbi/tableau-assessment):
+- usage available AND `views == 0`               → `retire`
+- `unhandled >= 1`                               → `needs-gap-scout`
+- `score >= 20 and (manual + unhandled) == 0`    → `migrate-first`
+- `score >= 10`                                  → `easy-win`
+- else                                           → `moderate`
+
+## `migration-plan.json` (written by `migration-plan.rb`)
+
+The hand-off contract for `quicksight-to-sigma`. Per-analysis `recommended_path`
+(`quicksight-to-sigma` / `quicksight-to-sigma-with-scout` / `retire` /
+`blocked`) plus DM clusters. Clustering key is the **shared dataset** — analyses
+that reference the same QuickSight dataset (or transitively overlap) share a
+Sigma data model by construction. See `migration-plan.rb` header for the full
+shape.
+
+## `readout.md`
+
+Markdown readout. See `refs/readout-template.md` for section ordering and
+placeholders. Deterministic composition from the JSON files above.

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/readout-template.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/readout-template.md
@@ -1,0 +1,195 @@
+# Amazon QuickSight Assessment — {{account_name}}
+
+**Account:** `{{account_name}}` | **Region:** {{region}} | **Edition:** {{edition}} | **Mode:** {{mode}} | **Generated:** {{generated_at}}
+
+> Lightweight pre-scoping readout produced by the `quicksight-assessment` skill.
+> READ-ONLY — nothing was written to QuickSight or posted to Sigma. The migration
+> shortlist below feeds directly into the `quicksight-to-sigma` conversion skill.
+
+{{#standard_edition_banner}}
+> ⛔ The `describe-*-definition` / `describe-data-set` APIs were rejected — this
+> looks like a **Standard-edition** account. Those APIs are **Enterprise-only**,
+> so per-analysis visual / calc-field complexity is **unavailable**: the readout
+> below is counts-only. Upgrade to Enterprise (or run against an Enterprise
+> account) to get the full complexity scoring and a real migration shortlist.
+{{/standard_edition_banner}}
+
+---
+
+## 1. Environment overview
+
+| | |
+|---|---|
+| Analyses | **{{analyses}}** |
+| Dashboards | {{dashboards}} |
+| Datasets | **{{datasets}}** |
+| Data sources | {{data_sources}} |
+
+{{#limited_mode_banner}}
+> ⚠️ Running WITHOUT per-analysis usage data. QuickSight has no per-analysis
+> view-count API on the standard surface, so the shortlist below is
+> **complexity-only**: it ranks analyses by size/richness, not by who actually
+> uses them. Supply a `usage.json` (CloudTrail/CloudWatch-derived) to add the
+> usage axis. Everything else (visual mix, calc-field buckets, dataset sources)
+> is accurate.
+{{/limited_mode_banner}}
+
+---
+
+## 2. Visual-type mix (account-wide)
+
+QuickSight visuals the workbook builder reproduces directly: KPI, bar, line,
+pie/donut. Everything else is a manual rebuild (mid catalog: table, pivot,
+combo, scatter, gauge, funnel, treemap, …) or has no Sigma equivalent (maps,
+sankey, insight ML, custom content, plugin).
+
+{{visuals_table}}
+
+---
+
+## 3. Analysis complexity
+
+Each analysis's conversion burden = its visual mix + calc fields + parameters,
+plus its datasets' source/prep/RLS burden (inherited via dataset references).
+
+{{analyses_table}}
+
+Calc-field convertibility buckets (from `refs/migration-test-slate.md`):
+- **a — mechanical** (~most calc fields): direct Sigma-formula rewrite
+  (`ifelse`→`If`, `switch`→nested `If`, arithmetic, string, date funcs).
+- **b — restructuring**: needs a grouped element or pre-aggregation.
+- **c — no Sigma equivalent**: window / table-calc functions (`sumOver`,
+  `runningSum`, `rank`, `percentOfTotal`, `periodOverPeriod*`, …) — the converter
+  degrades these to a `/* TODO */` placeholder.
+
+Across all scanned analyses: **{{total_calc_a}} mechanical / {{total_calc_b}}
+restructuring / {{total_calc_c}} no-equivalent** calc fields.
+
+---
+
+## 4. Datasets & sources
+
+Physical source kinds parsed from each dataset's `PhysicalTableMap`:
+
+{{source_table}}
+
+- **{{n_custom_sql}}** dataset(s) use **CustomSql** (converted via the
+  `[Custom SQL/<ALIAS>]` fixup — see `quicksight-to-sigma`).
+- **{{n_rls}}** dataset(s) have **row-level security** enabled.
+
+Migration signal: datasets on a cloud warehouse Sigma already supports
+(Snowflake, Redshift, Athena, BigQuery, Databricks, Postgres) are **drop-in** —
+Sigma reads the same tables directly. **S3 / SaaS** physical sources are a
+converter gap (placeholder) and surface as unhandled.
+
+---
+
+## 5. Analysis priority — {{usage_basis}}
+
+{{usage_table}}
+
+{{#has_usage}}
+**Cold (zero-view) analyses:** {{n_cold}} — retire-don't-migrate candidates.
+{{/has_usage}}
+{{^has_usage}}
+> Usage data unavailable. Analyses above are ranked by a complexity proxy
+> (sheet + visual count), not real view counts.
+{{/has_usage}}
+
+---
+
+## 6. Migration shortlist ({{value_basis}})
+
+`cost = 10·unhandled + 3·manual + 1·hint`, ranked by `value / (1 + cost)`.
+Higher score = better first-migration candidate. For QuickSight, `manual` =
+restructuring calc + mid-catalog visuals + dataset joins/transforms + parameters
++ RLS/CLS; `unhandled` = window/table-calc + exotic visuals + free-form/section
+layout + FilterGroups + S3/SaaS source.
+
+{{shortlist_table}}
+
+The top {{shortlist_top_n}} analyses have **{{shortlist_total_unhandled}}
+unhandled features between them**.
+
+---
+
+## 7. Per-analysis complexity
+
+{{complexity_table}}
+
+**Total unhandled features across the account: {{total_unhandled}}** spanning
+{{n_with_unhandled}} analyses. Each gets a `gap-scout`-style triage at conversion
+time.
+
+---
+
+## 8. What this skill found vs. what it didn't
+
+**Found (read-only, AWS-CLI delegated):**
+- Environment counts (analyses, dashboards, datasets, data sources)
+- Per-analysis: sheet count, visual count, visual-kind histogram
+- Per-analysis: calc-field count + a/b/c convertibility buckets, window-function detection
+- Per-analysis: parameter count, FilterGroup count, layout shape (free-form / section-based)
+- Per-dataset: source type(s), import mode (SPICE/DirectQuery), custom-sql, joins, transform count, RLS/CLS
+
+{{#has_usage}}
+**Added by supplied usage data:**
+- Per-analysis view counts and distinct-user counts
+- Usage-weighted migration shortlist
+- Cold-analysis detection
+{{/has_usage}}
+
+**Not gathered (out of scope):**
+- Per-visual field-level bindings (the converter re-derives these from the analysis definition at conversion time)
+{{^has_usage}}
+- Usage / adoption — QuickSight has no per-analysis view-count API on the
+  standard surface; supply a CloudTrail/CloudWatch-derived `usage.json` to add it.
+{{/has_usage}}
+
+---
+
+## 9. Privacy
+
+What crossed Anthropic's API on its way through Claude during this assessment:
+
+- Aggregate counts (analysis / dataset / data-source counts)
+- Analysis, dataset, and data-source names
+- **Analysis definitions** — visual configuration + **calc-field expressions**
+- Dataset metadata — physical source kinds, custom-sql presence, RLS/CLS flags
+
+What did NOT cross:
+- Warehouse / SPICE rows (this skill never queries the underlying data)
+- AWS credentials (handled by the AWS CLI, not surfaced)
+- Actual visual cell values
+
+---
+
+## 10. Hand-off package
+
+This directory contains:
+
+- `readout.md` — this report
+- `inventory.json` — raw environment + per-analysis + per-dataset metadata
+- `complexity.json` — per-analysis convertibility scoring
+- `shortlist.json` — value/cost-ranked migration shortlist
+- `migration-plan.json` — per-analysis `recommended_path` + DM clusters (by shared dataset)
+- `raw-defs/` — decoded analysis definitions (delete after review if you'd rather not retain calc-field text)
+- `raw-datasets/` — decoded dataset describes
+
+Nothing is uploaded automatically. To share, zip and send deliberately.
+
+---
+
+## 11. Next steps
+
+1. **Pilot the top {{recommended_pilot_n}} analyses** with the
+   `quicksight-to-sigma` skill — the migration-plan groups them into DM clusters
+   that share a Sigma data model (by shared dataset).
+2. **Triage the `needs-gap-scout` queue** ({{n_needs_scout}} analyses):
+   window/table-calc functions, exotic visuals, or free-form layout that need a
+   design decision first.
+{{#has_usage}}
+3. **Retire the `retire` queue** ({{n_retire}} analyses): zero views, no migration value.
+{{/has_usage}}
+4. **Supply usage data** (CloudTrail/CloudWatch) to get a usage-weighted (not
+   complexity-only) shortlist.

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/build-shortlist.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/build-shortlist.rb
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby
+# Phase 4 (QuickSight): cross-tabulate per-analysis usage with per-analysis
+# complexity and emit a value/cost-ranked migration shortlist.
+#
+# Adapted from powerbi-assessment/scripts/build-shortlist.rb — same scoring
+# shape + tag vocabulary so the readout renderer is shared. The VALUE signal:
+#
+#   - QuickSight has no per-analysis view-count API on the standard surface, so
+#     value defaults to a complexity-only proxy: value = 10 × (sheets +
+#     visuals/4), ranking "bigger / richer analyses first".
+#   - If the agent supplied usage.json (e.g. CloudTrail / CloudWatch-derived
+#     view counts, optional), value = views × √(distinct_users) — the tableau/
+#     powerbi formula.
+#
+#   cost  = 10·unhandled + 3·manual + 1·hint      (same weights as the others)
+#   score = value / (1 + cost)
+#
+# Tags (same vocabulary as powerbi/tableau-assessment):
+#   usage available AND views == 0                → "retire"
+#   unhandled >= 1                                → "needs-gap-scout"
+#   score >= 20 and (manual + unhandled) == 0     → "migrate-first"
+#   score >= 10                                   → "easy-win"
+#   else                                          → "moderate"
+#
+# Usage:  ruby scripts/build-shortlist.rb --out /tmp/qs-assessment-<acct>
+# Reads:  <out>/inventory.json, <out>/complexity.json, [<out>/usage.json]
+# Writes: <out>/shortlist.json
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new { |p| p.on('--out DIR') { |v| opts[:out] = v } }.parse!
+abort('--out required') unless opts[:out]
+
+complexity = JSON.parse(File.read(File.join(opts[:out], 'complexity.json')))
+
+usage_path = File.join(opts[:out], 'usage.json')
+usage = File.exist?(usage_path) ? JSON.parse(File.read(usage_path)) : nil
+usage_available = !usage.nil? && usage['available'] != false
+
+# usage.json (when supplied) shape: { "available": true,
+#   "by_analysis": { "<analysisId>": { "views": N, "users": M } } }
+usage_by_id = {}
+usage_by_id = usage['by_analysis'] if usage_available && usage['by_analysis']
+
+rows = []
+complexity.each do |aid, r|
+  u = usage_by_id[aid]
+  views = u ? u['views'].to_i : nil
+  users = u ? u['users'].to_i : nil
+
+  cost = r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3 + r['n_hint'].to_i * 1
+
+  value =
+    if usage_available && views
+      views * Math.sqrt([users || 1, 1].max).to_f
+    else
+      # complexity-only proxy: bigger / richer analyses rank first
+      10.0 * (r['sheets'].to_i + r['visuals'].to_i / 4.0)
+    end
+  score = value / (1 + cost).to_f
+
+  tag =
+    if usage_available && views && views.zero?
+      'retire'
+    elsif r['n_unhandled'].to_i >= 1
+      'needs-gap-scout'
+    elsif score >= 20 && (r['n_manual'].to_i + r['n_unhandled'].to_i).zero?
+      'migrate-first'
+    elsif score >= 10
+      'easy-win'
+    else
+      'moderate'
+    end
+
+  rows << {
+    'name'        => r['name'],
+    'id'          => aid,
+    'sheets'      => r['sheets'],
+    'visuals'     => r['visuals'],
+    'views'       => views,
+    'users'       => users,
+    'auto'        => r['n_auto'],
+    'hint'        => r['n_hint'],
+    'manual'      => r['n_manual'],
+    'unhandled'   => r['n_unhandled'],
+    'calc_buckets' => r['calc_buckets'],
+    'dataset_source_types' => r['dataset_source_types'],
+    'value'       => value.round(1),
+    'cost'        => cost,
+    'score'       => score.round(2),
+    'tag'         => tag
+  }
+end
+
+rows.sort_by! { |r| -r['score'] }
+
+result = {
+  'usage_available' => usage_available,
+  'value_basis'     => usage_available ? 'usage (views × √users)' : 'complexity-only proxy (sheets + visuals/4)',
+  'analyses'        => rows
+}
+
+File.write(File.join(opts[:out], 'shortlist.json'), JSON.pretty_generate(result))
+puts "wrote shortlist.json (#{rows.size} analyses, value_basis=#{result['value_basis']})"
+puts
+printf "%-40s %6s %5s %5s %7s %s\n", 'Analysis', 'views', 'manl', 'unhd', 'score', 'tag'
+rows.each do |r|
+  printf "%-40s %6s %5d %5d %7.2f %s\n",
+    (r['name'] || '')[0, 39], (r['views'] || '-').to_s, r['manual'], r['unhandled'], r['score'], r['tag']
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/migration-plan.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/migration-plan.rb
@@ -1,0 +1,146 @@
+#!/usr/bin/env ruby
+# Phase 6 (QuickSight): compose migration-plan.json — the input contract the
+# assessment hands to the `quicksight-to-sigma` conversion skill.
+#
+# Adapted from powerbi-assessment/scripts/migration-plan.rb. Differences:
+#   - per-ANALYSIS (not report); the analysis inherits its datasets' source
+#     types + data-prep + RLS via dataset_ids.
+#   - DM clusters are formed on SHARED DATASET — analyses that reference the same
+#     QuickSight dataset share a Sigma data model by construction (the clean,
+#     reliable signal, like Power BI's shared-model clustering). Analyses with
+#     overlapping dataset sets are merged into one cluster.
+#
+# recommended_path values:
+#   "quicksight-to-sigma"            → analysis ready for conversion
+#   "quicksight-to-sigma-with-scout" → has window calcs / exotic visuals / free-form; needs a design decision first
+#   "retire"                         → zero views (only when usage supplied); recommend not migrating
+#   "blocked"                        → > 5 manual/unhandled features; manual rework first
+#
+# Usage:  ruby scripts/migration-plan.rb --out /tmp/qs-assessment-<acct>
+# Reads:  <out>/shortlist.json, <out>/complexity.json, <out>/inventory.json
+# Writes: <out>/migration-plan.json
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new { |p| p.on('--out DIR') { |v| opts[:out] = v } }.parse!
+abort('--out required') unless opts[:out]
+
+shortlist  = JSON.parse(File.read(File.join(opts[:out], 'shortlist.json')))
+complexity = JSON.parse(File.read(File.join(opts[:out], 'complexity.json')))
+inventory  = JSON.parse(File.read(File.join(opts[:out], 'inventory.json')))
+
+datasets_by_id   = (inventory['datasets'] || []).each_with_object({}) { |d, h| h[d['id']] = d }
+analysis_dsids   = (inventory['analyses'] || []).each_with_object({}) { |a, h| h[a['id']] = (a['dataset_ids'] || []) }
+analyses = shortlist['analyses'] || []
+
+analysis_entries = analyses.map do |r|
+  aid = r['id']
+  cx = complexity[aid] || {}
+  manual = cx['n_manual'].to_i
+  unhandled = cx['n_unhandled'].to_i
+  ds_ids = analysis_dsids[aid] || []
+  src_types = ds_ids.flat_map { |id| (datasets_by_id[id] || {})['physical_kinds'] || [] }.uniq.sort
+
+  recommended_path =
+    case r['tag']
+    when 'retire'          then 'retire'
+    when 'needs-gap-scout' then 'quicksight-to-sigma-with-scout'
+    else
+      (manual + unhandled) > 5 ? 'blocked' : 'quicksight-to-sigma'
+    end
+
+  blockers = []
+  blockers << "#{unhandled} unhandled feature(s) (window calc / exotic visual / free-form layout / FilterGroups)" if unhandled.positive?
+  blockers << "#{manual} restructuring/join/transform/RLS/param feature(s)" if manual.positive?
+  blockers << 'no views (retire)' if r['tag'] == 'retire'
+
+  {
+    'analysisId'        => aid,
+    'name'              => r['name'],
+    'dataset_ids'       => ds_ids,
+    'dataset_source_types' => src_types,
+    'recommended_path'  => recommended_path,
+    'priority_tier'     => r['tag'],
+    'score'             => r['score'],
+    'views'             => r['views'],
+    'calc_buckets'      => r['calc_buckets'],
+    'blockers'          => blockers
+  }
+end
+
+# --- DM clustering: shared dataset ------------------------------------------
+# Analyses referencing the same dataset MUST share a Sigma data model. Union
+# analyses by overlapping dataset sets into clusters.
+clusterable = analysis_entries.select do |r|
+  %w[quicksight-to-sigma quicksight-to-sigma-with-scout].include?(r['recommended_path'])
+end
+
+# union-find over dataset overlap
+parent = {}
+find = lambda { |x| parent[x] = (parent[x] == x ? x : find.call(parent[x])); parent[x] }
+clusterable.each { |r| parent[r['analysisId']] = r['analysisId'] }
+by_dataset = Hash.new { |h, k| h[k] = [] }
+clusterable.each { |r| (r['dataset_ids'].empty? ? ["no-ds-#{r['analysisId']}"] : r['dataset_ids']).each { |d| by_dataset[d] << r['analysisId'] } }
+by_dataset.each_value do |aids|
+  aids.each_cons(2) { |a, b| parent[find.call(a)] = find.call(b) }
+end
+
+groups = Hash.new { |h, k| h[k] = [] }
+clusterable.each { |r| groups[find.call(r['analysisId'])] << r }
+
+clusters = groups.values.each_with_index.map do |members, i|
+  ds_ids = members.flat_map { |m| m['dataset_ids'] }.uniq.sort
+  ds_names = ds_ids.map { |id| (datasets_by_id[id] || {})['name'] }.compact
+  src = members.flat_map { |m| m['dataset_source_types'] }.uniq.sort
+  label = (ds_names.first || members.first['name'] || 'misc').downcase.gsub(/[^a-z0-9]+/, '-')[0, 24]
+  cluster_id = "cluster-#{(i + 1).to_s.rjust(2, '0')}-#{label}"
+  members.each { |m| m['cluster_id'] = cluster_id }
+  {
+    'id'                => cluster_id,
+    'dataset_ids'       => ds_ids,
+    'dataset_names'     => ds_names,
+    'analysisIds'       => members.map { |m| m['analysisId'] },
+    'analysis_names'    => members.map { |m| m['name'] },
+    'shared_source_types' => src,
+    'cluster_size'      => members.size
+  }
+end
+
+by_path = analysis_entries.group_by { |r| r['recommended_path'] }
+suggested_batch = analysis_entries
+  .select { |r| r['recommended_path'] == 'quicksight-to-sigma' }
+  .sort_by { |r| -(r['score'].to_f) }
+  .first(8)
+  .map { |r| { 'analysisId' => r['analysisId'], 'name' => r['name'], 'cluster_id' => r['cluster_id'] } }
+
+result = {
+  'analyses'    => analysis_entries,
+  'dm_clusters' => clusters,
+  'summary' => {
+    'analyses_total'      => analysis_entries.size,
+    'analyses_ready'      => (by_path['quicksight-to-sigma']            || []).size,
+    'analyses_need_scout' => (by_path['quicksight-to-sigma-with-scout'] || []).size,
+    'analyses_blocked'    => (by_path['blocked']                        || []).size,
+    'analyses_retire'     => (by_path['retire']                         || []).size,
+    'cluster_count'       => clusters.size,
+    'usage_available'     => shortlist['usage_available'] == true,
+    'suggested_batch'     => suggested_batch
+  }
+}
+
+File.write(File.join(opts[:out], 'migration-plan.json'), JSON.pretty_generate(result))
+s = result['summary']
+puts "wrote migration-plan.json"
+puts "analyses total: #{s['analyses_total']}"
+puts "  ready for quicksight-to-sigma: #{s['analyses_ready']}"
+puts "  need gap-scout:                #{s['analyses_need_scout']}"
+puts "  blocked:                       #{s['analyses_blocked']}"
+puts "  retire:                        #{s['analyses_retire']}"
+puts "DM clusters: #{s['cluster_count']}"
+clusters.each { |c| puts "  #{c['id']}: #{c['cluster_size']} analysis(es), datasets=#{c['dataset_names'].join(', ')}" }
+puts
+puts "suggested first batch (top #{suggested_batch.size} by score):"
+suggested_batch.each_with_index { |r, i| puts "  #{i + 1}. #{r['name']} (cluster: #{r['cluster_id'] || '-'})" }

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/quicksight-inventory.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/quicksight-inventory.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Phase 1-3 inventory extractor for the quicksight-assessment skill.
+
+READ-ONLY. Surveys an Amazon QuickSight account (what the configured AWS
+credentials can reach) and writes raw JSON the Ruby renderers consume:
+
+  <out>/inventory.json          — environment + per-analysis + per-dataset metadata
+  <out>/raw-defs/<id>.json      — describe-analysis-definition response per analysis
+  <out>/raw-datasets/<id>.json  — describe-data-set response per referenced dataset
+
+Auth is whatever the AWS CLI is already configured with: a named --profile, SSO
+(`aws sso login`), or gimme-aws-creds (Okta orgs). We shell out to `aws
+quicksight ...` via subprocess — NO boto3 dependency.
+
+Enterprise edition is REQUIRED: the describe-*-definition / describe-data-set
+calls are Enterprise-only. On a Standard account they 4xx; we record that and
+degrade gracefully (the analysis still inventories from list-* metadata, but
+without visual/calc-field complexity).
+
+QuickSight's identity region is often us-east-1 even when the data lives
+elsewhere — pass --region accordingly.
+
+Usage:
+  python3 scripts/quicksight-inventory.py --account-id <ID> --region us-east-1 \
+      --profile <p> --out /tmp/qs-assessment-<acct>
+  ... [--limit-analyses N]  [--dashboards-too]
+"""
+import argparse, json, os, re, subprocess, sys, time
+
+
+def aws(args, acct, region, profile):
+    """Run an aws quicksight subcommand; return (ok, parsed_json_or_errtext)."""
+    cmd = ["aws", "quicksight"] + args + [
+        "--aws-account-id", acct, "--region", region, "--output", "json"]
+    if profile:
+        cmd += ["--profile", profile]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    if p.returncode != 0:
+        return False, (p.stderr.strip() or "aws call failed: " + " ".join(args[:2]))
+    try:
+        return True, json.loads(p.stdout)
+    except Exception:
+        return True, {}
+
+
+def arn_id(arn):
+    return arn.rsplit("/", 1)[-1] if arn else None
+
+
+# ---------------------------------------------------------------------------
+# Complexity classification
+# ---------------------------------------------------------------------------
+
+# Visuals the workbook builder reproduces vs. not. From refs/migration-test-slate.md.
+VISUAL_BUILT = {"KPIVisual", "BarChartVisual", "LineChartVisual", "PieChartVisual"}
+VISUAL_MID = {  # in the catalog but not built — manual rebuild
+    "ComboChartVisual", "TableVisual", "PivotTableVisual", "ScatterPlotVisual",
+    "HeatMapVisual", "GaugeChartVisual", "FunnelChartVisual", "TreeMapVisual",
+    "HistogramVisual", "BoxPlotVisual", "WaterfallVisual", "RadarChartVisual",
+}
+VISUAL_UNHANDLED = {  # no Sigma equivalent / best-effort only
+    "SankeyDiagramVisual", "WordCloudVisual", "GeospatialMapVisual",
+    "FilledMapVisual", "LayerMapVisual", "InsightVisual",
+    "CustomContentVisual", "PluginVisual",
+}
+
+# QuickSight calc-field functions that have no clean Sigma formula equivalent —
+# the converter degrades these to a /* TODO */ placeholder. From the test slate.
+WINDOW_FUNCS = [
+    "sumOver", "avgOver", "countOver", "maxOver", "minOver", "runningSum",
+    "runningAvg", "runningCount", "runningMax", "runningMin", "rank",
+    "denseRank", "percentOfTotal", "percentileOver", "periodOverPeriodDifference",
+    "periodOverPeriodPercentDifference", "periodToDateSum", "periodToDateAvg",
+    "lag", "lead", "windowSum", "windowAvg", "windowCount", "windowMax",
+    "windowMin", "firstValue", "lastValue", "difference",
+]
+WINDOW_RE = re.compile(r"\b(" + "|".join(WINDOW_FUNCS) + r")\s*\(")
+FUNC_RE = re.compile(r"\b([a-zA-Z][a-zA-Z0-9]*)\s*\(")
+
+
+def classify_calc(expr):
+    """Return 'a' (mechanical) | 'b' (restructure) | 'c' (no-equiv window/table-calc)."""
+    if not expr:
+        return "a"
+    if WINDOW_RE.search(expr):
+        return "c"
+    # ifelse/switch nesting or aggregation-of-aggregation hints at restructuring;
+    # otherwise a direct rewrite.
+    funcs = set(f.lower() for f in FUNC_RE.findall(expr))
+    if {"percentiledisc", "percentilecont", "medianif", "distinctcountif"} & funcs:
+        return "b"
+    return "a"
+
+
+def analyze_definition(defn):
+    """Walk an AnalysisDefinition: visual-kind histogram, calc-field buckets, params,
+    sheet/layout shape. Returns a complexity-signal dict."""
+    out = {
+        "sheet_count": 0,
+        "visual_count": 0,
+        "visual_kinds": {},
+        "visuals_built": 0,
+        "visuals_mid": 0,
+        "visuals_unhandled": 0,
+        "calc_field_count": 0,
+        "calc_buckets": {"a": 0, "b": 0, "c": 0},
+        "window_calc_count": 0,
+        "parameter_count": 0,
+        "filter_group_count": 0,
+        "free_form_sheets": 0,
+        "section_based_sheets": 0,
+        "dataset_identifiers": [],
+    }
+    for sh in defn.get("Sheets", []):
+        out["sheet_count"] += 1
+        for v in sh.get("Visuals", []):
+            for vtype in v.keys():
+                out["visual_count"] += 1
+                out["visual_kinds"][vtype] = out["visual_kinds"].get(vtype, 0) + 1
+                if vtype in VISUAL_BUILT:
+                    out["visuals_built"] += 1
+                elif vtype in VISUAL_UNHANDLED:
+                    out["visuals_unhandled"] += 1
+                elif vtype in VISUAL_MID:
+                    out["visuals_mid"] += 1
+                else:
+                    out["visuals_mid"] += 1  # EmptyVisual/unknown → treat as mid
+        # layout shape per sheet
+        for lay in sh.get("Layouts", []):
+            cfg = lay.get("Configuration", {}) or {}
+            if "FreeFormLayout" in cfg:
+                out["free_form_sheets"] += 1
+            if "SectionBasedLayout" in cfg:
+                out["section_based_sheets"] += 1
+    for c in defn.get("CalculatedFields", []):
+        out["calc_field_count"] += 1
+        bucket = classify_calc(c.get("Expression"))
+        out["calc_buckets"][bucket] += 1
+        if bucket == "c":
+            out["window_calc_count"] += 1
+    out["parameter_count"] = len(defn.get("ParameterDeclarations", []))
+    out["filter_group_count"] = len(defn.get("FilterGroups", []))
+    out["dataset_identifiers"] = [
+        d.get("Identifier") for d in defn.get("DataSetIdentifierDeclarations", [])]
+    return out
+
+
+def analyze_dataset(dso):
+    """Source type(s), import mode, RLS/CLS presence, custom-sql usage."""
+    out = {
+        "import_mode": dso.get("ImportMode"),
+        "physical_kinds": [],
+        "has_custom_sql": False,
+        "has_joins": False,
+        "transform_count": 0,
+        "rls_enabled": bool(dso.get("RowLevelPermissionDataSet")),
+        "cls_enabled": bool(dso.get("ColumnLevelPermissionRules")),
+        "column_count": len(dso.get("OutputColumns", []) or []),
+    }
+    for ptv in (dso.get("PhysicalTableMap") or {}).values():
+        for kind in ptv.keys():
+            out["physical_kinds"].append(kind)
+            if kind == "CustomSql":
+                out["has_custom_sql"] = True
+    for ltv in (dso.get("LogicalTableMap") or {}).values():
+        src = ltv.get("Source", {}) or {}
+        if "JoinInstruction" in src:
+            out["has_joins"] = True
+        out["transform_count"] += len(ltv.get("DataTransforms", []) or [])
+    out["physical_kinds"] = sorted(set(out["physical_kinds"]))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--account-id", required=True)
+    ap.add_argument("--region", default="us-east-1",
+                    help="QuickSight identity region (often us-east-1)")
+    ap.add_argument("--profile")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--limit-analyses", type=int, default=0, help="cap analyses scanned (0=all)")
+    ap.add_argument("--dashboards-too", action="store_true",
+                    help="also list dashboards (counts only; conversion targets analyses)")
+    args = ap.parse_args()
+
+    acct, region, profile = args.account_id, args.region, args.profile
+    out = os.path.expanduser(args.out)
+    os.makedirs(os.path.join(out, "raw-defs"), exist_ok=True)
+    os.makedirs(os.path.join(out, "raw-datasets"), exist_ok=True)
+
+    inv = {
+        "account": {
+            "account_id": acct, "region": region,
+            "generated_at": time.strftime("%Y-%m-%d"),
+            "edition": None, "enterprise": None,
+        },
+        "analyses": [],
+        "datasets": [],
+        "data_sources": [],
+        "environment_overview": {
+            "analyses": 0, "dashboards": 0, "datasets": 0, "data_sources": 0,
+        },
+    }
+
+    # --- list analyses ------------------------------------------------------
+    ok, res = aws(["list-analyses"], acct, region, profile)
+    if not ok:
+        print(f"[list-analyses] FAILED: {res}", file=sys.stderr)
+        sys.exit(3)
+    analyses = [a for a in res.get("AnalysisSummaryList", [])
+                if a.get("Status") != "DELETED"]
+    inv["environment_overview"]["analyses"] = len(analyses)
+
+    # --- list datasets (catalog; describe per referenced dataset later) -----
+    ok, res = aws(["list-data-sets"], acct, region, profile)
+    ds_summaries = res.get("DataSetSummaries", []) if ok else []
+    inv["environment_overview"]["datasets"] = len(ds_summaries)
+
+    ok, res = aws(["list-data-sources"], acct, region, profile)
+    src_summaries = res.get("DataSources", []) if ok else []
+    inv["environment_overview"]["data_sources"] = len(src_summaries)
+    for s in src_summaries:
+        inv["data_sources"].append({
+            "id": arn_id(s.get("Arn")), "name": s.get("Name"), "type": s.get("Type")})
+
+    if args.dashboards_too:
+        ok, res = aws(["list-dashboards"], acct, region, profile)
+        inv["environment_overview"]["dashboards"] = len(res.get("DashboardSummaryList", [])) if ok else 0
+
+    # --- describe each analysis definition (Enterprise-only) ----------------
+    seen_datasets = {}
+    edition_flagged = False
+    scanned = 0
+    for a in analyses:
+        if args.limit_analyses and scanned >= args.limit_analyses:
+            break
+        aid, aname = a.get("AnalysisId"), a.get("Name")
+        print(f"[analysis] {aname}", file=sys.stderr)
+        entry = {"id": aid, "name": aname,
+                 "last_updated": a.get("LastUpdatedTime")}
+        ok, d = aws(["describe-analysis-definition", "--analysis-id", aid],
+                    acct, region, profile)
+        if not ok:
+            entry["def_error"] = str(d)[:200]
+            # First definition failure usually means Standard edition / no perms.
+            if not edition_flagged and re.search(
+                    r"Standard|Enterprise|not supported|AccessDenied", str(d), re.I):
+                inv["account"]["enterprise"] = False
+                inv["account"]["edition"] = "Standard? (definition API rejected)"
+                edition_flagged = True
+            inv["analyses"].append(entry)
+            scanned += 1
+            continue
+        inv["account"]["enterprise"] = True
+        inv["account"]["edition"] = "Enterprise"
+        defn = d.get("Definition", {}) or {}
+        with open(os.path.join(out, "raw-defs", f"{aid}.json"), "w") as fh:
+            json.dump(d, fh, indent=2)
+        entry.update(analyze_definition(defn))
+
+        # describe each referenced dataset once
+        for decl in defn.get("DataSetIdentifierDeclarations", []):
+            ds_id = arn_id(decl.get("DataSetArn"))
+            if not ds_id or ds_id in seen_datasets:
+                continue
+            ok2, ds = aws(["describe-data-set", "--data-set-id", ds_id],
+                          acct, region, profile)
+            if not ok2:
+                seen_datasets[ds_id] = {"id": ds_id, "ds_error": str(ds)[:160]}
+                continue
+            dso = ds.get("DataSet", {}) or {}
+            with open(os.path.join(out, "raw-datasets", f"{ds_id}.json"), "w") as fh:
+                json.dump(ds, fh, indent=2)
+            seen_datasets[ds_id] = dict(
+                {"id": ds_id, "name": dso.get("Name")}, **analyze_dataset(dso))
+        entry["dataset_ids"] = [arn_id(decl.get("DataSetArn"))
+                                for decl in defn.get("DataSetIdentifierDeclarations", [])]
+        inv["analyses"].append(entry)
+        scanned += 1
+
+    inv["datasets"] = list(seen_datasets.values())
+
+    with open(os.path.join(out, "inventory.json"), "w") as fh:
+        json.dump(inv, fh, indent=2)
+
+    eo = inv["environment_overview"]
+    print(f"\nWROTE {os.path.join(out, 'inventory.json')}", file=sys.stderr)
+    print(f"  analyses={eo['analyses']} dashboards={eo['dashboards']} "
+          f"datasets={eo['datasets']} data_sources={eo['data_sources']}", file=sys.stderr)
+    print(f"  edition={inv['account']['edition']}  analyses scanned for definition: {scanned}",
+          file=sys.stderr)
+    if inv["account"]["enterprise"] is False:
+        print("  WARNING: definition API rejected — this looks like a Standard-edition "
+              "account; complexity is unavailable (counts only).", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout.rb
@@ -1,0 +1,175 @@
+#!/usr/bin/env ruby
+# Compose <out>/readout.md from inventory.json, complexity.json, shortlist.json.
+#
+# Adapted from powerbi-assessment/scripts/render-readout.rb — the section_block /
+# md_table / md_cell helpers are reused verbatim (vendor-agnostic); the gather-
+# and-fill body is QuickSight-specific (analysis visual mix, calc-field buckets,
+# dataset source types, no license/cost section).
+#
+# Usage:  ruby scripts/render-readout.rb --out /tmp/qs-assessment-<acct>
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--out DIR') { |v| opts[:out] = v }
+  p.on('--template PATH') { |v| opts[:template] = v }
+end.parse!
+abort('--out required') unless opts[:out]
+
+template_path = opts[:template] || File.expand_path('../refs/readout-template.md', __dir__)
+tpl = File.read(template_path)
+
+inventory  = JSON.parse(File.read(File.join(opts[:out], 'inventory.json')))
+complexity_path = File.join(opts[:out], 'complexity.json')
+shortlist_path  = File.join(opts[:out], 'shortlist.json')
+complexity = File.exist?(complexity_path) ? JSON.parse(File.read(complexity_path)) : {}
+shortlist  = File.exist?(shortlist_path)  ? JSON.parse(File.read(shortlist_path))  : nil
+
+shortlist_analyses = shortlist ? (shortlist['analyses'] || []) : []
+has_usage = shortlist && shortlist['usage_available'] == true
+limited_mode = !has_usage
+account = inventory['account'] || {}
+enterprise = account['enterprise'] != false
+
+# -------- helpers (verbatim from powerbi/tableau-assessment) -----------------
+def md_cell(v)
+  v.to_s.gsub('|', '\\|')
+end
+
+def md_table(headers, rows)
+  out = '| ' + headers.map { |h| md_cell(h) }.join(' | ') + " |\n"
+  out += '|' + headers.map { '---' }.join('|') + "|\n"
+  rows.each { |r| out += '| ' + r.map { |c| md_cell(c) }.join(' | ') + " |\n" }
+  out
+end
+
+def section_block(tpl, key, keep)
+  opposite_open = keep ? "{{^#{key}}}" : "{{##{key}}}"
+  kept_open     = keep ? "{{##{key}}}" : "{{^#{key}}}"
+  close         = "{{/#{key}}}"
+  tpl = tpl.gsub(/#{Regexp.escape(opposite_open)}.*?#{Regexp.escape(close)}/m, '')
+  tpl.gsub(/#{Regexp.escape(kept_open)}(.*?)#{Regexp.escape(close)}/m) { $1 }
+end
+
+# -------- gather -------------------------------------------------------------
+eo = inventory['environment_overview'] || {}
+analyses = inventory['analyses'] || []
+datasets = inventory['datasets'] || []
+
+mode = has_usage ? 'Usage + complexity' : 'Complexity-only'
+
+# Section 3 — analysis complexity
+total_calc = { 'a' => 0, 'b' => 0, 'c' => 0 }
+analysis_rows = complexity.values.sort_by { |r| -(r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3) }.map do |r|
+  d = r['calc_buckets'] || {}
+  %w[a b c].each { |k| total_calc[k] += d[k].to_i }
+  [r['name'], r['sheets'], r['visuals'], r['calc_field_count'], r['window_calc_count'],
+   r['parameter_count'], "#{d['a'].to_i}/#{d['b'].to_i}/#{d['c'].to_i}"]
+end
+analyses_table = analysis_rows.empty? ? '_No analyses scanned (definition API unavailable?)._' :
+  md_table(['Analysis', 'Sheets', 'Visuals', 'CalcFields', 'Window', 'Params', 'Calc a/b/c'], analysis_rows)
+
+# Section 3b — visual-kind histogram (account-wide)
+vk = Hash.new(0)
+complexity.each_value { |r| (r['visual_kinds'] || {}).each { |k, n| vk[k] += n } }
+visual_rows = vk.sort_by { |_, n| -n }.map { |k, n| [k, n] }
+visuals_table = visual_rows.empty? ? '_No visuals parsed._' : md_table(['Visual type', 'Count'], visual_rows)
+
+# Section 4 — datasets / source types
+src = Hash.new(0)
+datasets.each { |d| (d['physical_kinds'] || []).each { |k| src[k] += 1 } }
+source_rows = src.sort_by { |_, n| -n }.map { |k, n| [k, n] }
+source_table = source_rows.empty? ? '_No dataset physical sources parsed._' :
+  md_table(['Physical source kind', 'Datasets'], source_rows)
+n_rls = datasets.count { |d| d['rls_enabled'] }
+n_custom_sql = datasets.count { |d| d['has_custom_sql'] }
+
+# Section 6 — priority
+usage_basis = has_usage ? 'by view count' : 'by complexity proxy'
+usage_rows = shortlist_analyses.first(15).map do |r|
+  [r['name'], r['sheets'], r['visuals'],
+   has_usage ? (r['views'] || 0) : '—',
+   has_usage ? (r['users'] || 0) : '—']
+end
+usage_table = usage_rows.empty? ? '_No analyses._' :
+  md_table(['Analysis', 'Sheets', 'Visuals', 'Views', 'Users'], usage_rows)
+n_cold = has_usage ? shortlist_analyses.count { |r| r['views'].to_i.zero? } : 0
+
+# Section 7 — shortlist
+value_basis = shortlist ? shortlist['value_basis'] : 'n/a'
+shortlist_rows = shortlist_analyses.first(15).map do |r|
+  tag_md = case r['tag']
+           when 'migrate-first'   then '**migrate-first**'
+           when 'needs-gap-scout' then '⚠️ needs-gap-scout'
+           when 'retire'          then '🗑 retire'
+           else r['tag'] end
+  d = r['calc_buckets'] || {}
+  [r['name'], has_usage ? (r['views'] || 0) : '—',
+   "#{d['a'].to_i}/#{d['b'].to_i}/#{d['c'].to_i}",
+   "#{r['auto']}/#{r['hint']}/#{r['manual']}/#{r['unhandled']}",
+   format('%.1f', r['value']), format('%.2f', r['score']), tag_md]
+end
+shortlist_table = shortlist_rows.empty? ? '_No shortlist._' :
+  md_table(['Analysis', 'Views', 'Calc a/b/c', 'Auto/Hint/Man/Unh', 'Value', 'Score', 'Tag'], shortlist_rows)
+top5 = shortlist_analyses.first(5)
+shortlist_top_n = top5.size
+shortlist_total_unhandled = top5.sum { |r| r['unhandled'].to_i }
+n_needs_scout = shortlist_analyses.count { |r| r['tag'] == 'needs-gap-scout' }
+n_retire = shortlist_analyses.count { |r| r['tag'] == 'retire' }
+
+# Section 8 — per-analysis complexity
+crows = complexity.values.sort_by { |r| -(r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3) }.map do |r|
+  [r['name'], r['sheets'], r['visuals'], r['calc_field_count'], r['window_calc_count'],
+   r['rls_role_count'], r['n_manual'], r['n_unhandled'].to_i.positive? ? "**#{r['n_unhandled']}**" : 0]
+end
+complexity_table = crows.empty? ? '_No complexity rows._' :
+  md_table(['Analysis', 'Sheets', 'Visuals', 'CalcFields', 'Window', 'RLS', 'Manual', 'Unhandled'], crows)
+total_unhandled = complexity.values.sum { |r| r['n_unhandled'].to_i }
+n_with_unhandled = complexity.values.count { |r| r['n_unhandled'].to_i.positive? }
+recommended_pilot_n = top5.size
+
+# -------- apply --------------------------------------------------------------
+out = tpl.dup
+out = section_block(out, 'limited_mode_banner', limited_mode)
+out = section_block(out, 'standard_edition_banner', !enterprise)
+out = section_block(out, 'has_usage', has_usage)
+
+repl = {
+  '{{account_name}}'    => (account['account_id'] || File.basename(opts[:out]).sub(/^qs-assessment-/, '')).to_s,
+  '{{region}}'          => account['region'].to_s,
+  '{{edition}}'         => (account['edition'] || 'unknown').to_s,
+  '{{mode}}'            => mode,
+  '{{generated_at}}'    => account['generated_at'] || Time.now.strftime('%Y-%m-%d'),
+  '{{analyses}}'        => eo['analyses'].to_s,
+  '{{dashboards}}'      => eo['dashboards'].to_s,
+  '{{datasets}}'        => eo['datasets'].to_s,
+  '{{data_sources}}'    => eo['data_sources'].to_s,
+  '{{analyses_table}}'  => analyses_table,
+  '{{visuals_table}}'   => visuals_table,
+  '{{total_calc_a}}'    => total_calc['a'].to_s,
+  '{{total_calc_b}}'    => total_calc['b'].to_s,
+  '{{total_calc_c}}'    => total_calc['c'].to_s,
+  '{{source_table}}'    => source_table,
+  '{{n_rls}}'           => n_rls.to_s,
+  '{{n_custom_sql}}'    => n_custom_sql.to_s,
+  '{{usage_basis}}'     => usage_basis,
+  '{{usage_table}}'     => usage_table,
+  '{{n_cold}}'          => n_cold.to_s,
+  '{{value_basis}}'     => value_basis,
+  '{{shortlist_table}}' => shortlist_table,
+  '{{shortlist_top_n}}' => shortlist_top_n.to_s,
+  '{{shortlist_total_unhandled}}' => shortlist_total_unhandled.to_s,
+  '{{complexity_table}}' => complexity_table,
+  '{{total_unhandled}}' => total_unhandled.to_s,
+  '{{n_with_unhandled}}' => n_with_unhandled.to_s,
+  '{{n_needs_scout}}'   => n_needs_scout.to_s,
+  '{{n_retire}}'        => n_retire.to_s,
+  '{{recommended_pilot_n}}' => recommended_pilot_n.to_s
+}
+repl.each { |k, v| out.gsub!(k, v.to_s) }
+
+readout_path = File.join(opts[:out], 'readout.md')
+File.write(readout_path, out)
+puts "wrote #{readout_path}"

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/requirements.txt
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/requirements.txt
@@ -1,0 +1,8 @@
+# QuickSight assessment — Python deps.
+# The inventory script shells out to the AWS CLI via subprocess (NO boto3), so
+# the only hard requirement is the AWS CLI v2 on PATH, configured for the
+# target account. The standard library covers JSON/argparse/subprocess.
+#
+# (No third-party Python packages are required. The AWS CLI itself is installed
+# separately — see https://docs.aws.amazon.com/cli/ — and authenticated via
+# `aws configure`, `aws sso login`, or gimme-aws-creds for Okta orgs.)

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/score-quicksight-complexity.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/score-quicksight-complexity.rb
@@ -1,0 +1,122 @@
+#!/usr/bin/env ruby
+# Phase 3 (QuickSight): derive per-analysis migration-effort and convertibility
+# scores from inventory.json (written by quicksight-inventory.py) and emit
+# complexity.json.
+#
+# QuickSight's complexity lives in TWO places — the analysis (visual-kind mix,
+# calc fields, parameters, FilterGroups, layout shape) and its datasets
+# (source type, custom-sql, joins, data-prep transforms, RLS/CLS). An analysis
+# inherits its datasets' burden via dataset_ids.
+#
+# Convertibility buckets (grounded in refs/migration-test-slate.md):
+#   easy   → auto      (built visual + mechanical calc + relational/customsql source)
+#   medium → manual    (mid-catalog visual / restructuring calc / joins+transforms / params+filtergroups / RLS)
+#   hard   → unhandled (window-table-calc funcs / map+sankey+insight+custom+plugin visuals / free-form+section layout / dataset-of-datasets)
+#
+# These map onto the same four-tier vocabulary tableau-assessment uses so the
+# downstream renderer/shortlist code is shared:
+#   easy → auto      medium → manual      hard → unhandled
+# (no "hint" tier analog — n_hint stays 0; kept for renderer/shortlist compat.)
+#
+# Usage:  ruby scripts/score-quicksight-complexity.rb --out /tmp/qs-assessment-<acct>
+# Reads:  <out>/inventory.json
+# Writes: <out>/complexity.json   (keyed by analysis id, tableau-compatible shape)
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new { |p| p.on('--out DIR') { |v| opts[:out] = v } }.parse!
+abort('--out required') unless opts[:out]
+
+inv = JSON.parse(File.read(File.join(opts[:out], 'inventory.json')))
+
+datasets_by_id = (inv['datasets'] || []).each_with_object({}) { |d, h| h[d['id']] = d }
+
+complexity = {}
+(inv['analyses'] || []).each do |an|
+  buckets = an['calc_buckets'] || { 'a' => 0, 'b' => 0, 'c' => 0 }
+  ca = buckets['a'].to_i
+  cb = buckets['b'].to_i
+  cc = buckets['c'].to_i
+
+  visuals_built     = an['visuals_built'].to_i
+  visuals_mid       = an['visuals_mid'].to_i
+  visuals_unhandled = an['visuals_unhandled'].to_i
+  window_calcs      = an['window_calc_count'].to_i
+  params            = an['parameter_count'].to_i
+  filter_groups     = an['filter_group_count'].to_i
+  free_form         = an['free_form_sheets'].to_i
+  section_based     = an['section_based_sheets'].to_i
+  sheets            = an['sheet_count'].to_i
+  visuals           = an['visual_count'].to_i
+
+  # roll up dataset-level burden
+  ds = (an['dataset_ids'] || []).map { |id| datasets_by_id[id] }.compact
+  ds_custom_sql = ds.count { |d| d['has_custom_sql'] }
+  ds_joins      = ds.count { |d| d['has_joins'] }
+  ds_transforms = ds.sum { |d| d['transform_count'].to_i }
+  ds_rls        = ds.count { |d| d['rls_enabled'] }
+  ds_cls        = ds.count { |d| d['cls_enabled'] }
+  ds_exotic_src = ds.count { |d| (d['physical_kinds'] || []).any? { |k| %w[S3Source].include?(k) } }
+
+  # Map → tableau-compatible feature tiers.
+  n_auto      = ca + visuals_built
+  n_hint      = 0
+  n_manual    = cb + visuals_mid + ds_joins + (ds_transforms.positive? ? 1 : 0) +
+                (params.positive? ? 1 : 0) + ds_rls + ds_cls
+  n_unhandled = cc + visuals_unhandled + free_form + section_based +
+                (filter_groups.positive? ? 1 : 0) + ds_exotic_src
+
+  features = []
+  features << { 'name' => 'calc_mechanical', 'status' => 'auto',      'count' => ca } if ca.positive?
+  features << { 'name' => 'calc_restructure', 'status' => 'manual',   'count' => cb } if cb.positive?
+  features << { 'name' => 'calc_window',      'status' => 'unhandled', 'count' => cc } if cc.positive?
+  features << { 'name' => 'visuals_built',    'status' => 'auto',      'count' => visuals_built } if visuals_built.positive?
+  features << { 'name' => 'visuals_rebuild',  'status' => 'manual',    'count' => visuals_mid } if visuals_mid.positive?
+  features << { 'name' => 'visuals_exotic',   'status' => 'unhandled', 'count' => visuals_unhandled } if visuals_unhandled.positive?
+  features << { 'name' => 'dataset_joins',    'status' => 'manual',    'count' => ds_joins } if ds_joins.positive?
+  features << { 'name' => 'dataset_transforms', 'status' => 'manual',  'count' => ds_transforms } if ds_transforms.positive?
+  features << { 'name' => 'parameters',       'status' => 'manual',    'count' => params } if params.positive?
+  features << { 'name' => 'filter_groups',    'status' => 'unhandled', 'count' => filter_groups } if filter_groups.positive?
+  features << { 'name' => 'rls_cls',          'status' => 'manual',    'count' => ds_rls + ds_cls } if (ds_rls + ds_cls).positive?
+  features << { 'name' => 'free_form_layout', 'status' => 'unhandled', 'count' => free_form + section_based } if (free_form + section_based).positive?
+  features << { 'name' => 'exotic_source',    'status' => 'unhandled', 'count' => ds_exotic_src } if ds_exotic_src.positive?
+
+  source_types = ds.flat_map { |d| d['physical_kinds'] || [] }.uniq.sort
+
+  complexity[an['id']] = {
+    'name'              => an['name'],
+    'sheets'            => sheets,
+    'visuals'           => visuals,
+    'visual_kinds'      => an['visual_kinds'] || {},
+    'calc_field_count'  => an['calc_field_count'].to_i,
+    'window_calc_count' => window_calcs,
+    'parameter_count'   => params,
+    'filter_group_count' => filter_groups,
+    'dataset_count'     => ds.size,
+    'dataset_source_types' => source_types,
+    'has_custom_sql'    => ds_custom_sql.positive?,
+    'has_joins'         => ds_joins.positive?,
+    'rls_role_count'    => ds_rls,
+    'cls_count'         => ds_cls,
+    'calc_buckets'      => { 'a' => ca, 'b' => cb, 'c' => cc },
+    'twb_size_kb'       => 0, # n/a; kept for renderer compat
+    'n_features'        => n_auto + n_hint + n_manual + n_unhandled,
+    'n_auto'            => n_auto,
+    'n_hint'            => n_hint,
+    'n_manual'          => n_manual,
+    'n_unhandled'       => n_unhandled,
+    'features'          => features
+  }
+end
+
+File.write(File.join(opts[:out], 'complexity.json'), JSON.pretty_generate(complexity))
+puts "wrote complexity.json (#{complexity.size} analyses)"
+puts
+printf "%-40s %4s %4s %5s %4s %5s %5s\n", 'Analysis', 'sht', 'vis', 'calc', 'win', 'manl', 'unhd'
+complexity.each_value do |r|
+  printf "%-40s %4d %4d %5d %4d %5d %5d\n",
+    (r['name'] || '')[0, 39], r['sheets'], r['visuals'], r['calc_field_count'],
+    r['window_calc_count'], r['n_manual'], r['n_unhandled']
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/QUICKSTART.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/QUICKSTART.md
@@ -1,0 +1,150 @@
+author: Sigma Computing
+summary: Migrating from Amazon QuickSight made easy — convert QuickSight analyses to Sigma with your coding agent
+id: developers_migrating_from_quicksight_made_easy
+categories: Developers, Migration, AI
+environments: Web
+status: Draft
+feedback link: https://github.com/sigmacomputing/quickstarts-public/issues
+
+# Migrating from Amazon QuickSight to Sigma made easy
+
+## Introduction & why it matters
+Duration: 2
+
+Manually rebuilding a QuickSight analysis in another tool means re-creating each
+dataset and its data-prep, re-writing every calculated field, re-laying-out each
+sheet — then proving the numbers still match.
+
+This quickstart automates it with **your coding agent** (Claude Code, Cursor, Cortex
+Code, …) + a set of QuickSight→Sigma skills: it extracts the analysis definition,
+datasets, and data sources over the AWS CLI, translates calculated fields and
+data-prep transforms to Sigma, builds a Sigma data model + workbook, lays it out,
+and **verifies data parity** against the same warehouse.
+
+positive
+: These skills are **agent-neutral** — each is a `SKILL.md` plus `scripts/`. `AGENTS.md` at the repo root maps each task to its skill, and the scripts auto-load credentials, so they run the same under any agent. Where this guide says "Claude Code," substitute your agent.
+
+negative
+: **Enterprise edition is required.** The `describe-analysis-definition` / `describe-dashboard-definition` / `describe-data-set` APIs this migration depends on are **Enterprise-only** — a Standard-edition QuickSight account rejects them and there is no extraction path. Confirm your edition before you start.
+
+## Who this is for
+Duration: 1
+
+- Sigma SEs and technical CSMs
+- Migration partners
+- QuickSight authors evaluating a move to Sigma
+
+The skills carry the QuickSight calc-field, visual, and Sigma-spec knowledge. You
+need AWS-CLI access to the QuickSight account (Enterprise) and a Sigma org whose
+connection reaches the same warehouse the datasets query.
+
+## Prerequisites
+Duration: 2
+
+- **A coding agent that runs skills** — Claude Code (CLI or desktop), Cursor, Cortex Code, etc.
+- **Python 3** and **Ruby** (the discovery script is Python; the build pipeline is Ruby).
+- **AWS CLI v2**, configured for the QuickSight account (see auth below).
+- **An Enterprise-edition QuickSight account** + the analysis (or dashboard) id you want to migrate.
+- **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`).
+- A **Sigma connection to the same warehouse** the datasets use (its `connection_id` feeds the converter), and a target **folder id**.
+- The **`convert_quicksight_to_sigma`** converter (part of the sigma-data-model MCP).
+
+## The two-skill ecosystem
+Duration: 2
+
+| Skill | Role |
+|---|---|
+| **`quicksight-assessment`** | Inventory a QuickSight account + score per-analysis complexity: visual-type mix, calc-field count, window-function detection, dataset source types, RLS → value/cost-ranked shortlist. Run first. |
+| **`quicksight-to-sigma`** | The conversion: extract analysis + datasets → translate calc fields → build Sigma data model + workbook → layout → parity-verify. |
+
+Same `value/(1+cost)` shortlist math and `migrate-first / easy-win / moderate /
+needs-gap-scout / retire` tags as the Tableau and Power BI migration skills.
+
+## Installation & setup
+Duration: 5
+
+1. **Clone the skills / install the plugin** so your agent can see both skills
+   (`quicksight-to-sigma` and `quicksight-assessment`). For Claude Code, install
+   the `quicksight-to-sigma` plugin; for other agents, point the agent at the
+   skill folders — `AGENTS.md` at the repo root indexes every skill.
+2. **AWS auth** — configure the AWS CLI for the QuickSight account:
+   ```bash
+   # SSO orgs:
+   aws sso login --profile <profile>
+   # Okta-fronted orgs: gimme-aws-creds writes a usable profile
+   gimme-aws-creds --profile <profile>
+   # confirm:
+   aws sts get-caller-identity --profile <profile>
+   ```
+   Note the **identity region is usually `us-east-1`** — the analysis/dataset/data-source
+   resources are read from the identity region, not necessarily the data region.
+3. **Sigma credentials** — export `SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET` (or
+   write the neutral `~/.sigma-migration/env` the scripts auto-source under any
+   agent). `scripts/get-token.sh` exchanges them for a `SIGMA_API_TOKEN`.
+4. **Verify discovery** runs:
+   ```bash
+   python3 scripts/quicksight-discover.py \
+     --account-id <ACCOUNT_ID> --region us-east-1 --profile <profile> \
+     --analysis-id <ANALYSIS_ID> --out-dir ~/quicksight-migration/<name>
+   ```
+   It prints a summary (datasets, data-source types, calc fields, parameters,
+   per-sheet visual kinds) and writes `signals.json` + raw defs.
+
+## Run the conversion
+Duration: 10
+
+Point the `quicksight-to-sigma` skill at an analysis. Phases:
+
+1. **Discover** (`quicksight-discover.py`) — AWS CLI → `describe-analysis-definition`
+   + datasets + data sources → `signals.json` and raw JSON.
+2. **Convert** — `convert-model.rb --emit-mcp` prints the exact
+   `convert_quicksight_to_sigma` MCP call (analysis + dataset jsons + your Sigma
+   `connection_id`); run it and save the returned Sigma data-model JSON.
+3. **Build the data model** — `convert-model.rb --fixup` (names elements, rewrites
+   sql refs, `schemaVersion: 1`, folder) → validate → POST to `/v2/dataModels/spec`;
+   verify every column has a concrete type (no `error` columns).
+4. **Build the workbook** — `build-workbook-from-quicksight.rb` recreates the QS
+   sheets/visuals as Sigma elements + a visualId→element map → POST `/v2/workbooks/spec`.
+5. **Layout** — `build-quicksight-layout.rb` maps the QS 1-based grid to Sigma's
+   24-col layout → `put-layout.rb`.
+6. **Verify parity** — query each element via `sigma-mcp-v2` and compare against the
+   QuickSight aggregation. The `assert-phase6-ran.rb` hard gate must pass before GREEN.
+
+positive
+: For many accounts, the assessment's migration plan clusters analyses by shared dataset so you reuse one Sigma data model across a batch.
+
+## Understanding the output
+Duration: 3
+
+- **Assessment readout** (`quicksight-assessment`) — per-analysis complexity buckets
+  (easy/medium/hard → auto/manual/unhandled), visual-kind histogram, calc-field /
+  window-function counts, dataset source types, RLS flags, and a ranked shortlist.
+- **Converter coverage:** KPI/bar/line/donut/pie visuals + RelationalTable / CustomSql /
+  JoinInstruction / DataTransforms + ~40 calc-field functions convert cleanly. Window /
+  table-calc functions, the exotic visual zoo (maps, sankey, insight ML, custom content,
+  plugin), and FilterGroups degrade to placeholders / a warning manifest — partial, not failed.
+- **Parity check** — GREEN only when the Sigma query results match the QuickSight aggregation.
+
+## Reference & gotchas
+Duration: 3
+
+- **Enterprise-only definition APIs** — Standard editions can't be extracted.
+- **Identity region** — usually `us-east-1`; pass `--region` accordingly.
+- **CustomSql / DIRECT_QUERY fixup** (`beads-sigma-vy4k`) — those DM elements come back
+  nameless with raw sql refs; the `--fixup` step names them and rewrites refs to
+  `[Custom SQL/<ALIAS>]`. Don't post the raw converter output.
+- **Workbook element refs** are `[<source element name>/<col>]`.
+- **pie/donut** use `color:{id}` + `value:{id}`, not `xAxis`/`yAxis`.
+- **Layout grid is 1-based** in QuickSight — offset by 1 before scaling to Sigma's grid.
+- See `refs/migration-test-slate.md` for the full complexity taxonomy + 20-dashboard slate.
+
+## The techniques worth carrying forward
+Duration: 1
+
+- **Assess first** — complexity buckets tell you effort before you touch an analysis.
+- **Extract analysis + datasets together** — the analysis gives the visuals, the datasets give the semantics + data-prep.
+- **Treat the warehouse as the source of truth** — parity is the gate, not POST success.
+- **Cluster by dataset** — migrate a family of analyses onto one Sigma data model.
+
+Next: run `quicksight-assessment` on your account, pick the shortlist, and let
+`quicksight-to-sigma` convert the top N.

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: quicksight-to-sigma
+description: Convert an Amazon QuickSight analysis or dashboard into a Sigma data model and matching dashboard. Use when the user has a QuickSight analysis/dashboard and wants to recreate it in Sigma. Covers AWS-CLI extraction of the analysis definition + datasets + data sources, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, posting the data model + workbook via the Sigma REST API, layout, and parity verification against the same warehouse.
+---
+
+# QuickSight → Sigma
+
+> Status: **foundation** (converter MCP + browser shipped 2026-05-28).
+> Beads: converter = `beads-sigma-j5e`; CustomSql/DIRECT_QUERY fixup = `beads-sigma-vy4k`.
+> Defers to: `sigma-workbooks` (canonical workbook spec), `sigma-data-models` (DM spec), the `convert_quicksight_to_sigma` MCP tool, and the shared vendor-neutral Sigma-side scripts (`post-and-readback.rb`, `put-layout.rb`, `find-or-pick-dm.rb`, `verify-parity.rb`) reused across the migration skills.
+
+## What's proven (the happy path)
+```
+1. AUTH      AWS CLI → QuickSight (Enterprise edition REQUIRED); Sigma creds via get-token.sh
+2. DISCOVER  describe-analysis-definition + describe-data-set(s) + describe-data-source(s)  → quicksight-discover.py → signals.json
+3. CONVERT   convert_quicksight_to_sigma MCP (analysis.json + dataset jsons + connectionId)  → Sigma DM JSON      [MCP gate]
+4. POST DM   fixup (name elements + passthrough cols, rewrite sql refs, schemaVersion=1) → validate → POST /v2/dataModels/spec
+5. WORKBOOK  master tables per DM element + chart elements mirroring the QS visuals → POST /v2/workbooks/spec
+6. LAYOUT    QS grid x,y,w,h → 24-col layout XML → put-layout.rb
+7. VERIFY    sigma-mcp-v2 query each element returns real rows; Phase 6 parity vs the QuickSight aggregation    [hard gate]
+```
+
+See `refs/migration-test-slate.md` for the complexity taxonomy + 20-dashboard test slate that grounds the converter's coverage and known gaps.
+
+## Phase 1 — Auth
+
+**QuickSight (AWS CLI).**
+- The `describe-analysis-definition`, `describe-dashboard-definition`, and `describe-data-set` APIs are **Enterprise-edition only**. A Standard-edition account rejects them — there is no extraction path on Standard. Confirm the edition first.
+- QuickSight's **identity region is often `us-east-1`** even when the data lives elsewhere; the analysis/dataset/data-source resources are read from the identity region. Pass `--region us-east-1` unless you know the account is regionalized differently.
+- Auth is whatever the AWS CLI is already configured with: a named `--profile`, SSO (`aws sso login`), or — for Okta-fronted orgs — `gimme-aws-creds` writing a profile. The discovery script just shells out to `aws quicksight ...`.
+- You need the account id (`aws sts get-caller-identity`) and the analysis (or dashboard) id.
+
+**Sigma.** Same as the other migration skills: `SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET` → `scripts/get-token.sh` exchanges them for a `SIGMA_API_TOKEN`. You also need a **Sigma connection** that reaches the same warehouse the QuickSight datasets query (its `connection_id` feeds the converter), and a target **folder id**.
+
+## Phase 2 — Discover
+
+```bash
+python3 scripts/quicksight-discover.py \
+  --account-id <ACCOUNT_ID> --region <REGION> --profile <PROFILE> \
+  --analysis-id <ANALYSIS_ID> \
+  --out-dir ~/quicksight-migration/<name>
+# (or --dashboard-id <DASHBOARD_ID> instead of --analysis-id)
+```
+
+Pulls `describe-analysis-definition` (or `-dashboard-definition`) + `describe-data-set` for every `DataSetIdentifierDeclarations` entry + `describe-data-source` for each referenced source, and writes into the out-dir:
+- `analysis.json` — the full describe-*-definition response (the converter's primary input).
+- `datasets/<id>.json` — one per dataset (PhysicalTableMap, LogicalTableMap/transforms, calc fields, output columns).
+- `datasources/<id>.json` — one per source (the `Type` tells you Snowflake / Redshift / Athena / S3 / SaaS).
+- `signals.json` — normalized: per-sheet visuals (type + VisualId + title + referenced ColumnNames), calc fields, parameters, datasets, sources. Drives the convert + workbook + layout phases.
+
+## Phase 3 — Convert (MCP gate)
+
+```bash
+ruby scripts/convert-model.rb --emit-mcp \
+  --discover-dir ~/quicksight-migration/<name> \
+  --connection-id <SIGMA_CONNECTION_ID> \
+  [--database <DB> --schema <SCHEMA>]
+```
+
+This prints the exact `convert_quicksight_to_sigma` MCP-tool call — `files` = `analysis.json` + each `datasets/*.json`, plus `connection_id` (and `database`/`schema` overrides if a dataset's source path is incomplete). **The agent then runs that MCP tool** and saves the returned Sigma data-model JSON (e.g. `converter-out.json`).
+
+What the converter handles vs. what it doesn't (see `refs/migration-test-slate.md` for the full taxonomy):
+- **Handled**: RelationalTable, CustomSql, JoinInstruction, DataTransforms (CreateColumns/Rename/Cast/Filter/Project), ~40 calc-field functions (`ifelse`→`If`, `switch`→nested `If`), parameters → Sigma controls. KPI / bar / line / donut/pie visuals on the workbook side.
+- **Gaps (degrade to `/* TODO */` placeholder or skipped)**: window / table-calc functions (`sumOver`, `runningSum`, `rank`, `percentOfTotal`, `periodOverPeriod*`, `window*`, `percentile*Over`); S3Source & SaaSTable physical sources; analysis-level FilterGroups; ColumnConfigurations (formatting); dataset-of-datasets. Un-migratable visuals (Insight ML, CustomContent, Plugin, Sankey, map family) → emit a partial migration + warning manifest; never call these "failed".
+
+## Phase 4 — Fixup + POST the data model
+
+The converter output needs fixups before `POST /v2/dataModels/spec` (gap `beads-sigma-vy4k`: CustomSql / DIRECT_QUERY elements come back nameless, and sql refs need rewriting):
+
+```bash
+ruby scripts/convert-model.rb --fixup \
+  --in converter-out.json \
+  --discover-dir ~/quicksight-migration/<name> \
+  --folder-id <FOLDER_ID> \
+  --out dm-spec.json
+ruby scripts/validate-spec.rb --type datamodel dm-spec.json
+ruby scripts/post-and-readback.rb --type datamodel --spec dm-spec.json --out dm-readback.json
+```
+
+`--fixup` forces `schemaVersion: 1`, names every element + its passthrough columns (so workbook masters can reference them), rewrites sql refs to `[Custom SQL/<ALIAS>]` form, and injects `folderId`. `post-and-readback.rb` confirms every column resolved to a concrete type — **no `error` columns**.
+
+## Phase 5 — Build the workbook
+
+```bash
+ruby scripts/build-workbook-from-quicksight.rb \
+  --analysis ~/quicksight-migration/<name>/analysis.json \
+  --dm-readback dm-readback.json \
+  --folder-id <FOLDER_ID> \
+  --out wb-spec.json
+ruby scripts/post-and-readback.rb --type workbook --spec wb-spec.json --out wb-readback.json
+```
+
+Mirrors the QuickSight visuals as Sigma elements off Data-page master tables, and emits a `wb-spec.map.json` (visualId → element-id) the layout phase consumes. Element shapes:
+- Workbook element column refs use **`[<source element name>/<col>]`** (the source element name comes from the DM element name set in Phase 4).
+- bar/line: `xAxis:{columnId}`, `yAxis:{columnIds:[...]}`.
+- **pie/donut: `color:{id}` + `value:{id}`** (NOT xAxis/yAxis).
+- KPI: a single measure formula wrapping the master column.
+
+## Phase 6 — Layout (do NOT skip — stacked ≠ done)
+
+```bash
+ruby scripts/build-quicksight-layout.rb \
+  --analysis ~/quicksight-migration/<name>/analysis.json \
+  --map wb-spec.map.json \
+  --out layout.xml
+ruby scripts/put-layout.rb --workbook <WORKBOOK_ID> --layout layout.xml
+```
+
+Maps each QuickSight visual's grid cell → a 24-col Sigma layout. **QuickSight grid lines are 1-based** — `ColumnIndex`/`RowIndex` start at 1, so subtract 1 before scaling to the 0-based Sigma grid. Free-form / section-based QS layouts are approximated to the grid.
+
+## Phase 7 — Parity (hard gate)
+
+```bash
+ruby scripts/phase6-parity-quicksight.rb --finalize --workbook <WORKBOOK_ID> ...
+ruby scripts/assert-phase6-ran.rb        # hard gate — must pass before declaring GREEN
+```
+
+**POST success ≠ working.** You MUST query-verify the built elements:
+- `sigma-mcp-v2 query` each element → confirm real rows (not blank / not all `error`).
+- True parity: compare each Sigma aggregation against the same aggregation computed from the QuickSight side (or the warehouse). `assert-phase6-ran.rb` is a hard gate — a subagent must run it and it must pass before reporting success.
+
+## Gotchas (carry these forward)
+- **Enterprise edition is mandatory** for the `describe-*-definition` APIs. Standard rejects them outright — there's no fallback extraction.
+- **QuickSight identity region is usually `us-east-1`** — resources read from the identity region, not the data region.
+- **CustomSql / DIRECT_QUERY converter gap (`beads-sigma-vy4k`)**: those elements come back nameless and with raw sql refs; the `--fixup` step names them + rewrites refs to `[Custom SQL/<ALIAS>]`. Don't post the converter output unfixed.
+- **Workbook element refs** are `[<source element name>/<col>]`, where the source element name is the DM element name set during fixup.
+- **pie/donut** use `color:{id}` + `value:{id}`, not the bar/line `xAxis`/`yAxis` shape.
+- **Layout grid is 1-based** in QuickSight — offset by 1 before scaling to Sigma's grid.
+- **Window/table-calc functions are a known gap** — they degrade to a `/* TODO */` placeholder; verify the graceful degradation rather than treating it as a failure, and surface it in the migration warning manifest.
+
+## Reuse, don't reinvent
+These vendor-agnostic Sigma-side scripts are reused across the migration skills: `get-token.sh`, `lib/sigma_rest.rb`, `post-and-readback.rb`, `put-layout.rb`, `find-or-pick-dm.rb`, `validate-spec.rb`, `verify-parity.rb`, `cleanup-orphan-workbooks.rb`. Only the QuickSight-specific stages (`quicksight-discover.py`, `convert-model.rb`, `build-workbook-from-quicksight.rb`, `build-quicksight-layout.rb`, `phase6-parity-quicksight.rb`) are new.

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/fixtures/dataset-orders-enriched.json
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/fixtures/dataset-orders-enriched.json
@@ -1,0 +1,218 @@
+{
+    "Status": 200,
+    "DataSet": {
+        "Arn": "arn:aws:quicksight:us-east-1:153722385948:dataset/orders-enriched",
+        "DataSetId": "orders-enriched",
+        "Name": "Orders Enriched",
+        "CreatedTime": "2026-06-06T07:54:15.422000-04:00",
+        "LastUpdatedTime": "2026-06-06T08:01:57.035000-04:00",
+        "PhysicalTableMap": {
+            "ordersSql": {
+                "CustomSql": {
+                    "DataSourceArn": "arn:aws:quicksight:us-east-1:153722385948:datasource/snowflake-csa-tj",
+                    "Name": "orders_enriched",
+                    "SqlQuery": "select f.ORDER_ID, f.ORDER_CHANNEL, f.ORDER_STATUS, f.QUANTITY_ORDERED, f.NET_REVENUE, f.GROSS_REVENUE, f.NET_PROFIT, f.DISCOUNT_AMOUNT, p.CATEGORY, p.SUBCATEGORY, p.BRAND, c.REGION, c.STATE, c.CUSTOMER_SEGMENT, c.LOYALTY_TIER, d.FULL_DATE, d.YEAR, d.QUARTER, d.MONTH_NUMBER, d.MONTH_NAME from CSA.TJ.ORDER_FACT f left join CSA.TJ.PRODUCT_DIM p on f.PRODUCT_KEY=p.PRODUCT_KEY left join CSA.TJ.CUSTOMER_DIM c on f.CUSTOMER_KEY=c.CUSTOMER_KEY left join CSA.TJ.DATE_DIM d on f.ORDER_DATE_KEY=d.DATE_KEY",
+                    "Columns": [
+                        {
+                            "Name": "ORDER_ID",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "ORDER_CHANNEL",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "ORDER_STATUS",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "QUANTITY_ORDERED",
+                            "Type": "INTEGER"
+                        },
+                        {
+                            "Name": "NET_REVENUE",
+                            "Type": "DECIMAL"
+                        },
+                        {
+                            "Name": "GROSS_REVENUE",
+                            "Type": "DECIMAL"
+                        },
+                        {
+                            "Name": "NET_PROFIT",
+                            "Type": "DECIMAL"
+                        },
+                        {
+                            "Name": "DISCOUNT_AMOUNT",
+                            "Type": "DECIMAL"
+                        },
+                        {
+                            "Name": "CATEGORY",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "SUBCATEGORY",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "BRAND",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "REGION",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "STATE",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "CUSTOMER_SEGMENT",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "LOYALTY_TIER",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "FULL_DATE",
+                            "Type": "DATETIME"
+                        },
+                        {
+                            "Name": "YEAR",
+                            "Type": "INTEGER"
+                        },
+                        {
+                            "Name": "QUARTER",
+                            "Type": "INTEGER"
+                        },
+                        {
+                            "Name": "MONTH_NUMBER",
+                            "Type": "INTEGER"
+                        },
+                        {
+                            "Name": "MONTH_NAME",
+                            "Type": "STRING"
+                        }
+                    ]
+                }
+            }
+        },
+        "LogicalTableMap": {
+            "ordersLogical": {
+                "Alias": "orders_enriched",
+                "Source": {
+                    "PhysicalTableId": "ordersSql"
+                }
+            }
+        },
+        "OutputColumns": [
+            {
+                "Name": "ORDER_ID",
+                "Id": "ordersLogical.ORDER_ID",
+                "Type": "STRING"
+            },
+            {
+                "Name": "ORDER_CHANNEL",
+                "Id": "ordersLogical.ORDER_CHANNEL",
+                "Type": "STRING"
+            },
+            {
+                "Name": "ORDER_STATUS",
+                "Id": "ordersLogical.ORDER_STATUS",
+                "Type": "STRING"
+            },
+            {
+                "Name": "QUANTITY_ORDERED",
+                "Id": "ordersLogical.QUANTITY_ORDERED",
+                "Type": "INTEGER"
+            },
+            {
+                "Name": "NET_REVENUE",
+                "Id": "ordersLogical.NET_REVENUE",
+                "Type": "DECIMAL"
+            },
+            {
+                "Name": "GROSS_REVENUE",
+                "Id": "ordersLogical.GROSS_REVENUE",
+                "Type": "DECIMAL"
+            },
+            {
+                "Name": "NET_PROFIT",
+                "Id": "ordersLogical.NET_PROFIT",
+                "Type": "DECIMAL"
+            },
+            {
+                "Name": "DISCOUNT_AMOUNT",
+                "Id": "ordersLogical.DISCOUNT_AMOUNT",
+                "Type": "DECIMAL"
+            },
+            {
+                "Name": "CATEGORY",
+                "Id": "ordersLogical.CATEGORY",
+                "Type": "STRING"
+            },
+            {
+                "Name": "SUBCATEGORY",
+                "Id": "ordersLogical.SUBCATEGORY",
+                "Type": "STRING"
+            },
+            {
+                "Name": "BRAND",
+                "Id": "ordersLogical.BRAND",
+                "Type": "STRING"
+            },
+            {
+                "Name": "REGION",
+                "Id": "ordersLogical.REGION",
+                "Type": "STRING"
+            },
+            {
+                "Name": "STATE",
+                "Id": "ordersLogical.STATE",
+                "Type": "STRING"
+            },
+            {
+                "Name": "CUSTOMER_SEGMENT",
+                "Id": "ordersLogical.CUSTOMER_SEGMENT",
+                "Type": "STRING"
+            },
+            {
+                "Name": "LOYALTY_TIER",
+                "Id": "ordersLogical.LOYALTY_TIER",
+                "Type": "STRING"
+            },
+            {
+                "Name": "FULL_DATE",
+                "Id": "ordersLogical.FULL_DATE",
+                "Type": "DATETIME"
+            },
+            {
+                "Name": "YEAR",
+                "Id": "ordersLogical.YEAR",
+                "Type": "INTEGER"
+            },
+            {
+                "Name": "QUARTER",
+                "Id": "ordersLogical.QUARTER",
+                "Type": "INTEGER"
+            },
+            {
+                "Name": "MONTH_NUMBER",
+                "Id": "ordersLogical.MONTH_NUMBER",
+                "Type": "INTEGER"
+            },
+            {
+                "Name": "MONTH_NAME",
+                "Id": "ordersLogical.MONTH_NAME",
+                "Type": "STRING"
+            }
+        ],
+        "ImportMode": "DIRECT_QUERY",
+        "ConsumedSpiceCapacityInBytes": 0,
+        "DataSetUsageConfiguration": {
+            "DisableUseAsDirectQuerySource": false,
+            "DisableUseAsImportedSource": false
+        }
+    },
+    "RequestId": "8ae2a6a3-e4b2-46cb-856b-39259276e5c7"
+}

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/fixtures/orders-overview-analysis.json
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/fixtures/orders-overview-analysis.json
@@ -1,0 +1,401 @@
+{
+    "Status": 200,
+    "AnalysisId": "orders-overview",
+    "Name": "Orders Overview",
+    "ResourceStatus": "UPDATE_SUCCESSFUL",
+    "Definition": {
+        "DataSetIdentifierDeclarations": [
+            {
+                "Identifier": "orders",
+                "DataSetArn": "arn:aws:quicksight:us-east-1:153722385948:dataset/orders-enriched"
+            }
+        ],
+        "Sheets": [
+            {
+                "SheetId": "sheet1",
+                "Name": "Orders Overview",
+                "Visuals": [
+                    {
+                        "KPIVisual": {
+                            "VisualId": "kpiRevenue",
+                            "Title": {
+                                "Visibility": "VISIBLE",
+                                "FormatText": {
+                                    "PlainText": "Total Net Revenue"
+                                }
+                            },
+                            "Subtitle": {
+                                "Visibility": "VISIBLE"
+                            },
+                            "ChartConfiguration": {
+                                "FieldWells": {
+                                    "Values": [
+                                        {
+                                            "NumericalMeasureField": {
+                                                "FieldId": "kpi-netrev",
+                                                "Column": {
+                                                    "DataSetIdentifier": "orders",
+                                                    "ColumnName": "NET_REVENUE"
+                                                },
+                                                "AggregationFunction": {
+                                                    "SimpleNumericalAggregation": "SUM"
+                                                },
+                                                "FormatConfiguration": {
+                                                    "FormatConfiguration": {
+                                                        "CurrencyDisplayFormatConfiguration": {
+                                                            "SeparatorConfiguration": {
+                                                                "ThousandsSeparator": {
+                                                                    "Symbol": "COMMA",
+                                                                    "Visibility": "VISIBLE"
+                                                                }
+                                                            },
+                                                            "Symbol": "USD",
+                                                            "DecimalPlacesConfiguration": {
+                                                                "DecimalPlaces": 0
+                                                            },
+                                                            "NumberScale": "NONE"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "TargetValues": [],
+                                    "TrendGroups": []
+                                },
+                                "SortConfiguration": {}
+                            },
+                            "Actions": [],
+                            "ColumnHierarchies": []
+                        }
+                    },
+                    {
+                        "KPIVisual": {
+                            "VisualId": "kpiMargin",
+                            "Title": {
+                                "Visibility": "VISIBLE",
+                                "FormatText": {
+                                    "PlainText": "Avg Profit Margin"
+                                }
+                            },
+                            "Subtitle": {
+                                "Visibility": "VISIBLE"
+                            },
+                            "ChartConfiguration": {
+                                "FieldWells": {
+                                    "Values": [
+                                        {
+                                            "NumericalMeasureField": {
+                                                "FieldId": "kpi-margin",
+                                                "Column": {
+                                                    "DataSetIdentifier": "orders",
+                                                    "ColumnName": "Profit Margin"
+                                                },
+                                                "AggregationFunction": {
+                                                    "SimpleNumericalAggregation": "AVERAGE"
+                                                },
+                                                "FormatConfiguration": {
+                                                    "FormatConfiguration": {
+                                                        "PercentageDisplayFormatConfiguration": {
+                                                            "DecimalPlacesConfiguration": {
+                                                                "DecimalPlaces": 1
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "TargetValues": [],
+                                    "TrendGroups": []
+                                },
+                                "SortConfiguration": {}
+                            },
+                            "Actions": [],
+                            "ColumnHierarchies": []
+                        }
+                    },
+                    {
+                        "BarChartVisual": {
+                            "VisualId": "barCategory",
+                            "Title": {
+                                "Visibility": "VISIBLE",
+                                "FormatText": {
+                                    "PlainText": "Net Revenue by Category"
+                                }
+                            },
+                            "Subtitle": {
+                                "Visibility": "VISIBLE"
+                            },
+                            "ChartConfiguration": {
+                                "FieldWells": {
+                                    "BarChartAggregatedFieldWells": {
+                                        "Category": [
+                                            {
+                                                "CategoricalDimensionField": {
+                                                    "FieldId": "bar-cat",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "CATEGORY"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "Values": [
+                                            {
+                                                "NumericalMeasureField": {
+                                                    "FieldId": "bar-rev",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "NET_REVENUE"
+                                                    },
+                                                    "AggregationFunction": {
+                                                        "SimpleNumericalAggregation": "SUM"
+                                                    },
+                                                    "FormatConfiguration": {
+                                                        "FormatConfiguration": {
+                                                            "CurrencyDisplayFormatConfiguration": {
+                                                                "SeparatorConfiguration": {
+                                                                    "ThousandsSeparator": {
+                                                                        "Symbol": "COMMA",
+                                                                        "Visibility": "VISIBLE"
+                                                                    }
+                                                                },
+                                                                "Symbol": "USD",
+                                                                "DecimalPlacesConfiguration": {
+                                                                    "DecimalPlaces": 0
+                                                                },
+                                                                "NumberScale": "NONE"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "Colors": []
+                                    }
+                                },
+                                "SortConfiguration": {},
+                                "Orientation": "HORIZONTAL",
+                                "BarsArrangement": "CLUSTERED",
+                                "DataLabels": {
+                                    "Visibility": "VISIBLE",
+                                    "Overlap": "DISABLE_OVERLAP"
+                                }
+                            },
+                            "Actions": [],
+                            "ColumnHierarchies": []
+                        }
+                    },
+                    {
+                        "LineChartVisual": {
+                            "VisualId": "lineMonth",
+                            "Title": {
+                                "Visibility": "VISIBLE",
+                                "FormatText": {
+                                    "PlainText": "Net Revenue Trend"
+                                }
+                            },
+                            "Subtitle": {
+                                "Visibility": "VISIBLE"
+                            },
+                            "ChartConfiguration": {
+                                "FieldWells": {
+                                    "LineChartAggregatedFieldWells": {
+                                        "Category": [
+                                            {
+                                                "DateDimensionField": {
+                                                    "FieldId": "line-date",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "FULL_DATE"
+                                                    },
+                                                    "DateGranularity": "MONTH",
+                                                    "HierarchyId": "line-date"
+                                                }
+                                            }
+                                        ],
+                                        "Values": [
+                                            {
+                                                "NumericalMeasureField": {
+                                                    "FieldId": "line-rev",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "NET_REVENUE"
+                                                    },
+                                                    "AggregationFunction": {
+                                                        "SimpleNumericalAggregation": "SUM"
+                                                    },
+                                                    "FormatConfiguration": {
+                                                        "FormatConfiguration": {
+                                                            "CurrencyDisplayFormatConfiguration": {
+                                                                "SeparatorConfiguration": {
+                                                                    "ThousandsSeparator": {
+                                                                        "Symbol": "COMMA",
+                                                                        "Visibility": "VISIBLE"
+                                                                    }
+                                                                },
+                                                                "Symbol": "USD",
+                                                                "DecimalPlacesConfiguration": {
+                                                                    "DecimalPlaces": 0
+                                                                },
+                                                                "NumberScale": "NONE"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "Colors": []
+                                    }
+                                },
+                                "SortConfiguration": {},
+                                "Type": "LINE"
+                            },
+                            "Actions": [],
+                            "ColumnHierarchies": [
+                                {
+                                    "DateTimeHierarchy": {
+                                        "HierarchyId": "line-date",
+                                        "DrillDownFilters": []
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PieChartVisual": {
+                            "VisualId": "pieProfit",
+                            "Title": {
+                                "Visibility": "VISIBLE",
+                                "FormatText": {
+                                    "PlainText": "Net Revenue by Region"
+                                }
+                            },
+                            "Subtitle": {
+                                "Visibility": "VISIBLE"
+                            },
+                            "ChartConfiguration": {
+                                "FieldWells": {
+                                    "PieChartAggregatedFieldWells": {
+                                        "Category": [
+                                            {
+                                                "CategoricalDimensionField": {
+                                                    "FieldId": "pie-region",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "REGION"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "Values": [
+                                            {
+                                                "NumericalMeasureField": {
+                                                    "FieldId": "pie-rev",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "NET_REVENUE"
+                                                    },
+                                                    "AggregationFunction": {
+                                                        "SimpleNumericalAggregation": "SUM"
+                                                    },
+                                                    "FormatConfiguration": {
+                                                        "FormatConfiguration": {
+                                                            "CurrencyDisplayFormatConfiguration": {
+                                                                "SeparatorConfiguration": {
+                                                                    "ThousandsSeparator": {
+                                                                        "Symbol": "COMMA",
+                                                                        "Visibility": "VISIBLE"
+                                                                    }
+                                                                },
+                                                                "Symbol": "USD",
+                                                                "DecimalPlacesConfiguration": {
+                                                                    "DecimalPlaces": 0
+                                                                },
+                                                                "NumberScale": "NONE"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "SortConfiguration": {},
+                                "DonutOptions": {
+                                    "ArcOptions": {
+                                        "ArcThickness": "MEDIUM"
+                                    }
+                                },
+                                "DataLabels": {
+                                    "Visibility": "VISIBLE",
+                                    "MeasureLabelVisibility": "VISIBLE",
+                                    "Overlap": "DISABLE_OVERLAP"
+                                }
+                            },
+                            "Actions": [],
+                            "ColumnHierarchies": []
+                        }
+                    }
+                ],
+                "Layouts": [
+                    {
+                        "Configuration": {
+                            "GridLayout": {
+                                "Elements": [
+                                    {
+                                        "ElementId": "kpiRevenue",
+                                        "ElementType": "VISUAL",
+                                        "ColumnSpan": 18,
+                                        "RowSpan": 12
+                                    },
+                                    {
+                                        "ElementId": "kpiMargin",
+                                        "ElementType": "VISUAL",
+                                        "ColumnSpan": 18,
+                                        "RowSpan": 12
+                                    },
+                                    {
+                                        "ElementId": "barCategory",
+                                        "ElementType": "VISUAL",
+                                        "ColumnSpan": 18,
+                                        "RowSpan": 12
+                                    },
+                                    {
+                                        "ElementId": "lineMonth",
+                                        "ElementType": "VISUAL",
+                                        "ColumnSpan": 18,
+                                        "RowSpan": 12
+                                    },
+                                    {
+                                        "ElementId": "pieProfit",
+                                        "ElementType": "VISUAL",
+                                        "ColumnSpan": 18,
+                                        "RowSpan": 12
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "ContentType": "INTERACTIVE"
+            }
+        ],
+        "CalculatedFields": [
+            {
+                "DataSetIdentifier": "orders",
+                "Name": "Profit Margin",
+                "Expression": "{NET_PROFIT} / {NET_REVENUE}"
+            },
+            {
+                "DataSetIdentifier": "orders",
+                "Name": "Profitability",
+                "Expression": "ifelse({NET_PROFIT} >= 0, 'Profitable', 'Unprofitable')"
+            }
+        ],
+        "ParameterDeclarations": [],
+        "FilterGroups": []
+    },
+    "RequestId": "851f9ff9-f441-419a-afef-ec68faa051f4"
+}

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/migration-test-slate.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/migration-test-slate.md
@@ -1,0 +1,72 @@
+# QuickSight → Sigma: complexity taxonomy + 20-dashboard test slate
+
+Reference for validating the quicksight-to-sigma skill against graduated complexity.
+Grounded in the QuickSight `describe-analysis-definition` schema and cross-referenced
+against this stack's known coverage + gaps.
+
+## Converter / builder coverage snapshot
+- **DM converter** (MCP `convert_quicksight_to_sigma`): handles RelationalTable, CustomSql,
+  JoinInstruction, DataTransforms (CreateColumns/Rename/Cast/Filter/Project), calc fields
+  (~40 functions; `ifelse`→If, `switch`→nested If). Params → Sigma controls.
+- **DM GAPS**: window/table-calc functions (~28+: sumOver, runningSum, rank, lag/lead via
+  periodOverPeriod*, percentOfTotal, window*, percentile*Over) → `/* TODO */` placeholder;
+  S3Source & SaaSTable → placeholder; analysis-level FilterGroups → skipped;
+  ColumnConfigurations (formatting) → skipped; dataset-of-datasets → out of scope.
+- **Workbook builder** recreates: KPI, bar, line, donut/pie. NOT built: table, pivot, combo,
+  scatter, gauge, funnel, treemap, histogram, boxplot, waterfall, sankey, wordcloud, radar,
+  maps (geospatial/filled/layer), insight, customcontent, plugin.
+
+## Visual catalog (API `Visual` union — 24 nodes)
+BUILT: `KPIVisual`, `BarChartVisual`, `LineChartVisual`, `PieChartVisual`.
+NOT BUILT: `ComboChartVisual`, `TableVisual`, `PivotTableVisual`, `ScatterPlotVisual`,
+`HeatMapVisual`, `GaugeChartVisual`, `FunnelChartVisual`, `TreeMapVisual`, `HistogramVisual`,
+`BoxPlotVisual`, `WaterfallVisual`, `SankeyDiagramVisual`, `WordCloudVisual`, `RadarChartVisual`,
+`GeospatialMapVisual`, `FilledMapVisual`, `LayerMapVisual`, `InsightVisual`,
+`CustomContentVisual`, `PluginVisual`, `EmptyVisual`(no-op).
+
+## Complexity axes (easy / medium / hard)
+- **A. Data topology**: 1 RelationalTable → CustomSql → multi-table JoinInstruction → dataset-of-datasets(out of scope). S3/SaaS sources = GAP.
+- **B. Data prep**: simple calc fields → transforms chain → window/table-calc funcs (GAP) / LAC.
+- **C. Visual types**: KPI/bar/line/pie → mid catalog (table/pivot/combo/…) → maps/sankey → insight/custom/plugin (un-migratable).
+- **D. Interactivity**: 1 filter control → param controls + relative-date → cascading/cross-sheet (FilterGroups GAP) → actions/drill (GAP).
+- **E. Layout**: single tiled grid → multi-sheet/fixed grid → free-form (pixel) / section-based (paginated). Free-form & section → approximate to Sigma grid.
+- **F. Governance/advanced**: text/images/themes → conditional formatting (GAP) → RLS/CLS → insight ML (un-migratable).
+
+## The 20-dashboard slate (low → high)
+**Tier 1 — trivial smoke (pass clean):**
+- D1 Single KPI (total revenue). baseline happy path.
+- D2 Bar by Region, simple `sum` calc.
+- D3 Line trend + Pie mix (multi-element grid).
+
+**Tier 2 — medium real-world:**
+- D4 Exec summary: 4 KPIs + bar + line + 1 filter control (sheet scope).
+- D5 CustomSql dataset → bar + **table** (table builder).
+- D6 Two-dataset **JoinInstruction** (orders⋈customers) → bar + KPI (cross-element ref form).
+- D7 **Parameters** + param controls (slider/dropdown) + what-if calc.
+- D8 **Combo** (dual-axis) + **Scatter** (size+color).
+- D9 **Gauge** + **Funnel** + **TreeMap**.
+- D10 Data-prep **transforms** chain (Create/Rename/Cast/Filter) → bar+KPI on derived cols.
+
+**Tier 3 — hard (hit gaps):**
+- D11 **Pivot table** multi-level (2 row dims, 1 col, 2 measures, subtotals) — rowsBy/columnsBy `{id}` arrays.
+- D12 **Window/table-calc** funcs (runningSum, percentOfTotal, rank, periodOverPeriod) → verify graceful `/* TODO */` degradation.
+- D13 **Cascading + cross-sheet filters** (FilterGroup AllSheets) — FilterGroups GAP.
+- D14 **Visual actions**: filter + navigation(+param) + URL — actions GAP (inventory/warn).
+- D15 **Free-form layout** w/ overlap + text box + image.
+- D16 **Section-based** paginated report (header/footer/page-break) + table.
+- D17 **Maps**: geospatial points + filled choropleth.
+- D18 **Exotic zoo**: waterfall + sankey + boxplot + histogram + wordcloud + radar.
+
+**Tier 4 — very hard / governance + un-migratable:**
+- D19 **RLS + CLS** secured + conditional formatting (color rules, data bars) on a table.
+- D20 **Kitchen sink**: multi-dataset join + window calcs + cascading params + free-form + **InsightVisual (ML) + CustomContent + Plugin** — verify clean PARTIAL migration + full warning manifest.
+- (optional D21: dataset-of-datasets recursion — negative test for the out-of-scope case.)
+
+## Un-migratable → scope as known-(c)-tail, never "failed":
+`InsightVisual` ML (forecast/anomaly/narrative); `CustomContentVisual` (iframe/HTML); `PluginVisual`
+(Highcharts etc.); Sankey + map family (best-effort parity); SectionBasedLayout + free-form pixel
+overlap; cascading filter *actions*; SPICE ingestion metadata; dataset-of-datasets recursion.
+Always emit a partial migration + warning manifest for these.
+
+_Doc sources: QuickSight API_Visual, AnalysisDefinition, FilterGroup/FilterScopeConfiguration,
+LayoutConfiguration/GridLayoutConfiguration, custom-actions, table-calculation-functions, RLS/CLS, ML-insights._

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,0 +1,312 @@
+#!/usr/bin/env ruby
+# Hard gate that proves a tableau-to-sigma conversion is actually complete.
+# The subagent MUST run this script before declaring GREEN. It checks four
+# independent things — failing ANY of them blocks the GREEN declaration:
+#
+#   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
+#      → beads-sigma-4pm
+#   2. No orphan workbooks left in the customer's My Documents
+#      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
+#      cleanup ran with no failed deletes)  → beads-sigma-38a
+#   3. The live workbook's /columns endpoint shows no column with
+#      type=error (catches circular refs / runtime errors introduced
+#      AFTER the initial POST's column-type guard ran)  → beads-sigma-38a
+#   4. The workbook has a non-empty layout XML applied (catches the
+#      "elements just listed in a single column" regression where the
+#      agent forgot to PUT a layout)  → beads-sigma-bw3
+#
+# Usage:
+#   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
+#     [--workbook-id <id>]     # override; default = read from wb-ids.json
+#     [--min-pass-rate 1.0]    # default 1.0 (every chart must PASS)
+#     [--allow-extract]        # treat extract-mode as acceptable
+#     [--skip-column-check]    # skip the live /columns type=error scan
+#     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
+#                              # that genuinely want multiple workbooks)
+#     [--skip-layout-check]    # skip the layout-applied scan
+#     [--min-layout-elements N] default 2 — single-page bare-element layouts
+#                              # often have just the page wrapper; require this
+#                              # many <LayoutElement> tags
+#
+# Exit codes:
+#   0  every gate passes — conversion is allowed to declare GREEN
+#   1  parity-final.json missing (Phase 6 skipped — the regression case)
+#   2  parity-final.json exists but status=FAIL / pass-rate below min /
+#      extract-mode without --allow-extract / charts_total==0
+#   3  parity-final.json malformed
+#   4  orphan workbooks left uncleaned (beads-sigma-38a)
+#   5  live workbook has column(s) with type=error (beads-sigma-38a)
+#   6  live workbook has no layout applied — single-column fallback
+#      (beads-sigma-bw3)
+#
+# Prints a per-gate summary to stdout regardless of exit code.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2 }
+OptionParser.new do |p|
+  p.on('--tableau DIR')              { |v| opts[:tab] = v }
+  p.on('--workbook-id ID')           { |v| opts[:wb] = v }
+  p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--allow-extract')            { opts[:allow_extract] = true }
+  p.on('--skip-column-check')        { opts[:skip_column] = true }
+  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
+  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+end.parse!
+abort('--tableau required') unless opts[:tab]
+
+summary_path = File.join(opts[:tab], 'parity-final.json')
+
+unless File.exist?(summary_path)
+  warn "[FAIL] Phase 6 skipped — #{summary_path} does not exist."
+  warn "       Run: ruby scripts/phase6-parity.rb --tableau #{opts[:tab]} --workbook-id <id>"
+  warn "       then collect actuals via mcp__sigma-mcp-v2__query and re-run with --finalize."
+  warn "       See SKILL.md Phase 6. This is the hard gate (beads-sigma-4pm)."
+  exit 1
+end
+
+begin
+  summary = JSON.parse(File.read(summary_path))
+rescue JSON::ParserError => e
+  warn "[FAIL] #{summary_path} is malformed JSON: #{e.message}"
+  exit 3
+end
+
+total = summary['charts_total'].to_i
+passed = summary['charts_pass'].to_i
+status = summary['status'].to_s
+mode = summary['mode'].to_s
+
+if total <= 0
+  warn "[FAIL] parity-final.json reports charts_total=#{total} — no charts were verified."
+  warn "       This usually means auto-parity-plan.rb matched zero Tableau views."
+  warn "       Phase 6 must verify at least one chart to declare GREEN."
+  exit 2
+end
+
+if mode == 'extract' && !opts[:allow_extract]
+  warn "[FAIL] parity ran in extract-mode but --allow-extract was not passed."
+  warn "       Extract-mode permits up to ±#{((summary['extract_tol'] || 0.30) * 100).to_i}% drift —"
+  warn "       only acceptable when the source Tableau workbook has hasExtracts=true."
+  exit 2
+end
+
+pass_rate = passed.to_f / total
+if status != 'PASS' || pass_rate < opts[:min_pass_rate]
+  warn "[FAIL] parity status=#{status} pass-rate=#{(pass_rate * 100).round(1)}% (#{passed}/#{total})"
+  warn "       Required: status=PASS and pass-rate >= #{(opts[:min_pass_rate] * 100).to_i}%"
+  if (fail_names = summary['fail_names']) && !fail_names.empty?
+    warn "       Failing charts: #{fail_names.join(', ')}"
+  end
+  exit 2
+end
+
+puts "[OK] gate 1/4: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+
+# ---------------------------------------------------------------------------
+# Gate 2 — orphan workbooks (beads-sigma-38a)
+# ---------------------------------------------------------------------------
+unless opts[:skip_orphan]
+  log = File.join(opts[:tab], 'posted-workbooks.jsonl')
+  if File.exist?(log)
+    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    unique_ids = posted.map { |e| e['id'] }.uniq
+    if unique_ids.length > 1
+      marker_path = File.join(opts[:tab], 'cleanup-marker.json')
+      unless File.exist?(marker_path)
+        warn "[FAIL] gate 2/4: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "       posted-workbooks.jsonl entries:"
+        unique_ids.each { |id| warn "         - #{id}" }
+        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        warn "       See beads-sigma-38a."
+        exit 4
+      end
+      marker = JSON.parse(File.read(marker_path)) rescue {}
+      if marker['failed'] && !marker['failed'].empty?
+        warn "[FAIL] gate 2/4: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "       Orphan workbooks are still in the customer's My Documents:"
+        marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
+        exit 4
+      end
+      if marker['dry_run']
+        warn "[FAIL] gate 2/4: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+        exit 4
+      end
+      kept = marker['kept'] || '(unknown)'
+      deleted = (marker['deleted'] || []).length
+      puts "[OK] gate 2/4: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+    else
+      puts "[OK] gate 2/4: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+    end
+  else
+    puts "[OK] gate 2/4: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+  end
+else
+  puts "[SKIP] gate 2/4: --skip-orphan-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 3 — live /columns type=error scan (beads-sigma-38a)
+# Catches circular references and runtime errors that the initial post-and-
+# readback column-type guard missed because they were introduced by later
+# PUTs (layout updates, spec edits during error recovery).
+# ---------------------------------------------------------------------------
+unless opts[:skip_column]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 3/4: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 3/4: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        cols = (JSON.parse(res.body)['entries'] rescue []) || []
+        error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
+        if error_cols.any?
+          warn "[FAIL] gate 3/4: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
+          warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
+          error_cols.first(10).each do |c|
+            warn "         element=#{c['elementId']} col=#{c['columnId']} label=#{c['label'].inspect}"
+            warn "           formula: #{c['formula']}"
+          end
+          warn "       See beads-sigma-38a."
+          exit 5
+        end
+        puts "[OK] gate 3/4: #{cols.length} live columns clean (no type=error)"
+      else
+        warn "[SKIP] gate 3/4: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 3/4: --skip-column-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 4 — layout applied (beads-sigma-bw3)
+# Fetches the live workbook spec and confirms a non-empty top-level `layout`
+# XML is set, with at least --min-layout-elements <LayoutElement> tags.
+# Catches the "agent forgot to PUT a layout" regression where elements
+# render as a single-column stack instead of the dashboard grid.
+# ---------------------------------------------------------------------------
+unless opts[:skip_layout]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 4/4: no workbook ID resolvable for layout check"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 4/4: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        body = res.body.to_s
+        spec =
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+          end
+        layout_xml = spec['layout'].to_s
+        elem_count = layout_xml.scan(/<LayoutElement\b/).length
+
+        # Detect the Sigma "auto-generated single-column stack" layout that
+        # the server produces when a workbook is POSTed without a layout.
+        # Signature: every non-Data page has all its elements at the same
+        # gridColumn value (typically "1 / 13" — left half, vertically stacked).
+        # Note: per-page detection — a workbook with one element per content
+        # page is structurally fine (degenerate case, not a stack).
+        non_data_stack_pages = []
+        # Walk one page at a time using the <Page id="..."> blocks
+        layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
+          next if page_id.to_s.downcase.include?('data')
+          cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
+          elems_on_page = page_body.scan(/<LayoutElement\b/).length
+          if elems_on_page >= 2 && cols_on_page.length == 1
+            non_data_stack_pages << [page_id, cols_on_page.first, elems_on_page]
+          end
+        end
+
+        if layout_xml.empty?
+          warn "[FAIL] gate 4/4: live workbook #{wb_id} has NO top-level layout XML."
+          warn "       Elements render as a single-column stack instead of the"
+          warn "       dashboard grid. Build a layout and PUT it:"
+          warn "         ruby scripts/build-dashboard-layout.rb \\"
+          warn "           --layout #{opts[:tab]}/dashboard-layout.json \\"
+          warn "           --wb-ids #{opts[:tab]}/wb-ids.json \\"
+          warn "           --out #{opts[:tab]}/layout.xml"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} \\"
+          warn "           --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        elsif elem_count < opts[:min_layout_elements]
+          warn "[FAIL] gate 4/4: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
+          warn "       The layout likely covers only the Data page — chart page is unstyled."
+          exit 6
+        elsif non_data_stack_pages.any?
+          warn "[FAIL] gate 4/4: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "       single-column stack layout (multiple elements at the same gridColumn"
+          warn "       on a non-Data page). This is what Sigma defaults to when you POST"
+          warn "       a workbook without a layout — exactly the CoCo regression."
+          non_data_stack_pages.each do |pid, col, n|
+            warn "         page=#{pid.inspect}: #{n} elements all at gridColumn=#{col.inspect}"
+          end
+          warn "       Build a real layout and PUT it:"
+          warn "         ruby scripts/build-dashboard-layout.rb --layout #{opts[:tab]}/dashboard-layout.json \\"
+          warn "           --wb-ids #{opts[:tab]}/wb-ids.json --out #{opts[:tab]}/layout.xml"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        else
+          puts "[OK] gate 4/4: layout XML applied with #{elem_count} positioned element(s)"
+        end
+      else
+        warn "[SKIP] gate 4/4: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 4/4: --skip-layout-check"
+end
+
+puts "[OK] all gates pass — conversion may declare GREEN"
+exit 0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-bookmark-workbooks.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-bookmark-workbooks.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""build-bookmark-workbooks.py — one Sigma workbook per saved view-state.
+
+VENDOR-NEUTRAL. Power BI bookmarks (extract-bookmarks.py) and Tableau custom
+views / story points (extract-custom-views.py) both normalize to the same
+state shape; this builds one Sigma workbook per state:
+
+  state = { name, displayName,
+            hidden:[visualId], spotlight:[visualId],   # show/hide  -> visible subset
+            filters: { "<column display name>": [values] } }  # filter state -> baked
+
+Per state:
+  - spotlight non-empty -> keep ONLY the spotlighted visuals (focus)
+  - else                -> all base visuals MINUS `hidden`
+  - filters             -> baked as a `list` filter on the Data-page MASTER
+                           element(s) carrying that column, so every chart that
+                           sources the master inherits it (page-filter semantics)
+
+The signals->workbook build is delegated to a vendor builder via --build-script
+(PBI: build-workbook-from-pbir.rb; Tableau: build-charts-from-signals.rb), so
+this orchestration is shared. Lives in tableau-to-sigma/scripts (the shared
+core); powerbi-to-sigma symlinks it.
+
+Usage:
+  python3 build-bookmark-workbooks.py --signals base/signals.json \
+    --bookmarks states.json --master-map mm.json --data-model <dmId> \
+    --folder-id <uuid> --name-prefix "<Report>" --out-dir /tmp/bm \
+    [--build-script /path/to/build-workbook-from-pbir.rb]
+"""
+import argparse, json, os, subprocess, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+def _bake_filters(spec, filters):
+    """Add `list` filters to the Data-page master element(s) holding each column."""
+    if not filters:
+        return 0
+    n = 0
+    masters = [el for pg in spec.get("pages", []) if pg.get("id") == "page-data"
+               for el in pg.get("elements", [])]
+    for col, vals in filters.items():
+        vlist = vals if isinstance(vals, list) else [vals]
+        for el in masters:
+            hit = next((c for c in el.get("columns", [])
+                        if (c.get("name") or "").lower() == str(col).lower()), None)
+            if not hit:
+                continue
+            el.setdefault("filters", []).append({
+                "id": f"bmf-{col}".replace(" ", "")[:20],
+                "columnId": hit["id"], "kind": "list", "mode": "include", "values": vlist})
+            n += 1
+    return n
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--signals", required=True); ap.add_argument("--bookmarks", required=True)
+    ap.add_argument("--master-map", required=True); ap.add_argument("--data-model", required=True)
+    ap.add_argument("--folder-id", required=True); ap.add_argument("--name-prefix", required=True)
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--build-script", default=os.path.join(HERE, "build-workbook-from-pbir.rb"),
+                    help="vendor signals->workbook builder (default: build-workbook-from-pbir.rb)")
+    a = ap.parse_args()
+    base = json.load(open(a.signals)); states = json.load(open(a.bookmarks))["bookmarks"]
+    os.makedirs(a.out_dir, exist_ok=True)
+    page = base["pages"][0]; all_vis = page["visuals"]; built = []
+    for b in states:
+        hidden, spot = set(b.get("hidden", [])), set(b.get("spotlight", []))
+        vis = ([v for v in all_vis if v["visual_id"] in spot] if spot
+               else [v for v in all_vis if v["visual_id"] not in hidden])
+        if not vis:
+            print(f"  [skip] {b['displayName']}: no visible visuals", file=sys.stderr); continue
+        d = os.path.join(a.out_dir, b["name"]); os.makedirs(d, exist_ok=True)
+        sigp = os.path.join(d, "signals.json")
+        json.dump(dict(base, pages=[dict(page, visuals=vis)]), open(sigp, "w"), indent=2)
+        spec = os.path.join(d, "workbook-spec.json"); lay = os.path.join(d, "layout.xml")
+        name = f"{a.name_prefix} — {b['displayName']} (from Power BI)"
+        r = subprocess.run(["ruby", a.build_script, "--signals", sigp, "--master-map", a.master_map,
+            "--data-model", a.data_model, "--name", name, "--folder-id", a.folder_id,
+            "--out", spec, "--layout-out", lay], capture_output=True, text=True)
+        if r.returncode != 0 or not os.path.exists(spec):
+            print(f"  ERR {b['displayName']}: {r.stderr[-200:]}", file=sys.stderr); continue
+        nf = 0
+        if b.get("filters"):                              # bake filter-state onto the master(s)
+            s = json.load(open(spec)); nf = _bake_filters(s, b["filters"]); json.dump(s, open(spec, "w"), indent=2)
+        print(f"  OK  {b['displayName']:22} {len(vis)} visual(s), {nf} filter(s) -> {spec}", file=sys.stderr)
+        built.append({"bookmark": b["name"], "name": name, "spec": spec, "layout": lay,
+                      "visuals": len(vis), "filters": nf})
+    json.dump({"built": built}, open(os.path.join(a.out_dir, "manifest.json"), "w"), indent=2)
+    print(f"[bookmark-workbooks] built {len(built)} -> {a.out_dir}/manifest.json", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-charts-from-signals.rb
@@ -1,0 +1,1499 @@
+#!/usr/bin/env ruby
+# Build Sigma chart-element specs from parse-twb-layout.rb output + view CSVs +
+# a master-column map.
+#
+# The agent's job is the data model + master table (deciding which DM columns
+# the master needs, naming them, wiring Lookup/Coalesce as needed). This
+# script's job is the chart layer: translating each Tableau chart zone into a
+# Sigma element using the new parser signals (chart_kind, sort, aggregations,
+# channels, filters) so chart kind / aggregator / sort match the source instead
+# of relying on agent defaults.
+#
+# Usage:
+#   ruby scripts/build-charts-from-signals.rb \
+#     --tableau-dir /tmp/<name> \
+#     --layout /tmp/<name>/dashboard-layout.json \
+#     --master-map /tmp/<name>/master-columns.json \
+#     --master-element-id master \
+#     --out /tmp/<name>/chart-specs.json
+#
+# Inputs:
+#   --tableau-dir       directory with get-workbook.json + views/<viewId>.csv
+#   --layout            parse-twb-layout.rb output (per-dashboard zone list)
+#   --master-map        JSON: regex-string → { id, name } mapping CSV header tokens
+#                       to master-table column IDs. Example:
+#                       { "(?i)region":      { "id": "m-region",  "name": "Region" },
+#                         "(?i)gross revenue": { "id": "m-gross-rev", "name": "Gross Revenue" } }
+#   --master-element-id ID of the master table in the workbook (default "master")
+#   --out               output JSON: array of chart-element specs ready to embed
+#                       in a workbook spec's pages[].elements[]
+#
+# Per chart zone, the script reads the matching view CSV's first two headers
+# (dim + measure). It then:
+#   - Maps each header to a master column using the regex map.
+#   - Picks the Sigma element `kind` from chart_kind (with `automatic` → bar
+#     fallback + a warning to verify against the PNG).
+#   - Reads zone.sort: emits xAxis.sort iff Tableau had a <sort>. Otherwise
+#     leaves xAxis unsorted (Sigma renders natural categorical / date order).
+#   - Reads zone.aggregations: applies the right Sigma aggregator. Tableau
+#     "Sum"→Sum, "Avg"→Avg, "Min"→Min, "Max"→Max, "Median"→Median,
+#     "CountD"→CountDistinct, "None"→raw column (no agg), "User"→already-
+#     aggregated calc field formula (use as-is via the master column).
+#   - Reads zone.channels.color: if present, build one yAxis per category in
+#     the master column's distinct values (best-effort — agent should fill in
+#     the real category list when they know it; we emit a TODO marker).
+#   - Skips action filters ("[Action (Foo)]") — those are cross-chart dashboard
+#     actions, not value filters.
+#
+# Output: array of element specs. Drop into pages[].elements[] in the workbook
+# spec and POST via post-and-readback.rb.
+
+require 'json'
+require 'csv'
+require 'date'
+require 'optparse'
+require_relative 'learned-rules'
+
+opts = { master_id: 'master' }
+OptionParser.new do |p|
+  p.on('--tableau-dir DIR')         { |v| opts[:tab] = v }
+  p.on('--layout PATH')             { |v| opts[:layout] = v }
+  p.on('--meta PATH', 'parse-twb-layout sister meta file (worksheets+shared_filters)') { |v| opts[:meta] = v }
+  p.on('--master-map PATH')         { |v| opts[:mmap] = v }
+  p.on('--master-element-id ID')    { |v| opts[:master_id] = v }
+  p.on('--controls PATH', 'JSON file: array of control specs to emit alongside the chart elements') { |v| opts[:controls] = v }
+  p.on('--title STR',     'Dashboard title text element to emit (e.g., "Orders Dashboard")')         { |v| opts[:title] = v }
+  p.on('--page-per-worksheet', 'Emit one Sigma page per Tableau worksheet (ignore dashboard layout)') { opts[:pages_mode] = :worksheet }
+  p.on('--auto-controls', 'Auto-emit Sigma controls from shared-view filters in --meta')              { opts[:auto_controls] = true }
+  p.on('--out PATH')                { |v| opts[:out] = v }
+end.parse!
+%i[tab layout mmap out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+
+# ---- chart_kind → Sigma element kind ----
+SIGMA_KIND = {
+  'bar'           => 'bar-chart',
+  'line'          => 'line-chart',
+  'area'          => 'area-chart',
+  'pie'           => 'pie-chart',
+  'scatter'       => 'scatter-chart',
+  'combo'         => 'combo-chart',
+  'map-region'    => 'region-map',
+  'map-point'     => 'point-map',
+  'pivot-table'   => 'pivot-table',
+  'table'         => 'table',
+  'kpi'           => 'kpi-chart',
+  'table-or-text' => 'table',         # legacy parser output — kept for back-compat
+  'automatic'     => 'bar-chart',     # fallback; agent verifies against PNG
+  'other'         => 'bar-chart'
+}.freeze
+
+# ---- Tableau derivation → Sigma aggregation function name ----
+SIGMA_AGG = {
+  'Sum'    => 'Sum',
+  'Avg'    => 'Avg',
+  'Min'    => 'Min',
+  'Max'    => 'Max',
+  'Median' => 'Median',
+  'CountD' => 'CountDistinct',
+  'Count'  => 'CountIf(IsNotNull(%s))',  # special — see render_agg below
+  'None'   => nil,                       # no aggregation; raw column ref
+  'User'   => nil                        # user-defined calc — already aggregated
+}.freeze
+
+# ---- Date truncation derivations ----
+DATE_TRUNC = {
+  'Year-Trunc'   => 'year',
+  'Quarter-Trunc'=> 'quarter',
+  'Month-Trunc'  => 'month',
+  'Week-Trunc'   => 'week',
+  'Day-Trunc'    => 'day',
+  'Hour-Trunc'   => 'hour'
+}.freeze
+
+def render_agg(agg, master_col_ref)
+  return master_col_ref if agg.nil?
+  if agg.include?('%s')
+    agg.sub('%s', master_col_ref)
+  else
+    "#{agg}(#{master_col_ref})"
+  end
+end
+
+# Translate the Tableau column reference inside aggregations dict to a clean key
+# we can look up. Tableau uses internal IDs like "[33b6c718-9b55-3dc0-9698-…]"
+# OR friendly names like "[NET_REVENUE]". We strip the brackets for matching.
+def strip_brackets(s)
+  s.to_s.sub(/^\[/, '').sub(/\]$/, '')
+end
+
+# Match a CSV header (e.g., "Gross Revenue", "Distinct count of Order Id") to
+# a master-table column using regex map.
+def map_column(header, mmap)
+  # Strip leading/trailing whitespace from the header before matching. Tableau
+  # column captions sometimes carry trailing whitespace (e.g., "Order Date ")
+  # from the source .twb XML — `(?i)^order date$` won't match it without this.
+  h = header.to_s.strip
+  mmap.each do |pat, info|
+    return info if Regexp.new(pat).match?(h)
+  end
+  nil
+end
+
+# Pick the best aggregation for a header. CSV headers often hint at the
+# aggregation ("Sum of X" / "Distinct count of X" / etc.).
+def infer_csv_agg(header)
+  case header.to_s
+  when /^sum of /i        then 'Sum'
+  when /^avg of /i        then 'Avg'
+  when /^min of /i        then 'Min'
+  when /^max of /i        then 'Max'
+  when /^median of /i     then 'Median'
+  when /\bdistinct count\b/i then 'CountD'
+  when /\bcount\b/i       then 'Count'
+  else nil
+  end
+end
+
+# ---- Load inputs ----
+layout = JSON.parse(File.read(opts[:layout]))
+mmap   = JSON.parse(File.read(opts[:mmap]))
+meta   = opts[:meta] ? JSON.parse(File.read(opts[:meta])) : { 'worksheets' => {}, 'shared_filters' => [] }
+# Customer-learned rules (~/.tableau-to-sigma/learned-rules.yaml). Empty list
+# is normal for first-time customers — rules accumulate as the gap-scout
+# subagent validates translations.
+LEARNED_RULES = LearnedRules.load
+warn "loaded #{LEARNED_RULES.length} customer-learned rule(s) from #{LearnedRules.rules_path}" if LEARNED_RULES.any?
+gw     = JSON.parse(File.read(File.join(opts[:tab], 'get-workbook.json')))
+views  = gw.dig('views', 'view') || []
+views  = [views] unless views.is_a?(Array)
+view_by_name = views.each_with_object({}) { |v, h| h[v['name']] = v }
+
+# Translate a Tableau format-value string (already parsed by the parser's
+# translate_format) into a Sigma format hash. Done here so we don't fork the
+# parser logic — we just call into it via a duplicated minimal translator.
+def tableau_format_to_sigma(s)
+  return nil if s.nil? || s.empty?
+  segments = s.split(';')
+  pos = segments[0] || s
+  neg = segments[1]
+  prefix = (neg && neg.include?('(') && neg.include?(')')) ? '(' : ''
+  if (m = pos.match(/^p\d*(?:\.(\d+))?%$/i))
+    decimals = (m[1] || '').length
+    return { 'kind' => 'number', 'formatString' => "#{prefix},.#{decimals}%" }
+  end
+  if (m = pos.match(/^C\d+(?:\.(\d+))?%?$/))
+    decimals = (m[1] || '').length
+    return { 'kind' => 'number', 'formatString' => "#{prefix}$,.#{decimals}f", 'currencySymbol' => '$' }
+  end
+  if pos =~ /^c?["\\]*\$/ || pos.start_with?('$')
+    decimals = (pos.match(/\.(0+)/) || [])[1].to_s.length
+    return { 'kind' => 'number', 'formatString' => "#{prefix}$,.#{decimals}f", 'currencySymbol' => '$' }
+  end
+  if pos =~ /^[#,0]+(?:\.(0+))?$/
+    decimals = ($1 || '').length
+    return { 'kind' => 'number', 'formatString' => "#{prefix},.#{decimals}f" }
+  end
+  if s =~ /yyyy|MMM|MM|dd|HH/
+    f = s.gsub('yyyy','%Y').gsub('yy','%y').gsub('MMMM','%B').gsub('MMM','%b').gsub('MM','%m')
+         .gsub('dd','%d').gsub('HH','%H').gsub('mm','%M').gsub('ss','%S')
+    return { 'kind' => 'datetime', 'formatString' => f }
+  end
+  nil
+end
+
+# Sigma formulas reference controls by `controlId` in brackets, NOT by display
+# name. This helper computes the controlId the auto-controls block will emit
+# for a given parameter caption so the translated Switch/If formulas match.
+def param_control_ref(caption)
+  "[ctl-param-#{caption.downcase.gsub(/\W+/, '-').sub(/-$/, '')}]"
+end
+
+# ---- Tableau table-calc translators ---------------------------------------
+# Translate Tableau table-calculation functions to their Sigma equivalents.
+# Returns the translated formula, plus a hint about Sigma-specific caveats
+# (e.g., "window functions silently error in grouping-table charts — add to a
+# non-grouping context or Custom SQL DM element").
+#
+# Function mappings (Sigma names):
+#   INDEX()                  → RowNumber()
+#   LOOKUP(expr, n)          → Lag(expr, n)  (positive n) / Lead(expr, -n) (neg)
+#   LOOKUP(expr, 0)          → expr  (zero offset is identity)
+#   RANK(expr [, 'desc'])    → Rank(expr [, "desc"])
+#   RANK_DENSE(expr)         → RankDense(expr)
+#   RANK_UNIQUE(expr)        → RowNumber() within ranked partition
+#   RANK_PERCENTILE(expr)    → RankPercentile(expr)
+#   TOTAL(SUM(x))            → Sum(x)  (Sigma metric on master without dim group)
+#   SIZE()                   → Count(*) OVER ()  — no direct Sigma fn; warn
+#   FIRST()                  → RowNumber() - 1   (Tableau FIRST returns 0-indexed)
+#   LAST()                   → no direct equiv; needs Count-RowNumber pattern
+#   ZN(x)                    → Coalesce(x, 0)
+#   COUNTD(x)                → CountDistinct(x)
+#   IIF(c, t, e)             → If(c, t, e)
+#   IFNULL(x, y)             → Coalesce(x, y)
+def translate_tableau_tc(formula)
+  return [nil, nil] if formula.nil? || formula.empty?
+  s = formula.dup
+  hints = []
+  changed = false
+
+  # Order matters — apply table-calc translations BEFORE simple renames so the
+  # match patterns (LOOKUP / TOTAL(COUNTD()) etc.) see the original Tableau
+  # syntax.
+
+  # INDEX() → RowNumber()
+  if s.gsub!(/\bINDEX\s*\(\s*\)/, 'RowNumber()')
+    hints << 'INDEX()→RowNumber()'; changed = true
+  end
+
+  # LOOKUP(expr, 0) — drop the wrapper. Use a balanced-paren match.
+  while s =~ /\bLOOKUP\s*\(\s*((?:[^,()]|\([^()]*\)|\([^()]*\([^()]*\)[^()]*\))+?)\s*,\s*0\s*\)/
+    s = s.sub($~[0], $1)
+    hints << 'LOOKUP(x, 0)→x'; changed = true
+  end
+  # LOOKUP(expr, -n) → Lead(expr, n)
+  while s =~ /\bLOOKUP\s*\(\s*((?:[^,()]|\([^()]*\)|\([^()]*\([^()]*\)[^()]*\))+?)\s*,\s*-(\d+)\s*\)/
+    s = s.sub($~[0], "Lead(#{$1}, #{$2})")
+    hints << 'LOOKUP(x, -n)→Lead(x, n)'; changed = true
+  end
+  # LOOKUP(expr, n) where n >= 1 → Lag(expr, n)
+  while s =~ /\bLOOKUP\s*\(\s*((?:[^,()]|\([^()]*\)|\([^()]*\([^()]*\)[^()]*\))+?)\s*,\s*(\d+)\s*\)/
+    s = s.sub($~[0], "Lag(#{$1}, #{$2})")
+    hints << 'LOOKUP(x, n)→Lag(x, n)'; changed = true
+  end
+
+  # TOTAL(SUM(x)) → Sum(x); TOTAL(COUNTD(x)) → CountDistinct(x); TOTAL(AVG(x))
+  if s.gsub!(/\bTOTAL\s*\(\s*SUM\s*\(((?:[^()]|\([^()]*\))+)\)\s*\)/, 'Sum(\1)')
+    hints << 'TOTAL(SUM(x))→Sum(x) (non-grouping context)'; changed = true
+  end
+  if s.gsub!(/\bTOTAL\s*\(\s*COUNTD\s*\(((?:[^()]|\([^()]*\))+)\)\s*\)/, 'CountDistinct(\1)')
+    hints << 'TOTAL(COUNTD(x))→CountDistinct(x) (non-grouping context)'; changed = true
+  end
+  if s.gsub!(/\bTOTAL\s*\(\s*AVG\s*\(((?:[^()]|\([^()]*\))+)\)\s*\)/, 'Avg(\1)')
+    hints << 'TOTAL(AVG(x))→Avg(x) (non-grouping context)'; changed = true
+  end
+
+  # RANK([col], 'desc') / RANK([col]) / RANK_DENSE / RANK_PERCENTILE
+  if s.gsub!(/\bRANK\s*\(\s*((?:[^,()]|\([^()]*\))+?)\s*,\s*'(asc|desc)'\s*\)/, 'Rank(\1, "\2")')
+    hints << "RANK→Rank"; changed = true
+  end
+  if s.gsub!(/\bRANK\s*\(\s*((?:[^,()]|\([^()]*\))+?)\s*\)/, 'Rank(\1)')
+    hints << "RANK→Rank"
+    changed = true
+  end
+  if s.gsub!(/\bRANK_DENSE\s*\(\s*((?:[^,()]|\([^()]*\))+?)\s*\)/, 'RankDense(\1)')
+    hints << "RANK_DENSE→RankDense"; changed = true
+  end
+  if s.gsub!(/\bRANK_PERCENTILE\s*\(\s*((?:[^,()]|\([^()]*\))+?)\s*\)/, 'RankPercentile(\1)')
+    hints << "RANK_PERCENTILE→RankPercentile"; changed = true
+  end
+
+  # Simple renames done AFTER table-calc rewrites so the table-calc patterns
+  # match the original Tableau spelling.
+  if s.gsub!(/\bZN\s*\(/, 'Coalesce(')
+    # ZN takes one arg; pair the matching close-paren and append `, 0`. Walk
+    # the string and balance parens to find the right `)`.
+    out = String.new
+    i = 0
+    while i < s.length
+      if s[i, 9] == 'Coalesce(' && (i == 0 || s[i - 1] !~ /\w/)
+        out << 'Coalesce('
+        depth = 1
+        j = i + 9
+        while j < s.length && depth > 0
+          depth += 1 if s[j] == '('
+          depth -= 1 if s[j] == ')'
+          break if depth == 0
+          j += 1
+        end
+        out << s[i + 9...j] << ', 0)'
+        i = j + 1
+      else
+        out << s[i]
+        i += 1
+      end
+    end
+    s = out
+    changed = true
+  end
+  if s.gsub!(/\bIIF\s*\(/, 'If(')
+    changed = true
+  end
+  if s.gsub!(/\bIFNULL\s*\(/, 'Coalesce(')
+    changed = true
+  end
+  if s.gsub!(/\bCOUNTD\s*\(/, 'CountDistinct(')
+    changed = true
+  end
+
+  # SIZE() — no direct Sigma equivalent for partition size at the formula level.
+  # Leave as-is and warn so the agent rewrites manually (commonly Count(*)+OVER).
+  if s.include?('SIZE()')
+    hints << 'SIZE() has no direct Sigma equivalent — rewrite as Count(*) in a non-grouping context or Custom SQL'
+  end
+
+  # FIRST() / LAST() — special.
+  if s.include?('FIRST()')
+    hints << 'FIRST() → RowNumber() - 1 (Tableau FIRST is 0-indexed first row)'
+  end
+  if s.include?('LAST()')
+    hints << 'LAST() → no direct Sigma equivalent — use a Count() - RowNumber() pattern or Custom SQL'
+  end
+
+  # LOD calcs — Tableau's `{FIXED [dim] : AGG([m])}` family.
+  # Translation strategy (Sigma):
+  #   {FIXED [dim] : SUM([m])}    → workbook metric `Sum([m])` grouped by [dim]
+  #                                 OR Custom SQL `SUM(m) OVER (PARTITION BY dim)`
+  #   {FIXED : SUM([m])}          → unscoped `Sum([m])` (workbook-level scalar)
+  #   {INCLUDE [dim] : SUM([m])}  → add [dim] to chart grouping and just use Sum
+  #   {EXCLUDE [dim] : SUM([m])}  → remove [dim] from chart grouping, use Sum
+  # The full translation needs context (chart's grouping cols), so we surface
+  # the suggested Sigma expression as a hint rather than auto-emitting.
+  if s =~ /\{\s*FIXED\s+\[([^\]]+)\]\s*:\s*(SUM|AVG|MIN|MAX|COUNT|COUNTD)\s*\(\[([^\]]+)\]\)\s*\}/i
+    dim, agg, m = $1, $2.upcase, $3
+    sigma_agg = { 'SUM' => 'Sum', 'AVG' => 'Avg', 'MIN' => 'Min', 'MAX' => 'Max',
+                  'COUNT' => 'Count', 'COUNTD' => 'CountDistinct' }[agg]
+    sigma_expr = "#{sigma_agg}([Master/#{m}]) over the partition of [Master/#{dim}]"
+    hints << "FIXED LOD → #{sigma_expr}; OR Custom SQL DM element with #{agg}(#{m}) OVER (PARTITION BY #{dim})"
+    changed = true
+  end
+  if s =~ /\{\s*FIXED\s*:\s*(SUM|AVG|MIN|MAX|COUNT|COUNTD)\s*\(\[([^\]]+)\]\)\s*\}/i
+    agg, m = $1.upcase, $2
+    sigma_agg = { 'SUM' => 'Sum', 'AVG' => 'Avg', 'MIN' => 'Min', 'MAX' => 'Max',
+                  'COUNT' => 'Count', 'COUNTD' => 'CountDistinct' }[agg]
+    hints << "FIXED-no-dim LOD → workbook scalar metric #{sigma_agg}([Master/#{m}]) (no group by)"
+    changed = true
+  end
+  if s =~ /\{\s*INCLUDE\s+\[([^\]]+)\]\s*:\s*(SUM|AVG)\s*\(\[([^\]]+)\]\)\s*\}/i
+    dim, agg, m = $1, $2.upcase, $3
+    hints << "INCLUDE LOD on [#{dim}] → add [Master/#{dim}] to chart grouping, use plain #{agg}([Master/#{m}])"
+    changed = true
+  end
+  if s =~ /\{\s*EXCLUDE\s+\[([^\]]+)\]\s*:\s*(SUM|AVG)\s*\(\[([^\]]+)\]\)\s*\}/i
+    dim, agg, m = $1, $2.upcase, $3
+    hints << "EXCLUDE LOD on [#{dim}] → remove [Master/#{dim}] from chart grouping, use plain #{agg}([Master/#{m}])"
+    changed = true
+  end
+
+  return [nil, nil] unless changed
+  hints.uniq!
+  hints << 'NOTE: Sigma window functions (Rank/Lag/Lead/Cumulative*) silently error in grouping-table charts and DM-element calc cols — add to a workbook-master non-grouping context OR a Custom SQL DM element' if hints.any? { |h| h =~ /Rank|Lag|Lead|RowNumber/ }
+  [s, hints.join('; ')]
+end
+
+# ---- Parameter / CASE translator ------------------------------------------
+# Tableau CASE-on-parameter:
+#   CASE [Parameters].[Analysis Type]
+#     WHEN "Customer Type" THEN [CUSTOMER_TYPE]
+#     WHEN "Overall"       THEN "Overall"
+#     WHEN "Region"        THEN [REGION_NAME]
+#     ELSE "Country"
+#   END
+# Sigma:
+#   Switch([Analysis Type], "Customer Type", [Customer Type], "Overall",
+#          "Overall", "Region", [Region Name], "Country")
+#
+# We accept the slightly-loose form Tableau uses (`Case` token-case insensitive,
+# bracket refs for parameter and for dim columns, mixed quoted strings).
+def translate_case_on_param(formula, param_captions)
+  return nil unless formula =~ /\bCASE\b/i
+  # Strip newlines + collapse spaces
+  s = formula.gsub(/\s+/, ' ').strip
+  m = s.match(/\bCASE\b\s+(.*?)\s+(WHEN\b.*?)\s+\bEND\b/i)
+  return nil unless m
+  param_ref = m[1].strip   # the value being switched, e.g. [Parameters].[X] or [X]
+  body = m[2]
+  # Pull WHEN ... THEN ... pairs + optional ELSE
+  pairs = body.scan(/WHEN\s+(.+?)\s+THEN\s+(.+?)(?=\s+WHEN\b|\s+ELSE\b|\z)/i).map { |a, b| [a.strip, b.strip] }
+  else_match = body.match(/\bELSE\b\s+(.+)\z/i)
+  else_expr = else_match && else_match[1].strip
+  return nil if pairs.empty?
+  # Normalise parameter reference: prefer the human caption when we know it,
+  # otherwise strip [Parameters].[...] wrapping.
+  param_caption = nil
+  if (mm = param_ref.match(/\[Parameters?(?:\s*\([^)]*\))?\]\s*\.\s*\[([^\]]+)\]/i))
+    param_caption = mm[1]
+  elsif (mm = param_ref.match(/\[([^\]]+)\]/))
+    param_caption = mm[1] if param_captions.include?(mm[1])
+  end
+  return nil unless param_caption
+  parts = [param_control_ref(param_caption)]
+  pairs.each { |when_val, then_val| parts << when_val; parts << then_val }
+  parts << else_expr if else_expr
+  "Switch(#{parts.join(', ')})"
+end
+
+# Translate IF/ELSEIF chains on a parameter ref:
+#   IF [Param] = "A" THEN x ELSEIF [Param] = "B" THEN y ELSE z END
+# → Switch([Param], "A", x, "B", y, z)
+def translate_if_chain_on_param(formula, param_captions)
+  s = formula.gsub(/\s+/, ' ').strip
+  return nil unless s =~ /\bIF\b.*\bEND\b/i
+  return nil unless param_captions.any? { |cap| s.include?("[#{cap}]") }
+  m = s.match(/\bIF\b\s+(.+?)\s+\bEND\b/i)
+  return nil unless m
+  body = m[1]
+  # Pull `<cond> THEN <result>` segments delimited by ELSEIF
+  segs = body.scan(/(.+?)\s+THEN\s+(.+?)(?=\s+ELSEIF\b|\s+ELSE\b|\z)/i).map { |c, r| [c.strip, r.strip] }
+  else_match = body.match(/\bELSE\b\s+(.+)\z/i)
+  else_expr = else_match && else_match[1].strip
+  return nil if segs.empty?
+  # All conditions must be `[Param] = "..."` for the same parameter
+  param_caption = nil
+  cases = []
+  segs.each do |cond, result|
+    cm = cond.match(/\[([^\]]+)\]\s*=\s*("[^"]*"|'[^']*'|\S+)/)
+    return nil unless cm
+    p_cap = cm[1]
+    return nil unless param_captions.include?(p_cap)
+    param_caption ||= p_cap
+    return nil unless p_cap == param_caption
+    val = cm[2]
+    val = val.gsub("'", '"') if val.start_with?("'")
+    cases << val << result
+  end
+  parts = [param_control_ref(param_caption)] + cases
+  parts << else_expr if else_expr
+  "Switch(#{parts.join(', ')})"
+end
+
+# Pick the Tableau format for a given header against a worksheet's formats dict.
+# Match by best-effort: field ref contains a column GUID OR a friendly name
+# fragment that overlaps with the header.
+def pick_tableau_format(formats, header)
+  return nil if formats.nil? || formats.empty?
+  hkey = header.to_s.downcase.gsub(/\W+/, '')
+  formats.each do |field, val|
+    body = field.to_s.downcase
+    # Friendly-name match: format key looks like `[usr:Return Rate:qk]`. Pull
+    # the human chunk and compare to header.
+    inner = body.scan(/\[([^\]]+)\]/).flatten.last.to_s
+    parts = inner.split(':')
+    friendly = parts.length >= 3 ? parts[1].to_s.gsub(/\W+/, '') : ''
+    if !friendly.empty? && (friendly == hkey || hkey.include?(friendly) || friendly.include?(hkey))
+      sigma = tableau_format_to_sigma(val)
+      return sigma if sigma
+    end
+  end
+  nil
+end
+
+# ---- Pivot-table emission --------------------------------------------------
+# Tableau crosstab worksheets (mark=Text or mark=Square with dims on both
+# Rows AND Cols shelves, OR the Measure Names crosstab pattern) translate to
+# a Sigma `pivot-table` element with `rowsBy` / `columnsBy` / `values` arrays,
+# NOT a plain `table`. Without this, parse-twb-layout's `pivot-table` chart_kind
+# would fall through to the default table builder and lose the pivot shape.
+#
+# Resolves shelf fields via the parser's columns_by_guid lookup + the master-
+# column regex map. Returns the element hash, or nil if shelf info is unusable
+# (caller falls back to the standard table/chart flow with a warning).
+SHELF_AGG_FOR_PREFIX = {
+  'sum' => 'Sum', 'avg' => 'Avg', 'min' => 'Min', 'max' => 'Max',
+  'median' => 'Median', 'count' => 'CountIf(IsNotNull(%s))',
+  'countd' => 'CountDistinct', 'cntd' => 'CountDistinct'
+}.freeze
+SHELF_TRUNC_FOR_PREFIX = {
+  'yr' => 'year', 'qr' => 'quarter', 'mn' => 'month',
+  'wk' => 'week', 'dy' => 'day', 'hr' => 'hour'
+}.freeze
+
+def resolve_shelf_field(field, meta, mmap)
+  guid = field['guid']
+  cap_for_field = nil
+  if guid
+    info = (meta['columns_by_guid'] || {})[guid]
+    cap_for_field = info && info['caption']
+  end
+  cap_for_field ||= field['raw'].to_s
+                                 .sub(/^\[[^\]]+\]\./, '')
+                                 .gsub(/^\[|\]$/, '')
+                                 .sub(/^[a-z]+:/i, '')
+                                 .sub(/:[a-z]+$/i, '')
+  m = map_column(cap_for_field, mmap)
+  m ||= { 'id' => "m-#{cap_for_field.downcase.gsub(/\W+/, '-')}", 'name' => cap_for_field }
+  [m, cap_for_field]
+end
+
+def build_pivot_element(z, meta, mmap, opts, warnings)
+  cap = z['caption']
+  el_id = "el-#{cap.downcase.gsub(/\W+/, '-')[0..40]}".sub(/-$/, '')
+  rows_shelf = z['rows_shelf'] || {}
+  cols_shelf = z['cols_shelf'] || {}
+
+  cols_array = []
+  rows_by    = []
+  cols_by    = []
+  values_arr = []
+  seen_ids   = {}
+
+  add_col = lambda do |field, target|
+    m, _cap = resolve_shelf_field(field, meta, mmap)
+    base = "p-#{el_id}-#{target}-#{(m['name'] || 'x').downcase.gsub(/\W+/, '-')}"
+    col_id = base
+    n = 1
+    while seen_ids[col_id]
+      col_id = "#{base}-#{n}"
+      n += 1
+    end
+    seen_ids[col_id] = true
+
+    deriv = field['derivation'].to_s.downcase
+    formula =
+      if field['role'] == 'measure'
+        agg = SHELF_AGG_FOR_PREFIX[deriv] || 'Sum'
+        if agg.include?('%s')
+          agg.sub('%s', "[Master/#{m['name']}]")
+        else
+          "#{agg}([Master/#{m['name']}])"
+        end
+      elsif field['role'] == 'dim' && SHELF_TRUNC_FOR_PREFIX[deriv]
+        %(DateTrunc("#{SHELF_TRUNC_FOR_PREFIX[deriv]}", [Master/#{m['name']}]))
+      else
+        "[Master/#{m['name']}]"
+      end
+
+    col_obj = { 'id' => col_id, 'name' => m['name'], 'formula' => formula }
+    if field['role'] == 'measure'
+      tab_fmt = pick_tableau_format(z['formats'], m['name'])
+      col_obj['format'] = tab_fmt if tab_fmt
+      col_obj['format'] ||= m['format'] if m['format'].is_a?(Hash)
+      col_obj['format'] ||= { 'kind' => 'number', 'formatString' => ',.0f' }
+    elsif SHELF_TRUNC_FOR_PREFIX[deriv]
+      col_obj['format'] = { 'kind' => 'datetime', 'formatString' => '%b %Y' }
+    end
+    cols_array << col_obj
+    case target
+    when :row   then rows_by    << { 'id' => col_id }
+    when :col   then cols_by    << { 'id' => col_id }
+    when :value then values_arr << col_id
+    end
+  end
+
+  (rows_shelf['fields'] || []).each do |f|
+    add_col.call(f, :row)   if f['role'] == 'dim'
+    add_col.call(f, :value) if f['role'] == 'measure'
+  end
+  (cols_shelf['fields'] || []).each do |f|
+    add_col.call(f, :col)   if f['role'] == 'dim'
+    add_col.call(f, :value) if f['role'] == 'measure'
+  end
+
+  # Measure-Names pattern: shelves carry the placeholder but the actual
+  # measures live in z['measures']. Materialize them here.
+  if values_arr.empty? && (z['measures'] || []).any?
+    z['measures'].each do |m|
+      add_col.call({
+        'role'       => 'measure',
+        'derivation' => (m['derivation'] || 'Sum').to_s.downcase,
+        'raw'        => m['column'],
+        'guid'       => guid_from_text(m['column'].to_s)
+      }, :value)
+    end
+  end
+
+  if values_arr.empty? || (rows_by.empty? && cols_by.empty?)
+    warnings << "'#{cap}' is flagged as a Tableau crosstab but shelves did not yield rows+cols+values — falling back to flat table"
+    return nil
+  end
+
+  {
+    'id'        => el_id,
+    'kind'      => 'pivot-table',
+    'name'      => cap,
+    'source'    => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+    'columns'   => cols_array,
+    'values'    => values_arr,
+    'rowsBy'    => rows_by,
+    'columnsBy' => cols_by
+  }
+end
+
+# Minimal GUID-from-text helper for shelf measures whose `column` reads like
+# `[federated.X].[sum:GUID:qk]` or just `[GUID]`. Mirrors the parser helper.
+def guid_from_text(s)
+  return nil if s.nil? || s.empty?
+  m = s.match(/\[(?:[a-z\-]+:)?([0-9a-f\-]{36})(?::[a-z]+)?\]/i)
+  m && m[1]
+end
+
+# ---- KPI emission ---------------------------------------------------------
+# Tableau "scorecard" / "big number" tiles — mark=Text or mark=Square with a
+# single measure and no dimensions — translate to a Sigma kpi-chart element.
+# Without this, the chart_kind=kpi worksheet would fall through to the
+# CSV-driven flat-table flow and quietly produce nothing usable.
+# See beads-sigma-bw3.
+def build_kpi_element(z, meta, mmap, opts, warnings)
+  cap = z['caption']
+  el_id = "el-kpi-#{cap.downcase.gsub(/\W+/, '-')[0..38]}".sub(/-$/, '')
+
+  rows_shelf = z['rows_shelf'] || {}
+  cols_shelf = z['cols_shelf'] || {}
+
+  # Find the KPI's measure: first from shelves (preferred — explicit derivation),
+  # then fall back to the worksheet's `measures` array (when the measure is on
+  # the Marks card via Text/Color/Size encoding rather than a shelf).
+  measure_field = nil
+  (rows_shelf['fields'] || []).each { |f| measure_field ||= f if f['role'] == 'measure' }
+  (cols_shelf['fields'] || []).each { |f| measure_field ||= f if f['role'] == 'measure' }
+  if measure_field.nil? && (z['measures'] || []).any?
+    m = z['measures'].first
+    measure_field = {
+      'role'       => 'measure',
+      'derivation' => (m['derivation'] || 'Sum').to_s.downcase,
+      'raw'        => m['column'],
+      'guid'       => guid_from_text(m['column'].to_s)
+    }
+  end
+
+  if measure_field.nil?
+    warnings << "'#{cap}' is flagged as KPI but no measure resolved from shelves or worksheet — skipping"
+    return nil
+  end
+
+  master, _cap = resolve_shelf_field(measure_field, meta, mmap)
+  deriv = measure_field['derivation'].to_s.downcase
+  agg_template = SHELF_AGG_FOR_PREFIX[deriv] || 'Sum'
+  formula =
+    if agg_template.include?('%s')
+      agg_template.sub('%s', "[Master/#{master['name']}]")
+    else
+      "#{agg_template}([Master/#{master['name']}])"
+    end
+
+  measure_col_id = "k-#{el_id}"
+  measure_col = {
+    'id'      => measure_col_id,
+    'name'    => master['name'],
+    'formula' => formula
+  }
+
+  # Format: prefer Tableau format string for this measure, then master-map
+  # format, then heuristic by name.
+  tab_fmt = pick_tableau_format(z['formats'], master['name'])
+  measure_col['format'] = tab_fmt if tab_fmt
+  measure_col['format'] ||= master['format'] if master['format'].is_a?(Hash)
+  measure_col['format'] ||=
+    case master['name'].downcase
+    when /(revenue|profit|cost|sales|amount|spend)/
+      { 'kind' => 'number', 'formatString' => '$,.0f', 'currencySymbol' => '$' }
+    when /(rate|margin|pct|percent|ratio)/
+      { 'kind' => 'number', 'formatString' => ',.1%' }
+    else
+      { 'kind' => 'number', 'formatString' => ',.0f' }
+    end
+
+  element = {
+    'id'      => el_id,
+    'kind'    => 'kpi-chart',
+    'name'    => cap,
+    'source'  => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+    'columns' => [measure_col],
+    'value'   => { 'id' => measure_col_id }
+  }
+
+  # If the Tableau worksheet had Show Mark Labels on (typical for KPIs since
+  # the number IS the chart), we don't need a separate dataLabel — kpi-chart
+  # always renders the value. No-op.
+
+  element
+end
+
+# A workbook may have multiple dashboards; iterate all and concatenate elements.
+# Drop the chart_kind=automatic warnings to stderr so the caller can act on them.
+elements = []
+warnings = []
+
+layout.each do |dash|
+  dash['zones'].each do |z|
+    next unless z['kind'] == 'chart'
+    cap = z['caption']
+    next if cap.nil? || cap.empty?
+
+    # Pivot-table fast path: Tableau crosstabs (chart_kind=pivot-table from
+    # parse-twb-layout) emit a Sigma pivot-table element with rowsBy/columnsBy/
+    # values derived from shelf info — independent of the view CSV shape.
+    # Falls through to the CSV-driven flat-table path if shelves can't be
+    # resolved cleanly (logged via warnings).
+    if z['chart_kind'] == 'pivot-table'
+      pivot_el = build_pivot_element(z, meta, mmap, opts, warnings)
+      if pivot_el
+        elements << pivot_el
+        warnings << "'#{cap}' auto-emitted as Sigma pivot-table from Tableau crosstab (rows/cols shelves) — verify dim placement"
+        next
+      end
+      # else: fall through to flat-table flow
+    end
+
+    # KPI fast path: Tableau scorecards (chart_kind=kpi) emit a Sigma kpi-chart
+    # with a single measure as value. Without this, the worksheet would fall
+    # into the CSV-driven 2-column flow which requires headers.length >= 2 and
+    # silently drops single-measure tiles. beads-sigma-bw3.
+    if z['chart_kind'] == 'kpi'
+      kpi_el = build_kpi_element(z, meta, mmap, opts, warnings)
+      if kpi_el
+        elements << kpi_el
+        warnings << "'#{cap}' auto-emitted as Sigma kpi-chart from Tableau scorecard (Text mark + single measure) — verify value formula"
+        next
+      end
+      # else: fall through with the warning already logged
+    end
+
+    view = view_by_name[cap]
+    if view.nil?
+      warnings << "no Tableau view matched '#{cap}'"
+      next
+    end
+    csv_path = File.join(opts[:tab], 'views', "#{view['id']}.csv")
+    unless File.exist?(csv_path)
+      warnings << "missing CSV for '#{cap}' at #{csv_path}"
+      next
+    end
+    rows = CSV.read(csv_path)
+    next if rows.empty?
+    headers = rows.shift
+    next unless headers.length >= 2
+
+    dim_hdr  = headers[0]
+    meas_hdr = headers[1]
+    dim  = map_column(dim_hdr,  mmap)
+    meas = map_column(meas_hdr, mmap)
+    if dim.nil?
+      warnings << "no master column matched dim header '#{dim_hdr}' for '#{cap}' — falling back to raw header"
+      dim  = { 'id' => "m-#{dim_hdr.downcase.gsub(/\W+/,'-')}", 'name' => dim_hdr }
+    end
+    if meas.nil?
+      warnings << "no master column matched measure header '#{meas_hdr}' for '#{cap}'"
+      meas = { 'id' => "m-#{meas_hdr.downcase.gsub(/\W+/,'-')}", 'name' => meas_hdr }
+    end
+
+    # Decide the Sigma aggregator. Priority:
+    #   1. parse-twb-layout.rb's aggregations dict (most authoritative — comes
+    #      from Tableau's column-instance derivation)
+    #   2. CSV header naming heuristic ("Sum of X" → Sum)
+    #   3. Default Sum for numeric, no-agg for text
+    agg_label = nil
+    (z['aggregations'] || {}).each do |col_ref, deriv|
+      stripped = strip_brackets(col_ref)
+      if stripped.casecmp(meas['name']).zero? ||
+         stripped.casecmp(meas_hdr).zero? ||
+         meas_hdr.downcase.include?(stripped.downcase[0..15])
+        agg_label = deriv
+        break
+      end
+    end
+    agg_label ||= infer_csv_agg(meas_hdr)
+    agg_label ||= 'Sum'
+    sigma_agg = SIGMA_AGG[agg_label] || 'Sum'
+
+    # Decide if the dimension is a date that needs DateTrunc. The parser's
+    # aggregations dict surfaces Month-Trunc / Year-Trunc / etc. on the date col.
+    dim_trunc = nil
+    (z['aggregations'] || {}).each do |col_ref, deriv|
+      stripped = strip_brackets(col_ref)
+      if DATE_TRUNC.key?(deriv) &&
+         (stripped.casecmp(dim['name']).zero? || dim_hdr.downcase.include?('date'))
+        dim_trunc = DATE_TRUNC[deriv]
+        break
+      end
+    end
+
+    el_id = "el-#{cap.downcase.gsub(/\W+/, '-')[0..40]}".sub(/-$/, '')
+
+    # If the dim column is aliased in Tableau (raw → display mapping), wrap the
+    # master ref in a Switch() so the chart displays the friendly labels.
+    aliases_for_dim = (meta['column_aliases'] || {})[dim['name']] ||
+                      (meta['column_aliases'] || {})[dim_hdr]
+    dim_formula = if dim['formula']                     # explicit formula override
+                    dim['formula']
+                  elsif aliases_for_dim && !aliases_for_dim.empty?
+                    parts = ["[Master/#{dim['name']}]"]
+                    aliases_for_dim.each { |a| parts << a['key'].inspect; parts << a['value'].inspect }
+                    parts << "[Master/#{dim['name']}]"  # default: pass through raw value
+                    "Switch(#{parts.join(', ')})"
+                  elsif dim_trunc
+                    %(DateTrunc("#{dim_trunc}", [Master/#{dim['name']}]))
+                  else
+                    "[Master/#{dim['name']}]"
+                  end
+    # If the measure mapping carries a `formula` key, that's a workbook-level
+    # calc like Return Rate = Sum(...)/Count(...). Use it verbatim. Otherwise
+    # wrap the master-table column with the Sigma aggregator picked above.
+    measure_formula = if meas['formula']
+                        meas['formula']
+                      else
+                        render_agg(sigma_agg, "[Master/#{meas['name']}]")
+                      end
+
+    dim_col_obj = { 'id' => "x-#{el_id}", 'name' => dim['name'], 'formula' => dim_formula }
+    dim_col_obj['format'] = { 'kind' => 'datetime', 'formatString' => '%b %Y' } if dim_trunc
+    meas_col_obj = { 'id' => "y-#{el_id}", 'name' => meas['name'], 'formula' => measure_formula }
+    # Format priority:
+    #   1. explicit `format` on the master-map entry
+    #   2. Tableau's own format string for this measure (zone.formats — only set
+    #      when --meta was provided)
+    #   3. heuristic by header name
+    meas_col_obj['format'] = meas['format'] if meas['format'].is_a?(Hash)
+    if meas_col_obj['format'].nil?
+      tab_fmt = pick_tableau_format(z['formats'], meas_hdr) ||
+                pick_tableau_format(z['formats'], meas['name'])
+      meas_col_obj['format'] = tab_fmt if tab_fmt
+    end
+    if meas_col_obj['format'].nil?
+      meas_col_obj['format'] =
+        case meas['name'].downcase
+        when /(revenue|profit|cost|sales|amount|spend)/
+          { 'kind' => 'number', 'formatString' => '$,.0f', 'currencySymbol' => '$' }
+        when /(rate|margin|pct|percent|ratio)/
+          { 'kind' => 'number', 'formatString' => ',.1%' }
+        else
+          { 'kind' => 'number', 'formatString' => ',.0f' }
+        end
+    end
+    # Allow `format` on map entries to be either a Sigma format object OR a
+    # bare formatString string for convenience.
+    if meas['format'].is_a?(String)
+      meas_col_obj['format'] = { 'kind' => 'number', 'formatString' => meas['format'] }
+    end
+
+    kind = SIGMA_KIND[z['chart_kind']] || 'bar-chart'
+    if z['chart_kind'] == 'automatic'
+      warnings << "'#{cap}' has chart_kind=automatic — defaulted to bar-chart; verify against PNG"
+    end
+
+    # Dual-axis / combo detection: if Tableau marked this worksheet as
+    # synchronized-axes OR there are 2+ measures in the pane AND the view CSV
+    # has a second measure column, emit a combo-chart with two yAxis groups.
+    extra_meas_col = nil
+    if z['dual_axis'] && headers.length >= 3
+      meas2_hdr = headers[2]
+      meas2 = map_column(meas2_hdr, mmap) ||
+              { 'id' => "m-#{meas2_hdr.downcase.gsub(/\W+/,'-')}", 'name' => meas2_hdr }
+      meas2_formula = meas2['formula'] || render_agg(sigma_agg, "[Master/#{meas2['name']}]")
+      extra_meas_col = {
+        'id'      => "y2-#{el_id}",
+        'name'    => meas2['name'],
+        'formula' => meas2_formula,
+        'format'  => meas2['format'].is_a?(Hash) ? meas2['format'] :
+                     ({ 'kind' => 'number', 'formatString' => ',.0f' })
+      }
+      kind = 'combo-chart' unless %w[pie-chart donut-chart].include?(kind)
+      # Sigma combo-chart dual-axis IS persisted in the spec — the secondary
+      # axis is implied by yAxis.columnIds entries in object form
+      # (`{columnId, type}`) vs bare-string form. Bare strings go to the
+      # primary (left) axis; object-form entries go to the secondary (right)
+      # axis with the specified mark type. Verified 2026-05-22 against
+      # UI-built workbook readback (workbookUrlId 5xKqmuAXGooHxRgFrdk6VY).
+      # The right axis is auto-scaled by default; custom right-axis scale
+      # configuration (log/min/max/zero) is unverified — yAxis.format only
+      # governs the left axis.
+      warnings << "'#{cap}' detected as dual-axis (synchronized=true or 2+ measures) — emitted as combo-chart with secondary measure on right axis (yAxis.columnIds object form). Right axis is auto-scaled; if Tableau had a custom right-axis range, configure manually in the Sigma editor."
+    end
+
+    element = {
+      'id'      => el_id,
+      'kind'    => kind,
+      'name'    => cap,
+      'source'  => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+      'columns' => [dim_col_obj, meas_col_obj]
+    }
+    element['columns'] << extra_meas_col if extra_meas_col
+
+    # Reference lines / bands / trendlines from Tableau → Sigma `refMarks`.
+    # Verified shape (from a UI-built workbook readback, 2026-05-21):
+    #   refMarks:
+    #     - type: line | band
+    #       axis: series | series2 | axis
+    #       value:
+    #         { type: constant, value: <number> }     # constant threshold
+    #         { type: formula,  formula: "<expr>" }   # any Sigma formula
+    #       label:
+    #         { visibility: shown|hidden, text?: "..." }
+    #
+    # Docs (charts.md) suggested bare numbers / strings for `value` but the
+    # live API only accepts the wrapped object form. `value.type: column` is
+    # also rejected — use `formula` with a column ref instead.
+    ref_emit, trend_emit, ref_skip = [], [], []
+    if z['ref_marks'] && !z['ref_marks'].empty? && %w[bar-chart line-chart area-chart combo-chart scatter-chart].include?(kind)
+      meas_name = meas_col_obj['name']
+      tab_to_sigma_agg = { 'average' => 'Avg', 'median' => 'Median', 'max' => 'Max', 'min' => 'Min', 'sum' => 'Sum', 'count' => 'Count' }
+      # Trendline shape verified 2026-05-22 against a UI-built workbook
+      # (workbookUrlId 5xKqmuAXGooHxRgFrdk6VY). Only `linear` is canonically
+      # verified; other Tableau model-types are passed through under the same
+      # name (Sigma docs list logarithmic/exponential/polynomial/quadratic/power)
+      # and will surface a per-element WARN to verify visually.
+      tab_to_sigma_model = {
+        'linear'      => 'linear',
+        'logarithmic' => 'logarithmic',
+        'exponential' => 'exponential',
+        'polynomial'  => 'polynomial',
+        'power'       => 'power'
+      }
+      z['ref_marks'].each do |rm|
+        case rm['kind']
+        when 'line'
+          # Skip band-styled lines (fill/percentage bands) — they need the band shape, not line.
+          if rm['band_values'] || rm['fill_below'] == 'true' || rm['fill_above'] == 'true' || rm['percentage_bands'] == 'true'
+            ref_skip << rm
+            next
+          end
+          fagg = tab_to_sigma_agg[rm['formula']]
+          if fagg
+            label_text = rm['label_type'] == 'custom' ? rm['label'] : "#{fagg} #{meas_name}"
+            ref_emit << {
+              'type'  => 'line',
+              'axis'  => 'series',
+              'value' => { 'type' => 'formula', 'formula' => "#{fagg}([Master/#{meas_name}])" },
+              'label' => { 'visibility' => 'shown', 'text' => label_text }.compact
+            }
+          else
+            ref_skip << rm
+          end
+        when 'trendline'
+          model = tab_to_sigma_model[rm['model'].to_s] || 'linear'
+          trend_emit << {
+            'columnId' => meas_col_obj['id'],
+            'model'    => model,
+            'label'    => { 'visibility' => 'shown' },
+            'value'    => { 'visibility' => 'shown' }
+          }
+        when 'band', 'distribution'
+          # Bands need the {type:band} variant which we haven't verified.
+          ref_skip << rm
+        end
+      end
+      element['refMarks']   = ref_emit   unless ref_emit.empty?
+      element['trendlines'] = trend_emit unless trend_emit.empty?
+      if !ref_skip.empty?
+        skip_kinds = ref_skip.map { |r| r['kind'] }.tally.map { |k, n| "#{n}× #{k}" }.join(', ')
+        warnings << "'#{cap}' has #{ref_skip.size} Tableau reference mark(s) not auto-emitted (#{skip_kinds}) — bands/distributions need manual review (beads-sigma-7ak)"
+      end
+      if !ref_emit.empty?
+        warnings << "'#{cap}' auto-emitted #{ref_emit.size} Sigma refMarks from Tableau reference marks — verify visual fidelity"
+      end
+      if !trend_emit.empty?
+        models_used = trend_emit.map { |t| t['model'] }.uniq
+        non_linear = models_used - ['linear']
+        msg = "'#{cap}' auto-emitted #{trend_emit.size} Sigma trendline(s) (model: #{models_used.join(', ')})"
+        msg += " — only `linear` is canonically verified; visually verify #{non_linear.join('/')} fits" unless non_linear.empty?
+        warnings << msg
+      end
+    end
+
+    if kind == 'pie-chart' || kind == 'donut-chart'
+      element['color'] = { 'id' => dim_col_obj['id'] }
+      element['value'] = { 'id' => meas_col_obj['id'] }
+    else
+      # Breaking-change-2026-05-21: xAxis takes singular `columnId` (string),
+      # yAxis takes plural `columnIds` (array on the object — NOT array of
+      # objects). The old `xAxis: {id: ...}` / `yAxis: [{id: ...}]` shape
+      # is rejected by the live API on new POSTs.
+      x_axis = { 'columnId' => dim_col_obj['id'] }
+      # Sort: only set when Tableau explicitly sorted. parse-twb-layout emits
+      # nil when there's no <sort> on the worksheet — leave Sigma's xAxis
+      # unsorted in that case (natural order matches Tableau's default).
+      if z['sort']
+        dir = z.dig('sort', 'direction').to_s
+        sigma_dir = (dir =~ /desc/i) ? 'descending' : 'ascending'
+        x_axis['sort'] = { 'by' => meas_col_obj['id'], 'direction' => sigma_dir }
+      end
+      element['xAxis'] = x_axis
+      # Combo-chart: yAxis.columnIds is a mixed array — bare strings default to
+      # bar; { columnId, type: 'line' } objects override the series type.
+      # For non-combo: just bare strings.
+      y_column_ids = [meas_col_obj['id']]
+      if extra_meas_col
+        y_column_ids << (kind == 'combo-chart' ?
+          { 'columnId' => extra_meas_col['id'], 'type' => 'line' } :
+          extra_meas_col['id'])
+      end
+      element['yAxis'] = { 'columnIds' => y_column_ids }
+
+      # Axis format (log scale, fixed min/max). parse-twb-layout extracts these
+      # from Tableau's <style-rule element='axis'><encoding attr='space' ...>
+      # nodes per worksheet. Sigma side shape verified 2026-05-22:
+      #   format: { scale: { type: log | linear, domain: {min, max}, zero } }
+      # Tableau→Sigma scope mapping: rows→yAxis, cols→xAxis. class='0' is
+      # primary, class='1' is secondary (dual-axis right side, currently
+      # unverified from Sigma side — emit primary only for now).
+      (z['axis_formats'] || []).each do |af|
+        next unless af['class'].to_s == '0'  # primary only
+        target = af['scope'] == 'rows' ? 'yAxis' : 'xAxis'
+        scale = {}
+        scale['type']   = 'log' if af['scale'] == 'log'
+        if af['range_type'] == 'fixed' && af['min'] && af['max']
+          scale['domain'] = { 'min' => af['min'], 'max' => af['max'] }
+        end
+        next if scale.empty?
+        element[target] ||= {}
+        element[target]['format'] ||= {}
+        element[target]['format']['scale'] = scale
+        warnings << "'#{cap}' auto-emitted #{target}.format.scale from Tableau axis override (scale=#{af['scale']}, range=#{af['range_type']}) — verify visual fidelity"
+      end
+    end
+
+    # Surface action filters (they get skipped — these are cross-chart actions,
+    # not value filters)
+    action_filters = (z['filters'] || []).select { |f|
+      f['column'].to_s.include?('[Action (') || f['column'].to_s.start_with?('[Action ')
+    }
+    if action_filters.any?
+      warnings << "'#{cap}' has #{action_filters.size} Tableau action filter(s) — skipped (cross-chart actions, not value filters)"
+    end
+
+    # If channels.color is set, that's a multi-series signal. Emit a TODO note
+    # so the agent can fan-out the yAxis with one If() per category. We don't
+    # auto-fan because we don't have a reliable categorical-values list here.
+    if z.dig('channels', 'color', 'column')
+      warnings << "'#{cap}' has a color channel on #{z['channels']['color']['column']} — chart is single-series; agent should fan-out yAxis with one If() per category (see refs/workbook-layout.md \"Multi-series chart patterns\")"
+    end
+
+    # Data labels — verified canonical shape 2026-05-22 against UI-built workbook
+    # (workbookUrlId 5xKqmuAXGooHxRgFrdk6VY): minimum required is just
+    #   dataLabel: { labels: shown }
+    # Two Tableau signals trigger this:
+    #   1. Label or Text encoding channel on the worksheet (drag-to-shelf)
+    #   2. Worksheet-level "Show Mark Labels" toggle, surfaced by parse-twb-layout
+    #      from <pane><style><style-rule element='mark'>
+    #             <format attr='mark-labels-show' value='true'/>
+    #      (verified against "Orders Conversion Test" workbook, 2026-05-22)
+    if %w[bar-chart line-chart area-chart combo-chart scatter-chart pie-chart donut-chart].include?(kind)
+      has_label_channel = z.dig('channels', 'label', 'column') || z.dig('channels', 'text', 'column')
+      has_mark_labels   = z['mark_labels_show'] == true
+      if has_label_channel || has_mark_labels
+        element['dataLabel'] = { 'labels' => 'shown' }
+        src = has_label_channel ? 'Label/Text encoding' : 'worksheet "Show Mark Labels" toggle'
+        warnings << "'#{cap}' auto-emitted dataLabel:{labels:shown} from Tableau #{src} — verify formatting (Sigma defaults are minimal)"
+      end
+    end
+
+    # Per-chart value filters (skip action filters — already warned above).
+    # Translate each non-action filter into a Sigma element-level filter spec
+    # using the parser's normalized fields (column_caption, kind, members,
+    # period_type, etc.). We map the caption → master column via the same
+    # regex map used for dim/measure.
+    value_filters = (z['filters'] || []).reject { |f| f['is_action'] }
+    el_filters = []
+    value_filters.each do |f|
+      fcap = f['column_caption'] || f['raw_param']
+      m = fcap ? map_column(fcap, mmap) : nil
+      if m.nil?
+        warnings << "value filter on '#{cap}' targets '#{fcap}' — no master column matched, skipping"
+        next
+      end
+      case f['kind']
+      when 'list'
+        el_filters << {
+          'columnId' => m['id'],
+          'kind' => 'list', 'mode' => 'include', 'selectionMode' => 'multiple',
+          'values' => (f['members'] || []), 'includeNulls' => false
+        }
+      when 'relative-date'
+        # Tableau first-period=0, last-period=0 + period-type=year means
+        # "this year". Translate to Sigma relative date-range.
+        el_filters << {
+          'columnId' => m['id'], 'kind' => 'date-range', 'mode' => 'relative',
+          'unit' => f['period_type'] || 'year', 'count' => 1,
+          'includeNulls' => f['include_null'].to_s == 'true'
+        }
+      when 'number-range'
+        el_filters << {
+          'columnId' => m['id'], 'kind' => 'number-range', 'mode' => 'between',
+          'min' => f['min'], 'max' => f['max']
+        }
+      end
+    end
+    element['filters'] = el_filters unless el_filters.empty?
+
+    # Surface Tableau-side calculated fields the worksheet uses, and auto-
+    # translate the ones we know how to handle (parameter-driven Switch).
+    # Otherwise emit a translation hint so the agent can wire it up by hand.
+    param_caps = (meta['parameters'] || []).map { |p| p['caption'] }.compact
+    (z['calculations'] || []).each do |c|
+      formula = c['formula'].to_s
+      next if formula.empty?
+      next if formula =~ /\A\s*(SUM|COUNT|AVG|MIN|MAX)\(\[[^\]]+\]\)\s*\z/
+      next if formula =~ /\A\s*\[[^\]]+\]\s*\z/
+
+      # Try parameter-driven translations first (CASE / IF chain on param).
+      translated = translate_case_on_param(formula, param_caps) ||
+                   translate_if_chain_on_param(formula, param_caps)
+      if translated
+        # Drop the calc onto the chart element as an inline calc column. The
+        # column id is derived from the calc name (strip brackets) so it's
+        # stable across re-runs.
+        calc_name = c['name'].to_s.gsub(/^\[|\]$/, '')
+        calc_id   = "calc-#{calc_name.downcase.gsub(/\W+/, '-')[0..40]}".sub(/-$/, '')
+        element['columns'] << {
+          'id'      => calc_id,
+          'name'    => calc_name,
+          'formula' => translated
+        }
+        warnings << "'#{cap}' parameter-driven calc #{c['name']} → translated to Switch: #{translated[0..120]}"
+        next
+      end
+
+      # Try customer-learned rules FIRST — these are translations the scout
+      # subagent has validated against this customer's Sigma site. Anything
+      # here is known-to-work in their context, so it wins over built-in
+      # heuristics. Source: ~/.tableau-to-sigma/learned-rules.yaml (user home,
+      # never clobbered by skill updates).
+      lr_translated, lr_hint = LearnedRules.apply(LEARNED_RULES, formula)
+      if lr_translated
+        warnings << "'#{cap}' learned-rule applied to #{c['name']} → Sigma:  #{lr_translated[0..160]}  [#{lr_hint}]"
+        next
+      end
+
+      # Try table-calc / common-fn translations (INDEX/LOOKUP/TOTAL/RANK/ZN/etc.).
+      tc_translated, tc_hint = translate_tableau_tc(formula)
+      if tc_translated
+        warnings << "'#{cap}' Tableau table-calc #{c['name']} → Sigma:  #{tc_translated[0..160]}  [#{tc_hint}]"
+        next
+      end
+
+      hint = if formula =~ /\bIIF\(.*=.*0.*,\s*SUM.*\/\s*SUM/
+               'ratio calc — translate as `Sum(num) / NullIf(Sum(den), 0)` on master OR via Custom SQL'
+             elsif formula =~ /\bIF\b.*\bELSEIF\b.*\bEND\b/i
+               'IF/ELSEIF chain — translate to nested Sigma If(...) or Switch(...) on master'
+             elsif formula =~ /\bCASE\b/i
+               'CASE statement — translate to Sigma Switch(value, when1, then1, ...) on master'
+             elsif formula =~ /\bSUM\(.*\)\s*\/\s*COUNT\(/i
+               'ratio calc — translate as `Sum(...) / Count(...)` (or CountIf for NotNull) on master'
+             elsif formula =~ /\[Parameters?\]\.|\[Parameters?\s+\(/
+               'parameter-driven calc — translate to Sigma control + Switch()/If() formula'
+             else
+               'calc — translate to Sigma formula and add as a master column or workbook calc'
+             end
+      warnings << "'#{cap}' uses Tableau calc #{c['name']}: #{hint}. Formula: #{formula[0..120]}"
+    end
+
+    # Stamp with worksheet name so the page-per-worksheet emitter can group.
+    element['_worksheet'] = cap
+    elements << element
+  end
+end
+
+# ---- Title text element ----
+# If --title given, emit a text element. If --title omitted AND the parser
+# found a title/text zone, infer the dashboard name from the parser output.
+auto_title = nil
+if opts[:title].nil?
+  layout.each do |dash|
+    next unless dash['zones'].any? { |z| %w[title text].include?(z['kind']) && (z['y_pct'] || 100) < 10 }
+    auto_title = dash['dashboard']
+    break
+  end
+end
+title_text = opts[:title] || auto_title
+
+extras = []
+if title_text
+  extras << {
+    'id'   => 'title-text',
+    'kind' => 'text',
+    'body' => "## #{title_text}"
+  }
+end
+
+# ---- Auto-generated parameter controls (--auto-controls) ------------------
+# Tableau parameters become Sigma controls. The control's name matches the
+# parameter caption so any translated `Switch([Param Caption], ...)` formula
+# resolves to this control.
+param_controls = []
+if opts[:auto_controls]
+  # Determine which parameter captions are actually referenced by any worksheet
+  # calc. Tableau workbooks often define orphan parameters (defined but not used
+  # by any calc field) — emitting controls for those clutters the dashboard
+  # with widgets that filter nothing. Skip them.
+  referenced_caps = (meta['worksheets'] || {}).values
+    .flat_map { |w| (w['calculations'] || []).flat_map { |c| c['parameter_refs'] || [] } }
+    .uniq
+  (meta['parameters'] || []).each_with_index do |p, i|
+    cap = p['caption'].to_s.strip
+    next if cap.empty?
+    unless referenced_caps.include?(cap)
+      warnings << "parameter '#{cap}' is defined in Tableau but not referenced by any worksheet calc — skipped auto-control (orphan parameter)"
+      next
+    end
+    slug = cap.downcase.gsub(/\W+/, '-').sub(/-$/, '')
+    spec = {
+      'id'        => "el-param-#{slug}",
+      'kind'      => 'control',
+      'controlId' => "ctl-param-#{slug}",
+      'name'      => cap,
+      'includeNulls' => 'when-no-value-is-selected'
+    }
+    if p['param_domain'] == 'list'
+      spec['controlType']   = 'segmented'
+      spec['source'] = {
+        'kind' => 'manual', 'valueType' => 'text',
+        'values' => p['members'] || [], 'labels' => []
+      }
+      spec['value'] = p['default_value']
+    elsif p['param_domain'] == 'range' && %w[integer real].include?(p['datatype'])
+      # Numeric range parameter → Sigma `number-range` control (discovered by
+      # gap-scout 2026-05-20, beads-sigma-ebw). Two-handle slider; the single-
+      # value Tableau parameter is rendered as a range with handles initially
+      # collapsed to the default. `mode` and `values` don't round-trip on
+      # readback but the workbook renders correctly (known Sigma quirk).
+      spec['controlType'] = 'number-range'
+      spec['mode']        = 'between'
+      min = p['min'] ? (p['datatype'] == 'real' ? p['min'].to_f : p['min'].to_i) : nil
+      max = p['max'] ? (p['datatype'] == 'real' ? p['max'].to_f : p['max'].to_i) : nil
+      spec['values']      = [min, max].compact if min && max
+      warnings << "parameter '#{cap}' is a numeric range — emitted as number-range control (Sigma 2-handle slider; Tableau's single-handle UX needs manual post-publish tweak)"
+    elsif p['param_domain'] == 'range' && %w[date datetime].include?(p['datatype'])
+      spec['controlType'] = 'date-range'
+      spec['mode'] = 'between'
+    else
+      # Generic fallback — text input
+      spec['controlType'] = 'text'
+      spec['value'] = p['default_value']
+    end
+    param_controls << spec
+  end
+end
+
+# ---- Auto-generated controls from shared-view filters (--auto-controls) ----
+auto_controls = []
+if opts[:auto_controls]
+  (meta['shared_filters'] || []).each_with_index do |f, i|
+    next if f['is_action']
+    cap = f['column_caption']
+    if cap.nil?
+      warnings << "shared filter ##{i} has no resolvable column_caption (raw_param=#{f['raw_param']}) — skipping auto-control"
+      next
+    end
+    m = map_column(cap, mmap)
+    if m.nil?
+      warnings << "shared filter on '#{cap}' has no master-map entry — add a regex to master-columns.json"
+      next
+    end
+    slug = cap.downcase.gsub(/\W+/, '-').sub(/-$/, '')
+    spec = {
+      'id'           => "el-ctl-#{slug}",
+      'kind'         => 'control',
+      'controlId'    => "ctl-#{slug}",
+      'name'         => cap.strip,
+      'includeNulls' => 'when-no-value-is-selected'
+    }
+    case f['kind']
+    when 'list'
+      spec['controlType']   = 'list'
+      spec['mode']          = 'include'
+      spec['selectionMode'] = 'multiple'
+      spec['values']        = []  # default to all; user adjusts in UI
+      spec['source'] = {
+        'kind'     => 'source',
+        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+        'columnId' => m['id']
+      }
+      spec['filters'] = [{
+        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+        'columnId' => m['id']
+      }]
+    when 'relative-date'
+      # Tableau "this year" / "this month" / "this quarter" → translate to
+      # Sigma `mode: between` with hardcoded startDate/endDate. The previously-
+      # tried `mode: current, unit: <period>` only applies at UI render time —
+      # it does NOT filter Sigma's chart-data SQL queries (Phase 6 parity
+      # showed every relative-date chart returning unfiltered data). Hardcoded
+      # dates apply at query time AND on the UI. Trade-off: filter "freezes"
+      # — next year someone must update it manually. The mirror of v4's
+      # reference workbook.
+      spec['controlType'] = 'date-range'
+      spec['mode']        = 'between'
+      period = (f['period_type'] || 'year').downcase
+      now = Time.now
+      if period == 'year'
+        start_d = "#{now.year}-01-01T00:00:00Z"
+        end_d   = "#{now.year}-12-31T23:59:59Z"
+      elsif period == 'quarter'
+        q       = ((now.month - 1) / 3) + 1
+        start_m = (q - 1) * 3 + 1
+        start_d = "#{now.year}-#{start_m.to_s.rjust(2, '0')}-01T00:00:00Z"
+        end_m   = start_m + 2
+        end_day = Date.new(now.year, end_m, -1).day
+        end_d   = "#{now.year}-#{end_m.to_s.rjust(2, '0')}-#{end_day.to_s.rjust(2,'0')}T23:59:59Z"
+      elsif period == 'month'
+        start_d = now.strftime('%Y-%m-01T00:00:00Z')
+        last    = Date.new(now.year, now.month, -1).day
+        end_d   = now.strftime("%Y-%m-#{last.to_s.rjust(2,'0')}T23:59:59Z")
+      else
+        # Fallback: pass-through current+unit; agent updates manually
+        spec['mode'] = 'current'
+        spec['unit'] = period
+        spec['filters'] = [{
+          'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+          'columnId' => m['id']
+        }]
+        next
+      end
+      spec['startDate'] = start_d
+      spec['endDate']   = end_d
+      spec['filters'] = [{
+        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+        'columnId' => m['id']
+      }]
+      warnings << "shared filter '#{cap}' relative-date '#{period}' → emitted as mode:between with hardcoded current-#{period} dates (#{start_d[0..9]}..#{end_d[0..9]}). Re-run next #{period} to refresh."
+    when 'number-range'
+      spec['controlType'] = 'range-slider'
+      spec['filters'] = [{
+        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+        'columnId' => m['id']
+      }]
+    end
+    auto_controls << spec
+  end
+end
+
+# ---- Filter controls ----
+# Caller supplies the column targets explicitly via --controls. We don't try
+# to infer the column from filter zone metadata because the Tableau filter
+# shelf doesn't reliably tell us which dimension it filters in this XML.
+if opts[:controls]
+  controls = JSON.parse(File.read(opts[:controls]))
+  controls.each_with_index do |c, i|
+    spec = {
+      'id'          => "el-ctl-#{c['name'] ? c['name'].downcase.gsub(/\W+/, '-') : "f#{i}"}",
+      'kind'        => 'control',
+      'controlId'   => "ctl-#{c['name'] ? c['name'].downcase.gsub(/\W+/, '-') : "f#{i}"}",
+      'name'        => c['name'] || "Filter #{i + 1}",
+      'controlType' => c['type'] || 'list',
+      'includeNulls' => 'when-no-value-is-selected',
+      'filters' => [
+        {
+          'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+          'columnId' => c['column']
+        }
+      ]
+    }
+    case spec['controlType']
+    when 'list'
+      spec['mode'] = c['mode'] || 'include'
+      spec['selectionMode'] = c['selectionMode'] || 'multiple'
+      spec['values'] = c['values'] || []
+      spec['source'] = {
+        'kind'     => 'source',
+        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+        'columnId' => c['column']
+      }
+    when 'date-range'
+      spec['mode'] = c['mode'] || 'between'
+      if c['default']
+        d = c['default']
+        spec['startDate'] = d['startDate'] if d['startDate']
+        spec['endDate']   = d['endDate']   if d['endDate']
+        spec['unit']      = d['unit']      if d['unit']
+        spec['mode']      = d['mode']      if d['mode']
+      end
+    when 'segmented'
+      spec['source'] = c['source'] || {
+        'kind' => 'manual', 'valueType' => 'text', 'values' => c['values'] || [], 'labels' => []
+      }
+      spec['value'] = c['value']
+    end
+    extras << spec
+  end
+end
+
+all_extras = extras + param_controls + auto_controls
+
+# ---- Output mode ----
+#   Default       → flat array of elements (legacy behaviour). Extras first.
+#   --page-per-worksheet → emit { pages: [{name, elements:[]}] }. One page per
+#                          worksheet that has a chart, with the shared-filter
+#                          auto-controls AND a title text duplicated onto each
+#                          page so the customer sees the same filter set on
+#                          every page (Tableau dashboard-level filter semantics).
+if opts[:pages_mode] == :worksheet
+  pages = []
+  by_ws = elements.group_by { |e| e['_worksheet'] }
+  by_ws.each do |ws_name, els|
+    els.each { |e| e.delete('_worksheet') }
+    page_extras = []
+    if title_text
+      page_extras << {
+        'id'   => "title-text-#{ws_name.downcase.gsub(/\W+/,'-')[0..30]}".sub(/-$/, ''),
+        'kind' => 'text',
+        'body' => "## #{ws_name}"
+      }
+    end
+    # Auto-controls duplicated per page. Both `id` and `controlId` need to be
+    # workbook-globally unique (Sigma rejects duplicates). We track per-page
+    # controlId rewrites so any param-driven Switch() formula on this page's
+    # charts can be rewritten to reference the suffixed controlId.
+    ws_slug = ws_name.downcase.gsub(/\W+/, '-')[0..20]
+    ctl_rewrites = {}
+    (param_controls + auto_controls).each do |c|
+      dup = JSON.parse(c.to_json)
+      original_cid = dup['controlId']
+      dup['id']        = "#{dup['id']}-#{ws_slug}"
+      dup['controlId'] = "#{dup['controlId']}-#{ws_slug}"
+      ctl_rewrites[original_cid] = dup['controlId']
+      page_extras << dup
+    end
+    # Rewrite Switch / If formulas on this page's chart calc columns.
+    els.each do |el|
+      (el['columns'] || []).each do |col|
+        f = col['formula'].to_s
+        ctl_rewrites.each do |from, to|
+          f = f.gsub("[#{from}]", "[#{to}]")
+        end
+        col['formula'] = f
+      end
+    end
+    pages << {
+      'name'     => ws_name,
+      'elements' => page_extras + els
+    }
+  end
+  File.write(opts[:out], JSON.pretty_generate({ 'pages' => pages }))
+  warn "wrote #{opts[:out]} (page-per-worksheet: #{pages.size} pages, #{auto_controls.size} auto-controls per page)"
+else
+  elements.each { |e| e.delete('_worksheet') }
+  all_elements = all_extras + elements
+  File.write(opts[:out], JSON.pretty_generate(all_elements))
+  warn "wrote #{opts[:out]}  (#{all_elements.size} elements: #{all_extras.size} controls/text + #{elements.size} charts)"
+end
+warnings.each { |w| warn "  WARN  #{w}" }
+
+# ---- Tableau dashboard actions companion file -----------------------------
+# Action filters were translated into element-level filters when possible; the
+# leftover Tableau-internal action wiring (which source-tile filters which
+# target-tile set) is non-translatable without Sigma's cross-element wiring
+# API. Emit a companion actions.md so the agent (or customer) can replicate
+# the cross-chart interactivity by hand post-publish.
+actions = []
+(layout || []).each do |dash|
+  (dash['zones'] || []).each do |z|
+    next unless z['kind'] == 'chart'
+    (z['filters'] || []).select { |f| f['is_action'] }.each do |af|
+      # Tableau's action filter column looks like
+      #   [federated.<id>].[Action (Region)]
+      # Pull "Region" out as the dim that the action filters on.
+      raw = (af['raw_param'] || af['column'] || '').to_s
+      dim = (raw[/\[Action \(([^)]+)\)\]/, 1] || raw)
+      actions << {
+        'target'  => z['caption'],
+        'source'  => dim,
+        'column'  => dim
+      }
+    end
+  end
+end
+unless actions.empty?
+  actions_md_path = opts[:out].sub(/\.json$/, '-actions.md')
+  md = String.new
+  md << "# Tableau dashboard actions — post-publish setup\n\n"
+  md << "Sigma cross-chart filtering replaces Tableau's filter actions. For each\n"
+  md << "row below, in the published Sigma workbook: select the source element,\n"
+  md << "open Actions → Add filter action, target the listed element on the named\n"
+  md << "column.\n\n"
+  md << "| Source dim | Target chart | Filter column |\n"
+  md << "|---|---|---|\n"
+  actions.uniq.each do |a|
+    md << "| #{a['source']} | #{a['target']} | #{a['column']} |\n"
+  end
+  File.write(actions_md_path, md)
+  warn "wrote #{actions_md_path} (#{actions.size} action entries)"
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
@@ -1,0 +1,129 @@
+#!/usr/bin/env ruby
+# build-quicksight-layout.rb
+# Emit a Sigma layout XML for a QuickSight-derived workbook, faithfully mapping the
+# QuickSight sheet layout to Sigma's 24-col grid (1-based grid lines).
+#
+# Handles:
+#   - GridLayout (TILED) with explicit ColumnIndex/RowIndex/ColumnSpan/RowSpan (36-col grid)
+#   - GridLayout auto-flow (spans only, no indices) → flow left-to-right, wrap by span
+#   - FreeFormLayout (pixel X/Y/W/H) → normalized to the bounding box
+#   - fallback: 2-per-row flow when no layout info is present
+#
+# Usage:
+#   ruby scripts/build-quicksight-layout.rb --analysis DISCOVER_DIR/analysis.json \
+#        --map /tmp/wb-spec.map.json --out /tmp/layout.xml
+require 'json'
+require 'optparse'
+require_relative 'lib/layout'
+include SigmaLayout
+
+opts = {}
+OptionParser.new do |o|
+  o.on('--analysis F') { |v| opts[:an] = v }
+  o.on('--map F') { |v| opts[:map] = v }
+  o.on('--out F') { |v| opts[:out] = v }
+end.parse!
+%i[an map out].each { |k| abort "missing --#{k}" unless opts[k] }
+
+defn = JSON.parse(File.read(opts[:an]))['Definition']
+map = JSON.parse(File.read(opts[:map]))
+v2e = map['visualToElement']             # QS VisualId -> Sigma element id
+GRID = 36.0                              # QuickSight grid width
+SIG = 24                                 # Sigma grid width
+
+def num(s) # "120px" / "50%" / 120 -> float
+  s.to_s.gsub(/[^0-9.\-]/, '').to_f
+end
+
+def scale_cols(x, w, canvas)
+  c0 = (x.to_f / canvas * SIG).round + 1
+  c1 = ((x.to_f + w.to_f) / canvas * SIG).round + 1
+  c0 = 1 if c0 < 1
+  c1 = c0 + 1 if c1 <= c0
+  c1 = SIG + 1 if c1 > SIG + 1
+  [c0, c1]
+end
+
+placed = []   # [elId, c0, c1, r0, r1]
+sheet = defn['Sheets'][0] || {}
+cfg = (sheet['Layouts'] || [{}])[0].fetch('Configuration', {})
+
+if (g = cfg['GridLayout'])
+  els = g['Elements'] || []
+  explicit = els.any? { |e| !e['ColumnIndex'].nil? }
+  if explicit
+    els.each do |e|
+      eid = v2e[e['ElementId']]; next unless eid
+      c0, c1 = scale_cols(e['ColumnIndex'] || 0, e['ColumnSpan'] || 12, GRID)
+      r0 = (e['RowIndex'] || 0) + 1
+      r1 = r0 + (e['RowSpan'] || 8)
+      placed << [eid, c0, c1, r0, r1]
+    end
+  else
+    # auto-flow by span across the 36-col grid
+    col = 0; row = 1; row_h = 0
+    els.each do |e|
+      eid = v2e[e['ElementId']]; next unless eid
+      span = e['ColumnSpan'] || 18
+      col = 0 if col + span > GRID
+      row += row_h if col.zero? && row_h.positive?
+      c0, c1 = scale_cols(col, span, GRID)
+      h = (e['RowSpan'] || 12)
+      placed << [eid, c0, c1, row, row + h]
+      col += span; row_h = [row_h, h].max
+      if col >= GRID
+        col = 0; row += row_h; row_h = 0
+      end
+    end
+  end
+elsif (f = cfg['FreeFormLayout'])
+  els = f['Elements'] || []
+  cw = els.map { |e| num(e['XAxisLocation']) + num(e['Width']) }.max || 1.0
+  ch_unit = 40.0 # ~px per Sigma row
+  els.each do |e|
+    eid = v2e[e['ElementId']]; next unless eid
+    c0, c1 = scale_cols(num(e['XAxisLocation']), num(e['Width']), cw <= 0 ? 1 : cw)
+    r0 = (num(e['YAxisLocation']) / ch_unit).round + 1
+    r1 = r0 + [(num(e['Height']) / ch_unit).round, 4].max
+    placed << [eid, c0, c1, r0, r1]
+  end
+end
+
+# fallback: 2-per-row flow over whatever elements we have a mapping for
+if placed.empty?
+  col = 1; row = 1
+  v2e.each_value do |eid|
+    if col > 13
+      col = 1; row += 12
+    end
+    placed << [eid, col, col + 12, row, row + 12]
+    col += 12
+  end
+end
+
+# Collision guard (D15 free-form overlap → Sigma rejects "Element collisions").
+# Two elements collide when their column AND row ranges both overlap. If ANY pair
+# collides, fall back to a clean stacked layout: full-width rows in placement
+# order, each a fixed height. (beads-sigma — free-form overlap)
+def collides?(a, b)
+  _, ac0, ac1, ar0, ar1 = a
+  _, bc0, bc1, br0, br1 = b
+  (ac0 < bc1 && bc0 < ac1) && (ar0 < br1 && br0 < ar1)
+end
+overlap = placed.combination(2).any? { |a, b| collides?(a, b) }
+if overlap
+  STDERR.puts "layout: detected element collisions in free-form layout — collapsing #{placed.size} elements to stacked rows"
+  row = 1; row_h = 12
+  placed = placed.map do |eid, _c0, _c1, _r0, _r1|
+    r0 = row; row += row_h
+    [eid, 1, SIG + 1, r0, r0 + row_h]
+  end
+end
+
+dash_children = placed.map { |eid, c0, c1, r0, r1| le(eid, c0, c1, r0, r1) }
+data_page = page_xml('page-data', le(map['masterElementId'], 1, 25, 1, 15))
+dash_page = page_xml(map['dashPageId'], *dash_children)
+
+File.write(opts[:out], assemble(data_page, dash_page))
+STDERR.puts "layout: #{placed.size} elements mapped from QuickSight #{cfg.keys.first || 'flow-fallback'} → #{opts[:out]}"
+placed.each { |eid, c0, c1, r0, r1| STDERR.puts "  #{eid}  col #{c0}-#{c1}  row #{r0}-#{r1}" }

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -1,0 +1,331 @@
+#!/usr/bin/env ruby
+# build-workbook-from-quicksight.rb
+# Build a Sigma workbook that mirrors a QuickSight analysis, bound to the
+# data model produced by the convert phase.
+#
+# Architecture (matches the Qlik/PowerBI builders):
+#   - a master "table" element on a Data page, source = {dataModelId, elementId, kind:"data-model"},
+#     surfacing the columns the dashboard needs via [Custom SQL/RAW] (or a translated calc-field expr);
+#   - one dashboard page whose chart elements source the master via {elementId, kind:"table"}
+#     and reference master columns as [<MasterName>/<Col>] with the QuickSight aggregation.
+#
+# Key behaviours (beads-sigma-nc6g / woaa / 23xu):
+#   - the master sources the DM element whose columns COVER the charted columns (the
+#     denormalized join element), NOT a hardcoded pages[0].elements[0];
+#   - QuickSight window/table-calc functions (runningSum/percentOfTotal/rank/difference/…)
+#     are NOT passed through as live Sigma formulas — they are neutralized to Null (the
+#     original expr goes into the column description);
+#   - a dataset FilterOperation surfaced by convert-model (dm-filters.json) is APPLIED as a
+#     real element-level list filter on the master, so downstream aggregates honor it;
+#   - GaugeChartVisual -> kpi-chart, FunnelChartVisual -> bar-chart, TreeMapVisual -> bar-chart
+#     (Sigma has no native gauge/funnel/treemap kind; this mirrors the PBI builder's mapping).
+#
+# Usage:
+#   ruby scripts/build-workbook-from-quicksight.rb \
+#     --analysis DISCOVER_DIR/analysis.json --dm-readback /tmp/dm-readback.json \
+#     [--dm-spec /tmp/dm-spec.json] [--filters /tmp/dm-filters.json] \
+#     --folder-id ID --out /tmp/wb-spec.json
+require 'json'
+require 'optparse'
+require 'securerandom'
+require 'set'
+
+opts = {}
+OptionParser.new do |o|
+  o.on('--analysis F') { |v| opts[:an] = v }
+  o.on('--dm-readback F') { |v| opts[:rb] = v }
+  o.on('--dm-spec F') { |v| opts[:dmspec] = v }
+  o.on('--filters F') { |v| opts[:filters] = v }
+  o.on('--folder-id ID') { |v| opts[:folder] = v }
+  o.on('--master-name NAME') { |v| opts[:mname] = v }
+  o.on('--out F') { |v| opts[:out] = v }
+end.parse!
+%i[an rb out].each { |k| abort "missing --#{k}" unless opts[k] }
+
+an = JSON.parse(File.read(opts[:an]))
+defn = an['Definition']
+rb = JSON.parse(File.read(opts[:rb]))
+dm_id = rb['dataModelId']
+
+def disp(raw); raw.to_s.gsub(/[_.]/, ' ').split.map { |w| w[0..0].upcase + w[1..-1].to_s.downcase }.join(' '); end
+
+# ---- derive the columns the dashboard actually references (raw col names) ----
+def visual_cols(inner)
+  out = []
+  walk = lambda do |o|
+    if o.is_a?(Hash)
+      if (c = o['Column']) && c.is_a?(Hash) && c['ColumnName']
+        out << c['ColumnName']
+      end
+      o.each_value { |v| walk.call(v) }
+    elsif o.is_a?(Array)
+      o.each { |v| walk.call(v) }
+    end
+  end
+  walk.call(inner['ChartConfiguration'] || {})
+  out
+end
+
+calc_names = {}
+(defn['CalculatedFields'] || []).each { |c| calc_names[c['Name']] = c['Expression'] }
+
+needed_raw = []
+defn['Sheets'].each do |sh|
+  (sh['Visuals'] || []).each do |v|
+    _, inner = v.first
+    needed_raw.concat(visual_cols(inner))
+  end
+end
+needed_raw.uniq!
+# calc fields resolve to raw columns inside their expressions; expand
+needed_resolved = needed_raw.flat_map do |n|
+  if calc_names.key?(n)
+    calc_names[n].to_s.scan(/\{([^}]+)\}/).flatten.map(&:strip)
+  else
+    [n]
+  end
+end.uniq
+
+# ---- pick the DM element whose columns COVER the charted columns ----
+# Use the dm-spec (has column display names) to score coverage; fall back to the
+# dm-readback element list when no dm-spec is provided. (beads-sigma-nc6g point 4)
+dm_spec = opts[:dmspec] && File.exist?(opts[:dmspec]) ? JSON.parse(File.read(opts[:dmspec])) : nil
+needed_disp = needed_resolved.map { |c| disp(c) }.to_set
+
+best = nil
+if dm_spec
+  spec_els = (dm_spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+  scored = spec_els.map do |el|
+    names = (el['columns'] || []).map { |c| c['name'] }.compact.to_set
+    cover = needed_disp.count { |d| names.include?(d) }
+    [cover, (el['columns'] || []).size, el['name']]
+  end
+  # most coverage; tie-break on more columns (the denormalized view wins)
+  top = scored.max_by { |cover, ncols, _| [cover, ncols] }
+  best = top && top[2]
+end
+
+rb_els = (rb['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+dm_el_obj =
+  if best
+    rb_els.find { |e| e['name'] == best } || rb_els.first
+  else
+    # no dm-spec: pick the readback element with the most columns isn't available,
+    # so prefer the last (synthesized join element is appended last) else first.
+    rb_els.last || rb_els.first
+  end
+abort 'no DM elements in readback' unless dm_el_obj
+dm_el = dm_el_obj['id']
+DMEL = dm_el_obj['name'] || 'Custom SQL'   # DM element name — master refs cols as [DMEL/Col]
+M = opts[:mname] || 'Orders'               # master element name (used in [M/Col] refs from charts)
+
+def nid(p = 'el'); "#{p}-" + SecureRandom.hex(5); end
+NUM = ->(fs) { { 'kind' => 'number', 'formatString' => fs } }
+AGG = { 'SUM' => 'Sum', 'AVERAGE' => 'Avg', 'MIN' => 'Min', 'MAX' => 'Max',
+        'COUNT' => 'Count', 'DISTINCT_COUNT' => 'CountDistinct', 'MEDIAN' => 'Median' }
+
+# QuickSight window / table-calc function names (must match convert-model.rb). A
+# calc field using any of these can't be a live Sigma formula — neutralize to Null.
+QS_WINDOW_FUNCS = %w[
+  runningSum runningAvg runningCount runningMax runningMin
+  percentOfTotal percentDifference difference
+  rank denseRank percentileRank
+  lag lead firstValue lastValue
+  windowSum windowAvg windowCount windowMax windowMin
+  movingSum movingAverage
+].freeze
+def qs_window_func?(expr)
+  e = expr.to_s
+  QS_WINDOW_FUNCS.any? { |fn| e =~ /(?<![A-Za-z0-9_])#{Regexp.escape(fn)}\s*\(/ }
+end
+
+# minimal QuickSight-expr → Sigma-formula translator for calc fields referenced by visuals
+def qs_expr_to_sigma(expr, dmel)
+  s = expr.to_s.dup
+  s = s.gsub(/\{([^}]+)\}/) { "[#{dmel}/#{disp(Regexp.last_match(1).strip)}]" }
+  s = s.gsub('<>', '!=')
+  s = s.gsub(/\bifelse\s*\(/i, 'If(')
+  s = s.gsub(/'([^']*)'/) { "\"#{Regexp.last_match(1)}\"" }
+  s
+end
+
+calc = {}
+(defn['CalculatedFields'] || []).each { |c| calc[c['Name']] = c['Expression'] }
+
+def field_role(f)
+  if (mf = f['NumericalMeasureField'])
+    [:meas, mf['Column']['ColumnName'], (mf.dig('AggregationFunction', 'SimpleNumericalAggregation') || 'SUM')]
+  elsif (mf = f['CategoricalMeasureField'])
+    [:meas, mf['Column']['ColumnName'], 'COUNT']
+  elsif (df = f['CategoricalDimensionField'])
+    [:dim, df['Column']['ColumnName'], nil]
+  elsif (df = f['DateDimensionField'])
+    [:dim, df['Column']['ColumnName'], nil]
+  end
+end
+
+# QuickSight visual type -> Sigma element kind. Sigma has no native gauge/funnel/
+# treemap kind, so (mirroring the PBI builder, beads-sigma-1zh9): gauge -> kpi-chart
+# (single value), funnel/treemap -> bar-chart (category + measure).
+KIND = { 'KPIVisual' => 'kpi-chart', 'BarChartVisual' => 'bar-chart',
+         'LineChartVisual' => 'line-chart', 'PieChartVisual' => 'pie-chart',
+         'ComboChartVisual' => 'combo-chart', 'ScatterPlotVisual' => 'scatter-chart',
+         'TableVisual' => 'table', 'PivotTableVisual' => 'pivot-table',
+         'GaugeChartVisual' => 'kpi-chart', 'FunnelChartVisual' => 'bar-chart',
+         'TreeMapVisual' => 'bar-chart' }
+
+master_cols = {}   # colname(raw or calc) -> {id, formula, name}
+def fmt_for(name)
+  case name
+  when /margin|pct|percent|ratio|rate/i then '.1%'
+  when /revenue|profit|cost|sales|amount|price|discount/i then '$,.0f'
+  else ',.0f'
+  end
+end
+
+def master_ref(colname, calc, master_cols, dmel)
+  return master_cols[colname] if master_cols[colname]
+  if calc.key?(colname)
+    if qs_window_func?(calc[colname])
+      # neutralize: a window/table-calc field can't be a live Sigma calc column.
+      formula = 'Null'; nm = colname
+      master_cols[colname] = { 'id' => "m-#{SecureRandom.hex(4)}", 'formula' => formula, 'name' => nm,
+                               'description' => "QuickSight table-calc (neutralized — re-author in Sigma): #{calc[colname]}",
+                               '_window' => true }
+      return master_cols[colname]
+    end
+    formula = qs_expr_to_sigma(calc[colname], dmel); nm = colname
+  else
+    formula = "[#{dmel}/#{disp(colname)}]"; nm = disp(colname)
+  end
+  master_cols[colname] = { 'id' => "m-#{SecureRandom.hex(4)}", 'formula' => formula, 'name' => nm }
+end
+
+def dim_col(role, calc, mc, dmel, m)
+  ref = master_ref(role[1], calc, mc, dmel); id = nid('d')
+  [{ 'id' => id, 'formula' => "[#{m}/#{ref['name']}]", 'name' => ref['name'] }, id]
+end
+
+def meas_col(role, calc, mc, dmel, m)
+  _, col, agg = role; ref = master_ref(col, calc, mc, dmel); id = nid('m')
+  # a neutralized window calc field can't be aggregated as a live formula either
+  if ref['_window']
+    return [{ 'id' => id, 'formula' => 'Null', 'name' => ref['name'],
+              'description' => ref['description'] }, id]
+  end
+  [{ 'id' => id, 'formula' => "#{AGG[agg] || 'Sum'}([#{m}/#{ref['name']}])", 'name' => ref['name'],
+     'format' => NUM.(fmt_for(ref['name'])) }, id]
+end
+
+elements = []
+vis_map = {}
+defn['Sheets'].each do |sh|
+  (sh['Visuals'] || []).each do |v|
+    vtype, inner = v.first
+    kind = KIND[vtype]; next unless kind
+    title = (inner.dig('Title', 'FormatText', 'PlainText') || inner['VisualId'])
+    eid = nid
+    vis_map[inner['VisualId']] = eid
+    kind = 'donut-chart' if vtype == 'PieChartVisual' && inner.dig('ChartConfiguration', 'DonutOptions')
+    fw = (inner['ChartConfiguration'] || {})['FieldWells'] || {}
+    w = fw.values.find { |x| x.is_a?(Hash) } || fw
+    rol = ->(key) { (w[key] || []).map { |f| field_role(f) }.compact }
+    base = { 'id' => eid, 'kind' => kind, 'name' => title, 'source' => { 'elementId' => 'master', 'kind' => 'table' } }
+    el = nil
+
+    case kind
+    when 'kpi-chart'
+      # KPI + Gauge both surface a single value
+      vals = rol.('Values'); (next if vals.empty?)
+      c, cid = meas_col(vals[0], calc, master_cols, DMEL, M)
+      el = base.merge('columns' => [c.merge('name' => title)], 'value' => { 'columnId' => cid })
+    when 'bar-chart', 'line-chart', 'area-chart'
+      # funnel/treemap land here too: their dim is in Category/Groups, measure in Values/Sizes
+      dims = rol.('Category'); dims = rol.('Groups') if dims.empty?
+      vals = rol.('Values'); vals = rol.('Sizes') if vals.empty?
+      (next if dims.empty? || vals.empty?)
+      dc, did = dim_col(dims[0], calc, master_cols, DMEL, M); cols = [dc]; ycids = []
+      vals.each { |mv| c, id = meas_col(mv, calc, master_cols, DMEL, M); cols << c; ycids << id }
+      el = base.merge('columns' => cols, 'xAxis' => { 'columnId' => did }, 'yAxis' => { 'columnIds' => ycids })
+    when 'pie-chart', 'donut-chart'
+      dims = rol.('Category'); vals = rol.('Values'); (next if dims.empty? || vals.empty?)
+      dc, did = dim_col(dims[0], calc, master_cols, DMEL, M); mc2, mid = meas_col(vals[0], calc, master_cols, DMEL, M)
+      el = base.merge('columns' => [dc, mc2], 'color' => { 'id' => did }, 'value' => { 'id' => mid })
+    when 'combo-chart'
+      dims = rol.('Category'); bars = rol.('BarValues'); lines = rol.('LineValues')
+      (next if dims.empty? || (bars.empty? && lines.empty?))
+      dc, did = dim_col(dims[0], calc, master_cols, DMEL, M); cols = [dc]; ycids = []
+      bars.each  { |mv| c, id = meas_col(mv, calc, master_cols, DMEL, M); cols << c; ycids << id }
+      lines.each { |mv| c, id = meas_col(mv, calc, master_cols, DMEL, M); cols << c; ycids << { 'columnId' => id, 'type' => 'line' } }
+      el = base.merge('columns' => cols, 'xAxis' => { 'columnId' => did }, 'yAxis' => { 'columnIds' => ycids })
+    when 'scatter-chart'
+      xs = rol.('XAxis'); ys = rol.('YAxis'); cat = rol.('Category'); (next if xs.empty? || ys.empty?)
+      xc, xid = meas_col(xs[0], calc, master_cols, DMEL, M); yc, yid = meas_col(ys[0], calc, master_cols, DMEL, M)
+      el = base.merge('columns' => [xc, yc], 'xAxis' => { 'columnId' => xid }, 'yAxis' => { 'columnIds' => [yid] })
+      if cat.any?
+        dc, did = dim_col(cat[0], calc, master_cols, DMEL, M); el['columns'] << dc; el['color'] = { 'by' => 'category', 'column' => did }
+      end
+    when 'table'
+      dims = rol.('GroupBy'); vals = rol.('Values'); cols = []; gids = []; cids = []
+      dims.each { |d| c, id = dim_col(d, calc, master_cols, DMEL, M); cols << c; gids << id }
+      vals.each { |mv| c, id = meas_col(mv, calc, master_cols, DMEL, M); cols << c; cids << id }
+      (next if cols.empty?)
+      el = base.merge('columns' => cols)
+      el['groupings'] = [{ 'id' => nid('g'), 'groupBy' => gids, 'calculations' => cids }] unless gids.empty?
+    when 'pivot-table'
+      rows = rol.('Rows'); pcols = rol.('Columns'); vals = rol.('Values'); cols = []; rids = []; coids = []; vids = []
+      rows.each  { |d| c, id = dim_col(d, calc, master_cols, DMEL, M); cols << c; rids << id }
+      pcols.each { |d| c, id = dim_col(d, calc, master_cols, DMEL, M); cols << c; coids << id }
+      vals.each  { |mv| c, id = meas_col(mv, calc, master_cols, DMEL, M); cols << c; vids << id }
+      (next if rids.empty? || vids.empty?)
+      el = base.merge('columns' => cols, 'rowsBy' => rids.map { |i| { 'id' => i } }, 'values' => vids)
+      el['columnsBy'] = coids.map { |i| { 'id' => i } } unless coids.empty?
+    end
+    elements << el if el
+  end
+end
+
+# strip the private _window marker before emit
+master_cols.each_value { |c| c.delete('_window'); c.delete('description') if c['formula'] != 'Null' }
+
+master = { 'id' => 'master', 'name' => M, 'kind' => 'table', 'visibleAsSource' => false,
+           'source' => { 'dataModelId' => dm_id, 'elementId' => dm_el, 'kind' => 'data-model' },
+           'columns' => master_cols.values }
+
+# ---- apply surfaced dataset filter(s) (beads-sigma-23xu FilterOperation) ----
+# convert-model writes the QS predicate(s) to dm-filters.json. We translate a simple
+# {COL}='VALUE' equality predicate into a Sigma element-level list filter on the
+# master, so every downstream aggregate honors it. The filtered column is added to
+# the master if it isn't already projected.
+filters_path = opts[:filters] || File.join(File.dirname(File.expand_path(opts[:an])), 'dm-filters.json')
+applied_filters = []
+if File.exist?(filters_path)
+  fdata = JSON.parse(File.read(filters_path)) rescue {}
+  (fdata['filters'] || []).each do |pred|
+    m = pred.to_s.match(/\{([^}]+)\}\s*=\s*'([^']*)'/) || pred.to_s.match(/\{([^}]+)\}\s*=\s*"([^"]*)"/)
+    next unless m
+    raw_col = m[1].strip; val = m[2]
+    ref = master_ref(raw_col, calc, master_cols, DMEL)
+    # master_cols may have been re-read; ensure the col is on the master
+    unless master.fetch('columns').any? { |c| c['id'] == ref['id'] }
+      master['columns'] << master_cols[raw_col]
+    end
+    applied_filters << { 'id' => "flt-#{SecureRandom.hex(4)}", 'kind' => 'list',
+                         'columnId' => ref['id'], 'values' => [val] }
+  end
+  master['filters'] = applied_filters unless applied_filters.empty?
+end
+# refresh master columns (master_ref may have added the filter column)
+master['columns'] = master_cols.values
+
+spec = { 'name' => (an['Name'] || 'QuickSight Migration') + ' (from QuickSight)',
+         'schemaVersion' => 1,
+         'pages' => [{ 'id' => 'page-data', 'name' => 'Data', 'elements' => [master] },
+                     { 'id' => 'page-dash', 'name' => (an['Name'] || 'Dashboard'), 'elements' => elements }] }
+spec['folderId'] = opts[:folder] if opts[:folder]
+
+File.write(opts[:out], JSON.pretty_generate(spec))
+map_out = opts[:out].sub(/\.json$/, '') + '.map.json'
+File.write(map_out, JSON.pretty_generate('dashPageId' => 'page-dash', 'masterElementId' => 'master', 'visualToElement' => vis_map))
+STDERR.puts "workbook spec: master sources DM element \"#{DMEL}\" (#{dm_el}); #{elements.size} chart elements, #{master_cols.size} master cols#{applied_filters.empty? ? '' : "; #{applied_filters.size} filter(s) applied"} → #{opts[:out]} (+ #{map_out})"
+elements.each { |e| STDERR.puts "  - #{e['kind']}: #{e['name']}" }

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-spec.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-spec.rb
@@ -1,0 +1,149 @@
+#!/usr/bin/env ruby
+# Assemble a complete Sigma workbook spec from build-charts-from-signals
+# output + DM IDs + a master-columns config. Replaces the per-conversion
+# hand-written assemble-*.py one-offs that crept in during dashboard-mode
+# conversions.
+#
+# Usage:
+#   ruby scripts/build-workbook-spec.rb \
+#     --chart-specs /tmp/<name>/chart-specs.json    # build-charts-from-signals output
+#     --dm-ids      /tmp/<name>/dm-ids.json         # post-and-readback output for the DM
+#     --master-cols /tmp/<name>/master-columns.yaml # see schema below
+#     --workbook-name "<name>"
+#     --description "<one-liner>"
+#     --folder-id   <uuid>
+#     [--mode dashboard|page-per-worksheet]         # default: page-per-worksheet
+#     [--dm-element-name "Order Fact"]              # which DM element the master sources from (default: first non-Date)
+#     --out /tmp/<name>/wb-spec.json
+#
+# --master-cols schema (YAML):
+#   columns:
+#     - { id: m-order-id,      name: "Order Id",       formula: "[Order Fact/Order Id]" }
+#     - { id: m-order-date,    name: "Order Date",     formula: "[Order Fact/Order Date]" }
+#     - { id: m-gross-revenue, name: "Gross Revenue",  formula: "[Order Fact/Gross Revenue]" }
+#     ...
+#
+# Or omit --master-cols entirely: the script will auto-build a master that
+# passes through every column of the named DM element by name. Suitable for
+# small workbooks; for complex masters with renames or Lookup columns, supply
+# the YAML explicitly.
+
+require 'json'
+require 'yaml'
+require 'optparse'
+require 'net/http'
+require 'uri'
+require 'base64'
+
+opts = { mode: 'page-per-worksheet' }
+OptionParser.new do |p|
+  p.on('--chart-specs PATH')    { |v| opts[:specs] = v }
+  p.on('--dm-ids PATH')         { |v| opts[:dm_ids] = v }
+  p.on('--master-cols PATH')    { |v| opts[:master_cols] = v }
+  p.on('--workbook-name S')     { |v| opts[:name] = v }
+  p.on('--description S')       { |v| opts[:description] = v }
+  p.on('--folder-id S')         { |v| opts[:folder_id] = v }
+  p.on('--mode S')              { |v| opts[:mode] = v }
+  p.on('--dm-element-name S')   { |v| opts[:dm_el_name] = v }
+  p.on('--out PATH')            { |v| opts[:out] = v }
+end.parse!
+%i[specs dm_ids name folder_id out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+abort("--mode must be dashboard or page-per-worksheet") unless %w[dashboard page-per-worksheet].include?(opts[:mode])
+
+specs   = JSON.parse(File.read(opts[:specs]))
+dm_ids  = JSON.parse(File.read(opts[:dm_ids]))
+
+dm_id = dm_ids['dataModelId'] || abort('dm-ids.json missing dataModelId')
+
+# Find the DM element to source the master from. Default heuristic: pick the
+# first element whose name doesn't start with a dimension-table prefix
+# (Date Dim / Customer Dim / etc.). User can override via --dm-element-name.
+dm_elements = (dm_ids['pages'] || []).flat_map { |p| p['elements'] || [] }
+abort('no elements in dm-ids') if dm_elements.empty?
+target = if opts[:dm_el_name]
+           dm_elements.find { |e| e['name'] == opts[:dm_el_name] } ||
+             abort("no DM element named #{opts[:dm_el_name].inspect}")
+         else
+           # First non-dim-suffixed element, fallback to first
+           dm_elements.find { |e| !(e['name'] || '').end_with?(' Dim') } || dm_elements.first
+         end
+dm_el_id   = target['id']
+dm_el_name = target['name']
+
+# Master columns: either explicit from --master-cols or auto-passthrough from the DM element
+master_columns =
+  if opts[:master_cols]
+    cfg = YAML.safe_load(File.read(opts[:master_cols]))
+    cfg['columns'] || abort('master-cols YAML missing `columns:` key')
+  else
+    # Auto: pull the DM element's column DDL via REST (limited fields — name only)
+    # Sigma.request handles initial token fetch + 401-retry-with-refresh.
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    spec = Sigma.request(:get, "/v2/dataModels/#{dm_id}/spec")
+    el = spec['pages'].flat_map { |p| p['elements'] }.find { |e| e['id'] == dm_el_id }
+    abort("DM element #{dm_el_id} not found in spec") unless el
+    (el['columns'] || []).map do |c|
+      nm = c['name'] || (c['formula'].to_s.match(/^\[[^\/]+\/([^\]]+)\]$/) || [nil, c['id']])[1]
+      slug = nm.to_s.downcase.gsub(/\W+/, '-').sub(/-$/, '')
+      { 'id' => "m-#{slug}", 'name' => nm, 'formula' => "[#{dm_el_name}/#{nm}]" }
+    end
+  end
+abort('no master columns to emit') if master_columns.empty?
+
+# Build the data page
+data_page = {
+  'id'   => 'page-data',
+  'name' => 'Data',
+  'elements' => [{
+    'id'   => 'master',
+    'kind' => 'table',
+    'name' => 'Master',
+    'visibleAsSource' => false,
+    'source' => { 'kind' => 'data-model', 'dataModelId' => dm_id, 'elementId' => dm_el_id },
+    'columns' => master_columns,
+    'order'   => master_columns.map { |c| c['id'] }
+  }]
+}
+
+# Build the visible pages from chart-specs.json
+# Two shapes:
+#  - dashboard mode: chart-specs.json is a flat array → one page with all elements
+#  - page-per-worksheet: chart-specs.json is { pages: [{name, elements}, ...] }
+visible_pages = []
+if specs.is_a?(Hash) && specs['pages']
+  specs['pages'].each do |p|
+    slug = p['name'].to_s.downcase
+    %w[ / ( ) %].each { |ch| slug = slug.tr(ch, '-') }
+    slug = slug.tr(' ', '-').gsub(/-+/, '-').sub(/^-/, '').sub(/-$/, '')[0..40]
+    visible_pages << {
+      'id'       => "page-#{slug}",
+      'name'     => p['name'],
+      'elements' => p['elements']
+    }
+  end
+elsif specs.is_a?(Array)
+  # Dashboard mode → single visible page
+  visible_pages << {
+    'id'       => 'page-overview',
+    'name'     => opts[:name] && opts[:mode] == 'dashboard' ? opts[:name].sub(/\(.*\)$/, '').strip : 'Overview',
+    'elements' => specs
+  }
+else
+  abort('chart-specs.json must be either { pages: [...] } or [ ... ]')
+end
+
+wb = {
+  'name'          => opts[:name],
+  'schemaVersion' => 1,
+  'folderId'      => opts[:folder_id],
+  'pages'         => [data_page] + visible_pages
+}
+wb['description'] = opts[:description] if opts[:description]
+
+File.write(opts[:out], JSON.pretty_generate(wb))
+warn "wrote #{opts[:out]}"
+warn "  mode: #{opts[:mode]}"
+warn "  Data page: master sourced from '#{dm_el_name}' (#{dm_el_id})  #{master_columns.size} columns"
+warn "  visible pages: #{visible_pages.size}"
+visible_pages.each { |p| warn "    - #{p['name']}: #{p['elements'].size} elements" }

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,0 +1,142 @@
+#!/usr/bin/env ruby
+# Delete orphan Sigma workbooks left behind by spec-iteration retries during
+# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
+# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
+# and deletes everything older via DELETE /v2/files/{id} (per
+# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+#
+# See beads-sigma-38a for the regression motivating this script: a customer
+# migration on 2026-05-28 created three workbooks (one final + two orphans
+# from iterative POSTs) and the agent declared done without cleaning up.
+#
+# Usage:
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
+#     [--dry-run]               # report what would be deleted; don't call DELETE
+#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
+#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
+#                                 silently anyway; this flag is just for clarity)
+#
+# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
+# assert-phase6-ran.rb can confirm cleanup ran.
+#
+# Exit codes:
+#   0  cleanup ran (or no cleanup needed — single workbook in log)
+#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
+#   2  setup error (missing env, bad args)
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'time'
+require 'optparse'
+
+opts = { dry_run: false }
+OptionParser.new do |p|
+  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
+  p.on('--dry-run')        { opts[:dry_run] = true }
+  p.on('--keep ID')        { |v| opts[:keep] = v }
+  p.on('--allow-empty-log') { opts[:allow_empty] = true }
+end.parse!
+abort('--workdir required') unless opts[:workdir]
+
+log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+unless File.exist?(log)
+  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+  exit 0
+end
+
+ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+if ids.empty?
+  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
+  exit 0
+end
+
+# Keep target: --keep override, otherwise the most-recent (last appended) entry.
+keep_id = opts[:keep] || ids.last['id']
+to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
+
+if to_delete.empty?
+  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+  marker = {
+    'ran_at'  => Time.now.utc.iso8601,
+    'kept'    => keep_id,
+    'deleted' => [],
+    'dry_run' => opts[:dry_run]
+  }
+  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
+  exit 0
+end
+
+base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+def http_delete(base, tok, path)
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{base}#{path}")
+    req = Net::HTTP::Delete.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept']        = 'application/json'
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
+end
+
+puts "Keeping:  #{keep_id}"
+puts "Orphans:  #{to_delete.length}"
+to_delete.each { |id| puts "          - #{id}" }
+puts ''
+
+if opts[:dry_run]
+  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
+  marker = {
+    'ran_at'  => Time.now.utc.iso8601,
+    'kept'    => keep_id,
+    'deleted' => [],
+    'would_delete' => to_delete,
+    'dry_run' => true
+  }
+  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
+  exit 0
+end
+
+deleted = []
+failed  = []
+to_delete.each do |id|
+  r = http_delete(base, nil, "/v2/files/#{id}")
+  code = r.code.to_i
+  if code.between?(200, 299) || code == 404
+    # 404 = already gone; treat as success for idempotency
+    puts "  [deleted] #{id} (HTTP #{code})"
+    deleted << { 'id' => id, 'status' => code }
+  else
+    body = r.body.to_s[0..200]
+    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
+    failed << { 'id' => id, 'status' => code, 'body' => body }
+  end
+end
+
+marker = {
+  'ran_at'  => Time.now.utc.iso8601,
+  'kept'    => keep_id,
+  'deleted' => deleted,
+  'failed'  => failed,
+  'dry_run' => false
+}
+File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
+
+if failed.any?
+  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
+  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
+  warn "delete them manually via the Sigma UI before declaring done."
+  exit 1
+end
+
+puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
+exit 0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
@@ -1,0 +1,397 @@
+#!/usr/bin/env ruby
+# convert-model.rb — quicksight-to-sigma "convert" phase helper.
+#
+# MODE A (--emit-mcp): print the exact convert_quicksight_to_sigma MCP-tool call the agent
+#                      should run (files = analysis.json + each dataset json from discovery).
+# MODE B (--fixup):    take the converter's output Sigma DM JSON and make it POST-ready:
+#                        - force schemaVersion = 1
+#                        - ensure EVERY element has a non-empty, paren-free `name`
+#                          (beads-sigma-vy4k: nameless elements; beads-sigma-nc6g: join-view
+#                           and warehouse-table elements also need names)
+#                        - rewrite kind:sql refs to [Custom SQL/RAW] form
+#                        - rewrite kind:table (join "view") refs so the leading segment is the
+#                          SOURCE ELEMENT's display name (beads-sigma-nc6g)
+#                        - synthesize a single denormalized kind:sql element for CustomSql
+#                          multi-table JoinInstruction datasets (beads-sigma-nc6g)
+#                        - fix CastColumnType self-reference (Text([self]) -> Text([Custom SQL/RAW]))
+#                          (beads-sigma-23xu)
+#                        - neutralize window/table-calc placeholder formulas to `Null` + description
+#                          (beads-sigma-woaa)
+#                        - drop unapplied FilterOperation boolean calc columns from the DM and
+#                          surface the filter so the workbook builder can apply it (beads-sigma-23xu)
+#                        - optionally inject folderId
+#
+# Usage:
+#   ruby scripts/convert-model.rb --emit-mcp --discover-dir DIR --connection-id ID [--database DB --schema SCH]
+#   ruby scripts/convert-model.rb --fixup --in converter-out.json --discover-dir DIR [--folder-id ID] --out dm-spec.json
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |o|
+  o.on('--emit-mcp') { opts[:emit] = true }
+  o.on('--fixup') { opts[:fixup] = true }
+  o.on('--in F') { |v| opts[:in] = v }
+  o.on('--out F') { |v| opts[:out] = v }
+  o.on('--discover-dir D') { |v| opts[:dir] = File.expand_path(v) }
+  o.on('--connection-id ID') { |v| opts[:conn] = v }
+  o.on('--database DB') { |v| opts[:db] = v }
+  o.on('--schema SCH') { |v| opts[:schema] = v }
+  o.on('--folder-id ID') { |v| opts[:folder] = v }
+end.parse!
+
+def titleize(s)
+  s.to_s.gsub(/[_.]/, ' ').split.map { |w| w[0..0].upcase + w[1..-1].to_s.downcase }.join(' ')
+end
+
+# Strip parentheses (and their contents) and other ref-breaking chars out of an
+# element/column name. The converter sometimes emits cross-relation columns like
+# "Region (CUSTOMER_DIM)" — the parens collide with Sigma's function-call syntax
+# inside [..] refs, so a downstream [El/Region (CUSTOMER_DIM)] ref never resolves.
+# (beads-sigma-nc6g point 3)
+def sanitize_name(s)
+  s.to_s.gsub(/\s*\([^)]*\)/, '').gsub(/[()\[\]]/, '').strip
+end
+
+# QuickSight window / table-calc function names. A DM/workbook calc column that
+# uses any of these silently errors in Sigma (window aggregates aren't allowed in
+# a calc-column context), so we neutralize them to a valid `Null` formula and move
+# the original QS expression into the column description. (beads-sigma-woaa)
+QS_WINDOW_FUNCS = %w[
+  runningSum runningAvg runningCount runningMax runningMin
+  percentOfTotal percentDifference difference
+  rank denseRank percentileRank
+  lag lead firstValue lastValue
+  windowSum windowAvg windowCount windowMax windowMin
+  movingSum movingAverage
+].freeze
+
+def qs_window_func?(expr)
+  e = expr.to_s
+  QS_WINDOW_FUNCS.any? { |fn| e =~ /(?<![A-Za-z0-9_])#{Regexp.escape(fn)}\s*\(/ }
+end
+
+# True when a formula is ONLY a /* ... */ comment (the converter's window
+# placeholder). Sigma rejects a comment-only formula as "Invalid formula", which
+# fails the WHOLE all-or-nothing DM POST. (beads-sigma-woaa)
+def comment_only_formula?(f)
+  f.to_s.strip =~ /\A\/\*.*\*\/\z/m ? true : false
+end
+
+# Recover the original QS expression embedded in a placeholder comment, e.g.
+# "/* TODO QuickSight table-calc — re-author in Sigma: runningSum(...) */".
+def expr_from_comment(f)
+  m = f.to_s.match(/re-author in Sigma:\s*(.*?)\s*\*\/\s*\z/m)
+  m ? m[1] : f.to_s.gsub(%r{\A/\*\s*}, '').gsub(%r{\s*\*/\z}, '').strip
+end
+
+# Reconstruct a single denormalized SELECT for a QuickSight dataset whose
+# LogicalTableMap contains one or more JoinInstructions, so that a CustomSql
+# multi-table dataset (which the converter splits into N separate kind:sql
+# elements with no join) collapses to ONE kind:sql element that contains every
+# OutputColumn the visuals reference. (beads-sigma-nc6g — CustomSql-join path)
+# Returns the SQL string, or nil if the dataset isn't a join.
+def synth_join_sql(ds)
+  ltm = ds['LogicalTableMap'] || {}
+  ptm = ds['PhysicalTableMap'] || {}
+  return nil unless ltm.values.any? { |v| v.dig('Source', 'JoinInstruction') }
+
+  frag = {}      # logicalId -> "(...)" or "DB.SCH.TBL"
+  colmap = {}    # logicalId -> { logicalColName => physicalColName }
+  ltm.each do |lid, lt|
+    src = lt['Source'] || {}
+    pid = src['PhysicalTableId']
+    next unless pid
+    phys = ptm[pid] || {}
+    cmap = {}
+    if (cs = phys['CustomSql'])
+      frag[lid] = "(#{cs['SqlQuery'].to_s.strip})"
+      (cs['Columns'] || []).each { |c| cmap[c['Name']] = c['Name'] }
+    elsif (rt = phys['RelationalTable'])
+      parts = [rt['Catalog'], rt['Schema'], rt['Name']].compact.reject(&:empty?)
+      frag[lid] = parts.join('.')
+      (rt['InputColumns'] || []).each { |c| cmap[c['Name']] = c['Name'] }
+    end
+    (lt['DataTransforms'] || []).each do |t|
+      if (ro = t['RenameColumnOperation'])
+        old = ro['ColumnName']; nw = ro['NewColumnName']
+        cmap[nw] = cmap.delete(old) || old
+      end
+    end
+    colmap[lid] = cmap
+  end
+
+  # SQL-safe table aliases (logical ids may contain hyphens, e.g. "orders-log")
+  sa = {}
+  ltm.each_key { |lid| sa[lid] = lid.to_s.gsub(/[^A-Za-z0-9_]/, "_") }
+  joins = ltm.select { |_, v| v.dig("Source", "JoinInstruction") }
+  referenced = joins.values.flat_map { |v| ji = v['Source']['JoinInstruction']; [ji['LeftOperand'], ji['RightOperand']] }
+  root_id = joins.keys.find { |jid| !referenced.include?(jid) } || joins.keys.first
+
+  emitted = {}
+  from_sql = +''
+  walk = lambda do |jid|
+    ji = ltm[jid]['Source']['JoinInstruction']
+    jt = (ji['Type'] || 'INNER').upcase
+    left = ji['LeftOperand']; right = ji['RightOperand']
+    if joins.key?(left)
+      walk.call(left)
+    elsif !emitted[left]
+      from_sql << "#{frag[left]} #{sa[left]}"
+      emitted[left] = true
+    end
+    if joins.key?(right)
+      walk.call(right)
+    elsif !emitted[right]
+      on = ji['OnClause'].to_s
+      on_sql = on.gsub(/\{([^}]+)\}/) do
+        col = Regexp.last_match(1).strip
+        owner = ([left, right] + emitted.keys).uniq.find { |lid| (colmap[lid] || {}).key?(col) }
+        phys = owner ? colmap[owner][col] : col
+        owner ? "#{sa[owner]}.#{phys}" : col
+      end
+      from_sql << " #{jt} JOIN #{frag[right]} #{sa[right]} ON #{on_sql}"
+      emitted[right] = true
+    end
+  end
+  walk.call(root_id)
+
+  sels = (ds['OutputColumns'] || []).map do |oc|
+    lid, _ = oc['Id'].to_s.split('.', 2)
+    pcol = (colmap[lid] || {})[oc['Name']] || oc['Name']
+    "#{sa[lid]}.#{pcol} AS #{oc['Name']}"
+  end
+  return nil if sels.empty? || from_sql.empty?
+  "SELECT #{sels.join(', ')} FROM #{from_sql}"
+end
+
+dir = opts[:dir]
+sig_path = dir && File.join(dir, 'signals.json')
+signals = (sig_path && File.exist?(sig_path)) ? JSON.parse(File.read(sig_path)) : nil
+
+if opts[:emit]
+  abort 'need --discover-dir' unless dir
+  files = [File.join(dir, 'analysis.json')] + Dir[File.join(dir, 'datasets', '*.json')].sort
+  puts 'Call the MCP tool `convert_quicksight_to_sigma` with:'
+  puts '  files: [ {name, content} for each ]'
+  files.each { |f| puts "    - #{f}" }
+  puts "  connection_id: #{opts[:conn] || '<SIGMA_CONNECTION_ID>'}"
+  puts "  database: #{opts[:db] || '(override if dataset path is incomplete)'}"
+  puts "  schema:   #{opts[:schema] || '(override if dataset path is incomplete)'}"
+  puts
+  puts "Save the returned model, then: ruby scripts/convert-model.rb --fixup --in <model>.json --discover-dir #{dir} --out dm-spec.json"
+  exit 0
+end
+
+if opts[:fixup]
+  abort 'need --in' unless opts[:in]
+  model = JSON.parse(File.read(opts[:in]))
+  model = model['model'] if model.is_a?(Hash) && model['model']
+  model['schemaVersion'] = 1
+  ds_names = signals ? signals['datasets'].map { |d| d['name'] }.compact : []
+
+  ds_jsons = []
+  if dir
+    Dir[File.join(dir, 'datasets', '*.json')].sort.each do |f|
+      j = JSON.parse(File.read(f)) rescue nil
+      ds = j && (j['DataSet'] || j)
+      ds_jsons << ds if ds.is_a?(Hash) && ds['LogicalTableMap']
+    end
+  end
+  # Any dataset with a JoinInstruction (CustomSql OR RelationalTable physical
+  # tables). The converter mishandles BOTH shapes: CustomSql joins are split into
+  # N nameless kind:sql elements with no join at all; RelationalTable joins get a
+  # fragile relationship "view" element that under-projects dimension columns and
+  # drops the 2nd join hop on a chained 3-way join. We replace both with a single
+  # denormalized kind:sql element built straight from the QS join tree, so the
+  # workbook master sources every charted column from one element. (beads-sigma-nc6g)
+  join_dataset = ds_jsons.find do |ds|
+    (ds['LogicalTableMap'] || {}).values.any? { |v| v.dig('Source', 'JoinInstruction') }
+  end
+
+  fixed = 0
+  rewrote = 0
+  neutralized = 0
+  filter_exprs = []
+
+  if join_dataset
+    join_sql = synth_join_sql(join_dataset)
+    if join_sql
+      conn = nil
+      (model['pages'] || []).each do |pg|
+        (pg['elements'] || []).each { |el| conn ||= el.dig('source', 'connectionId') }
+      end
+      out_cols = (join_dataset['OutputColumns'] || []).map do |oc|
+        nm = sanitize_name(titleize(oc['Name']))
+        { 'id' => "Custom SQL/#{oc['Name']}", 'name' => nm, 'formula' => "[Custom SQL/#{oc['Name']}]" }
+      end
+      # physical table names participating in this join (to identify which
+      # warehouse-table elements to remove when collapsing to the SQL element)
+      join_tables = (join_dataset['PhysicalTableMap'] || {}).values.map do |p|
+        (p.dig('RelationalTable', 'Name'))
+      end.compact
+      join_el = {
+        'id' => "join-#{join_dataset['DataSetId'] || 'view'}".gsub(/[^A-Za-z0-9_-]/, ''),
+        'kind' => 'table',
+        'name' => sanitize_name(join_dataset['Name'] || ds_names[0] || 'Join View'),
+        'source' => { 'connectionId' => conn, 'kind' => 'sql', 'statement' => join_sql },
+        'columns' => out_cols,
+        'order' => out_cols.map { |c| c['id'] }
+      }
+      (model['pages'] || []).each do |pg|
+        kept = (pg['elements'] || []).reject do |el|
+          srck = el.dig('source', 'kind')
+          srck == 'sql' || srck == 'table' ||
+            (srck == 'warehouse-table' && join_tables.include?((el.dig('source', 'path') || []).last))
+        end
+        pg['elements'] = kept + [join_el]
+      end
+      STDERR.puts "fixup: synthesized join element \"#{join_el['name']}\" with #{out_cols.size} cols (collapsed #{join_tables.size} joined table(s))"
+      fixed += 1
+    end
+  end
+
+  all_els = (model['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+
+  all_els.each_with_index do |el, i|
+    src = el['source'] || {}
+    if el['name'].nil? || el['name'].to_s.empty?
+      el['name'] =
+        if src['kind'] == 'warehouse-table' && src['path'].is_a?(Array) && !src['path'].empty?
+          titleize(src['path'].last)
+        elsif src['kind'] == 'table'
+          'Join View'
+        elsif ds_names[i]
+          ds_names[i]
+        elsif ds_names.length == 1
+          ds_names[0]
+        else
+          "Query #{i + 1}"
+        end
+      fixed += 1
+    end
+    el['name'] = sanitize_name(el['name'])
+  end
+
+  id_to_name = {}
+  table_to_name = {}
+  all_els.each do |el|
+    id_to_name[el['id']] = el['name']
+    src = el['source'] || {}
+    if src['kind'] == 'warehouse-table' && src['path'].is_a?(Array) && !src['path'].empty?
+      table_to_name[src['path'].last] = el['name']
+    end
+  end
+
+  all_els.each do |el|
+    next unless el.dig('source', 'kind') == 'table'
+    next unless el['name'] == 'Join View'
+    srcnm = id_to_name[el.dig('source', 'elementId')]
+    el['name'] = sanitize_name("#{srcnm} View") if srcnm
+    id_to_name[el['id']] = el['name']
+  end
+
+  all_els.each do |el|
+    src = el['source'] || {}
+    cols = el['columns'] || []
+
+    cols.each do |c|
+      if c['name'].nil? || c['name'].to_s.empty?
+        alias_raw = c['id'].to_s.split('/').last
+        c['name'] = titleize(alias_raw) unless alias_raw.nil? || alias_raw.empty?
+      end
+      c['name'] = sanitize_name(c['name']) if c['name']
+    end
+
+    cols.each do |c|
+      f = c['formula'].to_s
+      orig = nil
+      if comment_only_formula?(f)
+        orig = expr_from_comment(f)
+      elsif qs_window_func?(f)
+        orig = f
+      end
+      next unless orig
+      c['formula'] = 'Null'
+      existing = c['description'].to_s
+      note = "QuickSight table-calc (neutralized — re-author in Sigma): #{orig}"
+      c['description'] = existing.empty? ? note : "#{existing}\n#{note}"
+      neutralized += 1
+    end
+
+    if src['kind'] == 'sql'
+      disp_to_alias = {}
+      cols.each do |c|
+        alias_raw = c['id'].to_s.split('/').last
+        next if alias_raw.nil? || alias_raw.empty?
+        disp_to_alias[titleize(alias_raw)] = alias_raw
+        disp_to_alias[sanitize_name(titleize(alias_raw))] = alias_raw
+        f = c['formula'].to_s
+        m = f.match(/\A\[(.+)\]\z/)
+        disp_to_alias[m[1]] = alias_raw if m
+      end
+      cols.each do |c|
+        next unless c['formula']
+        next if c['formula'] == 'Null'
+        new_f = c['formula'].gsub(/\[([^\]\/]+)\]/) do
+          inner = Regexp.last_match(1)
+          disp_to_alias[inner] ? "[Custom SQL/#{disp_to_alias[inner]}]" : "[#{inner}]"
+        end
+        if new_f != c['formula']
+          c['formula'] = new_f
+          rewrote += 1
+        end
+      end
+
+    elsif src['kind'] == 'table'
+      src_name = id_to_name[src['elementId']]
+      cols.each do |c|
+        next unless c['formula']
+        next if c['formula'] == 'Null'
+        new_f = c['formula'].gsub(/\[([^\]]+)\]/) do
+          ref = Regexp.last_match(1)
+          parts = ref.split('/')
+          if table_to_name.key?(parts[0])
+            parts[0] = table_to_name[parts[0]]
+          elsif src_name
+            parts[0] = src_name
+          end
+          "[#{parts.join('/')}]"
+        end
+        if new_f != c['formula']
+          c['formula'] = new_f
+          rewrote += 1
+        end
+      end
+    end
+
+    before = cols.size
+    keep = cols.reject do |c|
+      m = c['name'].to_s.match(/\AFilter:\s*(.+)\z/)
+      if m
+        filter_exprs << m[1].strip
+        true
+      else
+        false
+      end
+    end
+    if keep.size != before
+      el['columns'] = keep
+      el['order'] = (el['order'] || []).select { |oid| keep.any? { |c| c['id'] == oid } } if el['order']
+    end
+  end
+
+  model['folderId'] = opts[:folder] if opts[:folder]
+
+  if dir && !filter_exprs.empty?
+    File.write(File.join(dir, 'dm-filters.json'), JSON.pretty_generate('filters' => filter_exprs.uniq))
+    STDERR.puts "fixup: surfaced #{filter_exprs.uniq.size} dataset filter(s) -> dm-filters.json (#{filter_exprs.uniq.join('; ')})"
+  end
+
+  out = opts[:out] || 'dm-spec.json'
+  File.write(out, JSON.pretty_generate(model))
+  STDERR.puts "fixup: named #{fixed} element(s); rewrote #{rewrote} ref(s); neutralized #{neutralized} window calc(s); schemaVersion=1#{opts[:folder] ? '; folderId set' : ''} -> #{out}"
+  exit 0
+end
+
+abort 'specify --emit-mcp or --fixup'

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/find-or-pick-dm.rb
@@ -1,0 +1,342 @@
+#!/usr/bin/env ruby
+# Phase 1.5 — Reuse existing Sigma data models when one already covers the
+# Tableau workbook's needs. Goals:
+#   1. Avoid DM sprawl: don't add a 4th "Orders" DM when the customer already
+#      has three that all point at the same warehouse table.
+#   2. Performance: skip Phase 2 (warehouse column discovery) and Phase 3
+#      (DM build + POST + validate) when reusing — often 2-3 min savings.
+#
+# This script DOES NOT mutate any DM. It only scores existing DMs against the
+# Tableau workbook signature and recommends a candidate (with a warning about
+# inherited columns / RLS / metrics). The downstream phase decides whether to
+# reuse or create new.
+#
+# Usage:
+#   ruby scripts/find-or-pick-dm.rb \
+#     --workbook-signature /tmp/<name>/workbook-signature.json \
+#     --out /tmp/<name>/dm-match.json \
+#     [--limit 200]                    # max DMs to scan
+#     [--min-score 0.6]                # below: no recommendation, build new
+#     [--force-new]                    # always recommend new (skip scan)
+#
+# Input signature shape (produced by Phase 1 + 2.5 — adjust paths as needed):
+#   {
+#     "tableau_workbook":   "Monthly Revenue",
+#     "warehouse_tables":   ["CSA.ORDER_FACT"],          # FQN list
+#     "referenced_columns": ["ORDER_DATE","GROSS_REVENUE","REGION","STATE"],
+#     "measures":           [{"col":"GROSS_REVENUE","derivation":"Sum"}, ...]
+#   }
+#
+# Output: dm-match.json with shape documented in SKILL.md Phase 1.5.
+# Exit: 0 if any candidate ≥ --min-score, 1 if none (caller can choose to
+# build new). Never aborts on missing inputs — always emits a result file so
+# the agent can decide.
+
+require 'json'
+require 'yaml'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
+# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
+# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
+# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
+# picker run with no score regression. beads-sigma-3kw.
+opts = { limit: 25, min_score: 0.6 }
+OptionParser.new do |p|
+  p.on('--workbook-signature P') { |v| opts[:sig]      = v }
+  p.on('--out P')                { |v| opts[:out]      = v }
+  p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
+  p.on('--force-new')            { |_| opts[:force_new]= true }
+  p.on('--auto-pick',
+       'Auto-recommend without UX prompt when top score >= --auto-pick-threshold AND no other candidate within --auto-pick-tie-window of it. Sets `auto_picked: true` on the result so the caller can WARN about inherited columns.') { |_| opts[:auto_pick] = true }
+  p.on('--auto-pick-threshold F', Float, 'Min score for auto-pick (default 0.55).')                  { |v| opts[:auto_pick_threshold] = v }
+  p.on('--auto-pick-tie-window F', Float, 'Gap from top score within which other candidates count as a tie that disables auto-pick (default 0.05).') { |v| opts[:auto_pick_tie_window] = v }
+end.parse!
+%i[sig out].each { |k| abort "missing --#{k}" unless opts[k] }
+
+BASE = ENV.fetch('SIGMA_BASE_URL')
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+# DM-shortlisting scans many candidates and is called per-follower in cluster
+# orchestration — auto-refresh on 401 to survive long batch runs.
+def http_get(path)
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{BASE}#{path}")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept'] = 'application/json'
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
+end
+
+sig = JSON.parse(File.read(opts[:sig]))
+warn "workbook: #{sig['tableau_workbook'] || '(unnamed)'}"
+warn "  warehouse_tables:   #{sig['warehouse_tables']&.size || 0}"
+warn "  referenced_columns: #{sig['referenced_columns']&.size || 0}"
+
+# Force-new short-circuit: emit a no-match result and exit 1.
+if opts[:force_new]
+  File.write(opts[:out], JSON.pretty_generate({
+    'recommended_dm_id' => nil,
+    'score' => 0.0,
+    'rationale' => '--force-new: bypassed DM-reuse scan',
+    'candidates' => []
+  }))
+  warn "force-new mode — wrote empty match"
+  exit 1
+end
+
+# 1. List ALL data models, then sort deterministically before applying --limit.
+# Sigma's /v2/dataModels list endpoint returns server page-order, not
+# relevance order. Without a stable client-side sort, the same workbook
+# picks different candidates on different runs (observed: 3 conversions of
+# the same Tableau workbook reached 3 different recommendations). Fix:
+# fetch all DMs (cheap — one list call per 100), sort by updatedAt desc
+# (recent DMs are usually more relevant), then take the first --limit for
+# parallel spec-fetch + scoring. Stable tiebreaker by name. beads-sigma-3kw.
+all_dms = []
+page = nil
+hard_cap = 500
+loop do
+  qs = "limit=100"
+  qs += "&page=#{page}" if page
+  r = http_get("/v2/dataModels?#{qs}")
+  break unless r.code.to_i == 200
+  data = JSON.parse(r.body)
+  rows = data['entries'] || data['dataModels'] || []
+  break if rows.empty?
+  all_dms.concat(rows)
+  break if all_dms.size >= hard_cap
+  page = data['nextPage']
+  break if page.nil? || page.empty?
+end
+
+# Deterministic ranking: updatedAt desc, then name asc.
+all_dms = all_dms.sort_by do |dm|
+  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+end
+require 'time'   # ensure Time.parse loaded (rescue covers if not)
+
+warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+
+# 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
+def normalize_fqn(s)
+  return nil if s.nil? || s.empty?
+  parts = s.to_s.split('.').reject(&:empty?).map(&:upcase)
+  parts.join('.')
+end
+
+def normalize_col(s)
+  s.to_s.upcase.gsub(/[^A-Z0-9]/, '')
+end
+
+# Fetch all DM specs in parallel (10 threads). Some DMs return non-200
+# (archived, permission-restricted, broken refs) — log and continue. Single
+# transient 5xx errors are retried once.
+dm_specs = {}
+dm_failures = []
+require 'thread'
+mu = Mutex.new
+queue = Queue.new
+all_dms.take(opts[:limit]).each { |dm| queue << dm }
+threads = 5.times.map do
+  Thread.new do
+    until queue.empty?
+      dm = queue.pop(true) rescue nil
+      break unless dm
+      dm_id = dm['dataModelId'] || dm['id']
+      next unless dm_id
+      r = nil
+      # Retry on 429 (Cloudflare burst limit) with exponential backoff. The
+      # /v2/dataModels endpoint commonly 429s at >5 concurrent across
+      # tj-wells-1989 — see beads-sigma-cn5.
+      4.times do |attempt|
+        r = http_get("/v2/dataModels/#{dm_id}/spec")
+        code = r.code.to_i
+        break if code == 200 || (code != 429 && code < 500)
+        sleep (0.5 * (2 ** attempt))  # 0.5s, 1s, 2s, 4s
+      end
+      if r.code.to_i != 200
+        mu.synchronize { dm_failures << { name: dm['name'], id: dm_id, code: r.code, body_head: r.body[0..80] } }
+        next
+      end
+      spec = begin
+        JSON.parse(r.body)
+      rescue JSON::ParserError
+        YAML.safe_load(r.body, permitted_classes: [Date, Time])
+      end
+      mu.synchronize { dm_specs[dm_id] = spec }
+    end
+  end
+end
+threads.each(&:join)
+warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
+dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
+
+dm_signatures = []
+all_dms.take(opts[:limit]).each do |dm|
+  dm_id = dm['dataModelId'] || dm['id']
+  spec = dm_specs[dm_id]
+  next unless spec
+
+  tables = []
+  columns = []
+  metrics = []
+  column_captions = {}  # normalized → original, so output can be human-readable
+
+  # Walk every element. Sigma DM specs nest elements under pages[*].elements
+  # (NOT top-level `elements` — that's a workbook-only convention). Fall back
+  # to top-level for robustness in case schema changes.
+  all_elements = spec['elements'] || (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  all_elements.each do |el|
+    src = el['source'] || {}
+    case src['kind']
+    when 'warehouse-table', 'table'
+      # source like { kind: warehouse-table, connectionId, path: "DB.SCHEMA.TABLE" }
+      fqn = src['path'] || [src['database'], src['schema'], src['name']].compact.join('.')
+      tables << normalize_fqn(fqn) if fqn && !fqn.empty?
+    when 'sql'
+      # Custom SQL — surface a sentinel so the agent knows; not directly comparable
+      tables << 'CUSTOM_SQL'
+    end
+    (el['columns'] || []).each do |c|
+      colname = c['name'] || (c['formula'].to_s.match(/\[.*?([^\/\]]+)\]/) || [])[1]
+      if colname && !colname.empty?
+        norm = normalize_col(colname)
+        columns << norm
+        column_captions[norm] ||= colname
+      end
+    end
+    (el['metrics'] || []).each do |m|
+      metrics << "#{m['name']}/#{m['aggregation'] || m['derivation']}"
+    end
+  end
+
+  dm_signatures << {
+    dm_id: dm_id,
+    dm_name: dm['name'],
+    tables: tables.uniq.compact,
+    columns: columns.uniq.compact,
+    column_captions: column_captions,
+    metrics: metrics.uniq.compact,
+    raw_element_count: all_elements.size
+  }
+end
+
+# 3. Score each DM.
+tableau_tables  = (sig['warehouse_tables']   || []).map { |t| normalize_fqn(t) }.compact
+# Keep both forms: normalized for matching, original for human-readable output.
+tableau_columns_orig = (sig['referenced_columns'] || [])
+tableau_columns      = tableau_columns_orig.map { |c| normalize_col(c) }
+tableau_col_caption  = tableau_columns.zip(tableau_columns_orig).to_h
+tableau_measure_keys = (sig['measures'] || []).map { |m| "#{normalize_col(m['col'])}/#{m['derivation']}" }
+
+candidates = dm_signatures.map do |dm|
+  # Table match: 1.0 if Tableau tables ⊆ DM tables. 0.5 if partial. 0 if disjoint.
+  shared_tables = (tableau_tables & dm[:tables])
+  table_match =
+    if tableau_tables.empty?
+      0.0
+    elsif shared_tables.size == tableau_tables.size
+      1.0
+    elsif shared_tables.any?
+      0.5 + 0.5 * (shared_tables.size.to_f / tableau_tables.size)
+    else
+      0.0
+    end
+
+  # Column match: % of Tableau-referenced columns present in DM.
+  shared_cols = (tableau_columns & dm[:columns])
+  col_match =
+    tableau_columns.empty? ? 0.0 : shared_cols.size.to_f / tableau_columns.size
+
+  # Metric overlap (small weight).
+  shared_metrics = (tableau_measure_keys & dm[:metrics])
+  metric_match =
+    tableau_measure_keys.empty? ? 0.0 : shared_metrics.size.to_f / tableau_measure_keys.size
+
+  # Weighting rationale: column overlap is the most reliable signal —
+  # a DM's source table FQN can vary (raw warehouse table vs view vs joined
+  # element) but the column set must be a superset of what the workbook
+  # references for reuse to be safe. Table-match is a soft tiebreaker.
+  score = 0.2 * table_match + 0.7 * col_match + 0.1 * metric_match
+
+  # Extras the workbook would inherit. Surface original captions (not the
+  # normalized form) so the user-facing report is readable.
+  extra_cols_norm = dm[:columns] - tableau_columns
+  caption_of = ->(norm) { dm[:column_captions][norm] || norm }
+  {
+    'dm_id'             => dm[:dm_id],
+    'dm_name'           => dm[:dm_name],
+    'score'             => score.round(3),
+    'table_match'       => table_match.round(2),
+    'column_match'      => col_match.round(2),
+    'metric_match'      => metric_match.round(2),
+    'shared_tables'     => shared_tables,
+    'missing_tables'    => tableau_tables - dm[:tables],
+    'shared_columns'    => shared_cols.map(&caption_of),
+    'missing_columns'   => (tableau_columns - dm[:columns]).map { |c| tableau_col_caption[c] || c },
+    'extra_columns'     => extra_cols_norm.size,
+    'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
+    'raw_element_count' => dm[:raw_element_count]
+  }
+end.sort_by { |c| -c['score'] }
+
+best = candidates.first
+second = candidates[1]
+
+# Auto-pick gate: only fires when (a) --auto-pick flag is set, (b) top score
+# clears the auto-pick threshold, and (c) the next candidate is at least
+# auto_pick_tie_window below the top. The tie check protects against silently
+# picking the wrong one of two very-close candidates (e.g., a duplicate DM).
+auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
+auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
+tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
+auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && !tie_with_second
+
+# Standard recommend path keeps the old semantics.
+recommended_via_std  = best && best['score'] >= opts[:min_score]
+recommended_dm_id    = (auto_picked || recommended_via_std) ? best['dm_id'] : nil
+
+rationale =
+  if best.nil?
+    'no DMs in org'
+  elsif auto_picked
+    "AUTO-PICKED at score #{best['score']} (>= #{auto_pick_threshold}, no tie within #{auto_pick_tie_window}). #{best['shared_columns'].size}/#{tableau_columns.size} cols matched. Caller must WARN about #{best['extra_columns']} inherited columns."
+  elsif best['score'] >= 0.85
+    "auto-reuse candidate (#{best['shared_columns'].size}/#{tableau_columns.size} cols, #{best['shared_tables'].size}/#{tableau_tables.size} tables)"
+  elsif opts[:auto_pick] && best['score'] >= auto_pick_threshold && tie_with_second
+    "would auto-pick but second candidate at #{second['score']} is within #{auto_pick_tie_window} — TIE — falling back to ASK USER"
+  elsif best['score'] >= opts[:min_score]
+    'ambiguous match — ASK USER before reusing'
+  else
+    'no candidate above min-score; build a new DM'
+  end
+
+result = {
+  'workbook_signature_path' => opts[:sig],
+  'scanned_dm_count'        => candidates.size,
+  'recommended_dm_id'       => recommended_dm_id,
+  'auto_picked'             => auto_picked,
+  'score'                   => best ? best['score'] : 0.0,
+  'rationale'               => rationale,
+  'warning'                 => (best && best['extra_columns'] > 0) ? "Reusing inherits #{best['extra_columns']} extra columns (sample: #{best['extra_columns_sample'].join(', ')})" : nil,
+  'candidates'              => candidates.first(5)
+}.compact
+
+File.write(opts[:out], JSON.pretty_generate(result))
+warn ""
+warn "wrote #{opts[:out]}"
+warn "best score: #{result['score']}  →  #{result['rationale']}"
+exit result['recommended_dm_id'].nil? ? 1 : 0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get-token.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get-token.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Exchange Sigma client credentials for a bearer token.
+# Usage:  eval "$(scripts/get-token.sh)"
+# Sets SIGMA_API_TOKEN in the calling shell.
+
+set -euo pipefail
+
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  "$SIGMA_BASE_URL/v2/auth/token") || {
+    echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null \
+  || echo "$RESPONSE" | ruby -r json -e "print JSON.parse(STDIN.read)['access_token']")
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Token exchange failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+echo "export SIGMA_API_TOKEN=${TOKEN}"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout.rb
@@ -1,0 +1,23 @@
+# Layout-XML helpers. require'd by per-workbook layout configs.
+module SigmaLayout
+  module_function
+
+  def gc(eid, c0, c1, r0, r1, inner)
+    "<GridContainer elementId=\"#{eid}\" type=\"grid\" " \
+    "gridColumn=\"#{c0} / #{c1}\" gridRow=\"#{r0} / #{r1}\" " \
+    "gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n#{inner}\n</GridContainer>"
+  end
+
+  def le(eid, c0, c1, r0, r1)
+    "  <LayoutElement elementId=\"#{eid}\" gridColumn=\"#{c0} / #{c1}\" gridRow=\"#{r0} / #{r1}\"/>"
+  end
+
+  def page_xml(page_id, *children)
+    header = "<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"#{page_id}\">"
+    [header, *children.compact, "</Page>"].join("\n")
+  end
+
+  def assemble(*pages)
+    %(<?xml version="1.0" encoding="utf-8"?>\n) + pages.join("\n")
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_functions.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_functions.rb
@@ -1,0 +1,120 @@
+# Canonical Sigma formula function whitelist.
+# Source: https://help.sigmacomputing.com (Function reference, categories below).
+# Last refreshed: 2026-05-18.
+#
+# Use this list to validate that every function name appearing in a Sigma calc
+# formula is a real Sigma function. Anything outside the list is either a
+# Tableau-syntax leak (IIF / COUNTD / WINDOW_*), a non-existent helper an agent
+# imagined (IsIn / ToText / DateParse — wait, DateParse IS real, see below), or
+# a typo. The right fix is always:
+#   - rewrite the formula using a function from this list, OR
+#   - move the logic into a Custom SQL data-model element (kind: "sql") and
+#     reference its columns as plain `[Custom SQL/COL]` refs
+
+module SigmaFunctions
+  CATEGORIES = {
+    aggregate: %w[
+      ArrayAgg ArrayAggDistinct Avg AvgIf Corr Count CountDistinct
+      CountDistinctIf CountIf GrandTotal ListAgg ListAggDistinct Max MaxIf
+      Median Min MinIf PercentileCont PercentileDisc PercentOfTotal
+      RegressionIntercept RegressionR2 RegressionSlope StdDev Subtotal Sum
+      SumIf SumProduct Variance VariancePop
+    ],
+    array: %w[
+      Array ArrayCompact ArrayConcat ArrayContains ArrayDistinct ArrayExcept
+      ArrayIntersection ArrayJoin ArrayLength ArraySlice RaggedHierarchy
+      Sequence SplitToArray Sparkline SparklineAgg
+    ],
+    date: %w[
+      ConvertTimezone DateAdd DateDiff DateFormat DateFromUnix DateFromUnixMs
+      DateFromUnixUs DateLookback DatePart DateParse DateTrunc Day DayOfYear
+      EndOfMonth Hour InDateRange InPriorDateRange LastDay MakeDate Minute
+      Month MonthName Now Quarter Second Today Weekday WeekdayName Year
+    ],
+    financial: %w[CAGR Effect FV IPmt Nominal NPer Pmt PPmt PV XNPV],
+    geography: %w[
+      Area Centroid Distance Geography Intersects Json Latitude Longitude
+      MakeLine MakePoint Perimeter Text Within
+    ],
+    logical: %w[Between Choose Coalesce If In IsNotNull IsNull Switch Zn NullIf],
+    math: %w[
+      Abs Acos Asin Atan Atan2 BinFixed BinRange BitAnd BitOr Ceiling Cos Cot
+      Degrees DistanceGlobe DistancePlane Div Exp Floor Greatest GreatestNonNull
+      Int IsEven IsOdd Least LeastNonNull Ln Log Mod MRound Pi Power Radians
+      Round RoundDown RoundUp RowAvg Sign Sin Sqrt Tan Trunc
+    ],
+    text: %w[
+      Concat Contains EndsWith Find ILike Left Len Like LPad Lower LTrim MD5
+      Mid Proper RegexpCount RegexpExtract RegexpMatch RegexpReplace Repeat
+      Replace Reverse Right RPad RTrim SHA256 SplitPart StartsWith Substring
+      Trim Upper UrlPart
+    ],
+    type_conversion: %w[Date Json Logical Number Text Variant],
+    window: %w[
+      CumulativeAvg CumulativeCorr CumulativeCount CumeDist CumulativeMax
+      CumulativeMin CumulativeStdDev CumulativeSum CumulativeVariance FillDown
+      First FirstNonNull Lag Last LastNonNull Lead MovingAvg MovingCorr
+      MovingCount MovingMax MovingMin MovingStdDev MovingSum MovingVariance
+      Nth Ntile Rank RankDense RankPercentile RowNumber VisibilityLimit
+    ],
+    join: %w[Lookup Rollup],
+    system: %w[
+      CurrentTimezone CurrentUserAttributeText CurrentUserEmail
+      CurrentUserFirstName CurrentUserFullName CurrentUserInTeam
+    ],
+    passthrough: %w[
+      AggDatetime AggGeography AggLogical AggNumber AggText AggVariant
+      CallDatetime CallGeography CallLogical CallNumber CallText CallVariant
+    ]
+  }.freeze
+
+  ALL = CATEGORIES.values.flatten.freeze
+  ALL_SET = ALL.to_set rescue Set.new(ALL)
+
+  def self.includes?(name)
+    ALL_SET.include?(name)
+  end
+
+  # Returns the list of UNDOCUMENTED function names referenced in a formula.
+  # Detection rule: identifier followed by `(` that isn't already a known Sigma
+  # function. Identifiers are simple [A-Za-z_][A-Za-z0-9_]*.
+  def self.unknown_functions(formula)
+    return [] if formula.nil?
+    # Strip string literals so SQL-ish content inside Custom SQL contexts doesn't
+    # trigger false positives. Sigma calc formulas use "..." for strings.
+    cleaned = formula.gsub(/"(?:\\.|[^"\\])*"/, '""')
+    names = cleaned.scan(/\b([A-Za-z_][A-Za-z0-9_]*)\s*\(/).flatten.uniq
+    names.reject { |n| includes?(n) }
+  end
+
+  # Known Tableau-syntax leak patterns. These DEFINITELY don't work in Sigma
+  # and most of them resemble valid Sigma syntax just enough that a non-strict
+  # whitelist might miss them. Flag with explicit translation hints.
+  TABLEAU_LEAKS = {
+    /\bIIF\s*\(/i        => 'IIF(c, t, e) → Sigma If(c, t, e)',
+    /\bCOUNTD\s*\(/i     => 'COUNTD(x) → Sigma CountDistinct(x)',
+    /\bIFNULL\s*\(/i     => 'IFNULL(x, y) → Sigma Coalesce(x, y)',
+    /\bIS\s+NULL\b/i     => 'x IS NULL → Sigma IsNull(x)',
+    /\bIS\s+NOT\s+NULL\b/i => 'x IS NOT NULL → Sigma IsNotNull(x)',
+    /\bDATEPART\s*\(\s*['"]/i => 'DATEPART("part", date) → Sigma DatePart("part", date) — capitalization matters',
+    /\bWINDOW_(SUM|AVG|MIN|MAX|COUNT|MEDIAN|PERCENTILE)\b/i =>
+      'WINDOW_* aggregates → use Sigma Cumulative*/Moving* OR a Custom SQL element with OVER(...)',
+    /\bRUNNING_(SUM|AVG|COUNT|MIN|MAX)\b/i =>
+      'RUNNING_* → Sigma CumulativeSum/CumulativeAvg/etc. inside a non-grouping context, OR Custom SQL with OVER(... ROWS UNBOUNDED PRECEDING)',
+    /\bRANK_(DENSE|MODIFIED|UNIQUE|PERCENTILE)\b/i =>
+      'RANK_* → Sigma RankDense / RankPercentile / RowNumber, OR Custom SQL with RANK()/DENSE_RANK()/ROW_NUMBER() OVER(...)',
+    /\b\{\s*(FIXED|INCLUDE|EXCLUDE)\b/i =>
+      'Tableau LOD → use Sigma window function family OR a Custom SQL data-model element',
+    /\bIsIn\s*\(/        => 'IsIn() is not a Sigma function — use Sigma In(value, list...) OR an or chain',
+    /\bToText\s*\(/      => 'ToText() is not a Sigma function — use Sigma Text(...) instead',
+    /\bToString\s*\(/    => 'ToString() is not a Sigma function — use Sigma Text(...) instead',
+    /\bToNumber\s*\(/    => 'ToNumber() is not a Sigma function — use Sigma Number(...) instead'
+  }.freeze
+
+  def self.tableau_leaks(formula)
+    return [] if formula.nil?
+    TABLEAU_LEAKS.each_with_object([]) do |(re, hint), acc|
+      acc << hint if formula.match?(re)
+    end
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
@@ -1,0 +1,130 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Sigma creds aren't in ENV yet, load
+# them from the neutral cred file written by setup.rb. Existing env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env) do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN'] || refresh_token!
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      @token_mutex.synchronize { @token_override = tok }
+      # Surface the refreshed token to child processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/tableau_rest.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/tableau_rest.rb
@@ -1,0 +1,212 @@
+# Tableau REST API wrapper for tableau-to-sigma when the MCP isn't available.
+# Requires TABLEAU_SERVER_URL, TABLEAU_SITE_ID, TABLEAU_AUTH_TOKEN, TABLEAU_API_VERSION in ENV
+# (set by scripts/get-tableau-token.sh).
+#
+# All methods return parsed Hash/Array (or raw bytes for view_image). Network/HTTP errors raise
+# Tableau::Error with the response body included.
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'cgi'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Tableau PAT creds aren't in ENV yet,
+# load them from the neutral cred file written by setup-tableau.rb. Existing
+# env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['TABLEAU_PAT_SECRET'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env) do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+module Tableau
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @site_id_override = nil
+
+  module_function
+
+  def server_url
+    ENV.fetch('TABLEAU_SERVER_URL') { raise Error, 'TABLEAU_SERVER_URL not set — run get-tableau-token.sh' }
+  end
+
+  def site_id
+    @token_mutex.synchronize { @site_id_override } || ENV.fetch('TABLEAU_SITE_ID') { raise Error, 'TABLEAU_SITE_ID not set — run get-tableau-token.sh' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV.fetch('TABLEAU_AUTH_TOKEN') { raise Error, 'TABLEAU_AUTH_TOKEN not set — run get-tableau-token.sh' }
+  end
+
+  def api_version
+    ENV.fetch('TABLEAU_API_VERSION', '3.22')
+  end
+
+  # Re-sign in with the PAT env vars and update the in-memory token. Thread-safe.
+  # Long-running scripts (hours) should call this before Tableau's session times
+  # out (cloud default: 240 min idle, can be much shorter under strict policies).
+  # Single-flight: concurrent callers all wait for one signin and share the result.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      name = ENV.fetch('TABLEAU_PAT_NAME')   { raise AuthError, 'TABLEAU_PAT_NAME not set — cannot refresh' }
+      secret = ENV.fetch('TABLEAU_PAT_SECRET'){ raise AuthError, 'TABLEAU_PAT_SECRET not set — cannot refresh' }
+      site_url = ENV.fetch('TABLEAU_SITE_CONTENT_URL') { raise AuthError, 'TABLEAU_SITE_CONTENT_URL not set' }
+      uri = URI.join(server_url, "/api/#{api_version}/auth/signin")
+      req = Net::HTTP::Post.new(uri)
+      req['Content-Type'] = 'application/xml'
+      req['Accept'] = 'application/json'
+      req.body = %(<tsRequest><credentials personalAccessTokenName="#{name}" personalAccessTokenSecret="#{secret}"><site contentUrl="#{site_url}"/></credentials></tsRequest>)
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "signin -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      j = JSON.parse(res.body)
+      @token_mutex.synchronize do
+        @token_override = j.dig('credentials', 'token')
+        @site_id_override = j.dig('credentials', 'site', 'id')
+      end
+      @token_override
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def base_path
+    "/api/#{api_version}/sites/#{site_id}"
+  end
+
+  # ---- low-level transport -------------------------------------------------
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI.join(server_url, path)
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get  then Net::HTTP::Get.new(uri)
+            when :post then Net::HTTP::Post.new(uri)
+            when :put  then Net::HTTP::Put.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['X-Tableau-Auth'] = auth_token
+      req['Accept'] = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 120) { |h| h.request(req) }
+            end
+      if res.code.to_i == 401 && attempts == 1 && ENV['TABLEAU_PAT_NAME']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+
+  # ---- workbooks -----------------------------------------------------------
+
+  # Returns the first workbook matching name, or nil. Use search_workbooks for full list.
+  def find_workbook_by_name(name)
+    encoded = CGI.escape("name:eq:#{name}")
+    j = request(:get, "#{base_path}/workbooks?filter=#{encoded}")
+    list = j.dig('workbooks', 'workbook') || []
+    list = [list] unless list.is_a?(Array)
+    list.first
+  end
+
+  def get_workbook(workbook_id)
+    request(:get, "#{base_path}/workbooks/#{workbook_id}")['workbook']
+  end
+
+  # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
+  # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
+  def download_workbook_content(workbook_id, include_extract: false)
+    qs = include_extract ? '' : '?includeExtract=false'
+    request(:get, "#{base_path}/workbooks/#{workbook_id}/content#{qs}",
+            accept: '*/*', binary: true)
+  end
+
+  # ---- views ---------------------------------------------------------------
+
+  def view_data(view_id)
+    request(:get, "#{base_path}/views/#{view_id}/data", accept: '*/*')
+  end
+
+  def view_image(view_id, width: 1400, height: 900, resolution: 'high')
+    qs = "?resolution=#{resolution}&maxAge=1"
+    qs += "&vf_width=#{width}&vf_height=#{height}" if width && height
+    request(:get, "#{base_path}/views/#{view_id}/image#{qs}", accept: '*/*', binary: true)
+  end
+
+  # ---- datasources ---------------------------------------------------------
+
+  def list_datasources(page_size: 100, page: 1)
+    request(:get, "#{base_path}/datasources?pageSize=#{page_size}&pageNumber=#{page}")
+  end
+
+  def find_datasource_by_name(name)
+    encoded = CGI.escape("name:eq:#{name}")
+    j = request(:get, "#{base_path}/datasources?filter=#{encoded}")
+    list = j.dig('datasources', 'datasource') || []
+    list = [list] unless list.is_a?(Array)
+    list.first
+  end
+
+  # VizQL Data Service — full field list with calc formulas. This is the REST equivalent
+  # of mcp__tableau__get-datasource-metadata.
+  def read_metadata(datasource_luid)
+    body = { datasource: { datasourceLuid: datasource_luid } }.to_json
+    request(:post, "/api/v1/vizql-data-service/read-metadata", body: body)
+  end
+
+  # ---- metadata GraphQL ----------------------------------------------------
+
+  # Convenience: fetch a published datasource by luid, returning fields + calc formulas.
+  # Cleaner display names than read_metadata (which uses GUIDs for fields belonging to
+  # joined logical tables).
+  def graphql_datasource_fields(datasource_luid)
+    query = <<~GQL
+      {
+        publishedDatasources(filter:{luid:"#{datasource_luid}"}) {
+          name luid
+          fields {
+            name
+            fullyQualifiedName
+            ... on CalculatedField { formula isHidden }
+          }
+        }
+      }
+    GQL
+    body = { query: query }.to_json
+    request(:post, "/api/metadata/graphql", body: body)
+  end
+
+  def graphql(query, variables: nil)
+    payload = { query: query }
+    payload[:variables] = variables if variables
+    request(:post, "/api/metadata/graphql", body: payload.to_json)
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/post-and-readback.rb
@@ -1,0 +1,188 @@
+#!/usr/bin/env ruby
+# POST a DM or workbook spec, parse the YAML response, then GET the spec back
+# and emit a clean JSON map of pages → elements with server-assigned IDs.
+#
+# Usage:
+#   ruby post-and-readback.rb --type datamodel|workbook --spec <spec.json> --out <id-map.json>
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'yaml'
+require 'date'
+require 'time'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--type T', %w[datamodel workbook]) { |v| opts[:type] = v }
+  p.on('--spec P')                         { |v| opts[:spec] = v }
+  p.on('--out P')                          { |v| opts[:out]  = v }
+  p.on('--workdir P', 'Per-conversion working dir (default: dir of --spec). Used to track posted workbook IDs across retries.') { |v| opts[:workdir] = v }
+end.parse!
+%i[type spec out].each { |k| abort("missing --#{k}") unless opts[k] }
+opts[:workdir] ||= File.dirname(File.expand_path(opts[:spec]))
+require 'fileutils'
+FileUtils.mkdir_p(opts[:workdir])
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+BASE = ENV.fetch('SIGMA_BASE_URL')
+
+POST_PATH = opts[:type] == 'datamodel' ? '/v2/dataModels/spec'              : '/v2/workbooks/spec'
+GET_PATH  = opts[:type] == 'datamodel' ? '/v2/dataModels/%s/spec'           : '/v2/workbooks/%s/spec'
+ID_FIELD  = opts[:type] == 'datamodel' ? 'dataModelId'                      : 'workbookId'
+
+# Wraps a single Sigma REST call with automatic 401-retry-after-refresh
+# (tokens last ~1 hour; long conversions outlive a single token). Returns
+# the raw Net::HTTPResponse so existing .body / .is_a?(Net::HTTPSuccess)
+# checks below keep working unchanged.
+def http(method, path, body = nil, accept_json: false)
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{BASE}#{path}")
+    req = case method
+          when :post then r = Net::HTTP::Post.new(uri); r.body = body; r['Content-Type'] = 'application/json'; r
+          when :get  then Net::HTTP::Get.new(uri)
+          end
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept']        = 'application/json' if accept_json
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      warn '  [auth] Sigma token expired mid-run, refreshing and retrying...'
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
+end
+
+# Orphan-prevention pre-check: workbook POSTs are create-only. If this is a
+# second invocation in the same conversion, the previous workbook is being
+# orphaned in the customer's My Documents. WARN loudly and emit the PUT
+# alternative. Tracked at beads-sigma-38a (3-workbook customer regression).
+posted_log = File.join(opts[:workdir], 'posted-workbooks.jsonl') if opts[:type] == 'workbook'
+prior_ids = []
+if posted_log && File.exist?(posted_log)
+  prior_ids = File.readlines(posted_log).map { |l| JSON.parse(l)['id'] rescue nil }.compact
+end
+if prior_ids.any?
+  warn ''
+  warn '============================================================'
+  warn "WARN — orphan workbook risk (beads-sigma-38a)"
+  warn '============================================================'
+  warn "This is invocation ##{prior_ids.size + 1} of post-and-readback for this"
+  warn "conversion. Each POST creates a NEW workbook. Already created:"
+  prior_ids.each { |id| warn "  - #{id}" }
+  warn ''
+  warn 'If you are RETRYING after a spec error, you should be using PUT,'
+  warn 'not POST:'
+  warn ''
+  warn "  curl -X PUT -H \"Authorization: Bearer $SIGMA_API_TOKEN\" \\"
+  warn "    -H 'Content-Type: application/json' \\"
+  warn "    -d @#{opts[:spec]} \\"
+  warn "    \"$SIGMA_BASE_URL/v2/workbooks/#{prior_ids.last}/spec\""
+  warn ''
+  warn "If you genuinely meant to create a parallel workbook, ignore this."
+  warn "Otherwise, run scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:workdir]}"
+  warn "to delete the orphans before declaring done — assert-phase6-ran.rb"
+  warn "will FAIL the gate if uncleaned orphans remain."
+  warn '============================================================'
+  warn ''
+end
+
+resp = http(:post, POST_PATH, File.read(opts[:spec]))
+parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+oid = parsed[ID_FIELD] or abort("POST failed: #{parsed.inspect}")
+warn "POST ok: #{ID_FIELD}=#{oid}"
+
+# Append the new ID to the per-conversion log. Newline-delimited JSON so
+# multiple processes can append safely (atomic append on POSIX).
+if posted_log
+  File.open(posted_log, 'a') do |f|
+    f.puts(JSON.generate({ 'id' => oid, 'ran_at' => Time.now.utc.iso8601 }))
+  end
+end
+
+# Read back
+spec = JSON.parse(http(:get, format(GET_PATH, oid), accept_json: true).body)
+out = {
+  ID_FIELD => oid,
+  'pages'  => spec.fetch('pages', []).map do |p|
+    {
+      'id'       => p['id'],
+      'name'     => p['name'],
+      'visibility' => p['visibility'],
+      'elements' => (p['elements'] || []).map { |e| { 'id' => e['id'], 'kind' => e['kind'], 'name' => e['name'] } }
+    }
+  end
+}
+File.write(opts[:out], JSON.pretty_generate(out))
+puts JSON.pretty_generate(out)
+
+# Universal silent-error guard: scan every column's resolved type via the
+# `/columns` endpoint and fail loudly on any column with type `error`.
+#
+# A column ends up "error" when the formula compiles successfully against the
+# validator but fails at runtime. Typical causes:
+#   - Referenced column doesn't exist (typo)
+#   - Function doesn't exist in Sigma (e.g., IsIn — see memory feedback_sigma_formula_isin.md)
+#   - Window aggregate used in calc-column context (validate-spec catches the known
+#     function names; this catches anything else that produces an error type)
+#   - Cross-element ref without a Lookup wrapper (compiles, returns NULL forever — actually
+#     resolves as the column's declared type, not "error", so this guard misses it; that's
+#     why refs/data-model-spec.md has its own callout)
+#
+# Endpoint: GET /v2/{dataModels|workbooks}/<id>/columns — returns one entry per
+# column with `type.type` resolved. Scan for type == "error".
+
+columns_path = opts[:type] == 'datamodel' ?
+  "/v2/dataModels/#{oid}/columns" :
+  "/v2/workbooks/#{oid}/columns"
+
+res = http(:get, columns_path, accept_json: true)
+if res.is_a?(Net::HTTPSuccess)
+  cols_json = JSON.parse(res.body) rescue { 'entries' => [] }
+  error_columns = (cols_json['entries'] || []).select { |c| c.dig('type', 'type') == 'error' }
+  if error_columns.any?
+    warn "\n========================================"
+    warn "FAIL — #{error_columns.size} column(s) compiled to type \"error\":"
+    error_columns.each do |c|
+      warn "  [element=#{c['elementId']}] #{c['label']} (#{c['columnId']}):"
+      warn "    formula: #{c['formula']}"
+    end
+    warn 'Fix these formulas before continuing — Phase 6 parity would fail downstream.'
+    warn 'Common causes: typo in a column ref, IsIn() / non-existent function, window'
+    warn 'aggregate in a calc column (use a Custom SQL element instead — see Phase 3).'
+    warn '========================================'
+    exit(2)
+  else
+    total = (cols_json['entries'] || []).size
+    warn "column-type guard: #{total} columns clean (no `error` types)"
+  end
+else
+  warn "WARN: could not fetch /columns for type guard (got HTTP #{res.code}); skipping"
+end
+
+# Phase 6 nag — column-type guard catches formula-resolution errors but does
+# NOT compare data values to Tableau. Phase 6 (mandatory per SKILL.md) is the
+# ONLY thing that confirms the chart actually reproduces the source. Emit a
+# clear next-step prompt so the agent (or human) doesn't silently skip it.
+if opts[:type] == 'workbook'
+  warn ""
+  warn "================================================================"
+  warn "NEXT STEP — Phase 6 (MANDATORY): verify data parity vs Tableau"
+  warn "================================================================"
+  warn "Column-type guard PASSES means formulas RESOLVE. It does NOT mean"
+  warn "the chart values match Tableau's. Run this BEFORE declaring done:"
+  warn ""
+  warn "  ruby scripts/phase6-parity.rb \\"
+  warn "    --tableau <dir-with-views/-and-get-workbook.json> \\"
+  warn "    --workbook-id #{oid}"
+  warn ""
+  warn "Add --extract-mode --extract-tol 0.30 if the Tableau workbook has"
+  warn "a .hyper extract (drift between live + cached data is expected)."
+  warn "================================================================"
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/put-layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/put-layout.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+# GET a workbook spec, replace per-page layouts with a single top-level layout
+# XML (provided), strip read-only fields, PUT back.
+#
+# Usage:
+#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml>
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'yaml'
+require 'date'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook ID') { |v| opts[:wb] = v }
+  p.on('--layout PATH') { |v| opts[:layout] = v }
+end.parse!
+%i[wb layout].each { |k| abort("missing --#{k}") unless opts[k] }
+
+BASE = ENV.fetch('SIGMA_BASE_URL')
+TOK  = ENV.fetch('SIGMA_API_TOKEN')
+
+def http(method, path, body = nil)
+  uri = URI("#{BASE}#{path}")
+  req = case method
+        when :get then Net::HTTP::Get.new(uri)
+        when :put then r = Net::HTTP::Put.new(uri); r.body = body; r['Content-Type'] = 'application/json'; r
+        end
+  req['Authorization'] = "Bearer #{TOK}"
+  req['Accept']        = 'application/json'
+  Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
+end
+
+xml = File.read(opts[:layout])
+abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
+
+spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec").body)
+spec['pages'].each { |p| p.delete('layout') }
+spec['layout'] = xml
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
+
+resp = http(:put, "/v2/workbooks/#{opts[:wb]}/spec", JSON.pretty_generate(spec))
+parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+puts parsed['workbookId'] ? "PUT ok: workbookId=#{parsed['workbookId']}" : "ERROR: #{parsed.inspect}"
+exit(parsed['workbookId'] ? 0 : 1)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/quicksight-discover.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/quicksight-discover.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Phase 1 discovery for quicksight-to-sigma.
+
+Pulls a QuickSight analysis (or dashboard) definition + its datasets + data sources
+via the AWS CLI, and writes a normalized signals.json the convert + workbook phases consume.
+
+Enterprise edition required for the *-definition calls (Standard edition rejects them).
+QuickSight's identity region (often us-east-1) is where the resources live — pass --region accordingly.
+
+Usage:
+  python3 scripts/quicksight-discover.py \
+    --account-id 153722385948 --region us-east-1 --profile pivot \
+    --analysis-id orders-overview --out-dir ~/quicksight-migration/orders-overview
+"""
+import argparse, json, os, subprocess, sys
+
+
+def aws(args, acct, region, profile):
+    cmd = ["aws", "quicksight"] + args + ["--aws-account-id", acct, "--region", region, "--output", "json"]
+    if profile:
+        cmd += ["--profile", profile]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError(p.stderr.strip() or "aws call failed: " + " ".join(args[:2]))
+    return json.loads(p.stdout)
+
+
+def arn_id(arn):
+    return arn.rsplit("/", 1)[-1]
+
+
+def field_columns(inner):
+    """Shallow-walk a visual's ChartConfiguration collecting referenced ColumnNames."""
+    cols = []
+    def walk(o):
+        if isinstance(o, dict):
+            col = o.get("Column")
+            if isinstance(col, dict) and "ColumnName" in col:
+                cols.append(col["ColumnName"])
+            for v in o.values():
+                walk(v)
+        elif isinstance(o, list):
+            for v in o:
+                walk(v)
+    walk(inner.get("ChartConfiguration", {}))
+    # dedupe, preserve order
+    seen, out = set(), []
+    for c in cols:
+        if c not in seen:
+            seen.add(c); out.append(c)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--account-id", required=True)
+    ap.add_argument("--region", required=True)
+    ap.add_argument("--profile")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--analysis-id")
+    g.add_argument("--dashboard-id")
+    ap.add_argument("--out-dir", required=True)
+    a = ap.parse_args()
+
+    out = os.path.expanduser(a.out_dir)
+    os.makedirs(os.path.join(out, "datasets"), exist_ok=True)
+    os.makedirs(os.path.join(out, "datasources"), exist_ok=True)
+
+    # 1. the analysis / dashboard definition
+    if a.analysis_id:
+        d = aws(["describe-analysis-definition", "--analysis-id", a.analysis_id], a.account_id, a.region, a.profile)
+        src_kind, src_id = "analysis", a.analysis_id
+    else:
+        d = aws(["describe-dashboard-definition", "--dashboard-id", a.dashboard_id], a.account_id, a.region, a.profile)
+        src_kind, src_id = "dashboard", a.dashboard_id
+    name = d.get("Name")
+    defn = d["Definition"]
+    json.dump(d, open(os.path.join(out, "analysis.json"), "w"), indent=2)
+
+    # 2. datasets referenced by the definition
+    ds_meta, src_arns = [], set()
+    for decl in defn.get("DataSetIdentifierDeclarations", []):
+        ident, ds_id = decl["Identifier"], arn_id(decl["DataSetArn"])
+        ds = aws(["describe-data-set", "--data-set-id", ds_id], a.account_id, a.region, a.profile)
+        json.dump(ds, open(os.path.join(out, "datasets", ds_id + ".json"), "w"), indent=2)
+        dso = ds["DataSet"]
+        for ptv in (dso.get("PhysicalTableMap") or {}).values():
+            for v in ptv.values():
+                if isinstance(v, dict) and v.get("DataSourceArn"):
+                    src_arns.add(v["DataSourceArn"])
+        ds_meta.append({"identifier": ident, "dataSetId": ds_id, "name": dso.get("Name"),
+                        "importMode": dso.get("ImportMode"),
+                        "columns": [c.get("Name") for c in dso.get("OutputColumns", [])]})
+
+    # 3. data sources (type tells us Snowflake/Redshift/S3/etc.)
+    src_meta = []
+    for arn in sorted(src_arns):
+        sid = arn_id(arn)
+        try:
+            s = aws(["describe-data-source", "--data-source-id", sid], a.account_id, a.region, a.profile)
+            json.dump(s, open(os.path.join(out, "datasources", sid + ".json"), "w"), indent=2)
+            so = s["DataSource"]
+            src_meta.append({"dataSourceId": sid, "name": so.get("Name"), "type": so.get("Type")})
+        except RuntimeError as e:
+            src_meta.append({"dataSourceId": sid, "name": None, "type": "UNKNOWN", "error": str(e)[:120]})
+
+    # 4. signals: per-sheet visuals + calc fields + params
+    sheets = []
+    for sh in defn.get("Sheets", []):
+        vis = []
+        for v in sh.get("Visuals", []):
+            (vtype, inner), = v.items()
+            t = inner.get("Title", {})
+            title = (t.get("FormatText") or {}).get("PlainText") if isinstance(t, dict) else None
+            vis.append({"type": vtype, "visualId": inner.get("VisualId"),
+                        "title": title, "columns": field_columns(inner)})
+        sheets.append({"sheetId": sh.get("SheetId"), "name": sh.get("Name"), "visuals": vis})
+
+    calc = [{"name": c.get("Name"), "expression": c.get("Expression"), "dataset": c.get("DataSetIdentifier")}
+            for c in defn.get("CalculatedFields", [])]
+    params = [{"name": (list(p.values())[0] or {}).get("Name")} for p in defn.get("ParameterDeclarations", [])]
+
+    signals = {"source": {"kind": src_kind, "id": src_id, "name": name},
+               "datasets": ds_meta, "dataSources": src_meta,
+               "calculatedFields": calc, "parameters": params, "sheets": sheets}
+    json.dump(signals, open(os.path.join(out, "signals.json"), "w"), indent=2)
+
+    # summary
+    print(f"Discovered {src_kind} '{name}' → {out}")
+    print(f"  datasets: {len(ds_meta)}  | data sources: {[s['type'] for s in src_meta]}")
+    print(f"  calc fields: {len(calc)} | parameters: {len(params)}")
+    for s in sheets:
+        kinds = ", ".join(v["type"] for v in s["visuals"])
+        print(f"  sheet '{s['name']}': {len(s['visuals'])} visuals — {kinds}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/validate-spec.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/validate-spec.rb
@@ -1,0 +1,242 @@
+#!/usr/bin/env ruby
+# Validate a DM or workbook spec before POST/PUT.
+# Encapsulates the embedded Python validator from SKILL.md (in Ruby), and adds
+# cross-source ref support for workbook specs that reference DM elements.
+#
+# Usage:
+#   ruby validate-spec.rb --type datamodel <spec.json>
+#   ruby validate-spec.rb --type workbook  --dm-context <dm-id-map.json> <spec.json>
+#
+#   <dm-id-map.json> is the output of post-and-readback.rb for the DM:
+#     { dataModelId: "...", pages: [{ id, name, elements: [{id, name}] }] }
+
+require 'json'
+require 'optparse'
+require 'set'
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_functions'
+
+opts = { type: nil, dm_context: nil }
+op = OptionParser.new do |p|
+  p.on('--type T', %w[datamodel workbook]) { |v| opts[:type] = v }
+  p.on('--dm-context PATH')                { |v| opts[:dm_context] = v }
+end
+op.parse!
+abort('--type required (datamodel|workbook)') unless opts[:type]
+abort('usage: validate-spec.rb --type T [--dm-context P] <spec.json>') if ARGV.empty?
+
+spec = JSON.parse(File.read(ARGV[0]))
+
+# Known prefixes the validator considers valid for cross-element refs
+external_names = []  # element names that are sources OUTSIDE this spec (e.g., DM elements when validating a workbook)
+if opts[:type] == 'workbook' && opts[:dm_context]
+  ctx = JSON.parse(File.read(opts[:dm_context]))
+  # Accept both shapes:
+  #   - post-and-readback.rb output: { pages: [{ elements: [...] }] }
+  #   - flat element list:           { elements: [...] }   (legacy / hand-written)
+  if ctx['pages'].is_a?(Array)
+    external_names.concat(ctx['pages'].flat_map { |p| p.fetch('elements', []).map { |e| e['name'] } }.compact)
+  elsif ctx['elements'].is_a?(Array)
+    external_names.concat(ctx['elements'].map { |e| e['name'] }.compact)
+  end
+  if external_names.empty?
+    abort "validate-spec.rb: --dm-context loaded 0 element names from #{opts[:dm_context]}. " \
+          "Expected either {pages:[{elements:[...]}]} (post-and-readback output) or {elements:[...]} (flat). " \
+          "Re-run post-and-readback.rb --type datamodel and pass its --out file."
+  end
+end
+
+errors = []
+all_element_names = []
+spec.fetch('pages', []).each do |page|
+  page.fetch('elements', []).each { |el| all_element_names << el['name'] if el['name'] }
+end
+all_known_prefixes = (all_element_names + external_names).to_set rescue (all_element_names + external_names)
+require 'set' rescue nil
+all_known_set = all_known_prefixes.is_a?(Set) ? all_known_prefixes : Set.new(all_known_prefixes)
+
+errors << 'spec contains rgb(...) color strings (Cloudflare WAF blocks)' if JSON.generate(spec).include?('rgb(')
+
+spec.fetch('pages', []).each do |page|
+  page.fetch('elements', []).each do |el|
+    kind = el['kind'] || ''
+    name = el['name'] || el['id'] || '?'
+    cols = (el['columns'] || []) + (el['metrics'] || [])
+    sibling_names = Set.new(cols.map { |c| c['name'] }.compact)
+
+    src = el['source'] || {}
+    own_prefixes = Set.new
+    if src['kind'] == 'warehouse-table' && src['path']
+      own_prefixes << src['path'].last
+    end
+    own_prefixes << 'Custom SQL' if src['kind'] == 'sql'
+
+    cols.each do |col|
+      f = (col['formula'] || '').to_s
+
+      # ---- Whitelist enforcement: every function call name must be in the
+      # canonical Sigma function library. Anything else is a Tableau-syntax
+      # leak, an imagined helper (IsIn / ToText), or a typo. Rewrite using a
+      # documented function OR move the logic into a Custom SQL element.
+      unknown = SigmaFunctions.unknown_functions(f) - [name, col['name']].compact
+      # Tableau formula refs use lots of identifiers that look like fn calls
+      # but are bracket-delimited (e.g., `[ORDERS/Sales]`). The regex already
+      # only matches identifiers followed by `(`, so this is the cleanup set.
+      # Skip the IF chain on uppercase Tableau identifiers like `IF`, `THEN`,
+      # `END`, `WHEN`, which the agent may slip through inadvertently.
+      reserved_tableau = %w[IF THEN ELSE ELSEIF END WHEN CASE AND OR NOT]
+      unknown.reject! { |n| reserved_tableau.include?(n.upcase) }
+      unless unknown.empty?
+        errors << "#{name}.#{col['name']}: formula references function(s) not in Sigma's library: #{unknown.join(', ')}. Either rewrite using a documented function (see scripts/lib/sigma_functions.rb) OR move the logic into a Custom SQL data-model element (kind: \"sql\")."
+      end
+      # ---- Tableau-syntax leak detection. Catches IIF / COUNTD / WINDOW_* /
+      # RUNNING_* / RANK_* / LOD braces / IsIn / ToText / etc. with explicit
+      # translation hints.
+      SigmaFunctions.tableau_leaks(f).each do |hint|
+        errors << "#{name}.#{col['name']}: #{hint}"
+      end
+
+      f.scan(/\[([^\]]+)\]/).flatten.each do |ref|
+        if ref.include?('/')
+          prefix = ref.split('/', 1)[0] # bug-fix: split with limit 2
+          prefix = ref.split('/', 2)[0]
+          unless own_prefixes.include?(prefix) || all_known_set.include?(prefix)
+            errors << "#{name}.#{col['name']}: ref [#{ref}] — prefix \"#{prefix}\" unknown " \
+                      "(known: #{(own_prefixes + all_known_set).to_a.sort.join(', ')})"
+          end
+        else
+          unless sibling_names.include?(ref)
+            errors << "#{name}.#{col['name']}: bare ref [#{ref}] not a sibling column"
+          end
+        end
+      end
+
+      if f =~ /\b(Weekday|Month|Year|Quarter|Day|Hour|Minute)\s*\(/i
+        if f.include?('If(') && !f.include?('IsNull(') && !f.include?('Coalesce(')
+          errors << "#{name}.#{col['name']}: nested-If on date function without IsNull/Coalesce guard"
+        end
+      end
+    end
+
+    errors << "#{name}: invalid kind \"kpi\" — must be \"kpi-chart\"" if kind == 'kpi'
+    errors << "#{name}: invalid kind \"pie\" — must be \"pie-chart\"" if kind == 'pie'
+    errors << "#{name}: invalid kind \"donut\" — must be \"donut-chart\"" if kind == 'donut'
+    errors << "#{name}: kpi-chart missing value" if kind == 'kpi-chart' && !el['value']
+
+    if %w[pie-chart donut-chart].include?(kind)
+      errors << "#{name}: #{kind} missing color" unless el['color']
+      errors << "#{name}: #{kind} missing value" unless el['value']
+    end
+
+    if kind == 'donut-chart' && el['holeValue']
+      hv = el['holeValue']
+      if !hv.is_a?(Hash) || !hv['id']
+        errors << "#{name}: donut-chart holeValue must be {\"id\":...}"
+      elsif hv['id'] == el.dig('value', 'id')
+        errors << "#{name}: donut-chart holeValue.id equals value.id — element silently dropped"
+      end
+    end
+
+    # --- Color-channel shape — cartesian + map charts use {by, column}, NOT {id}.
+    # Pie/donut use {id}. Caught 2 of Superstore's HTTP 400s (area + region-map).
+    if %w[bar-chart line-chart area-chart combo-chart scatter-chart region-map point-map].include?(kind)
+      if (color = el['color']).is_a?(Hash) && color['id'] && !color['by'] && !color['column']
+        errors << "#{name}: #{kind} color uses pie/donut shape {id: ...} — must be {by: \"category\"|\"scale\", column: \"...\"} for cartesian + map charts (API rejects with `Invalid value: object`)"
+      end
+    end
+
+    # --- Axis sort direction — must be "ascending"/"descending", NOT "asc"/"desc".
+    # Caught 1 of Superstore's HTTP 400s.
+    %w[xAxis yAxis].each do |axis_key|
+      ax = el[axis_key]
+      ax = ax.first if ax.is_a?(Array) && ax.first.is_a?(Hash)
+      next unless ax.is_a?(Hash)
+      next unless (sort = ax['sort']).is_a?(Hash)
+      dir = sort['direction']
+      if %w[asc desc].include?(dir)
+        errors << "#{name}: #{axis_key}.sort.direction \"#{dir}\" — must be \"ascending\" or \"descending\" (API rejects abbreviations)"
+      end
+    end
+
+    if %w[bar-chart line-chart area-chart combo-chart scatter-chart].include?(kind)
+      errors << "#{name}: use yAxis not measures for #{kind}" if el['measures']
+      errors << "#{name}: #{kind} missing yAxis" unless el['yAxis']
+      # Breaking-change-2026-05-21: xAxis / yAxis took new shape.
+      # OLD (now rejected): xAxis: {id: ...}, yAxis: [{id: ...}]
+      # NEW (required):     xAxis: {columnId: ...}, yAxis: {columnIds: [...]}
+      if (xa = el['xAxis']).is_a?(Hash) && xa['id'] && !xa['columnId']
+        errors << "#{name}: xAxis uses old shape {id: ...} — must be {columnId: ...} (breaking change 2026-05-21)"
+      end
+      if (ya = el['yAxis']).is_a?(Array)
+        errors << "#{name}: yAxis uses old shape [{id: ...}] — must be {columnIds: [...]} (breaking change 2026-05-21)"
+      elsif ya.is_a?(Hash) && !ya['columnIds']
+        errors << "#{name}: yAxis missing columnIds array"
+      end
+    end
+
+    if kind == 'pivot-table'
+      errors << "#{name}: pivot-table must use rowsBy/columnsBy" if el['rows'] || el['columnGroups']
+      errors << "#{name}: pivot-table without rowsBy renders only a grand-total row" if (el['rowsBy'] || []).empty?
+      # Wrong-field-name: agents often write `valuesBy` because rowsBy/columnsBy
+      # exist. The right field is bare `values`. Caught 1 of Superstore's HTTP 400s.
+      if el['valuesBy'] && !el['values']
+        errors << "#{name}: pivot-table field is `values` (bare string array), not `valuesBy` — rename `valuesBy` → `values`"
+      end
+      # Month-name string dimension on a pivot sorts alphabetically (Apr / Aug /
+      # Dec / Feb...). Catch the common MonthName(...) formula on a rowsBy /
+      # columnsBy column. Suggest Month(...) (returns 1-12) or a pre-computed
+      # Month Num column.
+      pivot_dim_ids = (el['rowsBy'].to_a + el['columnsBy'].to_a)
+                      .select { |x| x.is_a?(Hash) }.map { |x| x['id'] }.compact.to_set
+      cols.each do |col|
+        next unless pivot_dim_ids.include?(col['id'])
+        f = col['formula'].to_s
+        if f =~ /\bMonthName\s*\(/i || f =~ /\bDayName\s*\(/i
+          errors << "#{name}.#{col['name']}: pivot-table dim uses MonthName/DayName (string) — sorts alphabetically (Apr/Aug/Dec/Feb...). Use Month(...) (1-12) / Weekday(...) (1-7) for chronological order, then format the label downstream."
+        end
+      end
+      # Shape: values is a flat string-array of column IDs; rowsBy/columnsBy are {id: "..."} object arrays.
+      # Mixing these up costs multiple POST iterations because the API rejects with a generic Invalid array message.
+      if (vals = el['values']).is_a?(Array)
+        bad_val = vals.find { |v| v.is_a?(Hash) }
+        errors << "#{name}: pivot-table values must be a flat string array like [\"col-id\"], not [{id:...}] (got #{bad_val.inspect})" if bad_val
+      end
+      %w[rowsBy columnsBy].each do |key|
+        next unless (entries = el[key]).is_a?(Array)
+        bad = entries.find { |e| e.is_a?(String) || (e.is_a?(Hash) && !e['id']) }
+        if bad.is_a?(String)
+          errors << "#{name}: pivot-table #{key} must be objects like [{id: \"col-id\"}], not bare strings (got #{bad.inspect})"
+        elsif bad.is_a?(Hash) && bad['columnId']
+          errors << "#{name}: pivot-table #{key} entries use {id: ...}, not {columnId: ...} (got #{bad.inspect})"
+        elsif bad
+          errors << "#{name}: pivot-table #{key} entry missing id key (got #{bad.inspect})"
+        end
+      end
+    end
+  end
+end
+
+if opts[:type] == 'workbook'
+  spec.fetch('pages', []).each do |page|
+    els = page.fetch('elements', [])
+    masters = els.select do |e|
+      e['kind'] == 'table' &&
+        e['visibleAsSource'] == false &&
+        e.dig('source', 'kind') == 'data-model'
+    end
+    next if masters.empty?
+
+    others = els.reject { |e| masters.include?(e) }
+    unless others.empty?
+      master_names = masters.map { |m| m['name'] || m['id'] }.join(', ')
+      kind_counts = Hash.new(0)
+      others.each { |o| kind_counts[o['kind']] += 1 }
+      other_kinds = kind_counts.map { |k, n| "#{n} #{k}" }.join(', ')
+      errors << "page \"#{page['name'] || page['id']}\" mixes master table(s) [#{master_names}] with #{other_kinds}. Move the master to a dedicated \"Data\" page; charts on content pages reference it via cross-page elementId."
+    end
+  end
+end
+
+errors.each { |e| puts "ERROR: #{e}" }
+puts "--- #{errors.size} errors"
+exit(errors.empty? ? 0 : 1)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-parity.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-parity.rb
@@ -1,0 +1,195 @@
+#!/usr/bin/env ruby
+# Parity verification: compare expected (from Tableau CSVs) vs actual
+# (from Sigma queries) for each chart in a plan.
+#
+# Plan format (JSON array):
+#   [{ "chart": "...",
+#      "expected": [[dim, val], ...],
+#      "actual":   { "rows": [[dim, val], ...] },
+#      "extract":  true|false   # optional per-chart override
+#   }]
+#
+# A top-level wrapper is also accepted:
+#   { "extract": true, "charts": [ ... ] }
+# in which case `extract` propagates to every chart.
+#
+# --strict      value-exact comparison (default)
+# --extract-mode  structural comparison only — when Tableau view CSVs come from
+#                 a workbook with hasExtracts=true, the absolute values can drift
+#                 from Sigma (live warehouse) while the chart shape is correct.
+#                 Extract-mode checks:
+#                   - same number of buckets (rows)
+#                   - same set of dimension values
+#                   - same sort order on the dimension column
+#                   - measure values within `--extract-tol` relative tolerance
+#                     (default 0.30 = 30%) IF both are non-null, otherwise skipped
+#
+# Usage:
+#   ruby verify-parity.rb --plan plan.json
+#   ruby verify-parity.rb --plan plan.json --extract-mode
+#   ruby verify-parity.rb --plan plan.json --extract-mode --extract-tol 0.50
+
+require 'json'
+require 'set'
+require 'optparse'
+
+opts = { mode: :strict, tol: 0.30 }
+OptionParser.new do |p|
+  p.on('--plan P')              { |v| opts[:plan] = v }
+  p.on('--extract-mode')        {     opts[:mode] = :extract }
+  p.on('--extract-tol TOL', Float) { |v| opts[:tol] = v }
+end.parse!
+abort('--plan required') unless opts[:plan]
+
+MONTH_NUM = {
+  'january' => 1, 'february' => 2, 'march' => 3, 'april' => 4, 'may' => 5, 'june' => 6,
+  'july' => 7, 'august' => 8, 'september' => 9, 'october' => 10, 'november' => 11, 'december' => 12,
+  'jan' => 1, 'feb' => 2, 'mar' => 3, 'apr' => 4, 'jun' => 6,
+  'jul' => 7, 'aug' => 8, 'sep' => 9, 'sept' => 9, 'oct' => 10, 'nov' => 11, 'dec' => 12
+}.freeze
+
+# Canonicalize date-like dimension values so monthly buckets compare equal across
+# representations (e.g. Sigma raw SQL "2026-01-01T00:00:00.000" vs Tableau view
+# label "January 2026" both → "2026-01"). Non-date strings pass through.
+def canonicalize_dim(v)
+  return v unless v.is_a?(String)
+  s = v.strip
+  # ISO datetime, day=1, midnight → month bucket (T or space separator)
+  if (m = s.match(/\A(\d{4})-(\d{2})-01[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
+    return "#{m[1]}-#{m[2]}"
+  end
+  # ISO date, first of month → month bucket
+  if (m = s.match(/\A(\d{4})-(\d{2})-01\z/))
+    return "#{m[1]}-#{m[2]}"
+  end
+  # "January 2026" / "Jan 2026"
+  if (m = s.match(/\A([A-Za-z]+)\s+(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
+    return format('%s-%02d', m[2], mnum)
+  end
+  # Already-canonical "YYYY-MM"
+  return s if s.match?(/\A\d{4}-\d{2}\z/)
+  v
+end
+
+def round_row(row)
+  # Convert all numerics to Float-rounded so Integer 11 and Float 11.0 compare equal in the set,
+  # and canonicalize date-like dim strings so equivalent monthly buckets match.
+  row.map do |v|
+    if v.is_a?(Numeric)
+      v.to_f.round(2)
+    else
+      canonicalize_dim(v)
+    end
+  end
+end
+
+def strict_compare(exp, act)
+  exp_set = Set.new(exp.map { |r| r.first(2) })
+  act_set = Set.new(act.map { |r| r.first(2) })
+  if exp_set == act_set
+    { status: 'PASS', only_in_tableau: [], only_in_sigma: [] }
+  else
+    { status: 'DIVERGE',
+      only_in_tableau: (exp_set - act_set).to_a,
+      only_in_sigma:   (act_set - exp_set).to_a }
+  end
+end
+
+# Extract-mode: same row count + same dim set + same dim sort. Measure values
+# only flagged if they're WILDLY off (beyond extract_tol) — small drift is
+# expected because Sigma reads live warehouse while extracts are frozen snapshots.
+def extract_compare(exp, act, tol:)
+  exp_dims = exp.map { |r| r[0] }
+  act_dims = act.map { |r| r[0] }
+  exp_set  = Set.new(exp_dims)
+  act_set  = Set.new(act_dims)
+
+  notes = []
+  status = 'PASS'
+
+  if exp.size != act.size
+    status = 'DIVERGE'
+    notes << "bucket count differs: tableau=#{exp.size} sigma=#{act.size}"
+  end
+
+  unless exp_set == act_set
+    status = 'DIVERGE'
+    notes << "dim set differs: tableau-only=#{(exp_set - act_set).to_a[0..3].inspect}, sigma-only=#{(act_set - exp_set).to_a[0..3].inspect}"
+  end
+
+  # If dim sets match, check sort order on the dimension
+  if exp_set == act_set && exp_dims != act_dims
+    notes << "dim sort order differs (extract-mode flags only — not a failure)"
+  end
+
+  # Wild-divergence check on measures (10x or more drift = probably a real bug,
+  # not just extract staleness)
+  if exp.size == act.size && exp_set == act_set
+    exp_h = exp.each_with_object({}) { |r, h| h[r[0]] = r[1] }
+    act_h = act.each_with_object({}) { |r, h| h[r[0]] = r[1] }
+    big_drifts = []
+    exp_h.each do |k, v|
+      a = act_h[k]
+      next if v.nil? || a.nil?
+      next unless v.is_a?(Numeric) && a.is_a?(Numeric)
+      denom = [v.abs.to_f, a.abs.to_f, 1.0].max
+      drift = (v - a).abs.to_f / denom
+      big_drifts << [k, v, a, drift] if drift > tol
+    end
+    if big_drifts.any?
+      notes << "#{big_drifts.size} measure value(s) drift > #{(tol * 100).to_i}% — review:"
+      big_drifts.first(3).each do |k, v, a, d|
+        notes << "    #{k.inspect} tableau=#{v} sigma=#{a} drift=#{(d * 100).round}%"
+      end
+    end
+  end
+
+  { status: status, notes: notes,
+    only_in_tableau: (exp_set - act_set).to_a,
+    only_in_sigma:   (act_set - exp_set).to_a }
+end
+
+raw = JSON.parse(File.read(opts[:plan]))
+default_extract = false
+if raw.is_a?(Hash) && raw['charts']
+  default_extract = !!raw['extract']
+  plan = raw['charts']
+else
+  plan = raw
+end
+
+# Top-level --extract-mode overrides default
+mode_forced = opts[:mode] == :extract
+
+results = plan.map do |p|
+  exp = (p['expected'] || []).map { |r| round_row(r) }
+  act = (p.dig('actual', 'rows') || []).map { |r| round_row(r) }
+
+  this_extract = if p.key?('extract')
+                   p['extract']
+                 elsif mode_forced
+                   true
+                 else
+                   default_extract
+                 end
+
+  result = this_extract ? extract_compare(exp, act, tol: opts[:tol]) : strict_compare(exp, act)
+  result.merge(chart: p['chart'], extract: this_extract)
+end
+
+results.each do |r|
+  tag = r[:extract] ? '[extract]' : '[strict] '
+  printf "%-7s  %s  %s\n", r[:status], tag, r[:chart]
+  if r[:status] != 'PASS' || (r[:notes] && r[:notes].any?)
+    Array(r[:notes]).each { |n| puts "    #{n}" }
+    if r[:only_in_tableau].any? || r[:only_in_sigma].any?
+      puts "    Tableau-only: #{r[:only_in_tableau].inspect[0..200]}"
+      puts "    Sigma-only:   #{r[:only_in_sigma].inspect[0..200]}"
+    end
+  end
+end
+
+failed = results.count { |r| r[:status] != 'PASS' }
+puts '---'
+puts "#{results.size - failed}/#{results.size} pass" + (mode_forced ? '  (extract-mode)' : '')
+exit(failed.zero? ? 0 : 1)


### PR DESCRIPTION
Amazon QuickSight → Sigma migration plugin, built + validated against **20 graduated test dashboards** (D1–D20) on a live QuickSight Enterprise account.

## Skills
- **quicksight-to-sigma** — discover (AWS CLI) → convert (MCP `convert_quicksight_to_sigma`) + fixup → data model → workbook (KPI/bar/line/pie/donut/combo/scatter/table/pivot, gauge→kpi, funnel/treemap→bar) → faithful layout → parity. Handles CustomSql + multi-table joins, window-calc graceful degrade, cast/filter transforms, free-form collision resolution.
- **quicksight-assessment** — read-only inventory → complexity → value/cost shortlist → migration-plan + readout.

## Validation
D1–D12 migrate with **exact warehouse parity**; D15 layout resolved; D16/D19/D20 partial-by-design; D17 (maps) / D18 (exotic charts) the genuine (c)-tail. Pairs with converter fixes in sigma-data-model-mcp (beads vy4k/nc6g/woaa/23xu). Follow-up: beads-sigma-dqyv (slim fixup now that the converter owns DM-side bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)