### PR TITLE
builder+validator: ne48/qb2i/8vzj (powerbi builder) + 1t6c (validator, 3 plugins)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -133,6 +133,11 @@ def apply_fmt(col, queryref, fields, vfmts)
 end
 
 def measure_formula(fs)
+  # bead qb2i: an explicit `formula` wins — lets the master-map emit a verbatim
+  # Sigma expression (e.g. a window calc "Lag(Sum([X/v]), 1)" / "Rank(Sum([X/v]),
+  # \"desc\")" / percent-of-total "Sum([X/v]) / GrandTotal(Sum([X/v]))") the
+  # agg/`?` encodings can't express, instead of falling back to a wrong stub.
+  return fs['formula'] if fs['formula'].is_a?(String) && !fs['formula'].empty?
   agg = fs['agg']
   return fs['ref'] if agg.nil? || (agg.respond_to?(:empty?) && agg.empty?)
   # Multi-arg aggregator support (bead 14w c): PercentileCont(col, 0.9), etc.
@@ -205,6 +210,21 @@ def build_element(rec, fields, masters)
   end
 
   master = visual_master(rec, fields)
+  # bead 8vzj: a Sigma element sources exactly ONE master. visual_master picks the
+  # one covering the MOST fields, but any bound field that cannot resolve on it
+  # (not its master and not among its `alts`) is silently DROPPED. Warn loudly so
+  # the agent supplies a single joined master (or per-field override) for those.
+  if master
+    unreachable = rec['bindings'].values.flatten.compact.reject do |qr|
+      fs = field_spec(qr, fields)
+      fs['master'] == master || Array(fs['alts']).any? { |a| a['master'] == master }
+    end.map { |qr| qr.to_s }.uniq
+    unless unreachable.empty?
+      warn "[build-workbook] WARN visual '#{(rec['title'] || rec['visual_id'])}' has field(s) " \
+           "#{unreachable.join(', ')} not reachable on the chosen master '#{master}'; a Sigma element " \
+           "sources only one master, so they will be DROPPED — point them at a single joined master element."
+    end
+  end
   master_id = master && masters[master] ? masters[master]['id'] : nil
   el = { 'id' => eid, 'kind' => kind, 'name' => name }
   el['source'] = { 'elementId' => master_id, 'kind' => 'table' } if master_id
@@ -370,23 +390,26 @@ def build_element(rec, fields, masters)
     # grouping whose `calculations` lists the measure col ids (bead 14w(f)).
     # The first non-aggregated (dimension) column becomes the groupBy; every
     # aggregated column id goes into that grouping's calculations[].
-    group_id = nil; calc_ids = []
+    # bead ne48: group by ALL leading dimension columns, not just the first —
+    # otherwise a 2-dim matrix collapses to the wrong grain. A field with an
+    # explicit `formula` (bead qb2i window calc) is a calculation, never a groupBy.
+    group_ids = []; calc_ids = []
     (b['Values'] || []).each_with_index do |qr, i|
       fs = field_spec(qr, fields, master)
       cid = "#{eid}-c#{i}"
-      is_dim = fs['agg'].to_s.empty?
+      is_dim = fs['agg'].to_s.empty? && fs['formula'].to_s.empty?
       col = { 'id' => cid, 'formula' => is_dim ? fs['ref'] : measure_formula(fs),
               'name' => qr.split('.').last }
       apply_fmt(col, qr, fields, vfmts) unless is_dim
       cols << col
       if is_dim
-        group_id ||= cid
+        group_ids << cid
       else
         calc_ids << cid
       end
     end
-    if group_id && !calc_ids.empty?
-      el['groupings'] = [{ 'id' => "#{eid}-g", 'groupBy' => [group_id], 'calculations' => calc_ids }]
+    if !group_ids.empty? && !calc_ids.empty?
+      el['groupings'] = [{ 'id' => "#{eid}-g", 'groupBy' => group_ids, 'calculations' => calc_ids }]
     end
   when 'pivot-table'
     rows = (b['Rows'] || b['Category'] || [])

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
@@ -70,6 +70,17 @@ spec.fetch('pages', []).each do |page|
       own_prefixes << src['path'].last
     end
     own_prefixes << 'Custom SQL' if src['kind'] == 'sql'
+    # bead 1t6c: a master sourcing a DM element (kind: data-model) carries
+    # pass-through column formulas like [EMPLOYEES/Department] whose prefix is the
+    # DM element's source-table name — that lives INSIDE the data model, not this
+    # spec, so it can't be cross-checked here and was false-flagged "unknown
+    # prefix". The DM post already validated these columns; trust the prefixes the
+    # element's own formulas use.
+    if src['kind'] == 'data-model'
+      cols.each do |c|
+        (c['formula'] || '').to_s.scan(/\[([^\]\/]+)\//).flatten.each { |p| own_prefixes << p }
+      end
+    end
 
     cols.each do |col|
       f = (col['formula'] || '').to_s

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/validate-spec.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/validate-spec.rb
@@ -70,6 +70,17 @@ spec.fetch('pages', []).each do |page|
       own_prefixes << src['path'].last
     end
     own_prefixes << 'Custom SQL' if src['kind'] == 'sql'
+    # bead 1t6c: a master sourcing a DM element (kind: data-model) carries
+    # pass-through column formulas like [EMPLOYEES/Department] whose prefix is the
+    # DM element's source-table name — that lives INSIDE the data model, not this
+    # spec, so it can't be cross-checked here and was false-flagged "unknown
+    # prefix". The DM post already validated these columns; trust the prefixes the
+    # element's own formulas use.
+    if src['kind'] == 'data-model'
+      cols.each do |c|
+        (c['formula'] || '').to_s.scan(/\[([^\]\/]+)\//).flatten.each { |p| own_prefixes << p }
+      end
+    end
 
     cols.each do |col|
       f = (col['formula'] || '').to_s

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/validate-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/validate-spec.rb
@@ -70,6 +70,17 @@ spec.fetch('pages', []).each do |page|
       own_prefixes << src['path'].last
     end
     own_prefixes << 'Custom SQL' if src['kind'] == 'sql'
+    # bead 1t6c: a master sourcing a DM element (kind: data-model) carries
+    # pass-through column formulas like [EMPLOYEES/Department] whose prefix is the
+    # DM element's source-table name — that lives INSIDE the data model, not this
+    # spec, so it can't be cross-checked here and was false-flagged "unknown
+    # prefix". The DM post already validated these columns; trust the prefixes the
+    # element's own formulas use.
+    if src['kind'] == 'data-model'
+      cols.each do |c|
+        (c['formula'] || '').to_s.scan(/\[([^\]\/]+)\//).flatten.each { |p| own_prefixes << p }
+      end
+    end
 
     cols.each do |col|
       f = (col['formula'] || '').to_s


### PR DESCRIPTION
builder+validator: re-vendor ne48/qb2i/8vzj (powerbi builder) + 1t6c (validator, all 3 plugins)

Propagates the verified staging fixes into the public marketplace (re-applied,
not blind-copied — sanitization preserved, no staging paths / baked ids):

- ne48: tableEx groupBy now collects ALL leading dimension columns (was first
  only). Verified: a 2-dim matrix groups by [Order Size Band, Cust Region].
- qb2i: measure_formula honors an explicit "formula" field, so a master-map field
  can emit a window / percent-of-total expression (Lag/Rank/GrandTotal) as a
  grouping calculation instead of a CountDistinct stub; a "formula" field is a
  calc, not a groupBy dim.
- 8vzj: warn loudly when a bound field can't resolve on the chosen single master
  (adapted to this build's coverage-maximizing visual_master + alts) so dropped
  fields aren't silent.
- 1t6c: validate-spec.rb (powerbi + quicksight + tableau copies) now trusts a
  data-model-source master's own [Elem/Col] prefixes (the DM element's
  source-table name lives inside the DM) — kills the "unknown prefix" false
  positive.

ruby -c clean on all 4 files; sanitization gate clean (no forbidden patterns).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
