### PR TITLE
Add looker-to-sigma plugin (converter + assessment)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace-manifest.json",
   "name": "sigma-migration-skills",
-  "description": "Skills for migrating BI tools (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight) to Sigma — converters + assessments, validated end-to-end with warehouse parity.",
+  "description": "Skills for migrating BI tools (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight, Looker) to Sigma — converters + assessments, validated end-to-end with warehouse parity.",
   "version": "1.0.0",
   "owner": { "name": "Thomas Wells" },
   "metadata": { "pluginRoot": "./plugins" },
@@ -40,6 +40,13 @@
       "description": "Amazon QuickSight analyses/dashboards → Sigma data model + workbook (KPI/bar/line/pie/donut/combo/scatter/table/pivot), with parity verification. Bundles quicksight-to-sigma + quicksight-assessment.",
       "category": "migration",
       "keywords": ["quicksight", "amazon", "aws", "migration", "bi"]
+    },
+    {
+      "name": "looker-to-sigma",
+      "source": "./looker-to-sigma",
+      "description": "Looker (LookML semantic model + LookML/user-defined dashboards) → Sigma data model + workbook (KPI/bar/line/area/pie/donut/scatter/table/pivot, table calcs), with 3-way warehouse parity. Bundles looker-to-sigma + looker-assessment.",
+      "category": "migration",
+      "keywords": ["looker", "lookml", "migration", "bi"]
     }
   ]
 }

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "looker-to-sigma",
+  "displayName": "Looker → Sigma",
+  "version": "1.0.0",
+  "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma — discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML→data-model conversion via convert_lookml_to_sigma, dashboard→workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
+  "author": { "name": "Thomas Wells" },
+  "license": "MIT",
+  "keywords": ["looker", "lookml", "sigma", "migration", "bi", "converter"],
+  "skills": "./skills/"
+}

--- a/plugins/looker-to-sigma/README.md
+++ b/plugins/looker-to-sigma/README.md
@@ -1,0 +1,96 @@
+# Looker → Sigma
+
+Convert a **Looker instance** — its **LookML semantic model** and its **dashboards** —
+into a governed **Sigma data model** and matching **Sigma workbook(s)**. Discovery via the
+Looker REST API 4.0 (or the Looker MCP server, or offline `.lkml`), LookML → data-model
+conversion via the `convert_lookml_to_sigma` converter, dashboard → workbook conversion from
+the Looker Dashboard API JSON, build via the Sigma REST API, and **3-way parity
+verification** (Looker vs Sigma vs the source warehouse). The agent supplies the judgment
+(which explore, which join strategy, which tile kind, which layout); the `scripts/*` do the
+mechanical work.
+
+> **Validated end-to-end (2026-06-10)** against a live `hakkoda1.cloud.looker.com` Looker
+> instance pointed at the same `CSA.TJ` Snowflake as Sigma: 2 dashboards (Orders Overview +
+> Orders Deep Dive) migrated clean with **no hand-edits**, DM = 7 elements / 161 cols / 24
+> metrics / 5 relationships, and **3-way parity to the cent** on region revenue and the ratio
+> metrics (AOV / margin / return). See `skills/looker-to-sigma/refs/` for the coverage matrix.
+
+This plugin ships one skill (`looker-to-sigma`); a `looker-assessment` sibling is handled
+separately.
+
+---
+
+## Two artifacts, two pipelines
+
+Looker has two independent layers; convert them separately.
+
+| Layer | Source (production = API-first) | Converter | Sigma output |
+|---|---|---|---|
+| **Semantic model** | LookML views + model — via the Looker API / Looker MCP, or files offline | `convert_lookml_to_sigma` (Sigma data-model converter, MCP) | data model |
+| **Dashboards** | `GET /dashboards/{id}` JSON — covers **user-defined (UDD) AND LookML dashboards** | `fetch_looker_dashboard.py` → contract → `build_workbook.py` | workbook |
+
+**Critical:** most real Looker dashboards are **user-defined (UDD)** — built in the UI, not
+in any LookML file. They are reachable only via the Looker API, which returns UDD and LookML
+dashboards as the **same** `Dashboard` JSON. So the dashboard converter keys off that API JSON
+(source-agnostic); the offline `.dashboard.lookml` parse normalizes into the same contract.
+**UDD is the primary path.**
+
+---
+
+## Phases & tools
+
+| Phase | What it does | Tools / scripts |
+|---|---|---|
+| **0 — Assess** | Scope the Looker estate (inventory, complexity, shortlist). Defer to the `looker-assessment` sibling skill. | *(separate skill)* |
+| **1 — Discover** | List explores + dashboards; pull a dashboard into the normalized contract (UDD or LookML), or parse `.dashboard.lookml` offline | `looker_api.py`, `fetch_looker_dashboard.py`, `parse_lookml_dashboard.py` · **Looker REST API 4.0 / Looker MCP** |
+| **2 — Convert semantic model** | LookML views+model → Sigma DM spec; POST + register + verify | `convert_lookml_to_sigma` (MCP) · `convert_dm.mjs`, `post_dm.py` · **Sigma REST** (`/v2/dataModels/spec`) |
+| **3 — Convert dashboards** | Each Looker dashboard's tiles → Sigma elements, filters → controls, newspaper layout → 24-col grid | `fetch_looker_dashboard.py`, `build_workbook.py` · **Sigma REST** (`/v2/workbooks/spec`) |
+| **4 — Parity** | 3-way compare: Looker `run_inline_query` vs Sigma `query` vs warehouse | **Sigma MCP (sigma-mcp-v2)** + Looker API |
+| **5 — Enhance** | Wire UI-only features post-publish (cross-filtering, trellis, tooltips, 2nd-KPI comparisons) | *(judgment)* |
+
+The phase structure mirrors `tableau-to-sigma` (Assess → Discover → Convert → Build → Verify →
+Enhance); see `skills/looker-to-sigma/SKILL.md` for the full per-phase reference and gotchas.
+
+---
+
+## Test-fixture builders
+
+`scripts/build_looker_dashboard.py` and `build_looker_dashboard2.py` are **test-fixture
+builders**, not part of a customer migration. They author UDD dashboards on a Looker instance
+via the API ("Orders Overview" and "Orders Deep Dive" on the `csa_thelook` model) so you have
+known migration targets to convert and check parity against. Use them to stand up demo content;
+never run them against a customer's Looker.
+
+---
+
+## Toolchain
+
+- **Looker REST API 4.0** — `~/.looker/looker.ini` (API3 client_id/secret, admin role, base_url
+  on `:19999`). `looker_api.py` is a no-SDK client; `fetch_looker_dashboard.py` is self-contained.
+- **Looker MCP server** *(preview)* — list models, find Looks/dashboards, get schema, query.
+  Admin enables tools (off by default). Preferred for live discovery when wired in.
+- **Sigma data-model converter** — `convert_lookml_to_sigma` (MCP): LookML views+model → Sigma DM
+  spec, resolving measure `${dim}`/`${measure}` refs and wiring snowflake (multi-hop) joins.
+- **Sigma REST API** (`get-token.sh` → `SIGMA_API_TOKEN`, ~1h TTL) — `/v2/dataModels/spec`,
+  `/v2/workbooks/spec`, `/v2/files`.
+- **Sigma MCP** (`sigma-mcp-v2`) — live parity queries in Phase 4.
+- **Warehouse** — reached through the Sigma connection (warehouse-agnostic). Looker needs its
+  **own** direct warehouse auth (a Looker connection), separate from Sigma's connection.
+
+---
+
+## Quickstart
+
+```bash
+# Looker: ~/.looker/looker.ini with API3 client_id/secret (base_url on :19999, admin)
+# Sigma:  ruby scripts/setup.rb once (writes ~/.sigma-migration/env) — see the sigma-api skill
+```
+
+Then invoke the **`looker-to-sigma`** skill with a Looker dashboard ID (or an explore name)
+and it runs the phases above. See `skills/looker-to-sigma/QUICKSTART.md` for a runnable
+walkthrough and `skills/looker-to-sigma/SKILL.md` for the full phase reference. Read the
+`refs/` first: `dashboard-contract.md`, `looker-dashboard-layout.md`.
+
+> **Canonical workbook/data-model spec shape** (element kinds, controls, formulas, formatting)
+> lives in the companion **`sigma-workbooks`** / **`sigma-data-models`** skills — this skill
+> restates only the Looker-conversion-specific patterns.

--- a/plugins/looker-to-sigma/skills/looker-assessment/PRIVACY.md
+++ b/plugins/looker-to-sigma/skills/looker-assessment/PRIVACY.md
@@ -1,0 +1,43 @@
+# Privacy posture — looker-assessment
+
+**Surface this to the customer before running.**
+
+## What it reads
+- **Instance metadata** via the Looker REST API 4.0: LookML models (+ explores),
+  projects, connections (name / dialect / database / host), Looks, dashboards
+  (title / owner / folder / kind), users, groups, folders.
+- **Usage** via Looker's **System Activity** model (`system__activity`, the `history`
+  explore): per-dashboard / per-Look run counts and active-user counts over the
+  selected window. Aggregate counts only — no per-user content rows.
+- **Per-dashboard tile definitions** (deep mode, default): vis types, pivots, table
+  calcs (`dynamic_fields`), filters, merged-result references, Liquid usage — to
+  bucket migration complexity. No business **data rows** are read.
+
+## What it does NOT do
+- **No writes of any kind.** Only `GET` requests and System Activity inline queries
+  (`POST /queries/run/json` is a read against the system model — it creates no saved
+  object). Nothing in Looker is created, edited, or deleted. Contrast with
+  `qlik-assessment`, which briefly creates a temporary object; this skill does not.
+- Reads no warehouse content rows; runs no content query; reads no PDT/cache data.
+- Transmits nothing to third parties; output stays local.
+
+> Like every Claude Code skill, what the scan reads is sent through the Anthropic API
+> to Claude. This is a weaker posture than a tool that keeps everything inside your
+> warehouse. The user should be told this before running.
+
+## What it produces
+`<out>/inventory.json` + `<out>/readout.md` + `<out>/readout.html` locally. Nothing is
+uploaded — the user decides what to share.
+
+## Sensitive fields
+- The users list and System Activity counts may carry personal data (names, run
+  counts) — treat as confidential; delete after the engagement if policy requires.
+- Connection `host` / `database` identify warehouse endpoints (not credentials) —
+  flagged for the dialect mapping, never the secret.
+
+## Credentials
+Looker API3 client credentials in `~/.looker/looker.ini` (`base_url` on `:19999`,
+`client_id`, `client_secret`). Never commit the secret; create the ini in your own
+environment. The System Activity queries need a role with
+`see_system_activity` (admin or equivalent); without it, usage degrades to a
+tile-count proxy and the rest of the assessment still runs.

--- a/plugins/looker-to-sigma/skills/looker-assessment/README.md
+++ b/plugins/looker-to-sigma/skills/looker-assessment/README.md
@@ -1,0 +1,104 @@
+# Looker Assessment
+
+A Claude Code skill that inventories a Looker instance and produces a
+migration-readiness readout. Designed to be run by a customer (or a Sigma rep with
+the customer present) before deciding which Looker dashboards to migrate to Sigma.
+
+**READ-ONLY.** Only `GET` requests and System Activity inline queries — no object is
+created, edited, or deleted in Looker, and no warehouse rows are ever read. The skill
+never posts to Sigma.
+
+## What it produces
+
+A directory (`/tmp/assessment-<host>/` by default) with:
+
+- `inventory.json` — environment counts (models, explores, projects, connections,
+  Looks, dashboards split UDD vs LookML, users, groups, folders), connection dialects,
+  System Activity usage, per-dashboard complexity buckets, an ownership rollup,
+  feature/viz rollups, and the value/cost-ranked **migration shortlist**. The single
+  file the renderer + `looker-to-sigma` consume.
+- `readout.md` — a compact markdown summary, written by `looker-inventory.py`.
+- `readout.html` — a customer-facing, Sigma-branded HTML report (the same theme as
+  `tableau-assessment` / `qlik-assessment`), written by `render-readout-html.rb`.
+  Open it in a browser or print to PDF to share.
+
+Nothing in this directory is uploaded anywhere. To share, zip and send deliberately.
+
+## Prerequisites
+
+- Claude Code installed
+- A `~/.looker/looker.ini` for the instance you want to assess:
+
+  ```ini
+  [Looker]
+  base_url=https://<host>.cloud.looker.com:19999
+  client_id=...
+  client_secret=...
+  verify_ssl=true
+  ```
+
+  The `:19999` API port matters. Confirm with
+  `python3 scripts/looker_api.py whoami`.
+- Python 3 (inventory script) and Ruby (HTML renderer)
+
+For the **usage axis** (dashboard / Look runs, active users), the role needs access
+to the `system__activity` model (`see_system_activity` — admin or equivalent). Without
+it, usage degrades to a tile-count proxy and everything else still runs.
+
+## How to run
+
+In Claude Code:
+
+```
+/looker-assessment
+```
+
+Or directly:
+
+```bash
+python3 scripts/looker-inventory.py --out /tmp/assessment-<host> --usage-days 90
+ruby   scripts/render-readout-html.rb --out /tmp/assessment-<host>
+```
+
+The skill will:
+
+1. Probe auth + role (`looker_api.py whoami`)
+2. Inventory models / explores / projects / connections / Looks / dashboards / users /
+   groups / folders
+3. Pull dashboard / Look usage + active users from the System Activity model
+4. Open each dashboard to bucket tile vis-types and hard-to-migrate features (pivots,
+   table calcs, merged results, custom viz, Liquid, filters)
+5. Score `value / (1 + cost)` and tag each dashboard
+6. Write `inventory.json` + `readout.md`, then render `readout.html`
+7. Offer to hand off the shortlist to `looker-to-sigma`
+
+Flags: `--out DIR`, `--usage-days N` (System Activity window, default 90),
+`--no-deep` (skip the per-dashboard scan — counts + usage only), `--ini PATH`.
+
+## The key idea
+
+The same rules that drive `convert_lookml_to_sigma` + the dashboard builder also
+**predict migration effort**: bucket each tile's vis-type and features against Sigma's
+coverage. Pivots / table calcs / Liquid → `manual` (brief setup in Sigma); merged
+results / custom viz → `unhandled` (review). Usage comes from Looker's System Activity
+model. See `refs/complexity-scoring.md`.
+
+## What this is NOT
+
+- **Not** a write tool. It cannot and will not modify Looker content or post to Sigma.
+- **Not** a complete instance audit. It covers the signals that matter for Sigma
+  migration scoping (no folder/group ACL audit, no PDT/datagroup analysis).
+- **Not** the converter. It scopes; `looker-to-sigma` converts. The `shortlist` in
+  `inventory.json` is the hand-off between them.
+
+## Privacy
+
+This skill sends instance/dashboard metadata (not warehouse rows) through the
+Anthropic API. See [`PRIVACY.md`](./PRIVACY.md) for the full disclosure to review with
+your privacy/legal team before running.
+
+## Sibling skills
+
+- [`looker-to-sigma`](../looker-to-sigma/) — the conversion skill this feeds into.
+- `tableau-assessment` / `qlik-assessment` — the analogs this skill mirrors (same
+  scoring framework, same Sigma-branded readout theme).

--- a/plugins/looker-to-sigma/skills/looker-assessment/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-assessment/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: looker-assessment
+description: >-
+  Take inventory of a Looker instance and produce a migration-readiness readout —
+  model / explore / project / connection (dialect) / Look / dashboard (UDD vs
+  LookML) / user / group / folder counts, per-dashboard complexity (vis-type mix,
+  pivots, table calcs, merged results, custom viz, Liquid, filters), usage from
+  Looker's System Activity model, and a value/cost-ranked migration shortlist. Use
+  to scope a Looker→Sigma migration or audit BI sprawl. Looker REST API 4.0 driven
+  (read-only); hands off to looker-to-sigma.
+user-invocable: true
+---
+
+# Looker Assessment
+
+> **STATUS: working inventory (Looker REST API 4.0 driven, live-validated on
+> `hakkoda1.cloud.looker.com`).** Mirrors `tableau-assessment` / `qlik-assessment`:
+> same `value / (1 + cost)` scoring, same
+> `migrate-first / easy-win / moderate / needs-gap-scout / retire` tags, and the
+> byte-identical Sigma-branded HTML readout theme.
+
+**Read first:**
+- `refs/complexity-scoring.md` — the Looker convertibility rubric (vis-type + feature buckets)
+- `refs/output-shapes.md` — exact `inventory.json` shape the renderer consumes
+- `../looker-to-sigma/SKILL.md` — the conversion skill this feeds into; auth recipe
+- `PRIVACY.md` — read-only posture
+
+## The key idea
+The same translation rules that drive `convert_lookml_to_sigma` + the dashboard
+builder (`../looker-to-sigma/scripts/build_workbook.py`) also **predict migration
+effort**: bucket each dashboard tile's vis-type and hard-to-migrate features
+against Sigma's coverage. Pivots / table calcs / Liquid → `manual` (a brief
+post-conversion step in Sigma); merged results / marketplace-or-custom viz →
+`unhandled` (no direct Sigma equivalent — review). Usage (the value axis) comes
+from Looker's own **System Activity** model, which Looker exposes well (unlike most
+BI tools where usage telemetry is the weak spot).
+
+**Read-only.** Only `GET`s and System Activity inline queries
+(`POST /queries/run/json` against `model: system__activity`). No object is created,
+edited, or deleted; no warehouse content query is ever run.
+
+**UDD and LookML dashboards convert through the same path.** `GET /dashboards/{id}`
+returns user-defined (UI-built) and LookML dashboards as the same JSON shape, so the
+assessment treats them identically and just records the `kind` for reporting. UDD is
+the primary path.
+
+## Auth & environment
+Looker API3 credentials in `~/.looker/looker.ini`:
+
+```ini
+[Looker]
+base_url=https://<host>.cloud.looker.com:19999
+client_id=...
+client_secret=...
+verify_ssl=true
+```
+
+The `:19999` API port matters (login there returns the bearer). `scripts/looker_api.py`
+(copied in for self-containment) reads the ini and logs in fresh per call. Confirm
+access with `python3 scripts/looker_api.py whoami`. Most counts need only a normal
+role; the **System Activity** queries need a role with permission to the
+`system__activity` model (admin or a role granted `see_system_activity`) — if that
+permission is missing, usage falls back to 0 and dashboards score on a tile-count
+proxy. Point at a different ini with `--ini PATH`.
+
+## Phases
+0. **Probe** — `python3 scripts/looker_api.py whoami` confirms auth + role. A System
+   Activity test query confirms usage access (the inventory script degrades
+   gracefully to proxy scoring if it's denied).
+1. **Environment counts** — `GET /lookml_models` (+ explores rolled up),
+   `/projects`, `/connections` (dialects), `/looks`, `/dashboards`, `/folders`,
+   `/groups`, `/users`. Dashboards split UDD vs LookML by id shape (`model::name`
+   = LookML).
+2. **Usage (System Activity)** — `POST /queries/run/json` on `system__activity`:
+   the `history` explore grouped by `dashboard.id`/`look.id` for run counts over the
+   last N days, and a totals query for `user.count` (active users) + query/dashboard
+   run volume. See `refs/complexity-scoring.md` for the exact field list.
+3. **Per-dashboard complexity** — `GET /dashboards/{id}` per dashboard; bucket each
+   tile's vis-type and detect pivots (`query.pivots`), table calcs
+   (`query.dynamic_fields`, a JSON string), merged results (`merge_result_id`),
+   custom/marketplace viz (vis type outside the known set), and Liquid (`{{ }}` /
+   `{% %}` in the query). Count filters.
+4. **Shortlist** — `cost = 10·unhandled + 3·manual + 1·hint`;
+   `value = dashboard_runs × √query_runs` (tile-count proxy when cold);
+   `score = value / (1 + cost)`; tag.
+5. **Readout** — `looker-inventory.py` writes `inventory.json` + `readout.md`; then
+   `render-readout-html.rb --out <dir>` renders the customer-facing, Sigma-branded
+   `readout.html` (same theme as `tableau-assessment` / `qlik-assessment`).
+6. **Hand off** — to `looker-to-sigma` (ask the user which dashboards first).
+
+## How to run
+```bash
+# one pass: counts + System Activity usage + per-dashboard complexity + shortlist
+python3 scripts/looker-inventory.py --out /tmp/assessment-<host> --usage-days 90
+ruby   scripts/render-readout-html.rb --out /tmp/assessment-<host>
+```
+
+Flags:
+- `--out DIR` — output dir (default `assessment-<host>`).
+- `--usage-days N` — System Activity window (default 90); surfaced in the readout.
+- `--no-deep` — skip the per-dashboard `GET /dashboards/{id}` scan (counts + usage
+  only; the shortlist falls back to usage-only). Useful for a fast first pass or when
+  there are hundreds of dashboards.
+- `--ini PATH` — alternate `looker.ini`.
+
+## Scripts
+| Script | Phase | Purpose |
+|---|---|---|
+| `scripts/looker_api.py` | all | Minimal Looker API 4.0 client (copied from `looker-to-sigma` for self-containment; reads `~/.looker/looker.ini`, logs in fresh per call). |
+| `scripts/looker-inventory.py` | 1–4 | Enumerate the environment, pull System Activity usage, scan per-dashboard complexity, score + tag → `inventory.json` + `readout.md`. Reuses the same tile/feature normalization as `looker-to-sigma`'s `fetch_looker_dashboard.py`. |
+| `scripts/render-readout-html.rb` | 5 | Render the Sigma-branded `readout.html` from `inventory.json`. |
+
+## Deliverables (in `<out>/`)
+- `inventory.json` — environment counts, connection dialects, System Activity usage,
+  per-dashboard complexity buckets, ownership rollup, feature/viz rollups, and the
+  value/cost-ranked **shortlist**. The single file the renderer + `looker-to-sigma`
+  consume.
+- `readout.md` — compact markdown summary (written by the Python script).
+- `readout.html` — customer-facing, Sigma-branded HTML report. Open in a browser or
+  print to PDF to share.
+
+Nothing in this directory is uploaded anywhere — sharing is a deliberate action.
+
+## Live validation
+Validated end-to-end against `hakkoda1.cloud.looker.com` (Looker 26.8.11) on
+2026-06-10: 6 models / 29 explores / 5 projects / 3 Snowflake connections / 1 Look /
+8 dashboards (all UDD) / 13 folders / 3 groups. System Activity over 90 days returned
+real run counts (Snowflake Operations = 22 dashboard runs / 43 queries → top of the
+shortlist as `migrate-first`; Orders Overview = 2 runs / 18 queries) and 2 active
+users. Per-dashboard scan correctly flagged Orders Deep Dive's pivot + table-calc
+tiles as `manual`.
+
+## Hand off to looker-to-sigma
+After the readout, present the user a choice (which dashboards to migrate first) and
+invoke `looker-to-sigma` with the shortlisted dashboard ids — the converter handles
+the LookML model (`convert_lookml_to_sigma`) and rebuilds each dashboard from its
+Looker Dashboard API JSON. The `shortlist` array in `inventory.json` is the hand-off
+contract.
+
+## Open work
+- **Per-tile usage** is dashboard-level; the System Activity `history` explore can
+  also break out by `query.id`/`dashboard_element` for tile-level attention if needed.
+- **Folder/group ACL audit** (who can see what) is out of scope — counts only.
+- Large instances (hundreds of dashboards): use `--no-deep` for the first pass, then
+  deep-scan only the usage-ranked top slice.

--- a/plugins/looker-to-sigma/skills/looker-assessment/refs/complexity-scoring.md
+++ b/plugins/looker-to-sigma/skills/looker-assessment/refs/complexity-scoring.md
@@ -1,0 +1,61 @@
+# Looker complexity scoring rubric
+
+Same framework as the other assessments — features classed **auto / hint / manual /
+unhandled**; `cost = 10·n_unhandled + 3·n_manual + 1·n_hint`;
+`value = dashboard_runs × sqrt(query_runs)` (or `5 × tile_count` proxy when usage is
+unavailable); `score = value / (1 + cost)`.
+
+Tags: `runs==0 and queries==0`→**retire**; `n_unhandled>=1`→**needs-gap-scout**;
+`score>=20 and (manual+unhandled)==0`→**migrate-first**; `score>=10`→**easy-win**;
+else **moderate**.
+
+Looker-specific signals:
+
+## 1. Tile vis-type → Sigma element coverage
+Mirrors `looker-to-sigma`'s `build_workbook.py` tile map and the converter's coverage.
+
+| Tier | Looker vis types |
+|---|---|
+| **auto** | `single_value`, `looker_single_record`, `table`, `looker_grid`, `looker_column`, `looker_bar`, `looker_line`, `looker_area`, `looker_scatter`, `looker_pie`, `looker_donut_multiples`, `looker_funnel`, `looker_google_map`, `text` (→ Sigma text element), `looker_timeline`, `looker_boxplot` |
+| **manual** | `looker_map` / geo coordinates / choropleth, `looker_waterfall`, `looker_wordcloud`, `looker_heatmap`, `sankey` (recreate with the closest Sigma element) |
+| **unhandled** | anything else — **marketplace / custom-viz extensions** (no direct Sigma equivalent) |
+| **skipped** | `button`, `divider`, `image` — non-chart tiles; not counted as a migration cost |
+
+## 2. Hard-to-migrate dashboard features (added to cost)
+Detected on each tile's backing query (direct `query` or `result_maker.query`):
+
+| Feature | Detected via | Tier | Sigma mapping |
+|---|---|---|---|
+| **Pivot** | `query.pivots` non-empty | `manual` | Sigma pivot table (`rowsBy` + `columnsBy`) |
+| **Table calc** | `query.dynamic_fields` (a JSON string of calcs) | `manual` | Sigma formula (running_total → `CumulativeSum`, `sum()` → `GrandTotal`, etc.) |
+| **Liquid** | `{{ }}` / `{% %}` anywhere in the query JSON | `manual` | re-author (parameterized SQL / dynamic refs) |
+| **Merged result** | `merge_result_id` on the element / result_maker | `unhandled` | multiple explores stitched into one tile → a data-model join, reviewed case by case |
+| **Custom / marketplace viz** | vis type outside the known set | `unhandled` | recreate or accept loss — needs review |
+
+Each `manual` feature adds +1 to the dashboard's `n_manual`; each `unhandled`
+feature adds +1 to `n_unhandled`. (`merge_result_id` adds to `n_unhandled`;
+`custom_viz` is already counted when the tile's vis bucket is `unhandled`.)
+
+## 3. Value (usage) — from System Activity
+Looker exposes usage well through the `system__activity` model — query it via
+`POST /queries/run/json`. The assessment uses three queries (window = `--usage-days`,
+default 90):
+
+| Query | model / view | fields | filters |
+|---|---|---|---|
+| **Dashboard runs** | `system__activity` / `history` | `dashboard.id`, `dashboard.title`, `history.query_run_count`, `history.dashboard_run_count` | `history.created_date: "<N> days"`, `dashboard.id: NOT NULL` |
+| **Look usage** | `system__activity` / `history` | `look.id`, `look.title`, `history.query_run_count` | `history.created_date: "<N> days"`, `look.id: NOT NULL` |
+| **Activity totals** | `system__activity` / `history` | `user.count` (active users), `history.query_run_count`, `history.dashboard_run_count` | `history.created_date: "<N> days"` |
+
+- **Usage mode:** `value = dashboard_runs × √query_runs`.
+- **Proxy (no System Activity access / cold dashboard):** `value = 5 × tile_count`.
+
+> The `dashboard.view_count` / `favorite_count` fields on `GET /dashboards` come back
+> `null` on the live instance — **do not** rely on them; System Activity is the
+> authoritative usage source.
+
+## Output (`inventory.json`)
+Per dashboard: `{id, name, kind (UDD|LookML), folder, owner, runs, queries, tiles,
+filters, viz_types:{...}, features:{pivots, table_calcs, merged_results, custom_viz,
+liquid, cross_filtering}, n_auto, n_hint, n_manual, n_unhandled, cost, score, tag}`.
+See `refs/output-shapes.md` for the full document shape.

--- a/plugins/looker-to-sigma/skills/looker-assessment/refs/output-shapes.md
+++ b/plugins/looker-to-sigma/skills/looker-assessment/refs/output-shapes.md
@@ -1,0 +1,112 @@
+# Output shapes
+
+`looker-inventory.py` emits **one JSON file** (`inventory.json`) plus a compact
+`readout.md` to `<out>/`. `render-readout-html.rb` reads `inventory.json` alone to
+produce the Sigma-branded `readout.html`; `looker-to-sigma` reads the `shortlist`
+array.
+
+Like `qlik-assessment` (and unlike `tableau-assessment`'s three files), Looker packs
+everything into a single `inventory.json` — the REST API enumerates an instance's
+environment, usage, and per-dashboard complexity in one pass. The renderer's section
+vocabulary lines up with the other assessments
+(dashboard↔workbook, tile↔sheet/view, explore↔datasource-field-set,
+model↔semantic-layer, connection↔datasource, Look↔view, dashboard run↔access event).
+
+## `inventory.json` (written by `looker-inventory.py`)
+
+`--no-deep` mode writes the same shape with per-dashboard complexity fields all zero
+and `feature_usage` / `viz_mix` empty.
+
+```json
+{
+  "instance": {
+    "name": "<host>",                       // e.g. hakkoda1.cloud.looker.com
+    "url": "https://<host>",
+    "generated_at": "YYYY-MM-DD",
+    "usage_window_days": <int>,             // --usage-days (default 90)
+    "mode": "rest-4.0 + deep" | "rest-4.0 inventory-only"
+  },
+  "environment_overview": {
+    "models": <int>,
+    "explores": <int>,                      // summed across all models
+    "projects": <int>,
+    "connections": <int>,
+    "looks": <int>,
+    "dashboards": <int>,
+    "dashboards_udd": <int>,                // numeric id
+    "dashboards_lookml": <int>,             // "model::name" id
+    "users": <int>,                         // enabled (falls back to total if all enabled)
+    "groups": <int>,
+    "folders": <int>
+  },
+  "connections": {
+    "n_connections": <int>,
+    "dialects": [{ "dialect": "snowflake|bigquery|...", "n": <int> }, ...],
+    "detail": [{ "name": "...", "dialect": "...", "database": "...", "host": "..." }, ...]
+  },
+  "activity": {                             // from system__activity / history
+    "active_users": <int>,                  // user.count over the window
+    "queries": <int>,                       // history.query_run_count
+    "dashboard_runs": <int>,                // history.dashboard_run_count
+    "looks_used": <int>,
+    "look_usage": [{ "id": "<look id>", "queries": <int> }, ...]   // top 25
+  },
+  "feature_usage": {                        // summed across all scanned dashboards
+    "pivots": <int>, "table_calcs": <int>, "merged_results": <int>,
+    "custom_viz": <int>, "liquid": <int>, "cross_filtering": <int>
+  },
+  "viz_mix": [{ "type": "<looker vis type>", "n": <int> }, ...],
+  "ownership": [
+    { "owner": "<name/email>", "dashboards": <int>, "runs": <int>, "tiles": <int> }, ...
+  ],
+  "shortlist": [
+    {
+      "id": "<dashboard id>", "name": "...", "kind": "UDD"|"LookML",
+      "folder": "...", "owner": "...",
+      "runs": <int>, "queries": <int>,      // System Activity over the window
+      "tiles": <int>, "filters": <int>,
+      "viz_types": { "<type>": <int>, ... },
+      "features": { "pivots": <int>, "table_calcs": <int>, "merged_results": <int>,
+                    "custom_viz": <int>, "liquid": <int>, "cross_filtering": <int> },
+      "n_auto": <int>, "n_hint": <int>, "n_manual": <int>, "n_unhandled": <int>,
+      "cost": <int>, "score": <float>,
+      "tag": "migrate-first"|"easy-win"|"moderate"|"needs-gap-scout"|"retire"
+    }
+  ],
+  "dashboards": <int>, "models": <int>      // back-compat top-level counts
+}
+```
+
+`shortlist` is sorted by `score` descending — index 0 is the top migration
+candidate. The renderer treats the first 5 as the pilot and the first 15 as the
+displayed shortlist + complexity table.
+
+## Complexity buckets
+Mirrors the other assessments' four-tier vocabulary (see `refs/complexity-scoring.md`):
+
+- `n_auto` — tiles whose vis type Sigma covers directly.
+- `n_hint` — reserved for parity with the shared renderer (Looker does not currently
+  emit a `hint` tier; always 0).
+- `n_manual` — **Setup**: pivots, table calcs, Liquid, and `manual`-tier vis types
+  (geo / waterfall / heatmap / sankey).
+- `n_unhandled` — **Review**: merged results and marketplace / custom-viz extensions.
+
+## Scoring + tags
+`cost = 10·n_unhandled + 3·n_manual + 1·n_hint`;
+`value = dashboard_runs × √query_runs` (or `5 × tile_count` proxy when usage is
+unavailable); `score = value / (1 + cost)`.
+
+Tag rules:
+- `runs == 0 and queries == 0`                   → `retire`
+- `n_unhandled >= 1`                             → `needs-gap-scout`
+- `score >= 20 and (manual + unhandled) == 0`    → `migrate-first`
+- `score >= 10`                                  → `easy-win`
+- else                                           → `moderate`
+
+## `readout.html` / `readout.md`
+`readout.html` is an 8-section Sigma-branded report: masthead + hero, 01 environment,
+02 dashboard priority & usage, 03 ownership, 04 connections & dialects, 05 migration
+shortlist + per-dashboard complexity, 07 estimated effort (tokens/$), 08 data
+handling, 09 next steps. Sections 05/07 collapse out in `--no-deep` mode (no
+shortlist), renumbering data-handling to 05 and next-steps to 06. `readout.md` is the
+compact text equivalent written by the Python script.

--- a/plugins/looker-to-sigma/skills/looker-assessment/refs/token-model.json
+++ b/plugins/looker-to-sigma/skills/looker-assessment/refs/token-model.json
@@ -1,0 +1,53 @@
+{
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items (n_review_items = items the assessment flags with unsupported/needs-review features, n_unhandled > 0). Tokens are the portable unit; rescale $ by your coding agent's model pricing. ALL numbers below are MEASURED from controlled end-to-end conversions (2026-06-07) unless noted.",
+  "calibration": {
+    "date": "2026-06-07",
+    "models": ["opus", "sonnet"],
+    "rates_per_million_usd": {
+      "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
+      "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
+    },
+    "real_samples": {
+      "quicksight_D8_orchestrator":  { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders_orchestrator": { "opus_usd": 0.72, "sonnet_usd": 0.08 },
+      "tableau_Superstore_full":     { "opus_usd": 29.35, "sonnet_usd": 6.55 },
+      "per_review_interactive_delta_opus": 0.46
+    },
+    "for_reference_naive_vs_orchestrator": {
+      "quicksight_D8_naive": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "quicksight_D8_optimized_brief": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "quicksight_D8_orchestrator": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "note": "For tools WITH a mechanical converter, the one-shot orchestrator is ~12-20x cheaper than a naive agent-driven migration."
+    }
+  },
+  "per_dashboard": {
+    "mechanical": {
+      "tools": ["quicksight", "powerbi", "qlik", "thoughtspot"],
+      "opus_usd": 0.70,
+      "sonnet_usd": 0.11,
+      "tokens_output_plus_cache_creation": 25000,
+      "basis": "measured — one-shot orchestrator path (mechanical converter → deterministic; cost flat & tool-independent across QuickSight + Qlik)"
+    },
+    "tableau": {
+      "opus_usd": 29.0,
+      "sonnet_usd": 6.5,
+      "tokens_output_plus_cache_creation": 480000,
+      "range_opus_usd": [15.0, 45.0],
+      "basis": "measured — full agent-authored conversion (Superstore Overview: 7 KPIs + map + 2 area charts + controls)",
+      "note": "Tableau has NO mechanical converter, so the agent authors the entire DM+workbook spec from the .twb — ~40x the mechanical tools. The one-shot orchestrator does NOT reduce this (spec-authoring is the irreducible agent work, not the post-spec pipeline). Scales with dashboard richness + calc/LOD/custom-SQL complexity. The real lever to cut Tableau cost is building a mechanical Tableau->Sigma converter."
+    }
+  },
+  "per_review_item": {
+    "opus_usd": 0.46,
+    "sonnet_usd": 0.08,
+    "basis": "measured — interactive decision-checkpoint delta vs the --yes floor (QuickSight D8; one OPEN QUESTIONS round). Negligible at Sonnet pricing.",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator checkpoint. Does not apply to the mechanical floor when run with auto-accepted defaults."
+  },
+  "caveats": [
+    "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
+    "Mechanical-converter tools (QuickSight/PowerBI/Qlik/ThoughtSpot) assume the one-shot orchestrator path; a naive agent-driven migration is ~12-20x more expensive.",
+    "Tableau is the outlier (~40x) because its spec is agent-authored; its number is a full-conversion measurement, not an orchestrator floor.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and NOT included — this is LLM cost only.",
+    "Tableau is one measured sample (a rich standard dashboard); expect variance with dashboard complexity (range shown)."
+  ]
+}

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/looker-inventory.py
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/looker-inventory.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""looker-inventory — Looker instance inventory + per-dashboard migration complexity.
+
+    python3 looker-inventory.py [--out assessment-<host>] [--usage-days 90] [--ini PATH]
+
+Enumerates LookML models / explores / projects / connections (dialects), Looks,
+dashboards (UDD vs LookML), users / groups, folders. Then opens each dashboard via
+GET /dashboards/{id} to bucket vis-types and hard-to-migrate features (pivots, table
+calcs, merged results, custom viz, Liquid, cross-filtering) against Sigma coverage.
+Pulls per-dashboard / per-look usage and active-user counts from Looker's System
+Activity model (`system__activity`) via POST /queries/run/json, then scores
+value / (1 + cost) and tags each dashboard. Emits <out>/inventory.json + readout.md.
+
+READ-ONLY: only GETs and System Activity inline queries (no app mutation, no
+warehouse rows). Mirrors qlik-inventory.py / tableau-assessment's scoring + tags.
+
+Auth from ~/.looker/looker.ini (client_credentials, API 4.0) via looker_api.py.
+"""
+import json, os, re, sys, argparse, math, datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import looker_api as L
+
+
+# ---------------------------------------------------------------------------
+# Looker vis-type -> Sigma element coverage (mirrors build_workbook.py's tile map
+# in ../looker-to-sigma/scripts and the converter's known coverage).
+# ---------------------------------------------------------------------------
+VIZ_AUTO = {
+    "single_value", "looker_single_record", "table", "looker_grid",
+    "looker_column", "looker_bar", "looker_line", "looker_area",
+    "looker_scatter", "looker_pie", "looker_donut_multiples", "looker_funnel",
+    "looker_google_map", "text", "looker_field_text",  # text -> Sigma text element
+    "looker_timeline", "looker_boxplot",
+}
+VIZ_MANUAL = {
+    # recreate with the closest Sigma element (geo / waterfall / heatmap / sankey)
+    "looker_map", "looker_geo_coordinates", "looker_geo_choropleth",
+    "looker_waterfall", "looker_wordcloud", "looker_heatmap", "sankey",
+}
+# non-chart tile types (buttons / dividers) — not a migration cost, skipped
+VIZ_SKIP = {"button", "divider", "image"}
+# anything else (marketplace / custom viz extensions) -> unhandled
+
+
+def bucket_viz(t):
+    t = (t or "").lower()
+    if t in VIZ_SKIP:
+        return None
+    if t in VIZ_AUTO:
+        return "auto"
+    if t in VIZ_MANUAL:
+        return "manual"
+    return "unhandled"   # marketplace / custom viz extensions
+
+
+# Liquid templating in a field/filter/html string -> manual re-author
+LIQUID = re.compile(r"\{\{.*?\}\}|\{%.*?%\}")
+
+
+def _query_of(el):
+    """The query backing an element — direct or via result_maker."""
+    if el.get("query"):
+        return el["query"]
+    rm = el.get("result_maker") or {}
+    return rm.get("query") or {}
+
+
+def _vis_type(el, q):
+    for src in (q.get("vis_config"),
+                (el.get("result_maker") or {}).get("vis_config"),
+                el.get("vis_config")):
+        if isinstance(src, dict) and src.get("type"):
+            return src["type"]
+    return el.get("type")  # "vis" / "text"
+
+
+def _dyn(df):
+    """dashboard_element.query.dynamic_fields is a JSON string of table calcs."""
+    if isinstance(df, str):
+        try:
+            return json.loads(df)
+        except Exception:
+            return []
+    return df or []
+
+
+def _has_liquid(q):
+    blob = json.dumps(q)
+    return bool(LIQUID.search(blob))
+
+
+def scan_dashboard(did):
+    """Open one dashboard, return (rolled element features, viz mix, flags)."""
+    fields = ("id,title,dashboard_elements(id,type,title,merge_result_id,note_text,"
+              "query(view,model,pivots,dynamic_fields,filters,vis_config),"
+              "result_maker(query(view,model,pivots,dynamic_fields,filters,vis_config),"
+              "merge_result_id)),dashboard_filters(name,type,dimension)")
+    code, d = L.call("GET", f"/dashboards/{did}?fields={fields}")
+    if code != 200 or not isinstance(d, dict):
+        return None
+    els = d.get("dashboard_elements") or []
+    filters = d.get("dashboard_filters") or []
+
+    viz_types = {}
+    feats = {"pivots": 0, "table_calcs": 0, "merged_results": 0,
+             "custom_viz": 0, "liquid": 0, "cross_filtering": 0}
+    n_tiles = 0
+    n_auto = n_manual = n_unhandled = 0
+
+    for el in els:
+        etype = el.get("type")
+        q = _query_of(el)
+        if not q and etype in (None, "text") and not (el.get("title") or el.get("note_text")):
+            continue
+        vt = _vis_type(el, q)
+        b = bucket_viz(vt)
+        if b is None:   # button / divider / image — not a chart, skip entirely
+            continue
+        n_tiles += 1
+        viz_types[vt] = viz_types.get(vt, 0) + 1
+
+        if b == "auto":
+            n_auto += 1
+        elif b == "manual":
+            n_manual += 1
+        else:
+            n_unhandled += 1
+            feats["custom_viz"] += 1
+
+        if q.get("pivots"):
+            feats["pivots"] += 1
+            n_manual += 1
+        dyn = _dyn(q.get("dynamic_fields"))
+        if dyn:
+            feats["table_calcs"] += len(dyn)
+            n_manual += 1
+        if el.get("merge_result_id") or (el.get("result_maker") or {}).get("merge_result_id"):
+            feats["merged_results"] += 1
+            n_unhandled += 1
+        if q and _has_liquid(q):
+            feats["liquid"] += 1
+            n_manual += 1
+
+    # cross-filtering proxy: a dashboard filter that >1 tile listens on is fine,
+    # but Looker's auto cross-filter (filterables linking tiles) is the manual one.
+    # We approximate "has filters wired to tiles" as a normal (auto) feature and only
+    # flag explicit cross_filtering when a dashboard sets it. The filter COUNT is the
+    # migration signal.
+    n_filters = len(filters)
+
+    return {
+        "tiles": n_tiles, "filters": n_filters, "viz_types": viz_types,
+        "features": feats, "n_auto": n_auto, "n_manual": n_manual,
+        "n_unhandled": n_unhandled,
+    }
+
+
+# ---------------------------------------------------------------------------
+# System Activity usage (the value axis)
+# ---------------------------------------------------------------------------
+def sa_query(view, fields, filters, sorts=None, limit="5000"):
+    body = {"model": "system__activity", "view": view, "fields": fields,
+            "filters": filters, "limit": limit}
+    if sorts:
+        body["sorts"] = sorts
+    code, out = L.call("POST", "/queries/run/json", body)
+    return out if (code == 200 and isinstance(out, list)) else []
+
+
+def dashboard_usage(days):
+    rows = sa_query("history",
+                    ["dashboard.id", "dashboard.title",
+                     "history.query_run_count", "history.dashboard_run_count"],
+                    {"history.created_date": f"{days} days", "dashboard.id": "NOT NULL"},
+                    ["history.query_run_count desc"])
+    out = {}
+    for r in rows:
+        did = str(r.get("dashboard.id"))
+        out[did] = {"queries": int(r.get("history.query_run_count") or 0),
+                    "runs": int(r.get("history.dashboard_run_count") or 0)}
+    return out
+
+
+def look_usage(days):
+    rows = sa_query("history",
+                    ["look.id", "look.title", "history.query_run_count"],
+                    {"history.created_date": f"{days} days", "look.id": "NOT NULL"},
+                    ["history.query_run_count desc"])
+    return {str(r.get("look.id")): int(r.get("history.query_run_count") or 0) for r in rows}
+
+
+def activity_totals(days):
+    rows = sa_query("history",
+                    ["user.count", "history.query_run_count", "history.dashboard_run_count"],
+                    {"history.created_date": f"{days} days"}, None, "1")
+    if not rows:
+        return {"active_users": 0, "queries": 0, "dashboard_runs": 0}
+    r = rows[0]
+    return {"active_users": int(r.get("user.count") or 0),
+            "queries": int(r.get("history.query_run_count") or 0),
+            "dashboard_runs": int(r.get("history.dashboard_run_count") or 0)}
+
+
+# ---------------------------------------------------------------------------
+# Scoring (identical framework to tableau-assessment / qlik-assessment)
+# ---------------------------------------------------------------------------
+def score(runs, queries, n_auto, n_hint, n_manual, n_unhandled, tiles):
+    cost = 10 * n_unhandled + 3 * n_manual + 1 * n_hint
+    # value: dashboard runs weighted by query volume; proxy on tiles when cold
+    value = (runs * math.sqrt(max(queries, 1))) if (runs or queries) else 5 * tiles
+    return cost, round(value / (1 + cost), 2)
+
+
+def tag(runs, queries, sc, n_manual, n_unhandled):
+    if not runs and not queries:
+        return "retire"
+    if n_unhandled >= 1:
+        return "needs-gap-scout"
+    if sc >= 20 and (n_manual + n_unhandled) == 0:
+        return "migrate-first"
+    if sc >= 10:
+        return "easy-win"
+    return "moderate"
+
+
+# ---------------------------------------------------------------------------
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--usage-days", type=int, default=90)
+    ap.add_argument("--ini")
+    ap.add_argument("--no-deep", action="store_true",
+                    help="skip per-dashboard complexity scan (counts + usage only)")
+    a = ap.parse_args()
+    if a.ini:
+        L.INI = os.path.expanduser(a.ini)
+
+    # host / out dir
+    base, _, _, _ = L._cfg()
+    host = re.sub(r"^https?://", "", base).split(":")[0].split("/")[0]
+    out = a.out or f"assessment-{host}"
+    os.makedirs(out, exist_ok=True)
+
+    # ---- environment counts ----
+    def glist(path):
+        code, o = L.call("GET", path)
+        return o if (code == 200 and isinstance(o, list)) else []
+
+    models = glist("/lookml_models")
+    projects = glist("/projects")
+    connections = glist("/connections")
+    looks = glist("/looks?fields=id,title,user_id,deleted")
+    folders = glist("/folders")
+    groups = glist("/groups?fields=id,name")
+    users = glist("/users?fields=id,display_name,email,is_disabled")
+
+    # explores rolled up from models
+    n_explores = sum(len(m.get("explores") or []) for m in models)
+    dialects = {}
+    for c in connections:
+        dn = (c.get("dialect") or {}).get("name") or "unknown"
+        dialects[dn] = dialects.get(dn, 0) + 1
+
+    # ---- dashboards (UDD vs LookML kind) ----
+    dash = glist("/dashboards?fields=id,title,user_id,folder(name),deleted,hidden")
+    n_udd = sum(1 for d in dash if "::" not in str(d.get("id")))
+    n_lookml = len(dash) - n_udd
+
+    # ---- usage (System Activity) ----
+    days = a.usage_days
+    du = dashboard_usage(days)
+    lu = look_usage(days)
+    totals = activity_totals(days)
+
+    # ---- per-dashboard shortlist ----
+    user_name = {str(u.get("id")): (u.get("display_name") or u.get("email") or "?")
+                 for u in users}
+    rows = []
+    for d in dash:
+        did = str(d.get("id"))
+        kind = "LookML" if "::" in did else "UDD"
+        u = du.get(did, {"queries": 0, "runs": 0})
+        row = {
+            "id": did, "name": d.get("title"), "kind": kind,
+            "folder": (d.get("folder") or {}).get("name"),
+            "owner": user_name.get(str(d.get("user_id")), "(unknown)"),
+            "runs": u["runs"], "queries": u["queries"],
+            "tiles": 0, "filters": 0, "viz_types": {}, "features": {},
+            "n_auto": 0, "n_hint": 0, "n_manual": 0, "n_unhandled": 0,
+        }
+        if not a.no_deep:
+            sc = scan_dashboard(did)
+            if sc:
+                row.update({k: sc[k] for k in
+                            ("tiles", "filters", "viz_types", "features",
+                             "n_auto", "n_manual", "n_unhandled")})
+        c, s = score(row["runs"], row["queries"], row["n_auto"], row["n_hint"],
+                     row["n_manual"], row["n_unhandled"], row["tiles"])
+        row["cost"], row["score"] = c, s
+        row["tag"] = tag(row["runs"], row["queries"], s, row["n_manual"], row["n_unhandled"])
+        rows.append(row)
+    rows.sort(key=lambda r: r["score"], reverse=True)
+
+    # ---- ownership rollup ----
+    own = {}
+    for r in rows:
+        o = r.get("owner") or "(unknown)"
+        d = own.setdefault(o, {"owner": o, "dashboards": 0, "runs": 0, "tiles": 0})
+        d["dashboards"] += 1
+        d["runs"] += int(r.get("runs") or 0)
+        d["tiles"] += int(r.get("tiles") or 0)
+    ownership = sorted(own.values(), key=lambda d: -d["dashboards"])
+
+    # ---- feature rollup across all scanned dashboards ----
+    feat_totals = {"pivots": 0, "table_calcs": 0, "merged_results": 0,
+                   "custom_viz": 0, "liquid": 0, "cross_filtering": 0}
+    viz_totals = {}
+    for r in rows:
+        for k, v in (r.get("features") or {}).items():
+            feat_totals[k] = feat_totals.get(k, 0) + int(v)
+        for k, v in (r.get("viz_types") or {}).items():
+            viz_totals[k] = viz_totals.get(k, 0) + int(v)
+
+    inv = {
+        "instance": {
+            "name": host,
+            "url": f"https://{host}",
+            "generated_at": datetime.date.today().isoformat(),
+            "usage_window_days": days,
+            "mode": "rest-4.0 inventory-only" if a.no_deep else "rest-4.0 + deep",
+        },
+        "environment_overview": {
+            "models": len(models),
+            "explores": n_explores,
+            "projects": len(projects),
+            "connections": len(connections),
+            "looks": len(looks),
+            "dashboards": len(dash),
+            "dashboards_udd": n_udd,
+            "dashboards_lookml": n_lookml,
+            "users": len([u for u in users if not u.get("is_disabled")]) or len(users),
+            "groups": len(groups),
+            "folders": len(folders),
+        },
+        "connections": {
+            "n_connections": len(connections),
+            "dialects": [{"dialect": k, "n": v}
+                         for k, v in sorted(dialects.items(), key=lambda kv: -kv[1])],
+            "detail": [{"name": c.get("name"),
+                        "dialect": (c.get("dialect") or {}).get("name"),
+                        "database": c.get("database"), "host": c.get("host")}
+                       for c in connections],
+        },
+        "activity": {
+            "active_users": totals["active_users"],
+            "queries": totals["queries"],
+            "dashboard_runs": totals["dashboard_runs"],
+            "looks_used": len(lu),
+            "look_usage": [{"id": k, "queries": v}
+                           for k, v in sorted(lu.items(), key=lambda kv: -kv[1])][:25],
+        },
+        "feature_usage": feat_totals,
+        "viz_mix": [{"type": k, "n": v}
+                    for k, v in sorted(viz_totals.items(), key=lambda kv: -kv[1])],
+        "ownership": ownership,
+        "shortlist": rows,
+        # back-compat top-level counts
+        "dashboards": len(dash), "models": len(models),
+    }
+    json.dump(inv, open(os.path.join(out, "inventory.json"), "w"), indent=2)
+
+    # compact markdown
+    md = [f"# Looker → Sigma assessment — {host}\n",
+          f"- **Models:** {len(models)} · **Explores:** {n_explores} · "
+          f"**Dashboards:** {len(dash)} ({n_udd} UDD / {n_lookml} LookML) · "
+          f"**Looks:** {len(looks)} · **Connections:** {len(connections)}\n",
+          f"- **Usage window:** last {days} days · "
+          f"**Active users:** {totals['active_users']} · "
+          f"**Dashboard runs:** {totals['dashboard_runs']}\n",
+          "\n## Migration shortlist\n",
+          "| # | Dashboard | Kind | Runs | Tiles | Tag | Score | auto/manual/unhandled |",
+          "|--:|---|---|--:|--:|---|--:|---|"]
+    for i, r in enumerate(rows, 1):
+        md.append(f"| {i} | {r['name']} | {r['kind']} | {r['runs']} | {r['tiles']} | "
+                  f"**{r['tag']}** | {r['score']} | "
+                  f"{r['n_auto']}/{r['n_manual']}/{r['n_unhandled']} |")
+    open(os.path.join(out, "readout.md"), "w").write("\n".join(md) + "\n")
+
+    print(f"dashboards={len(dash)} ({n_udd} UDD/{n_lookml} LookML) models={len(models)} "
+          f"explores={n_explores} connections={len(connections)} "
+          f"active_users={totals['active_users']} -> {out}/inventory.json + readout.md"
+          + ("  (run without --no-deep for per-dashboard complexity)" if a.no_deep else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/looker_api.py
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/looker_api.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Minimal Looker API 4.0 client driven by ~/.looker/looker.ini (no SDK dep).
+
+Usage:
+  python3 looker_api.py whoami
+  python3 looker_api.py get  /connections
+  python3 looker_api.py post /connections '<json>'
+  python3 looker_api.py put  /connections/<name>/test
+  python3 looker_api.py raw  GET /lookml_models
+"""
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from configparser import ConfigParser
+
+INI = os.path.expanduser("~/.looker/looker.ini")
+
+
+def _cfg():
+    c = ConfigParser()
+    c.read(INI)
+    s = c["Looker"]
+    base = s["base_url"].rstrip("/")
+    if not base.endswith("/api/4.0"):
+        base = base + "/api/4.0"
+    return base, s["client_id"], s["client_secret"], s.getboolean("verify_ssl", True)
+
+
+def _ctx(verify):
+    import ssl
+    if verify:
+        return None
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def login():
+    base, cid, csec, verify = _cfg()
+    data = urllib.parse.urlencode({"client_id": cid, "client_secret": csec}).encode()
+    req = urllib.request.Request(base + "/login", data=data, method="POST")
+    with urllib.request.urlopen(req, context=_ctx(verify), timeout=30) as r:
+        tok = json.load(r)["access_token"]
+    return base, tok, verify
+
+
+def call(method, path, body=None):
+    base, tok, verify = login()
+    if not path.startswith("/"):
+        path = "/" + path
+    url = base + path
+    data = None
+    headers = {"Authorization": "Bearer " + tok}
+    if body is not None:
+        data = body.encode() if isinstance(body, str) else json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, context=_ctx(verify), timeout=60) as r:
+            raw = r.read().decode()
+            code = r.status
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        code = e.code
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        parsed = raw
+    return code, parsed
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "whoami"
+    if cmd == "whoami":
+        code, me = call("GET", "/user")
+        _, roles = call("GET", "/user/roles")
+        _, perms = call("GET", "/user/roles")  # placeholder
+        print("HTTP", code)
+        print("user:", me.get("display_name"), "| id", me.get("id"), "|", me.get("email"))
+        if isinstance(roles, list):
+            print("roles:", ", ".join(r.get("name", "?") for r in roles))
+        else:
+            print("roles raw:", roles)
+    elif cmd == "raw":
+        code, out = call(sys.argv[2].upper(), sys.argv[3], sys.argv[4] if len(sys.argv) > 4 else None)
+        print("HTTP", code)
+        print(json.dumps(out, indent=2)[:6000])
+    else:  # get/post/put/patch/delete
+        code, out = call(cmd.upper(), sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else None)
+        print("HTTP", code)
+        print(json.dumps(out, indent=2)[:8000] if not isinstance(out, str) else out[:8000])

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/render-readout-html.rb
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/render-readout-html.rb
@@ -1,0 +1,819 @@
+#!/usr/bin/env ruby
+# Render <out>/readout.html — a customer-facing, share-friendly HTML report for a
+# Looker -> Sigma migration assessment.
+#
+# Consumes <out>/inventory.json written by looker-inventory.py (environment counts +
+# connections + System Activity usage + per-dashboard complexity + shortlist +
+# ownership). The Sigma-branded theme is copied verbatim from qlik-assessment /
+# tableau-assessment's render-readout-html.rb so the look is byte-identical across
+# the assessment family; only the vocabulary (dashboard / tile / explore / model /
+# connection / dialect / Look / dashboard run) is Looker-specific.
+#
+# Usage: ruby scripts/render-readout-html.rb --out /tmp/assessment-<host>
+
+require 'json'
+require 'optparse'
+require 'cgi'
+require 'date'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--out DIR') { |v| opts[:out] = v }
+end.parse!
+abort('--out required') unless opts[:out]
+
+inv_path = File.join(opts[:out], 'inventory.json')
+abort("inventory.json not found in #{opts[:out]}") unless File.exist?(inv_path)
+inventory = JSON.parse(File.read(inv_path))
+
+def h(s); CGI.escapeHTML(s.to_s); end
+def num(n); n.to_i.to_s.reverse.scan(/.{1,3}/).join(',').reverse; end
+
+# ---------- gather computed values ----------
+inst   = inventory['instance'] || {}
+env    = inventory['environment_overview'] || {}
+conns  = inventory['connections'] || {}
+act    = inventory['activity'] || {}
+feats  = inventory['feature_usage'] || {}
+vizmix = inventory['viz_mix'] || []
+ownership = inventory['ownership'] || []
+shortlist = inventory['shortlist'] || []
+
+inst_name = inst['name'] || 'unknown'
+inst_url  = inst['url'] || ''
+days      = inst['usage_window_days'] || 90
+generated_at = inst['generated_at'] || Time.now.strftime('%Y-%m-%d')
+formatted_date = Date.parse(generated_at).strftime('%B %d, %Y') rescue generated_at
+
+has_shortlist = !shortlist.empty?
+has_complexity = shortlist.any? { |r| r['tiles'].to_i.positive? }
+
+# Usage
+total_runs = shortlist.sum { |r| r['runs'].to_i }
+cold_dash  = shortlist.select { |r| r['runs'].to_i.zero? && r['queries'].to_i.zero? }
+
+# Shortlist rollups
+sl_top5_runs      = shortlist.first(5).sum { |r| r['runs'].to_i }
+sl_top5_unhandled = shortlist.first(5).sum { |r| r['n_unhandled'].to_i }
+sl_total_unhandled = shortlist.sum { |r| r['n_unhandled'].to_i }
+sl_needs_scout    = shortlist.count { |r| r['tag'] == 'needs-gap-scout' }
+sl_retire         = shortlist.count { |r| r['tag'] == 'retire' }
+sl_migrate_first  = shortlist.count { |r| r['tag'] == 'migrate-first' }
+n_with_unhandled  = shortlist.count { |r| r['n_unhandled'].to_i.positive? }
+top5_pct = total_runs.zero? ? 0 : (sl_top5_runs.to_f / total_runs * 100).round
+
+# Top owner concentration
+top_owner_pct = 0
+top_owner_name = '—'
+total_owner_dash = ownership.sum { |o| o['dashboards'].to_i }
+if total_owner_dash > 0
+  top = ownership.max_by { |o| o['dashboards'].to_i }
+  top_owner_pct = (top['dashboards'].to_f / total_owner_dash * 100).round
+  top_owner_name = top['owner']
+end
+
+# ---------- HTML helpers ----------
+TAG_LABELS = {
+  'migrate-first'   => 'Migrate first',
+  'easy-win'        => 'Easy win',
+  'moderate'        => 'Standard',
+  'needs-gap-scout' => 'Needs review',
+  'retire'          => 'Retire'
+}
+TAG_CLASSES = {
+  'migrate-first'   => 'tag-go',
+  'easy-win'        => 'tag-blue',
+  'moderate'        => 'tag-gray',
+  'needs-gap-scout' => 'tag-warn',
+  'retire'          => 'tag-mute'
+}
+
+def tag_pill(t)
+  %(<span class="tag #{TAG_CLASSES[t]}">#{h(TAG_LABELS[t] || t)}</span>)
+end
+
+def bar_cell(value, max, color = 'bar-blue')
+  pct = max.zero? ? 0 : (value.to_f / max * 100).round
+  %(<div class="bar-cell"><div class="bar-track"><div class="bar-fill #{color}" style="width:#{pct}%"></div></div><div class="bar-num">#{num(value)}</div></div>)
+end
+
+def kpi(label, value, sub = nil)
+  s = sub ? %(<div class="kpi-sub">#{h(sub)}</div>) : ''
+  %(<div class="kpi"><div class="kpi-v">#{h(value)}</div><div class="kpi-l">#{h(label)}</div>#{s}</div>)
+end
+
+# ---------- section rendering ----------
+
+hero_finding =
+  if has_shortlist
+    if sl_top5_unhandled.zero? && sl_migrate_first.positive?
+      'Pilot migration is low-risk: the top 5 most-used dashboards contain no unsupported Looker features.'
+    elsif sl_total_unhandled.positive?
+      "The top-5 pilot is feasible. #{n_with_unhandled} dashboard#{n_with_unhandled == 1 ? '' : 's'} elsewhere include feature#{n_with_unhandled == 1 ? '' : 's'} (custom marketplace viz, merged results) that warrant individual review when planning their conversion."
+    else
+      'Migration shortlist ranked by usage and conversion complexity.'
+    end
+  else
+    'Environment scan complete.'
+  end
+
+# Section 1: KPI tiles
+kpi_html = [
+  kpi('Models',      env['models']),
+  kpi('Explores',    env['explores']),
+  kpi('Dashboards',  env['dashboards'], "#{env['dashboards_udd']} UDD · #{env['dashboards_lookml']} LookML"),
+  kpi('Looks',       env['looks']),
+  kpi('Connections', env['connections']),
+  kpi('Dashboard runs', num(act['dashboard_runs']), "last #{days} days · #{act['active_users']} active users")
+].join
+
+# Section 2: Dashboard priority & usage
+usage_html = ''
+unless shortlist.empty?
+  ranked = shortlist.sort_by { |r| -r['runs'].to_i }
+  max_v = [ranked.first['runs'].to_i, 1].max
+  rows = ranked.first(10).each_with_index.map do |r, i|
+    %(<tr>
+      <td class="rank">#{i + 1}</td>
+      <td>#{h(r['name'])}</td>
+      <td><span class="inline-pill">#{h(r['kind'])}</span></td>
+      <td class="muted">#{h((r['owner'] || '—').to_s.sub(/@.*/, ''))}</td>
+      <td>#{bar_cell(r['runs'], max_v)}</td>
+    </tr>)
+  end.join
+  usage_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th class="al-right">#</th>
+          <th>Dashboard</th>
+          <th>Kind</th>
+          <th>Owner</th>
+          <th>Runs</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 3: Ownership & concentration
+ownership_html = ''
+unless ownership.empty?
+  rows_data = ownership.sort_by { |o| -o['dashboards'].to_i }
+  max_d = [rows_data.first['dashboards'].to_i, 1].max
+  rows = rows_data.first(15).map do |o|
+    %(<tr>
+      <td>#{h((o['owner'] || '—').to_s.sub(/@.*/, ''))}</td>
+      <td>#{bar_cell(o['dashboards'], max_d)}</td>
+      <td class="al-right num muted">#{num(o['runs'])}</td>
+      <td class="al-right num muted">#{num(o['tiles'])}</td>
+    </tr>)
+  end.join
+  ownership_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Owner</th>
+          <th>Dashboards</th>
+          <th class="al-right">Runs</th>
+          <th class="al-right">Tiles</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 4: Connections & dialects
+ds_html = ''
+detail = (conns['detail'] || [])
+unless detail.empty?
+  rows = detail.map do |c|
+    %(<tr>
+      <td><code>#{h(c['name'])}</code></td>
+      <td><span class="ds-bucket ds-published">#{h(c['dialect'] || 'unknown')}</span></td>
+      <td class="muted">#{h(c['database'])}</td>
+    </tr>)
+  end.join
+  ds_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Connection</th>
+          <th>Dialect</th>
+          <th>Database</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Feature-usage stat row (hard-to-migrate features across all dashboards)
+feat_stats = ''
+if has_complexity
+  feat_stats = <<~HTML
+    <div class="stat-row">
+      <div class="stat #{feats['pivots'].to_i.positive? ? 'stat-warn' : ''}">
+        <div class="stat-l">Pivots</div>
+        <div class="stat-v #{feats['pivots'].to_i.positive? ? 'warn' : ''}">#{feats['pivots'] || 0}</div>
+        <div class="stat-sub">tiles pivoted — Sigma pivot table</div>
+      </div>
+      <div class="stat #{feats['table_calcs'].to_i.positive? ? 'stat-warn' : ''}">
+        <div class="stat-l">Table calcs</div>
+        <div class="stat-v #{feats['table_calcs'].to_i.positive? ? 'warn' : ''}">#{feats['table_calcs'] || 0}</div>
+        <div class="stat-sub">running totals / row-level calc → Sigma formulas</div>
+      </div>
+      <div class="stat #{(feats['merged_results'].to_i + feats['custom_viz'].to_i).positive? ? 'stat-warn' : ''}">
+        <div class="stat-l">Merged results · Custom viz</div>
+        <div class="stat-v #{(feats['merged_results'].to_i + feats['custom_viz'].to_i).positive? ? 'warn' : ''}">#{feats['merged_results'] || 0}<span style="font-size:16px;color:var(--mute);font-weight:600;"> · #{feats['custom_viz'] || 0}</span></div>
+        <div class="stat-sub">merge → data-model join · marketplace viz → review</div>
+      </div>
+    </div>
+  HTML
+end
+
+# ---------- estimated migration effort (token model) ----------
+effort_html = ''
+token_model_path = File.join(__dir__, '..', 'refs', 'token-model.json')
+if has_shortlist && File.exist?(token_model_path)
+  tm = JSON.parse(File.read(token_model_path)) rescue nil
+  if tm
+    bucket  = 'mechanical'
+    n_dash  = shortlist.size
+    n_rev   = n_with_unhandled
+    pd      = (tm['per_dashboard'] || {})[bucket] || {}
+    pr      = tm['per_review_item'] || {}
+    cal     = tm['calibration'] || {}
+    est = lambda { |m| (pd["#{m}_usd"].to_f * n_dash) + (pr["#{m}_usd"].to_f * n_rev) }
+    opus_usd   = est.call('opus')
+    sonnet_usd = est.call('sonnet')
+    fmt = lambda { |v| '$' + format('%.2f', v) }
+    effort_html = <<~HTML
+      <section>
+        <div class="section-head">
+          <span class="section-num">07</span>
+          <h2 class="section-title">Estimated migration effort (tokens / $)</h2>
+          <span class="section-aside">one-shot orchestrator path</span>
+        </div>
+        <p class="section-lede">A planning estimate of the LLM cost to migrate the shortlisted dashboards via the <code>looker-to-sigma</code> skill. The LookML→data-model converter and the dashboard builder are deterministic, so per-dashboard cost is flat; each dashboard flagged for review adds one human-decision round.</p>
+        <div class="stat-row">
+          <div class="stat stat-go">
+            <div class="stat-l">Estimated cost · Opus</div>
+            <div class="stat-v go">#{fmt.call(opus_usd)}</div>
+            <div class="stat-sub">#{n_dash} dashboards + #{n_rev} review</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Estimated cost · Sonnet</div>
+            <div class="stat-v">#{fmt.call(sonnet_usd)}</div>
+            <div class="stat-sub">same scope, Sonnet pricing</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Basis</div>
+            <div class="stat-v" style="font-size:20px;">#{n_dash}<span style="font-size:14px;color:var(--mute);font-weight:600;"> × per-dashboard</span></div>
+            <div class="stat-sub">+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</div>
+          </div>
+        </div>
+        <table class="data">
+          <thead>
+            <tr><th>Component</th><th class="al-right">Opus</th><th class="al-right">Sonnet</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>#{n_dash} dashboards × per-dashboard</td><td class="al-right num">#{fmt.call(pd['opus_usd'].to_f * n_dash)}</td><td class="al-right num">#{fmt.call(pd['sonnet_usd'].to_f * n_dash)}</td></tr>
+            <tr><td>+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</td><td class="al-right num">#{fmt.call(pr['opus_usd'].to_f * n_rev)}</td><td class="al-right num">#{fmt.call(pr['sonnet_usd'].to_f * n_rev)}</td></tr>
+            <tr><td><strong>Total estimated</strong></td><td class="al-right num"><strong>#{fmt.call(opus_usd)}</strong></td><td class="al-right num"><strong>#{fmt.call(sonnet_usd)}</strong></td></tr>
+          </tbody>
+        </table>
+        <p class="note">Calibrated #{h(cal['date'])}, one-shot orchestrator path — LLM cost only; rescale $ by your coding agent's pricing. A naive agent-driven migration is ~12–20× more expensive.</p>
+      </section>
+    HTML
+  end
+end
+
+# ---------- HTML ----------
+html = <<~HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Looker Environment Report — #{h(inst_name)}</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=DM+Mono:wght@400;500&display=swap');
+  :root {
+    /* Sigma brand palette — Shadow/Nimbus/White neutrals, Insight (CTA only), brand accents */
+    --bg:#fafafa; --card:#ffffff; --ink:#292929; --ink-2:#3d3d3d;
+    --line:#e5e5e5; --line-soft:#f5f5f5;
+    --accent:#292929; --accent-soft:#f0f0f0;
+    --insight:#f0ff45;
+    --go:#1f9d57; --go-soft:#e6fbef;
+    --warn:#c2562a; --warn-soft:#fff1ea;
+    --blue:#2b8ca6; --blue-soft:#eaf8fc;
+    --mute:#6e7877; --mute-soft:#f0f0f0;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
+  body {
+    font-family: "DM Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px; line-height: 1.55; -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 1120px; margin: 0 auto; padding: 48px 48px 80px; }
+
+  /* Brand masthead */
+  .brand-bar { display: flex; align-items: center; gap: 10px; margin-bottom: 28px; }
+  .brand-mark { font-weight: 700; font-size: 21px; letter-spacing: -0.02em; color: var(--ink); }
+  .brand-dot  { width: 9px; height: 9px; border-radius: 2px; background: var(--blue);
+                -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .brand-tag  { font-size: 12px; color: var(--mute); font-weight: 500;
+                text-transform: uppercase; letter-spacing: 0.08em; }
+
+  /* Header */
+  .doc-header { margin-bottom: 40px; }
+  .doc-eyebrow { font-size: 11px; font-weight: 600; color: var(--accent);
+                 text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+  .doc-title { font-size: 36px; font-weight: 700; letter-spacing: -0.02em;
+               margin: 0 0 8px; line-height: 1.1; color: var(--ink); }
+  .doc-meta { font-size: 13px; color: var(--ink-2); }
+  .doc-meta a { color: var(--ink-2); text-decoration: none; border-bottom: 1px dashed var(--line); }
+  .doc-meta a:hover { color: var(--ink); }
+
+  /* Hero finding banner */
+  .hero {
+    background: var(--accent-soft); border: 1px solid var(--line);
+    border-left: 4px solid var(--blue);
+    border-radius: 8px;
+    padding: 18px 22px; margin-bottom: 40px;
+    display: flex; align-items: center; gap: 16px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .hero-label { font-size: 11px; font-weight: 700; color: var(--accent);
+                text-transform: uppercase; letter-spacing: 0.08em;
+                white-space: nowrap; padding-right: 16px;
+                border-right: 1px solid var(--line); }
+  .hero-text { font-size: 15px; color: var(--ink); font-weight: 500; line-height: 1.4; }
+
+  /* Section */
+  section { margin-bottom: 56px; }
+  section.section-tight { margin-bottom: 36px; }
+  .section-head { display: flex; align-items: baseline; justify-content: space-between;
+                  margin-bottom: 16px; padding-bottom: 12px;
+                  border-bottom: 1px solid var(--line); }
+  .section-num { font-size: 12px; font-weight: 600; color: var(--mute);
+                 letter-spacing: 0.06em; }
+  .section-title { font-size: 22px; font-weight: 600; letter-spacing: -0.01em;
+                   margin: 0; flex: 1; padding-left: 14px; }
+  .section-aside { font-size: 12px; color: var(--mute); }
+  .section-lede { font-size: 14px; color: var(--ink-2); margin: -4px 0 16px; }
+
+  /* KPIs */
+  .kpi-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+  .kpi {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 18px 16px;
+  }
+  .kpi-v { font-size: 28px; font-weight: 700; letter-spacing: -0.01em;
+           color: var(--ink); line-height: 1; }
+  .kpi-l { font-size: 11px; color: var(--mute); text-transform: uppercase;
+           letter-spacing: 0.06em; font-weight: 600; margin-top: 10px; }
+  .kpi-sub { font-size: 11px; color: var(--mute); margin-top: 4px; line-height: 1.4; }
+
+  /* Stat callouts */
+  .stat-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
+              margin-bottom: 24px; }
+  .stat {
+    background: #fafafa;
+    border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 8px;
+    padding: 16px 18px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .stat.stat-go   { border-left-color: var(--go);   background: var(--go-soft); }
+  .stat.stat-warn { border-left-color: var(--warn); background: var(--warn-soft); }
+  .stat-l { font-size: 10px; color: var(--mute); text-transform: uppercase;
+            letter-spacing: 0.06em; font-weight: 700; margin-bottom: 6px; }
+  .stat-v { font-size: 30px; font-weight: 700; line-height: 1; letter-spacing: -0.02em;
+            color: var(--ink); }
+  .stat-v.go   { color: var(--go); }
+  .stat-v.warn { color: var(--warn); }
+  .stat-sub { font-size: 12px; color: var(--mute); margin-top: 6px; }
+
+  /* Tables */
+  table.data { width: 100%; border-collapse: collapse; background: var(--card);
+               border: 1px solid var(--line); border-radius: 10px; overflow: hidden;
+               font-size: 13px; }
+  table.data th { font-weight: 600; font-size: 11px; color: var(--mute);
+                  text-transform: uppercase; letter-spacing: 0.06em;
+                  padding: 12px 16px; background: #fafafa;
+                  border-bottom: 1px solid var(--line); text-align: left; }
+  table.data td { padding: 12px 16px; border-bottom: 1px solid var(--line-soft);
+                  vertical-align: middle; }
+  table.data tbody tr:last-child td { border-bottom: 0; }
+  table.data tbody tr:hover td { background: #fafafa; }
+  .al-right { text-align: right; }
+  .al-left  { text-align: left; }
+  table.data td.al-right, table.data th.al-right,
+  table.data td:has(.bar-cell) { width: 1%; white-space: nowrap; }
+  .num { font-variant-numeric: tabular-nums; }
+  .muted { color: var(--mute); }
+  .warn { color: var(--warn); }
+  .warn-num { color: var(--warn); font-weight: 700; }
+  .rank { font-variant-numeric: tabular-nums; color: var(--mute); font-weight: 600; width: 32px; }
+
+  /* Tags */
+  .tag { display: inline-block; padding: 3px 10px; border-radius: 99px;
+         font-size: 11px; font-weight: 600; letter-spacing: 0.01em;
+         white-space: nowrap; }
+  .tag-go    { background: var(--go-soft);    color: var(--go); }
+  .tag-blue  { background: var(--blue-soft);  color: var(--blue); }
+  .tag-gray  { background: #f5f5f5;           color: var(--ink-2); }
+  .tag-warn  { background: var(--warn-soft);  color: var(--warn); }
+  .tag-mute  { background: var(--mute-soft);  color: var(--mute); }
+
+  /* Bar cells (in tables) */
+  .bar-cell { display: flex; align-items: center; gap: 10px;
+              justify-content: flex-start; }
+  .bar-track { flex: none; width: 84px; height: 6px; background: #f5f5f5; border-radius: 4px;
+               overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 4px; }
+  .bar-blue { background: linear-gradient(90deg, #4cec8c, #2fb874); }
+  .bar-num { font-variant-numeric: tabular-nums; font-weight: 600;
+             min-width: 36px; text-align: right; }
+
+  /* Data-source bucket badge */
+  .ds-bucket { display: inline-block; padding: 3px 10px; border-radius: 6px;
+               font-size: 11px; font-weight: 600;
+               -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .ds-published { background: var(--blue-soft); color: var(--blue); }
+  .ds-embedded  { background: #f5f5f5; color: var(--ink-2); }
+
+  /* Risk chip — used in shortlist */
+  .risk-chip { display: inline-flex; align-items: center; gap: 6px;
+               font-size: 12px; font-variant-numeric: tabular-nums; }
+  .risk-dot { width: 8px; height: 8px; border-radius: 50%;
+              -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .risk-clean .risk-dot { background: var(--go); }
+  .risk-clean             { color: var(--go); font-weight: 600; }
+  .risk-green .risk-dot { background: #84cc16; }
+  .risk-green             { color: var(--ink-2); }
+  .risk-amber .risk-dot { background: #f59e0b; }
+  .risk-amber             { color: #a16207; font-weight: 600; }
+  .risk-red   .risk-dot { background: var(--warn); }
+  .risk-red               { color: var(--warn); font-weight: 700; }
+
+  /* Inline pill */
+  .inline-pill { display: inline-block; padding: 1px 7px; border-radius: 99px;
+                 font-size: 11px; background: #f1f5f9; color: var(--ink-2);
+                 font-variant-numeric: tabular-nums; margin-right: 4px;
+                 -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+
+  /* Notes + callouts */
+  .note { font-size: 12px; color: var(--mute); font-style: italic;
+          margin: 12px 0 0; }
+  .callout {
+    background: var(--warn-soft); border-left: 3px solid var(--warn);
+    padding: 12px 16px; border-radius: 6px; margin-top: 16px;
+    font-size: 13px; color: #7c2d12;
+  }
+  .callout strong { color: #7c2d12; }
+  .callout code { background: rgba(0,0,0,0.06); padding: 1px 5px; border-radius: 3px;
+                  font-size: 12px; }
+
+  code { font-family: "DM Mono", ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px;
+         background: var(--line-soft); padding: 1px 6px; border-radius: 4px; }
+
+  /* Next steps */
+  ol.next-steps { margin: 0; padding-left: 0; counter-reset: step;
+                  list-style: none; }
+  ol.next-steps li { counter-increment: step; padding: 14px 0 14px 44px;
+                     position: relative; border-bottom: 1px solid var(--line-soft);
+                     font-size: 14px; }
+  ol.next-steps li:last-child { border-bottom: 0; }
+  ol.next-steps li::before {
+    content: counter(step); position: absolute; left: 0; top: 14px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--accent-soft); color: var(--accent);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums;
+  }
+  ol.next-steps li strong { color: var(--ink); }
+
+  /* Privacy two-column */
+  .priv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .priv-col h3 { font-size: 13px; font-weight: 600; color: var(--ink);
+                 margin: 0 0 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .priv-col ul { margin: 0; padding-left: 0; list-style: none; }
+  .priv-col li { padding: 6px 0 6px 22px; position: relative;
+                 font-size: 13px; color: var(--ink-2); }
+  .priv-col.crossed li::before {
+    content: '→'; position: absolute; left: 0; color: var(--warn); font-weight: 700;
+  }
+  .priv-col.local li::before {
+    content: '◊'; position: absolute; left: 0; color: var(--go); font-weight: 700;
+  }
+
+  footer { color: var(--mute); font-size: 11px; text-align: center;
+           margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--line); }
+
+  @media print {
+    @page { margin: 0.6in 0.5in 0.6in; size: letter portrait; }
+    body { background: white; font-size: 11.5px; }
+    main { max-width: none; padding: 0; }
+    .doc-header { margin-bottom: 18px; }
+    .doc-title { font-size: 26px; }
+    .hero { margin-bottom: 24px; padding: 12px 16px; page-break-after: avoid; }
+    .hero-text { font-size: 13px; }
+    section { margin-bottom: 24px; page-break-inside: auto; }
+    section.section-tight { margin-bottom: 18px; }
+    .section-head { margin-bottom: 10px; padding-bottom: 8px; page-break-after: avoid; }
+    .section-title { font-size: 16px; }
+    .section-lede { font-size: 12px; margin: -2px 0 10px; }
+    .kpi-grid { gap: 8px; }
+    .kpi { padding: 12px; }
+    .kpi-v { font-size: 22px; }
+    .kpi-l { font-size: 10px; margin-top: 6px; }
+    .kpi-sub { font-size: 10px; margin-top: 3px; }
+    .stat-row { gap: 8px; margin-bottom: 14px; }
+    .stat { padding: 12px 14px; }
+    .stat-v { font-size: 24px; }
+    table.data { font-size: 11px; page-break-inside: auto; }
+    table.data thead { display: table-header-group; }
+    table.data th { padding: 8px 10px; font-size: 10px; }
+    table.data td { padding: 8px 10px; }
+    table.data tr { page-break-inside: avoid; page-break-after: auto; }
+    .tag, .ds-bucket { font-size: 10px; padding: 2px 8px; }
+    .bar-track { max-width: 60px; height: 5px; }
+    .note { font-size: 11px; }
+    .callout { padding: 8px 12px; font-size: 11px; }
+    ol.next-steps li { padding: 10px 0 10px 36px; font-size: 12px; }
+    ol.next-steps li::before { width: 22px; height: 22px; font-size: 11px; top: 10px; }
+    .priv-col li { font-size: 11px; padding: 4px 0 4px 18px; }
+    footer { margin-top: 24px; padding-top: 12px; }
+    .hero, .kpi, .stat, table.data, table.data th, .ds-bucket, .tag,
+    .bar-track, .bar-fill, .risk-dot, .callout, ol.next-steps li::before {
+      -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important;
+    }
+    section h2, .section-head { page-break-after: avoid; }
+    .stat-row, .priv-grid { page-break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+<main>
+
+<div class="brand-bar">
+  <span class="brand-dot"></span>
+  <span class="brand-mark">sigma</span>
+  <span class="brand-tag">Migration Assessment</span>
+</div>
+<div class="doc-header">
+  <div class="doc-eyebrow">Looker Environment Report</div>
+  <h1 class="doc-title">#{h(inst_name)}</h1>
+  <div class="doc-meta">
+    #{inst_url.empty? ? '' : %(<a href="#{h(inst_url)}" target="_blank" rel="noopener">#{h(inst_url)}</a> · )}
+    Generated #{h(formatted_date)}
+  </div>
+</div>
+
+<div class="hero">
+  <div class="hero-label">Headline finding</div>
+  <div class="hero-text">#{h(hero_finding)}</div>
+</div>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">01</span>
+    <h2 class="section-title">Environment overview</h2>
+  </div>
+  <div class="kpi-grid">#{kpi_html}</div>
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">02</span>
+    <h2 class="section-title">Dashboard priority &amp; usage</h2>
+    <span class="section-aside">Top 10 of #{env['dashboards']} dashboards · #{num(total_runs)} total runs</span>
+  </div>
+  <p class="section-lede">Most-used dashboards across the instance, ranked by run count from Looker's System Activity model. This is the foundation of any migration or consolidation plan — focus effort where audience attention already is. User-defined (UDD) and LookML dashboards convert through the same source-agnostic path.</p>
+  #{usage_html}
+  <p class="note">Run counts come from <code>system__activity</code> over the last #{days} days — a dashboard with zero runs here is cold over that window, which is the right retirement signal.</p>
+  #{cold_dash.any? ? %(<p class="note"><strong>#{cold_dash.size} dashboard#{cold_dash.size == 1 ? '' : 's'}</strong> had no runs in the last #{days} days: ) + cold_dash.first(20).map { |w| %(<code>#{h(w['name'])}</code>) }.join(', ') + ' — candidates for retirement.</p>' : ''}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">03</span>
+    <h2 class="section-title">Ownership &amp; concentration</h2>
+    <span class="section-aside">#{ownership.size} owners across #{env['dashboards']} dashboards</span>
+  </div>
+  <p class="section-lede">Dashboard ownership concentration across the instance. High concentration in one or two owners is a governance signal — what happens to those dashboards if that person leaves?</p>
+  #{ownership_html}
+  <p class="note">Top-owner concentration: <strong>#{top_owner_pct}%</strong> of dashboards owned by <code>#{h((top_owner_name || '—').to_s.sub(/@.*/, ''))}</code>.</p>
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">04</span>
+    <h2 class="section-title">Connections &amp; dialects</h2>
+    <span class="section-aside">#{conns['n_connections']} connection#{conns['n_connections'] == 1 ? '' : 's'} · #{(conns['dialects'] || []).map { |d| d['dialect'] }.join(', ')}</span>
+  </div>
+  <p class="section-lede">The warehouses Looker queries. Sigma reads from the same warehouses (Snowflake, BigQuery, Databricks, Redshift, Postgres, and more) — a Looker connection on a Sigma-supported dialect maps to a Sigma connection with no data movement, so the LookML semantic model can be re-pointed onto the existing tables.</p>
+  #{ds_html}
+</section>
+
+HTML
+
+# Section 5: Feature usage + per-dashboard complexity + shortlist
+if has_shortlist
+  max_v = [shortlist.map { |r| r['runs'].to_i }.max || 0, 1].max
+  sl_rows = shortlist.first(15).map do |r|
+    risk_cls, risk_txt =
+      if r['n_unhandled'].to_i.positive?
+        ['risk-red',   "#{r['n_unhandled']} to review"]
+      elsif r['n_manual'].to_i.positive?
+        ['risk-amber', "#{r['n_manual']} setup"]
+      else
+        ['risk-clean', 'No issues']
+      end
+    %(<tr>
+      <td>#{h(r['name'])}</td>
+      <td><span class="inline-pill">#{h(r['kind'])}</span></td>
+      <td>#{bar_cell(r['runs'], max_v)}</td>
+      <td><span class="risk-chip #{risk_cls}"><span class="risk-dot"></span>#{h(risk_txt)}</span></td>
+      <td class="al-right num">#{format('%.1f', r['score'].to_f)}</td>
+      <td>#{tag_pill(r['tag'])}</td>
+    </tr>)
+  end.join
+  shortlist_table = <<~HTML
+    <table class="data shortlist">
+      <thead>
+        <tr>
+          <th>Dashboard</th>
+          <th>Kind</th>
+          <th>Runs</th>
+          <th>Conversion risk</th>
+          <th class="al-right">Score</th>
+          <th>Recommendation</th>
+        </tr>
+      </thead>
+      <tbody>#{sl_rows}</tbody>
+    </table>
+    <p class="note">Conversion risk legend: <strong>No issues</strong> = converts automatically · <strong>N setup</strong> = brief post-conversion step in Sigma (pivot → Sigma pivot table, table calc → Sigma formula, Liquid → re-author) · <strong>N to review</strong> = uses a Looker feature with no direct Sigma equivalent (merged results, marketplace / custom viz) that warrants individual evaluation when planning the conversion.</p>
+  HTML
+
+  complexity_table = ''
+  if has_complexity
+    crows = shortlist.sort_by { |r| -(r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3) }.map do |r|
+      n_viz = (r['viz_types'] || {}).values.sum
+      unh_cell = r['n_unhandled'].to_i.positive? ? %(<span class="warn-num">#{r['n_unhandled']}</span>) : '<span class="muted">0</span>'
+      %(<tr>
+        <td>#{h(r['name'])}</td>
+        <td class="al-right num muted">#{r['tiles']}</td>
+        <td class="al-right num muted">#{r['filters']}</td>
+        <td class="al-right num muted">#{n_viz}</td>
+        <td class="al-right num muted">#{r['n_auto']}</td>
+        <td class="al-right num">#{r['n_manual']}</td>
+        <td class="al-right">#{unh_cell}</td>
+      </tr>)
+    end.join
+    complexity_table = <<~HTML
+      <h3>Per-dashboard complexity</h3>
+      <p class="section-lede" style="margin-top:0;">Tile vis-types and hard-to-migrate features (pivots, table calcs, merged results, custom viz, Liquid) bucketed against Sigma coverage. <strong>Auto</strong> converts mechanically; <strong>Setup</strong> = pivot / table calc / Liquid (brief manual step); <strong>Review</strong> = merged results / marketplace viz (no direct Sigma equivalent).</p>
+      <table class="data">
+        <thead>
+          <tr>
+            <th>Dashboard</th>
+            <th class="al-right">Tiles</th>
+            <th class="al-right">Filters</th>
+            <th class="al-right">Vis</th>
+            <th class="al-right">Auto</th>
+            <th class="al-right">Setup</th>
+            <th class="al-right">Review</th>
+          </tr>
+        </thead>
+        <tbody>#{crows}</tbody>
+      </table>
+    HTML
+  end
+
+  html += <<~HTML
+  <section>
+    <div class="section-head">
+      <span class="section-num">05</span>
+      <h2 class="section-title">Migration to Sigma — recommended sequence</h2>
+      <span class="section-aside">Sigma-specific recommendations</span>
+    </div>
+    <p class="section-lede">If you choose to migrate to Sigma, this is the order that minimizes risk while covering the most user impact. Dashboards are ranked by usage value relative to conversion complexity. The top of the list is the recommended starting point for a pilot.</p>
+
+    <div class="stat-row">
+      <div class="stat">
+        <div class="stat-l">Top-5 run share</div>
+        <div class="stat-v">#{top5_pct}<span style="font-size: 16px; color: var(--mute); font-weight: 600;">%</span></div>
+        <div class="stat-sub">of #{num(total_runs)} total runs</div>
+      </div>
+      <div class="stat stat-#{sl_top5_unhandled.zero? ? 'go' : 'warn'}">
+        <div class="stat-l">Top-5 conversion complexity</div>
+        <div class="stat-v #{sl_top5_unhandled.zero? ? 'go' : 'warn'}">#{sl_top5_unhandled}</div>
+        <div class="stat-sub">features to review across pilot</div>
+      </div>
+      <div class="stat">
+        <div class="stat-l">Needs review · Retire</div>
+        <div class="stat-v">#{sl_needs_scout}<span style="font-size: 16px; color: var(--mute); font-weight: 600;"> · #{sl_retire}</span></div>
+        <div class="stat-sub">dashboards of #{shortlist.size} total</div>
+      </div>
+    </div>
+
+    #{feat_stats}
+
+    #{shortlist_table}
+
+    #{sl_total_unhandled.positive? ?
+      %(<div class="callout"><strong>#{n_with_unhandled} dashboard#{n_with_unhandled == 1 ? '' : 's'}</strong> include features that warrant individual review when planning their conversion — typically merged results (multiple explores stitched in one tile) or marketplace / custom-viz extensions, where the right Sigma equivalent depends on how the dashboard actually uses them. Identifying these up-front means no surprises mid-migration.</div>) : ''}
+
+    #{complexity_table}
+  </section>
+
+  HTML
+  html += effort_html
+end
+
+# Privacy + next steps
+priv_num = has_shortlist ? '08' : '05'
+next_num = has_shortlist ? '09' : '06'
+
+html += <<~HTML
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{priv_num}</span>
+    <h2 class="section-title">Data handling</h2>
+  </div>
+  <p class="section-lede">This report was generated by an LLM-driven, read-only scan of your Looker instance via the REST API 4.0. What that means for the data that left your environment:</p>
+  <div class="priv-grid">
+    <div class="priv-col crossed">
+      <h3>Read by the scanner</h3>
+      <ul>
+        <li>Aggregate counts (models, explores, projects, connections, Looks, dashboards, users, groups, folders)</li>
+        <li>Dashboard titles, owner names, folder names, connection names + dialects</li>
+        <li>System Activity usage — dashboard / Look run counts and active-user counts</li>
+HTML
+
+if has_shortlist
+  html += "        <li>Per-dashboard tile definitions (vis types, pivots, table calcs, filters) for #{shortlist.size} dashboards — to bucket conversion complexity</li>\n"
+end
+
+html += <<~HTML
+      </ul>
+    </div>
+    <div class="priv-col local">
+      <h3>Never left your environment</h3>
+      <ul>
+        <li>Underlying warehouse rows — the scan never runs a content query</li>
+        <li>Database / connection credentials</li>
+        <li>No writes of any kind — no objects created, edited, or deleted in Looker</li>
+        <li>PDTs / cached results — never read</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{next_num}</span>
+    <h2 class="section-title">Recommended next steps</h2>
+  </div>
+  <ol class="next-steps">
+HTML
+
+if has_shortlist
+  html += <<~HTML
+    <li><strong>Pilot the top #{[5, shortlist.size].min} dashboards.</strong> They represent #{top5_pct}% of total runs with #{sl_top5_unhandled} feature#{sl_top5_unhandled == 1 ? '' : 's'} flagged for review between them — the lowest-risk way to demonstrate end-to-end migration with the <code>looker-to-sigma</code> skill.</li>
+  HTML
+  if sl_needs_scout.positive?
+    html += "    <li><strong>Plan individual review time for #{sl_needs_scout} dashboard#{sl_needs_scout == 1 ? '' : 's'}.</strong> Each contains a Looker capability (merged results, marketplace / custom viz) that benefits from a tailored conversion approach.</li>\n"
+  end
+  if sl_retire.positive?
+    html += "    <li><strong>Retire #{sl_retire} dashboard#{sl_retire == 1 ? '' : 's'}</strong> with no runs in the last #{days} days. No migration value, and dropping them simplifies the cutover.</li>\n"
+  end
+  html += "    <li><strong>Hand off to <code>looker-to-sigma</code></strong> with the pilot dashboards — it converts the LookML model via <code>convert_lookml_to_sigma</code> and rebuilds each dashboard from the Looker Dashboard API JSON.</li>\n"
+else
+  html += <<~HTML
+    <li><strong>Re-run without <code>--no-deep</code></strong> to add per-dashboard complexity (tile vis-type buckets, pivots / table calcs / merged results) and unlock the migration shortlist.</li>
+    <li><strong>Hand off to <code>looker-to-sigma</code></strong> to convert the dashboards you choose to migrate.</li>
+  HTML
+end
+
+html += <<~HTML
+  </ol>
+</section>
+
+<footer>
+  Report generated #{h(formatted_date)} · supporting JSON files alongside in the same folder
+</footer>
+
+</main>
+</body>
+</html>
+HTML
+
+out_path = File.join(opts[:out], 'readout.html')
+File.write(out_path, html)
+puts "wrote #{out_path} (#{File.size(out_path)} bytes)"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
@@ -1,0 +1,92 @@
+# Looker → Sigma — Quickstart
+
+End-to-end: a Looker LookML model + its dashboards (UDD or LookML-defined) → a Sigma data model
++ workbook(s), parity-verified against Looker AND the warehouse.
+
+## 1. Authenticate
+
+**Looker** (REST API 4.0). Put an API3 key in `~/.looker/looker.ini`:
+```ini
+[Looker]
+base_url=https://<your-instance>.cloud.looker.com:19999
+client_id=<API3 client_id>
+client_secret=<API3 client_secret>
+verify_ssl=True
+```
+Generate the key in Looker: **Admin → Users → (you) → Edit Keys → New API3 Key**. Test it:
+```bash
+python3 scripts/looker_api.py whoami        # HTTP 200 + your name/roles
+```
+
+**Sigma**: credentials via the `sigma-api` skill (`ruby scripts/setup.rb` once → `~/.sigma-migration/env`).
+```bash
+eval "$(scripts/get-token.sh)"              # sets SIGMA_API_TOKEN (~1h TTL)
+export SIGMA_CONNECTION_ID=<full-connection-uuid>   # NOT a short prefix
+```
+
+## 2. Discover
+
+```bash
+python3 scripts/looker_api.py raw GET /lookml_models   # list models/explores
+python3 scripts/looker_api.py raw GET /dashboards      # list dashboards (UDD + LookML)
+
+# pull one dashboard into the normalized contract (works for UDD AND LookML)
+python3 scripts/fetch_looker_dashboard.py <dashboard_id> /tmp/look/<dash>.contract.json
+# offline (dev/test only — cannot see UDDs):
+python3 scripts/parse_lookml_dashboard.py <file.dashboard.lookml> --out /tmp/look/<dash>.contract.json
+```
+
+## 3. Convert the semantic model
+
+Feed the LookML **model** (not the warehouse tables) to the **`convert_lookml_to_sigma`** MCP
+tool — it resolves the explore's join graph. For fixed output against a patched converter
+source tree (the MCP server serves the *deployed* build), run it directly:
+```bash
+LOOKML_DIR=/path/to/lookml \
+CONVERTER_SRC=/path/to/sigma-data-model-mcp/src/lookml.ts \
+  node --import tsx/esm scripts/convert_dm.mjs <explore> /tmp/look/dm-spec.json
+```
+Read the printed warnings. Then POST + register:
+```bash
+bash -c 'eval "$(scripts/get-token.sh)" && \
+  SIGMA_CONNECTION_ID=$SIGMA_CONNECTION_ID python3 scripts/post_dm.py /tmp/look/dm-spec.json'
+```
+This POSTs to `/v2/dataModels/spec` (auto-finds a folder, swaps in the full connection UUID).
+Verify with `mcp__sigma-mcp-v2__describe` (no `type=error` columns) + a raw-aggregate `query`.
+
+## 4. Convert the dashboards (model → DM → its dashboards → layout)
+
+```bash
+python3 scripts/build_workbook.py /tmp/look/<dash>.contract.json \
+  --views /path/to/lookml/views \
+  --dm-id <dataModelId> --element-id <denorm-element-id> \
+  --dm-element-name "<DM element display name>" \
+  --folder-id <writable-folder-id> \
+  --out /tmp/look/<dash>.workbook.json
+```
+Emits a `/v2/workbooks/spec` body: hidden Data page + master table, one element per tile,
+controls from filters, newspaper→24-col layout XML. POST it to `/v2/workbooks/spec` (returns
+YAML → record `workbookId`). **POST once; PUT every later edit** (re-POST leaves orphans).
+
+## 5. Verify parity (3-way) — MANDATORY
+
+Compare at the metric grain and per tile:
+- **Looker** — `POST /queries/run/json` for the explore.
+- **Sigma** — `mcp__sigma-mcp-v2__query` (raw aggregate; `metric()` returns "Missing Metric").
+- **Warehouse** — the source-of-truth `SELECT`.
+
+GREEN only when all three match (the validated run tied out to the cent).
+
+---
+
+### Notes / gotchas
+
+- **UDD is the primary path** — `GET /dashboards/{id}` returns user-defined and LookML dashboards
+  identically; the converter is source-agnostic via the contract.
+- **Spec endpoints return YAML** — never `json.load` / `jq` the response.
+- **KPI `value.columnId`** vs **donut/pie `value.id`**; **control elements need their own `id`**.
+- **Lossy + warned:** Liquid `{% %}` measures, manifest constants, `link:`/`html:` styling, pivot
+  cross-tab (flattened → rebuild as Sigma pivot-table in UI), table-calc window grain, cross-
+  filtering / trellis / tooltips (Sigma UI-only). Wire these in Phase 5 post-publish.
+- **`build_looker_dashboard.py` / `build_looker_dashboard2.py` are test-fixture builders** — they
+  author Looker dashboards (migration targets), not part of a customer migration.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -1,0 +1,439 @@
+---
+name: looker-to-sigma
+description: >-
+  Convert a Looker instance (LookML semantic model + dashboards) into a Sigma
+  data model and matching workbook(s). Use when the user has Looker content —
+  LookML projects, explores, or dashboards (user-defined OR LookML-defined) —
+  and wants to recreate it in Sigma. Discovery via the Looker REST API 4.0 /
+  Looker MCP server (or LookML files offline), model conversion via the
+  convert_lookml_to_sigma converter, dashboard → workbook conversion from the
+  Looker Dashboard API JSON, build via the Sigma REST API, and 3-way parity
+  verification against the source warehouse — driven by `scripts/*`.
+user-invocable: true
+---
+
+# Looker → Sigma Conversion
+
+Convert a Looker LookML semantic model into a Sigma data model, then build Sigma
+workbook(s) that mirror the Looker dashboards (user-defined OR LookML-defined) as
+closely as possible — and verify the numbers match Looker AND the warehouse.
+
+**Read ALL of the following before replying or taking any action. Do not make assumptions about skill conventions, prompts, or global instructions — read the files.**
+- `refs/dashboard-contract.md` — the normalized Looker Dashboard JSON contract both the live API fetch and the offline LookML parse produce. The dashboard pipeline is source-agnostic; it only sees this contract.
+- `refs/looker-dashboard-layout.md` — the deep desk study: Looker layout modes, newspaper→24-col grid math, tile-type / filter-type maps, and the full translation-hazard catalog (Liquid, `merged_results`, table calcs, view/explore field resolution, cross-filtering). **This is the design backbone of the dashboard pipeline.**
+
+**For canonical spec shape** (data-model element kinds, workbook element kinds, controls, formulas, formatting), defer to the companion **`sigma-data-models`** and **`sigma-workbooks`** skills. This skill restates only the Looker-conversion-specific patterns.
+
+---
+
+## The two artifacts, two pipelines
+
+Looker has two independent layers; convert them separately.
+
+| Layer | Source (production = API-first) | Converter | Sigma output |
+|---|---|---|---|
+| **Semantic model** | LookML views+model (Looker API/MCP, or files offline) | `mcp__sigma-data-model__convert_lookml_to_sigma` | data model |
+| **Dashboards** | `GET /dashboards/{id}` JSON — covers **user-defined (UDD) AND LookML dashboards** | `fetch_looker_dashboard.py` → contract → `build_workbook.py` | workbook |
+
+**Critical — UDD is the primary path.** Most real Looker dashboards are **user-defined
+(UDD)** — built in the UI, NOT in any LookML file. They are reachable ONLY via the Looker
+API, which returns UDD and LookML dashboards as the **same** `Dashboard` JSON
+(`dashboard_elements[]` + `dashboard_layouts[]` + `dashboard_filters[]`). So the dashboard
+converter keys off that API JSON, not LookML. `.dashboard.lookml` parsing is a secondary,
+offline-only path that normalizes into the same contract.
+
+---
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/get-token.sh` | Exchange `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` → `SIGMA_API_TOKEN` (~1h TTL). `eval "$(scripts/get-token.sh)"` |
+| `scripts/looker_api.py` | Minimal Looker REST API 4.0 client (no SDK). Reads `~/.looker/looker.ini`, logs in via `client_credentials`, exposes `L.call(method, path, body)`. CLI: `python3 looker_api.py whoami` / `get <path>` / `raw GET /lookml_models`. |
+| `scripts/fetch_looker_dashboard.py` | **Phase 1 (live):** `GET /dashboards/{id}` → the normalized contract (`refs/dashboard-contract.md`). Works for UDD AND LookML dashboards. Self-contained (reads `~/.looker/looker.ini`). `tileType` is read from `query.vis_config.type` (NOT `element.type`, which is always `"vis"`); `listen` from `result_maker.filterables`; layout from the **active** layout's components. |
+| `scripts/parse_lookml_dashboard.py` | **Phase 1 (offline):** parse a `.dashboard.lookml` (YAML) → the SAME contract. Dev/test only; cannot see UDD dashboards. Requires PyYAML. |
+| `scripts/convert_dm.mjs` | **Phase 2:** run `convertLookMLToSigma` against a directory of `.lkml` files for one explore → a Sigma DM spec JSON. Bypasses the deployed MCP build (see the converter-build gotcha below). Env: `LOOKML_DIR`, `CONVERTER_SRC`; args `<exploreName> <out.json>`. |
+| `scripts/post_dm.py` | **Phase 2:** POST a DM spec to `/v2/dataModels/spec` (auto-finds a writable folder, swaps in the full connection UUID). Env: `SIGMA_API_TOKEN`, `SIGMA_BASE_URL`, `SIGMA_CONNECTION_ID`; args `<spec.json>`. |
+| `scripts/build_workbook.py` | **Phase 3:** dashboard contract + the explore's view `.lkml` files → a Sigma `/v2/workbooks/spec` body (hidden Data page + master table, one element per tile, controls from filters, newspaper→24-col layout XML). Generates locally; does **not** POST. Handles ratio measures, joined-col `Field (alias)` naming, table calcs, pivot-flatten + warn. |
+| `scripts/build_looker_dashboard.py` | **TEST-FIXTURE BUILDER (not a migration step).** Builds the "Orders Overview" UDD on `csa_thelook` via the Looker API (4 KPIs + line/column/bar/pie + grid, 3 filters wired via `result_maker.filterables.listen`). |
+| `scripts/build_looker_dashboard2.py` | **TEST-FIXTURE BUILDER (not a migration step).** Builds the "Orders Deep Dive" UDD — area, pivot, table-calcs, scatter, donut, text tile — the harder dashboard surface for the converter. |
+
+> **Test-fixture builders vs migration scripts.** `build_looker_dashboard.py` /
+> `build_looker_dashboard2.py` **author** Looker dashboards (migration *targets*); they are
+> for standing up known demo content to convert and parity-check. Never run them against a
+> customer's Looker. Everything else converts *from* Looker *to* Sigma.
+
+---
+
+## Prerequisites
+
+### Looker credentials (`~/.looker/looker.ini`)
+
+```ini
+[Looker]
+base_url=https://<your-instance>.cloud.looker.com:19999
+client_id=<API3 client_id>
+client_secret=<API3 client_secret>
+verify_ssl=True
+```
+
+- **API 4.0**, key-pair-free `client_credentials` (login on `:19999` returns a bearer).
+- The credential's user needs **Admin** (or at least: see models, dashboards, run queries, and
+  — for the test-fixture builders or Git-deploy flow — develop + deploy).
+- Generate an API3 key in Looker: **Admin → Users → (your user) → Edit Keys → New API3 Key**.
+- Test: `python3 scripts/looker_api.py whoami` → prints HTTP 200, your display name + roles.
+
+### Sigma credentials
+
+`eval "$(scripts/get-token.sh)"` exchanges `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` (from
+`~/.sigma-migration/env`, written by the `sigma-api` skill's `setup.rb`) for a `SIGMA_API_TOKEN`.
+Also note your **full connection UUID** (`SIGMA_CONNECTION_ID`) and a writable **folderId**.
+
+> Tokens live ~1 hour. Re-fetch when a curl returns 401. Never use
+> `TOKEN=$(eval "$(scripts/get-token.sh)")` — `$()` is a subshell where the exported var dies.
+> Keep `eval` + `curl` in the same `bash -c '...'` invocation.
+
+> **Inline Python/Node inside bash — DON'T.** Triple-nested escapes silently break. Always
+> write a `.py`/`.mjs` file with `Write` and call it via `python3 file.py` / `node file.mjs`.
+> The scripts here already follow that rule.
+
+### The Looker-side warehouse connection (one-time, for live parity)
+
+Looker needs its **own** direct warehouse auth — Sigma's connection UUID is Sigma-side and
+unusable for Looker. To stand up an end-to-end test pointed at the same warehouse as Sigma
+(so 3-way parity is meaningful):
+
+- **Snowflake service identity:** create a `SERVICE`-type user with **key-pair** auth (Snowflake
+  blocks single-factor passwords for service users) + a role granting USAGE on the warehouse +
+  the db/schema and SELECT on the tables/views.
+- **Looker connection** (`POST /connections`): `uses_key_pair_auth: true`, `certificate` =
+  base64 of the `.p8` private key, `file_type: ".p8"`, warehouse via
+  `jdbc_additional_params=warehouse=<WH>`, host `<account>.snowflakecomputing.com`. Test via
+  `PUT /connections/{name}/test`.
+- **Git-backed project + model:** create a project in the **dev** workspace, add a deploy key to
+  the Git repo, set the git remote via **`PATCH /projects/{id}`** (PUT 404s). All dev-workspace
+  mutations need **ONE persistent session** (`PATCH /session {workspace_id: dev}`).
+
+> This setup is only needed to build a *live* test instance. For a customer migration the Looker
+> instance + connection already exist — you just read from them.
+
+---
+
+## Phase 0 — Assess the Looker estate
+
+Scope the migration before converting anything — inventory models/explores/dashboards, score
+complexity, and rank a migration shortlist. This is handled by the **`looker-assessment`**
+sibling skill (analogous to `tableau-assessment` / `qlik-assessment`). Run it first for any
+multi-dashboard migration; skip it for a single known dashboard.
+
+---
+
+## Phase 1 — Discover the Looker content
+
+Three transports, in order of preference: **Looker MCP** (when wired in) → **Looker REST API
+4.0** (the default here) → **offline `.lkml`** (dev/test, can't see UDDs).
+
+### 1a. Smoke-test + list
+
+```bash
+python3 scripts/looker_api.py whoami                 # confirm auth + admin
+python3 scripts/looker_api.py raw GET /lookml_models  # list models
+python3 scripts/looker_api.py raw GET /dashboards     # list dashboards (UDD + LookML)
+```
+
+For a specific explore's field graph:
+`python3 scripts/looker_api.py raw GET /lookml_models/<model>/explores/<explore>`.
+
+### 1b. Pull each dashboard into the normalized contract (live)
+
+```bash
+python3 scripts/fetch_looker_dashboard.py <dashboard_id> /tmp/<name>/<dash>.contract.json
+```
+
+This hits `GET /dashboards/{id}` and normalizes into `refs/dashboard-contract.md`. It works
+for UDD **and** LookML dashboards (the API returns both identically). Key extraction details
+(already handled by the script):
+- **`tileType` comes from `query.vis_config.type`**, not `element.type` (which is always
+  `"vis"` for chart tiles, `"text"` for text tiles).
+- **`listen`** (which dashboard filters a tile obeys) comes from
+  `result_maker.filterables[].listen`.
+- **layout** comes from the **active** layout's `dashboard_layout_components[]`
+  (`row`/`column`/`width`/`height`); ignore mobile variants.
+- **`dynamic_fields`** (table calcs / client-side custom measures) arrives as a **JSON string**
+  — the script `json.loads` it.
+
+### 1c. Offline path (dev/test only)
+
+```bash
+python3 scripts/parse_lookml_dashboard.py <file.dashboard.lookml> --out /tmp/<name>/<dash>.contract.json
+```
+
+Same contract shape. Cannot see UDD dashboards; LookML dashboards may also lag the live UI
+state (a `.dashboard.lookml` reflects source-of-truth, the API reflects edits). **Prefer the
+API.** Note: a deployed LookML dashboard does NOT auto-index for `import_lookml_dashboard`
+(Looker reindexes lazily, 404 until then) — just build/discover the UDD directly.
+
+> **No live instance?** A GCP free-trial account CANNOT provision Looker (instance quota is
+> `isFixed` = 0, Sales-gated). Build/test from sample LookML + the offline path. The validated
+> end-to-end run used a real `hakkoda1.cloud.looker.com` instance pointed at `CSA.TJ`.
+
+---
+
+## Phase 2 — Convert the LookML semantic model
+
+LookML views + model → Sigma data model. Resolve the explore's join graph, convert, POST,
+**register the model**, and verify.
+
+### 2a. Convert with `convert_lookml_to_sigma`
+
+The MCP tool `mcp__sigma-data-model__convert_lookml_to_sigma(files, connectionId, exploreName,
+joinStrategy)` is the primary path. Feed it the **LookML model**, NOT the warehouse tables —
+the converter walks the explore's `join`s to resolve `view.field` prefixes (alias vs `from:`
+view) and emits one element per resolved view plus a denormalized explore element.
+
+> **Converter-build gotcha.** The long-running MCP server serves the **deployed** build. After
+> editing `src/lookml.ts` + `npm run build`, the running MCP tool still serves the OLD code
+> until it restarts. For fixed output against an edited source tree, run the converter directly:
+>
+> ```bash
+> LOOKML_DIR=/path/to/lookml \
+> CONVERTER_SRC=/path/to/sigma-data-model-mcp/src/lookml.ts \
+>   node --import tsx/esm scripts/convert_dm.mjs <exploreName> /tmp/<name>/dm-spec.json
+> ```
+>
+> `convert_dm.mjs` reads `<model>.model.lkml` + every `views/*.view.lkml`, converts the explore
+> with `joinStrategy: 'relationships'`, and writes `res.model` (the return property is `.model`,
+> **not** `.sigmaDataModel`). It prints stats + warnings — **read every warning.**
+
+### 2b. Converter coverage (all live-validated 2026-06-10) — and what's still lossy
+
+The converter handles, end-to-end and clean:
+- **Dimensions** — `tier`, sql `CASE`, legacy `case:` (→ nested `If()`), `html`/`link`, custom
+  `value_format`.
+- **Time + duration `dimension_group`** — one column per timeframe (`DateTrunc`); duration groups
+  emit `sql_start`/`sql_end` physical columns.
+- **Measures** — `sum`/`count`/`count_distinct`/`avg`/`median`/`percentile`/filtered/**ratio**.
+  Measure `${dimension}` refs and measure-references-measure `${measure}` (ratio) refs resolve to
+  the right Sigma formula; `1.0` literals preserved; `NULLIF` → `NullIf`.
+- **Joins** — snowflake (multi-hop) joins wire the FK to the correct intermediate element (not
+  always the base); `full_outer` + field-limited joins; `sql_always_where` / `always_filter`.
+- **Other** — `derived_table`, `parameter` + Liquid, `drill_fields`, `set`, view/group labels,
+  multiple explores per model.
+
+These 8 converter bugs were found and **FIXED in source** (branch
+`tj/lookml-robustness-ratio-percentile-html-fixes`); treat them as **handled**, but know the
+shapes so you recognize a regression:
+
+| # | Bug (now fixed) | What it produced before the fix |
+|---|---|---|
+| BUG1 | measure `${dimension}` refs unresolved | literal `Sum([${sale price}])` + phantom `${...}` columns |
+| BUG2 | multi-hop (snowflake) joins mis-wired | FK hung off the base element instead of the intermediate |
+| BUG3 | ratio measures (`${measure}`, `1.0`→`0`) | phantom column + `0 * ${...}` formula |
+| BUG4 | `html:`/Liquid `%}` desynced the block parser | silently dropped ALL view fields after the html dimension |
+| BUG5 | `percentile` → bogus `CountIf` | wrong aggregation |
+| BUG6 | filtered `type:count` with no sql | bogus phantom value column |
+| BUG7 | `type:duration` dimension_group | dangling `DateDiff` (no sql_start/sql_end) |
+| BUG8 | legacy `case:{when/else}` dim | passthrough to a nonexistent column |
+
+> If the running MCP build predates these fixes, use the `convert_dm.mjs` direct path (2a)
+> against a patched source tree, OR repair the spec post-hoc — but the source fixes mean **raw
+> converter output now POSTs clean with no in-spec workarounds**.
+
+**Still lossy / unsupported (documented, warned — never silent):**
+- **Liquid `{% parameter %}` measures** and **manifest constants** — Looker API-deploy cache
+  quirk; review.
+- **`link:` / `html:` styling** — dropped (data is fine; the styling/hyperlink is lost).
+- **Pivot cross-tab** → flattened to columns + warn (rebuild as a Sigma `pivot-table` in the UI).
+- **Table-calc grain/sort** for window functions (rank / offset / percentile) → review.
+- **`merged_results`** → a DM join or a Custom SQL element (follow `merge_result_id` to the
+  source queries; >2 sources or non-equi joins → manual + warn).
+- **Not yet converted:** NDT (`explore_source`), PDT `datagroup`/`persist_for`, `many_to_many`,
+  `access_filter`.
+
+> **`metric()` returns "Missing Metric" in MCP SQL** — a known Sigma quirk, not a conversion
+> bug. Verify metric values via the **raw aggregate** (`Sum(...)`, `CountDistinct(...)`), not via
+> `metric()`.
+
+### 2c. POST the data model
+
+```bash
+bash -c 'eval "$(scripts/get-token.sh)" && \
+  SIGMA_CONNECTION_ID=<full-connection-uuid> \
+  python3 scripts/post_dm.py /tmp/<name>/dm-spec.json'
+```
+
+- Endpoint is `POST /v2/dataModels/spec` (NOT `/v2/workbooks/spec`).
+- **Use the FULL connection UUID** (e.g. `bc0319f8-9fe0-4315-aea3-6a2d1eef0623`), not a short
+  prefix — `convert_dm.mjs` writes a placeholder `connectionId`; `post_dm.py` swaps in
+  `$SIGMA_CONNECTION_ID`.
+- **`folderId` is required** — `post_dm.py` auto-picks a writable folder (preferring one whose
+  name mentions LOOKER/MIGRATION/TEST).
+- **The spec endpoints return YAML** (`success: true\nworkbookId: …`), not JSON — never
+  `json.load` the response or pipe it to `jq`.
+
+Record the returned `dataModelId` and (after a read-back) the element IDs.
+
+### 2d. Register the model + verify
+
+> A freshly POSTed/deployed LookML model **404s on query until you register it** (Looker side
+> for the Looker model; this is the deploy flow for standing up a test instance):
+>
+> ```
+> PATCH /session {workspace_id: dev}
+> PUT  /projects/{id}/git_branch {name: <dev-branch>, ref: origin/main}   # pull pushed commits into dev
+> POST /projects/{id}/validate                                            # expect 0 errors
+> POST /projects/{id}/deploy_to_production                                # 204
+> POST /lookml_models {name, project_name, allowed_db_connection_names:[<conn>]}
+> ```
+>
+> LookML param gotcha: params are **not** semicolon-separated — compact
+> `{ primary_key: yes; hidden: yes; sql: ... ;; }` fails ("Invalid lookml syntax") and cascades
+> into bogus join/field errors. Use multi-line blocks (only `;;` terminates a `sql`).
+> A refinement `view: +x` in a glob-included file fails ("Could not find a view to extend") —
+> fold the param/measure into the base view.
+
+**Verify the Sigma DM:** `mcp__sigma-mcp-v2__describe` the element (no `type=error` columns;
+metric formulas resolve clean), then `mcp__sigma-mcp-v2__query` a raw aggregate and confirm it
+matches the warehouse.
+
+---
+
+## Phase 3 — Convert the dashboards (UDD = primary)
+
+For each Looker dashboard, fetch its contract (Phase 1b), then build a Sigma workbook spec.
+
+### 3a. Build the workbook spec
+
+```bash
+python3 scripts/build_workbook.py /tmp/<name>/<dash>.contract.json \
+  --views /path/to/lookml/views \
+  --dm-id <dataModelId> \
+  --element-id <denorm-element-id> \
+  --dm-element-name "<DM element display name>" \
+  --folder-id <writable-folder-id> \
+  --out /tmp/<name>/<dash>.workbook.json
+```
+
+(`contract` is positional. `--dm-element-name` is the display name of the data-model element
+the master table pulls from; `--master-name` defaults to `Data`. The generated spec has
+placeholder defaults for any flag you omit, so it always generates locally — fill in the real
+ids before POSTing.)
+
+`build_workbook.py` consumes the contract + the explore's view `.lkml` files (to classify each
+`view.field` as a measure — agg + base col — or a dimension, and derive the Sigma formula) and
+emits a `/v2/workbooks/spec` body:
+- a **hidden "Data" page** with a master table sourced from the DM element,
+- a **dashboard page** with one element per Looker tile,
+- **controls** from the dashboard filters,
+- a **newspaper → 24-col grid layout** XML string.
+
+Tile-type, filter-type, and layout maps are in `refs/dashboard-contract.md` and
+`refs/looker-dashboard-layout.md` — **do not duplicate them; defer there.** Summary:
+
+| Looker tile `type:` | Sigma kind |
+|---|---|
+| `single_value` | `kpi-chart` |
+| `looker_column` / `looker_bar` | `bar-chart` |
+| `looker_line` | `line-chart` |
+| `looker_area` | `area-chart` |
+| `looker_pie` | `pie-chart` |
+| `looker_donut_multiples` | `donut-chart` (single ring) + warn |
+| `looker_scatter` | `scatter-chart` |
+| `looker_grid` / `table` | `table` |
+| `text` | `text` (markdown body) |
+| `looker_map` / geo / funnel / waterfall / boxplot / sankey / custom viz | none — approximate or drop + warn |
+
+Newspaper layout math (a single arithmetic transform, no spatial heuristic):
+`gridColumn = (col+1) / (col+1+width)`, `gridRow = (row+1) / (row+1+height)`. `tile` / `static`
+/ `grid` modes need a snap heuristic (lossy) — warn + stack; see `refs/looker-dashboard-layout.md` §3.
+
+### 3b. Workbook-spec gotchas (learned the hard way)
+
+- **`/v2/workbooks/spec` returns YAML** — don't `json.load` the response.
+- **control elements** live in `page.elements[]` with `kind: control` but REQUIRE an `id`
+  (separate from `controlId`); a missing `id` → `Invalid kind: "control"`.
+- **KPI `value` uses `value.columnId`** on the live API (the `sigma-workbooks`
+  `example-full.yaml` shows `value.id` — the API wants `columnId`). **BUT donut/pie `value`
+  uses `value.id`** (not columnId) — the two element types genuinely differ; verified by POST
+  400s both ways.
+- **Chart `color` channel differs by type:** bar/area/line series = `{by: "category", column:
+  <id>}`; donut/pie slice = `{id: <id>, sort?}`. (A Looker pivot maps to this color channel.)
+- **donut/pie use `value` + `color`, NOT `xAxis`/`yAxis`.**
+- **KPI comparison (`show_comparison`) has NO spec slot** — warn, don't build. (Recommend a 2nd
+  KPI tile or a UI delta post-publish.) Looker `donut_multiples` per-multiple dim is also dropped → warned.
+- **Master → DM-element refs:** a master table sourcing a DM element references columns as
+  `[<DM-element-NAME>/<col display>]`; tiles then reference `[<master-NAME>/<col display>]`.
+- **Joined-view columns** in the denorm DM element are named `<Field> (<joinAlias>)` (Sigma
+  disambiguates cross-element lookup cols) — master/tile refs must include the suffix, e.g.
+  `[Order Fact/Region (customer_dim)]`.
+- **Table calcs** → workbook formula columns: `running_total` → `CumulativeSum`,
+  `pct_of_total`/`sum()` → `GrandTotal`, `offset(…,-1)` → `Lag`. (`build_workbook.py` translates
+  these; `dynamic_fields` arrives JSON-parsed from discovery.)
+- **count on a joined view** → `CountDistinct` using that view's primary key (base-view counts
+  stay `Count()`).
+
+### 3c. POST the workbook + verify
+
+POST the spec to `/v2/workbooks/spec` (returns YAML → record the `workbookId`). Then
+`mcp__sigma-mcp-v2__describe` each element (no `type=error` columns) and confirm the layout
+applied. **POST is create-only** — every subsequent spec edit MUST use `PUT
+/v2/workbooks/{id}/spec`; re-POSTing leaves orphan workbooks in My Documents (delete via `DELETE
+/v2/files/{id}`).
+
+---
+
+## Phase 4 — Verify parity (3-way: Looker vs Sigma vs warehouse) — MANDATORY
+
+A conversion is not complete until the numbers tie out. Compare at **two grains**: the model's
+key metrics, and per-tile.
+
+1. **Looker** — `POST /queries/run/json` (or `run_inline_query`) for the model/explore, e.g.
+   net revenue by region.
+2. **Sigma** — `mcp__sigma-mcp-v2__query` against the DM element (raw aggregate, since
+   `metric()` returns "Missing Metric") AND against each workbook chart element.
+3. **Warehouse** — the source-of-truth `SELECT` (via the Sigma connection or `snow`).
+
+GREEN only when all three match. The validated run produced **exact** parity to the cent —
+region revenue (West 38906.82 / South 31650.98 / NE 21587.52 / MW 14966.20 / null 3231.23 =
+$109,765.89) and the ratio metrics (AOV / margin / return) identical across Looker and Sigma.
+
+> **If `mcp__sigma-mcp-v2__query` errors with an auth message mid-Phase-4**, the MCP session
+> staled — re-call `mcp__sigma-mcp-v2__begin_session` and retry. Do not skip parity over a
+> recoverable auth error.
+
+---
+
+## Phase 5 — Enhance (post-publish, UI-only features)
+
+Some Looker features have no spec-API analog and must be wired in the Sigma UI after publish.
+Set expectations up front (they appear as warnings from `build_workbook.py`):
+
+- **Cross-filtering** (clicking a Looker bar filters siblings) → Sigma "Set as filter" actions —
+  UI-only.
+- **Trellis / small multiples** (incl. `looker_donut_multiples`) → Sigma trellis — UI-only; the
+  spec API silently drops trellis fields.
+- **Tooltips / `note_text` / `subtitle_text`** → no spec slot; concatenate into the chart title
+  or add an adjacent `text` element.
+- **KPI comparison** (`show_comparison`) → add a 2nd KPI tile or a UI delta.
+- **Pivot cross-tab** → rebuild the flattened table as a Sigma `pivot-table` in the UI.
+- **Per-tile refresh intervals** → Sigma has workbook-level scheduled refresh only — drop + warn.
+
+---
+
+## Troubleshooting
+
+| Error / symptom | Cause | Fix |
+|---|---|---|
+| `convert_dm.mjs` output still has the old bug shape | Edited `src/lookml.ts` but the MCP server serves the deployed build | Run `convert_dm.mjs` via `node --import tsx/esm` against the patched `src/` (or restart the MCP server) |
+| Converter dropped all view fields after an `html:` dim | Stale build predating BUG4 fix | Use the patched source path; the `;;`-block pre-extraction now includes `html`/`sql_on`/etc. |
+| Metric formula contains `${...}` literals or `0 *` | Stale build predating BUG1/BUG3 fixes | Patched source resolves `${dim}`/`${measure}` refs and preserves `1.0` |
+| `metric()` returns "Missing Metric" in a Sigma query | Known Sigma quirk | Verify via raw aggregate (`Sum`/`CountDistinct`), not `metric()` |
+| `Source not found: warehouse table …` on DM POST | Short connectionId, or table not in Sigma's static catalog | Use the FULL connection UUID; if still failing, source via a Custom SQL DM element (`kind: "sql"`) |
+| `jq: parse error: Invalid numeric literal` | Sigma spec endpoints return YAML | Never pipe spec responses to `jq` / `json.load` |
+| `Invalid kind: "control"` on workbook POST | Control element missing its own `id` (separate from `controlId`) | Add a distinct `id` |
+| KPI POSTs 400 with `value.id` / donut POSTs 400 with `value.columnId` | The two element types use different value keys | KPI → `value.columnId`; donut/pie → `value.id` |
+| Tile shows the wrong chart kind | Read `element.type` (always `"vis"`) instead of `query.vis_config.type` | `fetch_looker_dashboard.py` already reads `vis_config.type` — re-fetch the contract |
+| Looker LookML deploy fails "Invalid lookml syntax" | Compact `{ a: yes; b: yes; }` params | Use multi-line blocks; only `;;` terminates a `sql` |
+| LookML model 404s on query right after deploy | Model not registered | `POST /lookml_models {name, project_name, allowed_db_connection_names}` |
+| `PUT /projects/{id}` 404 when setting git remote | Wrong verb | Use `PATCH /projects/{id}` |
+| Looker dev-workspace mutation has no effect | Each `looker_api.py` call logs in fresh (new session) | For multi-step dev flows use ONE persistent session (`PATCH /session {workspace_id: dev}` then reuse the bearer) |

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/dashboard-contract.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/dashboard-contract.md
@@ -1,0 +1,83 @@
+# Looker Dashboard → normalized JSON contract
+
+The dashboard converter consumes ONE normalized shape, produced by either source:
+- **Live (canonical):** Looker REST `GET /dashboards/{id}` + `GET /dashboards/{id}/dashboard_layouts`
+  (+ `dashboard_filters`). Covers user-defined (UDD) **and** LookML dashboards identically.
+- **Offline (dev only):** parse a `.dashboard.lookml` file and normalize into this shape.
+
+Keep the converter source-agnostic: it only sees this contract.
+
+## Shape
+
+```jsonc
+{
+  "id": "business_pulse",
+  "title": "Business Pulse",
+  "layoutMode": "newspaper",          // newspaper | tile | static | grid (research note §2c)
+  "source": "lookml" | "api",
+  "lookmlLinkId": null,                // set on API dashboards linked to a .dashboard.lookml
+  "filters": [
+    { "name": "Date", "title": "Date", "type": "date_filter",
+      "model": "training_ecommerce", "explore": "order_items",
+      "dimension": "order_items.created_date",   // field this filter binds to
+      "defaultValue": "30 days", "allowMultiple": false }
+  ],
+  "elements": [
+    {
+      "name": "Average Order Sale Price",
+      "tileType": "single_value",      // Looker vis type → Sigma kind via research note §5e
+      "model": "training_ecommerce",
+      "explore": "order_items",
+      "fields": ["order_items.average_sale_price"],   // view.field refs (resolve via explore joins)
+      "pivots": [],
+      "filters": { "order_items.status": "Complete" },// tile-level hard filters
+      "sorts": ["order_items.average_sale_price desc"],
+      "limit": 500,
+      "listen": {},                    // filterName → field (which dashboard filters this tile obeys)
+      "dynamicFields": [],             // table calcs / custom measures (client-side) → workbook formulas
+      "noteText": "…", "subtitleText": "…",
+      "layout": { "row": 0, "col": 0, "width": 8, "height": 6 }  // newspaper units
+    }
+  ]
+}
+```
+
+## Field provenance (API vs LookML)
+
+| Contract field | Looker API | LookML `.dashboard.lookml` |
+|---|---|---|
+| `elements[]` | `dashboard_elements[]` | `elements:` |
+| `tileType` | `dashboard_element.type` | element `type:` |
+| `fields` | `query.fields[]` (or `result_maker`) | `fields:` |
+| `filters` (tile) | `query.filters{}` | element `filters:` |
+| `listen` | `dashboard_element.listen` / `result_maker.filterables` | element `listen:` |
+| `layout` | `dashboard_layout_components[]` (active layout only) — `row/column/width/height` | inline `row/col/width/height` |
+| `filters[]` (dashboard) | `dashboard_filters[]` | top-level `filters:` |
+| `dynamicFields` | `query.dynamic_fields` (JSON) | element `dynamic_fields:` |
+
+Notes:
+- API uses `column`; LookML uses `col`. Normalize to `col`.
+- Only the **active** layout (`dashboard_layout.active == true`) matters; ignore mobile variants.
+- `lookmlLinkId` set ⇒ dashboard is LookML-linked but may have UI edits; the API returns the
+  edited (live) state — prefer it.
+
+## Tile types in the thelook fixture (business_pulse.dashboard.lookml)
+
+Observed: `single_value` ×2, `looker_column`, `looker_area`, `looker_donut_multiples`,
+`table`; filters `date_filter` ×1, `field_filter` ×3; **`advanced` ×4** (advanced/custom
+filter expressions — flag for manual review). Maps:
+- `single_value` → Sigma `kpi-chart`; `looker_column` → `bar-chart`;
+  `looker_area` → `area-chart`; `table` → `table`;
+  `looker_donut_multiples` → single `donut-chart` + warn (Looker shows N donuts).
+- Full tile-type, filter-type, and layout maps live in
+  `~/sigma-skills-staging/research/looker-dashboard-layout.md` §5e/§5f/§3 — do not duplicate; defer there.
+
+## Layout → Sigma 24-col grid (newspaper)
+`gridColumn = (col+1) / (col+1+width)`, `gridRow = (row+1) / (row+1+height)`.
+tile/static/grid modes need a snap heuristic — see research note §3 (lossy; warn + stack).
+
+## Translation hazards to enforce (research note §5)
+Liquid (`{%`/`{{`) → warn/partial; `merged_results` → DM join or custom SQL; table calcs
+(`pct_of_total`/`running_total`/`offset`) → workbook `Sum/GrandTotal`/`RunningSum`/`Lag`;
+field prefix resolution must walk explore `join`s (alias vs `from:` view); cross-filtering
++ trellis + tooltip are Sigma UI-only (ship without, document post-publish step).

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/looker-dashboard-layout.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/looker-dashboard-layout.md
@@ -1,0 +1,379 @@
+# Looker → Sigma Dashboard Layout Extraction (Spike)
+
+**Beads issue:** `beads-sigma-vgz`
+**Status:** Research / desk study (no live Looker access)
+**Recommendation:** **Partial — yes for `layout: newspaper` dashboards via the REST API, no for `layout: tile` / `layout: static` / `layout: grid` without a pixel→grid heuristic. Requires new MCP tooling that does not exist today.**
+
+---
+
+## 1. Why this spike exists
+
+The `tableau-to-sigma` skill ships a Phase 3 layout pipeline that mirrors a Tableau workbook onto Sigma's 24-column grid by:
+
+1. POSTing a workbook spec (charts, KPIs, controls) without layout.
+2. GETing the spec back to learn server-assigned element IDs.
+3. Generating layout XML in Ruby — `<Page>`, `<GridContainer>`, `<LayoutElement>` — with `gridColumn="c0 / c1"` / `gridRow="r0 / r1"` span notation against `repeat(24, 1fr)` columns.
+4. PUTing the spec back with one **top-level** `layout` field (per-page `layout` is silently ignored).
+
+We want Phase 3 coverage for Looker dashboards — i.e. given a Looker dashboard, produce equivalent Sigma element specs and a layout XML string that places those tiles where the Looker original placed them.
+
+References in this repo:
+- `tableau-to-sigma/SKILL.md` — overall pipeline shape
+- `tableau-to-sigma/refs/workbook-layout.md` — Sigma 24-col grid, Ruby `gc()`/`le()`/`page_xml()` helpers, KPI inner-row gotcha
+- `tableau-to-sigma/refs/data-model-spec.md` — data-model JSON shape
+- `sigma-workbooks/reference/specification/` — canonical workbook spec surface
+
+---
+
+## 2. Looker has two layout surfaces, and they disagree
+
+Unlike Tableau, where every workbook has a single canonical `.twb` representation, Looker exposes **two** layout sources that must be reconciled:
+
+### 2a. REST API (`GET /dashboards/{id}` + `dashboard_layouts`)
+
+Returns runtime objects:
+
+| Type | Key fields |
+|---|---|
+| `Dashboard` | `id`, `title`, `description`, `folder_id`, `slug`, `lookml_link_id`, `dashboard_filters[]`, `dashboard_elements[]`, `dashboard_layouts[]` |
+| `DashboardElement` | `id`, `dashboard_id`, `look_id`, `query` (object), `merge_result_id`, `result_maker`, `type` (vis kind), `title`, `subtitle_text`, `body_text`, `note_text`, `vis_config` (opaque JSON) |
+| `DashboardLayout` | `id`, `dashboard_id`, `type` (`newspaper` / `tile` / `static` / `grid`), `active`, `column_width`, `width`, `dashboard_layout_components[]` |
+| `DashboardLayoutComponent` | `id`, `dashboard_layout_id`, `dashboard_element_id`, `row` (int), `column` (int), `width` (int), `height` (int), plus `granular_row`/`granular_column`/`granular_width`/`granular_height` for high-DPI overrides, and `element_title`, `vis_type` |
+| `DashboardFilter` | `id`, `name`, `title`, `type`, `default_value`, `model`, `explore`, `dimension`, `allow_multiple_values`, `required` |
+
+The layout positions live in `DashboardLayoutComponent`, **not** on the element. One element can appear in multiple layouts (mobile vs desktop) and only the `active: true` layout matters.
+
+### 2b. LookML (`*.dashboard.lookml` files)
+
+YAML-flavoured Looker files where layout fields are inlined on each element. Sample (extracted live from `looker-open-source/block-redshift-admin`):
+
+```yaml
+- dashboard: redshift_admin
+  preferred_viewer: dashboards-next
+  title: Redshift Admin
+  layout: newspaper
+  query_timezone: query_saved
+  elements:
+  - title: Table Load Summary
+    name: Table Load Summary
+    model: block_redshift_admin_v2
+    explore: redshift_data_loads
+    type: table
+    fields: [redshift_data_loads.root_bucket, redshift_data_loads.s3_path_clean, ...]
+    sorts: [redshift_data_loads.root_bucket]
+    listen: {}
+    row: 0
+    col: 2
+    width: 20
+    height: 13
+```
+
+LookML and API representations diverge:
+- LookML uses `col`; API uses `column`.
+- LookML may omit `row`/`col` entirely (for `layout: tile` it auto-flows; for `layout: newspaper` defaults are `row: 0`, `col: 0`, `width: 8`, `height: 6`).
+- LookML `fields:` uses `view.field` syntax (e.g. `redshift_data_loads.root_bucket`); the API returns the same syntax inside the `query.fields` array.
+- A LookML dashboard linked to a database-backed copy will surface as a `Dashboard` row with `lookml_link_id` set; user edits in the UI become divergence.
+
+### 2c. The four `layout:` modes
+
+| Mode | Unit | Positioning | Notes |
+|---|---|---|---|
+| `newspaper` (default in modern Looker) | **24-column grid**, height in **6-row tile units** | `row` (0-based, top), `col` (0-based, left), `width` (columns 1–24), `height` (rows) | **Direct map to Sigma's 24-column grid.** Default tile height 6 ≈ default Looker dashboard "row of tiles". |
+| `tile` | `tile_size` pixels (default 160 px) | `row` / `col` in tile units, but tiles flow auto-arranged | Pre-newspaper "card grid". Most legacy LookML dashboards. |
+| `static` | `tile_size` pixels | `top` / `left` (pixels), `width` / `height` (pixels) | Free-form pixel positioning — no grid. |
+| `grid` | Newspaper-like, but 12 columns | Same fields as newspaper | Legacy — most upgrades convert it to newspaper. Looker docs flag this as a subset of newspaper. |
+
+---
+
+## 3. Mapping Looker newspaper → Sigma 24-column grid
+
+This is the path of least resistance and the recommended scope of Phase 3 v1.
+
+| Looker (newspaper) | Sigma (`refs/workbook-layout.md`) |
+|---|---|
+| 24 columns, `col` 0-based | 24 columns, `gridColumn` 1-based span |
+| `row` 0-based row (≈12 px units, but used relatively) | `gridRow` 1-based span; Sigma rows are "auto" relative units |
+| `width` in columns | `gridColumn` end - start = `width` |
+| `height` in rows | `gridRow` end - start = `height` |
+
+Conversion formulas (Looker → Sigma):
+
+```
+gridColumn = "${col + 1} / ${col + 1 + width}"
+gridRow    = "${row + 1} / ${row + 1 + height}"
+```
+
+So a Looker tile at `row: 0, col: 2, width: 20, height: 13` becomes:
+
+```xml
+<LayoutElement elementId="<sigma-id>" gridColumn="3 / 23" gridRow="1 / 14"/>
+```
+
+That's a single arithmetic transform — no spatial heuristic required for newspaper. The Ruby helpers in `tableau-to-sigma/refs/workbook-layout.md` (`gc()`, `le()`, `page_xml()`) work as-is once Looker components are loaded into the same `(elementId, c0, c1, r0, r1)` shape.
+
+### Container / sub-grouping
+Looker has no native container element analogous to Sigma's `container`. Tile groups in Looker are visual only (no parent ID), so the converter should:
+- emit each Looker element as a top-level `<LayoutElement>`,
+- **not** synthesize Sigma `container` elements automatically.
+
+KPI rows in Looker (`type: single_value`, `single_value` height typically 2–3 rows in newspaper) can optionally be wrapped in a Sigma `<GridContainer>` if the converter detects 3+ adjacent single-value tiles in the same row band — but this is a nice-to-have, not required.
+
+### Row-height calibration
+Looker rows ≠ Sigma rows. Looker newspaper rows are ~50 px each and elements typically span 6 rows for a chart. Sigma rows are "auto" — driven by content. Empirical heuristic from `refs/workbook-layout.md` row-sizing guide:
+
+| Looker `height` | Sigma typical span |
+|---|---|
+| 2–3 (single_value KPI) | 6–8 inner units (match container outer span if grouped) |
+| 6 (default chart) | 12–13 |
+| 13 (large table) | 18–20 |
+
+Rather than re-deriving, the converter can pass Looker `height` straight through as Sigma row units — because Sigma rows auto-size, the proportions hold even if the absolute pixel size differs. Visual verification post-publish is still required.
+
+### Static / tile / grid layouts
+For `layout: static` (pixel positions), a heuristic is needed: divide the canvas into a 24-column grid and snap each tile's `left`/`top`/`width`/`height` (in pixels) to the nearest column/row. This is lossy. Recommended fallback: emit a warning, place tiles in document order at `gridColumn="1 / 25"` stacked, leave manual layout to the user.
+
+For `layout: tile`, Looker auto-flows tiles in a 12-column grid; converter should expand to 24 by doubling each `col` and `width` value. No row positioning data exists, so emit tiles in document order.
+
+For `layout: grid` (12-column legacy), double each `col` and `width`.
+
+---
+
+## 4. Sigma-MCP tool validation — **blocked**
+
+The task asked for `parse_lookml` and `convert_lookml_to_sigma` MCP tools. **Neither exists in the currently exposed Sigma-MCP surface.**
+
+### 4a. Verbatim tool discovery
+
+Available `mcp__Sigma-MCP__*` tools, captured from the deferred-tool catalog:
+
+```
+mcp__Sigma-MCP__begin_session
+mcp__Sigma-MCP__create_workbook
+mcp__Sigma-MCP__describe
+mcp__Sigma-MCP__list_documents
+mcp__Sigma-MCP__query
+mcp__Sigma-MCP__search
+```
+
+Searching the catalog explicitly returns no matches:
+
+```
+ToolSearch query="+lookml"   max_results=10 → No matching deferred tools found
+ToolSearch query="+convert"  max_results=10 → No matching deferred tools found
+```
+
+The Sigma-Docs API endpoint catalog also has no matches:
+
+```
+mcp__Sigma-Docs__search-endpoints pattern="lookml"  → No matches found for "lookml"
+mcp__Sigma-Docs__search-endpoints pattern="convert" → No matches found for "convert"
+```
+
+`mcp__Sigma-MCP__begin_session` returns instructions covering only Tables / Data Models / Workbooks — no LookML import path is mentioned.
+
+`mcp__Sigma-Docs__search query="LookML Looker conversion import migration"` returned a single hit, `migrate-a-dataset-to-a-data-model`, which is about migrating Sigma datasets to Sigma data models — unrelated to Looker.
+
+### 4b. What this means for the spike
+
+We could not run a real LookML dashboard sample through `parse_lookml` / `convert_lookml_to_sigma` because neither tool is wired up in the MCP. The downstream comparison ("what the converter produces today vs. what's needed") cannot be made. The closest existing Sigma converter for LookML is the **browser-based "Convert from LookML"** tool referenced in `README.md`'s picker table — it's a UI flow, not exposed via MCP.
+
+We did successfully retrieve a real public LookML dashboard sample (`looker-open-source/block-redshift-admin/dashboards/redshift_admin.dashboard.lookml`) and confirmed the field shape matches Looker's documentation. The sample is reproduced in §2b above for downstream test cases.
+
+---
+
+## 5. Gotchas catalog
+
+These are translation hazards — issues a Looker→Sigma converter must detect or document, ranked by how often they bite real dashboards.
+
+### 5a. Liquid templating in fields and SQL
+
+Looker SQL and field expressions support [Liquid](https://cloud.google.com/looker/docs/liquid-variable-reference) — `{% if %}`, `{{ field._value }}`, `{% parameter %}`, `{% condition %}`. Sigma has no Liquid equivalent; the closest analog is a **parameter control** + an `If()`/`Coalesce()` formula or a **dynamic SQL** workaround.
+
+Examples and translation strategy:
+
+| Liquid pattern | Sigma equivalent |
+|---|---|
+| `{% if user_attribute['region'] == 'EU' %}eur_table{% else %}us_table{% endif %}` (table swap) | Two tables joined as separate sources; a `segmented` control selects which to show. Lossy for row-level swapping. |
+| `{% if value > 10000 %}High{% else %}Low{% endif %}` (display formatting) | A calculated column: `If([Master/value] > 10000, "High", "Low")`. Direct translation. |
+| `{% condition my_filter %} order_date {% endcondition %}` (templated filter) | Pass-through to a Sigma date-range control wired to `order_date`. Direct translation. |
+| `{{ field._value }}` (linking, drill URLs) | Sigma `Hyperlink()` formula or workbook drill-through. Often dropped. |
+| `{% parameter p_period %}` (LookML parameter) | Sigma `segmented`/`list` control. Direct translation when the parameter is a finite enum. |
+
+**Detection heuristic:** any field SQL containing `{%` or `{{` triggers a converter warning and stops auto-translation for that field.
+
+### 5b. `merged_results` queries
+
+Looker `merge_result_id` lets one tile join data from two completely different explores. The merge happens client-side using shared field values. Sigma has no client-side merge — the equivalent is either:
+
+- a **data model element** that joins the two underlying tables with a relationship; or
+- a **table element** in the workbook with a manual SQL CTE (Sigma allows custom SQL elements, but the team has a separate skill — `custom-sql-to-data-model` — for handling those).
+
+**Translation:** the converter must follow `merge_result_id` to fetch the source query specs, identify the join keys, and emit a single Sigma data-model element with the join. If the Looker merge has more than two sources or non-equi joins, fall back to manual conversion and warn.
+
+### 5c. Table calculations vs. measures
+
+Looker has two distinct things that look similar:
+- **Measures** — defined in LookML view files (`measure: sales { type: sum sql: ${TABLE}.sales ;; }`), pushed down to the warehouse, aggregated by the SQL engine.
+- **Table calculations** — defined per-tile in the dashboard (`pct_of_total`, `running_total`, `offset()`, etc.), evaluated **client-side** on the result set after SQL returns.
+
+Sigma's data model has **metrics** (analogous to measures, warehouse-evaluated). Sigma's workbook formulas (`Sum()`, `RunningTotal()`, etc.) cover most table-calculation use cases, but they evaluate on-grid against the element data, not on a separately-materialized result set. Mapping rules:
+
+| Looker | Sigma |
+|---|---|
+| LookML `measure` | Data model element column `formula: "Sum([TABLE/sales])"` (or a metric attached to the element). |
+| Table calc `pct_of_total(${revenue})` | Workbook column `[revenue] / Sum([revenue]) Over (All)` |
+| Table calc `running_total(${revenue})` | `RunningSum([revenue])` (preserved order) |
+| Table calc `offset(${revenue}, -1)` | `Lag([revenue], 1)` |
+| Table calc with `${field._is_filtered}` or `${field._in_query}` introspection | **No equivalent.** Drop and warn. |
+
+### 5d. View-vs-explore field-prefix resolution
+
+LookML field references look like `view_name.field_name` — but the **view name** is shadowed by the **explore name** when the explore renames a join (e.g. `join: customers { from: users sql_on: ... }` makes `customers.email` resolve to the `users` view). The converter must walk the explore's `join` clauses to resolve the actual view per prefix before generating Sigma column references.
+
+Sigma's column refs are flat: `[ElementName/Column Name]`. The Tableau pipeline already documents this — the data-model element's `name` becomes the prefix. For Looker, the converter should:
+
+1. For each tile, parse `query.fields[]` like `customers.email`.
+2. Resolve `customers` → underlying view via the explore's join graph.
+3. Find the warehouse table for that view (`view: users { sql_table_name: prod.public.users ;; }`).
+4. Emit a Sigma data-model element named after the **resolved view** (or the explore root for the base view), and reference the column with `[users/EMAIL]`.
+
+This is the single biggest source of bugs in any LookML→anything converter. **Mandatory test cases:** explore with `view_name` aliased; explore with self-join; explore with a `join` whose `relationship: many_to_one` differs from the warehouse FK direction.
+
+### 5e. Tile types Sigma cannot represent 1:1
+
+| Looker tile `type:` | Sigma analog | Notes |
+|---|---|---|
+| `looker_column`, `looker_bar` | `bar-chart` | Direct. Looker's `stacking` (`normal` / `percent`) maps to Sigma `"none"`/`"stacked"`/`"100"`. |
+| `looker_line` | `line-chart` | Direct. |
+| `looker_area` | `area-chart` | Direct. |
+| `looker_scatter` | `scatter-chart` | Direct (single x, multiple y). Bubble-size encoding is UI-only in Sigma. |
+| `looker_pie` | `pie-chart` | Direct. Beware `pie` vs `pie-chart` kind name — Sigma rejects `pie`. |
+| `looker_donut_multiples` | `donut-chart` (single ring) | Looker shows N donuts (one per dimension value); Sigma has one — emit a single donut and warn. |
+| `looker_grid`, `table` | `table` | Direct. |
+| `single_value` | `kpi-chart` | Direct. Use `value` field. |
+| `text` | `text` | Direct. Markdown body. Looker `subtitle_text` / `body_text` concatenate. |
+| `looker_map`, `looker_geo_coordinates`, `looker_geo_choropleth` | **None** — approximate as `bar-chart` of "Sales by State" sorted descending (Tableau pipeline does the same). |
+| `looker_funnel` | **None** — approximate as horizontal `bar-chart`. |
+| `looker_waterfall` | **None** — approximate as `combo-chart` with running-total line. |
+| `looker_boxplot` | **None** — drop and warn. |
+| `looker_wordcloud` | **None** — drop and warn. |
+| `looker_timeline` (Gantt) | **None** — drop and warn (same as Tableau pipeline). |
+| `looker_sankey` | **None** — drop and warn. |
+| Custom visualizations (third-party JS) | **None** — drop and warn. |
+| `button` | Sigma `text` with `Hyperlink()` body or workbook action — partial. |
+
+### 5f. Filters: Looker dashboard filters → Sigma controls
+
+Looker `dashboard_filters[]` map cleanly:
+
+| Looker filter `type` | Sigma `controlType` |
+|---|---|
+| `field_filter` (string list) | `list` |
+| `field_filter` (date) | `date-range` |
+| `field_filter` (number range) | `number-range` |
+| `parameter` | `segmented` (when enum), `text` (when free-form), `number` (when numeric) |
+
+Caveat: Looker filters use *templated filter* syntax (`{% condition %}`) inside SQL to apply themselves. Sigma controls bind directly to a column via `filters: [{source, columnId}]`. The converter must:
+
+1. Find every tile that listens to the filter (`listen:` block in LookML, `listens_to_filters[]` in API).
+2. For each, find the column in the Sigma element that corresponds to the bound LookML field.
+3. Emit a Sigma `control` whose `filters[]` array references all of those (element, column) pairs.
+
+A Looker filter listened-to by 0 tiles produces a dead Sigma control — drop it.
+
+### 5g. "Cross-filtering" (a tile filtering siblings)
+
+Looker dashboards-next supports cross-filtering — clicking a bar filters every other tile. Sigma supports the same via "Set as filter" actions on chart elements, but **this is not in the spec API today** — it is UI-only. Ship the dashboard without cross-filters and document the post-publish step.
+
+### 5h. `lookml_link_id` divergence
+
+A dashboard with `lookml_link_id` is connected to a `*.dashboard.lookml` file but may have user edits applied via the UI. The API returns the **edited** state; the LookML file represents the **source-of-truth** state. Pick one canonical input — I'd recommend the API, because:
+
+- The UI edits are what the user actually sees.
+- The API gives layout components separately (one source of truth for positioning).
+- It's the same path Tableau-to-Sigma uses (live API, not file).
+
+### 5i. Element title vs tile title vs note text
+
+Looker has three text fields on a tile:
+- `title` — the visualization caption (e.g. "Revenue by Month").
+- `subtitle_text` — small text below the title.
+- `note_text` / `note_display: hover|below|above` — descriptive note rendered in a tooltip or a fixed slot.
+
+Sigma element specs only persist `id`, `kind`, and a few content fields — chart titles are stored on the element but `subtitle_text`/`note_text` have no spec analog. Translation: concatenate into the chart's title or emit a separate adjacent `text` element.
+
+### 5j. Refresh interval / autorun
+
+Looker tiles can set `refresh: 5 minutes`. Sigma workbooks have a workbook-level scheduled refresh, not per-element. Drop and warn.
+
+---
+
+## 6. Feasibility verdict
+
+**Partial yes.** The mapping from Looker's newspaper layout to Sigma's 24-column grid is a single arithmetic transformation — `gridColumn = (col+1) / (col+1+width)`, `gridRow = (row+1) / (row+1+height)` — and the Ruby layout helpers in `tableau-to-sigma/refs/workbook-layout.md` work as-is once the Looker components are loaded.
+
+What's blocking a turnkey Phase 3:
+1. **No `parse_lookml` / `convert_lookml_to_sigma` MCP tool.** Source-format parsing is the precondition for layout extraction. The browser-based converter is UI-only.
+2. **Static / tile / grid layouts** require a heuristic snap-to-grid step that has no analog in the Tableau pipeline — non-trivial work.
+3. **Liquid, merged_results, table calculations, custom viz** are open-ended; full coverage is impossible. v1 should warn-and-drop.
+
+---
+
+## 7. Recommended additional MCP tooling
+
+To bring Looker-to-Sigma to feature parity with `tableau-to-sigma`, the Sigma MCP needs three new tools, sized roughly:
+
+### 7a. `parse_lookml` (small)
+Input: a `*.dashboard.lookml` file body, or a LookML project URL with auth. Output: structured JSON of dashboard + elements + filters with all positioning fields normalized to newspaper-grid units (snap heuristic for tile/static/grid). Returns warnings array for unsupported tile types, Liquid usage, table-calc usage, merged_results, custom viz.
+
+### 7b. `fetch_looker_dashboard` (medium)
+Input: Looker host + auth (API key or OAuth) + dashboard ID or slug. Output: same structured JSON as `parse_lookml` but pulled from the live `Dashboard` + `dashboard_layouts/{id}` endpoints with the **active** layout component set.
+
+The Tableau pipeline assumes live API access for the same reasons (authoritative state, layout, filter linkage). Looker's parallel is `dashboard_layouts` + `dashboard_dashboard_elements`.
+
+### 7c. `convert_lookml_to_sigma` (medium-large)
+Takes the structured output of (a) or (b) and emits:
+- a Sigma data-model spec (one element per resolved view, joined per the explore graph), ready for `POST /v2/dataModels/spec`;
+- a Sigma workbook spec (one element per Looker tile, controls per filter, references via `[ElementName/Column]`), ready for `POST /v2/workbooks/spec`;
+- a layout XML string usable directly in the Phase 3 PUT.
+
+This is the analogue of the manual `tableau-to-sigma` Phase 3–5 work, but driven entirely from the Looker JSON. Without it, every conversion is bespoke.
+
+### 7d. Optional: `validate_lookml_conversion` (small)
+After publishing, pull a chart's data from Sigma (already supported via `query`/`describe`) and compare to the Looker tile's `run_inline_query` result. Mirrors `tableau-to-sigma` Phase 6.
+
+---
+
+## 8. Suggested Phase 3 implementation outline (when tooling lands)
+
+1. **Discovery** — `fetch_looker_dashboard` (or `parse_lookml`) returns dashboard JSON.
+2. **Field resolution** — walk explore joins, resolve `view.field` prefixes, emit a Sigma data-model spec with one element per resolved view; POST it; GET the spec back to capture server-assigned IDs.
+3. **Workbook spec** — for each Looker `dashboard_element`, emit a Sigma element of the matching `kind`. Use the converter's tile-type table (§5e). Source from the master data-model element; column formulas use `[ElementName/Column]`. POST without layout; GET back to capture element IDs.
+4. **Layout XML** — generate via Ruby helpers in `tableau-to-sigma/refs/workbook-layout.md`, using `(col+1, col+1+width)` / `(row+1, row+1+height)` from the Looker components. Single top-level `layout`, no per-page `layout`.
+5. **PUT** the spec with layout. Strip read-only fields per `tableau-to-sigma/SKILL.md` Phase 5e.
+6. **Verify** — query each Sigma chart and compare to Looker tile data.
+
+The Tableau pipeline's invariants — element-name = formula prefix, `<GridContainer>` for containers, KPI inner-row span = container outer span, `kpi-chart` not `kpi`, `pie-chart` not `pie`, etc. — apply unchanged.
+
+---
+
+## 9. Sources
+
+- [Looker LookML dashboard parameters (Google Cloud)](https://docs.cloud.google.com/looker/docs/reference/param-lookml-dashboard) — `layout` modes (newspaper / tile / static / grid), `row` / `col` / `width` / `height`, `tile_size`.
+- [Looker Get DashboardLayout method](https://cloud.google.com/looker/docs/reference/looker-api/latest/methods/Dashboard/dashboard_layout) — `dashboard_layout_components` schema.
+- [DashboardLayout type (Looker API 3.1 archive)](https://cloud.google.com/looker/docs/reference/looker-api/3.1/23.12/types/DashboardLayout) — `column_width`, `width`, `active`, `dashboard_layout_components[]`.
+- [Looker DashboardElement type (latest)](https://docs.cloud.google.com/looker/docs/reference/looker-api/latest/types/DashboardElement) — `body_text`, `note_text`, `query`, `look_id`, `merge_result_id`, `result_maker`.
+- [Looker DashboardApi — keboola/looker-api docs](https://github.com/keboola/looker-api/blob/master/docs/Api/DashboardApi.md) — schema reference for Dashboard / DashboardElement / DashboardLayout / DashboardLayoutComponent / DashboardFilter.
+- [Looker DashboardApi — hirosassa/looker-rs docs](https://github.com/hirosassa/looker-rs/blob/master/docs/DashboardApi.md) — corroborating field list including `vis_config`, `lookml_link_id`.
+- [Building LookML dashboards (Google Cloud)](https://docs.cloud.google.com/looker/docs/building-lookml-dashboards) — concept docs for `*.dashboard.lookml`.
+- [Liquid variable reference (Looker)](https://cloud.google.com/looker/docs/liquid-variable-reference) — `{% if %}`, `{{ field._value }}`, `{% condition %}`, `{% parameter %}`.
+- [Templated filters and Liquid parameters (Looker)](https://docs.cloud.google.com/looker/docs/templated-filters) — runtime-only template substitution semantics; persistence not supported on derived tables that use these.
+- [Troubleshooting unsupported dashboard layout (Looker)](https://docs.cloud.google.com/looker/docs/best-practices/troubleshooting-unsupported-dashboard-layout) — confirms `static`/`tile`/`grid` are legacy and can render incorrectly.
+- [block-redshift-admin sample dashboard.lookml](https://github.com/looker-open-source/block-redshift-admin/blob/master/dashboards/redshift_admin.dashboard.lookml) — concrete LookML dashboard used in §2b.
+
+In-repo references:
+- `tableau-to-sigma/SKILL.md`
+- `tableau-to-sigma/refs/workbook-layout.md`
+- `tableau-to-sigma/refs/data-model-spec.md`
+- `tableau-to-sigma/refs/column-gotchas.md`
+- `README.md` (for the existing converter-MCP-vs-skill split)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_looker_dashboard.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_looker_dashboard.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Build the 'Orders Overview' UDD on csa_thelook via the Looker API:
+KPIs + trend + region/category/channel breakdowns + top-products table,
+with 3 dashboard filters wired to every tile via result_maker.filterables.listen.
+"""
+import json
+import sys
+import looker_api as L
+
+MODEL, EXPLORE = "csa_thelook", "order_fact"
+FILTERS = [
+    ("Order Date", "order_date.order_date"),
+    ("Region", "customer_dim.region"),
+    ("Category", "product_dim.category"),
+]
+LISTEN = [{"dashboard_filter_name": n, "field": f} for n, f in FILTERS]
+
+# (title, vis_type, fields, sorts, limit, row, col, width, height)
+TILES = [
+    ("Net Revenue",        "single_value", ["order_fact.total_net_revenue"],            None, None, 0, 0, 6, 3),
+    ("Orders",             "single_value", ["order_fact.distinct_order_count"],         None, None, 0, 6, 6, 3),
+    ("Avg Order Value",    "single_value", ["order_fact.average_order_value"],          None, None, 0, 12, 6, 3),
+    ("Units Ordered",      "single_value", ["order_fact.total_quantity"],               None, None, 0, 18, 6, 3),
+    ("Net Revenue by Month",    "looker_line",   ["order_date.order_month", "order_fact.total_net_revenue"], ["order_date.order_month"], None, 3, 0, 12, 8),
+    ("Net Revenue by Region",   "looker_column", ["customer_dim.region", "order_fact.total_net_revenue"], ["order_fact.total_net_revenue desc"], None, 3, 12, 12, 8),
+    ("Net Revenue by Category", "looker_bar",    ["product_dim.category", "order_fact.total_net_revenue"], ["order_fact.total_net_revenue desc"], None, 11, 0, 8, 8),
+    ("Net Revenue by Channel",  "looker_pie",    ["order_fact.order_channel", "order_fact.total_net_revenue"], ["order_fact.total_net_revenue desc"], None, 11, 8, 8, 8),
+    ("Top Products",            "looker_grid",   ["product_dim.product_name", "order_fact.total_net_revenue", "order_fact.total_quantity"], ["order_fact.total_net_revenue desc"], 10, 11, 16, 8, 8),
+]
+
+
+def main(folder_id):
+    # 1. dashboard
+    code, d = L.call("POST", "/dashboards", {"title": "Orders Overview", "folder_id": str(folder_id),
+                     "description": "Executive orders overview migrated source (Looker UDD)."})
+    if code >= 300:
+        print("dashboard create FAILED", code, d); sys.exit(1)
+    did = d["id"]
+    print(f"dashboard id={did}")
+
+    # 2. filters
+    for i, (name, field) in enumerate(FILTERS):
+        code, f = L.call("POST", "/dashboard_filters", {
+            "dashboard_id": did, "name": name, "title": name, "type": "field_filter",
+            "dimension": field, "model": MODEL, "explore": EXPLORE,
+            "allow_multiple_values": True, "row": i, "default_value": ""})
+        print(f"  filter {name}: {code}")
+
+    # 3. queries + elements (with listen via result_maker)
+    eid_by_idx = []
+    for (title, vis, fields, sorts, limit, *_pos) in TILES:
+        qbody = {"model": MODEL, "view": EXPLORE, "fields": fields}
+        if sorts: qbody["sorts"] = sorts
+        if limit: qbody["limit"] = str(limit)
+        qbody["vis_config"] = {"type": vis}
+        code, q = L.call("POST", "/queries", qbody)
+        if code >= 300:
+            print("  query FAILED", title, code, q); sys.exit(1)
+        qid = q["id"]
+        # create with query_id directly
+        code, e = L.call("POST", "/dashboard_elements",
+                         {"dashboard_id": did, "type": "vis", "query_id": qid, "title": title})
+        if code >= 300:
+            print("  element FAILED", title, code, e); sys.exit(1)
+        eid = e["id"]
+        # wire dashboard-filter listeners onto the element's result_maker
+        code, e2 = L.call("PATCH", f"/dashboard_elements/{eid}",
+                          {"result_maker": {"query_id": qid, "vis_config": {"type": vis},
+                                            "filterables": [{"model": MODEL, "view": EXPLORE,
+                                                             "name": "", "listen": LISTEN}]}})
+        listen_ok = code < 300
+        eid_by_idx.append(eid)
+        print(f"  element {title}: id={eid} listen_wired={listen_ok}")
+
+    # 4. layout + components
+    code, lay = L.call("POST", "/dashboard_layouts", {"dashboard_id": did, "type": "newspaper", "active": True})
+    lid = lay["id"]
+    print(f"layout id={lid}")
+    for eid, (title, vis, fields, sorts, limit, row, col, width, height) in zip(eid_by_idx, TILES):
+        code, c = L.call("POST", "/dashboard_layout_components", {
+            "dashboard_layout_id": lid, "dashboard_element_id": eid,
+            "row": row, "column": col, "width": width, "height": height})
+        if code >= 300:
+            print("  layout comp FAILED", title, code, c)
+    print(f"\nDONE. dashboard {did}")
+    return did
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "15")

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_looker_dashboard2.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_looker_dashboard2.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Build 'Orders Deep Dive' UDD on csa_thelook via the Looker API — advanced viz:
+area, pivot table, table-calcs (running total + % of total), scatter, donut, text tile.
+Exercises the harder dashboard surface for the Looker->Sigma converter.
+"""
+import json, sys
+import looker_api as L
+
+MODEL, EXPLORE = "csa_thelook", "order_fact"
+FILTERS = [("Order Date", "order_date.order_date"), ("Region", "customer_dim.region")]
+LISTEN = [{"dashboard_filter_name": n, "field": f} for n, f in FILTERS]
+
+# table calcs for the running-total tile
+DYN = json.dumps([
+    {"table_calculation": "running_revenue", "label": "Running Net Revenue",
+     "expression": "running_total(${order_fact.total_net_revenue})",
+     "value_format_name": "usd", "_kind_hint": "measure", "_type_hint": "number"},
+    {"table_calculation": "pct_of_total", "label": "% of Total",
+     "expression": "${order_fact.total_net_revenue}/sum(${order_fact.total_net_revenue})",
+     "value_format_name": "percent_1", "_kind_hint": "measure", "_type_hint": "number"},
+])
+
+# (title, vis, fields, pivots, sorts, limit, dynamic_fields, vis_extra, row,col,w,h)
+TILES = [
+    ("Revenue & Profit Trend", "looker_area",
+     ["order_date.order_month", "order_fact.total_net_revenue", "order_fact.total_net_profit"],
+     [], ["order_date.order_month"], None, None, {}, 3, 0, 12, 8),
+    ("Net Revenue by Region x Channel", "looker_grid",
+     ["customer_dim.region", "order_fact.total_net_revenue"],
+     ["order_fact.order_channel"], ["customer_dim.region"], None, None, {}, 3, 12, 12, 8),
+    ("Net Revenue Running Total by Month", "looker_grid",
+     ["order_date.order_month", "order_fact.total_net_revenue"],
+     [], ["order_date.order_month"], None, DYN, {}, 11, 0, 12, 8),
+    ("Price vs Volume by Category", "looker_scatter",
+     ["product_dim.category", "order_fact.avg_unit_price", "order_fact.total_quantity"],
+     [], ["order_fact.total_quantity desc"], None, None, {}, 11, 12, 6, 8),
+    ("Net Revenue by Loyalty Tier", "looker_pie",
+     ["customer_dim.loyalty_tier", "order_fact.total_net_revenue"],
+     [], ["order_fact.total_net_revenue desc"], None, None, {"inner_radius": 50}, 11, 18, 6, 8),
+]
+
+
+def main(folder_id):
+    code, d = L.call("POST", "/dashboards", {"title": "Orders Deep Dive", "folder_id": str(folder_id),
+                     "description": "Advanced viz coverage: area, pivot, table-calcs, scatter, donut, text."})
+    did = d["id"]; print("dashboard id=", did)
+
+    for i, (name, field) in enumerate(FILTERS):
+        L.call("POST", "/dashboard_filters", {"dashboard_id": did, "name": name, "title": name,
+            "type": "field_filter", "dimension": field, "model": MODEL, "explore": EXPLORE,
+            "allow_multiple_values": True, "row": i, "default_value": ""})
+
+    eids = []
+    # text/markdown tile
+    code, te = L.call("POST", "/dashboard_elements", {"dashboard_id": did, "type": "text",
+        "title_text": "Orders Deep Dive",
+        "body_text": "## Orders Deep Dive\nAdvanced analytics — trend, pivot, running totals, price/volume, mix."})
+    eids.append(("text", te["id"]))
+
+    for (title, vis, fields, pivots, sorts, limit, dyn, vextra, *_pos) in TILES:
+        q = {"model": MODEL, "view": EXPLORE, "fields": fields, "vis_config": dict({"type": vis}, **vextra)}
+        if pivots: q["pivots"] = pivots
+        if sorts: q["sorts"] = sorts
+        if limit: q["limit"] = str(limit)
+        if dyn: q["dynamic_fields"] = dyn
+        code, qr = L.call("POST", "/queries", q)
+        if code >= 300: print("query FAIL", title, code, qr); sys.exit(1)
+        code, e = L.call("POST", "/dashboard_elements",
+            {"dashboard_id": did, "type": "vis", "query_id": qr["id"], "title": title})
+        if code >= 300: print("element FAIL", title, code, e); sys.exit(1)
+        eid = e["id"]
+        L.call("PATCH", f"/dashboard_elements/{eid}", {"result_maker": {"query_id": qr["id"],
+            "vis_config": dict({"type": vis}, **vextra),
+            "filterables": [{"model": MODEL, "view": EXPLORE, "name": "", "listen": LISTEN}]}})
+        eids.append((title, eid))
+        print(f"  {title}: {eid}")
+
+    # layout
+    code, d2 = L.call("GET", f"/dashboards/{did}")
+    lay = next((l for l in d2["dashboard_layouts"] if l.get("active")), d2["dashboard_layouts"][0])
+    L.call("PATCH", f"/dashboard_layouts/{lay['id']}", {"active": True})
+    title_to_pos = {t[0]: (t[8], t[9], t[10], t[11]) for t in TILES}
+    title_to_pos["Orders Deep Dive"] = (0, 0, 24, 3)  # text tile top
+    eltitle = {e["id"]: (e.get("title") or e.get("title_text")) for e in d2["dashboard_elements"]}
+    for c in lay["dashboard_layout_components"]:
+        t = eltitle.get(c["dashboard_element_id"])
+        if t in title_to_pos:
+            r, col, w, h = title_to_pos[t]
+            L.call("PATCH", f"/dashboard_layout_components/{c['id']}", {"row": r, "column": col, "width": w, "height": h})
+    print("DONE dashboard", did)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "15")

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Dashboard contract -> Sigma workbook spec (LOCAL generation; does not POST).
+
+Consumes the normalized contract from parse_lookml_dashboard.py plus the
+explore's view .lkml files (to classify each view.field as a measure or a
+dimension and derive its Sigma formula). Emits a /v2/workbooks/spec body:
+  - a hidden "Data" page with a master table sourced from a data-model element
+  - a dashboard page with one element per Looker tile (kpi/bar/area/line/donut/table)
+  - controls from dashboard filters
+  - a newspaper -> 24-col grid layout XML string
+
+The data-model id / element id / connection id are pluggable (defaults are
+placeholders so the spec generates locally); wire them to a real converted DM
+before POSTing. Tile->kind, filter->control, and layout maps follow
+refs/dashboard-contract.md and research/looker-dashboard-layout.md.
+"""
+import argparse, json, os, re, secrets, string, glob
+
+def sid(p="el"): return p + "-" + "".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(8))
+def disp(seg):  return " ".join(w.capitalize() for w in str(seg).split("_"))
+def leaf(field): return field.split(".")[-1]            # users.traffic_source -> traffic_source
+
+TILE_KIND = {
+    "single_value": "kpi-chart", "looker_column": "bar-chart", "looker_bar": "bar-chart",
+    "looker_area": "area-chart", "looker_line": "line-chart", "looker_pie": "pie-chart",
+    "looker_donut_multiples": "donut-chart", "table": "table", "looker_grid": "table",
+    "looker_scatter": "scatter-chart",
+}
+AGG = {"average": "Avg", "sum": "Sum", "min": "Min", "max": "Max", "median": "Median"}
+
+# ── parse view files: classify fields as measure (agg + base col) or dimension ──
+def build_field_index(view_files):
+    measures = {}   # "view.field" -> (agg_type, base_display_or_None)
+    dims = set()    # "view.field"
+    view_pk = {}    # "view" -> primary-key dimension name
+    for path in view_files:
+        txt = open(path).read()
+        txt = re.sub(r"#[^\n]*", "", txt)               # strip comments
+        vm = re.search(r"view:\s*(\w+)", txt)
+        if not vm: continue
+        view = vm.group(1)
+        for d in re.finditer(r"\b(dimension|dimension_group)\s*:\s*(\w+)", txt):
+            dims.add(f"{view}.{d.group(2)}")
+        # primary key: dimension block containing primary_key: yes
+        for m in re.finditer(r"dimension:\s*(\w+)\s*\{", txt):
+            name = m.group(1); start = m.end(); depth, i = 1, start
+            while i < len(txt) and depth:
+                depth += {"{": 1, "}": -1}.get(txt[i], 0); i += 1
+            if re.search(r"primary_key:\s*yes", txt[start:i]):
+                view_pk[view] = name
+        # measure blocks: measure: name { ... }
+        for m in re.finditer(r"measure:\s*(\w+)\s*\{", txt):
+            name = m.group(1); start = m.end()
+            depth, i = 1, start
+            while i < len(txt) and depth:
+                depth += {"{": 1, "}": -1}.get(txt[i], 0); i += 1
+            block = txt[start:i]
+            mtype = (re.search(r"type:\s*(\w+)", block) or [None, "count"])[1].lower()
+            sqlm = re.search(r"sql:\s*(.+?);;", block, re.S)
+            base = None
+            if sqlm:
+                s = sqlm.group(1)
+                ref = re.search(r"\$\{(?:TABLE\}\.)?(\w+)\}?", s)  # ${dim} or ${TABLE}.col
+                r2 = re.search(r"\$\{TABLE\}\.(\w+)", s)
+                base = disp((r2 or ref).group(1)) if (r2 or ref) else None
+            measures[f"{view}.{name}"] = (mtype, base, (sqlm.group(1).strip() if sqlm else ""))
+    return measures, dims, view_pk
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("contract")
+    ap.add_argument("--views", required=True, help="dir of *.view.lkml for the explore")
+    ap.add_argument("--dm-id", default="<DATA_MODEL_ID>")
+    ap.add_argument("--element-id", default="<DENORM_ELEMENT_ID>")
+    ap.add_argument("--dm-element-name", default="<DM_ELEMENT_NAME>",
+                    help="display name of the data-model element the master pulls from")
+    ap.add_argument("--master-name", default="Data")
+    ap.add_argument("--folder-id", default="<FOLDER_ID>")
+    ap.add_argument("--out", default="/tmp/workbook.spec.json")
+    a = ap.parse_args()
+
+    dash = json.load(open(a.contract))
+    measures, dims, view_pk = build_field_index(sorted(glob.glob(os.path.join(a.views, "*.view.lkml"))))
+    warnings = []
+
+    def is_measure(f): return f in measures
+    def is_ratio(f):
+        """Measure whose sql references other measures or is a type:number arithmetic
+        expression (e.g. AOV = revenue/orders) — has no single base column."""
+        if not is_measure(f): return False
+        mtype, _base, sql = measures[f]
+        view = f.split(".")[0]
+        refs = [r for r in re.findall(r"\$\{(\w+)\}", sql or "") if f"{view}.{r}" in measures]
+        body = re.sub(r"\$\{[^}]+\}", "X", sql or "")
+        return bool(refs) or (mtype == "number" and bool(re.search(r"[+\-*/]", body)))
+    def ratio_components(f):
+        view = f.split(".")[0]
+        return [f"{view}.{r}" for r in re.findall(r"\$\{(\w+)\}", measures[f][2])
+                if f"{view}.{r}" in measures]
+    def col_display(f, explore):
+        """Display name of the MASTER column a field maps to. Joined-view columns
+        in the denormalized DM element are disambiguated as '<Field> (<joinAlias>)'
+        (the field's view prefix); base-explore-view columns are plain."""
+        view = f.split(".")[0]
+        suf = "" if view == explore else f" ({view})"
+        if is_measure(f):
+            if is_ratio(f): return None           # composite — components needed separately
+            base = measures[f][1]                 # base column (None for plain count)
+            return (base + suf) if base else None
+        return disp(leaf(f)) + suf
+    def pk_display(view, explore):
+        """Display name of a view's primary-key column in the denorm element."""
+        pk = view_pk.get(view)
+        if not pk: return None
+        return disp(pk) + ("" if view == explore else f" ({view})")
+    def ratio_formula(f, explore):
+        """Substitute each ${measure} with its Sigma agg formula; NULLIF→NullIf."""
+        view = f.split(".")[0]
+        def sub(m):
+            key = f"{view}.{m.group(1)}"
+            return "(" + formula_for(key, explore) + ")" if key in measures else m.group(0)
+        e = re.sub(r"\$\{(\w+)\}", sub, measures[f][2])
+        return re.sub(r"\bNULLIF\s*\(", "NullIf(", e, flags=re.I).replace("${TABLE}.", "").strip()
+    def formula_for(f, explore):
+        if is_measure(f) and is_ratio(f):
+            return ratio_formula(f, explore)
+        cd = col_display(f, explore)
+        if is_measure(f):
+            mtype = measures[f][0]; view = f.split(".")[0]
+            if mtype == "count":
+                # plain count on a JOINED view counts that view's entities, not fact
+                # rows → CountDistinct on its PK in the denormalized element.
+                if view != explore:
+                    pkd = pk_display(view, explore)
+                    if pkd: return f"CountDistinct([{a.master_name}/{pkd}])"
+                return "Count()"
+            if mtype == "count_distinct": return f"CountDistinct([{a.master_name}/{cd}])" if cd else "Count()"
+            fn = AGG.get(mtype)
+            return f"{fn}([{a.master_name}/{cd}])" if fn and cd else "Count()"
+        return f"[{a.master_name}/{cd}]"
+    def _warn_count(f, el):
+        if measures.get(f, (None,))[0] == "count":
+            v = f.split(".")[0]
+            if v != el.get("explore") and not view_pk.get(v):
+                warnings.append(f"tile '{el['name']}': '{f}' is a plain count on joined view '{v}' "
+                                f"with no primary_key — used Count() (counts fact rows). Add a PK to "
+                                f"'{v}' for CountDistinct parity.")
+
+    # ── master columns: every dim col used + every measure base col + filter cols ──
+    needed = {}   # display -> col id (stable, for control binding)
+    def need(display):
+        if display and display not in needed: needed[display] = sid("col")
+        return needed.get(display)
+    for el in dash["elements"]:
+        for f in el["fields"]:
+            need(col_display(f, el["explore"]))
+            # ratio measures: pull each referenced component measure's base column
+            if is_measure(f) and is_ratio(f):
+                for comp in ratio_components(f):
+                    need(col_display(comp, el["explore"]))
+            # plain count on a joined view needs that view's PK column in the master
+            if is_measure(f) and measures[f][0] == "count" and f.split(".")[0] != el["explore"]:
+                need(pk_display(f.split(".")[0], el["explore"]))
+        for p in (el.get("pivots") or []):       # pivot/series fields are master columns too
+            need(col_display(p, el["explore"]))
+        for fld in (el.get("filters") or {}):        # tile-level hard-filter fields
+            need(col_display(fld, el["explore"]))
+    for flt in dash["filters"]:
+        fld = flt.get("dimension") or flt.get("field")
+        if fld: need(col_display(fld, flt.get("explore") or fld.split(".")[0]))
+    # date_filter has no field; bind it to the column tiles listen it to
+    for flt in dash["filters"]:
+        if flt["type"] == "date_filter" and not flt.get("field"):
+            for el in dash["elements"]:
+                tgt = el["listen"].get(flt["name"])
+                if tgt: flt["_resolvedField"] = tgt; flt["_resolvedExplore"] = el["explore"]; need(col_display(tgt, el["explore"])); break
+
+    master = {
+        "id": "m-master", "name": a.master_name, "kind": "table",
+        "source": {"dataModelId": a.dm_id, "elementId": a.element_id, "kind": "data-model"},
+        "columns": [{"id": cid, "formula": f"[{a.dm_element_name}/{d}]", "name": d} for d, cid in needed.items()],
+    }
+
+    # ── tile -> Sigma element ──
+    elements, layout_items = [], []
+    for el in dash["elements"]:
+        kind = TILE_KIND.get(el["tileType"])
+        if not kind:
+            warnings.append(f"tile '{el['name']}' type '{el['tileType']}' has no Sigma mapping — skipped")
+            continue
+        ex = el["explore"]
+        ms = [f for f in el["fields"] if is_measure(f)]
+        ds = [f for f in el["fields"] if not is_measure(f)]
+        eid = sid()
+        base = {"id": eid, "kind": kind, "name": el["name"], "source": {"elementId": "m-master", "kind": "table"}}
+
+        if kind == "kpi-chart":
+            vf = formula_for(ms[0], ex) if ms else "Count()"
+            cid = sid("v")
+            base["columns"] = [{"id": cid, "formula": vf, "name": el["name"]}]
+            base["value"] = {"columnId": cid}
+            if ms: _warn_count(ms[0], el)
+            if el.get("showComparison"):
+                warnings.append(f"tile '{el['name']}': Looker show_comparison ({el.get('comparisonType')}) — "
+                                f"Sigma KPI spec has no comparison/delta slot; add a second KPI side-by-side or set it in the UI")
+        elif kind == "scatter-chart":
+            # both axes are measures; the (optional) dimension becomes the color split
+            xf = ms[0] if ms else None
+            yf = ms[1] if len(ms) > 1 else None
+            xid, yid, cols = sid("x"), sid("y"), []
+            cols.append({"id": xid, "formula": formula_for(xf, ex) if xf else "Count()",
+                         "name": disp(leaf(xf)) if xf else "X"})
+            cols.append({"id": yid, "formula": formula_for(yf, ex) if yf else "Count()",
+                         "name": disp(leaf(yf)) if yf else "Y"})
+            base["columns"] = cols
+            base["xAxis"] = {"columnId": xid}; base["yAxis"] = {"columnIds": [yid]}
+            if ds:
+                clr = sid("clr")
+                cols.append({"id": clr, "formula": formula_for(ds[0], ex), "name": col_display(ds[0], ex)})
+                base["color"] = {"by": "category", "column": clr}
+            for mf in (ms[:2] or []): _warn_count(mf, el)
+        elif kind in ("bar-chart", "area-chart", "line-chart"):
+            cols, ymids = [], []
+            xid = sid("x"); xf = ds[0] if ds else (el["fields"][0] if el["fields"] else None)
+            cols.append({"id": xid, "formula": formula_for(xf, ex) if xf else "Count()",
+                         "name": (col_display(xf, ex) if xf else None) or "Group"})
+            for mf in (ms or []):
+                yid = sid("y"); cols.append({"id": yid, "formula": formula_for(mf, ex), "name": disp(leaf(mf))})
+                ymids.append(yid)
+                _warn_count(mf, el)
+            if not ymids:
+                yid = sid("y"); cols.append({"id": yid, "formula": "Count()", "name": "Count"}); ymids.append(yid)
+            base["columns"] = cols
+            base["xAxis"] = {"columnId": xid}; base["yAxis"] = {"columnIds": ymids}
+            # Looker pivot → Sigma series via the color channel (split/stack by the
+            # pivot dimension). One color channel; extra pivots → UI.
+            if el["pivots"]:
+                pf = el["pivots"][0]
+                pcid = sid("clr")
+                cols.append({"id": pcid, "formula": formula_for(pf, ex), "name": col_display(pf, ex)})
+                base["color"] = {"by": "category", "column": pcid}
+                if len(el["pivots"]) > 1:
+                    warnings.append(f"tile '{el['name']}': multiple pivots {el['pivots']} — only first set as series; add the rest in Sigma UI")
+            if el["tileType"] == "looker_donut_multiples":
+                warnings.append(f"tile '{el['name']}': donut_multiples -> single donut-chart (Looker shows N donuts)")
+        elif kind in ("pie-chart", "donut-chart"):
+            # donut/pie use value + color (slice category), NOT xAxis/yAxis.
+            catf = el["pivots"][0] if el["pivots"] else (ds[0] if ds else (el["fields"][0] if el["fields"] else None))
+            valf = ms[0] if ms else None
+            catid = sid("cat"); valid = sid("val")
+            base["columns"] = [
+                {"id": catid, "formula": formula_for(catf, ex) if catf else "Count()",
+                 "name": (col_display(catf, ex) if catf else None) or "Category"},
+                {"id": valid, "formula": formula_for(valf, ex) if valf else "Count()",
+                 "name": (disp(leaf(valf)) if valf else "Count")},
+            ]
+            base["value"] = {"id": valid}      # donut/pie use value.id (KPI uses value.columnId)
+            base["color"] = {"id": catid}
+            if valf: _warn_count(valf, el)
+            if el["tileType"] == "looker_donut_multiples":
+                warnings.append(f"tile '{el['name']}': donut_multiples → single donut sliced by "
+                                f"'{leaf(catf) if catf else 'category'}'; the per-multiple dimension is dropped — review in Sigma")
+        elif kind == "table":
+            cols = []
+            for f in el["fields"] + (el.get("pivots") or []):
+                cols.append({"id": sid("c"), "formula": formula_for(f, ex), "name": disp(leaf(f))})
+                if is_measure(f): _warn_count(f, el)
+            base["columns"] = cols
+            if el.get("pivots"):
+                warnings.append(f"tile '{el['name']}': pivot {el['pivots']} flattened to columns — "
+                                f"rebuild as a Sigma pivot-table for true cross-tab")
+
+        # tile-level hard filters → element filters (string values; date/numeric → warn)
+        for fld, val in (el.get("filters") or {}).items():
+            d = col_display(fld, ex)
+            if "date" in leaf(fld).lower() or isinstance(val, (int, float)):
+                warnings.append(f"tile '{el['name']}': filter {fld}={val} (date/numeric) — add manually in Sigma")
+                continue
+            col = next((c for c in base["columns"] if c["name"] == d), None)
+            if not col:
+                col = {"id": sid("c"), "formula": f"[{a.master_name}/{d}]", "name": d}
+                base["columns"].append(col)
+            vals = [v.strip() for v in str(val).split(",") if v.strip()]
+            base.setdefault("filters", []).append(
+                {"id": sid("f"), "columnId": col["id"], "kind": "list", "mode": "include", "values": vals})
+        # Looker table calcs (dynamic_fields) → Sigma formula columns
+        for dyn in (el.get("dynamicFields") or []):
+            if not isinstance(dyn, dict):
+                continue
+            expr = dyn.get("expression") or ""
+            label = dyn.get("label") or dyn.get("table_calculation") or "Calc"
+            def _subfield(m):
+                f = m.group(1)
+                return formula_for(f, ex) if is_measure(f) else f"[{a.master_name}/{col_display(f, ex)}]"
+            sig = re.sub(r"\$\{([\w.]+)\}", _subfield, expr)
+            sig = re.sub(r"\brunning_total\s*\(", "CumulativeSum(", sig)
+            sig = re.sub(r"\bsum\s*\(", "GrandTotal(", sig)          # pct-of-total denominator
+            sig = re.sub(r"\bmean\s*\(", "GrandTotal(", sig)
+            if re.search(r"\b(rank|row|offset|pivot_\w+|percentile)\s*\(", sig):
+                warnings.append(f"tile '{el['name']}': table calc '{label}' uses an unsupported "
+                                f"window fn — review: {expr}")
+                continue
+            base.setdefault("columns", []).append({"id": sid("tc"), "formula": sig.strip(), "name": label})
+        elements.append(base)
+
+        # newspaper -> 24-col grid
+        L = el["layout"]; c0 = L["col"] + 1; c1 = L["col"] + 1 + L["width"]
+        r0 = L["row"] + 1; r1 = L["row"] + 1 + L["height"]
+        layout_items.append((eid, c0, c1, r0, r1))
+
+    # ── controls from dashboard filters ──
+    controls = []
+    for flt in dash["filters"]:
+        fld = flt.get("dimension") or flt.get("field") or flt.get("_resolvedField")
+        fex = flt.get("explore") or flt.get("_resolvedExplore") or (fld.split(".")[0] if fld else "")
+        cdisp = col_display(fld, fex) if fld else None
+        col_id = needed.get(cdisp)
+        ctype = "date-range" if flt["type"] == "date_filter" else "list"
+        ctrl = {"kind": "control", "id": sid("ctrl"), "controlId": flt["name"].lower().replace(" ", "-"),
+                "name": flt["title"], "controlType": ctype}
+        if col_id:
+            ctrl["filters"] = [{"source": {"kind": "table", "elementId": "m-master"}, "columnId": col_id}]
+            if ctype == "list":
+                ctrl.update({"mode": "include", "selectionMode": "multiple", "values": [],
+                             "source": {"kind": "source", "source": {"kind": "table", "elementId": "m-master"}, "columnId": col_id}})
+            else:
+                ctrl["mode"] = "between"
+        else:
+            warnings.append(f"filter '{flt['name']}': could not bind to a master column")
+        controls.append(ctrl)
+
+    # ── layout XML (single top-level field; newspaper maps 1:1 to 24 cols) ──
+    page_id = "page-dash"
+    les = "\n".join(f'  <LayoutElement elementId="{e}" gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}"/>'
+                    for (e, c0, c1, r0, r1) in layout_items)
+    layout_xml = ('<?xml version="1.0" encoding="utf-8"?>\n'
+                  f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">\n'
+                  f'{les}\n</Page>')
+
+    spec = {
+        "name": f"{dash['title']} (from Looker)", "folderId": a.folder_id, "schemaVersion": 1,
+        "layout": layout_xml,
+        "pages": [
+            {"id": "page-data", "name": "Data", "elements": [master]},
+            {"id": page_id, "name": dash["title"], "elements": controls + elements},
+        ],
+    }
+    open(a.out, "w").write(json.dumps(spec, indent=2))
+    print(f"wrote {a.out}")
+    print(f"  master cols: {len(master['columns'])}  tiles: {len(elements)}  controls: {len(controls)}")
+    for e in elements:
+        print(f"    {e['kind']:11} {e['name']}")
+    if warnings:
+        print("\n  WARNINGS:")
+        for w in warnings: print("   -", w)
+
+if __name__ == "__main__":
+    main()

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -152,6 +152,8 @@ def main():
         if display and display not in needed: needed[display] = sid("col")
         return needed.get(display)
     for el in dash["elements"]:
+        if el.get("tileType") == "text":      # text tiles have no query/fields
+            continue
         for f in el["fields"]:
             need(col_display(f, el["explore"]))
             # ratio measures: pull each referenced component measure's base column
@@ -184,6 +186,27 @@ def main():
     # ── tile -> Sigma element ──
     elements, layout_items = [], []
     for el in dash["elements"]:
+        # Text/markdown tiles → Sigma text element (kind: "text"). No query, no
+        # master columns, no source — just a Markdown `body` (title_text as a
+        # heading + body_text). See sigma-workbooks reference/specification/text.md.
+        if el["tileType"] == "text":
+            eid = sid()
+            title = (el.get("titleText") or "").strip()
+            bodytxt = (el.get("bodyText") or "").strip()
+            parts = []
+            # Looker often duplicates the title as a heading in body_text; only
+            # prepend title_text as an H1 if body_text doesn't already lead with it.
+            first_line = bodytxt.splitlines()[0].lstrip("# ").strip().lower() if bodytxt else ""
+            if title and title.lower() != first_line:
+                parts.append(f"# {title}")
+            if bodytxt:
+                parts.append(bodytxt)
+            body = "\n\n".join(parts) if parts else (el.get("name") or title or "")
+            elements.append({"id": eid, "kind": "text", "body": body})
+            L = el["layout"]; c0 = L["col"] + 1; c1 = L["col"] + 1 + L["width"]
+            r0 = L["row"] + 1; r1 = L["row"] + 1 + L["height"]
+            layout_items.append((eid, c0, c1, r0, r1))
+            continue
         kind = TILE_KIND.get(el["tileType"])
         if not kind:
             warnings.append(f"tile '{el['name']}' type '{el['tileType']}' has no Sigma mapping — skipped")
@@ -349,7 +372,7 @@ def main():
     print(f"wrote {a.out}")
     print(f"  master cols: {len(master['columns'])}  tiles: {len(elements)}  controls: {len(controls)}")
     for e in elements:
-        print(f"    {e['kind']:11} {e['name']}")
+        print(f"    {e['kind']:11} {e.get('name', '(text)')}")
     if warnings:
         print("\n  WARNINGS:")
         for w in warnings: print("   -", w)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/convert_dm.mjs
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/convert_dm.mjs
@@ -1,0 +1,43 @@
+// Convert a LookML explore to a Sigma data-model spec file, running the
+// converter directly against a source tree (bypasses the deployed MCP build —
+// see SKILL.md "Converter-build gotcha").
+//
+// Usage:
+//   LOOKML_DIR=/path/to/lookml-project \
+//   CONVERTER_SRC=/path/to/sigma-data-model-mcp/src/lookml.ts \
+//     node --import tsx/esm convert_dm.mjs <exploreName> <out.json>
+//
+// LOOKML_DIR must contain <something>.model.lkml + a views/ dir of *.view.lkml.
+// CONVERTER_SRC points at the converter's lookml.ts (so you get the latest fixes
+// without waiting for the long-running MCP server to reload). SIGMA_CONNECTION_ID
+// is written into the spec as a placeholder; post_dm.py swaps in the full UUID.
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+const explore = process.argv[2] || 'order_fact';
+const out = process.argv[3] || '/tmp/looker_dm.json';
+
+const dir = process.env.LOOKML_DIR;
+if (!dir) { console.error('Set LOOKML_DIR=/path/to/lookml-project'); process.exit(1); }
+const converterSrc = process.env.CONVERTER_SRC;
+if (!converterSrc) { console.error('Set CONVERTER_SRC=/path/to/sigma-data-model-mcp/src/lookml.ts'); process.exit(1); }
+const connectionId = process.env.SIGMA_CONNECTION_ID || 'PLACEHOLDER_CONNECTION_ID';
+
+const { convertLookMLToSigma } = await import(pathToFileURL(converterSrc).href);
+
+const modelFile = fs.readdirSync(dir).find(f => f.endsWith('.model.lkml'));
+if (!modelFile) { console.error(`No *.model.lkml in ${dir}`); process.exit(1); }
+const files = [{ name: modelFile, content: fs.readFileSync(path.join(dir, modelFile), 'utf8') }];
+const viewsDir = path.join(dir, 'views');
+for (const f of fs.readdirSync(viewsDir)) {
+  if (f.endsWith('.view.lkml'))
+    files.push({ name: f, content: fs.readFileSync(path.join(viewsDir, f), 'utf8') });
+}
+
+const res = convertLookMLToSigma(files, { connectionId, exploreName: explore, joinStrategy: 'relationships' });
+fs.writeFileSync(out, JSON.stringify(res.model, null, 2));   // NOTE: return prop is `.model`, not `.sigmaDataModel`
+console.error(`explore=${explore} -> ${out}`);
+console.error('stats:', JSON.stringify(res.stats));
+console.error('warnings:', res.warnings.length);
+res.warnings.forEach(w => console.error('  ' + w));

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_dashboard.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_dashboard.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Live discovery: Looker `GET /dashboards/{id}` -> the normalized dashboard
+contract (refs/dashboard-contract.md). Works for user-defined AND LookML
+dashboards (the API returns both as the same shape).
+
+Auth from ~/.looker/looker.ini (client_credentials, API 4.0).
+
+Usage:
+  python3 fetch_looker_dashboard.py <dashboard_id> [out.json]
+"""
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from configparser import ConfigParser
+
+INI = os.path.expanduser("~/.looker/looker.ini")
+
+
+def _client():
+    c = ConfigParser(); c.read(INI); s = c["Looker"]
+    base = s["base_url"].rstrip("/")
+    if not base.endswith("/api/4.0"):
+        base += "/api/4.0"
+    data = urllib.parse.urlencode({"client_id": s["client_id"],
+                                   "client_secret": s["client_secret"]}).encode()
+    tok = json.load(urllib.request.urlopen(
+        urllib.request.Request(base + "/login", data=data, method="POST"), timeout=30))["access_token"]
+    return base, tok
+
+
+def get(path):
+    base, tok = get._cache if hasattr(get, "_cache") else (None, None)
+    if base is None:
+        base, tok = _client(); get._cache = (base, tok)
+    req = urllib.request.Request(base + path, headers={"Authorization": "Bearer " + tok})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.load(r)
+
+
+def _query_of(el):
+    """Return the query dict backing an element (direct query or via result_maker)."""
+    if el.get("query"):
+        return el["query"]
+    rm = el.get("result_maker") or {}
+    return rm.get("query") or {}
+
+
+def _vis_type(el, q):
+    for src in (q.get("vis_config"), (el.get("result_maker") or {}).get("vis_config"), el.get("vis_config")):
+        if isinstance(src, dict) and src.get("type"):
+            return src["type"]
+    return el.get("type")  # fallback ("vis"/"text")
+
+
+def _dyn(df):
+    """Looker returns dashboard_element.query.dynamic_fields as a JSON string."""
+    if isinstance(df, str):
+        try:
+            return json.loads(df)
+        except Exception:
+            return []
+    return df or []
+
+
+def _listen(el):
+    """filterName -> field, from result_maker.filterables[].listen."""
+    out = {}
+    rm = el.get("result_maker") or {}
+    for f in rm.get("filterables") or []:
+        for l in f.get("listen") or []:
+            if l.get("dashboard_filter_name"):
+                out[l["dashboard_filter_name"]] = l.get("field")
+    return out
+
+
+def normalize(d):
+    # active layout -> element_id -> {row,col,width,height}
+    layout_mode, comp_by_el = "newspaper", {}
+    for lay in d.get("dashboard_layouts", []):
+        if lay.get("active"):
+            layout_mode = lay.get("type", "newspaper")
+            for c in lay.get("dashboard_layout_components", []):
+                comp_by_el[c.get("dashboard_element_id")] = {
+                    "row": c.get("row"), "col": c.get("column"),
+                    "width": c.get("width"), "height": c.get("height")}
+
+    filters = []
+    for f in d.get("dashboard_filters", []):
+        filters.append({
+            "name": f.get("name"), "title": f.get("title"), "type": f.get("type"),
+            "model": f.get("model"), "explore": f.get("explore"),
+            "dimension": f.get("dimension"),
+            "defaultValue": f.get("default_value"),
+            "allowMultiple": f.get("allow_multiple_values"),
+        })
+
+    elements = []
+    for el in d.get("dashboard_elements", []):
+        q = _query_of(el)
+        if not q and el.get("type") in (None, "text") and not el.get("title"):
+            continue
+        elements.append({
+            "name": el.get("title") or el.get("title_text") or f"element_{el.get('id')}",
+            "tileType": _vis_type(el, q),
+            "model": q.get("model"), "explore": q.get("view"),
+            "fields": q.get("fields") or [],
+            "pivots": q.get("pivots") or [],
+            "filters": q.get("filters") or {},
+            "sorts": q.get("sorts") or [],
+            "limit": int(q["limit"]) if str(q.get("limit") or "").isdigit() else q.get("limit"),
+            "listen": _listen(el),
+            "dynamicFields": _dyn(q.get("dynamic_fields")),
+            "noteText": el.get("note_text"), "subtitleText": el.get("subtitle_text"),
+            "bodyText": el.get("body_text"),
+            "layout": comp_by_el.get(el.get("id"), {}),
+        })
+
+    return {
+        "id": str(d.get("id")),
+        "title": d.get("title"),
+        "layoutMode": layout_mode,
+        "source": "api",
+        "lookmlLinkId": d.get("lookml_link_id"),
+        "filters": filters,
+        "elements": elements,
+    }
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__); sys.exit(1)
+    did = sys.argv[1]
+    d = get(f"/dashboards/{urllib.parse.quote(did, safe='')}")
+    contract = normalize(d)
+    out = sys.argv[2] if len(sys.argv) > 2 else None
+    txt = json.dumps(contract, indent=2)
+    if out:
+        with open(out, "w") as f:
+            f.write(txt)
+        print(f"wrote {out}: {len(contract['elements'])} elements, {len(contract['filters'])} filters")
+    else:
+        print(txt)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_dashboard.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/fetch_looker_dashboard.py
@@ -99,6 +99,18 @@ def normalize(d):
     elements = []
     for el in d.get("dashboard_elements", []):
         q = _query_of(el)
+        # Text/markdown tiles (headers, notes) have no query/fields — capture them
+        # as text elements so the builder can emit a Sigma text element.
+        if el.get("type") == "text" or (not q and (el.get("title_text") or el.get("body_text"))):
+            elements.append({
+                "name": el.get("title") or el.get("title_text") or f"element_{el.get('id')}",
+                "tileType": "text",
+                "titleText": el.get("title_text"),
+                "bodyText": el.get("body_text"),
+                "subtitleText": el.get("subtitle_text"),
+                "layout": comp_by_el.get(el.get("id"), {}),
+            })
+            continue
         if not q and el.get("type") in (None, "text") and not el.get("title"):
             continue
         elements.append({

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get-token.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get-token.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Exchange Sigma client credentials for a bearer token.
+# Usage:  eval "$(scripts/get-token.sh)"
+# Sets SIGMA_API_TOKEN in the calling shell.
+
+set -euo pipefail
+
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  "$SIGMA_BASE_URL/v2/auth/token") || {
+    echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null \
+  || echo "$RESPONSE" | ruby -r json -e "print JSON.parse(STDIN.read)['access_token']")
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Token exchange failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+echo "export SIGMA_API_TOKEN=${TOKEN}"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/looker_api.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/looker_api.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Minimal Looker API 4.0 client driven by ~/.looker/looker.ini (no SDK dep).
+
+Usage:
+  python3 looker_api.py whoami
+  python3 looker_api.py get  /connections
+  python3 looker_api.py post /connections '<json>'
+  python3 looker_api.py put  /connections/<name>/test
+  python3 looker_api.py raw  GET /lookml_models
+"""
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from configparser import ConfigParser
+
+INI = os.path.expanduser("~/.looker/looker.ini")
+
+
+def _cfg():
+    c = ConfigParser()
+    c.read(INI)
+    s = c["Looker"]
+    base = s["base_url"].rstrip("/")
+    if not base.endswith("/api/4.0"):
+        base = base + "/api/4.0"
+    return base, s["client_id"], s["client_secret"], s.getboolean("verify_ssl", True)
+
+
+def _ctx(verify):
+    import ssl
+    if verify:
+        return None
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def login():
+    base, cid, csec, verify = _cfg()
+    data = urllib.parse.urlencode({"client_id": cid, "client_secret": csec}).encode()
+    req = urllib.request.Request(base + "/login", data=data, method="POST")
+    with urllib.request.urlopen(req, context=_ctx(verify), timeout=30) as r:
+        tok = json.load(r)["access_token"]
+    return base, tok, verify
+
+
+def call(method, path, body=None):
+    base, tok, verify = login()
+    if not path.startswith("/"):
+        path = "/" + path
+    url = base + path
+    data = None
+    headers = {"Authorization": "Bearer " + tok}
+    if body is not None:
+        data = body.encode() if isinstance(body, str) else json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, context=_ctx(verify), timeout=60) as r:
+            raw = r.read().decode()
+            code = r.status
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        code = e.code
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        parsed = raw
+    return code, parsed
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "whoami"
+    if cmd == "whoami":
+        code, me = call("GET", "/user")
+        _, roles = call("GET", "/user/roles")
+        _, perms = call("GET", "/user/roles")  # placeholder
+        print("HTTP", code)
+        print("user:", me.get("display_name"), "| id", me.get("id"), "|", me.get("email"))
+        if isinstance(roles, list):
+            print("roles:", ", ".join(r.get("name", "?") for r in roles))
+        else:
+            print("roles raw:", roles)
+    elif cmd == "raw":
+        code, out = call(sys.argv[2].upper(), sys.argv[3], sys.argv[4] if len(sys.argv) > 4 else None)
+        print("HTTP", code)
+        print(json.dumps(out, indent=2)[:6000])
+    else:  # get/post/put/patch/delete
+        code, out = call(cmd.upper(), sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else None)
+        print("HTTP", code)
+        print(json.dumps(out, indent=2)[:8000] if not isinstance(out, str) else out[:8000])

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/parse_lookml_dashboard.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/parse_lookml_dashboard.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Offline path: parse a Looker `.dashboard.lookml` file into the normalized
+Dashboard contract (refs/dashboard-contract.md). Dashboard LookML is YAML.
+
+Live path (later): a fetch-looker-dashboard script hits the Looker REST API
+(`GET /dashboards/{id}` + `dashboard_layouts`) and emits the SAME contract, so
+the workbook builder stays source-agnostic.
+
+Usage:
+    python3 parse_lookml_dashboard.py <file.dashboard.lookml> [--out contract.json]
+"""
+import argparse, json, sys
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML required: pip install pyyaml")
+
+
+def norm_element(el):
+    return {
+        "name": el.get("name") or el.get("title"),
+        "title": el.get("title"),
+        "tileType": el.get("type"),
+        "model": el.get("model"),
+        "explore": el.get("explore"),
+        "fields": el.get("fields") or [],
+        "pivots": el.get("pivots") or [],
+        # tile-level hard filters {field: expr}
+        "filters": el.get("filters") or {},
+        "sorts": el.get("sorts") or [],
+        "limit": el.get("limit"),
+        # which dashboard filters this tile obeys: {FilterName: field}
+        "listen": el.get("listen") or {},
+        # client-side table calcs / custom measures → workbook formulas
+        "dynamicFields": el.get("dynamic_fields") or [],
+        "noteText": el.get("note_text"),
+        "subtitleText": el.get("subtitle_text"),
+        # single_value comparison (Sigma KPI spec has no comparison slot → warn)
+        "showComparison": bool(el.get("show_comparison")),
+        "comparisonType": el.get("comparison_type"),
+        # newspaper grid units (LookML uses `col`; API uses `column` — normalize to col)
+        "layout": {
+            "row": el.get("row", 0), "col": el.get("col", 0),
+            "width": el.get("width", 8), "height": el.get("height", 6),
+        },
+    }
+
+
+def norm_filter(f):
+    return {
+        "name": f.get("name"),
+        "title": f.get("title") or f.get("name"),
+        "type": f.get("type"),                # date_filter | field_filter | ...
+        "model": f.get("model"),
+        "explore": f.get("explore"),
+        "field": f.get("field"),              # view.field this filter binds to
+        "defaultValue": f.get("default_value"),
+        "allowMultiple": bool(f.get("allow_multiple_values")),
+        "listensToFilters": f.get("listens_to_filters") or [],
+    }
+
+
+def parse(path):
+    with open(path) as fh:
+        docs = yaml.safe_load(fh)
+    # A .dashboard.lookml is a YAML list of dashboards (usually one).
+    if isinstance(docs, dict):
+        docs = [docs]
+    out = []
+    for d in docs:
+        out.append({
+            "id": d.get("dashboard"),
+            "title": d.get("title"),
+            "layoutMode": d.get("layout", "newspaper"),
+            "source": "lookml",
+            "lookmlLinkId": None,
+            "filters": [norm_filter(f) for f in (d.get("filters") or [])],
+            "elements": [norm_element(e) for e in (d.get("elements") or [])],
+        })
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("file")
+    ap.add_argument("--out")
+    a = ap.parse_args()
+    dashboards = parse(a.file)
+    js = json.dumps(dashboards if len(dashboards) > 1 else dashboards[0], indent=2)
+    if a.out:
+        open(a.out, "w").write(js)
+        d0 = dashboards[0]
+        print(f"wrote {a.out}: {d0['title']} — {len(d0['elements'])} elements, "
+              f"{len(d0['filters'])} filters, layout={d0['layoutMode']}")
+    else:
+        print(js)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/post_dm.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/post_dm.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""POST a Sigma data-model spec to /v2/dataModels/spec.
+
+- Swaps any placeholder connectionId in the spec for the full connection UUID
+  ($SIGMA_CONNECTION_ID). convert_dm.mjs writes a placeholder; use the FULL UUID
+  here (a short prefix → "Source not found: warehouse table ...").
+- Auto-picks a writable folder (folderId is required), preferring one whose name
+  mentions LOOKER / MIGRATION / TEST; override with --folder-id.
+- The spec endpoints return YAML, not JSON — don't json.load the response.
+
+Usage:
+  eval "$(scripts/get-token.sh)"
+  SIGMA_CONNECTION_ID=<full-uuid> python3 post_dm.py <spec.json> [--folder-id <id>]
+"""
+import argparse, json, os, re, sys, urllib.request, urllib.error
+
+BASE = os.environ["SIGMA_BASE_URL"]
+TOK = os.environ["SIGMA_API_TOKEN"]
+FULL_CONN = os.environ.get("SIGMA_CONNECTION_ID")
+
+
+def api(method, path, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE + path, data=data, method=method,
+        headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+    except urllib.error.HTTPError as e:
+        print("HTTP", e.code, method, path, "->", e.read().decode()[:1000], file=sys.stderr); raise
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw  # YAML/text
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("spec")
+    ap.add_argument("--folder-id")
+    a = ap.parse_args()
+
+    spec = json.load(open(a.spec))
+
+    # rewrite every connectionId (placeholder or short prefix) to the full UUID
+    if FULL_CONN:
+        s = re.sub(r'("connectionId"\s*:\s*)"[^"]*"', rf'\1"{FULL_CONN}"', json.dumps(spec))
+        spec = json.loads(s)
+    else:
+        print("WARN: SIGMA_CONNECTION_ID unset — posting spec connectionId as-is", file=sys.stderr)
+
+    folder = a.folder_id
+    if not folder:
+        files = api("GET", "/v2/files?typeFilters=folder&limit=200")
+        entries = files.get("entries", files.get("data", [])) if isinstance(files, dict) else []
+        for f in entries:
+            if any(k in (f.get("name", "") or "").upper() for k in ("LOOKER", "MIGRATION", "TEST")):
+                folder = f["id"]; break
+        if not folder and entries:
+            folder = entries[0]["id"]
+    print("folderId:", folder, file=sys.stderr)
+    if folder:
+        spec["folderId"] = folder
+
+    res = api("POST", "/v2/dataModels/spec", spec)
+    print(json.dumps(res, indent=2)[:600] if isinstance(res, dict) else str(res)[:600])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
New canonical `looker-to-sigma` plugin, validated end-to-end against a live Looker instance with exact 3-way warehouse parity.

- **looker-to-sigma** skill — phase-structured SKILL.md (Assess → Discover → Convert model → Convert dashboards → Parity → Enhance) + QUICKSTART + scripts (Looker REST client, live dashboard discovery, LookML→DM, workbook builder) + refs. Handles UDD and LookML dashboards; KPI/bar/line/area/pie/donut/scatter/table/pivot/text tiles + table calcs.
- **looker-assessment** skill — instance inventory + complexity scoring + System Activity usage → Sigma-branded HTML readout (mirrors the other assessment skills). Live-validated on hakkoda1.
- Registered in marketplace.json (6 plugins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)