### PR TITLE
assessments: per-dashboard token/$ migration-cost estimator

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/token-model.json
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/token-model.json
@@ -1,0 +1,50 @@
+{
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Calibrated on the ONE-SHOT ORCHESTRATOR path (migrate-<tool>.rb): the agent runs ~1 command and the conversion is deterministic script work, so LLM cost is tiny and ~flat. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items, where n_review_items = items whose assessment found unsupported/needs-review features (n_unhandled > 0). Tokens are the portable unit; rescale $ by your model's price.",
+  "calibration": {
+    "date": "2026-06-07",
+    "path": "one-shot orchestrator (migrate-<tool>.rb, --yes / auto-accepted defaults)",
+    "models": ["opus", "sonnet"],
+    "rates_per_million_usd": {
+      "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
+      "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
+    },
+    "real_samples": {
+      "quicksight_D8": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders": { "opus_usd": 0.72, "sonnet_usd": 0.08 }
+    },
+    "for_reference_non_orchestrator": {
+      "naive_agent_path_standard_dashboard": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "optimized_brief_path": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "note": "The orchestrator path is ~12-20x cheaper than a naive agent-driven migration. These are shown so customers understand the savings of running via the orchestrator."
+    }
+  },
+  "per_dashboard": {
+    "mechanical": {
+      "tools": ["quicksight", "powerbi", "qlik", "thoughtspot"],
+      "opus_usd": 0.70,
+      "sonnet_usd": 0.11,
+      "tokens_output_plus_cache_creation": 25000,
+      "note": "Mechanical model converter → deterministic; cost is flat and tool-independent (measured on QuickSight + Qlik)."
+    },
+    "tableau": {
+      "opus_usd": 4.0,
+      "sonnet_usd": 1.0,
+      "tokens_output_plus_cache_creation": 250000,
+      "confidence": "estimate — NOT yet benchmarked on the orchestrator path",
+      "range_opus_usd": [2.0, 8.0],
+      "note": "Tableau has no mechanical converter; the data-model/workbook SPEC is agent-authored (pluggable Specs module), so cost is higher and scales with calc/LOD/custom-SQL complexity. Refine by benchmarking migrate-tableau.rb with a real Specs generator."
+    }
+  },
+  "per_review_item": {
+    "opus_usd": 0.50,
+    "sonnet_usd": 0.12,
+    "confidence": "estimate",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator's checkpoint. The --yes benchmarks auto-accepted defaults, so this increment is estimated, not directly measured."
+  },
+  "caveats": [
+    "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
+    "Assumes the ONE-SHOT ORCHESTRATOR path. A naive agent-driven migration is ~12-20x more expensive.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and not included here — this is LLM cost only.",
+    "Tableau number is an estimate pending an orchestrator-path benchmark with a Specs generator."
+  ]
+}

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout-html.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout-html.rb
@@ -458,6 +458,63 @@ if complexity
   HTML
 end
 
+# ---------- estimated migration effort (token model) ----------
+effort_html = ''
+token_model_path = File.join(__dir__, '..', 'refs', 'token-model.json')
+if has_shortlist && File.exist?(token_model_path)
+  tm = JSON.parse(File.read(token_model_path)) rescue nil
+  if tm
+    bucket  = 'mechanical'
+    n_dash  = shortlist_reports.size
+    n_rev   = n_with_unhandled
+    pd      = (tm['per_dashboard'] || {})[bucket] || {}
+    pr      = tm['per_review_item'] || {}
+    cal     = tm['calibration'] || {}
+    est = lambda { |m| (pd["#{m}_usd"].to_f * n_dash) + (pr["#{m}_usd"].to_f * n_rev) }
+    opus_usd   = est.call('opus')
+    sonnet_usd = est.call('sonnet')
+    fmt = lambda { |v| '$' + format('%.2f', v) }
+    effort_html = <<~HTML
+      <section>
+        <div class="section-head">
+          <span class="section-num">07</span>
+          <h2 class="section-title">Estimated migration effort (tokens / $)</h2>
+          <span class="section-aside">one-shot orchestrator path</span>
+        </div>
+        <p class="section-lede">A planning estimate of the LLM cost to migrate the shortlisted reports via the <code>powerbi-to-sigma</code> one-shot orchestrator. The mechanical model converter is deterministic, so per-report cost is flat; each report flagged for review adds one human-decision round.</p>
+        <div class="stat-row">
+          <div class="stat stat-go">
+            <div class="stat-l">Estimated cost · Opus</div>
+            <div class="stat-v go">#{fmt.call(opus_usd)}</div>
+            <div class="stat-sub">#{n_dash} reports + #{n_rev} review</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Estimated cost · Sonnet</div>
+            <div class="stat-v">#{fmt.call(sonnet_usd)}</div>
+            <div class="stat-sub">same scope, Sonnet pricing</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Basis</div>
+            <div class="stat-v" style="font-size:20px;">#{n_dash}<span style="font-size:14px;color:var(--mute);font-weight:600;"> × per-dashboard</span></div>
+            <div class="stat-sub">+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</div>
+          </div>
+        </div>
+        <table class="data">
+          <thead>
+            <tr><th>Component</th><th class="al-right">Opus</th><th class="al-right">Sonnet</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>#{n_dash} reports × per-dashboard</td><td class="al-right num">#{fmt.call(pd['opus_usd'].to_f * n_dash)}</td><td class="al-right num">#{fmt.call(pd['sonnet_usd'].to_f * n_dash)}</td></tr>
+            <tr><td>+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</td><td class="al-right num">#{fmt.call(pr['opus_usd'].to_f * n_rev)}</td><td class="al-right num">#{fmt.call(pr['sonnet_usd'].to_f * n_rev)}</td></tr>
+            <tr><td><strong>Total estimated</strong></td><td class="al-right num"><strong>#{fmt.call(opus_usd)}</strong></td><td class="al-right num"><strong>#{fmt.call(sonnet_usd)}</strong></td></tr>
+          </tbody>
+        </table>
+        <p class="note">Calibrated #{h(cal['date'])}, one-shot orchestrator path — LLM cost only; rescale $ by your coding agent's pricing. A naive agent-driven migration is ~12–20× more expensive.</p>
+      </section>
+    HTML
+  end
+end
+
 # ---------- HTML document ----------
 html = <<~HTML
 <!DOCTYPE html>
@@ -871,10 +928,11 @@ if has_shortlist
     %(<div class="callout"><strong>#{n_with_unhandled} report#{n_with_unhandled == 1 ? '' : 's'}</strong> include DAX or custom visuals with no Sigma equivalent that warrant individual review when planning their conversion — typically PATH hierarchies, dynamic-context measures, or unsupported custom visuals where the right Sigma equivalent depends on how the report actually uses them. Identifying these up-front means no surprises mid-migration.</div>) : ''}
 </section>
   HTML
+  html += effort_html
 end
 
-priv_num = has_shortlist ? '07' : '06'
-next_num = has_shortlist ? '08' : '07'
+priv_num = has_shortlist ? '08' : '06'
+next_num = has_shortlist ? '09' : '07'
 
 html += <<~HTML
 

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/refs/token-model.json
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/refs/token-model.json
@@ -1,0 +1,50 @@
+{
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Calibrated on the ONE-SHOT ORCHESTRATOR path (migrate-<tool>.rb): the agent runs ~1 command and the conversion is deterministic script work, so LLM cost is tiny and ~flat. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items, where n_review_items = items whose assessment found unsupported/needs-review features (n_unhandled > 0). Tokens are the portable unit; rescale $ by your model's price.",
+  "calibration": {
+    "date": "2026-06-07",
+    "path": "one-shot orchestrator (migrate-<tool>.rb, --yes / auto-accepted defaults)",
+    "models": ["opus", "sonnet"],
+    "rates_per_million_usd": {
+      "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
+      "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
+    },
+    "real_samples": {
+      "quicksight_D8": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders": { "opus_usd": 0.72, "sonnet_usd": 0.08 }
+    },
+    "for_reference_non_orchestrator": {
+      "naive_agent_path_standard_dashboard": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "optimized_brief_path": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "note": "The orchestrator path is ~12-20x cheaper than a naive agent-driven migration. These are shown so customers understand the savings of running via the orchestrator."
+    }
+  },
+  "per_dashboard": {
+    "mechanical": {
+      "tools": ["quicksight", "powerbi", "qlik", "thoughtspot"],
+      "opus_usd": 0.70,
+      "sonnet_usd": 0.11,
+      "tokens_output_plus_cache_creation": 25000,
+      "note": "Mechanical model converter → deterministic; cost is flat and tool-independent (measured on QuickSight + Qlik)."
+    },
+    "tableau": {
+      "opus_usd": 4.0,
+      "sonnet_usd": 1.0,
+      "tokens_output_plus_cache_creation": 250000,
+      "confidence": "estimate — NOT yet benchmarked on the orchestrator path",
+      "range_opus_usd": [2.0, 8.0],
+      "note": "Tableau has no mechanical converter; the data-model/workbook SPEC is agent-authored (pluggable Specs module), so cost is higher and scales with calc/LOD/custom-SQL complexity. Refine by benchmarking migrate-tableau.rb with a real Specs generator."
+    }
+  },
+  "per_review_item": {
+    "opus_usd": 0.50,
+    "sonnet_usd": 0.12,
+    "confidence": "estimate",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator's checkpoint. The --yes benchmarks auto-accepted defaults, so this increment is estimated, not directly measured."
+  },
+  "caveats": [
+    "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
+    "Assumes the ONE-SHOT ORCHESTRATOR path. A naive agent-driven migration is ~12-20x more expensive.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and not included here — this is LLM cost only.",
+    "Tableau number is an estimate pending an orchestrator-path benchmark with a Specs generator."
+  ]
+}

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/render-readout-html.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/render-readout-html.rb
@@ -263,6 +263,63 @@ unless rl_rows.empty?
   HTML
 end
 
+# ---------- estimated migration effort (token model) ----------
+effort_html = ''
+token_model_path = File.join(__dir__, '..', 'refs', 'token-model.json')
+if has_shortlist && File.exist?(token_model_path)
+  tm = JSON.parse(File.read(token_model_path)) rescue nil
+  if tm
+    bucket  = 'mechanical'
+    n_dash  = shortlist.size
+    n_rev   = n_with_unhandled
+    pd      = (tm['per_dashboard'] || {})[bucket] || {}
+    pr      = tm['per_review_item'] || {}
+    cal     = tm['calibration'] || {}
+    est = lambda { |m| (pd["#{m}_usd"].to_f * n_dash) + (pr["#{m}_usd"].to_f * n_rev) }
+    opus_usd   = est.call('opus')
+    sonnet_usd = est.call('sonnet')
+    fmt = lambda { |v| '$' + format('%.2f', v) }
+    effort_html = <<~HTML
+      <section>
+        <div class="section-head">
+          <span class="section-num">07</span>
+          <h2 class="section-title">Estimated migration effort (tokens / $)</h2>
+          <span class="section-aside">one-shot orchestrator path</span>
+        </div>
+        <p class="section-lede">A planning estimate of the LLM cost to migrate the shortlisted apps via the <code>qlik-to-sigma</code> one-shot orchestrator. The mechanical model converter is deterministic, so per-app cost is flat; each app flagged for review adds one human-decision round.</p>
+        <div class="stat-row">
+          <div class="stat stat-go">
+            <div class="stat-l">Estimated cost · Opus</div>
+            <div class="stat-v go">#{fmt.call(opus_usd)}</div>
+            <div class="stat-sub">#{n_dash} apps + #{n_rev} review</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Estimated cost · Sonnet</div>
+            <div class="stat-v">#{fmt.call(sonnet_usd)}</div>
+            <div class="stat-sub">same scope, Sonnet pricing</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Basis</div>
+            <div class="stat-v" style="font-size:20px;">#{n_dash}<span style="font-size:14px;color:var(--mute);font-weight:600;"> × per-dashboard</span></div>
+            <div class="stat-sub">+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</div>
+          </div>
+        </div>
+        <table class="data">
+          <thead>
+            <tr><th>Component</th><th class="al-right">Opus</th><th class="al-right">Sonnet</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>#{n_dash} apps × per-dashboard</td><td class="al-right num">#{fmt.call(pd['opus_usd'].to_f * n_dash)}</td><td class="al-right num">#{fmt.call(pd['sonnet_usd'].to_f * n_dash)}</td></tr>
+            <tr><td>+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</td><td class="al-right num">#{fmt.call(pr['opus_usd'].to_f * n_rev)}</td><td class="al-right num">#{fmt.call(pr['sonnet_usd'].to_f * n_rev)}</td></tr>
+            <tr><td><strong>Total estimated</strong></td><td class="al-right num"><strong>#{fmt.call(opus_usd)}</strong></td><td class="al-right num"><strong>#{fmt.call(sonnet_usd)}</strong></td></tr>
+          </tbody>
+        </table>
+        <p class="note">Calibrated #{h(cal['date'])}, one-shot orchestrator path — LLM cost only; rescale $ by your coding agent's pricing. A naive agent-driven migration is ~12–20× more expensive.</p>
+      </section>
+    HTML
+  end
+end
+
 # ---------- HTML ----------
 html = <<~HTML
 <!DOCTYPE html>
@@ -770,11 +827,12 @@ if has_shortlist
   </section>
 
   HTML
+  html += effort_html
 end
 
 # Privacy + next steps
-priv_num = has_shortlist ? '07' : '06'
-next_num = has_shortlist ? '08' : '07'
+priv_num = has_shortlist ? '08' : '06'
+next_num = has_shortlist ? '09' : '07'
 
 html += <<~HTML
 <section class="section-tight">

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/token-model.json
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/token-model.json
@@ -1,0 +1,50 @@
+{
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Calibrated on the ONE-SHOT ORCHESTRATOR path (migrate-<tool>.rb): the agent runs ~1 command and the conversion is deterministic script work, so LLM cost is tiny and ~flat. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items, where n_review_items = items whose assessment found unsupported/needs-review features (n_unhandled > 0). Tokens are the portable unit; rescale $ by your model's price.",
+  "calibration": {
+    "date": "2026-06-07",
+    "path": "one-shot orchestrator (migrate-<tool>.rb, --yes / auto-accepted defaults)",
+    "models": ["opus", "sonnet"],
+    "rates_per_million_usd": {
+      "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
+      "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
+    },
+    "real_samples": {
+      "quicksight_D8": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders": { "opus_usd": 0.72, "sonnet_usd": 0.08 }
+    },
+    "for_reference_non_orchestrator": {
+      "naive_agent_path_standard_dashboard": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "optimized_brief_path": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "note": "The orchestrator path is ~12-20x cheaper than a naive agent-driven migration. These are shown so customers understand the savings of running via the orchestrator."
+    }
+  },
+  "per_dashboard": {
+    "mechanical": {
+      "tools": ["quicksight", "powerbi", "qlik", "thoughtspot"],
+      "opus_usd": 0.70,
+      "sonnet_usd": 0.11,
+      "tokens_output_plus_cache_creation": 25000,
+      "note": "Mechanical model converter → deterministic; cost is flat and tool-independent (measured on QuickSight + Qlik)."
+    },
+    "tableau": {
+      "opus_usd": 4.0,
+      "sonnet_usd": 1.0,
+      "tokens_output_plus_cache_creation": 250000,
+      "confidence": "estimate — NOT yet benchmarked on the orchestrator path",
+      "range_opus_usd": [2.0, 8.0],
+      "note": "Tableau has no mechanical converter; the data-model/workbook SPEC is agent-authored (pluggable Specs module), so cost is higher and scales with calc/LOD/custom-SQL complexity. Refine by benchmarking migrate-tableau.rb with a real Specs generator."
+    }
+  },
+  "per_review_item": {
+    "opus_usd": 0.50,
+    "sonnet_usd": 0.12,
+    "confidence": "estimate",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator's checkpoint. The --yes benchmarks auto-accepted defaults, so this increment is estimated, not directly measured."
+  },
+  "caveats": [
+    "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
+    "Assumes the ONE-SHOT ORCHESTRATOR path. A naive agent-driven migration is ~12-20x more expensive.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and not included here — this is LLM cost only.",
+    "Tableau number is an estimate pending an orchestrator-path benchmark with a Specs generator."
+  ]
+}

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout-html.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout-html.rb
@@ -463,6 +463,63 @@ if complexity
   HTML
 end
 
+# ---------- estimated migration effort (token model) ----------
+effort_html = ''
+token_model_path = File.join(__dir__, '..', 'refs', 'token-model.json')
+if has_shortlist && File.exist?(token_model_path)
+  tm = JSON.parse(File.read(token_model_path)) rescue nil
+  if tm
+    bucket  = 'mechanical'
+    n_dash  = shortlist.size
+    n_rev   = n_with_unhandled
+    pd      = (tm['per_dashboard'] || {})[bucket] || {}
+    pr      = tm['per_review_item'] || {}
+    cal     = tm['calibration'] || {}
+    est = lambda { |m| (pd["#{m}_usd"].to_f * n_dash) + (pr["#{m}_usd"].to_f * n_rev) }
+    opus_usd   = est.call('opus')
+    sonnet_usd = est.call('sonnet')
+    fmt = lambda { |v| '$' + format('%.2f', v) }
+    effort_html = <<~HTML
+      <section>
+        <div class="section-head">
+          <span class="section-num">07</span>
+          <h2 class="section-title">Estimated migration effort (tokens / $)</h2>
+          <span class="section-aside">one-shot orchestrator path</span>
+        </div>
+        <p class="section-lede">A planning estimate of the LLM cost to migrate the shortlisted analyses via the <code>quicksight-to-sigma</code> one-shot orchestrator. The mechanical model converter is deterministic, so per-dashboard cost is flat; each analysis flagged for review adds one human-decision round.</p>
+        <div class="stat-row">
+          <div class="stat stat-go">
+            <div class="stat-l">Estimated cost · Opus</div>
+            <div class="stat-v go">#{fmt.call(opus_usd)}</div>
+            <div class="stat-sub">#{n_dash} analyses + #{n_rev} review</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Estimated cost · Sonnet</div>
+            <div class="stat-v">#{fmt.call(sonnet_usd)}</div>
+            <div class="stat-sub">same scope, Sonnet pricing</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Basis</div>
+            <div class="stat-v" style="font-size:20px;">#{n_dash}<span style="font-size:14px;color:var(--mute);font-weight:600;"> × per-dashboard</span></div>
+            <div class="stat-sub">+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</div>
+          </div>
+        </div>
+        <table class="data">
+          <thead>
+            <tr><th>Component</th><th class="al-right">Opus</th><th class="al-right">Sonnet</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>#{n_dash} analyses × per-dashboard</td><td class="al-right num">#{fmt.call(pd['opus_usd'].to_f * n_dash)}</td><td class="al-right num">#{fmt.call(pd['sonnet_usd'].to_f * n_dash)}</td></tr>
+            <tr><td>+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</td><td class="al-right num">#{fmt.call(pr['opus_usd'].to_f * n_rev)}</td><td class="al-right num">#{fmt.call(pr['sonnet_usd'].to_f * n_rev)}</td></tr>
+            <tr><td><strong>Total estimated</strong></td><td class="al-right num"><strong>#{fmt.call(opus_usd)}</strong></td><td class="al-right num"><strong>#{fmt.call(sonnet_usd)}</strong></td></tr>
+          </tbody>
+        </table>
+        <p class="note">Calibrated #{h(cal['date'])}, one-shot orchestrator path — LLM cost only; rescale $ by your coding agent's pricing. A naive agent-driven migration is ~12–20× more expensive.</p>
+      </section>
+    HTML
+  end
+end
+
 # ---------- assemble HTML ----------
 html = <<~HTML
 <!DOCTYPE html>
@@ -878,10 +935,11 @@ if has_shortlist
   </section>
 
   HTML
+  html += effort_html
 end
 
-priv_num = has_shortlist ? '07' : '06'
-next_num = has_shortlist ? '08' : '07'
+priv_num = has_shortlist ? '08' : '06'
+next_num = has_shortlist ? '09' : '07'
 
 html += <<~HTML
 <section class="section-tight">

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/refs/token-model.json
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/refs/token-model.json
@@ -1,0 +1,50 @@
+{
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Calibrated on the ONE-SHOT ORCHESTRATOR path (migrate-<tool>.rb): the agent runs ~1 command and the conversion is deterministic script work, so LLM cost is tiny and ~flat. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items, where n_review_items = items whose assessment found unsupported/needs-review features (n_unhandled > 0). Tokens are the portable unit; rescale $ by your model's price.",
+  "calibration": {
+    "date": "2026-06-07",
+    "path": "one-shot orchestrator (migrate-<tool>.rb, --yes / auto-accepted defaults)",
+    "models": ["opus", "sonnet"],
+    "rates_per_million_usd": {
+      "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
+      "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
+    },
+    "real_samples": {
+      "quicksight_D8": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders": { "opus_usd": 0.72, "sonnet_usd": 0.08 }
+    },
+    "for_reference_non_orchestrator": {
+      "naive_agent_path_standard_dashboard": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "optimized_brief_path": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "note": "The orchestrator path is ~12-20x cheaper than a naive agent-driven migration. These are shown so customers understand the savings of running via the orchestrator."
+    }
+  },
+  "per_dashboard": {
+    "mechanical": {
+      "tools": ["quicksight", "powerbi", "qlik", "thoughtspot"],
+      "opus_usd": 0.70,
+      "sonnet_usd": 0.11,
+      "tokens_output_plus_cache_creation": 25000,
+      "note": "Mechanical model converter → deterministic; cost is flat and tool-independent (measured on QuickSight + Qlik)."
+    },
+    "tableau": {
+      "opus_usd": 4.0,
+      "sonnet_usd": 1.0,
+      "tokens_output_plus_cache_creation": 250000,
+      "confidence": "estimate — NOT yet benchmarked on the orchestrator path",
+      "range_opus_usd": [2.0, 8.0],
+      "note": "Tableau has no mechanical converter; the data-model/workbook SPEC is agent-authored (pluggable Specs module), so cost is higher and scales with calc/LOD/custom-SQL complexity. Refine by benchmarking migrate-tableau.rb with a real Specs generator."
+    }
+  },
+  "per_review_item": {
+    "opus_usd": 0.50,
+    "sonnet_usd": 0.12,
+    "confidence": "estimate",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator's checkpoint. The --yes benchmarks auto-accepted defaults, so this increment is estimated, not directly measured."
+  },
+  "caveats": [
+    "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
+    "Assumes the ONE-SHOT ORCHESTRATOR path. A naive agent-driven migration is ~12-20x more expensive.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and not included here — this is LLM cost only.",
+    "Tableau number is an estimate pending an orchestrator-path benchmark with a Specs generator."
+  ]
+}

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/render-readout-html.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/render-readout-html.rb
@@ -1293,8 +1293,66 @@ HTML
 
 next_sec += 1
 migration_num = format('%02d', next_sec)
-priv_num      = format('%02d', has_shortlist ? next_sec + 1 : next_sec)
-next_num      = format('%02d', has_shortlist ? next_sec + 2 : next_sec + 1)
+priv_num      = format('%02d', has_shortlist ? next_sec + 2 : next_sec)
+next_num      = format('%02d', has_shortlist ? next_sec + 3 : next_sec + 1)
+
+# ---------- estimated migration effort (token model) ----------
+effort_html = ''
+token_model_path = File.join(__dir__, '..', 'refs', 'token-model.json')
+if has_shortlist && File.exist?(token_model_path)
+  tm = JSON.parse(File.read(token_model_path)) rescue nil
+  if tm
+    bucket  = 'tableau'
+    n_dash  = shortlist.size
+    n_rev   = n_with_unhandled
+    pd      = (tm['per_dashboard'] || {})[bucket] || {}
+    pr      = tm['per_review_item'] || {}
+    cal     = tm['calibration'] || {}
+    est = lambda { |m| (pd["#{m}_usd"].to_f * n_dash) + (pr["#{m}_usd"].to_f * n_rev) }
+    opus_usd   = est.call('opus')
+    sonnet_usd = est.call('sonnet')
+    fmt = lambda { |v| '$' + format('%.2f', v) }
+    effort_num = format('%02d', next_sec + 1)
+    effort_html = <<~HTML
+      <section>
+        <div class="section-head">
+          <span class="section-num">#{effort_num}</span>
+          <h2 class="section-title">Estimated migration effort (tokens / $)</h2>
+          <span class="section-aside">one-shot orchestrator path</span>
+        </div>
+        <p class="section-lede">A planning estimate of the LLM cost to migrate the shortlisted workbooks via the <code>tableau-to-sigma</code> one-shot orchestrator. Tableau has no mechanical converter — the data-model and workbook specs are agent-authored — so per-workbook cost is higher and scales with calc / LOD / custom-SQL complexity. Each workbook flagged for review adds one human-decision round.</p>
+        <div class="stat-row">
+          <div class="stat stat-go">
+            <div class="stat-l">Estimated cost · Opus</div>
+            <div class="stat-v go">#{fmt.call(opus_usd)}</div>
+            <div class="stat-sub">#{n_dash} workbooks + #{n_rev} review</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Estimated cost · Sonnet</div>
+            <div class="stat-v">#{fmt.call(sonnet_usd)}</div>
+            <div class="stat-sub">same scope, Sonnet pricing</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Basis</div>
+            <div class="stat-v" style="font-size:20px;">#{n_dash}<span style="font-size:14px;color:var(--mute);font-weight:600;"> × per-dashboard</span></div>
+            <div class="stat-sub">+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</div>
+          </div>
+        </div>
+        <table class="data">
+          <thead>
+            <tr><th>Component</th><th class="al-right">Opus</th><th class="al-right">Sonnet</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>#{n_dash} workbooks × per-dashboard</td><td class="al-right num">#{fmt.call(pd['opus_usd'].to_f * n_dash)}</td><td class="al-right num">#{fmt.call(pd['sonnet_usd'].to_f * n_dash)}</td></tr>
+            <tr><td>+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</td><td class="al-right num">#{fmt.call(pr['opus_usd'].to_f * n_rev)}</td><td class="al-right num">#{fmt.call(pr['sonnet_usd'].to_f * n_rev)}</td></tr>
+            <tr><td><strong>Total estimated</strong></td><td class="al-right num"><strong>#{fmt.call(opus_usd)}</strong></td><td class="al-right num"><strong>#{fmt.call(sonnet_usd)}</strong></td></tr>
+          </tbody>
+        </table>
+        <p class="note">Calibrated #{h(cal['date'])}, one-shot orchestrator path — LLM cost only; rescale $ by your coding agent's pricing. A naive agent-driven migration is ~12–20× more expensive. The Tableau number is an estimate (specs are agent-authored, not yet benchmarked on the orchestrator path).</p>
+      </section>
+    HTML
+  end
+end
 
 if has_shortlist
   html += <<~HTML
@@ -1332,6 +1390,8 @@ if has_shortlist
 
   HTML
 end
+
+html += effort_html
 
 html += <<~HTML
 <section class="section-tight">

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/token-model.json
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/token-model.json
@@ -1,0 +1,50 @@
+{
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Calibrated on the ONE-SHOT ORCHESTRATOR path (migrate-<tool>.rb): the agent runs ~1 command and the conversion is deterministic script work, so LLM cost is tiny and ~flat. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items, where n_review_items = items whose assessment found unsupported/needs-review features (n_unhandled > 0). Tokens are the portable unit; rescale $ by your model's price.",
+  "calibration": {
+    "date": "2026-06-07",
+    "path": "one-shot orchestrator (migrate-<tool>.rb, --yes / auto-accepted defaults)",
+    "models": ["opus", "sonnet"],
+    "rates_per_million_usd": {
+      "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
+      "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
+    },
+    "real_samples": {
+      "quicksight_D8": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders": { "opus_usd": 0.72, "sonnet_usd": 0.08 }
+    },
+    "for_reference_non_orchestrator": {
+      "naive_agent_path_standard_dashboard": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "optimized_brief_path": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "note": "The orchestrator path is ~12-20x cheaper than a naive agent-driven migration. These are shown so customers understand the savings of running via the orchestrator."
+    }
+  },
+  "per_dashboard": {
+    "mechanical": {
+      "tools": ["quicksight", "powerbi", "qlik", "thoughtspot"],
+      "opus_usd": 0.70,
+      "sonnet_usd": 0.11,
+      "tokens_output_plus_cache_creation": 25000,
+      "note": "Mechanical model converter → deterministic; cost is flat and tool-independent (measured on QuickSight + Qlik)."
+    },
+    "tableau": {
+      "opus_usd": 4.0,
+      "sonnet_usd": 1.0,
+      "tokens_output_plus_cache_creation": 250000,
+      "confidence": "estimate — NOT yet benchmarked on the orchestrator path",
+      "range_opus_usd": [2.0, 8.0],
+      "note": "Tableau has no mechanical converter; the data-model/workbook SPEC is agent-authored (pluggable Specs module), so cost is higher and scales with calc/LOD/custom-SQL complexity. Refine by benchmarking migrate-tableau.rb with a real Specs generator."
+    }
+  },
+  "per_review_item": {
+    "opus_usd": 0.50,
+    "sonnet_usd": 0.12,
+    "confidence": "estimate",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator's checkpoint. The --yes benchmarks auto-accepted defaults, so this increment is estimated, not directly measured."
+  },
+  "caveats": [
+    "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
+    "Assumes the ONE-SHOT ORCHESTRATOR path. A naive agent-driven migration is ~12-20x more expensive.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and not included here — this is LLM cost only.",
+    "Tableau number is an estimate pending an orchestrator-path benchmark with a Specs generator."
+  ]
+}

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/render-readout-html.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/render-readout-html.rb
@@ -375,6 +375,64 @@ if models_used.any?
                      (models_used.size > 20 ? " + #{models_used.size - 20} more" : '') + '.</p>'
 end
 
+# ---------- estimated migration effort (token model) ----------
+effort_html = ''
+token_model_path = File.join(__dir__, '..', 'refs', 'token-model.json')
+if shortlist.any? && File.exist?(token_model_path)
+  tm = JSON.parse(File.read(token_model_path)) rescue nil
+  if tm
+    bucket  = 'mechanical'
+    n_dash  = shortlist.size
+    n_rev   = n_with_unsup
+    pd      = (tm['per_dashboard'] || {})[bucket] || {}
+    pr      = tm['per_review_item'] || {}
+    cal     = tm['calibration'] || {}
+    est = lambda { |m| (pd["#{m}_usd"].to_f * n_dash) + (pr["#{m}_usd"].to_f * n_rev) }
+    opus_usd   = est.call('opus')
+    sonnet_usd = est.call('sonnet')
+    fmt = lambda { |v| '$' + format('%.2f', v) }
+    effort_num = format('%02d', section_n + 1)
+    effort_html = <<~HTML
+      <section>
+        <div class="section-head">
+          <span class="section-num">#{effort_num}</span>
+          <h2 class="section-title">Estimated migration effort (tokens / $)</h2>
+          <span class="section-aside">one-shot orchestrator path</span>
+        </div>
+        <p class="section-lede">A planning estimate of the LLM cost to migrate the shortlisted Liveboards via the <code>thoughtspot-to-sigma</code> one-shot orchestrator. The mechanical model converter is deterministic, so per-Liveboard cost is flat; each Liveboard flagged for review adds one human-decision round.</p>
+        <div class="stat-row">
+          <div class="stat stat-go">
+            <div class="stat-l">Estimated cost · Opus</div>
+            <div class="stat-v go">#{fmt.call(opus_usd)}</div>
+            <div class="stat-sub">#{n_dash} Liveboards + #{n_rev} review</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Estimated cost · Sonnet</div>
+            <div class="stat-v">#{fmt.call(sonnet_usd)}</div>
+            <div class="stat-sub">same scope, Sonnet pricing</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Basis</div>
+            <div class="stat-v" style="font-size:20px;">#{n_dash}<span style="font-size:14px;color:var(--mute);font-weight:600;"> × per-dashboard</span></div>
+            <div class="stat-sub">+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</div>
+          </div>
+        </div>
+        <table class="data">
+          <thead>
+            <tr><th>Component</th><th class="al-right">Opus</th><th class="al-right">Sonnet</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>#{n_dash} Liveboards × per-dashboard</td><td class="al-right num">#{fmt.call(pd['opus_usd'].to_f * n_dash)}</td><td class="al-right num">#{fmt.call(pd['sonnet_usd'].to_f * n_dash)}</td></tr>
+            <tr><td>+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</td><td class="al-right num">#{fmt.call(pr['opus_usd'].to_f * n_rev)}</td><td class="al-right num">#{fmt.call(pr['sonnet_usd'].to_f * n_rev)}</td></tr>
+            <tr><td><strong>Total estimated</strong></td><td class="al-right num"><strong>#{fmt.call(opus_usd)}</strong></td><td class="al-right num"><strong>#{fmt.call(sonnet_usd)}</strong></td></tr>
+          </tbody>
+        </table>
+        <p class="note">Calibrated #{h(cal['date'])}, one-shot orchestrator path — LLM cost only; rescale $ by your coding agent's pricing. A naive agent-driven migration is ~12–20× more expensive.</p>
+      </section>
+    HTML
+  end
+end
+
 # ---------- assemble HTML ----------
 html = <<~HTML
 <!DOCTYPE html>
@@ -761,8 +819,8 @@ if activity_html != ''
 end
 
 mig_num  = format('%02d', section_n)
-priv_num = format('%02d', section_n + 1)
-next_num = format('%02d', section_n + 2)
+priv_num = format('%02d', section_n + 2)
+next_num = format('%02d', section_n + 3)
 
 # Section: Migration shortlist + complexity
 html += <<~HTML
@@ -799,6 +857,9 @@ html += <<~HTML
   #{sl_total_unsup.positive? ?
     %(<div class="callout"><strong>#{n_with_unsup} Liveboard#{n_with_unsup == 1 ? '' : 's'}</strong> use a chart type without a 1:1 Sigma mapping in the current pipeline (PIVOT_TABLE, WATERFALL, FUNNEL, SCATTER, BUBBLE, TREEMAP, GEO_AREA, LINE_STACKED_COLUMN). Sigma supports most of these natively — they just need element-builder mapping work, identified up-front so there are no surprises mid-migration.</div>) : ''}
 </section>
+HTML
+html += effort_html
+html += <<~HTML
 
 <section class="section-tight">
   <div class="section-head">


### PR DESCRIPTION
refs/token-model.json + an 'Estimated migration effort (tokens/$)' section in all 5 assessment readouts. Calibrated on the one-shot orchestrator path (QuickSight $0.69/$0.14 + Qlik $0.72/$0.08 → flat ~$0.70 Opus/$0.11 Sonnet per mechanical-converter dashboard; Tableau flagged higher/estimate). Opus+Sonnet totals, stamped + caveated. 🤖 Generated with [Claude Code](https://claude.com/claude-code)