### PR TITLE
token-model.json: measured Tableau (~$29) + per-review ($0.46) numbers

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/token-model.json
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/token-model.json
@@ -1,21 +1,23 @@
 {
-  "_doc": "Per-dashboard token/$ estimator for migration assessments. Calibrated on the ONE-SHOT ORCHESTRATOR path (migrate-<tool>.rb): the agent runs ~1 command and the conversion is deterministic script work, so LLM cost is tiny and ~flat. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items, where n_review_items = items whose assessment found unsupported/needs-review features (n_unhandled > 0). Tokens are the portable unit; rescale $ by your model's price.",
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items (n_review_items = items the assessment flags with unsupported/needs-review features, n_unhandled > 0). Tokens are the portable unit; rescale $ by your coding agent's model pricing. ALL numbers below are MEASURED from controlled end-to-end conversions (2026-06-07) unless noted.",
   "calibration": {
     "date": "2026-06-07",
-    "path": "one-shot orchestrator (migrate-<tool>.rb, --yes / auto-accepted defaults)",
     "models": ["opus", "sonnet"],
     "rates_per_million_usd": {
       "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
       "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
     },
     "real_samples": {
-      "quicksight_D8": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
-      "qlik_RetailOrders": { "opus_usd": 0.72, "sonnet_usd": 0.08 }
+      "quicksight_D8_orchestrator":  { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders_orchestrator": { "opus_usd": 0.72, "sonnet_usd": 0.08 },
+      "tableau_Superstore_full":     { "opus_usd": 29.35, "sonnet_usd": 6.55 },
+      "per_review_interactive_delta_opus": 0.46
     },
-    "for_reference_non_orchestrator": {
-      "naive_agent_path_standard_dashboard": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
-      "optimized_brief_path": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
-      "note": "The orchestrator path is ~12-20x cheaper than a naive agent-driven migration. These are shown so customers understand the savings of running via the orchestrator."
+    "for_reference_naive_vs_orchestrator": {
+      "quicksight_D8_naive": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "quicksight_D8_optimized_brief": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "quicksight_D8_orchestrator": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "note": "For tools WITH a mechanical converter, the one-shot orchestrator is ~12-20x cheaper than a naive agent-driven migration."
     }
   },
   "per_dashboard": {
@@ -24,27 +26,28 @@
       "opus_usd": 0.70,
       "sonnet_usd": 0.11,
       "tokens_output_plus_cache_creation": 25000,
-      "note": "Mechanical model converter → deterministic; cost is flat and tool-independent (measured on QuickSight + Qlik)."
+      "basis": "measured — one-shot orchestrator path (mechanical converter → deterministic; cost flat & tool-independent across QuickSight + Qlik)"
     },
     "tableau": {
-      "opus_usd": 4.0,
-      "sonnet_usd": 1.0,
-      "tokens_output_plus_cache_creation": 250000,
-      "confidence": "estimate — NOT yet benchmarked on the orchestrator path",
-      "range_opus_usd": [2.0, 8.0],
-      "note": "Tableau has no mechanical converter; the data-model/workbook SPEC is agent-authored (pluggable Specs module), so cost is higher and scales with calc/LOD/custom-SQL complexity. Refine by benchmarking migrate-tableau.rb with a real Specs generator."
+      "opus_usd": 29.0,
+      "sonnet_usd": 6.5,
+      "tokens_output_plus_cache_creation": 480000,
+      "range_opus_usd": [15.0, 45.0],
+      "basis": "measured — full agent-authored conversion (Superstore Overview: 7 KPIs + map + 2 area charts + controls)",
+      "note": "Tableau has NO mechanical converter, so the agent authors the entire DM+workbook spec from the .twb — ~40x the mechanical tools. The one-shot orchestrator does NOT reduce this (spec-authoring is the irreducible agent work, not the post-spec pipeline). Scales with dashboard richness + calc/LOD/custom-SQL complexity. The real lever to cut Tableau cost is building a mechanical Tableau->Sigma converter."
     }
   },
   "per_review_item": {
-    "opus_usd": 0.50,
-    "sonnet_usd": 0.12,
-    "confidence": "estimate",
-    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator's checkpoint. The --yes benchmarks auto-accepted defaults, so this increment is estimated, not directly measured."
+    "opus_usd": 0.46,
+    "sonnet_usd": 0.08,
+    "basis": "measured — interactive decision-checkpoint delta vs the --yes floor (QuickSight D8; one OPEN QUESTIONS round). Negligible at Sonnet pricing.",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator checkpoint. Does not apply to the mechanical floor when run with auto-accepted defaults."
   },
   "caveats": [
     "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
-    "Assumes the ONE-SHOT ORCHESTRATOR path. A naive agent-driven migration is ~12-20x more expensive.",
-    "Warehouse/compute cost (Sigma + Snowflake query) is separate and not included here — this is LLM cost only.",
-    "Tableau number is an estimate pending an orchestrator-path benchmark with a Specs generator."
+    "Mechanical-converter tools (QuickSight/PowerBI/Qlik/ThoughtSpot) assume the one-shot orchestrator path; a naive agent-driven migration is ~12-20x more expensive.",
+    "Tableau is the outlier (~40x) because its spec is agent-authored; its number is a full-conversion measurement, not an orchestrator floor.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and NOT included — this is LLM cost only.",
+    "Tableau is one measured sample (a rich standard dashboard); expect variance with dashboard complexity (range shown)."
   ]
 }

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/refs/token-model.json
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/refs/token-model.json
@@ -1,21 +1,23 @@
 {
-  "_doc": "Per-dashboard token/$ estimator for migration assessments. Calibrated on the ONE-SHOT ORCHESTRATOR path (migrate-<tool>.rb): the agent runs ~1 command and the conversion is deterministic script work, so LLM cost is tiny and ~flat. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items, where n_review_items = items whose assessment found unsupported/needs-review features (n_unhandled > 0). Tokens are the portable unit; rescale $ by your model's price.",
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items (n_review_items = items the assessment flags with unsupported/needs-review features, n_unhandled > 0). Tokens are the portable unit; rescale $ by your coding agent's model pricing. ALL numbers below are MEASURED from controlled end-to-end conversions (2026-06-07) unless noted.",
   "calibration": {
     "date": "2026-06-07",
-    "path": "one-shot orchestrator (migrate-<tool>.rb, --yes / auto-accepted defaults)",
     "models": ["opus", "sonnet"],
     "rates_per_million_usd": {
       "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
       "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
     },
     "real_samples": {
-      "quicksight_D8": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
-      "qlik_RetailOrders": { "opus_usd": 0.72, "sonnet_usd": 0.08 }
+      "quicksight_D8_orchestrator":  { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders_orchestrator": { "opus_usd": 0.72, "sonnet_usd": 0.08 },
+      "tableau_Superstore_full":     { "opus_usd": 29.35, "sonnet_usd": 6.55 },
+      "per_review_interactive_delta_opus": 0.46
     },
-    "for_reference_non_orchestrator": {
-      "naive_agent_path_standard_dashboard": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
-      "optimized_brief_path": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
-      "note": "The orchestrator path is ~12-20x cheaper than a naive agent-driven migration. These are shown so customers understand the savings of running via the orchestrator."
+    "for_reference_naive_vs_orchestrator": {
+      "quicksight_D8_naive": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "quicksight_D8_optimized_brief": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "quicksight_D8_orchestrator": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "note": "For tools WITH a mechanical converter, the one-shot orchestrator is ~12-20x cheaper than a naive agent-driven migration."
     }
   },
   "per_dashboard": {
@@ -24,27 +26,28 @@
       "opus_usd": 0.70,
       "sonnet_usd": 0.11,
       "tokens_output_plus_cache_creation": 25000,
-      "note": "Mechanical model converter → deterministic; cost is flat and tool-independent (measured on QuickSight + Qlik)."
+      "basis": "measured — one-shot orchestrator path (mechanical converter → deterministic; cost flat & tool-independent across QuickSight + Qlik)"
     },
     "tableau": {
-      "opus_usd": 4.0,
-      "sonnet_usd": 1.0,
-      "tokens_output_plus_cache_creation": 250000,
-      "confidence": "estimate — NOT yet benchmarked on the orchestrator path",
-      "range_opus_usd": [2.0, 8.0],
-      "note": "Tableau has no mechanical converter; the data-model/workbook SPEC is agent-authored (pluggable Specs module), so cost is higher and scales with calc/LOD/custom-SQL complexity. Refine by benchmarking migrate-tableau.rb with a real Specs generator."
+      "opus_usd": 29.0,
+      "sonnet_usd": 6.5,
+      "tokens_output_plus_cache_creation": 480000,
+      "range_opus_usd": [15.0, 45.0],
+      "basis": "measured — full agent-authored conversion (Superstore Overview: 7 KPIs + map + 2 area charts + controls)",
+      "note": "Tableau has NO mechanical converter, so the agent authors the entire DM+workbook spec from the .twb — ~40x the mechanical tools. The one-shot orchestrator does NOT reduce this (spec-authoring is the irreducible agent work, not the post-spec pipeline). Scales with dashboard richness + calc/LOD/custom-SQL complexity. The real lever to cut Tableau cost is building a mechanical Tableau->Sigma converter."
     }
   },
   "per_review_item": {
-    "opus_usd": 0.50,
-    "sonnet_usd": 0.12,
-    "confidence": "estimate",
-    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator's checkpoint. The --yes benchmarks auto-accepted defaults, so this increment is estimated, not directly measured."
+    "opus_usd": 0.46,
+    "sonnet_usd": 0.08,
+    "basis": "measured — interactive decision-checkpoint delta vs the --yes floor (QuickSight D8; one OPEN QUESTIONS round). Negligible at Sonnet pricing.",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator checkpoint. Does not apply to the mechanical floor when run with auto-accepted defaults."
   },
   "caveats": [
     "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
-    "Assumes the ONE-SHOT ORCHESTRATOR path. A naive agent-driven migration is ~12-20x more expensive.",
-    "Warehouse/compute cost (Sigma + Snowflake query) is separate and not included here — this is LLM cost only.",
-    "Tableau number is an estimate pending an orchestrator-path benchmark with a Specs generator."
+    "Mechanical-converter tools (QuickSight/PowerBI/Qlik/ThoughtSpot) assume the one-shot orchestrator path; a naive agent-driven migration is ~12-20x more expensive.",
+    "Tableau is the outlier (~40x) because its spec is agent-authored; its number is a full-conversion measurement, not an orchestrator floor.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and NOT included — this is LLM cost only.",
+    "Tableau is one measured sample (a rich standard dashboard); expect variance with dashboard complexity (range shown)."
   ]
 }

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/token-model.json
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/token-model.json
@@ -1,21 +1,23 @@
 {
-  "_doc": "Per-dashboard token/$ estimator for migration assessments. Calibrated on the ONE-SHOT ORCHESTRATOR path (migrate-<tool>.rb): the agent runs ~1 command and the conversion is deterministic script work, so LLM cost is tiny and ~flat. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items, where n_review_items = items whose assessment found unsupported/needs-review features (n_unhandled > 0). Tokens are the portable unit; rescale $ by your model's price.",
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items (n_review_items = items the assessment flags with unsupported/needs-review features, n_unhandled > 0). Tokens are the portable unit; rescale $ by your coding agent's model pricing. ALL numbers below are MEASURED from controlled end-to-end conversions (2026-06-07) unless noted.",
   "calibration": {
     "date": "2026-06-07",
-    "path": "one-shot orchestrator (migrate-<tool>.rb, --yes / auto-accepted defaults)",
     "models": ["opus", "sonnet"],
     "rates_per_million_usd": {
       "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
       "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
     },
     "real_samples": {
-      "quicksight_D8": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
-      "qlik_RetailOrders": { "opus_usd": 0.72, "sonnet_usd": 0.08 }
+      "quicksight_D8_orchestrator":  { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders_orchestrator": { "opus_usd": 0.72, "sonnet_usd": 0.08 },
+      "tableau_Superstore_full":     { "opus_usd": 29.35, "sonnet_usd": 6.55 },
+      "per_review_interactive_delta_opus": 0.46
     },
-    "for_reference_non_orchestrator": {
-      "naive_agent_path_standard_dashboard": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
-      "optimized_brief_path": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
-      "note": "The orchestrator path is ~12-20x cheaper than a naive agent-driven migration. These are shown so customers understand the savings of running via the orchestrator."
+    "for_reference_naive_vs_orchestrator": {
+      "quicksight_D8_naive": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "quicksight_D8_optimized_brief": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "quicksight_D8_orchestrator": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "note": "For tools WITH a mechanical converter, the one-shot orchestrator is ~12-20x cheaper than a naive agent-driven migration."
     }
   },
   "per_dashboard": {
@@ -24,27 +26,28 @@
       "opus_usd": 0.70,
       "sonnet_usd": 0.11,
       "tokens_output_plus_cache_creation": 25000,
-      "note": "Mechanical model converter → deterministic; cost is flat and tool-independent (measured on QuickSight + Qlik)."
+      "basis": "measured — one-shot orchestrator path (mechanical converter → deterministic; cost flat & tool-independent across QuickSight + Qlik)"
     },
     "tableau": {
-      "opus_usd": 4.0,
-      "sonnet_usd": 1.0,
-      "tokens_output_plus_cache_creation": 250000,
-      "confidence": "estimate — NOT yet benchmarked on the orchestrator path",
-      "range_opus_usd": [2.0, 8.0],
-      "note": "Tableau has no mechanical converter; the data-model/workbook SPEC is agent-authored (pluggable Specs module), so cost is higher and scales with calc/LOD/custom-SQL complexity. Refine by benchmarking migrate-tableau.rb with a real Specs generator."
+      "opus_usd": 29.0,
+      "sonnet_usd": 6.5,
+      "tokens_output_plus_cache_creation": 480000,
+      "range_opus_usd": [15.0, 45.0],
+      "basis": "measured — full agent-authored conversion (Superstore Overview: 7 KPIs + map + 2 area charts + controls)",
+      "note": "Tableau has NO mechanical converter, so the agent authors the entire DM+workbook spec from the .twb — ~40x the mechanical tools. The one-shot orchestrator does NOT reduce this (spec-authoring is the irreducible agent work, not the post-spec pipeline). Scales with dashboard richness + calc/LOD/custom-SQL complexity. The real lever to cut Tableau cost is building a mechanical Tableau->Sigma converter."
     }
   },
   "per_review_item": {
-    "opus_usd": 0.50,
-    "sonnet_usd": 0.12,
-    "confidence": "estimate",
-    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator's checkpoint. The --yes benchmarks auto-accepted defaults, so this increment is estimated, not directly measured."
+    "opus_usd": 0.46,
+    "sonnet_usd": 0.08,
+    "basis": "measured — interactive decision-checkpoint delta vs the --yes floor (QuickSight D8; one OPEN QUESTIONS round). Negligible at Sonnet pricing.",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator checkpoint. Does not apply to the mechanical floor when run with auto-accepted defaults."
   },
   "caveats": [
     "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
-    "Assumes the ONE-SHOT ORCHESTRATOR path. A naive agent-driven migration is ~12-20x more expensive.",
-    "Warehouse/compute cost (Sigma + Snowflake query) is separate and not included here — this is LLM cost only.",
-    "Tableau number is an estimate pending an orchestrator-path benchmark with a Specs generator."
+    "Mechanical-converter tools (QuickSight/PowerBI/Qlik/ThoughtSpot) assume the one-shot orchestrator path; a naive agent-driven migration is ~12-20x more expensive.",
+    "Tableau is the outlier (~40x) because its spec is agent-authored; its number is a full-conversion measurement, not an orchestrator floor.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and NOT included — this is LLM cost only.",
+    "Tableau is one measured sample (a rich standard dashboard); expect variance with dashboard complexity (range shown)."
   ]
 }

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/refs/token-model.json
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/refs/token-model.json
@@ -1,21 +1,23 @@
 {
-  "_doc": "Per-dashboard token/$ estimator for migration assessments. Calibrated on the ONE-SHOT ORCHESTRATOR path (migrate-<tool>.rb): the agent runs ~1 command and the conversion is deterministic script work, so LLM cost is tiny and ~flat. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items, where n_review_items = items whose assessment found unsupported/needs-review features (n_unhandled > 0). Tokens are the portable unit; rescale $ by your model's price.",
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items (n_review_items = items the assessment flags with unsupported/needs-review features, n_unhandled > 0). Tokens are the portable unit; rescale $ by your coding agent's model pricing. ALL numbers below are MEASURED from controlled end-to-end conversions (2026-06-07) unless noted.",
   "calibration": {
     "date": "2026-06-07",
-    "path": "one-shot orchestrator (migrate-<tool>.rb, --yes / auto-accepted defaults)",
     "models": ["opus", "sonnet"],
     "rates_per_million_usd": {
       "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
       "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
     },
     "real_samples": {
-      "quicksight_D8": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
-      "qlik_RetailOrders": { "opus_usd": 0.72, "sonnet_usd": 0.08 }
+      "quicksight_D8_orchestrator":  { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders_orchestrator": { "opus_usd": 0.72, "sonnet_usd": 0.08 },
+      "tableau_Superstore_full":     { "opus_usd": 29.35, "sonnet_usd": 6.55 },
+      "per_review_interactive_delta_opus": 0.46
     },
-    "for_reference_non_orchestrator": {
-      "naive_agent_path_standard_dashboard": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
-      "optimized_brief_path": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
-      "note": "The orchestrator path is ~12-20x cheaper than a naive agent-driven migration. These are shown so customers understand the savings of running via the orchestrator."
+    "for_reference_naive_vs_orchestrator": {
+      "quicksight_D8_naive": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "quicksight_D8_optimized_brief": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "quicksight_D8_orchestrator": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "note": "For tools WITH a mechanical converter, the one-shot orchestrator is ~12-20x cheaper than a naive agent-driven migration."
     }
   },
   "per_dashboard": {
@@ -24,27 +26,28 @@
       "opus_usd": 0.70,
       "sonnet_usd": 0.11,
       "tokens_output_plus_cache_creation": 25000,
-      "note": "Mechanical model converter → deterministic; cost is flat and tool-independent (measured on QuickSight + Qlik)."
+      "basis": "measured — one-shot orchestrator path (mechanical converter → deterministic; cost flat & tool-independent across QuickSight + Qlik)"
     },
     "tableau": {
-      "opus_usd": 4.0,
-      "sonnet_usd": 1.0,
-      "tokens_output_plus_cache_creation": 250000,
-      "confidence": "estimate — NOT yet benchmarked on the orchestrator path",
-      "range_opus_usd": [2.0, 8.0],
-      "note": "Tableau has no mechanical converter; the data-model/workbook SPEC is agent-authored (pluggable Specs module), so cost is higher and scales with calc/LOD/custom-SQL complexity. Refine by benchmarking migrate-tableau.rb with a real Specs generator."
+      "opus_usd": 29.0,
+      "sonnet_usd": 6.5,
+      "tokens_output_plus_cache_creation": 480000,
+      "range_opus_usd": [15.0, 45.0],
+      "basis": "measured — full agent-authored conversion (Superstore Overview: 7 KPIs + map + 2 area charts + controls)",
+      "note": "Tableau has NO mechanical converter, so the agent authors the entire DM+workbook spec from the .twb — ~40x the mechanical tools. The one-shot orchestrator does NOT reduce this (spec-authoring is the irreducible agent work, not the post-spec pipeline). Scales with dashboard richness + calc/LOD/custom-SQL complexity. The real lever to cut Tableau cost is building a mechanical Tableau->Sigma converter."
     }
   },
   "per_review_item": {
-    "opus_usd": 0.50,
-    "sonnet_usd": 0.12,
-    "confidence": "estimate",
-    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator's checkpoint. The --yes benchmarks auto-accepted defaults, so this increment is estimated, not directly measured."
+    "opus_usd": 0.46,
+    "sonnet_usd": 0.08,
+    "basis": "measured — interactive decision-checkpoint delta vs the --yes floor (QuickSight D8; one OPEN QUESTIONS round). Negligible at Sonnet pricing.",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator checkpoint. Does not apply to the mechanical floor when run with auto-accepted defaults."
   },
   "caveats": [
     "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
-    "Assumes the ONE-SHOT ORCHESTRATOR path. A naive agent-driven migration is ~12-20x more expensive.",
-    "Warehouse/compute cost (Sigma + Snowflake query) is separate and not included here — this is LLM cost only.",
-    "Tableau number is an estimate pending an orchestrator-path benchmark with a Specs generator."
+    "Mechanical-converter tools (QuickSight/PowerBI/Qlik/ThoughtSpot) assume the one-shot orchestrator path; a naive agent-driven migration is ~12-20x more expensive.",
+    "Tableau is the outlier (~40x) because its spec is agent-authored; its number is a full-conversion measurement, not an orchestrator floor.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and NOT included — this is LLM cost only.",
+    "Tableau is one measured sample (a rich standard dashboard); expect variance with dashboard complexity (range shown)."
   ]
 }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/token-model.json
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/token-model.json
@@ -1,21 +1,23 @@
 {
-  "_doc": "Per-dashboard token/$ estimator for migration assessments. Calibrated on the ONE-SHOT ORCHESTRATOR path (migrate-<tool>.rb): the agent runs ~1 command and the conversion is deterministic script work, so LLM cost is tiny and ~flat. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items, where n_review_items = items whose assessment found unsupported/needs-review features (n_unhandled > 0). Tokens are the portable unit; rescale $ by your model's price.",
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items (n_review_items = items the assessment flags with unsupported/needs-review features, n_unhandled > 0). Tokens are the portable unit; rescale $ by your coding agent's model pricing. ALL numbers below are MEASURED from controlled end-to-end conversions (2026-06-07) unless noted.",
   "calibration": {
     "date": "2026-06-07",
-    "path": "one-shot orchestrator (migrate-<tool>.rb, --yes / auto-accepted defaults)",
     "models": ["opus", "sonnet"],
     "rates_per_million_usd": {
       "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
       "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
     },
     "real_samples": {
-      "quicksight_D8": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
-      "qlik_RetailOrders": { "opus_usd": 0.72, "sonnet_usd": 0.08 }
+      "quicksight_D8_orchestrator":  { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders_orchestrator": { "opus_usd": 0.72, "sonnet_usd": 0.08 },
+      "tableau_Superstore_full":     { "opus_usd": 29.35, "sonnet_usd": 6.55 },
+      "per_review_interactive_delta_opus": 0.46
     },
-    "for_reference_non_orchestrator": {
-      "naive_agent_path_standard_dashboard": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
-      "optimized_brief_path": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
-      "note": "The orchestrator path is ~12-20x cheaper than a naive agent-driven migration. These are shown so customers understand the savings of running via the orchestrator."
+    "for_reference_naive_vs_orchestrator": {
+      "quicksight_D8_naive": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "quicksight_D8_optimized_brief": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "quicksight_D8_orchestrator": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "note": "For tools WITH a mechanical converter, the one-shot orchestrator is ~12-20x cheaper than a naive agent-driven migration."
     }
   },
   "per_dashboard": {
@@ -24,27 +26,28 @@
       "opus_usd": 0.70,
       "sonnet_usd": 0.11,
       "tokens_output_plus_cache_creation": 25000,
-      "note": "Mechanical model converter → deterministic; cost is flat and tool-independent (measured on QuickSight + Qlik)."
+      "basis": "measured — one-shot orchestrator path (mechanical converter → deterministic; cost flat & tool-independent across QuickSight + Qlik)"
     },
     "tableau": {
-      "opus_usd": 4.0,
-      "sonnet_usd": 1.0,
-      "tokens_output_plus_cache_creation": 250000,
-      "confidence": "estimate — NOT yet benchmarked on the orchestrator path",
-      "range_opus_usd": [2.0, 8.0],
-      "note": "Tableau has no mechanical converter; the data-model/workbook SPEC is agent-authored (pluggable Specs module), so cost is higher and scales with calc/LOD/custom-SQL complexity. Refine by benchmarking migrate-tableau.rb with a real Specs generator."
+      "opus_usd": 29.0,
+      "sonnet_usd": 6.5,
+      "tokens_output_plus_cache_creation": 480000,
+      "range_opus_usd": [15.0, 45.0],
+      "basis": "measured — full agent-authored conversion (Superstore Overview: 7 KPIs + map + 2 area charts + controls)",
+      "note": "Tableau has NO mechanical converter, so the agent authors the entire DM+workbook spec from the .twb — ~40x the mechanical tools. The one-shot orchestrator does NOT reduce this (spec-authoring is the irreducible agent work, not the post-spec pipeline). Scales with dashboard richness + calc/LOD/custom-SQL complexity. The real lever to cut Tableau cost is building a mechanical Tableau->Sigma converter."
     }
   },
   "per_review_item": {
-    "opus_usd": 0.50,
-    "sonnet_usd": 0.12,
-    "confidence": "estimate",
-    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator's checkpoint. The --yes benchmarks auto-accepted defaults, so this increment is estimated, not directly measured."
+    "opus_usd": 0.46,
+    "sonnet_usd": 0.08,
+    "basis": "measured — interactive decision-checkpoint delta vs the --yes floor (QuickSight D8; one OPEN QUESTIONS round). Negligible at Sonnet pricing.",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator checkpoint. Does not apply to the mechanical floor when run with auto-accepted defaults."
   },
   "caveats": [
     "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
-    "Assumes the ONE-SHOT ORCHESTRATOR path. A naive agent-driven migration is ~12-20x more expensive.",
-    "Warehouse/compute cost (Sigma + Snowflake query) is separate and not included here — this is LLM cost only.",
-    "Tableau number is an estimate pending an orchestrator-path benchmark with a Specs generator."
+    "Mechanical-converter tools (QuickSight/PowerBI/Qlik/ThoughtSpot) assume the one-shot orchestrator path; a naive agent-driven migration is ~12-20x more expensive.",
+    "Tableau is the outlier (~40x) because its spec is agent-authored; its number is a full-conversion measurement, not an orchestrator floor.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and NOT included — this is LLM cost only.",
+    "Tableau is one measured sample (a rich standard dashboard); expect variance with dashboard complexity (range shown)."
   ]
 }


### PR DESCRIPTION
Replaces the estimated Tableau ($4→measured ~$29 Opus / $6.5 Sonnet, full agent-authored conversion, ~40x mechanical) and per-review ($0.50→measured $0.46/$0.08) values with real benchmark data. All buckets now measured. 🤖 Generated with [Claude Code](https://claude.com/claude-code)