### PR TITLE
README: list quicksight-to-sigma (it shipped but the README never showed it)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ shared `~/.sigma-migration/env` under any agent.
 /plugin install powerbi-to-sigma@sigma-migration-skills
 /plugin install qlik-to-sigma@sigma-migration-skills
 /plugin install thoughtspot-to-sigma@sigma-migration-skills
+/plugin install quicksight-to-sigma@sigma-migration-skills
 ```
 
 **Other agents (Cursor, Cortex Code, …)** — clone the repo and point your agent at the
@@ -42,6 +43,7 @@ and the skill drives discovery → translation → build → parity.
 | [`powerbi-to-sigma`](plugins/powerbi-to-sigma/) | Power BI | `powerbi-to-sigma`, `powerbi-assessment` |
 | [`qlik-to-sigma`](plugins/qlik-to-sigma/) | Qlik Sense / Cloud | `qlik-to-sigma`, `qlik-assessment` |
 | [`thoughtspot-to-sigma`](plugins/thoughtspot-to-sigma/) | ThoughtSpot | `thoughtspot-to-sigma`, `thoughtspot-assessment` |
+| [`quicksight-to-sigma`](plugins/quicksight-to-sigma/) | Amazon QuickSight | `quicksight-to-sigma`, `quicksight-assessment` |
 
 In Claude Code, installed skills are namespaced — e.g. `/powerbi-to-sigma:powerbi-assessment`.
 


### PR DESCRIPTION
The `quicksight-to-sigma` plugin has been in the repo since PR #5 (its `plugins/quicksight-to-sigma/` dir + `marketplace.json` entry + repo description all reference it), but the **README** — what GitHub renders on the landing page — was never updated. So anyone browsing the repo saw the install list and marketplace table stop at ThoughtSpot and reasonably concluded QuickSight was missing.

Adds:
- `/plugin install quicksight-to-sigma@sigma-migration-skills` to the Install block
- the `quicksight-to-sigma` → Amazon QuickSight → `quicksight-to-sigma`, `quicksight-assessment` row to the marketplace table

🤖 Generated with [Claude Code](https://claude.com/claude-code)