### PR TITLE
Assessments: Sigma-branded HTML readouts across all five tools (+ doc parity)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout-html.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout-html.rb
@@ -1,0 +1,957 @@
+#!/usr/bin/env ruby
+# Render <out>/readout.html — a customer-facing, share-friendly HTML report
+# for a Power BI / Fabric assessment.
+#
+# Sibling of tableau-assessment/scripts/render-readout-html.rb: the entire
+# <style> block, the h/num/kpi/table/bar_cell/tag_pill helpers, the
+# TAG_LABELS/TAG_CLASSES vocabulary, the risk chips, and the section scaffolding
+# are copied verbatim so the look is byte-identical. Only the gather-body and
+# the Power-BI vocabulary (report/semantic model/dataset/workspace/measure-DAX/
+# import-vs-DirectQuery/dataflow) differ.
+#
+# Reads: inventory.json (required), complexity.json, shortlist.json,
+#        usage.json (optional, Fabric-admin only).
+#
+# Usage: ruby scripts/render-readout-html.rb --out /tmp/pbi-assessment-<tenant>
+
+require 'json'
+require 'optparse'
+require 'cgi'
+require 'date'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--out DIR') { |v| opts[:out] = v }
+end.parse!
+abort('--out required') unless opts[:out]
+
+inv_path        = File.join(opts[:out], 'inventory.json')
+complexity_path = File.join(opts[:out], 'complexity.json')
+shortlist_path  = File.join(opts[:out], 'shortlist.json')
+usage_path      = File.join(opts[:out], 'usage.json')
+abort("inventory.json not found in #{opts[:out]}") unless File.exist?(inv_path)
+
+def load_json(path); File.exist?(path) ? JSON.parse(File.read(path)) : nil; end
+inventory  = JSON.parse(File.read(inv_path))
+complexity = load_json(complexity_path)
+shortlist  = load_json(shortlist_path)
+usage      = load_json(usage_path)
+
+shortlist_reports = shortlist ? (shortlist['reports'] || []) : []
+has_shortlist = !shortlist_reports.empty?
+has_usage     = (shortlist && shortlist['usage_available'] == true) ||
+                (usage && usage['available'] == true)
+
+def h(s); CGI.escapeHTML(s.to_s); end
+def num(n); n.to_i.to_s.reverse.scan(/.{1,3}/).join(',').reverse; end
+
+# ---------- gather computed values ----------
+tenant = inventory['tenant'] || {}
+env    = inventory['environment_overview'] || {}
+models = inventory['semantic_models'] || []
+reports = inventory['reports'] || []
+
+tenant_name = File.basename(opts[:out]).sub(/^pbi-assessment-/, '')
+tenant_name = 'Power BI tenant' if tenant_name.nil? || tenant_name.empty?
+generated_at = tenant['generated_at'] || Time.now.strftime('%Y-%m-%d')
+formatted_date = Date.parse(generated_at).strftime('%B %d, %Y') rescue generated_at
+
+mode_label = has_usage ? 'Fabric Admin (usage + complexity)' : 'User-delegated (complexity-only)'
+
+# DAX totals across all models
+total_dax = { 'a' => 0, 'b' => 0, 'c' => 0 }
+models.each { |m| (m['dax_buckets'] || {}).each { |k, n| total_dax[k] += n.to_i if total_dax.key?(k) } }
+
+# Usage / value
+total_views = has_usage ? shortlist_reports.sum { |r| r['views'].to_i } : 0
+cold_reports = has_usage ? shortlist_reports.select { |r| r['views'].to_i.zero? } : []
+
+# Shortlist rollups
+sl_top5_views     = 0
+sl_top5_unhandled = 0
+sl_total_unhandled = 0
+sl_needs_scout    = 0
+sl_retire         = 0
+sl_migrate_first  = 0
+if has_shortlist
+  top5 = shortlist_reports.first(5)
+  sl_top5_views     = top5.sum { |r| r['views'].to_i }
+  sl_top5_unhandled = top5.sum { |r| r['unhandled'].to_i }
+  sl_total_unhandled = shortlist_reports.sum { |r| r['unhandled'].to_i }
+  sl_needs_scout = shortlist_reports.count { |r| r['tag'] == 'needs-gap-scout' }
+  sl_retire      = shortlist_reports.count { |r| r['tag'] == 'retire' }
+  sl_migrate_first = shortlist_reports.count { |r| r['tag'] == 'migrate-first' }
+end
+top5_pct = (has_usage && total_views.positive?) ? (sl_top5_views.to_f / total_views * 100).round : 0
+
+# Ownership / concentration — keyed on workspace (PBI has no per-report owner email in inventory)
+ws_concentration = Hash.new { |hsh, k| hsh[k] = { reports: 0, models: 0 } }
+reports.each { |r| ws_concentration[r['workspace']][:reports] += 1 }
+models.each  { |m| ws_concentration[m['workspace']][:models] += 1 }
+top_ws_pct = 0
+top_ws_name = '—'
+if reports.any?
+  top = ws_concentration.max_by { |_, v| v[:reports] }
+  if top
+    top_ws_name = top[0]
+    top_ws_pct = (top[1][:reports].to_f / reports.size * 100).round
+  end
+end
+
+# Complexity
+n_scanned = complexity ? complexity.size : 0
+n_with_unhandled = complexity ? complexity.values.count { |r| r['n_unhandled'].to_i.positive? } : 0
+
+# ---------- HTML helpers ----------
+TAG_LABELS = {
+  'migrate-first'   => 'Migrate first',
+  'easy-win'        => 'Easy win',
+  'moderate'        => 'Standard',
+  'needs-gap-scout' => 'Needs review',
+  'retire'          => 'Retire'
+}
+TAG_CLASSES = {
+  'migrate-first'   => 'tag-go',
+  'easy-win'        => 'tag-blue',
+  'moderate'        => 'tag-gray',
+  'needs-gap-scout' => 'tag-warn',
+  'retire'          => 'tag-mute'
+}
+
+def tag_pill(t)
+  %(<span class="tag #{TAG_CLASSES[t]}">#{h(TAG_LABELS[t] || t)}</span>)
+end
+
+# Horizontal bar cell — value normalized to max
+def bar_cell(value, max, color = 'bar-blue')
+  pct = max.zero? ? 0 : (value.to_f / max * 100).round
+  %(<div class="bar-cell"><div class="bar-track"><div class="bar-fill #{color}" style="width:#{pct}%"></div></div><div class="bar-num">#{num(value)}</div></div>)
+end
+
+def kpi(label, value, sub = nil)
+  s = sub ? %(<div class="kpi-sub">#{h(sub)}</div>) : ''
+  %(<div class="kpi"><div class="kpi-v">#{h(value)}</div><div class="kpi-l">#{h(label)}</div>#{s}</div>)
+end
+
+# Generic data table renderer.
+def table(headers, rows, opts = {})
+  cls = opts[:class] || ''
+  cols = headers.size
+  align = opts[:align] || Array.new(cols, 'left')
+  thead = "<thead><tr>" + headers.each_with_index.map { |c, i| %(<th class="al-#{align[i]}">#{h(c)}</th>) }.join + "</tr></thead>"
+  tbody = "<tbody>" + rows.map do |r|
+    "<tr>" + r.each_with_index.map { |c, i|
+      cell = c.to_s
+      content = cell.start_with?('<') ? cell : h(cell)
+      %(<td class="al-#{align[i]}">#{content}</td>)
+    }.join + "</tr>"
+  end.join + "</tbody>"
+  %(<table class="data #{cls}">#{thead}#{tbody}</table>)
+end
+
+# ---------- section rendering ----------
+
+# Hero: headline finding
+hero_finding =
+  if has_shortlist
+    if sl_top5_unhandled.zero? && sl_migrate_first.positive?
+      'Pilot migration is low-risk: the top reports convert without any no-equivalent DAX or unsupported visuals.'
+    elsif sl_total_unhandled.positive?
+      "The top-5 pilot is feasible. #{n_with_unhandled} report#{n_with_unhandled == 1 ? '' : 's'} elsewhere in the tenant include feature#{n_with_unhandled == 1 ? '' : 's'} that warrant individual review when planning their conversion."
+    else
+      'Migration shortlist ranked by ' + (has_usage ? 'usage and conversion complexity.' : 'report richness and conversion complexity.')
+    end
+  else
+    'Environment scan complete.'
+  end
+
+# Section 01: KPI tiles — Power BI vocabulary
+kpi_html = [
+  kpi('Reports',        env['reports'], "#{env['dashboards'] || 0} dashboards"),
+  kpi('Semantic models', env['semantic_models']),
+  kpi('Datasets',       env['semantic_models'], 'one per semantic model'),
+  kpi('Workspaces',     env['workspaces'], "#{env['on_capacity_workspaces'] || 0} on Fabric capacity"),
+  kpi('Dataflows',      env['dataflows']),
+  kpi('DAX measures',   num(total_dax['a'] + total_dax['b'] + total_dax['c']),
+      "#{total_dax['a']} mechanical · #{total_dax['b']} restructure · #{total_dax['c']} no-equiv")
+].join
+
+# Section 02: Report priority & usage
+usage_html = ''
+if has_shortlist
+  ranked = shortlist_reports.sort_by { |r| -(has_usage ? r['views'].to_i : r['value'].to_f) }
+  max_val = has_usage ? (ranked.map { |r| r['views'].to_i }.max || 1) : (ranked.map { |r| r['value'].to_f }.max || 1)
+  rows = ranked.first(10).each_with_index.map do |r, i|
+    val = has_usage ? r['views'].to_i : r['value']
+    bar = has_usage ? bar_cell(r['views'].to_i, max_val) :
+          bar_cell(r['value'].round, [max_val.round, 1].max)
+    users_cell = has_usage ? (r['users'].nil? ? '<span class="muted">—</span>' : %(<span class="num">#{r['users']}</span>)) : '<span class="muted">—</span>'
+    %(<tr>
+      <td class="rank">#{i + 1}</td>
+      <td>#{h(r['name'])}</td>
+      <td class="muted">#{h(r['workspace'] || '—')}</td>
+      <td class="muted">#{h(r['model_name'] || '—')}</td>
+      <td>#{bar}</td>
+      <td class="al-right">#{users_cell}</td>
+    </tr>)
+  end.join
+  usage_col = has_usage ? 'Views' : 'Richness'
+  usage_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th class="al-right">#</th>
+          <th>Report</th>
+          <th>Workspace</th>
+          <th>Semantic model</th>
+          <th>#{usage_col}</th>
+          <th class="al-right">Distinct users</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 03: Ownership & concentration (by workspace)
+ownership_html = ''
+if reports.any?
+  rows_data = ws_concentration.to_a.sort_by { |_, v| -v[:reports] }
+  max_r = rows_data.first[1][:reports]
+  rows = rows_data.map do |name, v|
+    wsrec = (inventory['workspaces'] || []).find { |w| w['name'] == name }
+    cap = wsrec && wsrec['on_capacity'] ?
+      %(<span class="risk-chip risk-clean"><span class="risk-dot"></span>On capacity</span>) :
+      %(<span class="risk-chip risk-mute"><span class="risk-dot"></span>My workspace / shared</span>)
+    %(<tr>
+      <td>#{h(name)}</td>
+      <td>#{bar_cell(v[:reports], max_r)}</td>
+      <td class="al-right num muted">#{num(v[:models])}</td>
+      <td>#{cap}</td>
+    </tr>)
+  end.join
+  ownership_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Workspace</th>
+          <th>Reports</th>
+          <th class="al-right">Semantic models</th>
+          <th>Capacity</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 04: Data-source patterns (import/DirectQuery, warehouse sources, file flags)
+ds_html = ''
+import_models = models.count { |m| m['directquery_tables'].to_i.zero? && m['import_tables'].to_i.positive? }
+dq_models     = models.count { |m| m['directquery_tables'].to_i.positive? }
+wh = Hash.new(0)
+file_sources = []
+models.each do |m|
+  (m['warehouse_sources'] || []).each do |s|
+    wh[s] += 1
+    kind = s.to_s.split(':').first
+    file_sources << s if %w[Excel CSV File Folder Sheets Web SharePoint].include?(kind)
+  end
+end
+if models.any?
+  ds_stat_row = <<~ROW
+    <div class="stat-row" style="grid-template-columns: repeat(4, 1fr);">
+      <div class="stat #{import_models.positive? ? 'stat-go' : ''}">
+        <div class="stat-l">Import models</div>
+        <div class="stat-v #{import_models.positive? ? 'go' : ''}">#{import_models}</div>
+        <div class="stat-sub">cached extract — Sigma re-points to the M source</div>
+      </div>
+      <div class="stat">
+        <div class="stat-l">DirectQuery models</div>
+        <div class="stat-v">#{dq_models}</div>
+        <div class="stat-sub">live warehouse — drop-in for Sigma</div>
+      </div>
+      <div class="stat">
+        <div class="stat-l">Distinct warehouse hosts</div>
+        <div class="stat-v">#{wh.keys.size}</div>
+        <div class="stat-sub">parsed from M (Power Query)</div>
+      </div>
+      <div class="stat #{file_sources.any? ? 'stat-warn' : ''}">
+        <div class="stat-l">File-based sources</div>
+        <div class="stat-v #{file_sources.any? ? 'warn' : ''}">#{file_sources.uniq.size}</div>
+        <div class="stat-sub">need warehouse upload first</div>
+      </div>
+    </div>
+  ROW
+
+  if wh.any?
+    max_n = wh.values.max
+    wh_rows = wh.sort_by { |_, n| -n }.map do |src, n|
+      kind = src.to_s.split(':').first
+      host = src.to_s.split(':', 2)[1] || src
+      is_file = %w[Excel CSV File Folder Sheets Web SharePoint].include?(kind)
+      badge_cls = is_file ? 'ds-embedded' : 'ds-published'
+      flag = is_file ? %( <span class="risk-chip risk-amber"><span class="risk-dot"></span>land in warehouse</span>) : ''
+      %(<tr>
+        <td><span class="ds-bucket #{badge_cls}">#{h(kind)}</span></td>
+        <td><code>#{h(host)}</code>#{flag}</td>
+        <td>#{bar_cell(n, max_n)}</td>
+      </tr>)
+    end.join
+    wh_table = <<~HTML
+      <table class="data">
+        <thead>
+          <tr>
+            <th>Source type</th>
+            <th>Host (from M)</th>
+            <th>Models</th>
+          </tr>
+        </thead>
+        <tbody>#{wh_rows}</tbody>
+      </table>
+    HTML
+  else
+    wh_table = %(<p class="note">No warehouse sources parsed from M — models may be pure-import with no live source exposed.</p>)
+  end
+
+  ds_html = ds_stat_row + wh_table
+  ds_html += %(<p class="note">Models on a cloud warehouse Sigma supports (Snowflake, BigQuery, Databricks, Redshift, Synapse, Postgres) are <strong>drop-in</strong> — Sigma reads the same tables directly. Import-mode models hide the warehouse behind a cached extract; the M source above is what the <code>powerbi-to-sigma</code> converter re-points to.</p>) if wh.any?
+  ds_html += %(<div class="callout"><strong>#{file_sources.uniq.size} file-based source#{file_sources.uniq.size == 1 ? '' : 's'}</strong> (Excel / CSV / SharePoint) must be landed in your warehouse before migration — Sigma reads from the warehouse, not from local files.</div>) if file_sources.any?
+end
+
+# Section 05: Refresh insights
+refresh_html = ''
+refresh_rows = []
+models.each do |m|
+  rh = m['refresh_history']
+  next if rh.nil? || rh.empty?
+  durs = rh.map do |r|
+    if r['startTime'] && r['endTime']
+      (Time.parse(r['endTime']) - Time.parse(r['startTime'])) rescue nil
+    end
+  end.compact
+  avg_dur = durs.empty? ? nil : durs.sum / durs.size
+  n_fail = rh.count { |r| r['status'].to_s.downcase != 'completed' && r['status'].to_s.downcase != 'succeeded' }
+  last = rh.first
+  refresh_rows << [m, last, avg_dur, rh.size, n_fail]
+end
+require 'time'
+if refresh_rows.any?
+  rows = refresh_rows.map do |m, last, avg_dur, n_jobs, n_fail|
+    ok = (last['status'].to_s.downcase == 'completed' || last['status'].to_s.downcase == 'succeeded')
+    result_cls = ok ? 'tag-go' : 'tag-warn'
+    dur_txt = avg_dur ? format('%.1fs', avg_dur) : '—'
+    %(<tr>
+      <td>#{h(m['name'])}</td>
+      <td><span class="tag #{result_cls}">#{h(last['status'])}</span></td>
+      <td class="muted">#{h(last['refreshType'] || '—')}</td>
+      <td class="al-right num">#{num(n_jobs)}</td>
+      <td class="al-right num #{n_fail.positive? ? 'warn-num' : 'muted'}">#{n_fail}</td>
+      <td class="al-right num muted">#{dur_txt}</td>
+    </tr>)
+  end.join
+  refresh_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Semantic model</th>
+          <th>Last result</th>
+          <th>Type</th>
+          <th class="al-right">Jobs</th>
+          <th class="al-right">Failures</th>
+          <th class="al-right">Avg duration</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+elsif !tenant['refresh_history_available']
+  refresh_html = %(<p class="note">Refresh history unavailable — the Power BI REST token was not acquired. Re-run after a <code>powerbi-to-sigma</code> extract seeds the token cache.</p>)
+else
+  refresh_html = %(<p class="note">No refresh history rows — models may be DirectQuery (no scheduled refresh) or have never refreshed.</p>)
+end
+
+# Section 06: Migration shortlist (HERO table) + per-report complexity
+shortlist_html = ''
+if has_shortlist
+  max_score = shortlist_reports.map { |r| r['score'].to_f }.max || 1
+  rows = shortlist_reports.first(15).map do |r|
+    risk_cls, risk_txt =
+      if r['unhandled'].to_i.positive?
+        ['risk-red',   "#{r['unhandled']} to review"]
+      elsif r['manual'].to_i.positive?
+        ['risk-amber', "#{r['manual']} restructure"]
+      else
+        ['risk-clean', 'No issues']
+      end
+    d = r['dax_buckets'] || {}
+    dax_txt = "#{d['a'].to_i}/#{d['b'].to_i}/#{d['c'].to_i}"
+    %(<tr>
+      <td>#{h(r['name'])}</td>
+      <td class="muted">#{h(r['model_name'] || '—')}</td>
+      <td>#{bar_cell(r['value'].round, [max_score.round, 1].max)}</td>
+      <td class="al-right num muted">#{dax_txt}</td>
+      <td><span class="risk-chip #{risk_cls}"><span class="risk-dot"></span>#{h(risk_txt)}</span></td>
+      <td class="al-right num">#{format('%.1f', r['score'])}</td>
+      <td>#{tag_pill(r['tag'])}</td>
+    </tr>)
+  end.join
+  shortlist_html = <<~HTML
+    <table class="data shortlist">
+      <thead>
+        <tr>
+          <th>Report</th>
+          <th>Semantic model</th>
+          <th>Value</th>
+          <th class="al-right">DAX a/b/c</th>
+          <th>Conversion risk</th>
+          <th class="al-right">Score</th>
+          <th>Recommendation</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+    <p class="note">DAX a/b/c = mechanical / restructuring / no-equivalent measure counts inherited from the report's semantic model. Conversion risk: <strong>No issues</strong> = converts automatically · <strong>N restructure</strong> = needs a grouped element, parallel join, or pre-aggregation in Sigma · <strong>N to review</strong> = uses DAX or a custom visual with no Sigma equivalent and warrants individual evaluation.</p>
+  HTML
+end
+
+complexity_html = ''
+if complexity
+  rows = complexity.values.sort_by do |r|
+    -(r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3 + r['n_hint'].to_i)
+  end.map do |r|
+    d = r['dax_buckets'] || {}
+    dax_txt = "#{d['a'].to_i}/#{d['b'].to_i}/#{d['c'].to_i}"
+    unh_cell = r['n_unhandled'].to_i.positive? ? %(<span class="warn-num">#{r['n_unhandled']}</span>) : '<span class="muted">0</span>'
+    rls_cell = r['rls_role_count'].to_i.positive? ? %(<span class="warn-num">#{r['rls_role_count']}</span>) : '<span class="muted">0</span>'
+    %(<tr>
+      <td>#{h(r['name'])}</td>
+      <td class="al-right num muted">#{r['pages']}</td>
+      <td class="al-right num">#{r['visuals']}</td>
+      <td class="al-right num">#{r['measure_count']}</td>
+      <td class="al-right num muted">#{dax_txt}</td>
+      <td class="al-right num muted">#{r['calc_table_count']}</td>
+      <td class="al-right">#{rls_cell}</td>
+      <td class="al-right num">#{r['n_manual']}</td>
+      <td class="al-right">#{unh_cell}</td>
+    </tr>)
+  end.join
+  complexity_html = <<~HTML
+    <h3>Per-report complexity</h3>
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Report</th>
+          <th class="al-right">Pages</th>
+          <th class="al-right">Visuals</th>
+          <th class="al-right">Measures</th>
+          <th class="al-right">DAX a/b/c</th>
+          <th class="al-right">Calc tables</th>
+          <th class="al-right">RLS</th>
+          <th class="al-right">Restructure</th>
+          <th class="al-right">Review</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# ---------- HTML document ----------
+html = <<~HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Power BI Environment Report — #{h(tenant_name)}</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=DM+Mono:wght@400;500&display=swap');
+  :root {
+    /* Sigma brand palette — Shadow/Nimbus/White neutrals, Insight (CTA only), brand accents */
+    --bg:#fafafa; --card:#ffffff; --ink:#292929; --ink-2:#3d3d3d;
+    --line:#e5e5e5; --line-soft:#f5f5f5;
+    --accent:#292929; --accent-soft:#f0f0f0;
+    --insight:#f0ff45;
+    --go:#1f9d57; --go-soft:#e6fbef;
+    --warn:#c2562a; --warn-soft:#fff1ea;
+    --blue:#2b8ca6; --blue-soft:#eaf8fc;
+    --mute:#6e7877; --mute-soft:#f0f0f0;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
+  body {
+    font-family: "DM Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px; line-height: 1.55; -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 1120px; margin: 0 auto; padding: 48px 48px 80px; }
+
+  /* Brand masthead */
+  .brand-bar { display: flex; align-items: center; gap: 10px; margin-bottom: 28px; }
+  .brand-mark { font-weight: 700; font-size: 21px; letter-spacing: -0.02em; color: var(--ink); }
+  .brand-dot  { width: 9px; height: 9px; border-radius: 2px; background: var(--blue);
+                -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .brand-tag  { font-size: 12px; color: var(--mute); font-weight: 500;
+                text-transform: uppercase; letter-spacing: 0.08em; }
+
+  /* Header */
+  .doc-header { margin-bottom: 40px; }
+  .doc-eyebrow { font-size: 11px; font-weight: 600; color: var(--accent);
+                 text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+  .doc-title { font-size: 36px; font-weight: 700; letter-spacing: -0.02em;
+               margin: 0 0 8px; line-height: 1.1; color: var(--ink); }
+  .doc-meta { font-size: 13px; color: var(--ink-2); }
+  .doc-meta a { color: var(--ink-2); text-decoration: none; border-bottom: 1px dashed var(--line); }
+  .doc-meta a:hover { color: var(--ink); }
+
+  /* Hero finding banner */
+  .hero {
+    background: var(--accent-soft); border: 1px solid var(--line);
+    border-left: 4px solid var(--blue);
+    border-radius: 8px;
+    padding: 18px 22px; margin-bottom: 40px;
+    display: flex; align-items: center; gap: 16px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .hero-label { font-size: 11px; font-weight: 700; color: var(--accent);
+                text-transform: uppercase; letter-spacing: 0.08em;
+                white-space: nowrap; padding-right: 16px;
+                border-right: 1px solid var(--line); }
+  .hero-text { font-size: 15px; color: var(--ink); font-weight: 500; line-height: 1.4; }
+
+  /* Section */
+  section { margin-bottom: 56px; }
+  section.section-tight { margin-bottom: 36px; }
+  .section-head { display: flex; align-items: baseline; justify-content: space-between;
+                  margin-bottom: 16px; padding-bottom: 12px;
+                  border-bottom: 1px solid var(--line); }
+  .section-num { font-size: 12px; font-weight: 600; color: var(--mute);
+                 letter-spacing: 0.06em; }
+  .section-title { font-size: 22px; font-weight: 600; letter-spacing: -0.01em;
+                   margin: 0; flex: 1; padding-left: 14px; }
+  .section-aside { font-size: 12px; color: var(--mute); }
+  .section-lede { font-size: 14px; color: var(--ink-2); margin: -4px 0 16px; }
+
+  /* KPIs */
+  .kpi-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+  .kpi {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 18px 16px;
+  }
+  .kpi-v { font-size: 28px; font-weight: 700; letter-spacing: -0.01em;
+           color: var(--ink); line-height: 1; }
+  .kpi-l { font-size: 11px; color: var(--mute); text-transform: uppercase;
+           letter-spacing: 0.06em; font-weight: 600; margin-top: 10px; }
+  .kpi-sub { font-size: 11px; color: var(--mute); margin-top: 4px; line-height: 1.4; }
+
+  /* Stat callouts */
+  .stat-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
+              margin-bottom: 24px; }
+  .stat {
+    background: #fafafa;
+    border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 8px;
+    padding: 16px 18px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .stat.stat-go   { border-left-color: var(--go);   background: var(--go-soft); }
+  .stat.stat-warn { border-left-color: var(--warn); background: var(--warn-soft); }
+  .stat-l { font-size: 10px; color: var(--mute); text-transform: uppercase;
+            letter-spacing: 0.06em; font-weight: 700; margin-bottom: 6px; }
+  .stat-v { font-size: 30px; font-weight: 700; line-height: 1; letter-spacing: -0.02em;
+            color: var(--ink); }
+  .stat-v.go   { color: var(--go); }
+  .stat-v.warn { color: var(--warn); }
+  .stat-sub { font-size: 12px; color: var(--mute); margin-top: 6px; }
+
+  /* Tables */
+  table.data { width: 100%; border-collapse: collapse; background: var(--card);
+               border: 1px solid var(--line); border-radius: 10px; overflow: hidden;
+               font-size: 13px; }
+  table.data th { font-weight: 600; font-size: 11px; color: var(--mute);
+                  text-transform: uppercase; letter-spacing: 0.06em;
+                  padding: 12px 16px; background: #fafafa;
+                  border-bottom: 1px solid var(--line); text-align: left; }
+  table.data td { padding: 12px 16px; border-bottom: 1px solid var(--line-soft);
+                  vertical-align: middle; }
+  table.data tbody tr:last-child td { border-bottom: 0; }
+  table.data tbody tr:hover td { background: #fafafa; }
+  .al-right { text-align: right; }
+  .al-left  { text-align: left; }
+  /* Pin numeric + bar columns to content width so the text column absorbs the
+     slack — keeps a short value tight against its header instead of stranding it
+     across an over-wide column. */
+  table.data td.al-right, table.data th.al-right,
+  table.data td:has(.bar-cell) { width: 1%; white-space: nowrap; }
+  .num { font-variant-numeric: tabular-nums; }
+  .muted { color: var(--mute); }
+  .warn { color: var(--warn); }
+  .warn-num { color: var(--warn); font-weight: 700; }
+  .rank { font-variant-numeric: tabular-nums; color: var(--mute); font-weight: 600; width: 32px; }
+  .workbook-link { color: var(--ink); text-decoration: none;
+                   border-bottom: 1px solid var(--line); }
+  .workbook-link:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  .breakdown { font-size: 12px; font-variant-numeric: tabular-nums; }
+  .breakdown span { margin-right: 8px; }
+
+  /* Tags */
+  .tag { display: inline-block; padding: 3px 10px; border-radius: 99px;
+         font-size: 11px; font-weight: 600; letter-spacing: 0.01em;
+         white-space: nowrap; }
+  .tag-go    { background: var(--go-soft);    color: var(--go); }
+  .tag-blue  { background: var(--blue-soft);  color: var(--blue); }
+  .tag-gray  { background: #f5f5f5;           color: var(--ink-2); }
+  .tag-warn  { background: var(--warn-soft);  color: var(--warn); }
+  .tag-mute  { background: var(--mute-soft);  color: var(--mute); }
+
+  /* Bar cells (in tables) */
+  .bar-cell { display: flex; align-items: center; gap: 10px;
+              justify-content: flex-start; }
+  .bar-track { flex: none; width: 84px; height: 6px; background: #f5f5f5; border-radius: 4px;
+               overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 4px; }
+  .bar-blue { background: linear-gradient(90deg, #4cec8c, #2fb874); }
+  .bar-num { font-variant-numeric: tabular-nums; font-weight: 600;
+             min-width: 36px; text-align: right; }
+
+  /* Data-source bucket badge */
+  .ds-bucket { display: inline-block; padding: 3px 10px; border-radius: 6px;
+               font-size: 11px; font-weight: 600;
+               -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .ds-published { background: var(--blue-soft); color: var(--blue); }
+  .ds-embedded  { background: #f5f5f5; color: var(--ink-2); }
+
+  /* Risk chip — used in shortlist + verdicts + coverage */
+  .risk-chip { display: inline-flex; align-items: center; gap: 6px;
+               font-size: 12px; font-variant-numeric: tabular-nums; }
+  .risk-dot { width: 8px; height: 8px; border-radius: 50%;
+              -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .risk-clean .risk-dot { background: var(--go); }
+  .risk-clean             { color: var(--go); font-weight: 600; }
+  .risk-green .risk-dot { background: #84cc16; }
+  .risk-green             { color: var(--ink-2); }
+  .risk-amber .risk-dot { background: #f59e0b; }
+  .risk-amber             { color: #a16207; font-weight: 600; }
+  .risk-red   .risk-dot { background: var(--warn); }
+  .risk-red               { color: var(--warn); font-weight: 700; }
+  .risk-mute  .risk-dot { background: var(--mute); }
+  .risk-mute              { color: var(--mute); }
+
+  /* Cluster member display */
+  .cluster-member { padding: 2px 0; font-size: 12px; line-height: 1.4; }
+  .cluster-member + .cluster-member { border-top: 1px dashed var(--line-soft); }
+
+  /* Inline user pill (top-users cell) */
+  .inline-pill { display: inline-block; padding: 1px 7px; border-radius: 99px;
+                 font-size: 11px; background: #f1f5f9; color: var(--ink-2);
+                 font-variant-numeric: tabular-nums; margin-right: 4px;
+                 -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+
+  /* Top-view cell — most-used view per workbook */
+  .top-view-cell { font-size: 12px; line-height: 1.3; }
+  .top-view-pct  { font-size: 11px; margin-top: 2px; }
+
+  /* Per-user top-workbook list (inside table cell) */
+  .top-wb { font-size: 11px; line-height: 1.4; display: flex;
+            justify-content: space-between; gap: 12px;
+            padding: 1px 0; }
+  .top-wb + .top-wb { border-top: 1px dotted var(--line-soft); padding-top: 3px; margin-top: 3px; }
+  .top-wb span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 220px; }
+
+  /* Unique-to-user expander */
+  details.unique-detail { font-size: 11px; }
+  details.unique-detail summary { cursor: pointer; color: var(--accent); font-weight: 600;
+                                  list-style: none; padding: 2px 0; }
+  details.unique-detail summary::-webkit-details-marker { display: none; }
+  details.unique-detail summary::before { content: '▸ '; color: var(--mute); }
+  details.unique-detail[open] summary::before { content: '▾ '; }
+  details.unique-detail div { padding-left: 12px; font-size: 11px; line-height: 1.4; }
+
+  /* Notes + callouts */
+  .note { font-size: 12px; color: var(--mute); font-style: italic;
+          margin: 12px 0 0; }
+  .callout {
+    background: var(--warn-soft); border-left: 3px solid var(--warn);
+    padding: 12px 16px; border-radius: 6px; margin-top: 16px;
+    font-size: 13px; color: #7c2d12;
+  }
+  .callout strong { color: #7c2d12; }
+  .callout code { background: rgba(0,0,0,0.06); padding: 1px 5px; border-radius: 3px;
+                  font-size: 12px; }
+
+  code { font-family: "DM Mono", ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px;
+         background: var(--line-soft); padding: 1px 6px; border-radius: 4px; }
+
+  h3 { font-size: 15px; font-weight: 600; color: var(--ink); margin: 28px 0 12px; }
+
+  /* Next steps */
+  ol.next-steps { margin: 0; padding-left: 0; counter-reset: step;
+                  list-style: none; }
+  ol.next-steps li { counter-increment: step; padding: 14px 0 14px 44px;
+                     position: relative; border-bottom: 1px solid var(--line-soft);
+                     font-size: 14px; }
+  ol.next-steps li:last-child { border-bottom: 0; }
+  ol.next-steps li::before {
+    content: counter(step); position: absolute; left: 0; top: 14px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--accent-soft); color: var(--accent);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums;
+  }
+  ol.next-steps li strong { color: var(--ink); }
+
+  /* Privacy two-column */
+  .priv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .priv-col h3 { font-size: 13px; font-weight: 600; color: var(--ink);
+                 margin: 0 0 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .priv-col ul { margin: 0; padding-left: 0; list-style: none; }
+  .priv-col li { padding: 6px 0 6px 22px; position: relative;
+                 font-size: 13px; color: var(--ink-2); }
+  .priv-col.crossed li::before {
+    content: '→'; position: absolute; left: 0; color: var(--warn); font-weight: 700;
+  }
+  .priv-col.local li::before {
+    content: '◊'; position: absolute; left: 0; color: var(--go); font-weight: 700;
+  }
+
+  footer { color: var(--mute); font-size: 11px; text-align: center;
+           margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--line); }
+
+  @media print {
+    @page { margin: 0.6in 0.5in 0.6in; size: letter portrait; }
+    body { background: white; font-size: 11.5px; }
+    main { max-width: none; padding: 0; }
+    .doc-header { margin-bottom: 18px; }
+    .doc-title { font-size: 26px; }
+    .hero { margin-bottom: 24px; padding: 12px 16px; page-break-after: avoid; }
+    .hero-text { font-size: 13px; }
+    section { margin-bottom: 24px; page-break-inside: auto; }
+    section.section-tight { margin-bottom: 18px; }
+    .section-head { margin-bottom: 10px; padding-bottom: 8px; page-break-after: avoid; }
+    .section-title { font-size: 16px; }
+    .section-lede { font-size: 12px; margin: -2px 0 10px; }
+    .kpi-grid { gap: 8px; }
+    .kpi { padding: 12px; }
+    .kpi-v { font-size: 22px; }
+    .kpi-l { font-size: 10px; margin-top: 6px; }
+    .kpi-sub { font-size: 10px; margin-top: 3px; }
+    .stat-row { gap: 8px; margin-bottom: 14px; }
+    .stat { padding: 12px 14px; }
+    .stat-v { font-size: 24px; }
+    table.data { font-size: 11px; page-break-inside: auto; }
+    table.data thead { display: table-header-group; }
+    table.data th { padding: 8px 10px; font-size: 10px; }
+    table.data td { padding: 8px 10px; }
+    table.data tr { page-break-inside: avoid; page-break-after: auto; }
+    .tag, .ds-bucket { font-size: 10px; padding: 2px 8px; }
+    .bar-track { max-width: 60px; height: 5px; }
+    .note { font-size: 11px; }
+    .callout { padding: 8px 12px; font-size: 11px; }
+    ol.next-steps li { padding: 10px 0 10px 36px; font-size: 12px; }
+    ol.next-steps li::before { width: 22px; height: 22px; font-size: 11px; top: 10px; }
+    .priv-col li { font-size: 11px; padding: 4px 0 4px 18px; }
+    footer { margin-top: 24px; padding-top: 12px; }
+    /* Force backgrounds + colors to render */
+    .hero, .kpi, .stat, table.data, table.data th, .ds-bucket, .tag,
+    .bar-track, .bar-fill, .risk-dot, .callout, ol.next-steps li::before {
+      -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important;
+    }
+    /* Avoid awkward page splits at section boundaries */
+    section h2, .section-head { page-break-after: avoid; }
+    .stat-row, .priv-grid { page-break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+<main>
+
+<div class="brand-bar">
+  <span class="brand-dot"></span>
+  <span class="brand-mark">sigma</span>
+  <span class="brand-tag">Migration Assessment</span>
+</div>
+<div class="doc-header">
+  <div class="doc-eyebrow">Power BI Environment Report</div>
+  <h1 class="doc-title">#{h(tenant_name)}</h1>
+  <div class="doc-meta">
+    #{h(mode_label)} · Generated #{h(formatted_date)}
+  </div>
+</div>
+
+<div class="hero">
+  <div class="hero-label">Headline finding</div>
+  <div class="hero-text">#{h(hero_finding)}</div>
+</div>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">01</span>
+    <h2 class="section-title">Environment overview</h2>
+  </div>
+  <div class="kpi-grid">#{kpi_html}</div>
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">02</span>
+    <h2 class="section-title">Report priority &amp; usage</h2>
+    <span class="section-aside">#{has_usage ? "Top 10 of #{env['reports']} reports · #{num(total_views)} total views" : "Top 10 of #{env['reports']} reports · complexity-ranked"}</span>
+  </div>
+  <p class="section-lede">#{has_usage ? 'Most-used reports across the tenant, ranked by view count from the Activity Events API. This is the foundation of any migration or consolidation plan — focus effort where audience attention already is.' : 'Without the Fabric Administrator role, view counts are unavailable. Reports below are ranked by a richness proxy (pages + visuals). Re-run as an admin to rank by real usage.'}</p>
+  #{usage_html}
+  #{cold_reports.any? ? %(<p class="note"><strong>#{cold_reports.size} report#{cold_reports.size == 1 ? '' : 's'}</strong> have zero views in the activity-event window: ) + cold_reports.map { |r| %(<code>#{h(r['name'])}</code>) }.join(', ') + ' — strong candidates for retirement.</p>' : ''}
+  #{has_usage ? '<p class="note">Activity Events retains roughly a 30-day window — "views" reflect that period, not all-time.</p>' : ''}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">03</span>
+    <h2 class="section-title">Ownership &amp; concentration</h2>
+    <span class="section-aside">#{ws_concentration.size} workspace#{ws_concentration.size == 1 ? '' : 's'}</span>
+  </div>
+  <p class="section-lede">Power BI organizes content by workspace rather than per-report owner. Concentration in a single workspace (especially a personal "My workspace") is a governance signal — what happens to that content if its owner leaves?</p>
+  #{ownership_html}
+  <p class="note">Top-workspace concentration: <strong>#{top_ws_pct}%</strong> of reports live in <code>#{h(top_ws_name)}</code>. Content in <code>My workspace</code> is per-user and usually the first to consolidate.</p>
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">04</span>
+    <h2 class="section-title">Data-source patterns</h2>
+    <span class="section-aside">#{import_models} import · #{dq_models} DirectQuery · #{wh.keys.size} hosts</span>
+  </div>
+  <p class="section-lede">How each semantic model gets its data — import (cached extract) vs. DirectQuery (live), the warehouse hosts parsed from each model's M (Power Query) expression, and any file-based sources that need to land in a warehouse before migration.</p>
+  #{ds_html}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">05</span>
+    <h2 class="section-title">Refresh insights</h2>
+  </div>
+  <p class="section-lede">Scheduled dataset-refresh activity per semantic model — last result, failure counts, and average duration. Import-mode models refresh on a schedule; DirectQuery models query live and rarely appear here.</p>
+  #{refresh_html}
+</section>
+HTML
+
+if has_shortlist
+  html += <<~HTML
+
+<section>
+  <div class="section-head">
+    <span class="section-num">06</span>
+    <h2 class="section-title">Migration to Sigma — recommended sequence</h2>
+    <span class="section-aside">#{shortlist['value_basis'] ? h(shortlist['value_basis']) : 'value / (1 + cost)'}</span>
+  </div>
+  <p class="section-lede">If you choose to migrate to Sigma, this is the order that minimizes risk while covering the most user impact. Reports are ranked by value relative to conversion complexity (<code>score = value / (1 + cost)</code>, where <code>cost = 10·unhandled + 3·manual</code>). The top of the list is the recommended starting point for a pilot.</p>
+
+  <div class="stat-row">
+    <div class="stat">
+      <div class="stat-l">#{has_usage ? 'Top-5 view share' : 'Top-5 of shortlist'}</div>
+      <div class="stat-v">#{has_usage ? "#{top5_pct}<span style=\"font-size: 16px; color: var(--mute); font-weight: 600;\">%</span>" : [5, shortlist_reports.size].min.to_s}</div>
+      <div class="stat-sub">#{has_usage ? "of #{num(total_views)} total views" : "highest-value reports of #{shortlist_reports.size}"}</div>
+    </div>
+    <div class="stat stat-#{sl_top5_unhandled.zero? ? 'go' : 'warn'}">
+      <div class="stat-l">Top-5 conversion complexity</div>
+      <div class="stat-v #{sl_top5_unhandled.zero? ? 'go' : 'warn'}">#{sl_top5_unhandled}</div>
+      <div class="stat-sub">no-equivalent features to review across pilot</div>
+    </div>
+    <div class="stat">
+      <div class="stat-l">Needs review · Retire</div>
+      <div class="stat-v">#{sl_needs_scout}<span style="font-size: 16px; color: var(--mute); font-weight: 600;"> · #{sl_retire}</span></div>
+      <div class="stat-sub">reports of #{shortlist_reports.size} total</div>
+    </div>
+  </div>
+
+  #{shortlist_html}
+
+  #{complexity_html}
+
+  #{sl_total_unhandled.positive? ?
+    %(<div class="callout"><strong>#{n_with_unhandled} report#{n_with_unhandled == 1 ? '' : 's'}</strong> include DAX or custom visuals with no Sigma equivalent that warrant individual review when planning their conversion — typically PATH hierarchies, dynamic-context measures, or unsupported custom visuals where the right Sigma equivalent depends on how the report actually uses them. Identifying these up-front means no surprises mid-migration.</div>) : ''}
+</section>
+  HTML
+end
+
+priv_num = has_shortlist ? '07' : '06'
+next_num = has_shortlist ? '08' : '07'
+
+html += <<~HTML
+
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{priv_num}</span>
+    <h2 class="section-title">Data handling</h2>
+  </div>
+  <p class="section-lede">This report was generated by an LLM-driven scan of your Power BI / Fabric tenant. Power BI exposes more than Tableau's <code>.twb</code> — TMSL carries DAX and RLS role definitions. What that means for the data that left your environment:</p>
+  <div class="priv-grid">
+    <div class="priv-col crossed">
+      <h3>Read by the scanner</h3>
+      <ul>
+        <li>Aggregate counts (workspace, semantic-model, report, dataflow totals)</li>
+        <li>Report names, semantic-model names, workspace names</li>
+        <li>Full TMSL — DAX measure / calc-column expressions and <strong>RLS role definitions</strong></li>
+        <li>PBIR — visual configuration and page structure</li>
+        <li>Warehouse host names parsed from M (Power Query)</li>
+        <li>Refresh job results</li>
+      </ul>
+    </div>
+    <div class="priv-col local">
+      <h3>Never left your environment</h3>
+      <ul>
+        <li>Underlying warehouse rows — the scan never queries source data</li>
+        <li>The <code>.pbix</code> binary model blobs</li>
+        <li>Power BI / Entra credentials</li>
+        <li>Actual report cell values</li>
+      </ul>
+    </div>
+  </div>
+  <p class="note">If RLS roles or DAX encode business-sensitive logic, that text crossed the API. See <code>PRIVACY.md</code> for the full disclosure.</p>
+</section>
+
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{next_num}</span>
+    <h2 class="section-title">Recommended next steps</h2>
+  </div>
+  <ol class="next-steps">
+HTML
+
+if has_shortlist
+  pilot_n = [5, shortlist_reports.size].min
+  html += "    <li><strong>Pilot the top #{pilot_n} report#{pilot_n == 1 ? '' : 's'}.</strong> "
+  html += (has_usage ? "They represent #{top5_pct}% of total tenant views " : "They are the highest value-to-complexity reports ")
+  html += "with #{sl_top5_unhandled} feature#{sl_top5_unhandled == 1 ? '' : 's'} flagged for review between them — the lowest-risk way to demonstrate an end-to-end Power BI to Sigma migration. Reports off the same semantic model share a Sigma data model, so migrate by cluster.</li>\n"
+  if sl_needs_scout.positive?
+    html += "    <li><strong>Plan individual review time for #{sl_needs_scout} report#{sl_needs_scout == 1 ? '' : 's'}.</strong> Each contains no-equivalent DAX or an unsupported custom visual that benefits from a tailored conversion approach — identifying them up-front prevents surprises mid-migration.</li>\n"
+  end
+  if sl_retire.positive?
+    html += "    <li><strong>Retire #{sl_retire} report#{sl_retire == 1 ? '' : 's'}</strong> with zero views. No migration value, and dropping them simplifies the cutover.</li>\n"
+  end
+  unless has_usage
+    html += "    <li><strong>Re-run as a Fabric Administrator</strong> to add the usage axis (view counts, distinct users from the Activity Events API). The current shortlist is complexity-only — it ranks by report richness, not by who actually uses each report.</li>\n"
+  end
+  html += "    <li><strong>Hand off to <code>powerbi-to-sigma</code></strong> using <code>migration-plan.json</code> in this folder. The decoded <code>raw-tmsl/</code> and <code>raw-pbir/</code> are the converter's Phase-0 input — it reuses them instead of re-extracting.</li>\n"
+else
+  html += <<~HTML
+    <li><strong>Enable per-report conversion analysis</strong> by running the full inventory + complexity scan. This unlocks the migration shortlist and conversion-cost profile.</li>
+    <li><strong>Re-run as a Fabric Administrator</strong> to add usage/adoption (views, distinct users) and tenant-wide sprawl via the Scanner API.</li>
+  HTML
+end
+
+html += <<~HTML
+  </ol>
+</section>
+
+<footer>
+  Report generated #{h(formatted_date)} · supporting JSON files alongside in the same folder
+</footer>
+
+</main>
+</body>
+</html>
+HTML
+
+out_path = File.join(opts[:out], 'readout.html')
+File.write(out_path, html)
+puts "wrote #{out_path} (#{File.size(out_path)} bytes)"

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/README.md
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/README.md
@@ -1,0 +1,94 @@
+# Qlik Cloud Assessment
+
+A Claude Code skill that inventories a Qlik Cloud tenant and produces a
+migration-readiness readout. Designed to be run by a customer (or a Sigma rep
+with the customer present) before deciding which Qlik apps to migrate to Sigma.
+
+**READ-ONLY** in inventory mode. With `--deep` the only writes are a temporary
+`MeasureList` object per app (created then immediately removed, solely to
+enumerate master measures — qlik-cli has no read-only listing for them). The
+skill never reads warehouse rows and never posts to Sigma.
+
+## What it produces
+
+A directory (`/tmp/assessment-<tenant>/`) with:
+
+- `inventory.json` — environment counts, per-app metadata (usage, reload, Section
+  Access / DirectQuery flags), per-app complexity buckets, an ownership rollup,
+  data-connection rollup, reload-activity rollup, and the value/cost-ranked
+  **migration shortlist**. This is the single file the renderers consume.
+- `readout.md` — a compact markdown summary (environment, per-app complexity,
+  shortlist, caveats), written by `qlik-inventory.py`.
+- `readout.html` — a customer-facing, Sigma-branded HTML report (the same theme
+  as `tableau-assessment` / `powerbi-assessment`), written by
+  `render-readout-html.rb`. Open it in a browser or print to PDF to share.
+
+Nothing in this directory is uploaded anywhere. To share, zip and send deliberately.
+
+## Prerequisites
+
+- Claude Code installed
+- A working **qlik-cli context** (API key or OAuth M2M) for the tenant you want
+  to assess — see `../qlik-to-sigma/refs/connection.md` for the auth recipe and
+  the two M2M gotchas (an M2M identity only sees spaces it has been granted, and
+  cannot reload space-connection apps).
+- Ruby (for the HTML renderer) and Python 3 (for the inventory script)
+
+For the **usage axis** (app views), the tenant exposes `itemViews` on every app
+the context can see — no special admin role is required, but note `itemViews` is
+a **28-day rolling window**, not all-time.
+
+## How to run
+
+In Claude Code:
+
+```
+/qlik-assessment
+```
+
+The skill will:
+
+1. Probe the active qlik-cli context and confirm space/user visibility
+2. Inventory apps (+ usage, reload status/duration, Section Access, DirectQuery),
+   spaces, users, and data connections
+3. *(with `--deep`)* Open each app to bucket master-measure expressions and chart
+   viz types against Sigma coverage
+4. Score `value / (1 + cost)` and tag each app
+5. Write `inventory.json` + `readout.md` (`qlik-inventory.py`), then render
+   `readout.html` (`render-readout-html.rb`)
+6. Offer to hand off the shortlist to `qlik-to-sigma`
+
+```
+ruby scripts/render-readout-html.rb --out /tmp/assessment-<tenant>
+```
+
+## The key idea
+
+The same `convert_qlik_to_sigma` translation rules that drive the converter also
+**predict migration effort**: bucket each master-measure expression
+(auto / manual / unhandled) and each chart's viz type against Sigma's coverage.
+Set Analysis → `manual` (Sigma `SumIf`); `Aggr()` / `Dual()` / selection-state /
+`Range*` / alternate states → `unhandled`. See `refs/complexity-scoring.md`.
+
+## What this is NOT
+
+- **Not** a write tool. It cannot and will not modify app content or post to Sigma.
+- **Not** a complete tenant audit. It covers the signals that matter for Sigma
+  migration scoping, scoped to **what the active context can access** (an M2M
+  identity sees only its granted spaces). A tenant-wide sprawl scan needs the
+  Qlik governance "App analyzer" apps.
+- **Not** the converter. It scopes; `qlik-to-sigma` converts. The `shortlist` in
+  `inventory.json` is the hand-off between them.
+
+## Privacy
+
+This skill sends app/tenant metadata (not warehouse rows) through the Anthropic
+API. With `--deep` it pulls **master-measure expressions and chart object
+definitions** to bucket complexity. See [`PRIVACY.md`](./PRIVACY.md) for the full
+disclosure to review with your privacy/legal team before running.
+
+## Sibling skills
+
+- [`qlik-to-sigma`](../../../qlik-to-sigma/) — the conversion skill this feeds into.
+- `tableau-assessment` / `powerbi-assessment` — the analogs this skill mirrors
+  (same scoring framework, same Sigma-branded readout theme).

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/SKILL.md
@@ -20,6 +20,8 @@ user-invocable: true
 - `refs/complexity-scoring.md` — the Qlik convertibility rubric (expression + viz buckets)
 - `../qlik-to-sigma/refs/connection.md` — qlik-cli auth + the two M2M gotchas
 - `PRIVACY.md` — read-only posture
+- `refs/output-shapes.md` — exact `inventory.json` shape the renderers consume
+- `refs/readout-template.md` — `readout.html` section ordering + Sigma-branded theme
 
 ## The key idea
 The same `convert_qlik_to_sigma` translation rules that drive the converter also
@@ -32,13 +34,16 @@ unhandled) and each chart's viz type against Sigma's coverage. Set Analysis →
 1–2. **Inventory** — apps (+ `itemViews`, `resourceReloadStatus`, `lastReloadTime`, `hasSectionAccess`, `isDirectQueryMode`, `resourceSize`), spaces, users. `scripts/qlik-inventory.py`.
 3. **Per-app complexity** — master measures (Engine `MeasureList`) bucketed by expression; chart objects bucketed by viz type; Section Access & DirectQuery flags; data-model table count from the load script.
 4. **Shortlist** — `cost = 10·unhandled + 3·manual + 1·hint`; `value = itemViews × √(distinct, when available)` else size/complexity proxy; `score = value/(1+cost)`; tag.
-5. **Readout** — markdown summary (env, per-app complexity, shortlist, caveats).
+5. **Readout** — `qlik-inventory.py` writes `inventory.json` + `readout.md`; then
+   `scripts/render-readout-html.rb --out <dir>` renders the customer-facing,
+   Sigma-branded `readout.html` (same theme as `tableau-assessment`).
 6. **Hand off** — to `qlik-to-sigma` (ask the user which apps first).
 
 ## Scripts
 | Script | Phase | Purpose |
 |---|---|---|
 | `scripts/qlik-inventory.py` | 0–4 | Enumerate apps/spaces/users, per-app expression+viz complexity, score + tag → `inventory.json` + `readout.md` |
+| `scripts/render-readout-html.rb` | 5 | Render the Sigma-branded `readout.html` from `inventory.json` (`ruby scripts/render-readout-html.rb --out <dir>`) |
 
 `qlik-inventory.py --out assessment-<tenant>` (uses the active qlik-cli context).
 Per-app deep complexity reuses the `MeasureList` enumeration from

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/refs/output-shapes.md
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/refs/output-shapes.md
@@ -1,0 +1,109 @@
+# Output shapes
+
+`qlik-inventory.py` emits **one JSON file** (`inventory.json`) plus a compact
+`readout.md` to `<out>/`. `render-readout-html.rb` reads `inventory.json` alone
+to produce the Sigma-branded `readout.html`; `qlik-to-sigma` reads the
+`shortlist` array.
+
+Unlike `tableau-assessment` (three JSON files) and `powerbi-assessment` (four),
+Qlik packs everything into a single `inventory.json` — there is no separate
+`complexity.json` / `shortlist.json`, because qlik-cli enumerates an app's
+measures, charts, usage, and flags in one pass. The renderer's section
+vocabulary still lines up with the other assessments (app↔workbook,
+sheet↔view, master measure↔measure, space↔project, data connection↔datasource,
+Section Access↔RLS, DirectQuery↔live, reload↔refresh).
+
+## `inventory.json` (written by `qlik-inventory.py`)
+
+Inventory-only mode (no `--deep`) writes the same shape with per-app complexity
+fields all zero and `connection_types` possibly empty.
+
+```json
+{
+  "tenant": {
+    "name": "<tenant host or QLIK_TENANT>",
+    "url": "<QLIK_TENANT_URL or ''>",
+    "generated_at": "YYYY-MM-DD",
+    "mode": "qlik-cli + deep" | "qlik-cli inventory-only"
+  },
+  "environment_overview": {
+    "apps": <int>,
+    "sheets": <int>,            // summed across apps (deep only; else 0)
+    "master_measures": <int>,   // summed master-measure count (deep only; else 0)
+    "spaces": <int>,
+    "data_connections": <int>
+  },
+  "data_sources": {
+    "n_connections": <int>,
+    "n_directquery_apps": <int>,        // isDirectQueryMode = true
+    "n_inmemory_apps": <int>,           // apps - directquery
+    "n_section_access_apps": <int>,     // hasSectionAccess = true
+    "n_file_based_connections": <int>,  // connection type matches qvd/csv/xls/file/folder
+    "connection_types": [{ "type": "<str>", "n": <int> }, ...]
+  },
+  "reload_activity": {
+    "by_status": [{ "status": "SUCCEEDED|FAILED|unknown|...", "n": <int> }, ...],
+    "avg_duration_s": <float>|null,
+    "max_duration_s": <float>|null,
+    "n_with_duration": <int>
+  },
+  "ownership": [
+    { "owner": "<name/email>", "apps": <int>, "views": <int>, "measures": <int> }, ...
+  ],
+  "shortlist": [
+    {
+      "id": "...", "name": "...", "space": "...", "owner": "...",
+      "views": <int>,                 // itemViews — 28-day rolling window
+      "reloadStatus": "...", "lastReload": "...", "reloadDurationS": <num>|null,
+      "sectionAccess": <bool>, "directQuery": <bool>,
+      "sheets": <int>, "measures": <int>,
+      "n_auto": <int>, "n_hint": <int>, "n_manual": <int>, "n_unhandled": <int>,
+      "measure_buckets": { "auto": <int>, "manual": <int>, "unhandled": <int> },
+      "viz_types": { "<qViz type>": <int>, ... },
+      "cost": <int>, "score": <float>,
+      "tag": "migrate-first"|"easy-win"|"moderate"|"needs-gap-scout"|"retire"
+    }
+  ],
+  "apps": <int>, "spaces": <int>     // back-compat top-level counts
+}
+```
+
+`shortlist` is sorted by `score` descending — index 0 is the top migration
+candidate. The renderer treats the first 5 as the pilot and the first 15 as the
+displayed shortlist + complexity table.
+
+## Complexity buckets
+
+Mirrors the other assessments' four-tier vocabulary (see
+`refs/complexity-scoring.md`):
+
+- `n_auto` — master measures + charts that convert mechanically.
+- `n_hint` — reserved for parity with the shared renderer (Qlik does not
+  currently emit a `hint` tier; always 0).
+- `n_manual` — **Setup**: Set Analysis (→ Sigma `SumIf`), `Class()` binning,
+  manual-recreate viz (mekko/funnel/sankey/map/...), **plus** +1 each for
+  `sectionAccess` and `directQuery`.
+- `n_unhandled` — **Review**: `Aggr()`, `Dual()`, selection-state functions,
+  `Range*`, alternate states, and Qlik extensions / custom-viz objects.
+
+## Scoring + tags
+
+`cost = 10·n_unhandled + 3·n_manual + 1·n_hint`;
+`value = itemViews × √itemViews` (or `10×(charts + measures/4)` proxy when usage
+is unavailable); `score = value / (1 + cost)`.
+
+Tag rules:
+- `views == 0`                                   → `retire`
+- `n_unhandled >= 1`                             → `needs-gap-scout`
+- `score >= 20 and (manual + unhandled) == 0`    → `migrate-first`
+- `score >= 10`                                  → `easy-win`
+- else                                           → `moderate`
+
+## `readout.html` / `readout.md`
+
+`readout.html` is an 8-section Sigma-branded report (see
+`refs/readout-template.md`): masthead + hero, 01 environment, 02 app priority &
+usage, 03 ownership, 04 data sources & load-script patterns, 05 reload activity,
+06 migration shortlist + per-app complexity, 07 data handling, 08 next steps.
+Sections 06–08 collapse to 06–07 in inventory-only mode (no shortlist).
+`readout.md` is the compact text equivalent written by the Python script.

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/refs/readout-template.md
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/refs/readout-template.md
@@ -1,0 +1,96 @@
+# Qlik Cloud Assessment — readout section template
+
+`render-readout-html.rb` composes `readout.html` deterministically from
+`inventory.json`. Sections below match the gold-standard `tableau-assessment` /
+`powerbi-assessment` HTML readouts so the look is byte-identical; only the
+vocabulary is Qlik-specific. Placeholders in `{{ }}` come straight from the JSON.
+
+The masthead is always `sigma · Migration Assessment` with the eyebrow
+`Qlik Cloud Environment Report` and the tenant name as the H1.
+
+---
+
+## Hero — Headline finding
+
+One sentence. If the top-5 pilot has zero unhandled features and at least one
+`migrate-first` app: "Pilot migration is low-risk…". Else if any unhandled
+features exist: names the count of apps needing review (Set Analysis, Aggr(),
+alternate states). Else a neutral summary.
+
+---
+
+## 01. Environment overview
+
+Six KPI tiles: **Apps**, **Sheets**, **Master measures**, **Spaces**,
+**Data connections**, **Total app views** (sub-label: `28-day rolling window`).
+
+---
+
+## 02. App priority & usage
+
+Top 10 apps ranked by `itemViews`, with a bar cell, owner, and a Flags cell
+(Section Access / DirectQuery inline pills). Always followed by the note that
+`itemViews` is a **28-day rolling window**, not all-time. Cold apps (zero views)
+are listed as retirement candidates.
+
+---
+
+## 03. Ownership & concentration
+
+Apps-by-owner table (bar on apps; views + master measures as numeric columns).
+Note line states the top-owner concentration percentage — a governance signal.
+
+---
+
+## 04. Data sources & load-script patterns
+
+Three stat tiles: **DirectQuery apps** (drop-in to a Sigma connection),
+**In-memory apps** (reload from QVD/file/warehouse extract), **File-based
+connections** (QVD/CSV/Excel — land in warehouse first). Then a connection-type
+table (warehouse/live vs file-based badges). A callout fires when any app uses
+**Section Access** (row-level security → Sigma column/row-level security).
+
+---
+
+## 05. Reload activity
+
+Reload-status table (succeeded/failed/unknown counts) plus average and max
+last-reload duration. Frames reloads as migration motivation: Sigma queries the
+warehouse live and removes the reload step.
+
+---
+
+## 06. Migration to Sigma — recommended sequence  *(shortlist mode only)*
+
+Three stat tiles: **Top-5 tenant usage share** (`{{top5_pct}}%`), **Top-5
+conversion complexity** (`{{sl_top5_unhandled}}` features to review), **Needs
+review · Retire** counts. Then the shortlist table (App, Views bar, Conversion
+risk chip, Score, Recommendation pill) with the risk legend, an optional callout
+when unhandled features exist, and a **Per-app complexity** sub-table (master
+measures, charts, Auto / Setup / Review counts).
+
+Risk chip + recommendation tags use the shared `TAG_LABELS` / `TAG_CLASSES` /
+risk-chip helpers: `migrate-first`→Migrate first (green), `easy-win`→Easy win
+(blue), `moderate`→Standard (gray), `needs-gap-scout`→Needs review (amber),
+`retire`→Retire (mute).
+
+---
+
+## 07. Data handling
+
+Two-column privacy grid. **Read by the scanner**: aggregate counts, app/owner
+names, space IDs, reload + `itemViews`, and (deep mode) master-measure
+expressions + chart definitions. **Never left your environment**: warehouse
+rows, QVD/in-memory extracts, credentials, Section Access rules verbatim.
+
+---
+
+## 08. Recommended next steps
+
+Numbered list. Shortlist mode: pilot the top 5, plan review time for
+`needs-gap-scout` apps, retire zero-view apps, hand off to `qlik-to-sigma`
+(feed it the Qlik *model*, not the warehouse). Inventory-only mode: re-run with
+`--deep`, then hand off.
+
+Section numbering: 06–08 in shortlist mode; collapses to 06–07 (data handling +
+next steps) when no shortlist is present.

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/qlik-inventory.py
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/qlik-inventory.py
@@ -68,29 +68,105 @@ def main():
     rows=[]
     for it in apps:
         ra=it.get("resourceAttributes",{})
+        ow=it.get("owner")
+        owner=it.get("ownerName") or (ow.get("name") if isinstance(ow,dict) else ow) or it.get("ownerId") or "(unknown)"
         row={"id":it.get("resourceId"),"name":it.get("name"),"space":it.get("spaceId"),
+             "owner":owner,
              "views":(it.get("itemViews") or {}).get("trendCurrent",0) if isinstance(it.get("itemViews"),dict) else (it.get("itemViews") or 0),
              "reloadStatus":it.get("resourceReloadStatus"),"lastReload":ra.get("lastReloadTime"),
+             "reloadDurationS":(ra.get("lastReloadDuration") or it.get("reloadDuration")),
              "sectionAccess":bool(ra.get("hasSectionAccess")),"directQuery":bool(ra.get("isDirectQueryMode")),
+             "sheets":0,"measures":0,
              "n_auto":0,"n_hint":0,"n_manual":0,"n_unhandled":0,"measure_buckets":{},"viz_types":{}}
         if a.deep and row["id"]:
             exprs=enum_measures(row["id"],ctx)
             mb={"auto":0,"manual":0,"unhandled":0}
             for e in exprs: mb[bucket_expr(e)]+=1
             objs=q("app","object","ls","-a",row["id"],"--json",*ctx) or []
-            charts=0
+            charts=0; sheets=0
             for o in objs:
+                if (o.get("qType") or "").lower()=="sheet": sheets+=1
                 b=bucket_viz(o.get("qType"))
                 if b is None: continue
                 charts+=1; row["viz_types"][o.get("qType")]=row["viz_types"].get(o.get("qType"),0)+1
                 row[{"auto":"n_auto","manual":"n_manual","unhandled":"n_unhandled"}[b]]+=1
             row["n_auto"]+=mb["auto"]; row["n_manual"]+=mb["manual"]+(1 if row["sectionAccess"] else 0)+(1 if row["directQuery"] else 0); row["n_unhandled"]+=mb["unhandled"]
             row["measure_buckets"]=mb; row["_charts"]=charts; row["_measures"]=len(exprs)
+            row["sheets"]=sheets; row["measures"]=len(exprs)
         c,sc=score(row["views"],row["n_auto"],row["n_hint"],row["n_manual"],row["n_unhandled"],row.get("_charts",0),row.get("_measures",0))
         row["cost"],row["score"]=c,sc; row["tag"]=tag(row["views"],sc,row["n_manual"],row["n_unhandled"])
         rows.append(row)
     rows.sort(key=lambda r:r["score"],reverse=True)
-    inv={"tenant":os.environ.get("QLIK_TENANT","(active context)"),"apps":len(apps),"spaces":len(spaces),"shortlist":rows}
+
+    # ---- data connections (read-only enumeration) ----
+    conns=q("connection","ls","--limit","200","--json",*ctx) or q("item","ls","--resourceType","dataset","--limit","200","--json",*ctx) or []
+    conn_types={}
+    file_based=0
+    FILE_HINT=re.compile(r'(qvd|csv|xlsx?|txt|file|folder|datafiles)',re.I)
+    for c in conns:
+        t=(c.get("connectionType") or c.get("type") or c.get("datasourceKind") or "unknown")
+        conn_types[t]=conn_types.get(t,0)+1
+        if FILE_HINT.search(str(t)): file_based+=1
+    n_data_connections=len(conns)
+
+    # ---- environment rollups ----
+    total_sheets=sum(r.get("sheets",0) for r in rows)
+    total_measures=sum(r.get("measures",0) for r in rows)
+    n_section_access=sum(1 for r in rows if r["sectionAccess"])
+    n_directquery=sum(1 for r in rows if r["directQuery"])
+    n_inmemory=len(rows)-n_directquery
+
+    # ---- ownership concentration (apps/views by owner) ----
+    own={}
+    for r in rows:
+        o=r.get("owner") or "(unknown)"
+        d=own.setdefault(o,{"owner":o,"apps":0,"views":0,"measures":0})
+        d["apps"]+=1; d["views"]+=int(r.get("views") or 0); d["measures"]+=int(r.get("measures") or 0)
+    ownership=sorted(own.values(),key=lambda d:-d["apps"])
+
+    # ---- reload activity rollup ----
+    rl_by_status={}
+    rl_durations=[]
+    for r in rows:
+        st=(r.get("reloadStatus") or "unknown")
+        rl_by_status[st]=rl_by_status.get(st,0)+1
+        dur=r.get("reloadDurationS")
+        try:
+            if dur is not None: rl_durations.append(float(dur))
+        except (TypeError,ValueError): pass
+    reload_activity={
+        "by_status":[{"status":k,"n":v} for k,v in sorted(rl_by_status.items(),key=lambda kv:-kv[1])],
+        "avg_duration_s":round(sum(rl_durations)/len(rl_durations),1) if rl_durations else None,
+        "max_duration_s":round(max(rl_durations),1) if rl_durations else None,
+        "n_with_duration":len(rl_durations),
+    }
+
+    import datetime
+    inv={
+        "tenant":{
+            "name":os.environ.get("QLIK_TENANT","(active context)"),
+            "url":os.environ.get("QLIK_TENANT_URL",""),
+            "generated_at":datetime.date.today().isoformat(),
+            "mode":"qlik-cli + deep" if a.deep else "qlik-cli inventory-only",
+        },
+        "environment_overview":{
+            "apps":len(apps),"sheets":total_sheets,"master_measures":total_measures,
+            "spaces":len(spaces),"data_connections":n_data_connections,
+        },
+        "data_sources":{
+            "n_connections":n_data_connections,
+            "n_directquery_apps":n_directquery,
+            "n_inmemory_apps":n_inmemory,
+            "n_section_access_apps":n_section_access,
+            "n_file_based_connections":file_based,
+            "connection_types":[{"type":k,"n":v} for k,v in sorted(conn_types.items(),key=lambda kv:-kv[1])],
+        },
+        "reload_activity":reload_activity,
+        "ownership":ownership,
+        "shortlist":rows,
+        # back-compat top-level counts
+        "apps":len(apps),"spaces":len(spaces),
+    }
     json.dump(inv,open(os.path.join(a.out,"inventory.json"),"w"),indent=2)
 
     md=[f"# Qlik → Sigma assessment\n",f"- **Apps:** {len(apps)}  · **Spaces:** {len(spaces)}\n","\n## Migration shortlist\n",

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/render-readout-html.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/render-readout-html.rb
@@ -1,0 +1,855 @@
+#!/usr/bin/env ruby
+# Render <out>/readout.html — a customer-facing, share-friendly HTML report for a
+# Qlik Cloud → Sigma migration assessment.
+#
+# Consumes <out>/inventory.json written by qlik-inventory.py (apps + per-app
+# complexity + shortlist + ownership + data-connection + reload rollups). The
+# Sigma-branded theme is copied verbatim from tableau-assessment's
+# render-readout-html.rb so the look is byte-identical across the assessment
+# family; only the vocabulary (app / sheet / master measure / space / data
+# connection / Section Access / DirectQuery / reload task) is Qlik-specific.
+#
+# Usage: ruby scripts/render-readout-html.rb --out /tmp/assessment-<tenant>
+
+require 'json'
+require 'optparse'
+require 'cgi'
+require 'set'
+require 'date'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--out DIR') { |v| opts[:out] = v }
+end.parse!
+abort('--out required') unless opts[:out]
+
+inv_path = File.join(opts[:out], 'inventory.json')
+abort("inventory.json not found in #{opts[:out]}") unless File.exist?(inv_path)
+inventory = JSON.parse(File.read(inv_path))
+
+def h(s); CGI.escapeHTML(s.to_s); end
+def num(n); n.to_i.to_s.reverse.scan(/.{1,3}/).join(',').reverse; end
+
+# ---------- gather computed values ----------
+tenant = inventory['tenant'] || {}
+env    = inventory['environment_overview'] || {}
+dsrc   = inventory['data_sources'] || {}
+reload = inventory['reload_activity'] || {}
+ownership = inventory['ownership'] || []
+shortlist = inventory['shortlist'] || []
+
+tenant_name = tenant['name'] || inventory['tenant'].is_a?(String) ? (tenant['name'] || inventory['tenant']) : 'unknown'
+tenant_name = 'unknown' if tenant_name.nil? || tenant_name.to_s.empty?
+tenant_url  = tenant['url'] || ''
+generated_at = tenant['generated_at'] || Time.now.strftime('%Y-%m-%d')
+formatted_date = Date.parse(generated_at).strftime('%B %d, %Y') rescue generated_at
+
+has_shortlist = !shortlist.empty?
+has_complexity = shortlist.any? { |r| (r['n_auto'].to_i + r['n_manual'].to_i + r['n_unhandled'].to_i) > 0 || (r['measure_buckets'] || {}).any? }
+
+# Usage
+total_views = shortlist.sum { |r| r['views'].to_i }
+cold_apps   = shortlist.select { |r| r['views'].to_i.zero? }
+
+# Shortlist rollups
+sl_top5_views     = shortlist.first(5).sum { |r| r['views'].to_i }
+sl_top5_unhandled = shortlist.first(5).sum { |r| r['n_unhandled'].to_i }
+sl_total_unhandled = shortlist.sum { |r| r['n_unhandled'].to_i }
+sl_needs_scout    = shortlist.count { |r| r['tag'] == 'needs-gap-scout' }
+sl_retire         = shortlist.count { |r| r['tag'] == 'retire' }
+sl_migrate_first  = shortlist.count { |r| r['tag'] == 'migrate-first' }
+n_with_unhandled  = shortlist.count { |r| r['n_unhandled'].to_i.positive? }
+top5_pct = total_views.zero? ? 0 : (sl_top5_views.to_f / total_views * 100).round
+
+# Top owner concentration
+top_owner_pct = 0
+top_owner_name = '—'
+total_owner_apps = ownership.sum { |o| o['apps'].to_i }
+if total_owner_apps > 0
+  top = ownership.max_by { |o| o['apps'].to_i }
+  top_owner_pct = (top['apps'].to_f / total_owner_apps * 100).round
+  top_owner_name = top['owner']
+end
+
+# ---------- HTML helpers ----------
+TAG_LABELS = {
+  'migrate-first'   => 'Migrate first',
+  'easy-win'        => 'Easy win',
+  'moderate'        => 'Standard',
+  'needs-gap-scout' => 'Needs review',
+  'retire'          => 'Retire'
+}
+TAG_CLASSES = {
+  'migrate-first'   => 'tag-go',
+  'easy-win'        => 'tag-blue',
+  'moderate'        => 'tag-gray',
+  'needs-gap-scout' => 'tag-warn',
+  'retire'          => 'tag-mute'
+}
+
+def tag_pill(t)
+  %(<span class="tag #{TAG_CLASSES[t]}">#{h(TAG_LABELS[t] || t)}</span>)
+end
+
+# Horizontal bar cell — value normalized to max
+def bar_cell(value, max, color = 'bar-blue')
+  pct = max.zero? ? 0 : (value.to_f / max * 100).round
+  %(<div class="bar-cell"><div class="bar-track"><div class="bar-fill #{color}" style="width:#{pct}%"></div></div><div class="bar-num">#{num(value)}</div></div>)
+end
+
+# Generic data table renderer.
+# headers: array of strings
+# rows:    array of arrays of cell values (HTML-safe strings or numbers).
+#          Strings starting with '<' are inserted raw; everything else is escaped.
+# opts:    align: %w[left right center ...], class: extra CSS class on table
+def table(headers, rows, opts = {})
+  cls = opts[:class] || ''
+  cols = headers.size
+  align = opts[:align] || Array.new(cols, 'left')
+  thead = "<thead><tr>" + headers.each_with_index.map { |c, i| %(<th class="al-#{align[i]}">#{h(c)}</th>) }.join + "</tr></thead>"
+  tbody = "<tbody>" + rows.map do |r|
+    "<tr>" + r.each_with_index.map { |c, i|
+      cell = c.to_s
+      content = cell.start_with?('<') ? cell : h(cell)
+      %(<td class="al-#{align[i]}">#{content}</td>)
+    }.join + "</tr>"
+  end.join + "</tbody>"
+  %(<table class="data #{cls}">#{thead}#{tbody}</table>)
+end
+
+def kpi(label, value, sub = nil)
+  s = sub ? %(<div class="kpi-sub">#{h(sub)}</div>) : ''
+  %(<div class="kpi"><div class="kpi-v">#{h(value)}</div><div class="kpi-l">#{h(label)}</div>#{s}</div>)
+end
+
+# ---------- section rendering ----------
+
+# Hero: headline finding
+hero_finding =
+  if has_shortlist
+    if sl_top5_unhandled.zero? && sl_migrate_first.positive?
+      'Pilot migration is low-risk: the top 5 most-used apps contain no unsupported Qlik features.'
+    elsif sl_total_unhandled.positive?
+      "The top-5 pilot is feasible. #{n_with_unhandled} app#{n_with_unhandled == 1 ? '' : 's'} elsewhere on the tenant include feature#{n_with_unhandled == 1 ? '' : 's'} (Set Analysis, Aggr(), alternate states) that warrant individual review when planning their conversion."
+    else
+      'Migration shortlist ranked by usage and conversion complexity.'
+    end
+  else
+    'Environment scan complete.'
+  end
+
+# Section 1: KPI tiles
+kpi_html = [
+  kpi('Apps',            env['apps']),
+  kpi('Sheets',          env['sheets']),
+  kpi('Master measures', env['master_measures']),
+  kpi('Spaces',          env['spaces']),
+  kpi('Data connections', env['data_connections']),
+  kpi('Total app views', num(total_views), '28-day rolling window')
+].join
+
+# Section 2: App priority & usage
+usage_html = ''
+unless shortlist.empty?
+  ranked = shortlist.sort_by { |r| -r['views'].to_i }
+  max_v = ranked.first['views'].to_i
+  rows = ranked.first(10).each_with_index.map do |r, i|
+    flags = []
+    flags << 'Section Access' if r['sectionAccess']
+    flags << 'DirectQuery'    if r['directQuery']
+    flag_cell = flags.empty? ? '<span class="muted">—</span>' : flags.map { |f| %(<span class="inline-pill">#{h(f)}</span>) }.join(' ')
+    %(<tr>
+      <td class="rank">#{i + 1}</td>
+      <td>#{h(r['name'])}</td>
+      <td class="muted">#{h((r['owner'] || '—').to_s.sub(/@.*/, ''))}</td>
+      <td>#{bar_cell(r['views'], max_v)}</td>
+      <td>#{flag_cell}</td>
+    </tr>)
+  end.join
+  usage_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th class="al-right">#</th>
+          <th>App</th>
+          <th>Owner</th>
+          <th>Views</th>
+          <th>Flags</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 3: Ownership & concentration
+ownership_html = ''
+unless ownership.empty?
+  rows_data = ownership.sort_by { |o| -o['apps'].to_i }
+  max_apps = rows_data.first['apps'].to_i
+  rows = rows_data.first(15).map do |o|
+    %(<tr>
+      <td>#{h((o['owner'] || '—').to_s.sub(/@.*/, ''))}</td>
+      <td>#{bar_cell(o['apps'], max_apps)}</td>
+      <td class="al-right num muted">#{num(o['views'])}</td>
+      <td class="al-right num muted">#{num(o['measures'])}</td>
+    </tr>)
+  end.join
+  ownership_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Owner</th>
+          <th>Apps</th>
+          <th class="al-right">Views</th>
+          <th class="al-right">Master measures</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 4: Data-source / load-script patterns
+ds_html = ''
+conn_rows = (dsrc['connection_types'] || [])
+unless conn_rows.empty?
+  max_n = conn_rows.map { |r| r['n'].to_i }.max || 1
+  rows = conn_rows.sort_by { |r| -r['n'].to_i }.map do |r|
+    file_like = r['type'].to_s.match?(/qvd|csv|xls|txt|file|folder/i)
+    badge = file_like ? '<span class="ds-bucket ds-embedded">file-based</span>' : '<span class="ds-bucket ds-published">warehouse / live</span>'
+    %(<tr>
+      <td><code>#{h(r['type'])}</code></td>
+      <td>#{badge}</td>
+      <td>#{bar_cell(r['n'], max_n)}</td>
+    </tr>)
+  end.join
+  ds_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Connection type</th>
+          <th>Class</th>
+          <th>Count</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 5: Reload activity
+reload_html = ''
+rl_rows = (reload['by_status'] || [])
+unless rl_rows.empty?
+  rows = rl_rows.map do |b|
+    ok = b['status'].to_s.match?(/succ|ok|done/i)
+    result_cls = ok ? 'tag-go' : (b['status'].to_s.match?(/fail|error/i) ? 'tag-warn' : 'tag-gray')
+    %(<tr>
+      <td><span class="tag #{result_cls}">#{h(b['status'])}</span></td>
+      <td class="al-right num">#{num(b['n'])}</td>
+    </tr>)
+  end.join
+  reload_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Reload status</th>
+          <th class="al-right">Apps</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# ---------- HTML ----------
+html = <<~HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Qlik Cloud Environment Report — #{h(tenant_name)}</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=DM+Mono:wght@400;500&display=swap');
+  :root {
+    /* Sigma brand palette — Shadow/Nimbus/White neutrals, Insight (CTA only), brand accents */
+    --bg:#fafafa; --card:#ffffff; --ink:#292929; --ink-2:#3d3d3d;
+    --line:#e5e5e5; --line-soft:#f5f5f5;
+    --accent:#292929; --accent-soft:#f0f0f0;
+    --insight:#f0ff45;
+    --go:#1f9d57; --go-soft:#e6fbef;
+    --warn:#c2562a; --warn-soft:#fff1ea;
+    --blue:#2b8ca6; --blue-soft:#eaf8fc;
+    --mute:#6e7877; --mute-soft:#f0f0f0;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
+  body {
+    font-family: "DM Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px; line-height: 1.55; -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 1120px; margin: 0 auto; padding: 48px 48px 80px; }
+
+  /* Brand masthead */
+  .brand-bar { display: flex; align-items: center; gap: 10px; margin-bottom: 28px; }
+  .brand-mark { font-weight: 700; font-size: 21px; letter-spacing: -0.02em; color: var(--ink); }
+  .brand-dot  { width: 9px; height: 9px; border-radius: 2px; background: var(--blue);
+                -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .brand-tag  { font-size: 12px; color: var(--mute); font-weight: 500;
+                text-transform: uppercase; letter-spacing: 0.08em; }
+
+  /* Header */
+  .doc-header { margin-bottom: 40px; }
+  .doc-eyebrow { font-size: 11px; font-weight: 600; color: var(--accent);
+                 text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+  .doc-title { font-size: 36px; font-weight: 700; letter-spacing: -0.02em;
+               margin: 0 0 8px; line-height: 1.1; color: var(--ink); }
+  .doc-meta { font-size: 13px; color: var(--ink-2); }
+  .doc-meta a { color: var(--ink-2); text-decoration: none; border-bottom: 1px dashed var(--line); }
+  .doc-meta a:hover { color: var(--ink); }
+
+  /* Hero finding banner */
+  .hero {
+    background: var(--accent-soft); border: 1px solid var(--line);
+    border-left: 4px solid var(--blue);
+    border-radius: 8px;
+    padding: 18px 22px; margin-bottom: 40px;
+    display: flex; align-items: center; gap: 16px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .hero-label { font-size: 11px; font-weight: 700; color: var(--accent);
+                text-transform: uppercase; letter-spacing: 0.08em;
+                white-space: nowrap; padding-right: 16px;
+                border-right: 1px solid var(--line); }
+  .hero-text { font-size: 15px; color: var(--ink); font-weight: 500; line-height: 1.4; }
+
+  /* Section */
+  section { margin-bottom: 56px; }
+  section.section-tight { margin-bottom: 36px; }
+  .section-head { display: flex; align-items: baseline; justify-content: space-between;
+                  margin-bottom: 16px; padding-bottom: 12px;
+                  border-bottom: 1px solid var(--line); }
+  .section-num { font-size: 12px; font-weight: 600; color: var(--mute);
+                 letter-spacing: 0.06em; }
+  .section-title { font-size: 22px; font-weight: 600; letter-spacing: -0.01em;
+                   margin: 0; flex: 1; padding-left: 14px; }
+  .section-aside { font-size: 12px; color: var(--mute); }
+  .section-lede { font-size: 14px; color: var(--ink-2); margin: -4px 0 16px; }
+
+  /* KPIs */
+  .kpi-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+  .kpi {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 18px 16px;
+  }
+  .kpi-v { font-size: 28px; font-weight: 700; letter-spacing: -0.01em;
+           color: var(--ink); line-height: 1; }
+  .kpi-l { font-size: 11px; color: var(--mute); text-transform: uppercase;
+           letter-spacing: 0.06em; font-weight: 600; margin-top: 10px; }
+  .kpi-sub { font-size: 11px; color: var(--mute); margin-top: 4px; line-height: 1.4; }
+
+  /* Stat callouts */
+  .stat-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
+              margin-bottom: 24px; }
+  .stat {
+    background: #fafafa;
+    border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 8px;
+    padding: 16px 18px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .stat.stat-go   { border-left-color: var(--go);   background: var(--go-soft); }
+  .stat.stat-warn { border-left-color: var(--warn); background: var(--warn-soft); }
+  .stat-l { font-size: 10px; color: var(--mute); text-transform: uppercase;
+            letter-spacing: 0.06em; font-weight: 700; margin-bottom: 6px; }
+  .stat-v { font-size: 30px; font-weight: 700; line-height: 1; letter-spacing: -0.02em;
+            color: var(--ink); }
+  .stat-v.go   { color: var(--go); }
+  .stat-v.warn { color: var(--warn); }
+  .stat-sub { font-size: 12px; color: var(--mute); margin-top: 6px; }
+
+  /* Tables */
+  table.data { width: 100%; border-collapse: collapse; background: var(--card);
+               border: 1px solid var(--line); border-radius: 10px; overflow: hidden;
+               font-size: 13px; }
+  table.data th { font-weight: 600; font-size: 11px; color: var(--mute);
+                  text-transform: uppercase; letter-spacing: 0.06em;
+                  padding: 12px 16px; background: #fafafa;
+                  border-bottom: 1px solid var(--line); text-align: left; }
+  table.data td { padding: 12px 16px; border-bottom: 1px solid var(--line-soft);
+                  vertical-align: middle; }
+  table.data tbody tr:last-child td { border-bottom: 0; }
+  table.data tbody tr:hover td { background: #fafafa; }
+  .al-right { text-align: right; }
+  .al-left  { text-align: left; }
+  /* Pin numeric + bar columns to content width so the text column absorbs the
+     slack — keeps a short value tight against its header instead of stranding it
+     across an over-wide column. */
+  table.data td.al-right, table.data th.al-right,
+  table.data td:has(.bar-cell) { width: 1%; white-space: nowrap; }
+  .num { font-variant-numeric: tabular-nums; }
+  .muted { color: var(--mute); }
+  .warn { color: var(--warn); }
+  .warn-num { color: var(--warn); font-weight: 700; }
+  .rank { font-variant-numeric: tabular-nums; color: var(--mute); font-weight: 600; width: 32px; }
+  .workbook-link { color: var(--ink); text-decoration: none;
+                   border-bottom: 1px solid var(--line); }
+  .workbook-link:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  .breakdown { font-size: 12px; font-variant-numeric: tabular-nums; }
+  .breakdown span { margin-right: 8px; }
+
+  /* Tags */
+  .tag { display: inline-block; padding: 3px 10px; border-radius: 99px;
+         font-size: 11px; font-weight: 600; letter-spacing: 0.01em;
+         white-space: nowrap; }
+  .tag-go    { background: var(--go-soft);    color: var(--go); }
+  .tag-blue  { background: var(--blue-soft);  color: var(--blue); }
+  .tag-gray  { background: #f5f5f5;           color: var(--ink-2); }
+  .tag-warn  { background: var(--warn-soft);  color: var(--warn); }
+  .tag-mute  { background: var(--mute-soft);  color: var(--mute); }
+
+  /* Bar cells (in tables) */
+  .bar-cell { display: flex; align-items: center; gap: 10px;
+              justify-content: flex-start; }
+  .bar-track { flex: none; width: 84px; height: 6px; background: #f5f5f5; border-radius: 4px;
+               overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 4px; }
+  .bar-blue { background: linear-gradient(90deg, #4cec8c, #2fb874); }
+  .bar-num { font-variant-numeric: tabular-nums; font-weight: 600;
+             min-width: 36px; text-align: right; }
+
+  /* Data-source bucket badge */
+  .ds-bucket { display: inline-block; padding: 3px 10px; border-radius: 6px;
+               font-size: 11px; font-weight: 600;
+               -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .ds-published { background: var(--blue-soft); color: var(--blue); }
+  .ds-embedded  { background: #f5f5f5; color: var(--ink-2); }
+
+  /* Risk chip — used in shortlist + verdicts + coverage */
+  .risk-chip { display: inline-flex; align-items: center; gap: 6px;
+               font-size: 12px; font-variant-numeric: tabular-nums; }
+  .risk-dot { width: 8px; height: 8px; border-radius: 50%;
+              -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .risk-clean .risk-dot { background: var(--go); }
+  .risk-clean             { color: var(--go); font-weight: 600; }
+  .risk-green .risk-dot { background: #84cc16; }
+  .risk-green             { color: var(--ink-2); }
+  .risk-amber .risk-dot { background: #f59e0b; }
+  .risk-amber             { color: #a16207; font-weight: 600; }
+  .risk-red   .risk-dot { background: var(--warn); }
+  .risk-red               { color: var(--warn); font-weight: 700; }
+  .risk-mute  .risk-dot { background: var(--mute); }
+  .risk-mute              { color: var(--mute); }
+
+  /* Cluster member display */
+  .cluster-member { padding: 2px 0; font-size: 12px; line-height: 1.4; }
+  .cluster-member + .cluster-member { border-top: 1px dashed var(--line-soft); }
+
+  /* Inline user pill (top-users cell) */
+  .inline-pill { display: inline-block; padding: 1px 7px; border-radius: 99px;
+                 font-size: 11px; background: #f1f5f9; color: var(--ink-2);
+                 font-variant-numeric: tabular-nums; margin-right: 4px;
+                 -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+
+  /* Top-view cell — most-used view per workbook */
+  .top-view-cell { font-size: 12px; line-height: 1.3; }
+  .top-view-pct  { font-size: 11px; margin-top: 2px; }
+
+  /* Per-user top-workbook list (inside table cell) */
+  .top-wb { font-size: 11px; line-height: 1.4; display: flex;
+            justify-content: space-between; gap: 12px;
+            padding: 1px 0; }
+  .top-wb + .top-wb { border-top: 1px dotted var(--line-soft); padding-top: 3px; margin-top: 3px; }
+  .top-wb span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 220px; }
+
+  /* Unique-to-user expander */
+  details.unique-detail { font-size: 11px; }
+  details.unique-detail summary { cursor: pointer; color: var(--accent); font-weight: 600;
+                                  list-style: none; padding: 2px 0; }
+  details.unique-detail summary::-webkit-details-marker { display: none; }
+  details.unique-detail summary::before { content: '▸ '; color: var(--mute); }
+  details.unique-detail[open] summary::before { content: '▾ '; }
+  details.unique-detail div { padding-left: 12px; font-size: 11px; line-height: 1.4; }
+
+  /* Notes + callouts */
+  .note { font-size: 12px; color: var(--mute); font-style: italic;
+          margin: 12px 0 0; }
+  .callout {
+    background: var(--warn-soft); border-left: 3px solid var(--warn);
+    padding: 12px 16px; border-radius: 6px; margin-top: 16px;
+    font-size: 13px; color: #7c2d12;
+  }
+  .callout strong { color: #7c2d12; }
+  .callout code { background: rgba(0,0,0,0.06); padding: 1px 5px; border-radius: 3px;
+                  font-size: 12px; }
+
+  code { font-family: "DM Mono", ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px;
+         background: var(--line-soft); padding: 1px 6px; border-radius: 4px; }
+
+  /* Next steps */
+  ol.next-steps { margin: 0; padding-left: 0; counter-reset: step;
+                  list-style: none; }
+  ol.next-steps li { counter-increment: step; padding: 14px 0 14px 44px;
+                     position: relative; border-bottom: 1px solid var(--line-soft);
+                     font-size: 14px; }
+  ol.next-steps li:last-child { border-bottom: 0; }
+  ol.next-steps li::before {
+    content: counter(step); position: absolute; left: 0; top: 14px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--accent-soft); color: var(--accent);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums;
+  }
+  ol.next-steps li strong { color: var(--ink); }
+
+  /* Privacy two-column */
+  .priv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .priv-col h3 { font-size: 13px; font-weight: 600; color: var(--ink);
+                 margin: 0 0 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .priv-col ul { margin: 0; padding-left: 0; list-style: none; }
+  .priv-col li { padding: 6px 0 6px 22px; position: relative;
+                 font-size: 13px; color: var(--ink-2); }
+  .priv-col.crossed li::before {
+    content: '→'; position: absolute; left: 0; color: var(--warn); font-weight: 700;
+  }
+  .priv-col.local li::before {
+    content: '◊'; position: absolute; left: 0; color: var(--go); font-weight: 700;
+  }
+
+  footer { color: var(--mute); font-size: 11px; text-align: center;
+           margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--line); }
+
+  @media print {
+    @page { margin: 0.6in 0.5in 0.6in; size: letter portrait; }
+    body { background: white; font-size: 11.5px; }
+    main { max-width: none; padding: 0; }
+    .doc-header { margin-bottom: 18px; }
+    .doc-title { font-size: 26px; }
+    .hero { margin-bottom: 24px; padding: 12px 16px; page-break-after: avoid; }
+    .hero-text { font-size: 13px; }
+    section { margin-bottom: 24px; page-break-inside: auto; }
+    section.section-tight { margin-bottom: 18px; }
+    .section-head { margin-bottom: 10px; padding-bottom: 8px; page-break-after: avoid; }
+    .section-title { font-size: 16px; }
+    .section-lede { font-size: 12px; margin: -2px 0 10px; }
+    .kpi-grid { gap: 8px; }
+    .kpi { padding: 12px; }
+    .kpi-v { font-size: 22px; }
+    .kpi-l { font-size: 10px; margin-top: 6px; }
+    .kpi-sub { font-size: 10px; margin-top: 3px; }
+    .stat-row { gap: 8px; margin-bottom: 14px; }
+    .stat { padding: 12px 14px; }
+    .stat-v { font-size: 24px; }
+    table.data { font-size: 11px; page-break-inside: auto; }
+    table.data thead { display: table-header-group; }
+    table.data th { padding: 8px 10px; font-size: 10px; }
+    table.data td { padding: 8px 10px; }
+    table.data tr { page-break-inside: avoid; page-break-after: auto; }
+    .tag, .ds-bucket { font-size: 10px; padding: 2px 8px; }
+    .bar-track { max-width: 60px; height: 5px; }
+    .note { font-size: 11px; }
+    .callout { padding: 8px 12px; font-size: 11px; }
+    ol.next-steps li { padding: 10px 0 10px 36px; font-size: 12px; }
+    ol.next-steps li::before { width: 22px; height: 22px; font-size: 11px; top: 10px; }
+    .priv-col li { font-size: 11px; padding: 4px 0 4px 18px; }
+    footer { margin-top: 24px; padding-top: 12px; }
+    /* Force backgrounds + colors to render */
+    .hero, .kpi, .stat, table.data, table.data th, .ds-bucket, .tag,
+    .bar-track, .bar-fill, .risk-dot, .callout, ol.next-steps li::before {
+      -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important;
+    }
+    /* Avoid awkward page splits at section boundaries */
+    section h2, .section-head { page-break-after: avoid; }
+    .stat-row, .priv-grid { page-break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+<main>
+
+<div class="brand-bar">
+  <span class="brand-dot"></span>
+  <span class="brand-mark">sigma</span>
+  <span class="brand-tag">Migration Assessment</span>
+</div>
+<div class="doc-header">
+  <div class="doc-eyebrow">Qlik Cloud Environment Report</div>
+  <h1 class="doc-title">#{h(tenant_name)}</h1>
+  <div class="doc-meta">
+    #{tenant_url.empty? ? '' : %(<a href="#{h(tenant_url)}" target="_blank" rel="noopener">#{h(tenant_url)}</a> · )}
+    Generated #{h(formatted_date)}
+  </div>
+</div>
+
+<div class="hero">
+  <div class="hero-label">Headline finding</div>
+  <div class="hero-text">#{h(hero_finding)}</div>
+</div>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">01</span>
+    <h2 class="section-title">Environment overview</h2>
+  </div>
+  <div class="kpi-grid">#{kpi_html}</div>
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">02</span>
+    <h2 class="section-title">App priority &amp; usage</h2>
+    <span class="section-aside">Top 10 of #{env['apps']} apps · #{num(total_views)} total views</span>
+  </div>
+  <p class="section-lede">Most-used apps across the tenant, ranked by view count. This is the foundation of any migration or consolidation plan — focus effort where audience attention already is.</p>
+  #{usage_html}
+  <p class="note">Qlik's <code>itemViews</code> is a <strong>28-day rolling window</strong>, not all-time — an app with zero views here is cold over the last month, which is still the right retirement signal.</p>
+  #{cold_apps.any? ? %(<p class="note"><strong>#{cold_apps.size} app#{cold_apps.size == 1 ? '' : 's'}</strong> have no views in the last 28 days: ) + cold_apps.first(20).map { |w| %(<code>#{h(w['name'])}</code>) }.join(', ') + ' — strong candidates for retirement.</p>' : ''}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">03</span>
+    <h2 class="section-title">Ownership &amp; concentration</h2>
+    <span class="section-aside">#{ownership.size} owners across #{env['apps']} apps</span>
+  </div>
+  <p class="section-lede">App ownership concentration across the tenant. High concentration in one or two owners is a governance signal — what happens to those apps if that person leaves?</p>
+  #{ownership_html}
+  <p class="note">Top-owner concentration: <strong>#{top_owner_pct}%</strong> of apps owned by <code>#{h((top_owner_name || '—').to_s.sub(/@.*/, ''))}</code>.</p>
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">04</span>
+    <h2 class="section-title">Data sources &amp; load-script patterns</h2>
+    <span class="section-aside">#{dsrc['n_connections']} connections · #{dsrc['n_directquery_apps']} DirectQuery · #{dsrc['n_inmemory_apps']} in-memory</span>
+  </div>
+  <p class="section-lede">How data flows into your Qlik apps. <strong>DirectQuery</strong> apps already query a live warehouse — they map cleanly to a Sigma warehouse connection. <strong>In-memory</strong> apps reload into the Qlik engine from QVDs, files, or warehouse extracts; the load script's source is what Sigma re-points to. File-based sources (QVD/CSV/Excel) must be landed in a warehouse first.</p>
+
+  <div class="stat-row">
+    <div class="stat #{dsrc['n_directquery_apps'].to_i.positive? ? 'stat-go' : ''}">
+      <div class="stat-l">DirectQuery apps</div>
+      <div class="stat-v #{dsrc['n_directquery_apps'].to_i.positive? ? 'go' : ''}">#{dsrc['n_directquery_apps'] || 0}</div>
+      <div class="stat-sub">already live-query — drop-in to a Sigma connection</div>
+    </div>
+    <div class="stat">
+      <div class="stat-l">In-memory apps</div>
+      <div class="stat-v">#{dsrc['n_inmemory_apps'] || 0}</div>
+      <div class="stat-sub">reload from QVD / file / warehouse extract</div>
+    </div>
+    <div class="stat #{dsrc['n_file_based_connections'].to_i.positive? ? 'stat-warn' : ''}">
+      <div class="stat-l">File-based connections</div>
+      <div class="stat-v #{dsrc['n_file_based_connections'].to_i.positive? ? 'warn' : ''}">#{dsrc['n_file_based_connections'] || 0}</div>
+      <div class="stat-sub">QVD / CSV / Excel — land in warehouse first</div>
+    </div>
+  </div>
+
+  #{ds_html}
+  #{dsrc['n_section_access_apps'].to_i.positive? ? %(<div class="callout"><strong>#{dsrc['n_section_access_apps']} app#{dsrc['n_section_access_apps'] == 1 ? '' : 's'}</strong> use <strong>Section Access</strong> (row-level security in the load script). These translate to Sigma's column/row-level security on the data model — plan to re-author the access rules rather than auto-convert them.</div>) : ''}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">05</span>
+    <h2 class="section-title">Reload activity</h2>
+    #{reload['avg_duration_s'] ? %(<span class="section-aside">avg #{reload['avg_duration_s']}s · max #{reload['max_duration_s']}s · #{reload['n_with_duration']} timed</span>) : ''}
+  </div>
+  <p class="section-lede">Reload-task health across apps. In-memory Qlik apps depend on a scheduled reload to stay fresh; failing or long-running reloads are migration motivation, since Sigma queries the warehouse live and removes the reload step entirely.</p>
+  #{reload_html}
+  #{reload['avg_duration_s'] ? %(<p class="note">Average last-reload duration <strong>#{reload['avg_duration_s']}s</strong> (max <strong>#{reload['max_duration_s']}s</strong>) across #{reload['n_with_duration']} app#{reload['n_with_duration'] == 1 ? '' : 's'} reporting a duration.</p>) : ''}
+</section>
+
+HTML
+
+# Section 6: Migration shortlist + per-app complexity
+if has_shortlist
+  max_v = shortlist.map { |r| r['views'].to_i }.max || 1
+  sl_rows = shortlist.first(15).map do |r|
+    risk_cls, risk_txt =
+      if r['n_unhandled'].to_i.positive?
+        ['risk-red',   "#{r['n_unhandled']} to review"]
+      elsif r['n_manual'].to_i.positive?
+        ['risk-amber', "#{r['n_manual']} setup"]
+      elsif r['n_hint'].to_i.positive?
+        ['risk-green', "#{r['n_hint']} suggested"]
+      else
+        ['risk-clean', 'No issues']
+      end
+    %(<tr>
+      <td>#{h(r['name'])}</td>
+      <td>#{bar_cell(r['views'], max_v)}</td>
+      <td><span class="risk-chip #{risk_cls}"><span class="risk-dot"></span>#{h(risk_txt)}</span></td>
+      <td class="al-right num">#{format('%.1f', r['score'].to_f)}</td>
+      <td>#{tag_pill(r['tag'])}</td>
+    </tr>)
+  end.join
+  shortlist_table = <<~HTML
+    <table class="data shortlist">
+      <thead>
+        <tr>
+          <th>App</th>
+          <th>Views</th>
+          <th>Conversion risk</th>
+          <th class="al-right">Score</th>
+          <th>Recommendation</th>
+        </tr>
+      </thead>
+      <tbody>#{sl_rows}</tbody>
+    </table>
+    <p class="note">Conversion risk legend: <strong>No issues</strong> = converts automatically · <strong>N setup</strong> = brief post-conversion setup in Sigma (Set Analysis → <code>SumIf</code>, binning, Section Access, DirectQuery) · <strong>N to review</strong> = uses a Qlik feature with no direct Sigma equivalent (Aggr(), Dual(), selection-state, alternate states) that warrants individual evaluation when planning the conversion.</p>
+  HTML
+
+  # Per-app complexity table
+  complexity_table = ''
+  if has_complexity
+    crows = shortlist.sort_by { |r| -(r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3 + r['n_hint'].to_i) }.map do |r|
+      mb = r['measure_buckets'] || {}
+      n_viz = (r['viz_types'] || {}).values.sum
+      unh_cell = r['n_unhandled'].to_i.positive? ? %(<span class="warn-num">#{r['n_unhandled']}</span>) : '<span class="muted">0</span>'
+      %(<tr>
+        <td>#{h(r['name'])}</td>
+        <td class="al-right num muted">#{r['measures'] || (mb.values.sum)}</td>
+        <td class="al-right num muted">#{n_viz}</td>
+        <td class="al-right num muted">#{r['n_auto']}</td>
+        <td class="al-right num">#{r['n_manual']}</td>
+        <td class="al-right">#{unh_cell}</td>
+      </tr>)
+    end.join
+    complexity_table = <<~HTML
+      <h3>Per-app complexity</h3>
+      <p class="section-lede" style="margin-top:0;">Master-measure expressions and chart viz types bucketed against Sigma coverage. <strong>Auto</strong> converts mechanically; <strong>Setup</strong> = Set Analysis / binning / Section Access / DirectQuery (brief manual step); <strong>Review</strong> = Aggr() / Dual() / selection-state / alternate states (no direct Sigma equivalent).</p>
+      <table class="data">
+        <thead>
+          <tr>
+            <th>App</th>
+            <th class="al-right">Master measures</th>
+            <th class="al-right">Charts</th>
+            <th class="al-right">Auto</th>
+            <th class="al-right">Setup</th>
+            <th class="al-right">Review</th>
+          </tr>
+        </thead>
+        <tbody>#{crows}</tbody>
+      </table>
+    HTML
+  end
+
+  html += <<~HTML
+  <section>
+    <div class="section-head">
+      <span class="section-num">06</span>
+      <h2 class="section-title">Migration to Sigma — recommended sequence</h2>
+      <span class="section-aside">Sigma-specific recommendations</span>
+    </div>
+    <p class="section-lede">If you choose to migrate to Sigma, this is the order that minimizes risk while covering the most user impact. Apps are ranked by usage value relative to conversion complexity. The top of the list is the recommended starting point for a pilot.</p>
+
+    <div class="stat-row">
+      <div class="stat">
+        <div class="stat-l">Top-5 tenant usage share</div>
+        <div class="stat-v">#{top5_pct}<span style="font-size: 16px; color: var(--mute); font-weight: 600;">%</span></div>
+        <div class="stat-sub">of #{num(total_views)} total views</div>
+      </div>
+      <div class="stat stat-#{sl_top5_unhandled.zero? ? 'go' : 'warn'}">
+        <div class="stat-l">Top-5 conversion complexity</div>
+        <div class="stat-v #{sl_top5_unhandled.zero? ? 'go' : 'warn'}">#{sl_top5_unhandled}</div>
+        <div class="stat-sub">advanced features to review across pilot</div>
+      </div>
+      <div class="stat">
+        <div class="stat-l">Needs review · Retire</div>
+        <div class="stat-v">#{sl_needs_scout}<span style="font-size: 16px; color: var(--mute); font-weight: 600;"> · #{sl_retire}</span></div>
+        <div class="stat-sub">apps of #{shortlist.size} total</div>
+      </div>
+    </div>
+
+    #{shortlist_table}
+
+    #{sl_total_unhandled.positive? ?
+      %(<div class="callout"><strong>#{n_with_unhandled} app#{n_with_unhandled == 1 ? '' : 's'}</strong> include features that warrant individual review when planning their conversion — typically Set Analysis nested in <code>Aggr()</code>, dynamic selection-state expressions, or alternate states, where the right Sigma equivalent depends on how the app actually uses them. Identifying these up-front means no surprises mid-migration.</div>) : ''}
+
+    #{complexity_table}
+  </section>
+
+  HTML
+end
+
+# Privacy + next steps
+priv_num = has_shortlist ? '07' : '06'
+next_num = has_shortlist ? '08' : '07'
+
+html += <<~HTML
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{priv_num}</span>
+    <h2 class="section-title">Data handling</h2>
+  </div>
+  <p class="section-lede">This report was generated by an LLM-driven scan of your Qlik Cloud tenant. What that means for the data that left your environment:</p>
+  <div class="priv-grid">
+    <div class="priv-col crossed">
+      <h3>Read by the scanner</h3>
+      <ul>
+        <li>Aggregate counts (app, sheet, master-measure, space, data-connection, reload totals)</li>
+        <li>App names, owner names, space IDs</li>
+        <li>Reload status / duration and <code>itemViews</code> usage counts</li>
+HTML
+
+if has_shortlist
+  html += "        <li>Master-measure expressions and chart object definitions for #{shortlist.size} apps (to bucket conversion complexity)</li>\n"
+end
+
+html += <<~HTML
+      </ul>
+    </div>
+    <div class="priv-col local">
+      <h3>Never left your environment</h3>
+      <ul>
+        <li>Underlying warehouse rows — the scan never queries source data</li>
+        <li>QVD / in-memory data extracts — never read</li>
+        <li>Database / connection credentials</li>
+        <li>Section Access security rules — flagged by count, never exported verbatim</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{next_num}</span>
+    <h2 class="section-title">Recommended next steps</h2>
+  </div>
+  <ol class="next-steps">
+HTML
+
+if has_shortlist
+  html += <<~HTML
+    <li><strong>Pilot the top #{[5, shortlist.size].min} apps.</strong> They represent #{top5_pct}% of total tenant views with #{sl_top5_unhandled} feature#{sl_top5_unhandled == 1 ? '' : 's'} flagged for review between them — the lowest-risk way to demonstrate end-to-end migration with the <code>qlik-to-sigma</code> skill.</li>
+  HTML
+  if sl_needs_scout.positive?
+    html += "    <li><strong>Plan individual review time for #{sl_needs_scout} app#{sl_needs_scout == 1 ? '' : 's'}.</strong> Each contains an advanced Qlik capability (Aggr(), Dual(), selection-state, alternate states) that benefits from a tailored conversion approach.</li>\n"
+  end
+  if sl_retire.positive?
+    html += "    <li><strong>Retire #{sl_retire} app#{sl_retire == 1 ? '' : 's'}</strong> with no views in the last 28 days. No migration value, and dropping them simplifies the cutover.</li>\n"
+  end
+  html += "    <li><strong>Hand off to <code>qlik-to-sigma</code></strong> with the pilot apps — feed the converter the Qlik <em>model</em> (not the warehouse) so master measures and the load-script lineage carry over.</li>\n"
+else
+  html += <<~HTML
+    <li><strong>Re-run with <code>--deep</code></strong> to add per-app complexity (master-measure expression buckets, chart-type coverage) and unlock the migration shortlist.</li>
+    <li><strong>Hand off to <code>qlik-to-sigma</code></strong> to convert the apps you choose to migrate.</li>
+  HTML
+end
+
+html += <<~HTML
+  </ol>
+</section>
+
+<footer>
+  Report generated #{h(formatted_date)} · supporting JSON files alongside in the same folder
+</footer>
+
+</main>
+</body>
+</html>
+HTML
+
+out_path = File.join(opts[:out], 'readout.html')
+File.write(out_path, html)
+puts "wrote #{out_path} (#{File.size(out_path)} bytes)"

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/PRIVACY.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/PRIVACY.md
@@ -1,0 +1,89 @@
+# Privacy & data handling — `quicksight-assessment`
+
+Read this before running the skill, and share it with your privacy / security /
+legal team if your organization needs to review tools that send analysis and
+dataset metadata through a third-party LLM API.
+
+## What this skill reads and writes
+
+**READ-ONLY.** Every call is a `list-*` or `describe-*` (GET-equivalent). The
+skill **never** writes to QuickSight and **never** posts to Sigma. It connects to
+**two systems** on your behalf:
+
+1. **Your Amazon QuickSight account**, via the **AWS CLI** (`aws quicksight ...`,
+   shelled out as a subprocess — no boto3), authenticated as **you** through
+   whatever AWS profile you've already configured (`aws sso login`,
+   `gimme-aws-creds`, or static creds). QuickSight reads from the **identity
+   region** — almost always `us-east-1` even when data lives elsewhere. The skill
+   reads:
+   - Analysis / dashboard / dataset / data-source listings (counts)
+   - Per-analysis **AnalysisDefinition** — visual configuration + **calc-field
+     expressions** + parameters + FilterGroups + layout shape
+   - Per-dataset **describe-data-set** — physical source kinds, import mode
+     (SPICE / DIRECT_QUERY), custom-SQL presence, joins, transform count, RLS/CLS
+2. **The Anthropic API**, via Claude Code, to drive the agent.
+
+Everything the skill reads passes through Claude (and therefore the Anthropic
+API) on its way to producing the readout. Anthropic's API data handling:
+<https://www.anthropic.com/legal/privacy>.
+
+## What crosses the Anthropic API
+
+| Crosses API | Stays in your environment |
+|---|---|
+| **Aggregate counts** (analysis / dashboard / dataset / data-source counts) | Warehouse rows (this skill **never** queries the underlying database) |
+| **Names**: analysis names, dashboard names, dataset names, data-source names | **SPICE in-memory rows** (never read) |
+| **AnalysisDefinition** — visual config, **calc-field expressions**, parameter defaults, FilterGroup definitions, layout shape | AWS credentials (held by the AWS CLI, not surfaced to the agent) |
+| **Dataset metadata** — physical source kinds, import mode, custom-SQL presence, join/transform counts, **RLS/CLS flags** | The actual cell values your visuals display |
+| Data-source connection **types** (Snowflake, Redshift, Athena, …) — not credentials | The warehouse credentials QuickSight uses to connect |
+
+> **Calc-field expressions are the broadest data category that crosses the API.**
+> A QuickSight calculated field can encode business-sensitive logic (margin
+> formulas, eligibility rules, custom KPIs). When the skill reads an
+> AnalysisDefinition, that expression text crosses the Anthropic API. RLS rule
+> *configuration flags* cross (whether RLS is on), but the row-level predicate
+> values themselves are not pulled at definition time. Tell stakeholders this
+> before running.
+
+The AnalysisDefinition and dataset describes do **NOT** contain row-level data
+from your warehouse or SPICE. The data your visuals display is fetched live (or
+from the SPICE cache) at view time, which this skill never triggers.
+
+## What stays local
+
+All outputs are written to a directory of your choice (default
+`/tmp/qs-assessment-<acct>/`) and are **not uploaded anywhere**. The decoded
+definitions live under `raw-defs/` (analyses) and `raw-datasets/` (datasets). To
+share the readout with a Sigma rep, that's a deliberate action you take (zip and
+send).
+
+You can delete the decoded definitions after review with no impact on the
+already-rendered `readout.html` / `readout.md`:
+
+```bash
+rm -rf /tmp/qs-assessment-<acct>/raw-defs /tmp/qs-assessment-<acct>/raw-datasets
+```
+
+## How to limit exposure
+
+1. **Run counts-only.** A **Standard-edition** account rejects the
+   `describe-*-definition` / `describe-data-set` APIs, so the skill degrades to
+   environment counts only — no calc-field text crosses the API. (This is
+   automatic on Standard; on Enterprise the definition scan is the whole point.)
+2. **Delete the raw definitions immediately after rendering** (command above).
+3. **Review the JSON outputs before sharing** — `inventory.json` and the
+   `raw-defs/` decode contain calc-field text; `shortlist.json` and
+   `migration-plan.json` contain names and scores but no calc-field bodies.
+4. **Scope the AWS profile.** Run under an IAM principal scoped to
+   `quicksight:List*` / `quicksight:Describe*` on the account you intend to
+   assess — nothing more.
+
+## Where to direct privacy questions
+
+- Anthropic API privacy: <https://www.anthropic.com/legal/privacy>
+- Amazon QuickSight API reference:
+  <https://docs.aws.amazon.com/quicksight/latest/APIReference/Welcome.html>
+- This skill's source: every script under `scripts/` runs on your behalf and is
+  readable — `quicksight-inventory.py` is the only one that touches AWS, and
+  every call it makes is a read-only `list-*` / `describe-*`.
+- Sigma privacy policy: <https://www.sigmacomputing.com/privacy-policy>

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/README.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/README.md
@@ -1,0 +1,134 @@
+# Amazon QuickSight Assessment
+
+A Claude Code skill that inventories an Amazon QuickSight account and produces a
+migration-readiness readout. Designed to be run by a customer (or a Sigma rep
+with the customer present) before deciding which QuickSight analyses to migrate
+to Sigma.
+
+**READ-ONLY.** Every call is a `list-*` / `describe-*` (GET-equivalent). The
+skill never writes to QuickSight and never posts to Sigma.
+
+This is the QuickSight sibling of [`tableau-assessment`](../../../tableau-to-sigma/skills/tableau-assessment/)
+and [`powerbi-assessment`](../../../powerbi-to-sigma/skills/powerbi-assessment/) —
+same file layout, same readout sections, same privacy discipline, same
+value/cost shortlist scoring — adapted to QuickSight's two-artifact world
+(analysis + datasets).
+
+## What it produces
+
+A directory (`/tmp/qs-assessment-<acct>/`) with:
+
+- `readout.html` — a Sigma-branded, share-friendly HTML report (the customer
+  deliverable): environment KPIs, analysis/dashboard priority, dataset reuse &
+  concentration, data-source patterns (SPICE / DIRECT_QUERY, warehouse vs
+  file/S3), ingestion & refresh activity, a value/cost-ranked **migration
+  shortlist** + per-analysis conversion profile, data handling, hand-off package,
+  and next steps. Render it with `scripts/render-readout-html.rb`.
+- `readout.md` — the same report as markdown (template at `refs/readout-template.md`).
+- `inventory.json` — raw environment + per-analysis + per-dataset metadata.
+- `complexity.json` — per-analysis convertibility scoring
+  (`n_auto` / `n_hint` / `n_manual` / `n_unhandled`).
+- `shortlist.json` — the value/cost-ranked migration shortlist as JSON.
+- `migration-plan.json` — per-analysis `recommended_path` + DM clusters (keyed on
+  shared dataset), directly consumable by the `quicksight-to-sigma` skill.
+- `raw-defs/`, `raw-datasets/` — decoded analysis + dataset definitions (delete
+  after review).
+
+Nothing in this directory is uploaded anywhere.
+
+## Prerequisites
+
+- Claude Code installed
+- **AWS CLI v2**, authenticated to the account you want to assess (`aws sso login
+  --profile <p>`, or `gimme-aws-creds` for Okta-fronted orgs). Confirm with
+  `aws sts get-caller-identity --profile <p>`. No Python packages — the inventory
+  script shells out to the CLI (see `scripts/requirements.txt`).
+- **Enterprise edition** for the complexity layer. The
+  `describe-analysis-definition` / `describe-data-set` APIs are Enterprise-only; a
+  Standard account is detected and degraded to a counts-only readout (it never
+  crashes).
+- QuickSight reads from the **identity region** — pass `--region us-east-1` unless
+  you know the account is regionalized differently.
+
+## How to run
+
+In Claude Code:
+
+```
+/quicksight-assessment
+```
+
+The skill will:
+
+1. Probe access + edition (`get-caller-identity`, `list-analyses`).
+2. Inventory analyses, dashboards, datasets, data sources; per-analysis
+   AnalysisDefinition (visual mix, calc-field a/b/c buckets, params, FilterGroups,
+   layout shape); per-dataset source / prep / RLS.
+   (`quicksight-inventory.py` → `inventory.json`, `raw-defs/`, `raw-datasets/`)
+3. Score per-analysis convertibility.
+   (`score-quicksight-complexity.rb` → `complexity.json`)
+4. Cross-tabulate into a value/cost-ranked migration shortlist.
+   (`build-shortlist.rb` → `shortlist.json`)
+5. Render the report.
+   (`render-readout.rb` → `readout.md`; `render-readout-html.rb` → `readout.html`)
+6. Compose the hand-off contract.
+   (`migration-plan.rb` → `migration-plan.json`)
+7. Offer to hand off to `quicksight-to-sigma`.
+
+## Modes
+
+| Mode | Setup | Coverage |
+|---|---|---|
+| **Complexity-only** *(default)* | AWS CLI + Enterprise | Environment + per-analysis visual/calc complexity + per-dataset sources + complexity-only shortlist |
+| **Usage-weighted** | Supply a CloudTrail/CloudWatch-derived `usage.json` | Adds view/user weighting → usage-weighted shortlist + cold-analysis detection |
+
+QuickSight has no per-analysis view-count API on the standard surface, so the
+default is complexity-only; the readout says so.
+
+## Convertibility taxonomy (what drives the scoring)
+
+- **auto** (easy): built visuals (KPI / bar / line / pie), mechanical calc fields,
+  warehouse-backed datasets (RelationalTable / CustomSql).
+- **manual** (medium): mid-catalog visuals (table / pivot / combo / scatter /
+  gauge / …), restructuring calc fields, dataset joins + data-prep transforms,
+  parameters, RLS/CLS.
+- **unhandled** (hard): window / table-calc functions (no Sigma equivalent →
+  `/* TODO */`), exotic visuals (maps, sankey, insight ML, custom content,
+  plugin), free-form / section-based layout, analysis-level FilterGroups, S3 /
+  uploaded-file sources.
+
+Per-analysis `cost = 10·unhandled + 3·manual + 1·hint`; `score = value / (1 + cost)`.
+
+## What this is NOT
+
+- **Not** a write tool. It cannot and will not modify QuickSight or Sigma.
+- **Not** a complete account audit. It covers the signals that matter for Sigma
+  migration scoping, scoped to **what the configured AWS credentials can reach**.
+- **Not** the converter. It scopes; `quicksight-to-sigma` converts. The
+  `migration-plan.json` is the hand-off between them.
+
+## Privacy
+
+This skill sends analysis/dataset metadata (not warehouse rows) through the
+Anthropic API — including **calc-field expressions** from each AnalysisDefinition.
+See [`PRIVACY.md`](./PRIVACY.md) for the full disclosure to review with your
+privacy/legal team before running.
+
+## Reusing this for migration
+
+The `migration-plan.json` output is directly consumable by `quicksight-to-sigma`:
+
+```
+/quicksight-to-sigma migrate the top analyses from this plan: /tmp/qs-assessment-<acct>/migration-plan.json
+```
+
+Analyses are pre-grouped into DM clusters (analyses that reference the same
+QuickSight dataset share one Sigma data model by construction), and the decoded
+`raw-defs/` + `raw-datasets/` overlap the converter's Phase-2 discovery output —
+the converter reuses them rather than re-calling the AWS CLI.
+
+## Sibling skills
+
+- [`quicksight-to-sigma`](../../) — the conversion skill this feeds into.
+- [`tableau-assessment`](../../../tableau-to-sigma/skills/tableau-assessment/) — the Tableau analog.
+- [`powerbi-assessment`](../../../powerbi-to-sigma/skills/powerbi-assessment/) — the Power BI analog.

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout-html.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout-html.rb
@@ -1,0 +1,978 @@
+#!/usr/bin/env ruby
+# Render <out>/readout.html — a customer-facing, share-friendly HTML report for
+# a QuickSight→Sigma migration assessment.
+#
+# Reads the same JSON inputs as render-readout.rb (inventory.json,
+# complexity.json, shortlist.json). Customer-facing, so:
+#   - leads with the actionable finding (migration shortlist)
+#   - drops internal-skill jargon and methodology asides
+#   - assumes Enterprise mode (complexity + shortlist sections present)
+#
+# Sigma-branded — the <style> block + helper methods are copied VERBATIM from
+# tableau-assessment/scripts/render-readout-html.rb (the gold standard). Only the
+# gather-and-fill body is QuickSight-specific (analysis/dashboard, sheet, visual,
+# dataset, data source, calc field, SPICE vs DIRECT_QUERY).
+#
+# Usage: ruby scripts/render-readout-html.rb --out /tmp/qs-assessment-<acct>
+
+require 'json'
+require 'optparse'
+require 'cgi'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--out DIR') { |v| opts[:out] = v }
+end.parse!
+abort('--out required') unless opts[:out]
+
+inv_path        = File.join(opts[:out], 'inventory.json')
+complexity_path = File.join(opts[:out], 'complexity.json')
+shortlist_path  = File.join(opts[:out], 'shortlist.json')
+abort("inventory.json not found in #{opts[:out]}") unless File.exist?(inv_path)
+
+def load_json(path); File.exist?(path) ? JSON.parse(File.read(path)) : nil; end
+inventory  = JSON.parse(File.read(inv_path))
+complexity = load_json(complexity_path)
+shortlist_doc = load_json(shortlist_path)
+
+shortlist  = shortlist_doc ? (shortlist_doc['analyses'] || []) : nil
+has_shortlist = !shortlist.nil? && !shortlist.empty?
+has_usage     = shortlist_doc && shortlist_doc['usage_available'] == true
+
+def h(s); CGI.escapeHTML(s.to_s); end
+def num(n); n.to_i.to_s.reverse.scan(/.{1,3}/).join(',').reverse; end
+
+# ---------- gather computed values ----------
+account = inventory['account'] || {}
+env     = inventory['environment_overview'] || {}
+analyses = inventory['analyses'] || []
+datasets = inventory['datasets'] || []
+data_sources = inventory['data_sources'] || []
+
+account_id   = account['account_id'] || File.basename(opts[:out]).sub(/^qs-assessment-/, '')
+region       = account['region'] || ''
+edition      = account['edition'] || 'unknown'
+enterprise   = account['enterprise'] != false
+generated_at = account['generated_at'] || Time.now.strftime('%Y-%m-%d')
+formatted_date = Date.parse(generated_at).strftime('%B %d, %Y') rescue generated_at
+
+# Sheet / visual totals (account-wide)
+total_sheets  = analyses.sum { |a| a['sheet_count'].to_i }
+total_visuals = analyses.sum { |a| a['visual_count'].to_i }
+
+# Ingestion split (SPICE vs DIRECT_QUERY)
+n_spice  = datasets.count { |d| d['import_mode'] == 'SPICE' }
+n_direct = datasets.count { |d| d['import_mode'] == 'DIRECT_QUERY' }
+
+# Value basis / usage proxy
+value_basis = shortlist_doc ? (shortlist_doc['value_basis'] || 'complexity-only proxy') : 'n/a'
+
+# Usage source (for section 02). When usage isn't available, fall back to the
+# complexity-proxy value already computed in the shortlist.
+usage_source =
+  if has_shortlist
+    shortlist.map do |r|
+      {
+        'name'    => r['name'],
+        'id'      => r['id'],
+        'sheets'  => r['sheets'].to_i,
+        'visuals' => r['visuals'].to_i,
+        'views'   => r['views'],
+        'users'   => r['users'],
+        'value'   => r['value'].to_f
+      }
+    end
+  else
+    []
+  end
+total_views = has_usage ? usage_source.sum { |w| w['views'].to_i } : 0
+# "cold" = zero-view analyses (only meaningful when usage is available)
+cold_analyses = has_usage ? usage_source.select { |w| w['views'].to_i.zero? } : []
+
+# Shortlist roll-ups
+sl_top5_unhandled = 0
+sl_total_unhandled = 0
+sl_needs_scout = 0
+sl_retire = 0
+sl_migrate_first = 0
+sl_easy_win = 0
+sl_top5_value = 0.0
+sl_total_value = 0.0
+if has_shortlist
+  top5 = shortlist.first(5)
+  sl_top5_unhandled  = top5.sum { |r| r['unhandled'].to_i }
+  sl_total_unhandled = shortlist.sum { |r| r['unhandled'].to_i }
+  sl_needs_scout = shortlist.count { |r| r['tag'] == 'needs-gap-scout' }
+  sl_retire      = shortlist.count { |r| r['tag'] == 'retire' }
+  sl_migrate_first = shortlist.count { |r| r['tag'] == 'migrate-first' }
+  sl_easy_win      = shortlist.count { |r| r['tag'] == 'easy-win' }
+  sl_top5_value  = top5.sum { |r| r['value'].to_f }
+  sl_total_value = shortlist.sum { |r| r['value'].to_f }
+end
+top5_pct = sl_total_value.zero? ? 0 : (sl_top5_value / sl_total_value * 100).round
+
+# Dataset reuse / concentration (the QuickSight analog of ownership concentration).
+# Which datasets back the most analyses — the DM-cluster signal.
+ds_name_by_id = datasets.each_with_object({}) { |d, m| m[d['id']] = d['name'] }
+dataset_fanout = Hash.new { |hsh, k| hsh[k] = { 'analyses' => 0, 'name' => k } }
+analyses.each do |a|
+  (a['dataset_ids'] || []).uniq.each do |dsid|
+    dataset_fanout[dsid]['analyses'] += 1
+    dataset_fanout[dsid]['name'] = ds_name_by_id[dsid] || dsid
+  end
+end
+top_dataset_pct = 0
+top_dataset_name = 'unknown'
+unless dataset_fanout.empty?
+  total_refs = dataset_fanout.values.sum { |d| d['analyses'] }
+  if total_refs > 0
+    top = dataset_fanout.values.max_by { |d| d['analyses'] }
+    top_dataset_pct = (top['analyses'].to_f / total_refs * 100).round
+    top_dataset_name = top['name']
+  end
+end
+
+# Complexity roll-ups
+n_scanned = complexity ? complexity.size : 0
+n_with_unhandled = complexity ? complexity.values.count { |r| r['n_unhandled'].to_i.positive? } : 0
+total_calc = { 'a' => 0, 'b' => 0, 'c' => 0 }
+(complexity || {}).each_value do |r|
+  (r['calc_buckets'] || {}).each { |k, v| total_calc[k] += v.to_i }
+end
+
+# ---------- HTML helpers (copied verbatim from tableau-assessment) ----------
+TAG_LABELS = {
+  'migrate-first'   => 'Migrate first',
+  'easy-win'        => 'Easy win',
+  'moderate'        => 'Standard',
+  'needs-gap-scout' => 'Needs review',
+  'retire'          => 'Retire'
+}
+TAG_CLASSES = {
+  'migrate-first'   => 'tag-go',
+  'easy-win'        => 'tag-blue',
+  'moderate'        => 'tag-gray',
+  'needs-gap-scout' => 'tag-warn',
+  'retire'          => 'tag-mute'
+}
+
+def tag_pill(t)
+  %(<span class="tag #{TAG_CLASSES[t]}">#{h(TAG_LABELS[t] || t)}</span>)
+end
+
+# Horizontal bar cell — value normalized to max
+def bar_cell(value, max, color = 'bar-blue')
+  pct = max.zero? ? 0 : (value.to_f / max * 100).round
+  %(<div class="bar-cell"><div class="bar-track"><div class="bar-fill #{color}" style="width:#{pct}%"></div></div><div class="bar-num">#{num(value)}</div></div>)
+end
+
+def kpi(label, value, sub = nil)
+  s = sub ? %(<div class="kpi-sub">#{h(sub)}</div>) : ''
+  %(<div class="kpi"><div class="kpi-v">#{h(value)}</div><div class="kpi-l">#{h(label)}</div>#{s}</div>)
+end
+
+# Generic data table renderer (verbatim from tableau-assessment).
+def table(headers, rows, opts = {})
+  cls = opts[:class] || ''
+  cols = headers.size
+  align = opts[:align] || Array.new(cols, 'left')
+  thead = "<thead><tr>" + headers.each_with_index.map { |c, i| %(<th class="al-#{align[i]}">#{h(c)}</th>) }.join + "</tr></thead>"
+  tbody = "<tbody>" + rows.map do |r|
+    "<tr>" + r.each_with_index.map { |c, i|
+      cell = c.to_s
+      content = cell.start_with?('<') ? cell : h(cell)
+      %(<td class="al-#{align[i]}">#{content}</td>)
+    }.join + "</tr>"
+  end.join + "</tbody>"
+  %(<table class="data #{cls}">#{thead}#{tbody}</table>)
+end
+
+# ---------- section content ----------
+
+# Hero: headline finding
+hero_finding =
+  if has_shortlist
+    if sl_top5_unhandled.zero? && (sl_migrate_first.positive? || sl_easy_win.positive?)
+      'Pilot migration is low-risk: the top analyses contain no unsupported QuickSight features.'
+    elsif sl_total_unhandled.positive?
+      "The top-5 pilot is feasible. #{n_with_unhandled} analys#{n_with_unhandled == 1 ? 'is' : 'es'} elsewhere include feature#{n_with_unhandled == 1 ? '' : 's'} (window/table calcs, exotic visuals, or free-form layout) that warrant individual review when planning their conversion."
+    else
+      'Migration shortlist ranked by value and conversion complexity.'
+    end
+  else
+    'Environment scan complete.'
+  end
+
+# Section 1: KPI tiles
+kpi_html = [
+  kpi('Analyses',     env['analyses']),
+  kpi('Dashboards',   env['dashboards']),
+  kpi('Datasets',     env['datasets'], "#{n_spice} SPICE · #{n_direct} direct query"),
+  kpi('Data sources', env['data_sources']),
+  kpi('Sheets',       total_sheets),
+  kpi('Visuals',      total_visuals)
+].join
+
+# Section 2: Analysis priority & usage
+usage_html = ''
+if !usage_source.empty?
+  ranked = usage_source.sort_by { |w| -w['value'].to_f }
+  max_val = ranked.first['value'].to_f
+  max_val = 1.0 if max_val.zero?
+  rows = ranked.first(10).each_with_index.map do |w, i|
+    bar_basis = has_usage ? w['views'].to_i : w['value']
+    bar_max   = has_usage ? (ranked.map { |r| r['views'].to_i }.max || 1) : max_val
+    views_cell = has_usage ? w['views'].to_i : '—'
+    users_cell = has_usage ? w['users'].to_i : '—'
+    %(<tr>
+      <td class="rank">#{i + 1}</td>
+      <td>#{h(w['name'])}</td>
+      <td class="al-right num muted">#{w['sheets']}</td>
+      <td class="al-right num muted">#{w['visuals']}</td>
+      <td>#{bar_cell(bar_basis, bar_max)}</td>
+      <td class="al-right num muted">#{views_cell}</td>
+      <td class="al-right num muted">#{users_cell}</td>
+    </tr>)
+  end.join
+  usage_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th class="al-right">#</th>
+          <th>Analysis / dashboard</th>
+          <th class="al-right">Sheets</th>
+          <th class="al-right">Visuals</th>
+          <th>#{has_usage ? 'Views' : 'Value (proxy)'}</th>
+          <th class="al-right">Views</th>
+          <th class="al-right">Users</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 3: Dataset reuse & concentration
+ownership_html = ''
+unless dataset_fanout.empty?
+  rows_data = dataset_fanout.values.sort_by { |d| -d['analyses'] }
+  max_fan = rows_data.first['analyses']
+  max_fan = 1 if max_fan.zero?
+  rows = rows_data.map do |d|
+    %(<tr>
+      <td>#{h(d['name'])}</td>
+      <td>#{bar_cell(d['analyses'], max_fan)}</td>
+    </tr>)
+  end.join
+  ownership_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Dataset</th>
+          <th>Analyses backed</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 4: Data-source patterns (SPICE/DIRECT_QUERY, source types, file/S3 flagged)
+FILE_SOURCE_KINDS = %w[S3Source UploadedFile S3 File].freeze
+FILE_DS_TYPES     = %w[S3 FILE UPLOAD].freeze
+
+# Source-kind histogram across datasets (physical_kinds)
+src_kind = Hash.new(0)
+datasets.each { |d| (d['physical_kinds'] || []).each { |k| src_kind[k] += 1 } }
+src_rows_data = src_kind.sort_by { |_, n| -n }
+max_src = src_rows_data.empty? ? 1 : src_rows_data.first[1]
+src_kind_html = ''
+unless src_rows_data.empty?
+  rows = src_rows_data.map do |kind, n|
+    flagged = FILE_SOURCE_KINDS.include?(kind)
+    badge = flagged ? %(<span class="ds-bucket ds-embedded">file-based</span>) : %(<span class="ds-bucket ds-published">warehouse</span>)
+    %(<tr>
+      <td><code>#{h(kind)}</code></td>
+      <td>#{badge}</td>
+      <td>#{bar_cell(n, max_src)}</td>
+    </tr>)
+  end.join
+  src_kind_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Physical source kind</th>
+          <th>Sigma readiness</th>
+          <th>Datasets</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Connection (data-source) type table — the warehouse/engine each source points at
+ds_type_html = ''
+if !data_sources.empty?
+  type_hist = Hash.new(0)
+  data_sources.each { |s| type_hist[s['type'] || 'unknown'] += 1 }
+  rows_data = type_hist.sort_by { |_, n| -n }
+  max_t = rows_data.first[1]
+  rows = rows_data.map do |t, n|
+    flagged = FILE_DS_TYPES.include?(t.to_s.upcase)
+    cls = flagged ? 'ds-embedded' : 'ds-published'
+    label = flagged ? 'file / object store' : 'warehouse / engine'
+    %(<tr>
+      <td><code>#{h(t)}</code></td>
+      <td><span class="ds-bucket #{cls}">#{label}</span></td>
+      <td>#{bar_cell(n, max_t)}</td>
+    </tr>)
+  end.join
+  ds_type_html = "<h3>Data-source connection types</h3>" + <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Connection type</th>
+          <th>Sigma readiness</th>
+          <th>Count</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# File-based / S3 flagged callout
+n_file_datasets = datasets.count { |d| (d['physical_kinds'] || []).any? { |k| FILE_SOURCE_KINDS.include?(k) } }
+n_custom_sql    = datasets.count { |d| d['has_custom_sql'] }
+n_rls           = datasets.count { |d| d['rls_enabled'] }
+ds_callout = ''
+if n_file_datasets.positive?
+  ds_callout = %(<div class="callout"><strong>#{n_file_datasets} dataset#{n_file_datasets == 1 ? '' : 's'}</strong> source from S3 / uploaded files. Sigma reads from a cloud warehouse, not directly from S3 objects — these need to land in your warehouse first (the <code>quicksight-to-sigma</code> converter flags them as a gap). Warehouse-backed datasets (Snowflake, Redshift, Athena, BigQuery, Databricks, Postgres) are drop-in: Sigma reads the same tables directly.</div>)
+end
+
+# Section 5: Refresh / ingestion activity (SPICE vs DIRECT_QUERY)
+ingestion_html = ''
+unless datasets.empty?
+  rows = datasets.sort_by { |d| d['import_mode'] == 'SPICE' ? 0 : 1 }.map do |d|
+    mode = d['import_mode'] || '—'
+    mode_cls = mode == 'SPICE' ? 'tag-blue' : 'tag-go'
+    rls_chip = d['rls_enabled'] ? %(<span class="risk-chip risk-amber"><span class="risk-dot"></span>RLS</span>) : '<span class="muted">—</span>'
+    %(<tr>
+      <td>#{h(d['name'])}</td>
+      <td><span class="tag #{mode_cls}">#{h(mode)}</span></td>
+      <td class="al-right num muted">#{d['column_count']}</td>
+      <td class="al-right num muted">#{d['transform_count']}</td>
+      <td>#{rls_chip}</td>
+    </tr>)
+  end.join
+  ingestion_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Dataset</th>
+          <th>Ingestion</th>
+          <th class="al-right">Columns</th>
+          <th class="al-right">Transforms</th>
+          <th>Security</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 6: Migration shortlist (HERO table)
+shortlist_html = ''
+if has_shortlist
+  max_val = shortlist.map { |r| r['value'].to_f }.max || 1.0
+  max_val = 1.0 if max_val.zero?
+  rows = shortlist.first(15).map do |r|
+    risk_cls, risk_txt =
+      if r['unhandled'].to_i.positive?
+        ['risk-red',   "#{r['unhandled']} to review"]
+      elsif r['manual'].to_i.positive?
+        ['risk-amber', "#{r['manual']} setup"]
+      else
+        ['risk-clean', 'No issues']
+      end
+    cb = r['calc_buckets'] || {}
+    %(<tr>
+      <td>#{h(r['name'])}</td>
+      <td>#{bar_cell(r['value'].round, max_val.round)}</td>
+      <td class="al-right num muted">#{cb['a'].to_i}/#{cb['b'].to_i}/#{cb['c'].to_i}</td>
+      <td><span class="risk-chip #{risk_cls}"><span class="risk-dot"></span>#{h(risk_txt)}</span></td>
+      <td class="al-right num">#{format('%.1f', r['score'])}</td>
+      <td>#{tag_pill(r['tag'])}</td>
+    </tr>)
+  end.join
+  shortlist_html = <<~HTML
+    <table class="data shortlist">
+      <thead>
+        <tr>
+          <th>Analysis</th>
+          <th>#{has_usage ? 'Usage value' : 'Value (proxy)'}</th>
+          <th class="al-right">Calc a/b/c</th>
+          <th>Conversion risk</th>
+          <th class="al-right">Score</th>
+          <th>Recommendation</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+    <p class="note">Conversion risk legend: <strong>No issues</strong> = converts automatically · <strong>N setup</strong> = brief post-conversion setup in Sigma (dataset joins, parameters, RLS) · <strong>N to review</strong> = uses a QuickSight feature that warrants individual evaluation (window/table calcs, exotic visuals, free-form layout) when planning the conversion. Calc a/b/c = mechanical / restructuring / no-Sigma-equivalent calc fields.</p>
+  HTML
+end
+
+# Per-analysis complexity table
+complexity_html = ''
+if complexity
+  rows = complexity.values.sort_by do |r|
+    -(r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3 + r['n_hint'].to_i)
+  end.map do |r|
+    unh_cell = r['n_unhandled'].to_i.positive? ? %(<span class="warn-num">#{r['n_unhandled']}</span>) : '<span class="muted">0</span>'
+    cb = r['calc_buckets'] || {}
+    %(<tr>
+      <td>#{h(r['name'])}</td>
+      <td class="al-right num muted">#{r['sheets']}</td>
+      <td class="al-right num">#{r['visuals']}</td>
+      <td class="al-right num muted">#{cb['a'].to_i}/#{cb['b'].to_i}/#{cb['c'].to_i}</td>
+      <td class="al-right num muted">#{r['window_calc_count']}</td>
+      <td class="al-right num">#{r['n_manual']}</td>
+      <td class="al-right">#{unh_cell}</td>
+    </tr>)
+  end.join
+  complexity_html = <<~HTML
+    <h3>Per-analysis conversion profile</h3>
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Analysis</th>
+          <th class="al-right">Sheets</th>
+          <th class="al-right">Visuals</th>
+          <th class="al-right">Calc a/b/c</th>
+          <th class="al-right">Window calcs</th>
+          <th class="al-right">Setup</th>
+          <th class="al-right">Review</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+    <p class="note">Window/table-calc functions (the "c" calc bucket — <code>sumOver</code>, <code>runningSum</code>, <code>rank</code>, <code>percentOfTotal</code>, …) have no clean Sigma equivalent and convert to a <code>/* TODO */</code> placeholder. Across all scanned analyses: <strong>#{total_calc['a']} mechanical / #{total_calc['b']} restructuring / #{total_calc['c']} no-equivalent</strong> calc fields.</p>
+  HTML
+end
+
+# ---------- assemble HTML ----------
+html = <<~HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QuickSight Environment Report — #{h(account_id)}</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=DM+Mono:wght@400;500&display=swap');
+  :root {
+    /* Sigma brand palette — Shadow/Nimbus/White neutrals, Insight (CTA only), brand accents */
+    --bg:#fafafa; --card:#ffffff; --ink:#292929; --ink-2:#3d3d3d;
+    --line:#e5e5e5; --line-soft:#f5f5f5;
+    --accent:#292929; --accent-soft:#f0f0f0;
+    --insight:#f0ff45;
+    --go:#1f9d57; --go-soft:#e6fbef;
+    --warn:#c2562a; --warn-soft:#fff1ea;
+    --blue:#2b8ca6; --blue-soft:#eaf8fc;
+    --mute:#6e7877; --mute-soft:#f0f0f0;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
+  body {
+    font-family: "DM Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px; line-height: 1.55; -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 1120px; margin: 0 auto; padding: 48px 48px 80px; }
+
+  /* Brand masthead */
+  .brand-bar { display: flex; align-items: center; gap: 10px; margin-bottom: 28px; }
+  .brand-mark { font-weight: 700; font-size: 21px; letter-spacing: -0.02em; color: var(--ink); }
+  .brand-dot  { width: 9px; height: 9px; border-radius: 2px; background: var(--blue);
+                -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .brand-tag  { font-size: 12px; color: var(--mute); font-weight: 500;
+                text-transform: uppercase; letter-spacing: 0.08em; }
+
+  /* Header */
+  .doc-header { margin-bottom: 40px; }
+  .doc-eyebrow { font-size: 11px; font-weight: 600; color: var(--accent);
+                 text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+  .doc-title { font-size: 36px; font-weight: 700; letter-spacing: -0.02em;
+               margin: 0 0 8px; line-height: 1.1; color: var(--ink); }
+  .doc-meta { font-size: 13px; color: var(--ink-2); }
+  .doc-meta a { color: var(--ink-2); text-decoration: none; border-bottom: 1px dashed var(--line); }
+  .doc-meta a:hover { color: var(--ink); }
+
+  /* Hero finding banner */
+  .hero {
+    background: var(--accent-soft); border: 1px solid var(--line);
+    border-left: 4px solid var(--blue);
+    border-radius: 8px;
+    padding: 18px 22px; margin-bottom: 40px;
+    display: flex; align-items: center; gap: 16px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .hero-label { font-size: 11px; font-weight: 700; color: var(--accent);
+                text-transform: uppercase; letter-spacing: 0.08em;
+                white-space: nowrap; padding-right: 16px;
+                border-right: 1px solid var(--line); }
+  .hero-text { font-size: 15px; color: var(--ink); font-weight: 500; line-height: 1.4; }
+
+  /* Section */
+  section { margin-bottom: 56px; }
+  section.section-tight { margin-bottom: 36px; }
+  .section-head { display: flex; align-items: baseline; justify-content: space-between;
+                  margin-bottom: 16px; padding-bottom: 12px;
+                  border-bottom: 1px solid var(--line); }
+  .section-num { font-size: 12px; font-weight: 600; color: var(--mute);
+                 letter-spacing: 0.06em; }
+  .section-title { font-size: 22px; font-weight: 600; letter-spacing: -0.01em;
+                   margin: 0; flex: 1; padding-left: 14px; }
+  .section-aside { font-size: 12px; color: var(--mute); }
+  .section-lede { font-size: 14px; color: var(--ink-2); margin: -4px 0 16px; }
+
+  /* KPIs */
+  .kpi-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+  .kpi {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 18px 16px;
+  }
+  .kpi-v { font-size: 28px; font-weight: 700; letter-spacing: -0.01em;
+           color: var(--ink); line-height: 1; }
+  .kpi-l { font-size: 11px; color: var(--mute); text-transform: uppercase;
+           letter-spacing: 0.06em; font-weight: 600; margin-top: 10px; }
+  .kpi-sub { font-size: 11px; color: var(--mute); margin-top: 4px; line-height: 1.4; }
+
+  /* Stat callouts */
+  .stat-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
+              margin-bottom: 24px; }
+  .stat {
+    background: #fafafa;
+    border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 8px;
+    padding: 16px 18px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .stat.stat-go   { border-left-color: var(--go);   background: var(--go-soft); }
+  .stat.stat-warn { border-left-color: var(--warn); background: var(--warn-soft); }
+  .stat-l { font-size: 10px; color: var(--mute); text-transform: uppercase;
+            letter-spacing: 0.06em; font-weight: 700; margin-bottom: 6px; }
+  .stat-v { font-size: 30px; font-weight: 700; line-height: 1; letter-spacing: -0.02em;
+            color: var(--ink); }
+  .stat-v.go   { color: var(--go); }
+  .stat-v.warn { color: var(--warn); }
+  .stat-sub { font-size: 12px; color: var(--mute); margin-top: 6px; }
+
+  /* Tables */
+  table.data { width: 100%; border-collapse: collapse; background: var(--card);
+               border: 1px solid var(--line); border-radius: 10px; overflow: hidden;
+               font-size: 13px; }
+  table.data th { font-weight: 600; font-size: 11px; color: var(--mute);
+                  text-transform: uppercase; letter-spacing: 0.06em;
+                  padding: 12px 16px; background: #fafafa;
+                  border-bottom: 1px solid var(--line); text-align: left; }
+  table.data td { padding: 12px 16px; border-bottom: 1px solid var(--line-soft);
+                  vertical-align: middle; }
+  table.data tbody tr:last-child td { border-bottom: 0; }
+  table.data tbody tr:hover td { background: #fafafa; }
+  .al-right { text-align: right; }
+  .al-left  { text-align: left; }
+  /* Pin numeric + bar columns to content width so the text column absorbs the
+     slack — keeps a short value tight against its header instead of stranding it
+     across an over-wide column. */
+  table.data td.al-right, table.data th.al-right,
+  table.data td:has(.bar-cell) { width: 1%; white-space: nowrap; }
+  .num { font-variant-numeric: tabular-nums; }
+  .muted { color: var(--mute); }
+  .warn { color: var(--warn); }
+  .warn-num { color: var(--warn); font-weight: 700; }
+  .rank { font-variant-numeric: tabular-nums; color: var(--mute); font-weight: 600; width: 32px; }
+  .workbook-link { color: var(--ink); text-decoration: none;
+                   border-bottom: 1px solid var(--line); }
+  .workbook-link:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  .breakdown { font-size: 12px; font-variant-numeric: tabular-nums; }
+  .breakdown span { margin-right: 8px; }
+
+  /* Tags */
+  .tag { display: inline-block; padding: 3px 10px; border-radius: 99px;
+         font-size: 11px; font-weight: 600; letter-spacing: 0.01em;
+         white-space: nowrap; }
+  .tag-go    { background: var(--go-soft);    color: var(--go); }
+  .tag-blue  { background: var(--blue-soft);  color: var(--blue); }
+  .tag-gray  { background: #f5f5f5;           color: var(--ink-2); }
+  .tag-warn  { background: var(--warn-soft);  color: var(--warn); }
+  .tag-mute  { background: var(--mute-soft);  color: var(--mute); }
+
+  /* Bar cells (in tables) */
+  .bar-cell { display: flex; align-items: center; gap: 10px;
+              justify-content: flex-start; }
+  .bar-track { flex: none; width: 84px; height: 6px; background: #f5f5f5; border-radius: 4px;
+               overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 4px; }
+  .bar-blue { background: linear-gradient(90deg, #4cec8c, #2fb874); }
+  .bar-num { font-variant-numeric: tabular-nums; font-weight: 600;
+             min-width: 36px; text-align: right; }
+
+  /* Data-source bucket badge */
+  .ds-bucket { display: inline-block; padding: 3px 10px; border-radius: 6px;
+               font-size: 11px; font-weight: 600;
+               -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .ds-published { background: var(--blue-soft); color: var(--blue); }
+  .ds-embedded  { background: #f5f5f5; color: var(--ink-2); }
+
+  /* Risk chip — used in shortlist + verdicts + coverage */
+  .risk-chip { display: inline-flex; align-items: center; gap: 6px;
+               font-size: 12px; font-variant-numeric: tabular-nums; }
+  .risk-dot { width: 8px; height: 8px; border-radius: 50%;
+              -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .risk-clean .risk-dot { background: var(--go); }
+  .risk-clean             { color: var(--go); font-weight: 600; }
+  .risk-green .risk-dot { background: #84cc16; }
+  .risk-green             { color: var(--ink-2); }
+  .risk-amber .risk-dot { background: #f59e0b; }
+  .risk-amber             { color: #a16207; font-weight: 600; }
+  .risk-red   .risk-dot { background: var(--warn); }
+  .risk-red               { color: var(--warn); font-weight: 700; }
+  .risk-mute  .risk-dot { background: var(--mute); }
+  .risk-mute              { color: var(--mute); }
+
+  /* Cluster member display */
+  .cluster-member { padding: 2px 0; font-size: 12px; line-height: 1.4; }
+  .cluster-member + .cluster-member { border-top: 1px dashed var(--line-soft); }
+
+  /* Inline user pill (top-users cell) */
+  .inline-pill { display: inline-block; padding: 1px 7px; border-radius: 99px;
+                 font-size: 11px; background: #f1f5f9; color: var(--ink-2);
+                 font-variant-numeric: tabular-nums; margin-right: 4px;
+                 -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+
+  /* Top-view cell — most-used view per workbook */
+  .top-view-cell { font-size: 12px; line-height: 1.3; }
+  .top-view-pct  { font-size: 11px; margin-top: 2px; }
+
+  /* Per-user top-workbook list (inside table cell) */
+  .top-wb { font-size: 11px; line-height: 1.4; display: flex;
+            justify-content: space-between; gap: 12px;
+            padding: 1px 0; }
+  .top-wb + .top-wb { border-top: 1px dotted var(--line-soft); padding-top: 3px; margin-top: 3px; }
+  .top-wb span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 220px; }
+
+  /* Unique-to-user expander */
+  details.unique-detail { font-size: 11px; }
+  details.unique-detail summary { cursor: pointer; color: var(--accent); font-weight: 600;
+                                  list-style: none; padding: 2px 0; }
+  details.unique-detail summary::-webkit-details-marker { display: none; }
+  details.unique-detail summary::before { content: '▸ '; color: var(--mute); }
+  details.unique-detail[open] summary::before { content: '▾ '; }
+  details.unique-detail div { padding-left: 12px; font-size: 11px; line-height: 1.4; }
+
+  /* Notes + callouts */
+  .note { font-size: 12px; color: var(--mute); font-style: italic;
+          margin: 12px 0 0; }
+  .callout {
+    background: var(--warn-soft); border-left: 3px solid var(--warn);
+    padding: 12px 16px; border-radius: 6px; margin-top: 16px;
+    font-size: 13px; color: #7c2d12;
+  }
+  .callout strong { color: #7c2d12; }
+  .callout code { background: rgba(0,0,0,0.06); padding: 1px 5px; border-radius: 3px;
+                  font-size: 12px; }
+
+  code { font-family: "DM Mono", ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px;
+         background: var(--line-soft); padding: 1px 6px; border-radius: 4px; }
+
+  /* Next steps */
+  ol.next-steps { margin: 0; padding-left: 0; counter-reset: step;
+                  list-style: none; }
+  ol.next-steps li { counter-increment: step; padding: 14px 0 14px 44px;
+                     position: relative; border-bottom: 1px solid var(--line-soft);
+                     font-size: 14px; }
+  ol.next-steps li:last-child { border-bottom: 0; }
+  ol.next-steps li::before {
+    content: counter(step); position: absolute; left: 0; top: 14px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--accent-soft); color: var(--accent);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums;
+  }
+  ol.next-steps li strong { color: var(--ink); }
+
+  /* Privacy two-column */
+  .priv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .priv-col h3 { font-size: 13px; font-weight: 600; color: var(--ink);
+                 margin: 0 0 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .priv-col ul { margin: 0; padding-left: 0; list-style: none; }
+  .priv-col li { padding: 6px 0 6px 22px; position: relative;
+                 font-size: 13px; color: var(--ink-2); }
+  .priv-col.crossed li::before {
+    content: '→'; position: absolute; left: 0; color: var(--warn); font-weight: 700;
+  }
+  .priv-col.local li::before {
+    content: '◊'; position: absolute; left: 0; color: var(--go); font-weight: 700;
+  }
+
+  footer { color: var(--mute); font-size: 11px; text-align: center;
+           margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--line); }
+
+  @media print {
+    @page { margin: 0.6in 0.5in 0.6in; size: letter portrait; }
+    body { background: white; font-size: 11.5px; }
+    main { max-width: none; padding: 0; }
+    .doc-header { margin-bottom: 18px; }
+    .doc-title { font-size: 26px; }
+    .hero { margin-bottom: 24px; padding: 12px 16px; page-break-after: avoid; }
+    .hero-text { font-size: 13px; }
+    section { margin-bottom: 24px; page-break-inside: auto; }
+    section.section-tight { margin-bottom: 18px; }
+    .section-head { margin-bottom: 10px; padding-bottom: 8px; page-break-after: avoid; }
+    .section-title { font-size: 16px; }
+    .section-lede { font-size: 12px; margin: -2px 0 10px; }
+    .kpi-grid { gap: 8px; }
+    .kpi { padding: 12px; }
+    .kpi-v { font-size: 22px; }
+    .kpi-l { font-size: 10px; margin-top: 6px; }
+    .kpi-sub { font-size: 10px; margin-top: 3px; }
+    .stat-row { gap: 8px; margin-bottom: 14px; }
+    .stat { padding: 12px 14px; }
+    .stat-v { font-size: 24px; }
+    table.data { font-size: 11px; page-break-inside: auto; }
+    table.data thead { display: table-header-group; }
+    table.data th { padding: 8px 10px; font-size: 10px; }
+    table.data td { padding: 8px 10px; }
+    table.data tr { page-break-inside: avoid; page-break-after: auto; }
+    .tag, .ds-bucket { font-size: 10px; padding: 2px 8px; }
+    .bar-track { max-width: 60px; height: 5px; }
+    .note { font-size: 11px; }
+    .callout { padding: 8px 12px; font-size: 11px; }
+    ol.next-steps li { padding: 10px 0 10px 36px; font-size: 12px; }
+    ol.next-steps li::before { width: 22px; height: 22px; font-size: 11px; top: 10px; }
+    .priv-col li { font-size: 11px; padding: 4px 0 4px 18px; }
+    footer { margin-top: 24px; padding-top: 12px; }
+    /* Force backgrounds + colors to render */
+    .hero, .kpi, .stat, table.data, table.data th, .ds-bucket, .tag,
+    .bar-track, .bar-fill, .risk-dot, .callout, ol.next-steps li::before {
+      -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important;
+    }
+    /* Avoid awkward page splits at section boundaries */
+    section h2, .section-head { page-break-after: avoid; }
+    .stat-row, .priv-grid { page-break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+<main>
+
+<div class="brand-bar">
+  <span class="brand-dot"></span>
+  <span class="brand-mark">sigma</span>
+  <span class="brand-tag">Migration Assessment</span>
+</div>
+<div class="doc-header">
+  <div class="doc-eyebrow">QuickSight Environment Report</div>
+  <h1 class="doc-title">#{h(account_id)}</h1>
+  <div class="doc-meta">
+    Account #{h(account_id)} · #{h(region)} · #{h(edition)} edition · Generated #{h(formatted_date)}
+  </div>
+</div>
+
+<div class="hero">
+  <div class="hero-label">Headline finding</div>
+  <div class="hero-text">#{h(hero_finding)}</div>
+</div>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">01</span>
+    <h2 class="section-title">Environment overview</h2>
+  </div>
+  <div class="kpi-grid">#{kpi_html}</div>
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">02</span>
+    <h2 class="section-title">Analysis &amp; dashboard priority</h2>
+    <span class="section-aside">Top 10 of #{env['analyses']} analyses · ranked #{has_usage ? "by #{num(total_views)} total views" : 'by complexity proxy'}</span>
+  </div>
+  <p class="section-lede">#{has_usage ? 'Most-used analyses across the account, ranked by all-time view count. This is the foundation of any migration plan — focus effort where audience attention already is.' : 'QuickSight has no per-analysis view-count API on the standard surface, so analyses are ranked by a complexity proxy (sheets + visuals/4) rather than real usage. Supply a CloudTrail/CloudWatch-derived <code>usage.json</code> to add the usage axis.'}</p>
+  #{usage_html}
+  #{cold_analyses.any? ? %(<p class="note"><strong>#{cold_analyses.size} analys#{cold_analyses.size == 1 ? 'is has' : 'es have'}</strong> never been viewed: ) + cold_analyses.map { |w| %(<code>#{h(w['name'])}</code>) }.join(', ') + ' — strong candidates for retirement.</p>' : ''}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">03</span>
+    <h2 class="section-title">Dataset reuse &amp; concentration</h2>
+    <span class="section-aside">#{datasets.size} datasets</span>
+  </div>
+  <p class="section-lede">QuickSight has no per-analysis owner surface, so concentration here is measured by <strong>dataset reuse</strong>: how many analyses each dataset backs. Datasets shared across multiple analyses become a single Sigma data model by construction — the migration plan groups analyses into DM clusters on exactly this signal.</p>
+  #{ownership_html}
+  #{dataset_fanout.empty? ? '' : %(<p class="note">Most-reused dataset: <strong>#{top_dataset_pct}%</strong> of dataset references point at <code>#{h(top_dataset_name)}</code>. High reuse is a <em>good</em> migration signal — those analyses collapse into one shared Sigma data model.</p>)}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">04</span>
+    <h2 class="section-title">Data sources &amp; patterns</h2>
+    <span class="section-aside">#{datasets.size} datasets · #{n_spice} SPICE · #{n_direct} direct query</span>
+  </div>
+  <p class="section-lede">How data flows into your QuickSight analyses. Datasets backed by a cloud warehouse Sigma already supports (Snowflake, Redshift, Athena, BigQuery, Databricks, Postgres) are drop-in. File-based sources (S3, uploaded files) must land in a warehouse first.</p>
+  #{src_kind_html}
+  #{ds_type_html}
+  <p class="note"><strong>#{n_custom_sql} dataset#{n_custom_sql == 1 ? '' : 's'}</strong> use Custom SQL (converted via the <code>[Custom SQL/&lt;ALIAS&gt;]</code> fixup) · <strong>#{n_rls} dataset#{n_rls == 1 ? '' : 's'}</strong> have row-level security enabled.</p>
+  #{ds_callout}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">05</span>
+    <h2 class="section-title">Ingestion &amp; refresh activity</h2>
+    <span class="section-aside">#{n_spice} SPICE · #{n_direct} direct query</span>
+  </div>
+  <p class="section-lede">QuickSight datasets either pre-ingest into SPICE (its in-memory cache, refreshed on a schedule) or query the warehouse live (DIRECT_QUERY). SPICE datasets carry a refresh schedule that becomes a Sigma data-model materialization; direct-query datasets read live and need no ingestion plan.</p>
+  #{ingestion_html}
+</section>
+
+HTML
+
+if has_shortlist
+  html += <<~HTML
+  <section>
+    <div class="section-head">
+      <span class="section-num">06</span>
+      <h2 class="section-title">Migration to Sigma — recommended sequence</h2>
+      <span class="section-aside">#{value_basis}</span>
+    </div>
+    <p class="section-lede">If you choose to migrate to Sigma, this is the order that minimizes risk while covering the most value. Analyses are ranked by <code>value / (1 + cost)</code>, where <code>cost = 10·unhandled + 3·manual</code>. The top of the list is the recommended starting point for a pilot.</p>
+
+    <div class="stat-row">
+      <div class="stat">
+        <div class="stat-l">Top-5 #{has_usage ? 'usage' : 'value'} share</div>
+        <div class="stat-v">#{top5_pct}<span style="font-size: 16px; color: var(--mute); font-weight: 600;">%</span></div>
+        <div class="stat-sub">of total #{has_usage ? 'usage value' : 'value (proxy)'} across #{shortlist.size} analyses</div>
+      </div>
+      <div class="stat stat-#{sl_top5_unhandled.zero? ? 'go' : 'warn'}">
+        <div class="stat-l">Top-5 conversion complexity</div>
+        <div class="stat-v #{sl_top5_unhandled.zero? ? 'go' : 'warn'}">#{sl_top5_unhandled}</div>
+        <div class="stat-sub">advanced features to review across pilot</div>
+      </div>
+      <div class="stat">
+        <div class="stat-l">Needs review · Retire</div>
+        <div class="stat-v">#{sl_needs_scout}<span style="font-size: 16px; color: var(--mute); font-weight: 600;"> · #{sl_retire}</span></div>
+        <div class="stat-sub">analyses of #{shortlist.size} total</div>
+      </div>
+    </div>
+
+    #{shortlist_html}
+
+    #{complexity_html}
+
+    #{sl_total_unhandled.positive? ?
+      %(<div class="callout"><strong>#{n_with_unhandled} analys#{n_with_unhandled == 1 ? 'is' : 'es'}</strong> include features that warrant individual review when planning their conversion — typically window/table-calc functions (no clean Sigma equivalent), exotic visuals (maps, sankey, insight ML), or free-form / section-based layout. Identifying these up-front means no surprises mid-migration.</div>) : ''}
+  </section>
+
+  HTML
+end
+
+priv_num = has_shortlist ? '07' : '06'
+hand_num = has_shortlist ? '08' : '07'
+next_num = has_shortlist ? '09' : '08'
+
+html += <<~HTML
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{priv_num}</span>
+    <h2 class="section-title">Data handling</h2>
+  </div>
+  <p class="section-lede">This report was generated by an LLM-driven scan of your QuickSight account via the AWS CLI. What that means for the data that left your environment:</p>
+  <div class="priv-grid">
+    <div class="priv-col crossed">
+      <h3>Read by the scanner</h3>
+      <ul>
+        <li>Aggregate counts (analysis, dashboard, dataset, data-source totals)</li>
+        <li>Analysis, dataset, and data-source names</li>
+        <li>Analysis definitions — visual configuration and <strong>calc-field expressions</strong></li>
+        <li>Dataset metadata — physical source kinds, custom-SQL presence, RLS/CLS flags</li>
+      </ul>
+    </div>
+    <div class="priv-col local">
+      <h3>Never left your environment</h3>
+      <ul>
+        <li>Underlying warehouse rows — the scan never queries source data</li>
+        <li>SPICE in-memory rows — never read</li>
+        <li>AWS credentials (held by the AWS CLI, not surfaced to the agent)</li>
+        <li>Actual visual cell values</li>
+      </ul>
+    </div>
+  </div>
+  <p class="note">If your calc-field expressions encode business-sensitive logic, that text crossed the Anthropic API. See <code>PRIVACY.md</code> for the full disclosure to review with your privacy / legal team.</p>
+</section>
+
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{hand_num}</span>
+    <h2 class="section-title">Hand-off package</h2>
+  </div>
+  <p class="section-lede">This folder is the complete, self-contained deliverable. Nothing is uploaded anywhere — to share it with a Sigma rep, zip the directory and send it deliberately.</p>
+  <ul class="priv-col local" style="list-style:none;padding:0;">
+    <li><code>readout.html</code> — this report</li>
+    <li><code>readout.md</code> — the same report as markdown</li>
+    <li><code>inventory.json</code> — environment + per-analysis + per-dataset metadata</li>
+    <li><code>complexity.json</code> — per-analysis convertibility scoring</li>
+    <li><code>shortlist.json</code> — value/cost-ranked migration shortlist</li>
+    <li><code>migration-plan.json</code> — per-analysis recommended path + DM clusters (by shared dataset), consumable by <code>quicksight-to-sigma</code></li>
+    <li><code>raw-defs/</code>, <code>raw-datasets/</code> — decoded analysis + dataset definitions (delete after review if you'd rather not retain calc-field text)</li>
+  </ul>
+</section>
+
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{next_num}</span>
+    <h2 class="section-title">Recommended next steps</h2>
+  </div>
+  <ol class="next-steps">
+HTML
+
+if has_shortlist
+  html += <<~HTML
+    <li><strong>Pilot the top #{[5, shortlist.size].min} analyses.</strong> They represent #{top5_pct}% of total #{has_usage ? 'usage value' : 'value (proxy)'} with #{sl_top5_unhandled} feature#{sl_top5_unhandled == 1 ? '' : 's'} flagged for review between them — the lowest-risk way to demonstrate end-to-end migration. The <code>quicksight-to-sigma</code> skill converts them, grouped into DM clusters that share a Sigma data model by shared dataset.</li>
+  HTML
+  if sl_needs_scout.positive?
+    html += "    <li><strong>Plan individual review time for #{sl_needs_scout} analys#{sl_needs_scout == 1 ? 'is' : 'es'}.</strong> Each contains a window/table-calc function, an exotic visual, or free-form layout that benefits from a tailored conversion approach — identifying them up-front prevents surprises mid-migration.</li>\n"
+  end
+  if sl_retire.positive?
+    html += "    <li><strong>Retire #{sl_retire} analys#{sl_retire == 1 ? 'is' : 'es'}</strong> with zero views. No migration value, and dropping them simplifies the cutover.</li>\n"
+  end
+  unless has_usage
+    html += "    <li><strong>Supply usage data</strong> (CloudTrail / CloudWatch-derived <code>usage.json</code>) to upgrade the shortlist from a complexity-only proxy to a usage-weighted ranking and unlock cold-analysis detection.</li>\n"
+  end
+  html += "    <li><strong>Land any file-based datasets in your warehouse</strong> before converting. S3 / uploaded-file sources are a converter gap — Sigma reads from a warehouse, not directly from S3 objects.</li>\n"
+else
+  html += <<~HTML
+    <li><strong>Enable per-analysis conversion analysis</strong> by running against an Enterprise-edition account. The <code>describe-analysis-definition</code> / <code>describe-data-set</code> APIs are Enterprise-only; on Standard the readout degrades to counts-only.</li>
+    <li><strong>Supply usage data</strong> (CloudTrail / CloudWatch) to add a usage-weighted shortlist.</li>
+  HTML
+end
+
+html += <<~HTML
+  </ol>
+</section>
+
+<footer>
+  Report generated #{h(formatted_date)} · supporting JSON files alongside in the same folder · value basis: #{h(value_basis)}
+</footer>
+
+</main>
+</body>
+</html>
+HTML
+
+out_path = File.join(opts[:out], 'readout.html')
+File.write(out_path, html)
+puts "wrote #{out_path} (#{File.size(out_path)} bytes)"

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout-html.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout-html.rb
@@ -881,8 +881,7 @@ if has_shortlist
 end
 
 priv_num = has_shortlist ? '07' : '06'
-hand_num = has_shortlist ? '08' : '07'
-next_num = has_shortlist ? '09' : '08'
+next_num = has_shortlist ? '08' : '07'
 
 html += <<~HTML
 <section class="section-tight">
@@ -912,23 +911,6 @@ html += <<~HTML
     </div>
   </div>
   <p class="note">If your calc-field expressions encode business-sensitive logic, that text crossed the Anthropic API. See <code>PRIVACY.md</code> for the full disclosure to review with your privacy / legal team.</p>
-</section>
-
-<section class="section-tight">
-  <div class="section-head">
-    <span class="section-num">#{hand_num}</span>
-    <h2 class="section-title">Hand-off package</h2>
-  </div>
-  <p class="section-lede">This folder is the complete, self-contained deliverable. Nothing is uploaded anywhere — to share it with a Sigma rep, zip the directory and send it deliberately.</p>
-  <ul class="priv-col local" style="list-style:none;padding:0;">
-    <li><code>readout.html</code> — this report</li>
-    <li><code>readout.md</code> — the same report as markdown</li>
-    <li><code>inventory.json</code> — environment + per-analysis + per-dataset metadata</li>
-    <li><code>complexity.json</code> — per-analysis convertibility scoring</li>
-    <li><code>shortlist.json</code> — value/cost-ranked migration shortlist</li>
-    <li><code>migration-plan.json</code> — per-analysis recommended path + DM clusters (by shared dataset), consumable by <code>quicksight-to-sigma</code></li>
-    <li><code>raw-defs/</code>, <code>raw-datasets/</code> — decoded analysis + dataset definitions (delete after review if you'd rather not retain calc-field text)</li>
-  </ul>
 </section>
 
 <section class="section-tight">

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/render-readout-html.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/render-readout-html.rb
@@ -211,7 +211,7 @@ if has_shortlist
 
     %(<tr>
       <td>#{name_cell}</td>
-      <td class="al-right">#{bar_cell(r['accesses'], max_acc)}</td>
+      <td>#{bar_cell(r['accesses'], max_acc)}</td>
       <td class="al-right num">#{r['actors']}</td>
       <td><span class="risk-chip #{risk_cls}"><span class="risk-dot"></span>#{h(risk_txt)}</span></td>
       <td class="al-right num">#{format('%.1f', r['score'])}</td>
@@ -223,7 +223,7 @@ if has_shortlist
       <thead>
         <tr>
           <th>Workbook</th>
-          <th class="al-right">Usage</th>
+          <th>Usage</th>
           <th class="al-right">Viewers</th>
           <th>Conversion risk</th>
           <th class="al-right">Score</th>
@@ -306,7 +306,7 @@ if !usage_source.empty?
       <td class="rank">#{i + 1}</td>
       <td>#{name_cell}</td>
       <td class="muted">#{h((info['owner'] || '—').sub(/@.*/, ''))}</td>
-      <td class="al-right">#{bar_cell(w['accesses'], max_acc)}</td>
+      <td>#{bar_cell(w['accesses'], max_acc)}</td>
       <td>#{top_users_cell}</td>
       <td>#{top_view_cell}</td>
     </tr>)
@@ -318,7 +318,7 @@ if !usage_source.empty?
           <th class="al-right">#</th>
           <th>Workbook</th>
           <th>Owner</th>
-          <th class="al-right">Accesses</th>
+          <th>Accesses</th>
           <th>Top users</th>
           <th>Most-used view</th>
         </tr>
@@ -336,7 +336,7 @@ if inventory['content_ownership']
   rows = rows_data.map do |o|
     %(<tr>
       <td>#{h(o['owner'])}</td>
-      <td class="al-right">#{bar_cell(o['workbooks'], max_wb)}</td>
+      <td>#{bar_cell(o['workbooks'], max_wb)}</td>
       <td class="al-right num muted">#{num(o['datasources'])}</td>
       <td class="al-right num muted">#{num(o['views'])}</td>
       <td class="al-right num muted">#{num(o['flows'])}</td>
@@ -347,7 +347,7 @@ if inventory['content_ownership']
       <thead>
         <tr>
           <th>Owner</th>
-          <th class="al-right">Workbooks</th>
+          <th>Workbooks</th>
           <th class="al-right">Data sources</th>
           <th class="al-right">Views</th>
           <th class="al-right">Flows</th>
@@ -372,7 +372,7 @@ if inventory['datasource_types']
     %(<tr>
       <td><span class="ds-bucket #{badge_cls}">#{h(bucket)}</span></td>
       <td><code>#{h(db)}</code></td>
-      <td class="al-right">#{bar_cell(n, max_n)}</td>
+      <td>#{bar_cell(n, max_n)}</td>
     </tr>)
   end.join
   ds_html = <<~HTML
@@ -381,7 +381,7 @@ if inventory['datasource_types']
         <tr>
           <th>Type</th>
           <th>Connection class</th>
-          <th class="al-right">Count</th>
+          <th>Count</th>
         </tr>
       </thead>
       <tbody>#{rows}</tbody>
@@ -426,22 +426,33 @@ html = <<~HTML
 <meta charset="utf-8">
 <title>Tableau Environment Report — #{h(site_name)}</title>
 <style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=DM+Mono:wght@400;500&display=swap');
   :root {
-    --bg:#fafafa; --card:#ffffff; --ink:#0a0a0a; --ink-2:#525252;
+    /* Sigma brand palette — Shadow/Nimbus/White neutrals, Insight (CTA only), brand accents */
+    --bg:#fafafa; --card:#ffffff; --ink:#292929; --ink-2:#3d3d3d;
     --line:#e5e5e5; --line-soft:#f5f5f5;
-    --accent:#0f766e; --accent-soft:#f0fdfa;
-    --go:#15803d; --go-soft:#dcfce7;
-    --warn:#c2410c; --warn-soft:#fff7ed;
-    --blue:#1d4ed8; --blue-soft:#dbeafe;
-    --mute:#737373; --mute-soft:#f5f5f5;
+    --accent:#292929; --accent-soft:#f0f0f0;
+    --insight:#f0ff45;
+    --go:#1f9d57; --go-soft:#e6fbef;
+    --warn:#c2562a; --warn-soft:#fff1ea;
+    --blue:#2b8ca6; --blue-soft:#eaf8fc;
+    --mute:#6e7877; --mute-soft:#f0f0f0;
   }
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
   body {
-    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Inter, Roboto, sans-serif;
+    font-family: "DM Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     font-size: 14px; line-height: 1.55; -webkit-font-smoothing: antialiased;
   }
   main { max-width: 1120px; margin: 0 auto; padding: 48px 48px 80px; }
+
+  /* Brand masthead */
+  .brand-bar { display: flex; align-items: center; gap: 10px; margin-bottom: 28px; }
+  .brand-mark { font-weight: 700; font-size: 21px; letter-spacing: -0.02em; color: var(--ink); }
+  .brand-dot  { width: 9px; height: 9px; border-radius: 2px; background: var(--blue);
+                -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .brand-tag  { font-size: 12px; color: var(--mute); font-weight: 500;
+                text-transform: uppercase; letter-spacing: 0.08em; }
 
   /* Header */
   .doc-header { margin-bottom: 40px; }
@@ -455,8 +466,8 @@ html = <<~HTML
 
   /* Hero finding banner */
   .hero {
-    background: var(--accent-soft); border: 1px solid #99f6e4;
-    border-left: 4px solid var(--accent);
+    background: var(--accent-soft); border: 1px solid var(--line);
+    border-left: 4px solid var(--blue);
     border-radius: 8px;
     padding: 18px 22px; margin-bottom: 40px;
     display: flex; align-items: center; gap: 16px;
@@ -465,8 +476,8 @@ html = <<~HTML
   .hero-label { font-size: 11px; font-weight: 700; color: var(--accent);
                 text-transform: uppercase; letter-spacing: 0.08em;
                 white-space: nowrap; padding-right: 16px;
-                border-right: 1px solid #99f6e4; }
-  .hero-text { font-size: 15px; color: #134e4a; font-weight: 500; line-height: 1.4; }
+                border-right: 1px solid var(--line); }
+  .hero-text { font-size: 15px; color: var(--ink); font-weight: 500; line-height: 1.4; }
 
   /* Section */
   section { margin-bottom: 56px; }
@@ -527,6 +538,11 @@ html = <<~HTML
   table.data tbody tr:hover td { background: #fafafa; }
   .al-right { text-align: right; }
   .al-left  { text-align: left; }
+  /* Pin numeric + bar columns to content width so the text column absorbs the
+     slack — keeps a short value tight against its header instead of stranding it
+     across an over-wide column. */
+  table.data td.al-right, table.data th.al-right,
+  table.data td:has(.bar-cell) { width: 1%; white-space: nowrap; }
   .num { font-variant-numeric: tabular-nums; }
   .muted { color: var(--mute); }
   .warn { color: var(--warn); }
@@ -550,11 +566,11 @@ html = <<~HTML
 
   /* Bar cells (in tables) */
   .bar-cell { display: flex; align-items: center; gap: 10px;
-              justify-content: flex-end; min-width: 120px; }
-  .bar-track { flex: 1; height: 6px; background: #f5f5f5; border-radius: 4px;
-               overflow: hidden; max-width: 80px; }
+              justify-content: flex-start; }
+  .bar-track { flex: none; width: 84px; height: 6px; background: #f5f5f5; border-radius: 4px;
+               overflow: hidden; }
   .bar-fill { height: 100%; border-radius: 4px; }
-  .bar-blue { background: linear-gradient(90deg, #14b8a6, #0d9488); }
+  .bar-blue { background: linear-gradient(90deg, #4cec8c, #2fb874); }
   .bar-num { font-variant-numeric: tabular-nums; font-weight: 600;
              min-width: 36px; text-align: right; }
 
@@ -623,7 +639,7 @@ html = <<~HTML
   .callout code { background: rgba(0,0,0,0.06); padding: 1px 5px; border-radius: 3px;
                   font-size: 12px; }
 
-  code { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px;
+  code { font-family: "DM Mono", ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px;
          background: var(--line-soft); padding: 1px 6px; border-radius: 4px; }
 
   /* Next steps */
@@ -707,6 +723,11 @@ html = <<~HTML
 <body>
 <main>
 
+<div class="brand-bar">
+  <span class="brand-dot"></span>
+  <span class="brand-mark">sigma</span>
+  <span class="brand-tag">Migration Assessment</span>
+</div>
 <div class="doc-header">
   <div class="doc-eyebrow">Tableau Environment Report</div>
   <h1 class="doc-title">#{h(site_name)}</h1>

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/PRIVACY.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/PRIVACY.md
@@ -1,0 +1,73 @@
+# Privacy & data handling — `thoughtspot-assessment`
+
+Read this before running the skill, and share it with your privacy / security /
+legal team if your organization needs to review tools that send report and
+model metadata through a third-party LLM API.
+
+## What this skill reads and writes
+
+**READ-ONLY.** The skill never writes to ThoughtSpot and never posts to Sigma.
+It connects to **two systems** on your behalf:
+
+1. **Your ThoughtSpot instance**, via the ThoughtSpot REST v2 API, authenticated
+   as **you** through `TS_HOST` + `TS_TOKEN` (an SSO session token or a
+   Trusted-Auth service token). The skill reads:
+   - Object listings via `metadata/search` (LOGICAL_TABLE / LIVEBOARD / ANSWER /
+     CONNECTION) — counts, names, authors, connection types
+   - Per-Liveboard **TML** via `metadata/tml/export` (visualization config, chart
+     types, referenced models/worksheets, and any TML **formula** text)
+   - Per-object **usage** via `searchdata` against the `TS: BI Server` system
+     worksheet (views, distinct users, per-user activity) — admin scope
+2. **The Anthropic API**, via Claude Code, to drive the agent.
+
+Everything the skill reads passes through Claude (and therefore the Anthropic
+API) on its way to producing the readout. Anthropic's API data handling:
+<https://www.anthropic.com/legal/privacy>.
+
+## What crosses the Anthropic API
+
+| Crosses API | Stays in your environment |
+|---|---|
+| **Aggregate counts** (Liveboard / Answer / model / table / connection totals) | Warehouse rows (this skill **never** queries the underlying database) |
+| **Names**: Liveboard, model/worksheet, table, connection names; author names | Connection / database credentials |
+| **Liveboard TML** — visualization config, chart types, referenced models, and **TML formula expressions** (calculated-field definitions) | Falcon in-memory data and uploaded file (CSV/XLSX) contents |
+| **Usage**: per-object views + distinct users, per-user action volume from `TS: BI Server` | Answer result-set data (only metadata is read, never the rendered values) |
+| Connection **type** strings (e.g. `RDBMS_SNOWFLAKE`) — not credentials | |
+
+The TML does **NOT** contain row-level data from your warehouse. If your TML
+formulas encode business-sensitive logic, that text crosses the API — tell
+stakeholders before running. ThoughtSpot has no Tableau-style custom SQL or
+Power-BI-style RLS-role-definition surface in the TML the scan reads; the most
+sensitive payload is the formula text.
+
+## What stays local
+
+All outputs are written to `~/thoughtspot-migration/` (or the `--out` directory
+you choose) and are **not uploaded anywhere**. `assessment.json` holds the full
+machine-readable report; `readout.html` is the share-friendly rendering. To share
+with a Sigma rep, that's a deliberate action you take (zip and send).
+
+You can delete the outputs after review:
+
+```bash
+rm -rf ~/thoughtspot-migration
+```
+
+## How to limit exposure
+
+1. **Review `assessment.json` before sharing** — it carries Liveboard/model names
+   and TML formula counts (the renderer surfaces counts, not formula bodies; the
+   bodies live in the exported TML the agent read transiently).
+2. **Run with a scoped identity** if you only want to assess a subset of content
+   visible to that identity.
+3. **Delete `~/thoughtspot-migration` immediately after rendering** (command
+   above).
+
+## Where to direct privacy questions
+
+- Anthropic API privacy: <https://www.anthropic.com/legal/privacy>
+- ThoughtSpot REST v2 API: <https://developers.thoughtspot.com/docs/rest-apiv2>
+- This skill's source: every script under `scripts/` runs on your behalf and is
+  readable — `scan.py` is the only one that touches the network, and every call
+  is a read (`metadata/search`, `metadata/tml/export`, `searchdata`).
+- Sigma privacy policy: <https://www.sigmacomputing.com/privacy-policy>

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/README.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/README.md
@@ -1,0 +1,88 @@
+# ThoughtSpot Assessment
+
+A Claude Code skill that inventories a ThoughtSpot instance and produces a
+migration-readiness readout. Designed to be run by a customer (or a Sigma rep
+with the customer present) before deciding which Liveboards to migrate to Sigma.
+
+**READ-ONLY.** Every call is a read (`metadata/search`, `metadata/tml/export`,
+`searchdata`). The skill never writes to ThoughtSpot and never posts to Sigma.
+
+Built for a **real, populated production instance** — per-object usage from the
+`TS: BI Server` system worksheet is a first-class input, not an optional extra.
+
+## What it produces
+
+A directory (`~/thoughtspot-migration/`) with:
+
+- `readout.html` — a Sigma-branded, share-friendly report: environment counts,
+  usage-ranked Liveboard priority, ownership concentration, Embrace-vs-Falcon
+  data-source patterns, user activity, a value/cost-ranked **migration
+  shortlist**, per-Liveboard complexity, and chart-type coverage.
+- `assessment.json` — the full machine-readable report (the renderer's input).
+
+Nothing in this directory is uploaded anywhere.
+
+## Prerequisites
+
+- Claude Code installed
+- `TS_HOST` + `TS_TOKEN` for the instance you want to assess (an SSO session
+  token or a Trusted-Auth service token). For the usage axis, the identity needs
+  **admin scope** so it can read `TS: BI Server`.
+- Python 3 with `pyyaml` (`pip install pyyaml`)
+- Ruby (for the renderer — stdlib only, no gems)
+
+## How to run
+
+In Claude Code:
+
+```
+/thoughtspot-assessment
+```
+
+The skill will:
+
+1. Inventory connections, tables, models/worksheets, Liveboards, Answers via
+   `metadata/search`
+2. Resolve the `TS: BI Server` system worksheet and query per-Liveboard views +
+   distinct users + per-user activity
+3. Export each Liveboard's TML and score per-Liveboard complexity (viz count,
+   chart kinds, models touched, TML formulas, filters)
+4. Classify connections (Embrace live vs Falcon in-memory) and flag file-uploaded
+   tables
+5. Cross-tabulate into a value/cost-ranked migration shortlist
+6. Write `assessment.json`, then render `readout.html`:
+   `ruby scripts/render-readout-html.rb --out ~/thoughtspot-migration`
+
+## Usage data — the populated-instance assumption
+
+`TS: BI Server` is ThoughtSpot's built-in activity log. On a populated instance
+it yields per-object views + distinct users and per-user activity, which drives
+the value/cost shortlist and cold-content (retirement) detection. If the
+worksheet is genuinely absent — a brand-new instance, or an identity without
+admin scope — the scan records a single note and falls back to ranking by
+conversion effort. It never fails.
+
+## What this is NOT
+
+- **Not** a write tool. It cannot and will not modify ThoughtSpot or Sigma.
+- **Not** a complete instance audit. It covers the signals that matter for Sigma
+  migration scoping, scoped to **what the authenticated identity can read**.
+  System / sample Liveboards are export-forbidden and counted separately.
+- **Not** the converter. It scopes; `thoughtspot-to-sigma` converts.
+
+## Privacy
+
+This skill sends Liveboard/model metadata and TML (including TML formula text)
+through the Anthropic API — not warehouse rows. See [`PRIVACY.md`](./PRIVACY.md)
+for the full disclosure to review with your privacy/legal team before running.
+
+## Sibling skills
+
+- [`thoughtspot-to-sigma`](../thoughtspot-to-sigma/) — the conversion skill this feeds into.
+- [`tableau-assessment`](../../tableau-to-sigma/skills/tableau-assessment/) — the gold-standard analog this skill mirrors.
+
+## Where it lives
+
+Part of the `sigma-migration-skills` plugin set. The renderer
+(`scripts/render-readout-html.rb`) shares its Sigma-branded theme byte-for-byte
+with the tableau / powerbi / qlik / quicksight assessment readouts.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/SKILL.md
@@ -1,41 +1,70 @@
 ---
 name: thoughtspot-assessment
-description: Take inventory of a ThoughtSpot instance and produce a migration-readiness readout — models/worksheets, Liveboards, Answers, connections, per-Liveboard chart-type mix and complexity, chart-type coverage, and a value/cost-ranked migration shortlist. Use to scope a ThoughtSpot→Sigma migration or audit BI sprawl. Read-only.
+description: Take inventory of a ThoughtSpot instance and produce a migration-readiness readout — models/worksheets, Liveboards, Answers, tables, connections, per-object usage (views + distinct users from TS: BI Server), per-Liveboard chart-type mix and complexity, ownership concentration, Embrace-vs-Falcon data-source patterns, and a value/cost-ranked migration shortlist. Use to scope a ThoughtSpot→Sigma migration or audit BI sprawl. Read-only.
 ---
 
 # ThoughtSpot migration assessment
 
 Read-only pre-scoping for a ThoughtSpot → Sigma migration. Complements
-`thoughtspot-to-sigma` (which does the actual conversion).
+`thoughtspot-to-sigma` (which does the actual conversion). Designed for a **real,
+populated production instance** — usage data is a first-class signal, not an
+optional extra.
 
 ## Auth
 Same as `thoughtspot-to-sigma`: `TS_HOST` + `TS_TOKEN` (SSO session token or
-Trusted-Auth service token). No Sigma credentials needed — this only reads
-ThoughtSpot.
+Trusted-Auth service token). For the usage axis the identity needs admin scope so
+it can read the `TS: BI Server` system worksheet. No Sigma credentials needed —
+this only reads ThoughtSpot.
 
 ## Run
 `scripts/scan.py` — inventories the instance via `metadata/search`
-(LOGICAL_TABLE / LIVEBOARD / ANSWER / CONNECTION), exports each Liveboard's TML,
-and per Liveboard scores migration complexity from its visualizations:
-viz count + distinct chart kinds + models touched. Output:
-- inventory counts
-- how many Liveboards are readable via the API (system/sample objects are
-  export-FORBIDDEN and not migratable by a normal identity)
-- a migration shortlist, easiest first, flagging unsupported chart types
-- overall chart-type coverage % across all exportable visualizations
-- the set of models the Liveboards depend on (migrate these first)
+(LOGICAL_TABLE / LIVEBOARD / ANSWER / CONNECTION), pulls per-object usage from
+`TS: BI Server`, exports each Liveboard's TML, and per Liveboard scores migration
+complexity: viz count + distinct chart kinds + models touched + TML formula and
+filter weight. Writes `~/thoughtspot-migration/assessment.json`.
 
-Writes the full report to `~/thoughtspot-migration/assessment.json`.
+Then render the customer-facing report:
+`ruby scripts/render-readout-html.rb --out ~/thoughtspot-migration`
+→ `~/thoughtspot-migration/readout.html` (Sigma-branded, share-friendly).
+
+`scripts/render-readout-html.rb` is the **canonical renderer** (the old
+`render_html.py` is superseded — keep using the Ruby one for parity with the
+tableau / powerbi / qlik / quicksight assessment skills).
+
+## What the readout covers
+- **01 Environment overview** — KPI tiles: Liveboards, Answers, models/worksheets,
+  tables, connections.
+- **02 Liveboard priority & usage** — usage-ranked with bars from `TS: BI Server`;
+  cold / zero-view detection for retirement candidates.
+- **03 Ownership & concentration** — Liveboards by author; top-author concentration.
+- **04 Data-source patterns** — Embrace (live warehouse) vs Falcon (in-memory),
+  file-uploaded tables flagged for warehouse landing.
+- **05 User activity** — per-user action volume (only when `TS: BI Server` usage
+  is present).
+- **Migration shortlist + per-Liveboard complexity** — value/cost ranking, tag
+  pills (migrate-first / easy-win / needs-review / retire), chart-type coverage,
+  and the set of models the Liveboards depend on (migrate these first).
+
+## Usage data
+On a populated instance, `TS: BI Server` (ThoughtSpot's built-in activity log)
+yields per-Liveboard views + distinct users and per-user activity (admin scope).
+This drives the value/cost shortlist and cold-content detection. If the worksheet
+is genuinely absent (a brand-new instance, or a non-admin identity), the scan
+records a single note and falls back to effort-only ranking — but the design and
+the readout assume the populated case.
 
 ## Chart-type coverage
 The `thoughtspot-to-sigma` pipeline maps KPI / COLUMN / BAR / LINE / PIE / TABLE
 / ADVANCED_COLUMN / stacked / area / LINE_COLUMN to Sigma equivalents. Flagged
 for review (no direct 1:1 in the current pipeline): SCATTER, BUBBLE, GEO_AREA,
-PIVOT_TABLE, WATERFALL, FUNNEL, TREEMAP, LINE_STACKED_COLUMN.
+PIVOT_TABLE, WATERFALL, FUNNEL, TREEMAP, LINE_STACKED_COLUMN. Sigma supports most
+of these natively — they just need element-builder mapping work.
 
 ## Notes
 - TML export embeds raw control chars in JSON → `json.loads(..., strict=False)`.
 - ThoughtSpot TML uses bare `=` (`oper: =`) which trips PyYAML's value tag — the
   scan registers a constructor that reads it as a string.
-- Validated on a trial: 32 Liveboards / 27 models / 451 viz → 90.5% chart-type
-  coverage; the 12 migration fixtures ranked easiest, system dashboards hardest.
+- System / sample Liveboards are export-FORBIDDEN for a normal identity; the scan
+  counts them separately ("system/locked") rather than treating that as failure.
+- Privacy: see `PRIVACY.md`. Output shapes: see `refs/output-shapes.md`. Readout
+  layout: see `refs/readout-template.md`.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/output-shapes.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/output-shapes.md
@@ -1,0 +1,94 @@
+# Output shapes
+
+One JSON file + one rendered HTML emitted to `~/thoughtspot-migration/` (or the
+`--out` directory). `scripts/scan.py` writes `assessment.json`;
+`scripts/render-readout-html.rb` reads it to produce `readout.html`.
+
+## `assessment.json`
+
+Always written. Usage-dependent fields are present but zero/empty when
+`TS: BI Server` is absent (`usage_available: false`).
+
+```json
+{
+  "instance": {
+    "host": "<TS_HOST>",
+    "generated_at": "YYYY-MM-DD"
+  },
+  "environment_overview": {
+    "liveboards":  <int>,
+    "answers":     <int>,
+    "models":      <int>,
+    "tables":      <int>,
+    "connections": <int>
+  },
+  "profiles": [
+    {
+      "id":   "<liveboard guid>",
+      "name": "<liveboard name>",
+      "author": "<author name/email>",
+      "exportable": <bool>,
+      "note": "<reason>",                  // only when exportable=false
+      "viz":  <int>,                       // exportable only ↓
+      "chart_types": { "<TYPE>": <int>, ... },
+      "models": ["<model name>", ...],
+      "n_formula": <int>,                  // TML formulas referenced
+      "n_filter":  <int>,                  // viz + liveboard filters
+      "unsupported": ["<TYPE>", ...],      // chart kinds w/o 1:1 Sigma mapping
+      "complexity": <int>,
+      "views": <int>,                      // from TS: BI Server (0 if no usage)
+      "users": <int>,
+      "value_cost": <float>,               // views / (1 + complexity)
+      "tag": "migrate-first|easy-win|moderate|needs-gap-scout|retire"
+    }, ...
+  ],
+  "shortlist": [ <profile subset, ranked> ],   // exportable, value/cost desc (or effort asc)
+  "ownership": [ { "author": "<name>", "liveboards": <int> }, ... ],
+  "connections": [
+    { "id": "<guid>", "name": "<name>", "author": "<name>",
+      "connection_type": "<RDBMS_*>", "class": "embrace|falcon|unknown" }, ...
+  ],
+  "tables": [
+    { "id": "<guid>", "name": "<name>", "author": "<name>",
+      "type": "<header type>", "file_uploaded": <bool> }, ...
+  ],
+  "datasource_summary": {
+    "embrace": <int>, "falcon": <int>, "unknown": <int>,
+    "file_uploaded_tables": <int>, "tables_total": <int>
+  },
+  "usage_by_user": [ { "user": "<name>", "actions": <int> }, ... ],  // [] if no usage
+  "coverage": <float>,                    // % viz with a supported chart type
+  "chart_types": { "<TYPE>": <int>, ... },          // across all exportable LBs
+  "unsupported_chart_types": { "<TYPE>": <int>, ... },
+  "models_used": ["<model name>", ...],
+  "usage_available": <bool>,
+  "usage_note": "<string>" | null,        // single graceful note when usage absent
+  "total_views": <int>
+}
+```
+
+## Complexity scoring
+
+```
+complexity = viz_count
+           + 2 × distinct_chart_kinds
+           + 3 × models_touched
+           + 2 × tml_formulas
+           +     filters
+```
+
+A relative effort proxy, not a time estimate.
+
+## Tag rules (per exportable Liveboard)
+
+- `views == 0` and usage available                     → `retire`
+- any unsupported chart type                           → `needs-gap-scout`
+- `complexity < 20` and usage available                → `migrate-first`
+- `complexity < 30`                                    → `easy-win`
+- otherwise                                            → `moderate`
+
+## `readout.html`
+
+Sigma-branded HTML. See `refs/readout-template.md` for the section ordering and
+what each section renders. Composition is deterministic — the renderer takes
+`assessment.json` and emits the file; no template-fill step.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/readout-template.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/readout-template.md
@@ -1,0 +1,46 @@
+# Readout layout — `readout.html`
+
+`scripts/render-readout-html.rb` emits a Sigma-branded HTML report whose theme
+(palette, fonts, `.brand-bar` masthead, table/bar/risk-chip/tag CSS) is
+byte-identical to the `tableau-assessment` gold standard. ThoughtSpot vocabulary
+throughout: Liveboard / Answer, model / worksheet, table, connection, Embrace vs
+Falcon, TML formula.
+
+## Masthead + hero
+
+- **Brand masthead** — `sigma` brand-mark + "Migration Assessment" tag.
+- **Doc header** — eyebrow "ThoughtSpot Environment Report", instance host as
+  title, generated date.
+- **Hero headline finding** — the single most actionable sentence. On a populated
+  instance: top-5 pilot usage share + count of Liveboards needing chart-type
+  review. Without usage: count of readable Liveboards ranked by effort.
+
+## Sections
+
+| # | Title | Content |
+|---|---|---|
+| 01 | Environment overview | KPI tiles: Liveboards (readable / system-locked), Answers, models/worksheets, tables (file-uploaded count), connections (Embrace / Falcon), total views |
+| 02 | Liveboard priority & usage | Top-10 usage-ranked with bars from `TS: BI Server`; author, distinct users, viz count; cold / zero-view detection note. Falls back to listed order + a note if usage absent |
+| 03 | Ownership & concentration | Liveboards by author with bars; top-author concentration % |
+| 04 | Data-source patterns | Stat tiles Embrace / Falcon / file-uploaded; connection table with connector-class badges; file-uploaded tables flagged for warehouse landing |
+| 05 | User activity | Per-user action volume bars — **only rendered when `TS: BI Server` usage is present** (renumbers subsequent sections) |
+| 06* | Migration to Sigma — recommended sequence | Stat tiles (top-5 usage share, chart types to review, needs-review · retire counts); value/cost shortlist with risk chips + tag pills; per-Liveboard complexity table (viz, chart kinds, models, TML formulas, complexity, review); chart-type coverage bars; referenced-models note; unsupported-chart callout |
+| 07* | Data handling | Two-column privacy: read-by-scanner vs never-left-environment |
+| 08* | Recommended next steps | Numbered: pilot top-5, migrate referenced models first, land Falcon/file sources in warehouse, plan review time, retire cold Liveboards |
+
+\* Section numbers shift down by one when the optional User activity section (05)
+is absent — the renderer computes the numbering so the sequence is always
+contiguous.
+
+## Conversion-risk legend (shortlist)
+
+- **No issues** — every chart type and field converts automatically
+- **N formulas** — converts automatically; TML formulas translate to Sigma
+  formulas with a quick check
+- **N chart types to review** — uses a chart kind without a 1:1 Sigma mapping yet
+
+## Tag pills (recommendation column)
+
+`migrate-first` (go) · `easy-win` (blue) · `moderate`/Standard (gray) ·
+`needs-gap-scout`/Needs review (warn) · `retire` (mute) — same `TAG_LABELS` /
+`TAG_CLASSES` mapping as the other assessment renderers.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/render-readout-html.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/render-readout-html.rb
@@ -1,0 +1,869 @@
+#!/usr/bin/env ruby
+# Render <out>/readout.html — a customer-facing, share-friendly HTML report for a
+# ThoughtSpot -> Sigma migration assessment.
+#
+# Canonical renderer (replaces the divergent python render_html.py). Reads the
+# single assessment.json written by scripts/scan.py. Sigma-branded, byte-aligned
+# with the tableau-assessment gold standard.
+#
+# Usage:
+#   ruby scripts/render-readout-html.rb --out ~/thoughtspot-migration
+#   ruby scripts/render-readout-html.rb --json /path/assessment.json --out /tmp/x
+
+require 'json'
+require 'optparse'
+require 'cgi'
+require 'date'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--out DIR')  { |v| opts[:out]  = v }
+  p.on('--json FILE') { |v| opts[:json] = v }
+end.parse!
+abort('--out required') unless opts[:out]
+
+json_path = opts[:json] || File.join(opts[:out], 'assessment.json')
+abort("assessment.json not found at #{json_path}") unless File.exist?(json_path)
+d = JSON.parse(File.read(json_path))
+
+def h(s); CGI.escapeHTML(s.to_s); end
+def num(n); n.to_i.to_s.reverse.scan(/.{1,3}/).join(',').reverse; end
+
+# ---------- gather computed values ----------
+inst = d['instance'] || {}
+env  = d['environment_overview'] || {}
+host = inst['host'] || 'unknown'
+generated_at = inst['generated_at'] || Time.now.strftime('%Y-%m-%d')
+formatted_date = Date.parse(generated_at).strftime('%B %d, %Y') rescue generated_at
+
+profiles    = d['profiles'] || []
+exportable  = profiles.select { |p| p['exportable'] }
+locked      = profiles.reject { |p| p['exportable'] }
+shortlist   = d['shortlist'] || exportable
+ownership   = d['ownership'] || []
+connections = d['connections'] || []
+tables      = d['tables'] || []
+ds_summary  = d['datasource_summary'] || {}
+usage_by_user = d['usage_by_user'] || []
+total_views = (d['total_views'] || 0).to_i
+usage_available = d['usage_available']
+usage_note  = d['usage_note']
+coverage    = (d['coverage'] || 0).to_f
+chart_types = d['chart_types'] || {}
+unsupported_types = d['unsupported_chart_types'] || {}
+models_used = d['models_used'] || []
+
+total_viz = chart_types.values.sum
+n_unsupported_viz = unsupported_types.values.sum
+
+# usage-ranked profiles (cold = zero views when usage is available)
+ranked_by_views = profiles.sort_by { |p| -(p['views'] || 0).to_i }
+cold = usage_available ? profiles.select { |p| (p['views'] || 0).to_i.zero? } : []
+
+# shortlist roll-ups
+top5 = shortlist.first(5)
+sl_top5_views     = top5.sum { |r| (r['views'] || 0).to_i }
+sl_total_unsup    = shortlist.sum { |r| (r['unsupported'] || []).size }
+sl_migrate_first  = shortlist.count { |r| r['tag'] == 'migrate-first' }
+sl_easy_win       = shortlist.count { |r| r['tag'] == 'easy-win' }
+sl_needs_scout    = shortlist.count { |r| r['tag'] == 'needs-gap-scout' }
+sl_retire         = shortlist.count { |r| r['tag'] == 'retire' }
+top5_pct = total_views.zero? ? 0 : (sl_top5_views.to_f / total_views * 100).round
+n_with_unsup = exportable.count { |p| (p['unsupported'] || []).any? }
+
+# top owner concentration
+top_owner_pct  = 0
+top_owner_name = '—'
+total_owned = ownership.sum { |o| o['liveboards'].to_i }
+if total_owned.positive?
+  top = ownership.max_by { |o| o['liveboards'].to_i }
+  top_owner_pct  = (top['liveboards'].to_f / total_owned * 100).round
+  top_owner_name = top['author']
+end
+
+# ---------- HTML helpers ----------
+TAG_LABELS = {
+  'migrate-first'   => 'Migrate first',
+  'easy-win'        => 'Easy win',
+  'moderate'        => 'Standard',
+  'needs-gap-scout' => 'Needs review',
+  'retire'          => 'Retire'
+}
+TAG_CLASSES = {
+  'migrate-first'   => 'tag-go',
+  'easy-win'        => 'tag-blue',
+  'moderate'        => 'tag-gray',
+  'needs-gap-scout' => 'tag-warn',
+  'retire'          => 'tag-mute'
+}
+
+def tag_pill(t)
+  %(<span class="tag #{TAG_CLASSES[t]}">#{h(TAG_LABELS[t] || t)}</span>)
+end
+
+# Horizontal bar cell — value normalized to max
+def bar_cell(value, max, color = 'bar-blue')
+  pct = max.zero? ? 0 : (value.to_f / max * 100).round
+  %(<div class="bar-cell"><div class="bar-track"><div class="bar-fill #{color}" style="width:#{pct}%"></div></div><div class="bar-num">#{num(value)}</div></div>)
+end
+
+def kpi(label, value, sub = nil)
+  s = sub ? %(<div class="kpi-sub">#{h(sub)}</div>) : ''
+  %(<div class="kpi"><div class="kpi-v">#{h(value)}</div><div class="kpi-l">#{h(label)}</div>#{s}</div>)
+end
+
+# Generic data table renderer.
+def table(headers, rows, opts = {})
+  cls = opts[:class] || ''
+  cols = headers.size
+  align = opts[:align] || Array.new(cols, 'left')
+  thead = "<thead><tr>" + headers.each_with_index.map { |c, i| %(<th class="al-#{align[i]}">#{h(c)}</th>) }.join + "</tr></thead>"
+  tbody = "<tbody>" + rows.map do |r|
+    "<tr>" + r.each_with_index.map { |c, i|
+      cell = c.to_s
+      content = cell.start_with?('<') ? cell : h(cell)
+      %(<td class="al-#{align[i]}">#{content}</td>)
+    }.join + "</tr>"
+  end.join + "</tbody>"
+  %(<table class="data #{cls}">#{thead}#{tbody}</table>)
+end
+
+# Hero: headline finding
+hero_finding =
+  if usage_available && total_views.positive?
+    if sl_total_unsup.zero? && sl_migrate_first.positive?
+      'Pilot migration is low-risk: the most-used Liveboards use only chart types Sigma handles automatically.'
+    else
+      "The top-5 pilot covers #{top5_pct}% of all-time views. #{n_with_unsup} Liveboard#{n_with_unsup == 1 ? '' : 's'} elsewhere use a chart type that warrants individual review when planning their conversion."
+    end
+  elsif exportable.any?
+    "#{exportable.size} Liveboard#{exportable.size == 1 ? '' : 's'} are readable and ranked by conversion effort. Connect usage data to prioritize by audience."
+  else
+    'Environment scan complete.'
+  end
+
+# ---------- Section 01: KPI tiles ----------
+kpi_html = [
+  kpi('Liveboards',  env['liveboards'], "#{exportable.size} readable · #{locked.size} system/locked"),
+  kpi('Answers',     env['answers']),
+  kpi('Models / worksheets', env['models']),
+  kpi('Tables',      env['tables'], "#{ds_summary['file_uploaded_tables'] || 0} file-uploaded"),
+  kpi('Connections', env['connections'], "#{ds_summary['embrace'] || 0} Embrace · #{ds_summary['falcon'] || 0} Falcon"),
+  kpi('Total views', num(total_views), usage_available ? 'last 12 months' : 'usage not connected')
+].join
+
+# ---------- Section 02: Liveboard priority & usage ----------
+usage_html = ''
+if ranked_by_views.any?
+  max_v = [ranked_by_views.first['views'].to_i, 1].max
+  rows = ranked_by_views.first(10).each_with_index.map do |p, i|
+    name = p['name']
+    %(<tr>
+      <td class="rank">#{i + 1}</td>
+      <td>#{h(name)}</td>
+      <td class="muted">#{h((p['author'] || '—').to_s.sub(/@.*/, ''))}</td>
+      <td>#{bar_cell(p['views'] || 0, max_v)}</td>
+      <td class="al-right num muted">#{p['users'] || 0}</td>
+      <td class="al-right num muted">#{p['viz'] || '—'}</td>
+    </tr>)
+  end.join
+  usage_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th class="al-right">#</th>
+          <th>Liveboard</th>
+          <th>Author</th>
+          <th>Views</th>
+          <th class="al-right">Distinct users</th>
+          <th class="al-right">Viz</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# ---------- Section 03: Ownership & concentration ----------
+ownership_html = ''
+if ownership.any?
+  max_lb = [ownership.first['liveboards'].to_i, 1].max
+  rows = ownership.first(15).map do |o|
+    %(<tr>
+      <td>#{h(o['author'])}</td>
+      <td>#{bar_cell(o['liveboards'], max_lb)}</td>
+    </tr>)
+  end.join
+  ownership_html = <<~HTML
+    <table class="data">
+      <thead><tr><th>Author</th><th>Liveboards</th></tr></thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# ---------- Section 04: Data-source patterns ----------
+ds_stat_row = <<~ROW
+  <div class="stat-row">
+    <div class="stat #{(ds_summary['embrace'] || 0).positive? ? 'stat-go' : ''}">
+      <div class="stat-l">Embrace (live)</div>
+      <div class="stat-v #{(ds_summary['embrace'] || 0).positive? ? 'go' : ''}">#{ds_summary['embrace'] || 0}</div>
+      <div class="stat-sub">query pushed to the warehouse — Sigma connects to the same source</div>
+    </div>
+    <div class="stat #{(ds_summary['falcon'] || 0).positive? ? 'stat-warn' : ''}">
+      <div class="stat-l">Falcon (in-memory)</div>
+      <div class="stat-v #{(ds_summary['falcon'] || 0).positive? ? 'warn' : ''}">#{ds_summary['falcon'] || 0}</div>
+      <div class="stat-sub">in-memory cache — data must live in a warehouse for Sigma</div>
+    </div>
+    <div class="stat #{(ds_summary['file_uploaded_tables'] || 0).positive? ? 'stat-warn' : ''}">
+      <div class="stat-l">File-uploaded tables</div>
+      <div class="stat-v #{(ds_summary['file_uploaded_tables'] || 0).positive? ? 'warn' : ''}">#{ds_summary['file_uploaded_tables'] || 0}</div>
+      <div class="stat-sub">CSV/XLSX uploads — land in your warehouse first</div>
+    </div>
+  </div>
+ROW
+
+conn_html = ''
+if connections.any?
+  rows = connections.first(20).map do |c|
+    badge_cls = c['class'] == 'embrace' ? 'ds-published' : 'ds-embedded'
+    badge = c['class'] == 'embrace' ? 'Embrace — live' : (c['class'] == 'falcon' ? 'Falcon — in-memory' : 'Unknown')
+    %(<tr>
+      <td>#{h(c['name'])}</td>
+      <td><span class="ds-bucket #{badge_cls}">#{h(badge)}</span></td>
+      <td><code>#{h(c['connection_type'] || '—')}</code></td>
+      <td class="muted">#{h((c['author'] || '—').to_s.sub(/@.*/, ''))}</td>
+    </tr>)
+  end.join
+  conn_html = <<~HTML
+    <table class="data">
+      <thead><tr><th>Connection</th><th>Type</th><th>Connector class</th><th>Author</th></tr></thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+uploaded_tables = tables.select { |t| t['file_uploaded'] }
+uploaded_html = ''
+if uploaded_tables.any?
+  uploaded_html = %(<p class="note"><strong>#{uploaded_tables.size} file-uploaded table#{uploaded_tables.size == 1 ? '' : 's'}</strong> (no governed warehouse source): ) +
+                  uploaded_tables.first(20).map { |t| %(<code>#{h(t['name'])}</code>) }.join(', ') +
+                  (uploaded_tables.size > 20 ? " + #{uploaded_tables.size - 20} more" : '') +
+                  ' — these need a one-time load into your warehouse before the Sigma model can reference them.</p>'
+end
+
+# ---------- Section 05: User activity (only if BI Server usage present) ----------
+activity_html = ''
+if usage_by_user.any?
+  max_a = [usage_by_user.first['actions'].to_i, 1].max
+  rows = usage_by_user.first(15).map do |u|
+    %(<tr>
+      <td>#{h(u['user'].to_s.sub(/@.*/, ''))}</td>
+      <td>#{bar_cell(u['actions'], max_a)}</td>
+    </tr>)
+  end.join
+  activity_html = <<~HTML
+    <table class="data">
+      <thead><tr><th>User</th><th>Actions (last 12 months)</th></tr></thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# ---------- Section 06: Migration shortlist + per-Liveboard complexity ----------
+shortlist_html = ''
+if shortlist.any?
+  max_score = [shortlist.map { |r| r['value_cost'].to_f }.max || 0, 0.001].max
+  rows = shortlist.first(15).map do |r|
+    unsup = r['unsupported'] || []
+    risk_cls, risk_txt =
+      if unsup.any?
+        ['risk-red', "#{unsup.size} chart type#{unsup.size == 1 ? '' : 's'} to review"]
+      elsif (r['n_formula'] || 0).positive?
+        ['risk-amber', "#{r['n_formula']} formula#{r['n_formula'] == 1 ? '' : 's'}"]
+      else
+        ['risk-clean', 'No issues']
+      end
+    %(<tr>
+      <td>#{h(r['name'])}</td>
+      <td>#{bar_cell(r['views'] || 0, [ranked_by_views.first&.dig('views').to_i, 1].max)}</td>
+      <td class="al-right num">#{r['users'] || 0}</td>
+      <td><span class="risk-chip #{risk_cls}"><span class="risk-dot"></span>#{h(risk_txt)}</span></td>
+      <td class="al-right num">#{format('%.3f', r['value_cost'] || 0)}</td>
+      <td>#{tag_pill(r['tag'])}</td>
+    </tr>)
+  end.join
+  shortlist_html = <<~HTML
+    <table class="data shortlist">
+      <thead>
+        <tr>
+          <th>Liveboard</th>
+          <th>Usage</th>
+          <th class="al-right">Users</th>
+          <th>Conversion risk</th>
+          <th class="al-right">Value/cost</th>
+          <th>Recommendation</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+    <p class="note">Conversion risk legend: <strong>No issues</strong> = every chart type and field converts automatically · <strong>N formulas</strong> = converts automatically; TML formulas translate to Sigma formulas with a quick check · <strong>N chart types to review</strong> = uses a chart kind without a 1:1 Sigma mapping yet, warranting individual evaluation.</p>
+  HTML
+end
+
+complexity_html = ''
+if exportable.any?
+  rows = exportable.sort_by { |p| -p['complexity'].to_i }.map do |p|
+    unsup = p['unsupported'] || []
+    unsup_cell = unsup.any? ? %(<span class="warn-num">#{unsup.size}</span>) : '<span class="muted">0</span>'
+    types_cell = p['chart_types'].to_h.sort_by { |_, n| -n }.map { |k, n| "#{h(k)}×#{n}" }.join(', ')
+    %(<tr>
+      <td>#{h(p['name'])}</td>
+      <td class="al-right num">#{p['viz']}</td>
+      <td class="al-right num muted">#{(p['chart_types'] || {}).size}</td>
+      <td class="al-right num muted">#{(p['models'] || []).size}</td>
+      <td class="al-right num muted">#{p['n_formula'] || 0}</td>
+      <td class="al-right num">#{p['complexity']}</td>
+      <td class="al-right">#{unsup_cell}</td>
+      <td class="muted breakdown">#{types_cell}</td>
+    </tr>)
+  end.join
+  complexity_html = <<~HTML
+    <h3>Per-Liveboard complexity</h3>
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Liveboard</th>
+          <th class="al-right">Viz</th>
+          <th class="al-right">Chart kinds</th>
+          <th class="al-right">Models</th>
+          <th class="al-right">TML formulas</th>
+          <th class="al-right">Complexity</th>
+          <th class="al-right">Review</th>
+          <th>Chart types</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+    <p class="note">Complexity = viz count + 2×chart kinds + 3×models + 2×TML formulas + filters. A relative effort proxy, not a time estimate.</p>
+  HTML
+end
+
+# Chart-type coverage bars
+coverage_html = ''
+if total_viz.positive?
+  max_n = chart_types.values.max
+  rows = chart_types.sort_by { |_, n| -n }.map do |k, n|
+    unsup = unsupported_types.key?(k)
+    color = unsup ? 'bar-warn' : 'bar-blue'
+    [
+      %(<code>#{h(k)}</code>),
+      bar_cell(n, max_n, color),
+      unsup ? %(<span class="risk-chip risk-amber"><span class="risk-dot"></span>Needs mapping</span>) : %(<span class="risk-chip risk-clean"><span class="risk-dot"></span>Supported</span>)
+    ]
+  end
+  coverage_html = "<h3>Chart-type coverage — #{format('%.1f', coverage)}% (#{total_viz - n_unsupported_viz}/#{total_viz} viz supported)</h3>" +
+                  table(['Chart type', 'Count', 'Sigma readiness'], rows, align: %w[left left left]) +
+                  %(<p class="note">Supported types map to Sigma via the <code>thoughtspot-to-sigma</code> pipeline today. Types flagged for mapping (PIVOT_TABLE, WATERFALL, FUNNEL, SCATTER, BUBBLE, TREEMAP, GEO_AREA, LINE_STACKED_COLUMN) are mostly native in Sigma — they just need element-builder mapping work.</p>)
+end
+
+models_used_html = ''
+if models_used.any?
+  models_used_html = %(<p class="note"><strong>#{models_used.size} model#{models_used.size == 1 ? '' : 's'}/worksheet#{models_used.size == 1 ? '' : 's'}</strong> referenced by the exportable Liveboards — migrate these to Sigma data models first: ) +
+                     models_used.first(20).map { |m| %(<code>#{h(m)}</code>) }.join(', ') +
+                     (models_used.size > 20 ? " + #{models_used.size - 20} more" : '') + '.</p>'
+end
+
+# ---------- assemble HTML ----------
+html = <<~HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>ThoughtSpot Environment Report — #{h(host)}</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=DM+Mono:wght@400;500&display=swap');
+  :root {
+    /* Sigma brand palette — Shadow/Nimbus/White neutrals, Insight (CTA only), brand accents */
+    --bg:#fafafa; --card:#ffffff; --ink:#292929; --ink-2:#3d3d3d;
+    --line:#e5e5e5; --line-soft:#f5f5f5;
+    --accent:#292929; --accent-soft:#f0f0f0;
+    --insight:#f0ff45;
+    --go:#1f9d57; --go-soft:#e6fbef;
+    --warn:#c2562a; --warn-soft:#fff1ea;
+    --blue:#2b8ca6; --blue-soft:#eaf8fc;
+    --mute:#6e7877; --mute-soft:#f0f0f0;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
+  body {
+    font-family: "DM Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px; line-height: 1.55; -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 1120px; margin: 0 auto; padding: 48px 48px 80px; }
+
+  /* Brand masthead */
+  .brand-bar { display: flex; align-items: center; gap: 10px; margin-bottom: 28px; }
+  .brand-mark { font-weight: 700; font-size: 21px; letter-spacing: -0.02em; color: var(--ink); }
+  .brand-dot  { width: 9px; height: 9px; border-radius: 2px; background: var(--blue);
+                -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .brand-tag  { font-size: 12px; color: var(--mute); font-weight: 500;
+                text-transform: uppercase; letter-spacing: 0.08em; }
+
+  /* Header */
+  .doc-header { margin-bottom: 40px; }
+  .doc-eyebrow { font-size: 11px; font-weight: 600; color: var(--accent);
+                 text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+  .doc-title { font-size: 36px; font-weight: 700; letter-spacing: -0.02em;
+               margin: 0 0 8px; line-height: 1.1; color: var(--ink); }
+  .doc-meta { font-size: 13px; color: var(--ink-2); }
+  .doc-meta a { color: var(--ink-2); text-decoration: none; border-bottom: 1px dashed var(--line); }
+  .doc-meta a:hover { color: var(--ink); }
+
+  /* Hero finding banner */
+  .hero {
+    background: var(--accent-soft); border: 1px solid var(--line);
+    border-left: 4px solid var(--blue);
+    border-radius: 8px;
+    padding: 18px 22px; margin-bottom: 40px;
+    display: flex; align-items: center; gap: 16px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .hero-label { font-size: 11px; font-weight: 700; color: var(--accent);
+                text-transform: uppercase; letter-spacing: 0.08em;
+                white-space: nowrap; padding-right: 16px;
+                border-right: 1px solid var(--line); }
+  .hero-text { font-size: 15px; color: var(--ink); font-weight: 500; line-height: 1.4; }
+
+  /* Section */
+  section { margin-bottom: 56px; }
+  section.section-tight { margin-bottom: 36px; }
+  .section-head { display: flex; align-items: baseline; justify-content: space-between;
+                  margin-bottom: 16px; padding-bottom: 12px;
+                  border-bottom: 1px solid var(--line); }
+  .section-num { font-size: 12px; font-weight: 600; color: var(--mute);
+                 letter-spacing: 0.06em; }
+  .section-title { font-size: 22px; font-weight: 600; letter-spacing: -0.01em;
+                   margin: 0; flex: 1; padding-left: 14px; }
+  .section-aside { font-size: 12px; color: var(--mute); }
+  .section-lede { font-size: 14px; color: var(--ink-2); margin: -4px 0 16px; }
+
+  /* KPIs */
+  .kpi-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+  .kpi {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 18px 16px;
+  }
+  .kpi-v { font-size: 28px; font-weight: 700; letter-spacing: -0.01em;
+           color: var(--ink); line-height: 1; }
+  .kpi-l { font-size: 11px; color: var(--mute); text-transform: uppercase;
+           letter-spacing: 0.06em; font-weight: 600; margin-top: 10px; }
+  .kpi-sub { font-size: 11px; color: var(--mute); margin-top: 4px; line-height: 1.4; }
+
+  /* Stat callouts */
+  .stat-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
+              margin-bottom: 24px; }
+  .stat {
+    background: #fafafa;
+    border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 8px;
+    padding: 16px 18px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .stat.stat-go   { border-left-color: var(--go);   background: var(--go-soft); }
+  .stat.stat-warn { border-left-color: var(--warn); background: var(--warn-soft); }
+  .stat-l { font-size: 10px; color: var(--mute); text-transform: uppercase;
+            letter-spacing: 0.06em; font-weight: 700; margin-bottom: 6px; }
+  .stat-v { font-size: 30px; font-weight: 700; line-height: 1; letter-spacing: -0.02em;
+            color: var(--ink); }
+  .stat-v.go   { color: var(--go); }
+  .stat-v.warn { color: var(--warn); }
+  .stat-sub { font-size: 12px; color: var(--mute); margin-top: 6px; }
+
+  /* Tables */
+  table.data { width: 100%; border-collapse: collapse; background: var(--card);
+               border: 1px solid var(--line); border-radius: 10px; overflow: hidden;
+               font-size: 13px; }
+  table.data th { font-weight: 600; font-size: 11px; color: var(--mute);
+                  text-transform: uppercase; letter-spacing: 0.06em;
+                  padding: 12px 16px; background: #fafafa;
+                  border-bottom: 1px solid var(--line); text-align: left; }
+  table.data td { padding: 12px 16px; border-bottom: 1px solid var(--line-soft);
+                  vertical-align: middle; }
+  table.data tbody tr:last-child td { border-bottom: 0; }
+  table.data tbody tr:hover td { background: #fafafa; }
+  .al-right { text-align: right; }
+  .al-left  { text-align: left; }
+  /* Pin numeric + bar columns to content width so the text column absorbs the
+     slack — keeps a short value tight against its header instead of stranding it
+     across an over-wide column. */
+  table.data td.al-right, table.data th.al-right,
+  table.data td:has(.bar-cell) { width: 1%; white-space: nowrap; }
+  .num { font-variant-numeric: tabular-nums; }
+  .muted { color: var(--mute); }
+  .warn { color: var(--warn); }
+  .warn-num { color: var(--warn); font-weight: 700; }
+  .rank { font-variant-numeric: tabular-nums; color: var(--mute); font-weight: 600; width: 32px; }
+  .workbook-link { color: var(--ink); text-decoration: none;
+                   border-bottom: 1px solid var(--line); }
+  .workbook-link:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  .breakdown { font-size: 12px; font-variant-numeric: tabular-nums; }
+  .breakdown span { margin-right: 8px; }
+
+  /* Tags */
+  .tag { display: inline-block; padding: 3px 10px; border-radius: 99px;
+         font-size: 11px; font-weight: 600; letter-spacing: 0.01em;
+         white-space: nowrap; }
+  .tag-go    { background: var(--go-soft);    color: var(--go); }
+  .tag-blue  { background: var(--blue-soft);  color: var(--blue); }
+  .tag-gray  { background: #f5f5f5;           color: var(--ink-2); }
+  .tag-warn  { background: var(--warn-soft);  color: var(--warn); }
+  .tag-mute  { background: var(--mute-soft);  color: var(--mute); }
+
+  /* Bar cells (in tables) */
+  .bar-cell { display: flex; align-items: center; gap: 10px;
+              justify-content: flex-start; }
+  .bar-track { flex: none; width: 84px; height: 6px; background: #f5f5f5; border-radius: 4px;
+               overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 4px; }
+  .bar-blue { background: linear-gradient(90deg, #4cec8c, #2fb874); }
+  .bar-warn { background: linear-gradient(90deg, #f0a868, #c2562a); }
+  .bar-num { font-variant-numeric: tabular-nums; font-weight: 600;
+             min-width: 36px; text-align: right; }
+
+  /* Data-source bucket badge */
+  .ds-bucket { display: inline-block; padding: 3px 10px; border-radius: 6px;
+               font-size: 11px; font-weight: 600;
+               -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .ds-published { background: var(--blue-soft); color: var(--blue); }
+  .ds-embedded  { background: #f5f5f5; color: var(--ink-2); }
+
+  /* Risk chip — used in shortlist + verdicts + coverage */
+  .risk-chip { display: inline-flex; align-items: center; gap: 6px;
+               font-size: 12px; font-variant-numeric: tabular-nums; }
+  .risk-dot { width: 8px; height: 8px; border-radius: 50%;
+              -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .risk-clean .risk-dot { background: var(--go); }
+  .risk-clean             { color: var(--go); font-weight: 600; }
+  .risk-green .risk-dot { background: #84cc16; }
+  .risk-green             { color: var(--ink-2); }
+  .risk-amber .risk-dot { background: #f59e0b; }
+  .risk-amber             { color: #a16207; font-weight: 600; }
+  .risk-red   .risk-dot { background: var(--warn); }
+  .risk-red               { color: var(--warn); font-weight: 700; }
+  .risk-mute  .risk-dot { background: var(--mute); }
+  .risk-mute              { color: var(--mute); }
+
+  /* Cluster member display */
+  .cluster-member { padding: 2px 0; font-size: 12px; line-height: 1.4; }
+  .cluster-member + .cluster-member { border-top: 1px dashed var(--line-soft); }
+
+  /* Inline user pill (top-users cell) */
+  .inline-pill { display: inline-block; padding: 1px 7px; border-radius: 99px;
+                 font-size: 11px; background: #f1f5f9; color: var(--ink-2);
+                 font-variant-numeric: tabular-nums; margin-right: 4px;
+                 -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+
+  /* Top-view cell — most-used view per workbook */
+  .top-view-cell { font-size: 12px; line-height: 1.3; }
+  .top-view-pct  { font-size: 11px; margin-top: 2px; }
+
+  /* Per-user top-workbook list (inside table cell) */
+  .top-wb { font-size: 11px; line-height: 1.4; display: flex;
+            justify-content: space-between; gap: 12px;
+            padding: 1px 0; }
+  .top-wb + .top-wb { border-top: 1px dotted var(--line-soft); padding-top: 3px; margin-top: 3px; }
+  .top-wb span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 220px; }
+
+  /* Unique-to-user expander */
+  details.unique-detail { font-size: 11px; }
+  details.unique-detail summary { cursor: pointer; color: var(--accent); font-weight: 600;
+                                  list-style: none; padding: 2px 0; }
+  details.unique-detail summary::-webkit-details-marker { display: none; }
+  details.unique-detail summary::before { content: '▸ '; color: var(--mute); }
+  details.unique-detail[open] summary::before { content: '▾ '; }
+  details.unique-detail div { padding-left: 12px; font-size: 11px; line-height: 1.4; }
+
+  /* Notes + callouts */
+  .note { font-size: 12px; color: var(--mute); font-style: italic;
+          margin: 12px 0 0; }
+  .callout {
+    background: var(--warn-soft); border-left: 3px solid var(--warn);
+    padding: 12px 16px; border-radius: 6px; margin-top: 16px;
+    font-size: 13px; color: #7c2d12;
+  }
+  .callout strong { color: #7c2d12; }
+  .callout code { background: rgba(0,0,0,0.06); padding: 1px 5px; border-radius: 3px;
+                  font-size: 12px; }
+
+  code { font-family: "DM Mono", ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px;
+         background: var(--line-soft); padding: 1px 6px; border-radius: 4px; }
+
+  /* Next steps */
+  ol.next-steps { margin: 0; padding-left: 0; counter-reset: step;
+                  list-style: none; }
+  ol.next-steps li { counter-increment: step; padding: 14px 0 14px 44px;
+                     position: relative; border-bottom: 1px solid var(--line-soft);
+                     font-size: 14px; }
+  ol.next-steps li:last-child { border-bottom: 0; }
+  ol.next-steps li::before {
+    content: counter(step); position: absolute; left: 0; top: 14px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--accent-soft); color: var(--accent);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums;
+  }
+  ol.next-steps li strong { color: var(--ink); }
+
+  /* Privacy two-column */
+  .priv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .priv-col h3 { font-size: 13px; font-weight: 600; color: var(--ink);
+                 margin: 0 0 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .priv-col ul { margin: 0; padding-left: 0; list-style: none; }
+  .priv-col li { padding: 6px 0 6px 22px; position: relative;
+                 font-size: 13px; color: var(--ink-2); }
+  .priv-col.crossed li::before {
+    content: '→'; position: absolute; left: 0; color: var(--warn); font-weight: 700;
+  }
+  .priv-col.local li::before {
+    content: '◊'; position: absolute; left: 0; color: var(--go); font-weight: 700;
+  }
+
+  footer { color: var(--mute); font-size: 11px; text-align: center;
+           margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--line); }
+
+  @media print {
+    @page { margin: 0.6in 0.5in 0.6in; size: letter portrait; }
+    body { background: white; font-size: 11.5px; }
+    main { max-width: none; padding: 0; }
+    .doc-header { margin-bottom: 18px; }
+    .doc-title { font-size: 26px; }
+    .hero { margin-bottom: 24px; padding: 12px 16px; page-break-after: avoid; }
+    .hero-text { font-size: 13px; }
+    section { margin-bottom: 24px; page-break-inside: auto; }
+    section.section-tight { margin-bottom: 18px; }
+    .section-head { margin-bottom: 10px; padding-bottom: 8px; page-break-after: avoid; }
+    .section-title { font-size: 16px; }
+    .section-lede { font-size: 12px; margin: -2px 0 10px; }
+    .kpi-grid { gap: 8px; }
+    .kpi { padding: 12px; }
+    .kpi-v { font-size: 22px; }
+    .kpi-l { font-size: 10px; margin-top: 6px; }
+    .kpi-sub { font-size: 10px; margin-top: 3px; }
+    .stat-row { gap: 8px; margin-bottom: 14px; }
+    .stat { padding: 12px 14px; }
+    .stat-v { font-size: 24px; }
+    table.data { font-size: 11px; page-break-inside: auto; }
+    table.data thead { display: table-header-group; }
+    table.data th { padding: 8px 10px; font-size: 10px; }
+    table.data td { padding: 8px 10px; }
+    table.data tr { page-break-inside: avoid; page-break-after: auto; }
+    .tag, .ds-bucket { font-size: 10px; padding: 2px 8px; }
+    .bar-track { max-width: 60px; height: 5px; }
+    .note { font-size: 11px; }
+    .callout { padding: 8px 12px; font-size: 11px; }
+    ol.next-steps li { padding: 10px 0 10px 36px; font-size: 12px; }
+    ol.next-steps li::before { width: 22px; height: 22px; font-size: 11px; top: 10px; }
+    .priv-col li { font-size: 11px; padding: 4px 0 4px 18px; }
+    footer { margin-top: 24px; padding-top: 12px; }
+    /* Force backgrounds + colors to render */
+    .hero, .kpi, .stat, table.data, table.data th, .ds-bucket, .tag,
+    .bar-track, .bar-fill, .risk-dot, .callout, ol.next-steps li::before {
+      -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important;
+    }
+    /* Avoid awkward page splits at section boundaries */
+    section h2, .section-head { page-break-after: avoid; }
+    .stat-row, .priv-grid { page-break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+<main>
+
+<div class="brand-bar">
+  <span class="brand-dot"></span>
+  <span class="brand-mark">sigma</span>
+  <span class="brand-tag">Migration Assessment</span>
+</div>
+<div class="doc-header">
+  <div class="doc-eyebrow">ThoughtSpot Environment Report</div>
+  <h1 class="doc-title">#{h(host)}</h1>
+  <div class="doc-meta">Generated #{h(formatted_date)}</div>
+</div>
+
+<div class="hero">
+  <div class="hero-label">Headline finding</div>
+  <div class="hero-text">#{h(hero_finding)}</div>
+</div>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">01</span>
+    <h2 class="section-title">Environment overview</h2>
+  </div>
+  <div class="kpi-grid">#{kpi_html}</div>
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">02</span>
+    <h2 class="section-title">Liveboard priority &amp; usage</h2>
+    <span class="section-aside">Top 10 of #{env['liveboards']} Liveboards · #{num(total_views)} total views</span>
+  </div>
+  <p class="section-lede">Liveboards ranked by all-time interactive views from the <code>TS: BI Server</code> system worksheet — ThoughtSpot's built-in usage log. This is the foundation of any migration plan: focus effort where audience attention already is.</p>
+  #{usage_html}
+  #{usage_available ? '' : %(<p class="note">Usage data was not available for this run (#{h(usage_note)}). Liveboards above are ordered as listed; connect an admin identity to rank by views.</p>)}
+  #{cold.any? ? %(<p class="note"><strong>#{cold.size} Liveboard#{cold.size == 1 ? '' : 's'}</strong> have zero recorded views in the window: ) + cold.first(15).map { |p| %(<code>#{h(p['name'])}</code>) }.join(', ') + (cold.size > 15 ? " + #{cold.size - 15} more" : '') + ' — strong candidates for retirement.</p>' : ''}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">03</span>
+    <h2 class="section-title">Ownership &amp; concentration</h2>
+    <span class="section-aside">#{ownership.size} author#{ownership.size == 1 ? '' : 's'}</span>
+  </div>
+  <p class="section-lede">Liveboard authorship across the instance. High concentration in one or two authors is a governance signal — what happens to their content if they leave?</p>
+  #{ownership_html}
+  #{total_owned.positive? ? %(<p class="note">Top-author concentration: <strong>#{top_owner_pct}%</strong> of Liveboards authored by <code>#{h(top_owner_name)}</code>.</p>) : ''}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">04</span>
+    <h2 class="section-title">Data-source patterns</h2>
+    <span class="section-aside">#{env['connections']} connection#{env['connections'] == 1 ? '' : 's'} · #{env['tables']} tables</span>
+  </div>
+  <p class="section-lede">How data reaches your Liveboards. <strong>Embrace</strong> connections push queries live to a warehouse — Sigma connects to the same source with no data movement. <strong>Falcon</strong> (in-memory) and <strong>file-uploaded</strong> tables hold data inside ThoughtSpot and must be landed in a warehouse before Sigma can model them.</p>
+  #{ds_stat_row}
+  #{conn_html}
+  #{uploaded_html}
+</section>
+
+HTML
+
+# Section 05: User activity (conditional)
+section_n = 5
+if activity_html != ''
+  html += <<~HTML
+  <section>
+    <div class="section-head">
+      <span class="section-num">05</span>
+      <h2 class="section-title">User activity</h2>
+      <span class="section-aside">Top 15 of #{usage_by_user.size} active user#{usage_by_user.size == 1 ? '' : 's'}</span>
+    </div>
+    <p class="section-lede">Per-user action volume from the <code>TS: BI Server</code> log over the last 12 months. This is the population that needs to land smoothly on Sigma.</p>
+    #{activity_html}
+  </section>
+
+  HTML
+  section_n = 6
+end
+
+mig_num  = format('%02d', section_n)
+priv_num = format('%02d', section_n + 1)
+next_num = format('%02d', section_n + 2)
+
+# Section: Migration shortlist + complexity
+html += <<~HTML
+<section>
+  <div class="section-head">
+    <span class="section-num">#{mig_num}</span>
+    <h2 class="section-title">Migration to Sigma — recommended sequence</h2>
+    <span class="section-aside">#{shortlist.size} exportable Liveboards · #{format('%.1f', coverage)}% chart-type coverage</span>
+  </div>
+  <p class="section-lede">If you choose to migrate to Sigma, this is the order that minimizes risk while covering the most user impact. Liveboards are ranked by usage value relative to conversion complexity. The top of the list is the recommended starting point for a pilot.</p>
+
+  <div class="stat-row">
+    <div class="stat">
+      <div class="stat-l">Top-5 usage share</div>
+      <div class="stat-v">#{top5_pct}<span style="font-size: 16px; color: var(--mute); font-weight: 600;">%</span></div>
+      <div class="stat-sub">of #{num(total_views)} total views</div>
+    </div>
+    <div class="stat stat-#{sl_total_unsup.zero? ? 'go' : 'warn'}">
+      <div class="stat-l">Chart types to review</div>
+      <div class="stat-v #{sl_total_unsup.zero? ? 'go' : 'warn'}">#{sl_total_unsup}</div>
+      <div class="stat-sub">unsupported chart kinds across the shortlist</div>
+    </div>
+    <div class="stat">
+      <div class="stat-l">Needs review · Retire</div>
+      <div class="stat-v">#{sl_needs_scout}<span style="font-size: 16px; color: var(--mute); font-weight: 600;"> · #{sl_retire}</span></div>
+      <div class="stat-sub">Liveboards of #{shortlist.size} total</div>
+    </div>
+  </div>
+
+  #{shortlist_html}
+  #{complexity_html}
+  #{coverage_html}
+  #{models_used_html}
+  #{sl_total_unsup.positive? ?
+    %(<div class="callout"><strong>#{n_with_unsup} Liveboard#{n_with_unsup == 1 ? '' : 's'}</strong> use a chart type without a 1:1 Sigma mapping in the current pipeline (PIVOT_TABLE, WATERFALL, FUNNEL, SCATTER, BUBBLE, TREEMAP, GEO_AREA, LINE_STACKED_COLUMN). Sigma supports most of these natively — they just need element-builder mapping work, identified up-front so there are no surprises mid-migration.</div>) : ''}
+</section>
+
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{priv_num}</span>
+    <h2 class="section-title">Data handling</h2>
+  </div>
+  <p class="section-lede">This report was generated by an LLM-driven scan of your ThoughtSpot instance. What that means for the data that left your environment:</p>
+  <div class="priv-grid">
+    <div class="priv-col crossed">
+      <h3>Read by the scanner</h3>
+      <ul>
+        <li>Aggregate counts (Liveboard, Answer, model, table, connection totals)</li>
+        <li>Liveboard names, author names, connection names</li>
+        <li>Per-object views &amp; distinct users from <code>TS: BI Server</code></li>
+        <li>Liveboard TML — visualization config, chart types, referenced models, TML formula text</li>
+      </ul>
+    </div>
+    <div class="priv-col local">
+      <h3>Never left your environment</h3>
+      <ul>
+        <li>Underlying warehouse rows — the scan never queries source data</li>
+        <li>Falcon in-memory data and uploaded file contents</li>
+        <li>Database / connection credentials</li>
+        <li>Answer result-set data — only metadata is read</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{next_num}</span>
+    <h2 class="section-title">Recommended next steps</h2>
+  </div>
+  <ol class="next-steps">
+    <li><strong>Pilot the top #{[5, shortlist.size].min} Liveboard#{[5, shortlist.size].min == 1 ? '' : 's'}.</strong> They represent #{top5_pct}% of total interactive views with #{sl_total_unsup} chart type#{sl_total_unsup == 1 ? '' : 's'} flagged for review between them — the lowest-risk way to demonstrate end-to-end migration with the <code>thoughtspot-to-sigma</code> skill.</li>
+HTML
+
+if models_used.any?
+  html += "    <li><strong>Migrate the #{models_used.size} referenced model#{models_used.size == 1 ? '' : 's'}/worksheet#{models_used.size == 1 ? '' : 's'} to Sigma data models first.</strong> Liveboards re-point to a converted data model, so building these up-front lets multiple Liveboards share one model.</li>\n"
+end
+if (ds_summary['file_uploaded_tables'] || 0).positive? || (ds_summary['falcon'] || 0).positive?
+  n_land = (ds_summary['file_uploaded_tables'] || 0) + (ds_summary['falcon'] || 0)
+  html += "    <li><strong>Land #{n_land} in-memory / file-uploaded source#{n_land == 1 ? '' : 's'} in your warehouse.</strong> Falcon caches and CSV/XLSX uploads have no governed warehouse source — they must be loaded before Sigma can model them.</li>\n"
+end
+if sl_needs_scout.positive?
+  html += "    <li><strong>Plan individual review time for #{sl_needs_scout} Liveboard#{sl_needs_scout == 1 ? '' : 's'}.</strong> Each uses a chart type that benefits from a tailored conversion approach.</li>\n"
+end
+if sl_retire.positive?
+  html += "    <li><strong>Retire #{sl_retire} Liveboard#{sl_retire == 1 ? '' : 's'}</strong> with zero recorded views. No migration value, and dropping them simplifies the cutover.</li>\n"
+end
+
+html += <<~HTML
+  </ol>
+</section>
+
+<footer>
+  Report generated #{h(formatted_date)} · supporting JSON (<code>assessment.json</code>) alongside in the same folder
+</footer>
+
+</main>
+</body>
+</html>
+HTML
+
+out_path = File.join(opts[:out], 'readout.html')
+File.write(out_path, html)
+puts "wrote #{out_path} (#{File.size(out_path)} bytes)"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/scan.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/scan.py
@@ -1,18 +1,23 @@
 #!/usr/bin/env python3
 """ThoughtSpot migration-readiness assessment.
 
-Inventories the instance (models/worksheets + Liveboards + Answers +
-connections), and for every exportable Liveboard scores migration complexity
-from its visualizations: viz count, chart-type mix, and the model(s) it reads.
-Produces a value/cost-style shortlist for a ThoughtSpot -> Sigma migration.
+Inventories a REAL ThoughtSpot instance (models/worksheets + Liveboards +
+Answers + connections + tables), pulls per-object usage from the built-in
+`TS: BI Server` system worksheet (views + distinct users + per-user activity),
+and for every exportable Liveboard scores migration complexity from its TML:
+viz count, distinct chart kinds, models touched, plus TML formula and RLS
+complexity. Produces a value/cost-style migration shortlist for a
+ThoughtSpot -> Sigma migration.
 
-Chart types the thoughtspot-to-sigma pipeline handles today map to Sigma
-kpi/bar/line/table; pie/area/stacked are supported in Sigma and migrate as
-their nearest kind. Anything else is flagged for review.
+This assumes a populated production instance: usage data is a FIRST-CLASS
+signal, not an optional extra. If `TS: BI Server` is genuinely absent (a fresh
+instance, or an identity without admin scope) the scan records a single note and
+falls back to effort-only ranking — but the design and the readout are built for
+the populated case.
 
 Env: TS_HOST, TS_TOKEN.
 """
-import sys, os, json
+import sys, os, json, datetime
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import yaml, ts_lib
 
@@ -21,18 +26,33 @@ import yaml, ts_lib
 yaml.SafeLoader.add_constructor("tag:yaml.org,2002:value",
                                 lambda loader, node: loader.construct_scalar(node))
 
+OUT = os.path.expanduser("~/thoughtspot-migration/assessment.json")
+
+# Chart kinds the thoughtspot-to-sigma pipeline maps to Sigma today.
 SUPPORTED = {"KPI", "COLUMN", "BAR", "LINE", "PIE", "TABLE", "ADVANCED_COLUMN",
              "STACKED_COLUMN", "STACKED_BAR", "AREA", "STACKED_AREA", "LINE_COLUMN"}
 
-def liveboard_profile(lb_id, name):
+
+def _author(x):
+    """Best-effort author/owner display from a metadata/search hit."""
+    h = x.get("metadata_header", {}) or {}
+    return (h.get("authorName") or h.get("authorDisplayName")
+            or x.get("metadata_author_name") or h.get("author") or "unknown")
+
+
+def liveboard_profile(lb_id, name, author):
     edoc, err = ts_lib.export_tml(lb_id, "LIVEBOARD")
     if err:
-        return {"id": lb_id, "name": name, "exportable": False, "note": err.split(":")[0]}
+        return {"id": lb_id, "name": name, "author": author,
+                "exportable": False, "note": err.split(":")[0]}
     try:
         lb = yaml.safe_load(edoc)["liveboard"]
     except Exception as e:
-        return {"id": lb_id, "name": name, "exportable": False, "note": f"parse: {type(e).__name__}"}
+        return {"id": lb_id, "name": name, "author": author,
+                "exportable": False, "note": f"parse: {type(e).__name__}"}
     types, models, unsupported = {}, set(), []
+    n_formula = 0       # TML formulas (calculated fields) referenced
+    n_filter = 0        # viz-level / liveboard filters
     for v in lb.get("visualizations", []):
         a = v.get("answer")
         if not a:
@@ -43,64 +63,135 @@ def liveboard_profile(lb_id, name):
             unsupported.append(ct)
         for t in a.get("tables", []):
             models.add(t.get("name"))
+        n_formula += len(a.get("formulas", []) or [])
+        n_filter += len(a.get("filters", []) or [])
+    # Liveboard-level filters (cross-viz controls)
+    n_filter += len(lb.get("filters", []) or [])
     nviz = sum(types.values())
-    # crude complexity: viz count + distinct chart kinds + #models touched
-    complexity = nviz + 2 * len(types) + 3 * len(models)
-    return {"id": lb_id, "name": name, "exportable": True, "viz": nviz,
-            "chart_types": types, "models": sorted(models),
+    # complexity: viz count + distinct chart kinds + #models touched + TML
+    # formula weight + filter weight. Mirrors the value/cost intuition of the
+    # other assessment skills (auto/manual/review classes).
+    complexity = nviz + 2 * len(types) + 3 * len(models) + 2 * n_formula + n_filter
+    return {"id": lb_id, "name": name, "author": author, "exportable": True,
+            "viz": nviz, "chart_types": types, "models": sorted(models),
+            "n_formula": n_formula, "n_filter": n_filter,
             "unsupported": sorted(set(unsupported)), "complexity": complexity}
+
+
+def classify_connection(ctype):
+    """Embrace (live, query pushed to the warehouse) vs Falcon (in-memory)."""
+    if not ctype:
+        return "unknown"
+    c = str(ctype).upper()
+    if "FALCON" in c or c in ("RDBMS_FALCON", "DEFAULT"):
+        return "falcon"
+    return "embrace"
+
+
+def get_connections():
+    """Connections classified Embrace (live warehouse) vs Falcon (in-memory)."""
+    out = []
+    for x in ts_lib.search("CONNECTION"):
+        h = x.get("metadata_header", {}) or {}
+        ctype = (h.get("type") or x.get("metadata_type")
+                 or x.get("data_source_type") or h.get("dataSourceType"))
+        out.append({"id": x.get("metadata_id"), "name": x.get("metadata_name"),
+                    "author": _author(x), "connection_type": ctype,
+                    "class": classify_connection(ctype)})
+    return out
+
+
+def get_tables():
+    """Physical tables. file-uploaded (CSV/XLSX) tables flagged — they have no
+    governed warehouse source and must land in a warehouse for Sigma."""
+    out = []
+    for x in ts_lib.search("LOGICAL_TABLE"):
+        h = x.get("metadata_header", {}) or {}
+        t = h.get("type")
+        if t not in ("ONE_TO_ONE_LOGICAL", "SYSTEM_TABLE", "TABLE", None):
+            # WORKSHEET / MODEL handled separately
+            if t in ("WORKSHEET", "MODEL", "AGGR_WORKSHEET"):
+                continue
+        is_upload = bool(h.get("isImported") or h.get("isFileUpload")
+                         or "Imported Data" in str(h.get("databaseStripe", "")))
+        out.append({"id": x.get("metadata_id"), "name": x.get("metadata_name"),
+                    "author": _author(x), "type": t,
+                    "file_uploaded": is_upload})
+    return out
+
 
 def get_usage(days_query="[Timestamp].'last 12 months'"):
     """Per-object usage from the TS: BI Server system worksheet (ThoughtSpot's
-    built-in usage/activity log): {object_name: {views, users}}. BI Server logs
-    interactive views only, so API-created-but-never-viewed content reads 0.
-    Returns ({}, reason) if BI Server is absent/empty."""
-    bi = next((x for x in ts_lib.search("LOGICAL_TABLE") if x["metadata_name"] == "TS: BI Server"), None)
+    built-in usage/activity log). On a real instance with admin scope this is
+    the primary value signal. Returns:
+        (by_object, by_user, reason_or_None)
+      by_object: {object_name: {views, users}}
+      by_user:   {user: total_actions}
+    """
+    bi = next((x for x in ts_lib.search("LOGICAL_TABLE")
+               if x.get("metadata_name") == "TS: BI Server"), None)
     if not bi:
-        return {}, "TS: BI Server worksheet not found"
-    bid = bi["metadata_id"]
+        return {}, {}, "TS: BI Server worksheet not present (fresh instance or non-admin identity)"
+    bid = bi.get("metadata_id")
+    by_object, by_user = {}, {}
     try:
+        # Per-Liveboard/Answer: views + distinct users
         views = ts_lib.searchdata(
             f"[Answer Book Name] count [User Action] unique count [User] "
-            f"[User Action] != 'invalid' {days_query}", bid, record_size=500)
+            f"[User Action] != 'invalid' {days_query}", bid, record_size=1000)
+        for row in views["data_rows"]:
+            name = row[0]
+            if name is None:
+                continue
+            by_object[name] = {"views": row[1], "users": row[2]}
     except Exception as e:
-        return {}, f"BI Server query failed: {e}"
-    out = {}
-    for row in views["data_rows"]:
-        name = row[0]
-        if name is None:
-            continue
-        out[name] = {"views": row[1], "users": row[2]}
-    return out, ("no recorded views in window" if not out else None)
+        return {}, {}, f"BI Server views query failed: {e}"
+    try:
+        # Per-user activity (distinct users + their action volume)
+        ua = ts_lib.searchdata(
+            f"[User] count [User Action] [User Action] != 'invalid' {days_query}",
+            bid, record_size=1000)
+        for row in ua["data_rows"]:
+            u = row[0]
+            if u is None:
+                continue
+            by_user[u] = row[1]
+    except Exception:
+        pass  # per-user is a bonus; views are the load-bearing signal
+    reason = None if by_object else "no recorded views in window"
+    return by_object, by_user, reason
+
 
 def main():
     models = [x for x in ts_lib.search("LOGICAL_TABLE")
               if x.get("metadata_header", {}).get("type") in ("WORKSHEET", "MODEL")]
     lbs = ts_lib.search("LIVEBOARD")
     answers = ts_lib.search("ANSWER")
-    conns = ts_lib.search("CONNECTION")
+    conns = get_connections()
+    tables = get_tables()
 
-    print("="*64)
+    print("=" * 64)
     print("THOUGHTSPOT MIGRATION ASSESSMENT")
-    print("="*64)
+    print("=" * 64)
     print(f"Inventory: {len(conns)} connection(s), {len(models)} models/worksheets, "
-          f"{len(lbs)} Liveboards, {len(answers)} Answers\n")
+          f"{len(tables)} tables, {len(lbs)} Liveboards, {len(answers)} Answers\n")
 
-    profiles = [liveboard_profile(x["metadata_id"], x["metadata_name"]) for x in lbs]
+    profiles = [liveboard_profile(x["metadata_id"], x["metadata_name"], _author(x))
+                for x in lbs]
     exportable = [p for p in profiles if p.get("exportable")]
     locked = [p for p in profiles if not p.get("exportable")]
 
-    # Usage (ThoughtSpot's built-in activity log) — attach views/users per object.
-    usage, usage_note = get_usage()
+    # Usage (ThoughtSpot's built-in activity log) — FIRST-CLASS signal.
+    usage, by_user, usage_note = get_usage()
     for p in profiles:
         u = usage.get(p["name"]) or usage.get(p["name"].replace(" (TS)", ""))
         p["views"] = (u or {}).get("views", 0)
         p["users"] = (u or {}).get("users", 0)
     total_views = sum(p.get("views", 0) for p in profiles)
-    print("USAGE (TS: BI Server — interactive views; value signal for the shortlist):")
+
+    print("USAGE (TS: BI Server — interactive views, the migration value signal):")
     if total_views == 0:
-        print(f"  ⚠ no recorded usage in window ({usage_note or 'BI Server empty'}). "
-              f"On a populated instance this yields per-object views + distinct users.\n")
+        print(f"  note: {usage_note or 'no usage recorded'}\n")
     else:
         for p in sorted(profiles, key=lambda p: -p.get("views", 0))[:15]:
             if p.get("views"):
@@ -108,20 +199,34 @@ def main():
         print()
 
     print(f"Liveboards readable via API: {len(exportable)}/{len(profiles)} "
-          f"({len(locked)} system/locked, not migratable by this identity)\n")
+          f"({len(locked)} system/locked)\n")
 
     # value/cost ranking: value = interactive views, cost = complexity.
     for p in exportable:
         p["value_cost"] = round(p.get("views", 0) / (1 + p["complexity"]), 3)
     ranked = (sorted(exportable, key=lambda p: -p["value_cost"]) if total_views
               else sorted(exportable, key=lambda p: p["complexity"]))
-    print("MIGRATION SHORTLIST (%s):" % ("value/cost — migrate high-value, low-effort first"
-                                         if total_views else "easiest first; no usage yet, so by effort"))
+
+    # tag each ranked Liveboard
+    for p in ranked:
+        if total_views and p.get("views", 0) == 0:
+            p["tag"] = "retire"
+        elif p["unsupported"]:
+            p["tag"] = "needs-gap-scout"
+        elif p["complexity"] < 20 and total_views:
+            p["tag"] = "migrate-first"
+        elif p["complexity"] < 30:
+            p["tag"] = "easy-win"
+        else:
+            p["tag"] = "moderate"
+
+    print("MIGRATION SHORTLIST (%s):" % ("value/cost — high-value, low-effort first"
+                                         if total_views else "easiest first; rank by effort"))
     print(f"  {'Liveboard':32s} {'viz':>3s} {'kinds':>5s} {'cx':>4s} {'v/c':>6s}  chart types")
     for p in ranked:
-        flag = "  ⚠ " + ",".join(p["unsupported"]) if p["unsupported"] else ""
+        flag = "  ! " + ",".join(p["unsupported"]) if p["unsupported"] else ""
         print(f"  {p['name'][:32]:32s} {p['viz']:>3d} {len(p['chart_types']):>5d} {p['complexity']:>4d} "
-              f"{p['value_cost']:>6} {','.join(f'{k}×{v}' for k,v in p['chart_types'].items())}{flag}")
+              f"{p['value_cost']:>6} {','.join(f'{k}x{v}' for k,v in p['chart_types'].items())}{flag}")
 
     all_types = {}
     for p in exportable:
@@ -131,17 +236,58 @@ def main():
     total_viz = sum(all_types.values())
     cov = 100 * (total_viz - sum(unsup.values())) / total_viz if total_viz else 100
     print(f"\nChart-type coverage: {cov:.1f}%  ({total_viz} viz across exportable Liveboards)")
-    print(f"  all types: {all_types}")
-    if unsup:
-        print(f"  ⚠ needs review: {unsup}")
+
     models_used = sorted({m for p in exportable for m in p["models"]})
     print(f"\nModels referenced by exportable Liveboards: {len(models_used)}")
-    for m in models_used:
-        print(f"  - {m}")
-    json.dump({"profiles": profiles, "coverage": cov, "chart_types": all_types,
-               "usage_available": bool(usage), "usage_note": usage_note, "total_views": total_views},
-              open(os.path.expanduser("~/thoughtspot-migration/assessment.json"), "w"), indent=2)
-    print("\nFull report -> ~/thoughtspot-migration/assessment.json")
+
+    # Ownership / concentration by author (across Liveboards).
+    owners = {}
+    for p in profiles:
+        owners[p["author"]] = owners.get(p["author"], 0) + 1
+    ownership = sorted(({"author": a, "liveboards": n} for a, n in owners.items()),
+                       key=lambda o: -o["liveboards"])
+
+    # Data-source patterns
+    ds_summary = {
+        "embrace": sum(1 for c in conns if c["class"] == "embrace"),
+        "falcon": sum(1 for c in conns if c["class"] == "falcon"),
+        "unknown": sum(1 for c in conns if c["class"] == "unknown"),
+        "file_uploaded_tables": sum(1 for t in tables if t["file_uploaded"]),
+        "tables_total": len(tables),
+    }
+
+    report = {
+        "instance": {
+            "host": ts_lib.HOST,
+            "generated_at": datetime.date.today().strftime("%Y-%m-%d"),
+        },
+        "environment_overview": {
+            "liveboards": len(lbs),
+            "answers": len(answers),
+            "models": len(models),
+            "tables": len(tables),
+            "connections": len(conns),
+        },
+        "profiles": profiles,
+        "shortlist": ranked,
+        "ownership": ownership,
+        "connections": conns,
+        "tables": tables,
+        "datasource_summary": ds_summary,
+        "usage_by_user": [{"user": u, "actions": n}
+                          for u, n in sorted(by_user.items(), key=lambda kv: -kv[1])],
+        "coverage": cov,
+        "chart_types": all_types,
+        "unsupported_chart_types": unsup,
+        "models_used": models_used,
+        "usage_available": bool(usage),
+        "usage_note": usage_note,
+        "total_views": total_views,
+    }
+    os.makedirs(os.path.dirname(OUT), exist_ok=True)
+    json.dump(report, open(OUT, "w"), indent=2)
+    print(f"\nFull report -> {OUT}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Brings all five `*-assessment` skills to a consistent, Sigma-branded HTML readout and fills the doc-parity gaps. Tableau is the gold-standard reference; the other four adopt its theme verbatim, adapted to each tool's vocabulary and JSON.

## Branding
- Sigma palette (Shadow `#292929` ink, Nimbus neutrals, **Sky-blue `#2b8ca6` accent**, Grass `#4cec8c` data bars), DM Sans / DM Mono, `sigma` masthead.
- Table alignment fixed: bars left-aligned with a fixed 84px track; numeric + bar columns pinned to content width so the text column absorbs slack.

## Per tool
- **tableau-assessment** — re-skinned `render-readout-html.rb` (reference theme).
- **powerbi-assessment** — new branded `render-readout-html.rb` (PBI vocab: semantic models, DAX a/b/c, import/DirectQuery).
- **quicksight-assessment** — new branded `render-readout-html.rb` + **PRIVACY.md + README.md** (were missing); Hand-off section dropped for cross-tool parity.
- **qlik-assessment** — new branded `render-readout-html.rb` + README + refs; `qlik-inventory.py` extended to emit environment/data-source/reload/ownership rollups.
- **thoughtspot-assessment** — new branded `render-readout-html.rb` (supersedes the off-brand `render_html.py`) + PRIVACY + README + refs; `scan.py` **de-trialed** so usage (TS: BI Server) is a first-class signal.

## Verified live against real instances
- QuickSight (21 analyses / 22 dashboards), Qlik (9 apps / 114 master measures), Tableau (22 workbooks / 77 views), ThoughtSpot (459 viz / 16 models) — all render the branded readout from real data. Power BI verified against sample fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)