### PR TITLE
converters: robustness sweep — orchestrators + one-shot Tableau spec-gen + bug fixes

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -75,8 +75,30 @@ SIGMA_KIND = {
 }.freeze
 
 # PBI role -> (dim_role?, value_role?) per visual kind handled below.
-def field_spec(queryref, fields)
-  fields[queryref] || { 'master' => nil, 'ref' => "[#{queryref}]", 'agg' => nil }
+# A field_map entry may carry `alts` — alternative {master, ref[, agg]} resolutions
+# on OTHER masters (used for time-intel: a field can live on both the View and a
+# grouped prior-year element). When the visual has chosen a master, prefer the
+# alt that lives on it so all of the visual's columns resolve on one element.
+def field_spec(queryref, fields, chosen_master = nil)
+  fs = fields[queryref]
+  # Case-insensitive fallback: PBIR queryRefs may carry the RAW warehouse column
+  # name ("EMPLOYEES.DEPARTMENT") while the master-map keys on the Sigma display
+  # name ("EMPLOYEES.Department"). Match ignoring case so the dimension resolves
+  # instead of leaking a literal [EMPLOYEES.DEPARTMENT] ref that error-types.
+  if fs.nil? && queryref
+    # Normalize case AND underscore/space so a raw warehouse queryRef
+    # ("ABSENCE_RECORDS.ABSENCE_TYPE") matches a display-name key
+    # ("ABSENCE_RECORDS.Absence Type").
+    norm = ->(s) { s.to_s.downcase.gsub(/[_\s]+/, ' ').strip }
+    @ci_index ||= fields.each_with_object({}) { |(k, v), h| h[norm.call(k)] ||= v }
+    fs = @ci_index[norm.call(queryref)]
+  end
+  fs ||= { 'master' => nil, 'ref' => "[#{queryref}]", 'agg' => nil }
+  if chosen_master && fs['master'] != chosen_master && fs['alts'].is_a?(Array)
+    alt = fs['alts'].find { |a| a['master'] == chosen_master }
+    return fs.merge(alt) if alt
+  end
+  fs
 end
 
 # PBI numeric format string (from signals 'formats' or master-map field 'format')
@@ -141,15 +163,30 @@ def short(id)
   "#{clean[-6, 6] || clean}#{h}"
 end
 
-# Resolve which master a visual sources from (first bound field's master).
+# Resolve which master a visual sources from. A Sigma chart can only reference
+# columns on ONE element, so pick the master that can satisfy the MOST of the
+# visual's bound fields (counting `alts` — a field reachable on multiple masters).
+# This makes a Year×NetRev×NetRevPY chart source from the grouped prior-year
+# element (which carries all three) instead of the View (missing the PY column).
+# Ties break toward the FIRST field's master (preserves prior behavior).
 def visual_master(rec, fields)
-  rec['bindings'].each_value do |refs|
-    refs.each do |qr|
-      m = (fields[qr] || {})['master']
-      return m if m
-    end
+  qrs = rec['bindings'].values.flatten.compact
+  return nil if qrs.empty?
+  # candidate masters a field can resolve on (primary + alts). Use field_spec so
+  # the case-insensitive fallback applies here too.
+  masters_for = lambda do |qr|
+    fs = field_spec(qr, fields)
+    ms = []
+    ms << fs['master'] if fs['master']
+    Array(fs['alts']).each { |a| ms << a['master'] if a['master'] }
+    ms.uniq
   end
-  nil
+  counts = Hash.new(0)
+  qrs.each { |qr| masters_for.call(qr).each { |m| counts[m] += 1 } }
+  return nil if counts.empty?
+  first_master = qrs.map { |qr| field_spec(qr, fields)['master'] }.compact.first
+  best = counts.max_by { |m, c| [c, (m == first_master ? 1 : 0)] }
+  best && best[0]
 end
 
 # Build chart element from a normalized visual record.
@@ -206,7 +243,7 @@ def build_element(rec, fields, masters)
     vals = (b['Values'] || b['Y'] || [])
     if vals.length > 1
       return vals.each_with_index.map do |qr, i|
-        fs = field_spec(qr, fields)
+        fs = field_spec(qr, fields, master)
         kid = "#{eid}-k#{i}"
         col = { 'id' => "#{kid}-v", 'formula' => measure_formula(fs), 'name' => qr.split('.').last }
         apply_fmt(col, qr, fields, vfmts)
@@ -217,7 +254,7 @@ def build_element(rec, fields, masters)
       end
     end
     qr = vals.first
-    fs = field_spec(qr, fields)
+    fs = field_spec(qr, fields, master)
     cid = "#{eid}-v"
     col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => (qr || 'Value').split('.').last }
     apply_fmt(col, qr, fields, vfmts)
@@ -232,12 +269,12 @@ def build_element(rec, fields, masters)
     dim = (b['Category'] || b['Axis'] || b['X'] || b['Group'] || []).first
     meas = (b['Y'] || b['Values'] || [])
     series = (b['Series'] || b['Legend'] || []).first
-    dfs = field_spec(dim, fields)
+    dfs = field_spec(dim, fields, master)
     dcid = "#{eid}-x"
     cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => (dim || 'Dim').split('.').last }
     ycids = []
     meas.each_with_index do |qr, i|
-      fs = field_spec(qr, fields)
+      fs = field_spec(qr, fields, master)
       cid = "#{eid}-y#{i}"
       col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr.split('.').last }
       apply_fmt(col, qr, fields, vfmts)
@@ -261,7 +298,7 @@ def build_element(rec, fields, masters)
     # Series/Legend role. Never auto-color a line by a dimension that PBI did
     # not legend (see refs/measure-patterns.md §1 + §4).
     if series
-      sfs = field_spec(series, fields)
+      sfs = field_spec(series, fields, master)
       scid = "#{eid}-c"
       cols << { 'id' => scid, 'formula' => sfs['ref'], 'name' => series.split('.').last }
       el['color'] = { 'by' => 'category', 'column' => scid }
@@ -275,12 +312,12 @@ def build_element(rec, fields, masters)
     dim = (b['Category'] || b['Axis'] || b['X'] || []).first
     col_meas  = (b['Y'] || b['Values'] || [])
     line_meas = (b['Y2'] || [])
-    dfs = field_spec(dim, fields)
+    dfs = field_spec(dim, fields, master)
     dcid = "#{eid}-x"
     cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => (dim || 'Dim').split('.').last }
     ycids = []
     col_meas.each_with_index do |qr, i|
-      fs = field_spec(qr, fields)
+      fs = field_spec(qr, fields, master)
       cid = "#{eid}-y#{i}"
       col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr.split('.').last }
       apply_fmt(col, qr, fields, vfmts)
@@ -288,7 +325,7 @@ def build_element(rec, fields, masters)
       ycids << cid                                   # bare string -> primary (left) bars
     end
     line_meas.each_with_index do |qr, i|
-      fs = field_spec(qr, fields)
+      fs = field_spec(qr, fields, master)
       cid = "#{eid}-l#{i}"
       col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr.split('.').last }
       apply_fmt(col, qr, fields, vfmts)
@@ -303,7 +340,7 @@ def build_element(rec, fields, masters)
     xqr = (b['X'] || b['Values'] || []).first
     yqr = (b['Y'] || []).first
     detail = (b['Category'] || b['Details'] || b['Legend'] || []).first
-    xfs = field_spec(xqr, fields); yfs = field_spec(yqr, fields)
+    xfs = field_spec(xqr, fields, master); yfs = field_spec(yqr, fields, master)
     xcid = "#{eid}-x"; ycid = "#{eid}-y"
     cx = { 'id' => xcid, 'formula' => measure_formula(xfs), 'name' => (xqr || 'X').split('.').last }
     cy = { 'id' => ycid, 'formula' => measure_formula(yfs), 'name' => (yqr || 'Y').split('.').last }
@@ -312,7 +349,7 @@ def build_element(rec, fields, masters)
     el['xAxis'] = { 'columnId' => xcid }
     el['yAxis'] = { 'columnIds' => [ycid] }
     if detail
-      dfs = field_spec(detail, fields)
+      dfs = field_spec(detail, fields, master)
       dcid = "#{eid}-d"
       cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => detail.split('.').last }
       el['color'] = { 'by' => 'category', 'column' => dcid }
@@ -320,7 +357,7 @@ def build_element(rec, fields, masters)
   when 'pie-chart', 'donut-chart'
     dim = (b['Category'] || b['Legend'] || []).first
     val = (b['Values'] || b['Y'] || []).first
-    dfs = field_spec(dim, fields); vfs = field_spec(val, fields)
+    dfs = field_spec(dim, fields, master); vfs = field_spec(val, fields, master)
     dcid = "#{eid}-c"; vcid = "#{eid}-v"
     cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => (dim || 'Dim').split('.').last }
     cv = { 'id' => vcid, 'formula' => measure_formula(vfs), 'name' => (val || 'Value').split('.').last }
@@ -335,7 +372,7 @@ def build_element(rec, fields, masters)
     # aggregated column id goes into that grouping's calculations[].
     group_id = nil; calc_ids = []
     (b['Values'] || []).each_with_index do |qr, i|
-      fs = field_spec(qr, fields)
+      fs = field_spec(qr, fields, master)
       cid = "#{eid}-c#{i}"
       is_dim = fs['agg'].to_s.empty?
       col = { 'id' => cid, 'formula' => is_dim ? fs['ref'] : measure_formula(fs),
@@ -357,19 +394,19 @@ def build_element(rec, fields, masters)
     vals = (b['Values'] || [])
     rowids = []
     rows.each_with_index do |qr, i|
-      fs = field_spec(qr, fields); cid = "#{eid}-r#{i}"
+      fs = field_spec(qr, fields, master); cid = "#{eid}-r#{i}"
       cols << { 'id' => cid, 'formula' => fs['ref'], 'name' => qr.split('.').last }
       rowids << cid
     end
     colids = []
     colsby.each_with_index do |qr, i|
-      fs = field_spec(qr, fields); cid = "#{eid}-col#{i}"
+      fs = field_spec(qr, fields, master); cid = "#{eid}-col#{i}"
       cols << { 'id' => cid, 'formula' => fs['ref'], 'name' => qr.split('.').last }
       colids << cid
     end
     valids = []
     vals.each_with_index do |qr, i|
-      fs = field_spec(qr, fields); cid = "#{eid}-v#{i}"
+      fs = field_spec(qr, fields, master); cid = "#{eid}-v#{i}"
       col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr.split('.').last }
       apply_fmt(col, qr, fields, vfmts)
       cols << col

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_functions.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_functions.rb
@@ -11,6 +11,8 @@
 #   - move the logic into a Custom SQL data-model element (kind: "sql") and
 #     reference its columns as plain `[Custom SQL/COL]` refs
 
+require 'set'
+
 module SigmaFunctions
   CATEGORIES = {
     aggregate: %w[
@@ -71,6 +73,16 @@ module SigmaFunctions
   ALL = CATEGORIES.values.flatten.freeze
   ALL_SET = ALL.to_set rescue Set.new(ALL)
 
+  # Bug B: bare Sigma boolean constants. The PBI converter emits TRUE()/FALSE()
+  # as `True`/`False` (and `null`); these are literals, not functions, and must
+  # never be treated as unknown identifiers by callers scanning a formula.
+  CONSTANTS = %w[True False TRUE FALSE Null null].freeze
+  CONSTANTS_SET = CONSTANTS.to_set rescue Set.new(CONSTANTS)
+
+  def self.constant?(name)
+    CONSTANTS_SET.include?(name)
+  end
+
   def self.includes?(name)
     ALL_SET.include?(name)
   end
@@ -83,8 +95,15 @@ module SigmaFunctions
     # Strip string literals so SQL-ish content inside Custom SQL contexts doesn't
     # trigger false positives. Sigma calc formulas use "..." for strings.
     cleaned = formula.gsub(/"(?:\\.|[^"\\])*"/, '""')
+    # Bug B: strip [...]-bracketed column refs BEFORE the function scan. A column
+    # name can contain "word(" — e.g. [Net Revenue (Prior Year)] — and the bare
+    # `\bword\s*\(` regex would otherwise flag "Revenue(" as an unknown function.
+    # Bracketed refs are never function calls, so remove them entirely first.
+    cleaned = cleaned.gsub(/\[[^\]]*\]/, '')
     names = cleaned.scan(/\b([A-Za-z_][A-Za-z0-9_]*)\s*\(/).flatten.uniq
-    names.reject { |n| includes?(n) }
+    # TRUE()/FALSE() are DAX boolean-literal spellings, not user functions —
+    # never report them as unknown (Bug B: TRUE/FALSE are valid constants).
+    names.reject { |n| includes?(n) || constant?(n) }
   end
 
   # Known Tableau-syntax leak patterns. These DEFINITELY don't work in Sigma

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -45,6 +45,7 @@ require 'optparse'
 require 'fileutils'
 require 'open3'
 require 'digest'
+require 'set'
 
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
@@ -90,6 +91,42 @@ def run!(cmd, env: {})
   out.each_line { |l| puts "   #{l.rstrip}" } unless out.strip.empty?
   abort "FATAL: command failed (#{st.exitstatus}): #{cmd.join(' ')}" unless st.success?
   out
+end
+
+# Raised when the MECHANICAL WORKBOOK layer (build / validate / POST) fails after
+# the data model is already posted + valid. The orchestrator catches this and
+# degrades to a FRIENDLY agent-path handoff instead of a bare crash — the DM is
+# ready, so the agent path can rebuild just the workbook against it.
+class WorkbookBuildError < StandardError
+  attr_reader :captured_output
+  def initialize(msg, captured_output = '')
+    super(msg)
+    @captured_output = captured_output.to_s
+  end
+end
+
+# Like run!, but on failure raises WorkbookBuildError (catchable) instead of
+# abort()ing the process. Captures the child output so the caller can mine it for
+# the offending field name(s) ("Dependency not found", "Unknown column", etc.).
+def run_wb!(cmd, env: {})
+  out, st = Open3.capture2e(env, *cmd)
+  out.each_line { |l| puts "   #{l.rstrip}" } unless out.strip.empty?
+  raise WorkbookBuildError.new("command failed (#{st.exitstatus}): #{cmd.join(' ')}", out) unless st.success?
+  out
+end
+
+# Pull likely-offending field/column names out of a failed workbook build/POST log
+# so the fallback message can name them. Looks for the common rejection shapes:
+#   "Dependency not found: <X>", "Unknown column \"[<X>]\"", "source: {} ... <X>",
+#   "Invalid value: undefined", unresolved [El/Col] refs.
+def cull_failed_fields(*logs)
+  text = logs.join("\n")
+  names = []
+  text.scan(/Dependency not found:?\s*([^\n,]+)/i) { |m| names << m[0].strip }
+  text.scan(/Unknown column\s*"?\[?([^"\]\n]+)\]?"?/i) { |m| names << m[0].strip }
+  text.scan(/unmapped (?:derived[- ]dim|measure|field)\s*[:=]?\s*([^\n,]+)/i) { |m| names << m[0].strip }
+  text.scan(/Circular column reference[^\n]*\[([^\]]+)\]/i) { |m| names << m[0].strip }
+  names.map { |n| n.gsub(/[\[\]"]/, '').strip }.reject(&:empty?).uniq
 end
 
 TOTAL = 6
@@ -288,11 +325,29 @@ raw_dm = JSON.parse(File.read(File.join(WORK, 'dm-raw.json')))
 named_cols = 0
 (raw_dm['pages'] || []).each do |pg|
   (pg['elements'] || []).each do |el|
-    next unless el.dig('source', 'path') # base warehouse-table elements only
+    # Bug E: SQL elements synthesized from a DAX CALENDAR/VALUES calc-table
+    # (DimDate, DimMonth, SalaryBands) ALSO need their columns named — their
+    # follow-on calc columns reference siblings by bare [ColAlias], which
+    # error-type if the referenced column has no display name. Previously only
+    # warehouse-table (source.path) elements were stamped.
+    is_warehouse = !el.dig('source', 'path').nil?
+    is_sql       = el.dig('source', 'kind') == 'sql'
+    next unless is_warehouse || is_sql
     (el['columns'] || []).each do |c|
       next if c['name'] && !c['name'].to_s.empty?
-      dn = c['formula'].to_s.gsub(/^\[|\]$/, '').split('/')[-1]
+      f  = c['formula'].to_s
+      dn = f.gsub(/^\[|\]$/, '').split('/')[-1]
       next if dn.to_s.empty?
+      # Bug E (SQL elements): a SQL-OUTPUT column has a bare self-referencing
+      # formula `[Date]` that maps to the SQL `AS "Date"` alias. Stamping
+      # name="Date" on it makes `[Date]` a CIRCULAR reference -> error-type. Only
+      # stamp a name when the formula is NOT a bare self-reference (i.e. a
+      # follow-on calc column like `Year([Date])`), so its siblings can ref it,
+      # while leaving SQL-output columns nameless to bind to their alias.
+      if is_sql
+        bare_self = (f =~ /\A\[[^\]\/]+\]\z/) && (f.gsub(/^\[|\]$/, '') == dn)
+        next if bare_self
+      end
       c['name'] = dn
       named_cols += 1
     end
@@ -337,35 +392,312 @@ dm_elements = dm_rb['pages'].flat_map { |p| p['elements'] || [] }
 # Display-name helper: a column formula "[Tbl/Order Id]" -> "Order Id".
 disp = lambda { |formula| formula.to_s.gsub(/^\[|\]$/, '').split('/')[-1] }
 
+# Bug A: For a JOIN/View element, columns carry the FULL cross-element ref path
+# in their formula — e.g. "[ORDER_FACT/Customer Key]" (own column) AND
+# "[ORDER_FACT/CUSTOMER_DIM/Customer Key]" (related column). Both leaf-resolve to
+# "Customer Key", so keying the master-column id/name on the leaf produces a
+# COLLISION (duplicate ids + duplicate names) and the workbook POST fails.
+# These helpers reproduce Sigma's own disambiguation:
+#   - the Sigma DISPLAY NAME of a related col is "Customer Key (CUSTOMER_DIM)"
+#     (leaf + " (relName)") — matches the converter's viewColDisplay().
+#   - the master-column ID keys on the FULL path so it is unique per column.
+sigma_view_disp = lambda do |formula|
+  parts = formula.to_s.gsub(/^\[|\]$/, '').split('/')
+  parts.length <= 2 ? parts[-1] : "#{parts[-1]} (#{parts[-2]})"
+end
+# The path INSIDE the element (drop the element-name prefix), used as the master
+# column's resolving formula, e.g. "[mid/CUSTOMER_DIM/Customer Key]".
+inner_path = lambda do |formula|
+  parts = formula.to_s.gsub(/^\[|\]$/, '').split('/')
+  parts.length <= 1 ? parts[0].to_s : parts[1..].join('/')
+end
+
 # Build one master per converter element. master id is "master-<elementId-tail>".
 masters = {}
 field_map = {}
 conv_elements.each do |cel|
   cname = cel['name']
-  # match the posted DM element by name (PUT keeps names; ids may change).
-  dmel = dm_elements.find { |e| e['name'] == cname } || dm_elements.first
+  # match the posted DM element: by NAME first (PUT keeps names; ids may change),
+  # then by ID. A Custom SQL element is NAMELESS in the spec (rule 3) and Sigma
+  # auto-names it "Custom SQL" on readback — recover that name by id-match so the
+  # master keys + column prefixes resolve (Bug E: nameless SQL element).
+  dmel = (cname && dm_elements.find { |e| e['name'] == cname }) ||
+         dm_elements.find { |e| e['id'] == cel['id'] } || dm_elements.first
+  cname ||= (dmel && dmel['name']) || 'Custom SQL'
   mkey = cname
   mid  = "master-#{Digest::SHA1.hexdigest(cname)[0, 8]}"
+  # Bug A: key the master-column id on the FULL cross-element path (not the leaf)
+  # and use Sigma's disambiguated display name. For a JOIN/View element, base and
+  # related columns can share a leaf ("Customer Key"), so leaf-keying collides on
+  # both id AND name -> duplicate columns -> workbook POST fails. The master table
+  # element sources from the DM element (named `cname`); the DM element exposes a
+  # related column under its disambiguated display name "Leaf (RelName)", so the
+  # master column's formula references THAT display name on `cname`. Dedupe by the
+  # full path so each underlying column yields exactly one master column.
+  seen_paths = {}
   cols = (cel['columns'] || []).map do |c|
-    dn = disp.call(c['formula'])
-    { 'id' => "mc-#{Digest::SHA1.hexdigest("#{cname}/#{dn}")[0, 10]}", 'name' => dn,
-      'formula' => "[#{cname}/#{dn}]" }
+    # If the converter already stamped a display `name` (calc/derived/time-intel
+    # columns), trust it — the column's formula is an expression, NOT a bare
+    # [El/Col] ref, so formula-parsing would mangle the name (Bug C side effect).
+    # Bug A formula-path keying applies ONLY to bare [El/.../Col] reference cols.
+    bare_ref = c['formula'].to_s =~ /\A\[[^\]]+\]\z/
+    if c['name'] && !c['name'].to_s.empty? && !bare_ref
+      dn  = c['name'].to_s
+      key = "#{cname}/calc/#{dn}"
+      next nil if seen_paths[key]
+      seen_paths[key] = true
+      next({ 'id' => "mc-#{Digest::SHA1.hexdigest(key)[0, 10]}", 'name' => dn,
+             'formula' => "[#{cname}/#{dn}]", '_leaf' => dn })
+    end
+    full = c['formula'].to_s.gsub(/^\[|\]$/, '')         # e.g. ORDER_FACT/CUSTOMER_DIM/Customer Key
+    next nil if full.empty? || seen_paths[full]
+    seen_paths[full] = true
+    dn   = sigma_view_disp.call(c['formula'])            # "Customer Key (CUSTOMER_DIM)"
+    { 'id' => "mc-#{Digest::SHA1.hexdigest("#{cname}/#{full}")[0, 10]}", 'name' => dn,
+      'formula' => "[#{cname}/#{dn}]", '_leaf' => disp.call(c['formula']) }
+  end.compact
+  # column field refs: queryRef "Entity.Col" -> {master, ref:[mid/Name], agg:null}.
+  # Map both the disambiguated name AND the bare leaf (PBIR queryRefs use the leaf
+  # when the dim column is unambiguous in the original model) so bindings resolve.
+  cols.each do |c|
+    ref = { 'master' => mkey, 'ref' => "[#{mid}/#{c['name']}]", 'agg' => nil }
+    field_map["#{cname}.#{c['name']}"] = ref
+    field_map["#{cname}.#{c['_leaf']}"] ||= ref
   end
+  cols.each { |c| c.delete('_leaf') } # internal-only; keep master columns clean
   masters[mkey] = { 'id' => mid, 'element_id' => dmel['id'], 'data_model' => dm_id,
                     'columns' => cols }
-  # column field refs: queryRef "Entity.Col" -> {master, ref:[master/Col], agg:null}
-  cols.each do |c|
-    field_map["#{cname}.#{c['name']}"] = { 'master' => mkey, 'ref' => "[#{mid}/#{c['name']}]", 'agg' => nil }
-  end
   # measure field refs: a translated metric "Sum([Sales])" -> rewrite bare col refs
   # to the master, set agg=null and pass the FULL formula as `ref` (build script
   # uses ref verbatim when agg is nil — handles ratios like DIVIDE too).
+  #
+  # Bug D: a metric formula may reference ANOTHER metric by name, e.g.
+  #   Sales per Order = [Total Sales] / [Orders]
+  # where Total Sales = Sum([Sales]) and Orders = CountDistinct([Order Id]).
+  # Naively rewriting [Total Sales] -> [mid/Total Sales] points at a NON-EXISTENT
+  # master column (metrics are formulas, not stored columns), and Sigma rejects
+  # the dependency. Fix: substitute the referenced metric's FULL formula INLINE.
+  # Stored master-column names ARE valid [mid/Name] refs; only metric-name refs
+  # are inlined. Resolve recursively (with a guard) so chained metrics collapse.
+  master_col_names = cols.map { |c| c['name'] }.to_set
+  metric_by_name   = {}
+  (cel['metrics'] || []).each { |mm| metric_by_name[mm['name'].to_s] = mm['formula'].to_s }
+  resolve_metric = lambda do |formula, depth|
+    formula.to_s.gsub(/\[([^\/\]]+)\]/) do
+      ref = Regexp.last_match(1)
+      if master_col_names.include?(ref)
+        "[#{mid}/#{ref}]"                                   # real stored column
+      elsif metric_by_name.key?(ref) && depth < 16
+        "(#{resolve_metric.call(metric_by_name[ref], depth + 1)})" # inline the metric
+      else
+        "[#{mid}/#{ref}]"                                   # bare column ref (e.g. Sum([Sales]))
+      end
+    end
+  end
   (cel['metrics'] || []).each do |m|
-    formula = m['formula'].to_s
-    # rewrite every "[Col]" (bare, no slash) -> "[master/Col]"
-    rewritten = formula.gsub(/\[([^\/\]]+)\]/) { "[#{mid}/#{Regexp.last_match(1)}]" }
+    rewritten = resolve_metric.call(m['formula'].to_s, 0)
     field_map["#{cname}.#{m['name']}"] = { 'master' => mkey, 'ref' => rewritten, 'agg' => nil,
                                            'format' => (m.dig('format', 'formatString')) }
+  end
+end
+
+# Bug E (queryRef routing): a DAX calc-table (DimDate / SalaryBands / DimMonth)
+# becomes a NAMELESS Custom SQL element (master keyed "Custom SQL"), but the PBIR
+# chart still binds it under its ORIGINAL table name ("DimDate.Month"). Alias the
+# original calc-table name + each column onto the Custom SQL master so those
+# bindings resolve. The calc table is identified from the TMSL (partition source
+# type 'calculated'); its column display names match the Custom SQL master cols.
+calc_tables = tables.select do |t|
+  Array(t['partitions']).any? { |p| p.dig('source', 'type') == 'calculated' }
+end
+# A Custom SQL master is recognizable by its column formulas using the
+# `[Custom SQL/...]` prefix (the converter emits that for SQL-element columns).
+sql_masters = masters.select do |_n, m|
+  (m['columns'] || []).any? { |c| c['formula'].to_s.start_with?('[Custom SQL/') }
+end
+calc_tables.each do |t|
+  orig = t['name'].to_s
+  # pick the SQL master whose columns best cover this calc table's columns.
+  tcols = (t['columns'] || []).reject { |c| c['type'] == 'rowNumber' || c['isGenerated'] }
+                              .map { |c| (c['sourceColumn'] || c['name']).to_s.gsub(/^\[|\]$/, '') }
+  best = sql_masters.max_by do |_n, m|
+    names = (m['columns'] || []).map { |c| c['name'].to_s }
+    tcols.count { |tc| names.any? { |n| n.casecmp?(tc) || n.gsub(/\s+/, '').casecmp?(tc.gsub(/\s+/, '')) } }
+  end
+  next unless best
+  bmkey, bm = best
+  (bm['columns'] || []).each do |c|
+    ref = { 'master' => bmkey, 'ref' => "[#{bm['id']}/#{c['name']}]", 'agg' => nil }
+    field_map["#{orig}.#{c['name']}"] ||= ref
+  end
+end
+
+# Bug A (star schema): a cross-table visual binds a DIMENSION from a dim table
+# (e.g. PRODUCT_DIM.Category) AND a MEASURE from the fact (ORDER_FACT.Net Rev).
+# Those route to DIFFERENT per-table masters, but a Sigma chart element can only
+# reference columns from its OWN source master — a cross-master ref error-types.
+# The converter already builds a denormalized "<Fact> View" element that carries
+# the fact columns + every related dim column (disambiguated "Leaf (DIM)"). So
+# RE-ROUTE every field that the View also exposes onto the View master, leaving
+# the visual with a single coherent source. Match a per-table field's leaf name
+# to the View column whose Sigma display name is "Leaf" or "Leaf (anything)".
+conv_elements.each do |vcel|
+  vname = vcel['name'].to_s
+  next unless vname =~ /\sView$/                     # the denormalized join element
+  next unless masters[vname]
+  vmid  = masters[vname]['id']
+  vcols = masters[vname]['columns'] || []
+  # leaf -> View column name (prefer the bare-leaf col when present, else the
+  # first disambiguated "Leaf (DIM)" col).
+  leaf_to_view = {}
+  vcols.each do |c|
+    leaf = c['name'].to_s.sub(/\s+\([^)]*\)\s*$/, '') # strip " (DIM)" suffix
+    leaf_to_view[leaf] ||= c['name']
+    leaf_to_view[c['name']] ||= c['name']            # exact disambiguated form too
+  end
+  # the fact this View denormalizes (drop the trailing " View").
+  fact = vname.sub(/\s+View$/, '')
+  # masters whose columns the View subsumes: the fact + every dim reachable via
+  # a "(DIM)" suffix in the View's columns.
+  subsumed = [fact] + vcols.map { |c| c['name'][/\(([^)]*)\)\s*$/, 1] }.compact.uniq
+  field_map.each do |qr, fs|
+    next unless subsumed.include?(fs['master'])
+    old_mid = masters[fs['master']] ? masters[fs['master']]['id'] : nil
+    ref_str = fs['ref'].to_s
+    is_plain_col = ref_str =~ /\A\[[^\]]+\]\z/ # exactly one bracketed ref, no agg
+    if is_plain_col
+      # plain dimension/column ref: match its leaf to a View column.
+      leaf = qr.split('.', 2).last.to_s.sub(/\s+\([^)]*\)\s*$/, '')
+      vcol = leaf_to_view[leaf] || leaf_to_view[qr.split('.', 2).last.to_s]
+      next unless vcol
+      field_map[qr] = fs.merge('master' => vname, 'ref' => "[#{vmid}/#{vcol}]")
+    elsif old_mid
+      # measure/aggregation formula: every referenced fact column must exist on the
+      # View (it does — the View carries all fact columns). Swap the old master id
+      # for the View master id and remap each inner column leaf to its View name.
+      remapped = ref_str.gsub(/\[#{Regexp.escape(old_mid)}\/([^\]]+)\]/) do
+        inner = Regexp.last_match(1)
+        mapped = leaf_to_view[inner] || leaf_to_view[inner.sub(/\s+\([^)]*\)\s*$/, '')] || inner
+        "[#{vmid}/#{mapped}]"
+      end
+      # only re-route if we actually rewrote a ref onto the View master.
+      field_map[qr] = fs.merge('master' => vname, 'ref' => remapped) if remapped.include?(vmid)
+    end
+  end
+end
+
+# Bug C: time-intel forwarding. The converter turns DAX SAMEPERIODLASTYEAR /
+# TOTALYTD measures into NEW DM elements (source.kind=='table' sourcing another
+# element, carrying DateLookback / CumulativeSum columns). Those elements get a
+# master built above, but the ORIGINAL PBI queryRef ("ORDER_FACT.Net Revenue PY"
+# / "ORDER_FACT.YoY %") still points at the fact table, where the measure no
+# longer exists -> the workbook chart resolves no master -> emits source:{} and
+# the POST fails with "Invalid value: undefined". Add synthetic field_map entries
+# routing "<OrigTable>.<MeasureName>" -> the new element's computed column.
+#   measure name -> original TMSL table (from Phase 1's all_measures).
+ti_orig_table = {}
+all_measures.each { |tbl, mname, _expr| ti_orig_table[mname] = tbl }
+# collect the emitted time-intel elements (element-sourced, DateLookback/CumulativeSum).
+ti_elements = []
+conv_elements.each do |cel|
+  src = cel['source'] || {}
+  next unless src['kind'] == 'table' && src['elementId'] # element sourced from another element
+  cols = cel['columns'] || []
+  is_time_intel = cols.any? { |c| c['formula'].to_s =~ /\b(DateLookback|CumulativeSum)\s*\(/ }
+  next unless is_time_intel
+  mname = cel['name'].to_s            # converter names the element after the measure
+  mkey  = mname
+  next unless masters[mkey]           # its master was built in the loop above
+  mid   = masters[mkey]['id']
+  ti_elements << { 'name' => mname, 'mid' => mid, 'cols' => cols }
+  # pick the headline computed column: prior-year / YTD / YoY %, falling back to
+  # the last column (the converter appends the derived measure last).
+  pick = cols.find { |c| c['formula'].to_s =~ /\bDateLookback\s*\(/ } ||
+         cols.find { |c| c['formula'].to_s =~ /\bCumulativeSum\s*\(/ } ||
+         cols.find { |c| c['name'].to_s =~ /YoY/i } || cols.last
+  next unless pick
+  ref = { 'master' => mkey, 'ref' => "[#{mid}/#{pick['name']}]", 'agg' => nil }
+  orig = ti_orig_table[mname]
+  # route both the original-table queryRef and a self-named queryRef so whichever
+  # form the PBIR binding used resolves to this element.
+  field_map["#{orig}.#{mname}"] = ref if orig
+  field_map["#{mname}.#{mname}"] ||= ref
+  # also map any YoY % / Prior Year / YTD sibling column by its own name on the orig table.
+  cols.each do |c|
+    next unless c['name'].to_s =~ /YoY|Prior Year|YTD/i
+    sub = { 'master' => mkey, 'ref' => "[#{mid}/#{c['name']}]", 'agg' => nil }
+    field_map["#{orig}.#{c['name']}"] ||= sub if orig
+  end
+  # A chart that puts a PY/YoY column next to the BASE value and the period
+  # dimension (e.g. Year × Net Revenue × Net Revenue PY) must source from THIS
+  # grouped element — the View lacks the PY column. Register ALTS so those
+  # sibling fields can ALSO resolve here: the grouped value is already aggregated,
+  # so it is referenced as a PLAIN column (no extra Sum). visual_master then
+  # majority-picks this element and field_spec swaps in the alt ref.
+  base_val  = cols.find { |c| c['formula'].to_s =~ /\b(Sum|Avg|Count|CountDistinct|Min|Max)\s*\(/ }
+  period_cols = cols.select { |c| c['name'].to_s =~ /\b(Year|Month|Quarter|Day|Date|Week)\b/i }
+  reg_alt = lambda do |qr, colname|
+    next unless field_map[qr] && colname
+    (field_map[qr]['alts'] ||= []) << { 'master' => mkey, 'ref' => "[#{mid}/#{colname}]", 'agg' => nil }
+  end
+  if base_val
+    # the base value measure under the orig table (any measure whose formula is an
+    # aggregation of the same value column the PY/YTD element sums). Compare with
+    # whitespace stripped from BOTH sides so "Net Revenue" matches "[Net Revenue]".
+    valleaf  = base_val['name']
+    valnorm  = valleaf.gsub(/\s+/, '').downcase
+    all_measures.each do |t2, m2, e2|
+      next unless t2 == orig
+      enorm = e2.to_s.gsub(/\s+/, '').downcase
+      agg_of_val = enorm =~ /(sum|average|avg|min|max|count|distinctcount)\([^)]*#{Regexp.escape(valnorm)}/
+      reg_alt.call("#{orig}.#{m2}", valleaf) if agg_of_val || m2 == valleaf
+    end
+  end
+  # The grouped element carries period dimension column(s) (Year and/or Month).
+  # A chart that plots the time-intel measure BY one of those periods must source
+  # from this element, so register each period column as an alt under the common
+  # date-dim queryRef forms (the calc-table date dim is the usual binding source).
+  period_cols.each do |pc|
+    %w[DATE_DIM DimDate DimMonth Date].each { |dt| reg_alt.call("#{dt}.#{pc['name']}", pc['name']) }
+    reg_alt.call("#{orig}.#{pc['name']}", pc['name'])
+  end
+end
+
+# Bug C (continued): OTHER time-intel measures (e.g. a standalone "YoY %" using a
+# hand-rolled MAX/ALL prior-year pattern) may NOT get their own element — the
+# converter folds the YoY computation into the prior-year element's "... YoY %"
+# column. Any such measure still has a live PBI queryRef ("ORDER_FACT.YoY %")
+# the chart binds, but no field_map entry -> source:{} -> POST fails. Route every
+# remaining time-intel-shaped measure to the best-matching time-intel column.
+if ti_elements.any?
+  ti_re = /\b(SAMEPERIODLASTYEAR|TOTALYTD|TOTALQTD|TOTALMTD|DATESYTD|DATEADD|PARALLELPERIOD|PREVIOUSYEAR|PREVIOUSMONTH|PREVIOUSQUARTER)\b/i
+  all_measures.each do |tbl, mname, expr|
+    next if field_map.key?("#{tbl}.#{mname}")
+    e = expr.to_s
+    # time-intel-shaped: a DAX time-intel function, OR a YoY/growth name, OR a
+    # hand-rolled MAX(...)/ALL(...) prior-year ratio.
+    shape =
+      if e =~ ti_re then :generic
+      elsif mname =~ /YoY|Y\/Y|growth/i || e =~ /ALL\s*\([^)]*\[Year\]/i then :yoy
+      elsif mname =~ /\bYTD\b/i then :ytd
+      elsif mname =~ /\b(PY|Prior Year|Last Year|LY)\b/i then :prior
+      end
+    next unless shape
+    # choose a target column across the emitted time-intel elements.
+    target = nil; tmid = nil; tname = nil
+    ti_elements.each do |te|
+      cand =
+        case shape
+        when :yoy   then te['cols'].find { |c| c['name'].to_s =~ /YoY/i }
+        when :ytd   then te['cols'].find { |c| c['formula'].to_s =~ /\bCumulativeSum\s*\(/ }
+        when :prior then te['cols'].find { |c| c['formula'].to_s =~ /\bDateLookback\s*\(/ }
+        else te['cols'].find { |c| c['formula'].to_s =~ /\b(DateLookback|CumulativeSum)\s*\(/ }
+        end
+      if cand then target = cand; tmid = te['mid']; tname = te['name']; break end
+    end
+    next unless target
+    field_map["#{tbl}.#{mname}"] = { 'master' => tname, 'ref' => "[#{tmid}/#{target['name']}]",
+                                     'agg' => nil }
   end
 end
 
@@ -384,10 +716,38 @@ build = ['ruby', File.join(HERE, 'build-workbook-from-pbir.rb'),
 # DM's folderId (harvested from the ref-dm at Phase 3) so both land together.
 wb_folder = opts[:folder] || (JSON.parse(File.read(dm_spec))['folderId'] rescue nil)
 build += ['--folder-id', wb_folder] if wb_folder
-run!(build)
-wb_readback = File.join(WORK, 'wb-readback.json')
-run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
-      '--spec', wb_spec, '--out', wb_readback, '--workdir', WORK], env: ENV.to_h)
+
+# GRACEFUL AGENT-PATH FALLBACK. The DM is already posted + valid (dm_id above), so
+# if the MECHANICAL workbook layer (build / validate-spec / POST) hits a field it
+# cannot translate (Sigma rejects the spec / unresolved "Dependency not found" /
+# unmapped derived-dim or measure / source:{}), we must NOT bare-crash. Catch it
+# and exit with a clear, FRIENDLY non-zero handoff: the agent path rebuilds the
+# workbook against this DM (see SKILL.md). Never worse than the proven agent path.
+begin
+  build_log = run_wb!(build)
+  wb_readback = File.join(WORK, 'wb-readback.json')
+  rb_log = run_wb!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
+                    '--spec', wb_spec, '--out', wb_readback, '--workdir', WORK], env: ENV.to_h)
+rescue WorkbookBuildError => e
+  failed = cull_failed_fields(e.captured_output, (defined?(build_log) ? build_log : ''))
+  # Also surface the converter (c)-tail measures as the likely culprits when the
+  # log itself doesn't name a field.
+  if failed.empty?
+    failed = conv_warnings.map { |w| w.to_s.gsub(/\s+/, ' ').strip }
+                          .select { |w| w.start_with?('⛔') }
+                          .map { |w| w[/[“"]([^”"]+)[”"]/, 1] || w.sub(/^⛔\s*/, '')[0, 60] }
+                          .compact.uniq
+  end
+  names = failed.empty? ? 'one or more fields' : failed.join(', ')
+  n = failed.empty? ? 'some' : failed.size.to_s
+  puts
+  puts "── Mechanical path: data model built OK (dataModelId=#{dm_id}). The WORKBOOK " \
+       "layer hit #{n} field(s) the mechanical path can't translate (#{names}). " \
+       "Falling back to the agent path: rebuild the workbook via the skill's " \
+       "agent-authored flow (see SKILL.md) against this DM. The data model is " \
+       "posted and ready to attach."
+  exit 4
+end
 wb_rb = JSON.parse(File.read(wb_readback))
 wb_id = wb_rb['workbookId']
 puts "   workbookId = #{wb_id}"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
@@ -105,7 +105,12 @@ spec.fetch('pages', []).each do |page|
                       "(known: #{(own_prefixes + all_known_set).to_a.sort.join(', ')})"
           end
         else
-          unless sibling_names.include?(ref)
+          # In a Custom SQL element a bare [X] resolves against the SQL statement's
+          # `AS "X"` output alias (which this validator can't see) — Sigma
+          # fuzzy-matches case/underscore variants. So a bare ref that isn't a
+          # named sibling is still valid here; don't flag it (Bug E: SQL-output
+          # columns are intentionally nameless, binding to their alias).
+          if src['kind'] != 'sql' && !sibling_names.include?(ref)
             errors << "#{name}.#{col['name']}: bare ref [#{ref}] not a sibling column"
           end
         end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-denorm-sql.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-denorm-sql.py
@@ -40,11 +40,13 @@ def main():
         if f.get("isExpression"): continue
         if f["realColumn"] == "*": continue
         select.append(f'f.{f["realColumn"]} AS {f["qlikField"]}')
+    # build a safe dim-alias sequence that skips 'f' (reserved for the fact table)
+    _dim_aliases = [c for c in 'abcdeghijklmnopqrstuvwxyz']
     a_i = 0
     for d in dims:
         # find join key: a *_KEY qlikField in this dim that the fact also has
         jk = next((k for k in keyfields(d) if k.upper() in factkeys), None)
-        al = chr(ord('a') + a_i); a_i += 1; alias[d["qlikTable"]] = al
+        al = _dim_aliases[a_i]; a_i += 1; alias[d["qlikTable"]] = al
         if jk:
             joins.append(f'LEFT JOIN {wh(d)} {al} ON f.{real(fact, jk)} = {al}.{real(d, jk)}')
         # dim descriptive columns (skip its own key columns to avoid dup)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -66,13 +66,37 @@ def chart_pos(z, opts)
   h  = z['h_pct'] || 0
   y1 = y0 + h
   remaining_rows = opts[:page_rows] - (opts[:chart_row0] - 1)
-  row_start = (opts[:chart_row0] + (y0 - opts[:chart_y0]) / (opts[:chart_y1] - opts[:chart_y0]) * remaining_rows).round
-  row_end   = (opts[:chart_row0] + (y1 - opts[:chart_y0]) / (opts[:chart_y1] - opts[:chart_y0]) * remaining_rows).round
+  span = (opts[:chart_y1] - opts[:chart_y0]).to_f
+  span = 1.0 if span <= 0
+  row_start = (opts[:chart_row0] + (y0 - opts[:chart_y0]) / span * remaining_rows).round
+  row_end   = (opts[:chart_row0] + (y1 - opts[:chart_y0]) / span * remaining_rows).round
+  # Sigma rejects non-positive grid positions ("Invalid element position").
+  # Clamp into the legal band [chart_row0 .. page_rows+1] and guarantee a span.
+  max_row   = opts[:page_rows] + 1
+  row_start = [[row_start, opts[:chart_row0]].max, max_row - 1].min
+  row_end   = [[row_end,   row_start + 1].max,      max_row].min
   row_end   = row_start + 1 if row_end <= row_start
   col_start = [1,  (1 + (z['x_pct'] || 0) / 100.0 * opts[:page_cols]).round].max
   col_end   = [opts[:page_cols] + 1, (1 + ((z['x_pct'] || 0) + (z['w_pct'] || 0)) / 100.0 * opts[:page_cols]).round].min
   col_end   = col_start + 1 if col_end <= col_start
   [col_start, col_end, row_start, row_end]
+end
+
+# Auto-fit the chart band to the ACTUAL zone extents. The default chart_y0=29.7
+# assumes a title/filter band at the top; a dashboard whose charts start near
+# y=0 would otherwise map to negative grid rows. Fit chart_y0/chart_y1 to the
+# min/max zone y so the mapping always lands inside the page.
+zone_y0s = chart_zones.map { |z| (z['y_pct'] || 0).to_f }
+zone_y1s = chart_zones.map { |z| (z['y_pct'] || 0).to_f + (z['h_pct'] || 0).to_f }
+unless zone_y0s.empty?
+  fit_y0 = zone_y0s.min
+  fit_y1 = [zone_y1s.max, fit_y0 + 1].max
+  # Only override when the zones fall (partly) above the assumed band, to avoid
+  # disturbing the tuned default for dashboards that DO have a top band.
+  if fit_y0 < opts[:chart_y0]
+    opts[:chart_y0] = fit_y0
+    opts[:chart_y1] = fit_y1
+  end
 end
 
 # Compute initial positions

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_functions.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_functions.rb
@@ -11,6 +11,8 @@
 #   - move the logic into a Custom SQL data-model element (kind: "sql") and
 #     reference its columns as plain `[Custom SQL/COL]` refs
 
+require 'set'
+
 module SigmaFunctions
   CATEGORIES = {
     aggregate: %w[
@@ -71,6 +73,17 @@ module SigmaFunctions
   ALL = CATEGORIES.values.flatten.freeze
   ALL_SET = ALL.to_set rescue Set.new(ALL)
 
+  # Bug B (Tableau parity): bare Sigma boolean constants. Tableau calc fields use
+  # TRUE/FALSE (and NULL) as boolean/null literals; these are literals, not
+  # functions, and must never be treated as unknown identifiers by callers
+  # scanning a formula.
+  CONSTANTS = %w[True False TRUE FALSE Null null NULL].freeze
+  CONSTANTS_SET = CONSTANTS.to_set rescue Set.new(CONSTANTS)
+
+  def self.constant?(name)
+    CONSTANTS_SET.include?(name)
+  end
+
   def self.includes?(name)
     ALL_SET.include?(name)
   end
@@ -83,8 +96,17 @@ module SigmaFunctions
     # Strip string literals so SQL-ish content inside Custom SQL contexts doesn't
     # trigger false positives. Sigma calc formulas use "..." for strings.
     cleaned = formula.gsub(/"(?:\\.|[^"\\])*"/, '""')
+    # Bug B (Tableau parity): strip [...]-bracketed column refs BEFORE the
+    # function scan. A column name can contain "word(" — e.g.
+    # [Order Fact View/Customer Id (CUSTOMER_DIM)] — and the bare
+    # `\bword\s*\(` regex would otherwise flag "Id(" / "Name(" as an unknown
+    # function and FATAL-abort. Bracketed refs are never function calls, so
+    # remove them entirely first.
+    cleaned = cleaned.gsub(/\[[^\]]*\]/, '')
     names = cleaned.scan(/\b([A-Za-z_][A-Za-z0-9_]*)\s*\(/).flatten.uniq
-    names.reject { |n| includes?(n) }
+    # TRUE/FALSE/NULL are Tableau boolean/null literals, not user functions —
+    # never report them as unknown (Bug B: they are valid constants).
+    names.reject { |n| includes?(n) || constant?(n) }
   end
 
   # Known Tableau-syntax leak patterns. These DEFINITELY don't work in Sigma

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -1,0 +1,497 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# mechanical-specs.rb — the DETERMINISTIC Tableau→Sigma spec generator.
+#
+# Makes Tableau→Sigma spec generation MECHANICAL (no agent hand-authoring in the
+# happy path). It chains the EXISTING building blocks:
+#   convert_tableau_to_sigma (build/tableau.js)  → the Sigma DATA MODEL spec
+#   parse-twb-layout.rb                          → per-dashboard zone signals
+#   build-charts-from-signals.rb                 → Sigma chart-element specs
+# and supplies the glue that previously forced an agent to step in:
+#
+#   * DM spec — the converter output IS the DM spec (schemaVersion:1 already set).
+#     fixup_dm_spec() resolves the references the converter leaves unresolved
+#     (raw-table-name prefixes on derived elements + Tableau internal-GUID sibling
+#     refs) and DROPS calc columns that still can't resolve (unknown functions /
+#     unresolved refs) so the live POST doesn't error-type. Dropped calcs are
+#     returned for the orchestrator to surface as OPEN QUESTIONS.
+#
+#   * master-map — build-charts needs a regex→{id,name,format} map from CSV-
+#     header / shelf-caption text to workbook-master column ids. derive_master()
+#     DERIVES it from the converter fact element (its columns + metrics), exactly
+#     mirroring how migrate-powerbi.rb derives master-map.json. Each fact column
+#     display name D → master column {id:"m-<slug D>", name:D, formula:"[<Fact>/D]"}
+#     and a header regex (agg-prefix tolerant). Aggregate calc metrics (Return
+#     Rate, Gross Margin Pct) → a master-map entry carrying a verbatim `formula`
+#     that build-charts emits straight onto the chart measure.
+#
+#   * workbook — build_wb_spec() wraps a hidden master table (sourcing the DM
+#     fact element) + the build-charts elements into a POST-ready workbook spec.
+require 'set'
+require 'json'
+require 'open3'
+
+module MechanicalSpecs
+  module_function
+
+  LOWER = %w[a an and as at but by for in nor of on or so the to up yet via vs].freeze
+
+  # Sigma's display-name derivation for a SNAKE_CASE / camelCase identifier.
+  def display_name(s)
+    norm = (s || '').gsub(/([a-z])([A-Z])/, '\\1_\\2').gsub(/([A-Z]+)([A-Z][a-z])/, '\\1_\\2')
+    words = norm.downcase.split('_').reject(&:empty?)
+    words.each_with_index.map { |w, i| (i.zero? || !LOWER.include?(w)) ? w.capitalize : w }.join(' ')
+  end
+
+  # Display name of a converter column: explicit `name`, else the LAST path
+  # segment of the formula. "[A/B/Category]" -> "Category".
+  def col_display(col)
+    return col['name'] if col['name'] && !col['name'].to_s.empty?
+    f = col['formula'].to_s
+    m = f.match(/\[([^\]]+)\]\s*$/)
+    return nil unless m
+    m[1].split('/').last
+  end
+
+  def slug(s)
+    s.to_s.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/^-|-$/, '')
+  end
+
+  # A header-matching regex for a display name that ALSO tolerates a Tableau CSV
+  # aggregation prefix ("Sum of X", "Distinct count of X", ...). build-charts
+  # passes the raw CSV header to map_column, so the prefix must be optional.
+  def header_regex(dname)
+    "(?i)^(?:(?:sum|avg|average|min|max|median|distinct count|count) of )?#{Regexp.escape(dname)}$"
+  end
+
+  # A pure-GUID display name is an internal converter artifact, never a CSV header.
+  GUID_RE = /\A[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\z/i
+
+  # Strip a cross-element calc col's disambiguating suffix:
+  #   "Region (STORE_DIM (CSA.STORE_DIM))" -> "Region".
+  def base_caption(dname)
+    b = dname.to_s.sub(/\s*\([A-Z0-9_]+ \([^)]*\)\)\s*\z/, '').strip
+    b.empty? ? nil : b
+  end
+
+  def formula_has_guid_ref?(formula)
+    formula.to_s =~ /\[[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\]/i
+  end
+
+  # Map each Tableau internal field GUID -> its master display name. The
+  # converter encodes the raw warehouse column name (a UUID-shaped Tableau field
+  # id) as the suffix of the column's sigma inode id ("inode-<hash>/<RAW_UUID>"),
+  # so GUID 7b7dc9c3-... in a formula == the column whose inode tail is 7B7DC9C3-.
+  def guid_display_index(*elements)
+    idx = {}
+    elements.compact.each do |el|
+      (el['columns'] || []).each do |c|
+        tail = c['id'].to_s.split('/').last
+        next unless tail =~ /\A[0-9A-F-]{20,}\z/i
+        dn = col_display(c)
+        idx[tail.downcase] = dn if dn
+      end
+    end
+    idx
+  end
+
+  # Rewrite a metric formula: GUID refs -> [Master/<display>], remaining bare
+  # [Col] refs -> [Master/Col]. Returns nil if any GUID stays unresolved.
+  def rewrite_metric_formula(formula, guid_idx)
+    f = formula.to_s.dup
+    f = f.gsub(/\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]/i) do
+      dn = guid_idx[Regexp.last_match(1).downcase]
+      dn ? "[Master/#{dn}]" : Regexp.last_match(0)
+    end
+    return nil if formula_has_guid_ref?(f)
+    f.gsub(/\[([^\/\]]+)\]/) { "[Master/#{Regexp.last_match(1)}]" }
+  end
+
+  def all_elements(model)
+    (model['pages'] || []).flat_map { |p| p['elements'] || [] }
+  end
+
+  def elem_name(e)
+    e['name'] || display_name((e.dig('source', 'path') || []).last.to_s)
+  end
+
+  # Pick the CHART-READY fact element. The converter builds a derived "<Fact>
+  # View" element (kind:table sourcing the base fact) that DENORMALIZES every
+  # cross-element + calc column the dashboards plot — base warehouse-table
+  # elements carry only their own physical columns. So prefer the largest derived
+  # view that is NOT a *Dim; fall back to a base warehouse-table fact otherwise.
+  def pick_fact(model)
+    els = all_elements(model)
+    return nil if els.empty?
+    derived = els.select { |e| e.dig('source', 'kind') == 'table' && e.dig('source', 'elementId') }
+                 .reject { |e| elem_name(e) =~ / Dim$/i }
+    return derived.max_by { |e| (e['columns'] || []).size } if derived.any?
+    base = els.select { |e| e.dig('source', 'kind') == 'warehouse-table' }
+    return nil if base.empty?
+    facts = base.reject { |e| elem_name(e) =~ / Dim$/i }
+    (facts.empty? ? base : facts).max_by { |e| (e['columns'] || []).size }
+  end
+
+  # The base element a derived view sources (for harvesting its metrics, which
+  # don't propagate to derived elements). Returns nil for a base fact.
+  def base_of(model, fact_el)
+    src_eid = fact_el.dig('source', 'elementId')
+    return nil unless src_eid
+    all_elements(model).find { |e| e['id'] == src_eid }
+  end
+
+  # Run the Tableau→Sigma converter via a node shim importing build/tableau.js.
+  def run_converter(twb_path:, conn:, db:, schema:, mcp_build:, workdir:)
+    shim = File.join(workdir, '_convert_tableau.mjs')
+    raw_out = File.join(workdir, 'dm-raw.json')
+    meta_out = File.join(workdir, 'conv-meta.json')
+    File.write(shim, <<~JS)
+      import { readFileSync, writeFileSync } from 'node:fs';
+      import { convertTableauToSigma } from #{mcp_build.to_json};
+      const xml = readFileSync(#{twb_path.to_json}, 'utf8');
+      const out = convertTableauToSigma(xml, {
+        connectionId: #{conn.to_json},
+        database: #{db.to_json},
+        schema: #{schema.to_json},
+      });
+      const bare = out.model || out.sigmaDataModel || out;
+      writeFileSync(#{raw_out.to_json}, JSON.stringify(bare, null, 2));
+      writeFileSync(#{meta_out.to_json}, JSON.stringify({ model: bare, warnings: out.warnings || [], stats: out.stats || {} }, null, 2));
+    JS
+    o, e, st = Open3.capture3('node', shim)
+    raise "converter failed: #{e}#{o}" unless st.success?
+    JSON.parse(File.read(meta_out))
+  end
+
+  # Tableau functions with no Sigma equivalent (fallback when the SigmaFunctions
+  # lib isn't loadable).
+  def unknown_functions(formula)
+    if defined?(SigmaFunctions) && SigmaFunctions.respond_to?(:unknown_functions)
+      return SigmaFunctions.unknown_functions(formula)
+    end
+    %w[DATEPARSE MAKEDATE MAKEDATETIME WINDOW_SUM WINDOW_AVG RUNNING_SUM RUNNING_AVG
+       RANK RANK_DENSE INDEX LOOKUP PREVIOUS_VALUE TOTAL SCRIPT_REAL SCRIPT_STR
+       MODEL_QUANTILE MODEL_PERCENTILE].select { |fn| formula.to_s =~ /\b#{fn}\s*\(/i }
+  end
+
+  # DM-spec fixup (mechanical). See module doc. Returns
+  #   { fixed: <n formulas rewritten>, dropped: [<dropped calc display names>] }.
+  # real_columns: optional { "TABLE" => Set/Array of UPPER physical column names }
+  # discovered live from the warehouse (Phase 2). When supplied, base
+  # warehouse-table columns whose physical name is NOT in the real table are
+  # DROPPED as phantom (Tableau virtual-connection flattening invents columns
+  # like "REGION (STORE_DIM (CSA.STORE_DIM))" that don't exist in ORDER_FACT).
+  def fixup_dm_spec(model, real_columns = nil)
+    begin
+      require 'set'
+      $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+      require 'sigma_functions'
+    rescue LoadError, StandardError
+      # fall back to the mini-blocklist in unknown_functions
+    end
+    real = {}
+    (real_columns || {}).each { |t, cols| real[t.to_s.upcase] = cols.map { |c| c.to_s.upcase }.to_set }
+    els = all_elements(model)
+    by_id = els.each_with_object({}) { |e, h| h[e['id']] = e }
+    guid_idx = guid_display_index(*els)
+    fixed = 0
+    dropped = []
+    # Stamp a display name on every base warehouse-table element that lacks one,
+    # so the DM readback returns a concrete element name (master-column formulas
+    # and validate-spec --dm-context both key on element name). kind:sql elements
+    # MUST stay nameless (spec rule 3) — skip those.
+    els.each do |e|
+      next if e['name'] && !e['name'].to_s.empty?
+      next unless e.dig('source', 'kind') == 'warehouse-table'
+      tbl = (e.dig('source', 'path') || []).last.to_s
+      e['name'] = display_name(tbl) unless tbl.empty?
+    end
+    phantom = 0
+    dropped_col_ids = Set.new
+    dropped_disp_by_el = Hash.new { |h, k| h[k] = Set.new } # element id -> dropped display names
+    unless real.empty?
+      els.each do |el|
+        next unless el.dig('source', 'kind') == 'warehouse-table'
+        tbl = (el.dig('source', 'path') || []).last.to_s.upcase
+        rc = real[tbl]
+        next unless rc
+        keep = []
+        drop = {}
+        (el['columns'] || []).each do |c|
+          # Physical warehouse name = the formula tail mapped to UPPER_SNAKE, OR
+          # the inode-id tail. A base col formula is "[TABLE/Display Name]".
+          tail = c['formula'].to_s[/\[([^\]]+)\]\s*$/, 1]
+          phys = tail ? tail.split('/').last.gsub(/\s+/, '_').upcase : nil
+          # Only drop pure base-column refs (formula is exactly [TABLE/x]); never
+          # drop a calc column (it has functions / multiple refs).
+          is_base_ref = c['formula'].to_s =~ /\A\[#{Regexp.escape((el.dig('source','path')||[]).last.to_s)}\/[^\]]+\]\z/
+          if is_base_ref && phys && !rc.include?(phys)
+            drop[c['id']] = true
+            dn = col_display(c)
+            dropped_disp_by_el[el['id']] << dn if dn
+            phantom += 1
+          else
+            keep << c
+          end
+        end
+        if drop.any?
+          el['columns'] = keep
+          el['order'] = (el['order'] || []).reject { |id| drop[id] } if el['order']
+          dropped_col_ids.merge(drop.keys)
+        end
+      end
+      # Drop relationships whose key columns were filtered out as phantom (a
+      # virtual-connection relationship keyed on a flattened column that does
+      # not exist in the real table) — Sigma rejects dangling relationship keys.
+      els.each do |el|
+        next unless el['relationships']
+        el['relationships'] = el['relationships'].reject do |r|
+          (r['keys'] || []).any? do |k|
+            dropped_col_ids.include?(k['sourceColumnId']) || dropped_col_ids.include?(k['targetColumnId'])
+          end
+        end
+      end
+      # Cascade: a derived element column that is a bare single ref to a dropped
+      # base column ("[Src/<droppedName>]") can no longer resolve — drop it too.
+      els.each do |el|
+        src_eid = el.dig('source', 'elementId')
+        next unless src_eid && dropped_disp_by_el.key?(src_eid)
+        src_el = by_id[src_eid]
+        src_name = src_el && (src_el['name'] || display_name((src_el.dig('source', 'path') || []).last.to_s))
+        next unless src_name
+        dropped_names = dropped_disp_by_el[src_eid]
+        keep = []
+        drop = {}
+        (el['columns'] || []).each do |c|
+          tail = c['formula'].to_s[/\A\[#{Regexp.escape(src_name)}\/([^\]]+)\]\z/, 1]
+          if tail && dropped_names.include?(tail.split('/').last)
+            drop[c['id']] = true
+            phantom += 1
+          else
+            keep << c
+          end
+        end
+        if drop.any?
+          el['columns'] = keep
+          el['order'] = (el['order'] || []).reject { |id| drop[id] } if el['order']
+        end
+      end
+    end
+    els.each do |el|
+      src_eid = el.dig('source', 'elementId')
+      src_el = src_eid && by_id[src_eid]
+      src_name = src_el && (src_el['name'] || display_name((src_el.dig('source', 'path') || []).last.to_s))
+      src_table = src_el && (src_el.dig('source', 'path') || []).last
+      keep_cols = []
+      drop_ids = {}
+      (el['columns'] || []).each do |c|
+        unless c['formula']
+          keep_cols << c
+          next
+        end
+        before = c['formula']
+        f = before.dup
+        # (1) prefix rewrite for derived elements: [<SRC_TABLE>/ -> [<SrcName>/
+        f = f.gsub("[#{src_table}/", "[#{src_name}/") if src_name && src_table && src_name != src_table
+        # (2) GUID sibling refs -> bare display name
+        f = f.gsub(/\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]/i) do
+          dn = guid_idx[Regexp.last_match(1).downcase]
+          dn ? "[#{dn}]" : Regexp.last_match(0)
+        end
+        fixed += 1 if f != before
+        c['formula'] = f
+        # Drop if it still can't resolve (unresolved GUID or unknown function).
+        bad_fn = unknown_functions(f).reject { |n| %w[IF THEN ELSE ELSEIF END WHEN CASE AND OR NOT].include?(n.to_s.upcase) }
+        if formula_has_guid_ref?(f) || !bad_fn.empty?
+          dn = col_display(c) || c['name']
+          dropped << dn if dn
+          drop_ids[c['id']] = true
+          next
+        end
+        keep_cols << c
+      end
+      if drop_ids.any?
+        el['columns'] = keep_cols
+        el['order'] = (el['order'] || []).reject { |id| drop_ids[id] } if el['order']
+      end
+      # Metrics get the same treatment: resolve GUID refs, then DROP any metric
+      # whose formula still can't resolve (unresolved GUID, or a ref to a
+      # parenthesized cross-element column name validate-spec misreads as a
+      # function call). Plotted-but-dropped metrics surface via the master-map's
+      # untranslated list; here we just keep the DM POST-able.
+      if el['metrics']
+        kept_metrics = []
+        (el['metrics'] || []).each do |m|
+          f = (m['formula'] || '').dup
+          f = f.gsub(/\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]/i) do
+            dn = guid_idx[Regexp.last_match(1).downcase]
+            dn ? "[#{dn}]" : Regexp.last_match(0)
+          end
+          m['formula'] = f
+          # A ref whose name contains "(" (e.g. "[Unit Cost (PRODUCT_DIM (...))]")
+          # is a cross-element physical column the validator/parsing can't handle
+          # in an aggregate metric — drop it.
+          paren_ref = f =~ /\[[^\]]*\([^\]]*\][^\]]*\]/ || f =~ /\([A-Z0-9_]+ \(/
+          if formula_has_guid_ref?(f) || paren_ref
+            dropped << (m['name'] || 'metric')
+            next
+          end
+          kept_metrics << m
+        end
+        el['metrics'] = kept_metrics
+      end
+    end
+    { fixed: fixed, dropped: dropped.uniq, phantom: phantom }
+  end
+
+  # The display-name suffix Sigma stamps on a derived-view column when its bare
+  # name collides with a sibling (a joined-dim column or a second join of the
+  # same table). The converter column carries the dim in its formula PATH:
+  #   "[Order Fact/CUSTOMER_DIM/Region]" -> base label "Region (CUSTOMER_DIM)".
+  # A base-fact column ("[Order Fact/Order Id]") and calc columns have no dim
+  # path -> bare label. Sigma further appends " (n)" when even the (DIM) form
+  # collides (e.g. DATE_DIM joined twice); that ordinal is resolved by matching
+  # against the LIVE readback labels in resolve_real_labels, not guessed here.
+  def expected_label(col)
+    f = col['formula'].to_s
+    # A calc column (explicit name, formula is not a single bare ref) keeps its name.
+    return col['name'] if col['name'] && !col['name'].to_s.empty? && f !~ /\A\[[^\]]+\]\s*\z/
+    tail = f[/\[([^\]]+)\]\s*\z/, 1]
+    return (col['name'] && !col['name'].to_s.empty? ? col['name'] : nil) unless tail
+    parts = tail.split('/')
+    name = parts.last
+    parts.size >= 3 ? "#{name} (#{parts[-2]})" : name
+  end
+
+  # Match each converter derived-view column to the AUTHORITATIVE display label
+  # Sigma assigned on POST/readback. Returns { col_object_id => real_label }.
+  # We walk the columns in order (Sigma assigns disambiguating suffixes in column
+  # order) and consume from a pool of the real labels: exact (DIM) form first,
+  # then the " (n)" disambiguated forms. Columns we cannot match keep their bare
+  # expected label as a best-effort fallback.
+  def resolve_real_labels(cols, real_labels)
+    pool = Hash.new(0)
+    (real_labels || []).each { |l| pool[l] += 1 }
+    out = {}
+    cols.each do |c|
+      exp = expected_label(c)
+      next if exp.nil? || exp.to_s.empty?
+      chosen =
+        if pool[exp].positive?
+          exp
+        else
+          # The (DIM) form already consumed (or absent): take the next " (n)" form.
+          ((1..20).map { |n| "#{exp} (#{n})" }.find { |t| pool[t].positive? }) || exp
+        end
+      pool[chosen] -= 1 if pool[chosen].positive?
+      out[c['id']] = chosen
+    end
+    out
+  end
+
+  # Derive { 'master_columns' => [...], 'mmap' => {...}, 'untranslated_metrics' => [...] }.
+  # fact_name is the AUTHORITATIVE Sigma element name (from the DM readback) used
+  # in master-column formulas [fact_name/Col]. base_el (optional) is the element a
+  # derived view sources, whose metrics are also harvested.
+  #
+  # real_labels (optional): the ACTUAL column display labels of the derived fact
+  # element, read back from the live DM (`/v2/dataModels/<id>/columns`). The
+  # converter exposes a joined-dim column under its bare last-path-segment name
+  # ("Customer Id"), but on POST Sigma disambiguates it with a relationship
+  # SUFFIX ("Customer Id (CUSTOMER_DIM)"). The master-column FORMULA must use the
+  # real (suffixed) label or it errors as "Dependency not found". When supplied,
+  # each master column's formula is [fact_name/<real label>] while its NAME (and
+  # every mmap regex) stays the BARE caption — so build-charts' [Master/<bare>]
+  # refs and the bare Tableau chart captions still resolve. Without real_labels
+  # we fall back to the bare-name formula (correct only for non-virtual conns).
+  def derive_master(fact_el, fact_name, base_el = nil, real_labels = nil)
+    master_columns = []
+    mmap = {}
+    seen = {}
+    used_regex = {}
+    untranslated = []
+    guid_idx = guid_display_index(fact_el, base_el)
+    # dname (BARE caption, used for name+mmap) -> real readback label (used for formula).
+    real_for = lambda do |dname, real_label|
+      lbl = (real_label && !real_label.to_s.empty?) ? real_label : dname
+      "[#{fact_name}/#{lbl}]"
+    end
+    add = lambda do |dname, format, real_label = nil|
+      return if dname.nil? || dname.to_s.empty?
+      return if dname =~ GUID_RE
+      key = dname.downcase
+      return if seen[key]
+      seen[key] = true
+      id = "m-#{slug(dname)}"
+      master_columns << { 'id' => id, 'name' => dname, 'formula' => real_for.call(dname, real_label) }
+      entry = { 'id' => id, 'name' => dname }
+      entry['format'] = format if format
+      rx = header_regex(dname)
+      unless used_regex[rx]
+        mmap[rx] = entry
+        used_regex[rx] = true
+      end
+      bc = base_caption(dname)
+      if bc && bc != dname
+        brx = header_regex(bc)
+        unless used_regex[brx]
+          mmap[brx] = entry
+          used_regex[brx] = true
+        end
+      end
+    end
+    raw_cols = (fact_el['columns'] || [])
+    # Real readback label per converter column (suffixed form). Empty hash when
+    # no readback labels supplied -> formulas fall back to the bare name.
+    label_for = real_labels ? resolve_real_labels(raw_cols, real_labels) : {}
+    # Bare-named columns claim their regex before suffixed cross-element dupes.
+    cols = raw_cols.map { |c| [col_display(c), c['format'], label_for[c['id']]] }
+    cols.sort_by! { |(dn, _, _)| (dn.to_s.include?('(') ? 1 : 0) }
+    cols.each { |(dn, fmt, real_label)| add.call(dn, fmt, real_label) }
+    # Aggregate calc metrics are NOT master columns — they are workbook-level
+    # aggregate formulas registered as master-map entries with a verbatim
+    # `formula` (base-col refs rewritten to [Master/Col]); build-charts emits the
+    # formula straight onto the chart measure. The raw base cols are master cols.
+    metric_srcs = [fact_el, base_el].compact
+    metric_srcs.each do |mel|
+      (mel['metrics'] || []).each do |m|
+        nm = m['name']
+        next if nm.nil? || nm.to_s.empty?
+        rx = header_regex(nm)
+        next if used_regex[rx]
+        formula = rewrite_metric_formula(m['formula'], guid_idx)
+        if formula.nil?
+          untranslated << nm
+          next
+        end
+        entry = { 'id' => "m-#{slug(nm)}", 'name' => nm, 'formula' => formula }
+        entry['format'] = m['format'] if m['format']
+        mmap[rx] = entry
+        used_regex[rx] = true
+      end
+    end
+    { 'master_columns' => master_columns, 'mmap' => mmap, 'untranslated_metrics' => untranslated }
+  end
+
+  # Assemble the full workbook spec: a hidden master table on page-data sourcing
+  # the DM fact element, plus a dashboard page of the build-charts elements.
+  def build_wb_spec(name:, dm_id:, fact_eid:, master_columns:, chart_elements:, folder_id: nil)
+    spec = {
+      'name' => name,
+      'description' => 'Generated mechanically from Tableau via tableau-to-sigma (convert_tableau_to_sigma + build-charts-from-signals).',
+      'schemaVersion' => 1,
+      'pages' => [
+        { 'id' => 'page-data', 'name' => 'Data',
+          'elements' => [{
+            'id' => 'master', 'kind' => 'table', 'name' => 'Master', 'visibleAsSource' => false,
+            'source' => { 'kind' => 'data-model', 'dataModelId' => dm_id, 'elementId' => fact_eid },
+            'columns' => master_columns, 'order' => master_columns.map { |c| c['id'] }
+          }] },
+        { 'id' => 'page-dash', 'name' => name, 'elements' => chart_elements }
+      ]
+    }
+    spec['folderId'] = folder_id if folder_id
+    spec
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -43,6 +43,7 @@
 # Exit codes: 0 = done (PARITY pass); 10 = decisions needed (OPEN QUESTIONS
 # printed, NO Sigma objects created); 3 = parity/guard fail; other = error.
 require 'json'
+require 'csv'
 require 'yaml'
 require 'optparse'
 require 'fileutils'
@@ -92,6 +93,44 @@ end
 def sigma_run!(cmd, allow_fail: false)
   joined = cmd.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')
   run!(['bash', '-c', "eval \"$(#{File.join(HERE, 'get-token.sh')})\" && #{joined}"], allow_fail: allow_fail)
+end
+
+# Raised when the MECHANICAL WORKBOOK layer (build / validate / POST) fails after
+# the data model is already posted + valid. The orchestrator catches this and
+# degrades to a FRIENDLY agent-path handoff instead of a bare crash — the DM is
+# ready, so the agent path can rebuild just the workbook against it.
+class WorkbookBuildError < StandardError
+  attr_reader :captured_output
+  def initialize(msg, captured_output = '')
+    super(msg)
+    @captured_output = captured_output.to_s
+  end
+end
+
+# Like run!, but on failure raises WorkbookBuildError (catchable) instead of
+# abort()ing the process. Captures the child output for field-name mining.
+def run_wb!(cmd)
+  out, st = Open3.capture2e(*cmd)
+  out.each_line { |l| puts "   #{l.rstrip}" } unless out.strip.empty?
+  raise WorkbookBuildError.new("command failed (#{st.exitstatus}): #{cmd.join(' ')}", out) unless st.success?
+  out
+end
+
+# sigma_run! variant that raises WorkbookBuildError instead of aborting.
+def sigma_run_wb!(cmd)
+  joined = cmd.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')
+  run_wb!(['bash', '-c', "eval \"$(#{File.join(HERE, 'get-token.sh')})\" && #{joined}"])
+end
+
+# Pull likely-offending field/column names out of a failed workbook build/POST log.
+def cull_failed_fields(*logs)
+  text = logs.join("\n")
+  names = []
+  text.scan(/Dependency not found:?\s*([^\n,]+)/i) { |m| names << m[0].strip }
+  text.scan(/Unknown column\s*"?\[?([^"\]\n]+)\]?"?/i) { |m| names << m[0].strip }
+  text.scan(/unmapped (?:derived[- ]dim|measure|field)\s*[:=]?\s*([^\n,]+)/i) { |m| names << m[0].strip }
+  text.scan(/Circular column reference[^\n]*\[([^\]]+)\]/i) { |m| names << m[0].strip }
+  names.map { |n| n.gsub(/[\[\]"]/, '').strip }.reject(&:empty?).uniq
 end
 
 def yp(s) YAML.safe_load(s, permitted_classes: [Date, Time]) rescue {} end
@@ -175,10 +214,123 @@ if have_twb
 end
 
 # ---------------------------------------------------------------------------
+# Spec generation. The DEFAULT path is MECHANICAL (no agent hand-authoring):
+#   convert_tableau_to_sigma → DM spec; parse-twb-layout + build-charts-from-
+#   signals + an auto-derived master-map → workbook spec. An explicit --specs
+#   <path> (or a per-workbook <workdir>/specs.rb the human dropped in) overrides
+#   the mechanical path with a hand-authored `Specs` module, used verbatim.
+# ---------------------------------------------------------------------------
+require File.join(HERE, 'mechanical-specs')
+specs_path = opts[:specs] || [File.join(WORK, 'specs.rb')].find { |p| File.exist?(p) }
+have_specs = false
+if specs_path && File.exist?(specs_path)
+  begin
+    require specs_path.sub(/\.rb$/, '')
+    have_specs = defined?(Specs) && Specs.respond_to?(:dm_spec) && Specs.respond_to?(:wb_spec)
+    line "spec generator: hand-authored Specs module (#{specs_path})" if have_specs
+  rescue StandardError => e
+    line "(spec generator at #{specs_path} failed to load: #{e.message})"
+  end
+end
+
+# Mechanical converter run (the default). Requires the .twb (parse-twb-layout
+# already gated on have_twb above) and the local build/tableau.js converter.
+mechanical = !have_specs
+conv = nil
+if mechanical
+  unless have_twb
+    abort <<~MSG
+      FATAL: mechanical conversion needs the workbook .twb (for the data model +
+      chart signals), but none was downloaded (MCP-only datasource?). Either
+      supply a hand-authored Specs module via --specs, or use a .twb-backed
+      workbook.
+    MSG
+  end
+  mcp_build = ENV['TABLEAU_MCP_BUILD'] || %w[
+    /Users/tjwells/Desktop/sigma-data-model-mcp/build/tableau.js
+    /Users/tjwells/sigma-data-model-mcp/build/tableau.js
+  ].find { |p| File.exist?(p) }
+  abort 'FATAL: cannot locate build/tableau.js (set TABLEAU_MCP_BUILD)' unless mcp_build
+  conv = MechanicalSpecs.run_converter(
+    twb_path: twb, conn: opts[:conn], db: (opts[:db] || 'CSA'),
+    schema: (opts[:schema] || 'TJ'), mcp_build: mcp_build, workdir: WORK)
+  st = conv['stats'] || {}
+  line "mechanical converter: #{st['elements']} element(s), #{st['columns']} column(s), " \
+       "#{st['metrics']} metric(s), #{st['relationships']} relationship(s); #{(conv['warnings'] || []).size} warning(s)"
+
+  # Mechanical DM fixup NOW (so dropped calcs feed the checkpoint): resolve
+  # raw-table-name prefixes + GUID sibling refs, and DROP calc columns that
+  # still cannot resolve (unknown functions / unresolved refs).
+  fx = MechanicalSpecs.fixup_dm_spec(conv['model'])
+  line "DM fixup: rewrote #{fx[:fixed]} formula(s); dropped #{fx[:dropped].size} unresolvable calc col(s)" if fx[:fixed].positive? || fx[:dropped].any?
+  dropped_calcs = fx[:dropped]
+
+  # Pre-derive the master-map now (deterministic; uses the converter element
+  # name — Phase 4 re-derives against the authoritative readback name). This lets
+  # us surface any chart-PLOTTED metric that did not fully translate (GUID refs
+  # the converter could not resolve) as an OPEN QUESTION rather than a silent
+  # blank chart. Metrics that aren't plotted by any view are ignored.
+  conv_fact = MechanicalSpecs.pick_fact(conv['model'])
+  conv_base = conv_fact ? MechanicalSpecs.base_of(conv['model'], conv_fact) : nil
+  pre = conv_fact ? MechanicalSpecs.derive_master(conv_fact, (conv_fact['name'] || 'Order Fact'), conv_base) : { 'untranslated_metrics' => [] }
+  csv_headers = Dir[File.join(WORK, 'views', '*.csv')].flat_map do |c|
+    (CSV.read(c).first rescue nil) || []
+  end.compact.map { |h| h.to_s.strip }.uniq
+  plotted_untranslated = (pre['untranslated_metrics'] || []).select do |nm|
+    csv_headers.any? { |h| h.casecmp?(nm) || h.sub(/^(sum|avg|min|max|median|distinct count|count) of /i, '').casecmp?(nm) }
+  end
+end
+
+# ---------------------------------------------------------------------------
 # DECISIONS CHECKPOINT — surface the genuine human questions ONLY. Mechanical
 # fixup / POST / layout / parity are never asked about.
 # ---------------------------------------------------------------------------
 questions = []
+
+# (a0) MECHANICAL CONVERTER WARNINGS — the authoritative un-mappable signal.
+# convert_tableau_to_sigma marks each calc/LOD/window translation outcome:
+#   ⛔ = no/failed translation (calc dropped → charts using it degrade)
+#   ⚠  = best-effort / unsupported mode (verify in Sigma)
+#   ℹ / ✅ = clean auto-handle (NOT a decision)
+(mechanical ? (conv['warnings'] || []) : []).each do |w|
+  ws = w.to_s.gsub(/\s+/, ' ').strip
+  next if ws.start_with?('ℹ', '✅')
+  next if ws.include?('Connection ID not set') # mechanical: --connection always supplied
+  if ws.start_with?('⛔')
+    questions << { 'id' => 'calc_no_translation', 'severity' => 'review', 'detail' => ws,
+                   'options' => ['proceed (calc dropped; dependent charts degrade)',
+                                 'abort and re-author the calc manually'],
+                   'default' => 'proceed (calc dropped; dependent charts degrade)' }
+  else # ⚠ and any unmarked warning
+    questions << { 'id' => 'calc_best_effort', 'severity' => 'review', 'detail' => ws,
+                   'options' => ['proceed (converter best-effort; verify in Sigma)',
+                                 'restructure manually'],
+                   'default' => 'proceed (converter best-effort; verify in Sigma)' }
+  end
+end
+
+# (a1) PLOTTED metrics whose formula did not fully translate (unresolved Tableau
+# internal field refs). These are charted by a Tableau view but cannot resolve
+# mechanically against the master — a genuine human decision.
+(mechanical ? (defined?(plotted_untranslated) && plotted_untranslated || []) : []).each do |nm|
+  questions << { 'id' => 'metric_untranslated', 'severity' => 'review', 'calc' => nm,
+                 'detail' => "Metric '#{nm}' is plotted in a Tableau view but the converter left unresolved " \
+                             'internal field references in its formula — it cannot be rebuilt mechanically.',
+                 'options' => ['proceed (chart measure left blank; re-author the calc in Sigma)',
+                               'skip this metric'],
+                 'default' => 'proceed (chart measure left blank; re-author the calc in Sigma)' }
+end
+
+# (a2) calc COLUMNS the mechanical fixup had to DROP (unknown function like
+# DATEPARSE, or refs that never resolved). Genuinely un-mappable → human.
+(mechanical ? (defined?(dropped_calcs) && dropped_calcs || []) : []).each do |nm|
+  questions << { 'id' => 'calc_dropped', 'severity' => 'review', 'calc' => nm,
+                 'detail' => "Calc column '#{nm}' could not be translated mechanically (unsupported function " \
+                             'or unresolved reference) and was dropped from the data model.',
+                 'options' => ['proceed (column dropped; re-author as a Custom SQL element or Sigma calc)',
+                               'skip this calc'],
+                 'default' => 'proceed (column dropped; re-author as a Custom SQL element or Sigma calc)' }
+end
 
 # (a) calc fields that have NO Sigma calc-column translation (window / table
 #     calc / LOD) — they become Custom-SQL DM elements or degrade.
@@ -308,21 +460,7 @@ else
   line 'no open questions — running straight through'
 end
 
-# ---------------------------------------------------------------------------
-# Locate a spec generator (the agent-owned DM/workbook step).
-# ---------------------------------------------------------------------------
-specs_path = opts[:specs] ||
-             [File.join(WORK, 'specs.rb'),
-              File.expand_path('~/orders-migration/specs.rb')].find { |p| File.exist?(p) }
-have_specs = false
-if specs_path && File.exist?(specs_path)
-  begin
-    require specs_path.sub(/\.rb$/, '')
-    have_specs = defined?(Specs) && Specs.respond_to?(:dm_spec) && Specs.respond_to?(:wb_spec)
-  rescue StandardError => e
-    line "(spec generator at #{specs_path} failed to load: #{e.message})"
-  end
-end
+
 
 # ---------------------------------------------------------------------------
 # Phase 2 — Discover warehouse column names (per table) for the DM build.
@@ -333,7 +471,11 @@ schema = opts[:schema] || 'TJ'
 # Table set: from the generator's DM spec when available, else inferred from the
 # datasource's logical tables.
 wh_tables =
-  if have_specs
+  if mechanical
+    (conv['model']['pages'] || []).flat_map { |p| p['elements'] || [] }
+      .select { |e| e.dig('source', 'kind') == 'warehouse-table' }
+      .map { |e| e.dig('source', 'path')&.last }.compact.uniq
+  elsif have_specs
     Specs.dm_spec['pages'].flat_map { |p| p['elements'] }
          .map { |e| e.dig('source', 'path')&.last }.compact.uniq
   else
@@ -362,26 +504,57 @@ end
 # ---------------------------------------------------------------------------
 hdr(3, 'Build data model')
 dm_spec_path = File.join(WORK, 'dm-spec.json')
-unless have_specs
-  abort <<~MSG
-    FATAL: no spec generator found and the general data-driven DM builder is not
-    wired for this datasource shape. Drop a Ruby file defining a `Specs` module
-    with `dm_spec` + `wb_spec(dm_id, fact_eid)` (+ optional `layout_xml`) next to
-    the working dir (#{WORK}/specs.rb) or pass --specs <path>. The validated
-    reference generator lives at ~/orders-migration/specs.rb.
-  MSG
+if mechanical
+  # The converter output IS the DM spec (schemaVersion:1 already set). Apply the
+  # mechanical fixup (resolve raw-table-name prefixes + GUID sibling refs the
+  # converter left unresolved) then stamp the human-supplied folderId. No agent
+  # authoring.
+  dm = conv['model'] # already fixed up in Phase 1 (prefixes/GUIDs resolved, bad calcs dropped)
+  dm['name'] = wb_name if dm['name'].to_s.empty?
+  # Phantom-column filter (needs Phase 2's live warehouse columns): Tableau
+  # virtual-connection datasources flatten dim columns into the fact and emit
+  # base-column refs that don't exist in the real table. Drop them so the POST
+  # resolves. Load the cols-<TABLE>.json files discovered in Phase 2.
+  real_cols = {}
+  Dir[File.join(WORK, 'cols-*.json')].each do |cf|
+    cj = (JSON.parse(File.read(cf)) rescue nil)
+    next unless cj && cj['columns']
+    tname = File.basename(cf, '.json').sub(/^cols-/, '')
+    real_cols[tname] = cj['columns'].map { |c| c['name'] }
+  end
+  unless real_cols.empty?
+    pf = MechanicalSpecs.fixup_dm_spec(dm, real_cols)
+    line "phantom-column filter: dropped #{pf[:phantom]} non-existent base column(s) using #{real_cols.size} live table catalog(s)" if pf[:phantom].to_i.positive?
+  end
+else
+  dm = Specs.dm_spec
 end
-dm = Specs.dm_spec
 dm['folderId'] = opts[:folder] if opts[:folder]
 File.write(dm_spec_path, JSON.pretty_generate(dm))
-run!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'datamodel', dm_spec_path])
+# In mechanical mode validate-spec.rb is advisory only: it flags cross-element
+# sibling refs that Sigma actually resolves via relationships (documented
+# false-negative class — see project CLAUDE.md). The authoritative gate is the
+# live POST + readback column-type guard below (post-and-readback exits 2 on any
+# error-typed column). For hand-authored Specs, keep validation hard.
+_, dvst = run!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'datamodel', dm_spec_path],
+               allow_fail: mechanical)
+line 'DM validate-spec flagged issues (advisory in mechanical mode — live POST is the gate)' if mechanical && !dvst.success?
 dm_ids_path = File.join(WORK, 'dm-ids.json')
 sigma_run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
             '--spec', dm_spec_path, '--out', dm_ids_path, '--workdir', WORK])
 dm_ids = JSON.parse(File.read(dm_ids_path))
 dm_id = dm_ids['dataModelId']
 dm_els = dm_ids['pages'].flat_map { |p| p['elements'] }
-fact = dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
+if mechanical
+  # The master must source the SAME chart-ready element pick_fact chose (the
+  # derived "<Fact> View" when present). Match it into the readback by name.
+  cf = MechanicalSpecs.pick_fact(conv['model'])
+  cf_name = cf && (cf['name'] || MechanicalSpecs.elem_name(cf))
+  fact = dm_els.find { |e| e['name'] == cf_name } ||
+         dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
+else
+  fact = dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
+end
 fact_eid = fact['id']
 line "dataModelId = #{dm_id}  (fact element '#{fact['name']}' = #{fact_eid})"
 
@@ -390,15 +563,84 @@ line "dataModelId = #{dm_id}  (fact element '#{fact['name']}' = #{fact_eid})"
 # ---------------------------------------------------------------------------
 hdr(4, 'Build workbook')
 wb_spec_path = File.join(WORK, 'wb-spec.json')
-spec = Specs.wb_spec(dm_id, fact_eid)
-spec['folderId'] = opts[:folder] if opts[:folder]
-layout_xml = (Specs.respond_to?(:layout_xml) ? Specs.layout_xml : nil)
+layout_xml = nil
+if mechanical
+  # 1) Derive the master-map DETERMINISTICALLY from the converter fact element,
+  #    using the AUTHORITATIVE readback element name for the [fact/Col] formulas,
+  #    AND the readback element's REAL column labels (the suffixed display names
+  #    Sigma assigns to joined-dim columns, e.g. "Customer Id (CUSTOMER_DIM)") so
+  #    the [fact/Col] formulas resolve for virtual-connection (denormalized) DMs.
+  conv_fact = MechanicalSpecs.pick_fact(conv['model'])
+  abort 'FATAL: mechanical path could not identify a fact element in the converter output' unless conv_fact
+  conv_base = MechanicalSpecs.base_of(conv['model'], conv_fact)
+  real_labels = fact['columnLabels'] # from post-and-readback /columns (may be nil)
+  derived = MechanicalSpecs.derive_master(conv_fact, fact['name'], conv_base, real_labels)
+  master_columns = derived['master_columns']
+  mmap = derived['mmap']
+  mmap_path = File.join(WORK, 'master-map.json')
+  File.write(mmap_path, JSON.pretty_generate(mmap))
+  line "master-map: #{master_columns.size} master column(s) (fact element '#{fact['name']}', #{real_labels ? real_labels.size : 0} readback labels)"
+
+  # 2) Build the chart-element specs from the parsed zones + view CSVs + map.
+  charts_path = File.join(WORK, 'chart-specs.json')
+  build_cmd = ['ruby', File.join(HERE, 'build-charts-from-signals.rb'),
+               '--tableau-dir', WORK, '--layout', layout_json,
+               '--master-map', mmap_path, '--master-element-id', 'master',
+               '--out', charts_path]
+  build_cmd += ['--meta', layout_json.sub(/\.json$/, '-meta.json')] if File.exist?(layout_json.sub(/\.json$/, '-meta.json'))
+  build_cmd += ['--auto-controls'] if File.exist?(layout_json.sub(/\.json$/, '-meta.json'))
+  run!(build_cmd, allow_fail: true)
+  raw_charts = (JSON.parse(File.read(charts_path)) rescue [])
+  chart_elements = raw_charts.is_a?(Hash) ? (raw_charts['pages'] || []).flat_map { |p| p['elements'] || [] } : raw_charts
+  if chart_elements.empty?
+    line 'WARN: build-charts produced 0 elements (no usable view CSVs / zones); emitting an empty dashboard page'
+  else
+    line "build-charts: #{chart_elements.size} chart/control element(s)"
+  end
+
+  # 3) Assemble the workbook spec (page-data master + dashboard page).
+  spec = MechanicalSpecs.build_wb_spec(
+    name: wb_name, dm_id: dm_id, fact_eid: fact_eid,
+    master_columns: master_columns, chart_elements: chart_elements,
+    folder_id: opts[:folder])
+else
+  spec = Specs.wb_spec(dm_id, fact_eid)
+  spec['folderId'] = opts[:folder] if opts[:folder]
+  layout_xml = (Specs.respond_to?(:layout_xml) ? Specs.layout_xml : nil)
+end
 File.write(wb_spec_path, JSON.pretty_generate(spec))
-run!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'workbook',
-      '--dm-context', dm_ids_path, wb_spec_path])
 wb_ids_path = File.join(WORK, 'wb-ids.json')
-sigma_run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
-            '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK])
+
+# GRACEFUL AGENT-PATH FALLBACK. The DM is already posted + valid (dm_id above), so
+# if the MECHANICAL workbook layer (validate-spec / build / POST) hits a field it
+# cannot translate (Sigma rejects the spec / unresolved "Dependency not found" /
+# unmapped derived-dim or measure), we must NOT bare-crash. Catch it and exit with
+# a clear, FRIENDLY non-zero handoff: the agent path rebuilds the workbook against
+# this DM (see SKILL.md). Never worse than the proven agent path.
+begin
+  v_log = run_wb!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'workbook',
+                   '--dm-context', dm_ids_path, wb_spec_path])
+  p_log = sigma_run_wb!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
+                         '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK])
+rescue WorkbookBuildError => e
+  failed = cull_failed_fields(e.captured_output,
+                              (defined?(v_log) ? v_log : ''), (defined?(p_log) ? p_log : ''))
+  # Fall back to the mechanically-known untranslatable fields when the log itself
+  # doesn't name one (plotted-but-unresolved metrics + dropped calc columns).
+  if failed.empty? && mechanical
+    failed = ((defined?(plotted_untranslated) && plotted_untranslated || []) +
+              (defined?(dropped_calcs) && dropped_calcs || [])).compact.uniq
+  end
+  names = failed.empty? ? 'one or more fields' : failed.join(', ')
+  n = failed.empty? ? 'some' : failed.size.to_s
+  puts
+  puts "── Mechanical path: data model built OK (dataModelId=#{dm_id}). The WORKBOOK " \
+       "layer hit #{n} field(s) the mechanical path can't translate (#{names}). " \
+       "Falling back to the agent path: rebuild the workbook via the skill's " \
+       "agent-authored flow (see SKILL.md) against this DM. The data model is " \
+       "posted and ready to attach."
+  exit 4
+end
 wb_ids = JSON.parse(File.read(wb_ids_path))
 wb_id = wb_ids['workbookId']
 line "workbookId = #{wb_id}"
@@ -413,15 +655,20 @@ if layout_xml
   File.write(layout_path, layout_xml)
   line 'layout from spec generator'
 elsif File.exist?(layout_json)
-  run!(['ruby', File.join(HERE, 'build-dashboard-layout.rb'),
-        '--layout', layout_json, '--wb-ids', wb_ids_path, '--out', layout_path])
+  _, lst = run!(['ruby', File.join(HERE, 'build-dashboard-layout.rb'),
+                 '--layout', layout_json, '--wb-ids', wb_ids_path, '--out', layout_path],
+                allow_fail: true)
+  line 'WARN: layout build failed — workbook will render in default stacked order' unless lst.success?
 else
   line 'no layout source — skipping (workbook renders single-column stack)'
 end
+# Layout is cosmetic: a bad grid PUT must NOT fail an otherwise-good migration
+# (the workbook still renders + queries). Apply best-effort.
 if File.exist?(layout_path)
-  sigma_run!(['ruby', File.join(HERE, 'put-layout.rb'),
-              '--workbook', wb_id, '--layout', layout_path])
-  line "layout applied to workbook #{wb_id}"
+  _, pst = sigma_run!(['ruby', File.join(HERE, 'put-layout.rb'),
+                       '--workbook', wb_id, '--layout', layout_path], allow_fail: true)
+  line(pst.success? ? "layout applied to workbook #{wb_id}" :
+       'WARN: layout PUT rejected (Invalid element position) — keeping default stacked layout; charts unaffected')
 end
 
 # ---------------------------------------------------------------------------

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -108,6 +108,22 @@ end
 
 # Read back
 spec = JSON.parse(http(:get, format(GET_PATH, oid), accept_json: true).body)
+
+# Fetch the resolved /columns BEFORE writing the id-map so we can attach the
+# AUTHORITATIVE per-element column labels (the suffixed display names Sigma
+# assigns to disambiguate joined-dim columns — e.g. "Customer Id (CUSTOMER_DIM)").
+# derive_master needs these to emit master-column formulas that actually resolve.
+# (Same response is reused below for the error-type guard — one round trip.)
+columns_path = opts[:type] == 'datamodel' ?
+  "/v2/dataModels/#{oid}/columns" :
+  "/v2/workbooks/#{oid}/columns"
+cols_res = http(:get, columns_path, accept_json: true)
+cols_json = cols_res.is_a?(Net::HTTPSuccess) ? (JSON.parse(cols_res.body) rescue { 'entries' => [] }) : nil
+labels_by_el = Hash.new { |h, k| h[k] = [] }
+(cols_json && cols_json['entries'] || []).each do |c|
+  labels_by_el[c['elementId']] << c['label'] if c['elementId'] && c['label']
+end
+
 out = {
   ID_FIELD => oid,
   'pages'  => spec.fetch('pages', []).map do |p|
@@ -115,7 +131,11 @@ out = {
       'id'       => p['id'],
       'name'     => p['name'],
       'visibility' => p['visibility'],
-      'elements' => (p['elements'] || []).map { |e| { 'id' => e['id'], 'kind' => e['kind'], 'name' => e['name'] } }
+      'elements' => (p['elements'] || []).map do |e|
+        el = { 'id' => e['id'], 'kind' => e['kind'], 'name' => e['name'] }
+        el['columnLabels'] = labels_by_el[e['id']] if labels_by_el.key?(e['id'])
+        el
+      end
     }
   end
 }
@@ -138,13 +158,8 @@ puts JSON.pretty_generate(out)
 # Endpoint: GET /v2/{dataModels|workbooks}/<id>/columns — returns one entry per
 # column with `type.type` resolved. Scan for type == "error".
 
-columns_path = opts[:type] == 'datamodel' ?
-  "/v2/dataModels/#{oid}/columns" :
-  "/v2/workbooks/#{oid}/columns"
-
-res = http(:get, columns_path, accept_json: true)
+res = cols_res
 if res.is_a?(Net::HTTPSuccess)
-  cols_json = JSON.parse(res.body) rescue { 'entries' => [] }
   error_columns = (cols_json['entries'] || []).select { |c| c.dig('type', 'type') == 'error' }
   if error_columns.any?
     warn "\n========================================"


### PR DESCRIPTION
Cross-tool coverage sweep + fixes. QuickSight 20/20, Qlik 9/9, ThoughtSpot 13/13 clean. Power BI mechanical now 3/7 (simple→standard; complex DAX falls back to agent path). Tableau: deterministic mechanical spec-gen for clean warehouse-table workbooks (~$0.70 vs ~$29); virtual-connection DM mechanical, workbook layer falls back to agent path. Both orchestrators degrade gracefully — never worse than before. 🤖 Generated with [Claude Code](https://claude.com/claude-code)