### PR TITLE
quicksight-to-sigma: pie-vs-donut + layout-width fidelity

### DIFF
--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
@@ -28,8 +28,20 @@ end.parse!
 defn = JSON.parse(File.read(opts[:an]))['Definition']
 map = JSON.parse(File.read(opts[:map]))
 v2e = map['visualToElement']             # QS VisualId -> Sigma element id
-GRID = 36.0                              # QuickSight grid width
+GRID = 36.0                              # QuickSight max grid width (fallback only)
 SIG = 24                                 # Sigma grid width
+
+# QuickSight does NOT use a fixed 36-column grid. A sheet's effective grid width is
+# whatever the widest row of tiles adds up to — commonly 12, 18, 24, or 36 depending
+# on how the author sized things. Scaling every layout by a hardcoded 36 squeezes a
+# 12-wide D4 into the left third of the Sigma page. Infer the real width as the max
+# (ColumnIndex + ColumnSpan) across the sheet's elements, so relative widths + the
+# overall span are preserved when we scale to Sigma's 24 columns.
+def infer_grid_width(els)
+  edges = els.map { |e| (e['ColumnIndex'] || 0) + (e['ColumnSpan'] || 0) }
+  w = edges.compact.max.to_f
+  w >= 1 ? w : GRID
+end
 
 def num(s) # "120px" / "50%" / 120 -> float
   s.to_s.gsub(/[^0-9.\-]/, '').to_f
@@ -52,28 +64,57 @@ if (g = cfg['GridLayout'])
   els = g['Elements'] || []
   explicit = els.any? { |e| !e['ColumnIndex'].nil? }
   if explicit
+    # Honor QuickSight's explicit ColumnIndex/RowIndex/ColumnSpan/RowSpan, scaling the
+    # columns by the sheet's INFERRED grid width (not a hardcoded 36) so the relative
+    # widths + the dashboard's overall horizontal extent are faithfully reproduced.
+    # Rows are kept in QS row-units (RowIndex/RowSpan map 1:1 to Sigma grid rows), which
+    # preserves relative heights + vertical arrangement. (beads-sigma — QS grid width)
+    grid_w = infer_grid_width(els)
     els.each do |e|
       eid = v2e[e['ElementId']]; next unless eid
-      c0, c1 = scale_cols(e['ColumnIndex'] || 0, e['ColumnSpan'] || 12, GRID)
+      c0, c1 = scale_cols(e['ColumnIndex'] || 0, e['ColumnSpan'] || (grid_w / 2), grid_w)
       r0 = (e['RowIndex'] || 0) + 1
       r1 = r0 + (e['RowSpan'] || 8)
       placed << [eid, c0, c1, r0, r1]
     end
   else
-    # auto-flow by span across the 36-col grid
+    # auto-flow by span: wrap when the running column exceeds the inferred grid width
+    grid_w = infer_grid_width(els)
+    grid_w = GRID if grid_w <= 0
     col = 0; row = 1; row_h = 0
     els.each do |e|
       eid = v2e[e['ElementId']]; next unless eid
-      span = e['ColumnSpan'] || 18
-      col = 0 if col + span > GRID
+      span = e['ColumnSpan'] || (grid_w / 2)
+      col = 0 if col + span > grid_w
       row += row_h if col.zero? && row_h.positive?
-      c0, c1 = scale_cols(col, span, GRID)
+      c0, c1 = scale_cols(col, span, grid_w)
       h = (e['RowSpan'] || 12)
       placed << [eid, c0, c1, row, row + h]
       col += span; row_h = [row_h, h].max
-      if col >= GRID
+      if col >= grid_w
         col = 0; row += row_h; row_h = 0
       end
+    end
+  end
+elsif (sb = cfg['SectionBasedLayout'])
+  # QuickSight paginated/section layout (header/body/footer). Sigma has no page-section
+  # concept; flatten every section's free-form sub-elements into a single stacked column
+  # in document order so the report's vertical sequence is preserved. (D16 paginated)
+  sects = []
+  sects.concat(sb['HeaderSections'] || [])
+  sects.concat(sb['BodySections'] || [])
+  sects.concat(sb['FooterSections'] || [])
+  row = 1
+  sects.each do |sec|
+    sec_els = (sec.dig('Content', 'Layout', 'FreeFormLayout', 'Elements') || sec['Elements'] || [])
+    cw = sec_els.map { |e| num(e['XAxisLocation']) + num(e['Width']) }.max
+    cw = 1.0 if cw.nil? || cw <= 0
+    sec_els.each do |e|
+      eid = v2e[e['ElementId']]; next unless eid
+      c0, c1 = scale_cols(num(e['XAxisLocation']), num(e['Width']), cw)
+      h = [(num(e['Height']) / 40.0).round, 4].max
+      placed << [eid, c0, c1, row, row + h]
+      row += h
     end
   end
 elsif (f = cfg['FreeFormLayout'])

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -290,7 +290,17 @@ defn['Sheets'].each do |sh|
     end
     eid = nid
     vis_map[inner['VisualId']] = eid
-    kind = 'donut-chart' if vtype == 'PieChartVisual' && inner.dig('ChartConfiguration', 'DonutOptions')
+    # PieChartVisual → pie-chart by default. Map to donut-chart ONLY when QuickSight
+    # is rendering a REAL donut: DonutOptions.ArcOptions.ArcThickness is present AND
+    # not 'WHOLE'. QuickSight's ArcThickness enum is WHOLE|SMALL|MEDIUM|LARGE — WHOLE
+    # means a solid pie (no hole), SMALL/MEDIUM/LARGE are donuts. (The QS console also
+    # emits a DonutOptions block for a plain pie, so presence of the key alone is not a
+    # donut signal — orders-overview "Net Revenue by Region"=MEDIUM stays a donut;
+    # D3 "Revenue Mix by Channel"=WHOLE becomes a pie.)
+    if vtype == 'PieChartVisual'
+      arc = inner.dig('ChartConfiguration', 'DonutOptions', 'ArcOptions', 'ArcThickness')
+      kind = 'donut-chart' if arc && arc.to_s.upcase != 'WHOLE'
+    end
     fw = (inner['ChartConfiguration'] || {})['FieldWells'] || {}
     w = fw.values.find { |x| x.is_a?(Hash) } || fw
     rol = ->(key) { (w[key] || []).map { |f| field_role(f) }.compact }


### PR DESCRIPTION
Pie/donut: PieChartVisual→pie unless real donut (ArcThickness != WHOLE) — D3 fixed, orders donut preserved. Layout: infer per-sheet QS grid width instead of hardcoded 36 (narrower sheets were squeezed left) — 13 dashboards re-migrated in-place, layouts match QS, parity unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)