### PR TITLE
cognos-to-sigma: README listing + codelab QUICKSTART

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ shared `~/.sigma-migration/env` under any agent.
 /plugin install qlik-to-sigma@sigma-migration-skills
 /plugin install thoughtspot-to-sigma@sigma-migration-skills
 /plugin install quicksight-to-sigma@sigma-migration-skills
+/plugin install cognos-to-sigma@sigma-migration-skills
 ```
 
 **Other agents (Cursor, Cortex Code, …)** — clone the repo and point your agent at the
@@ -44,6 +45,7 @@ and the skill drives discovery → translation → build → parity.
 | [`qlik-to-sigma`](plugins/qlik-to-sigma/) | Qlik Sense / Cloud | `qlik-to-sigma`, `qlik-assessment` |
 | [`thoughtspot-to-sigma`](plugins/thoughtspot-to-sigma/) | ThoughtSpot | `thoughtspot-to-sigma`, `thoughtspot-assessment` |
 | [`quicksight-to-sigma`](plugins/quicksight-to-sigma/) | Amazon QuickSight | `quicksight-to-sigma`, `quicksight-assessment` |
+| [`cognos-to-sigma`](plugins/cognos-to-sigma/) | IBM Cognos Analytics | `cognos-to-sigma`, `cognos-assessment` |
 
 In Claude Code, installed skills are namespaced — e.g. `/powerbi-to-sigma:powerbi-assessment`.
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/QUICKSTART.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/QUICKSTART.md
@@ -1,50 +1,168 @@
-# Quickstart — Cognos → Sigma converter
+author: Sigma Computing
+summary: Migrating from IBM Cognos made easy — convert Cognos Analytics Data Modules and reports to Sigma with Claude Code
+id: developers_migrating_from_cognos_made_easy
+categories: Developers, Migration, AI
+environments: Web
+status: Draft
+feedback link: https://github.com/sigmacomputing/quickstarts-public/issues
 
-Runnable in ~1 minute on the bundled real-IBM-sample fixtures. No Cognos access needed.
+# Migrating from IBM Cognos Analytics to Sigma made easy
 
-```bash
-cd skills/cognos-to-sigma/converter
-npm install            # fast-xml-parser + tsx
-npm test               # convert every fixture in ../fixtures
-```
+## Introduction & why it matters
+Duration: 2
 
-Expected:
+Rebuilding IBM Cognos content in a new BI tool by hand is slow and error-prone — you
+re-derive the semantic layer from the Data Module, re-type every calculation in a new
+expression language, and hope the numbers still tie out.
 
-```
-✓ go-sales-performance.report.xml    report → 2 tables · 6 cols · 1 controls
-✓ great-outdoors.module.json         module → 25 elems · 114 cols · 10 metrics · 14 rels
-✓ sample-data-module.module.json     module → 4 elems · 63 cols · 26 metrics · 0 rels
-✓ telco-churn.module.json            module → 8 elems · 244 cols · 21 metrics · 7 rels
-all fixtures converted ✓
-```
+This quickstart automates the whole path with **your coding agent** (Claude Code,
+Cursor, Cortex Code, …) + a set of Cognos→Sigma skills: it discovers Cognos content,
+translates the Cognos expression DSL to Sigma formulas, builds a Sigma data model and a
+matching workbook (lists, crosstabs, charts, **and maps**), and **verifies data parity**
+against the same warehouse — typically to the cent.
 
-## Convert one artifact
+positive
+: These skills are **agent-neutral** — each is a `SKILL.md` plus `scripts/`. `AGENTS.md` at the repo root maps each task to its skill, and the scripts auto-load credentials, so they run the same under any agent. Where this guide says "Claude Code," substitute your agent.
 
-**Data Module JSON → Sigma data model:**
-```bash
-node --import tsx/esm cli.ts ../fixtures/great-outdoors.module.json --database CSA --schema PUBLIC
-```
-→ Sigma data-model JSON on stdout; `stats` + per-calc `warnings` on stderr (the warnings
-are exactly the bits that need manual authoring — read them).
+positive
+: The Sigma side reads your warehouse **live**, so the migrated workbook stays current with no scheduled refresh/extract — a difference you'll see in the parity check when new rows land.
 
-**Report-spec XML → Sigma workbook:**
-```bash
-node --import tsx/esm cli.ts ../fixtures/go-sales-performance.report.xml --dm <dataModelId>
-```
-→ Sigma workbook JSON. Lists become table elements, dataItems become columns,
-`prompt(...)` become controls; the prompt-driven "swap measure" macro is flagged with
-a `Switch([…])` placeholder.
+## Who this is for
+Duration: 1
 
-## Pull your own from Cognos
+- Sigma SEs and technical CSMs
+- Migration partners
+- Cognos authors evaluating a move to Sigma
 
-```bash
-export COGNOS_BASE="https://<host>/bi/v1"
-export COGNOS_COOKIE="…"   export COGNOS_XSRF="…"      # from DevTools → Copy as cURL
-../scripts/cognos-discover.sh list   <folderId>
-../scripts/cognos-discover.sh module <moduleId> > my.module.json
-../scripts/cognos-discover.sh report <reportId> > my.report.xml
-node --import tsx/esm cli.ts my.module.json
-```
+You do **not** need to be a Sigma or Cognos internals expert — the skills carry the
+domain knowledge. You do need access to a Cognos Analytics instance and a Sigma org whose
+connection reaches the same warehouse the Cognos content reports on.
 
-Then post the outputs to Sigma (`/v2/dataModels/spec`, `/v2/workbooks/spec`) — see `SKILL.md`
-Phases 2–4 for the readback-and-wire + verify steps.
+## Prerequisites
+Duration: 2
+
+- **A coding agent that runs skills** — Claude Code (CLI or desktop), Cursor, Cortex Code, etc.
+- **Cognos Analytics 11.1+ REST access** (on-prem or CA on Cloud). Base path is `<host>/bi/v1`
+  (**not** `/api/v1`). Auth = a logged-in session: a **session cookie** + the **`X-XSRF-Token`**
+  header. On IBMid-SSO trials you can't log in headlessly — grab a live browser session
+  (DevTools → Network → any `…/bi/v1/…` request → **Copy as cURL**) and feed it to
+  `scripts/get-cognos-session.sh`.
+- **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`).
+- A **Sigma connection to the same warehouse** the Cognos content reports on (for true parity).
+- The **`convert_cognos_to_sigma`** + **`convert_cognos_report_to_sigma`** converters (part of
+  the sigma-data-model MCP), or the bundled `converter/` (Node + `fast-xml-parser`).
+
+negative
+: CAoC (Cognos on Cloud) sessions are short-lived and sit behind Akamai bot-protection — a copied session can return **HTTP 441** within minutes (the SPA's `X-CA-SSO: 441` header is the re-auth signal), and curl replay may be rejected outright. Re-login + re-copy a *hot* session, or use a **CA API key / service credential** where the tenant allows it (the durable path).
+
+## The two-skill ecosystem
+Duration: 2
+
+| Skill | Role |
+|---|---|
+| **`cognos-assessment`** | Inventory a Cognos estate + score per-artifact migration complexity against the converter's exact coverage (which calcs/charts auto-convert vs. flag — macros, running-total/rank, treemap/network/word-cloud, FM `.cpf`, drill-through) → a value/cost-ranked shortlist. Run this first to decide what to migrate. |
+| **`cognos-to-sigma`** | The conversion: discover → convert Data Module + report → POST + read back ids → wire the workbook to the model → parity-verify. |
+
+Both mirror the Tableau / Power BI / Qlik migration skills: same shortlist math and the
+same `migrate-first / easy-win / needs-review` tagging.
+
+## Installation & setup
+Duration: 5
+
+1. **Add the marketplace and install the plugin** (Claude Code):
+   ```text
+   /plugin marketplace add twells89/sigma-migration-skills
+   /plugin install cognos-to-sigma@sigma-migration-skills
+   ```
+   Installs both skills, namespaced — e.g. `/cognos-to-sigma:cognos-assessment`.
+   **Other agents (Cursor, Cortex Code, …):** clone the repo and point your agent at
+   `plugins/cognos-to-sigma/skills/…`; `AGENTS.md` indexes every skill.
+2. **Sigma credentials** — export `SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`; the skill's
+   `scripts/get-token.sh` exchanges them for a `SIGMA_API_TOKEN`.
+3. **Cognos session** — capture a live browser session (keep secrets out of any transcript):
+   ```bash
+   # paste the FULL Cookie header (incl. Akamai _abck/bm_sz/bm_sv/ak_bmsc) into ~/.cognos/cookie.txt
+   export COG_BASE="https://<host>/bi/v1"  COG_XSRF="<X-XSRF-TOKEN value>"
+   eval "$(scripts/get-cognos-session.sh)"
+   cog_get "/objects/.public_folders/items?fields=defaultName,type,id"   # smoke test
+   ```
+4. **Verify the converter offline** (no Cognos access needed):
+   ```bash
+   cd converter && npm install && npm test   # converts every bundled real-IBM-sample fixture
+   ```
+
+## Prepare demo data (optional)
+Duration: 3
+
+No Cognos instance handy? The converter ships with **real IBM sample** fixtures
+(Great Outdoors, GO sales performance, Telco churn, a banking crosstab, a multi-chart
+sales overview) in `fixtures/` — `npm test` converts them all. For a **parity** demo,
+land IBM's published `GOSALES` / `GOSALESDW` sample databases into the warehouse your
+Sigma connection reads, and point the converter at a Cognos report built on them.
+
+## Run the conversion
+Duration: 10
+
+In Claude Code, point the `cognos-to-sigma` skill at a Data Module + report. The skill
+runs these phases (`scripts/*`):
+
+1. **Discover** (`cognos-discover.sh`) — list a folder, then pull the **Data Module JSON**
+   (`GET /bi/v1/metadata/modules/{id}`) and **report-spec XML**
+   (`GET /bi/v1/objects/{id}?fields=specification`).
+2. **Convert the Data Module** (`cli.ts <module.json>`) — query subjects → warehouse-table
+   elements, items → columns/metrics, calculations → Sigma formulas (`total..for`→`SumOver`,
+   `if/then/else`→`If`, date/string fns), relationships → DM relationships.
+3. **POST + read back** (`post-and-readback.mjs --type datamodel`) — POST to
+   `/v2/dataModels/spec`, read it back, and **fail on any `type=error` column** (a 200 POST
+   isn't proof — formulas can fail to resolve at query time).
+4. **Convert the report + wire it** (`cli.ts <report.xml> --dm <id>` →
+   `remap-wb-to-dm-ids.mjs`) — lists→tables, crosstabs→pivots, charts→bar/line/pie/etc.,
+   `tiledmap`→region-map/point-map, prompts→controls. `remap-wb-to-dm-ids.mjs` rewrites the
+   workbook's `source.elementId` placeholders to the real posted element ids.
+5. **POST the workbook** (`post-and-readback.mjs --type workbook`) → `/v2/workbooks/spec`,
+   error-column gate re-run.
+6. **Verify parity** (`assert-parity.mjs`) — `--plan` emits per-element SQL; run it, then
+   `--check` compares the actuals to the Cognos source. **GREEN only when `--check` passes.**
+
+positive
+: Run `cognos-assessment` first on the whole estate to rank what's worth migrating and surface the manual-work gaps *before* you start.
+
+## Understanding the output
+Duration: 3
+
+- **Assessment readout** (`cognos-assessment`) — per-artifact complexity, a converter-coverage
+  score (% auto-migratable), a named gap list (with the *reason* + remediation per gap), and a
+  ranked shortlist, rendered as a branded HTML report.
+- **Conversion warnings** — the converter **flags, never fakes**: runtime macros, running-total /
+  rank / lag-lead, `GetResourceString`, composite joins, and unsupported viz (treemap / network /
+  word-cloud → a flagged table) come out as warnings to re-author, not wrong logic.
+- **Parity check** — the migration is GREEN only when Sigma's numbers match the warehouse
+  (the skill hard-gates on this).
+
+## Reference & gotchas
+Duration: 3
+
+`refs/` collects the hard-won rules, including:
+
+- **Column formula prefix = the warehouse table tail** — `[ORDER_FACT/Net Revenue]`, not the
+  element display name (wrong prefix → "dependency not found" at POST).
+- **Pivot** `values` are **bare column-id strings** (not `{id}` objects); `rowsBy`/`columnsBy`
+  are `{id}` objects.
+- **Charts** map by slot: `categories`→`xAxis`, `values`/`size`→`yAxis` (aggregated by
+  `rollupMethod`), `series`/`color`→`color`; pie/donut use `value`+`color`.
+- **Maps** — `tiledmap` lat/long slots → `point-map`; named-location slots → `region-map`
+  (`regionType` defaults to `country`, flagged to confirm).
+- **Workbook POST responses are YAML**, not JSON — parse the `workbookId` accordingly.
+- **Sessions:** CAoC `HTTP 441` = re-login + re-copy the full cookie; prefer a CA API key.
+
+## The techniques worth carrying forward
+Duration: 1
+
+- **Assess first** — convert the high-value, low-effort artifacts before the long tail.
+- **Treat the warehouse as the source of truth** — Sigma reads it live; parity is the gate.
+- **Flag, never fake** — the parts with no clean Sigma analog come back as warnings, not
+  silently-wrong formulas.
+- **Read back + remap** — POST reassigns ids; `remap-wb-to-dm-ids.mjs` re-wires the workbook.
+
+Next: run `cognos-assessment` on your estate, pick the shortlist, and let `cognos-to-sigma`
+convert the top N.


### PR DESCRIPTION
Follow-up to PR #27 (which merged the plugin but didn't update the repo README).

- Adds `cognos-to-sigma` to the **Install** commands and the **What's in the marketplace** table (IBM Cognos Analytics → `cognos-to-sigma`, `cognos-assessment`).
- Reformats the plugin's `QUICKSTART.md` to the **Sigma codelab format** used by the sibling skills (author/summary/id header, `Duration:` sections, `positive`/`negative` callouts, two-skill table), reflecting the hardened scripted phases (post-and-readback / remap / assert-parity) + charts/maps coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)