### PR TITLE
quicksight convert-model.rb: unwrap sigmaDataModel in --fixup (removes retry loop)

### DIFF
--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
@@ -160,6 +160,10 @@ end
 if opts[:fixup]
   abort 'need --in' unless opts[:in]
   model = JSON.parse(File.read(opts[:in]))
+  # The MCP converter wraps its output; unwrap to the bare model. Newer builds
+  # double-wrap as {sigmaDataModel: {name, schemaVersion, pages}}, older ones as
+  # {model: {...}} — handle both (and a sigmaDataModel that itself nests model).
+  model = model['sigmaDataModel'] if model.is_a?(Hash) && model['sigmaDataModel']
   model = model['model'] if model.is_a?(Hash) && model['model']
   model['schemaVersion'] = 1
   ds_names = signals ? signals['datasets'].map { |d| d['name'] }.compact : []


### PR DESCRIPTION
MCP converter double-wraps as `{sigmaDataModel:{...}}`; `--fixup` only unwrapped `model`, so DM POST failed until hand-unwrapped. Now unwraps both. Validated end-to-end on the optimized D8 benchmark conversion. 🤖 Generated with [Claude Code](https://claude.com/claude-code)