### PR TITLE
looker-to-sigma: add RLS migration step + README plugin entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ shared `~/.sigma-migration/env` under any agent.
 /plugin install thoughtspot-to-sigma@sigma-migration-skills
 /plugin install quicksight-to-sigma@sigma-migration-skills
 /plugin install cognos-to-sigma@sigma-migration-skills
+/plugin install looker-to-sigma@sigma-migration-skills
 ```
 
 **Other agents (Cursor, Cortex Code, …)** — clone the repo and point your agent at the
@@ -46,6 +47,7 @@ and the skill drives discovery → translation → build → parity.
 | [`thoughtspot-to-sigma`](plugins/thoughtspot-to-sigma/) | ThoughtSpot | `thoughtspot-to-sigma`, `thoughtspot-assessment` |
 | [`quicksight-to-sigma`](plugins/quicksight-to-sigma/) | Amazon QuickSight | `quicksight-to-sigma`, `quicksight-assessment` |
 | [`cognos-to-sigma`](plugins/cognos-to-sigma/) | IBM Cognos Analytics | `cognos-to-sigma`, `cognos-assessment` |
+| [`looker-to-sigma`](plugins/looker-to-sigma/) | Looker | `looker-to-sigma`, `looker-assessment` |
 
 In Claude Code, installed skills are namespaced — e.g. `/powerbi-to-sigma:powerbi-assessment`.
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
@@ -34,7 +34,16 @@ python3 scripts/looker_api.py raw GET /dashboards      # list dashboards (UDD + 
 python3 scripts/fetch_looker_dashboard.py <dashboard_id> /tmp/look/<dash>.contract.json
 # offline (dev/test only — cannot see UDDs):
 python3 scripts/parse_lookml_dashboard.py <file.dashboard.lookml> --out /tmp/look/<dash>.contract.json
+
+# scan for row-level security (silent + exit 0 if none; if found → ONE decision gate before Phase 3)
+python3 scripts/detect_rls.py /path/to/lookml
 ```
+
+If `detect_rls.py` reports RLS (`access_filter` / `sql_always_where` / `access_grant`), stop ONCE
+before building: reuse any existing Sigma user attribute / DM, pre-fill the recommended mapping
+(`access_filter` → user-attribute row filter via `LookupUserAttributeText`/`CurrentUserAttributeText`;
+`sql_always_where` → DM/element filter; `access_grant` → note), then confirm/edit/skip in a single
+decision — and record ported/reused/skipped in the summary (never silently drop RLS).
 
 ## 3. Convert the semantic model
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -52,6 +52,7 @@ offline-only path that normalizes into the same contract.
 | `scripts/looker_api.py` | Minimal Looker REST API 4.0 client (no SDK). Reads `~/.looker/looker.ini`, logs in via `client_credentials`, exposes `L.call(method, path, body)`. CLI: `python3 looker_api.py whoami` / `get <path>` / `raw GET /lookml_models`. |
 | `scripts/fetch_looker_dashboard.py` | **Phase 1 (live):** `GET /dashboards/{id}` → the normalized contract (`refs/dashboard-contract.md`). Works for UDD AND LookML dashboards. Self-contained (reads `~/.looker/looker.ini`). `tileType` is read from `query.vis_config.type` (NOT `element.type`, which is always `"vis"`); `listen` from `result_maker.filterables`; layout from the **active** layout's components. |
 | `scripts/parse_lookml_dashboard.py` | **Phase 1 (offline):** parse a `.dashboard.lookml` (YAML) → the SAME contract. Dev/test only; cannot see UDD dashboards. Requires PyYAML. |
+| `scripts/detect_rls.py` | **Phase 1 (RLS scan):** dependency-free regex scan of a LookML dir/file (and/or model JSON) for row-level-security constructs (`access_filter`, `sql_always_where`, `access_grant`, `user_attribute`). Prints a structured summary + recommended Sigma mapping per finding (or `--json`). **Prints nothing / exits 0 when there's no RLS** (zero-overhead). `python3 detect_rls.py <lookml_dir> [--json]` |
 | `scripts/convert_dm.mjs` | **Phase 2:** run `convertLookMLToSigma` against a directory of `.lkml` files for one explore → a Sigma DM spec JSON. Bypasses the deployed MCP build (see the converter-build gotcha below). Env: `LOOKML_DIR`, `CONVERTER_SRC`; args `<exploreName> <out.json>`. |
 | `scripts/post_dm.py` | **Phase 2:** POST a DM spec to `/v2/dataModels/spec` (auto-finds a writable folder, swaps in the full connection UUID). Env: `SIGMA_API_TOKEN`, `SIGMA_BASE_URL`, `SIGMA_CONNECTION_ID`; args `<spec.json>`. |
 | `scripts/build_workbook.py` | **Phase 3:** dashboard contract + the explore's view `.lkml` files → a Sigma `/v2/workbooks/spec` body (hidden Data page + master table, one element per tile, controls from filters, newspaper→24-col layout XML). Generates locally; does **not** POST. Handles ratio measures, joined-col `Field (alias)` naming, table calcs, pivot-flatten + warn. |
@@ -177,6 +178,70 @@ API.** Note: a deployed LookML dashboard does NOT auto-index for `import_lookml_
 > `isFixed` = 0, Sales-gated). Build/test from sample LookML + the offline path. The validated
 > end-to-end run used a real `hakkoda1.cloud.looker.com` instance pointed at `CSA.TJ`.
 
+### 1d. Scan for row-level security (RLS) — cheap, silent if none
+
+Looker enforces row-level security in LookML, and **security is the one place a silent default
+is dangerous in both directions** — silently dropping RLS exposes data; silently porting a wrong
+mapping over- or under-restricts it. So scan for it during discovery, but stay out of the way
+when there's nothing to decide.
+
+```bash
+python3 scripts/detect_rls.py /path/to/lookml          # the project dir (and/or a model JSON)
+```
+
+- **Zero overhead on the happy path.** `detect_rls.py` is a cheap regex scan; **if it finds no
+  RLS it prints nothing and exits 0** — no prompt, no extra phase, the migration proceeds
+  straight to Phase 2 unchanged.
+- **If it finds RLS, it lists every finding** (construct, explore, field, `user_attribute`,
+  expression) plus the recommended Sigma mapping — that output feeds the **single** RLS decision
+  gate below (do NOT prompt per rule). The constructs it detects, and their Sigma targets:
+
+  | Looker RLS construct | What it does | Sigma target |
+  |---|---|---|
+  | `access_filter` (explore) | maps a `user_attribute` → a field; restricts rows to the caller's allowed values | a Sigma **user attribute** + a row filter using `LookupUserAttributeText(...)` / `CurrentUserAttributeText(...)` on that field |
+  | `sql_always_where` (explore) | a hardcoded SQL row filter always ANDed onto the explore | a Sigma **data-model / element filter** (if the expression references a `user_attribute` / `{{ _user_attributes[...] }}`, make it a user-attribute row filter, not a static one) |
+  | `access_grant` (model) | gates explores/fields/joins by a `user_attribute`'s allowed values | **note / review** — no 1:1 analog; map to Sigma **permissions** or a user-attribute filter |
+  | `user_attribute` reference | any other `_user_attributes[...]` / `user_attribute:` use | **provision** the matching Sigma user attribute (reuse if it already exists) |
+
+> The `convert_lookml_to_sigma` converter ALSO detects `access_filter` and emits an RLS note (and
+> a `CurrentUserAttributeText()` row-filter stub) in the DM spec. `detect_rls.py` is the
+> discovery-time, project-wide view that drives the **decision gate** — the converter handles the
+> per-spec emission once you've decided to port.
+
+---
+
+## Phase 1.5 — RLS decision gate (only if Phase 1d found RLS) — BEFORE building
+
+**Skip this phase entirely when `detect_rls.py` found nothing.** When it DID find RLS, stop ONCE,
+here, before POSTing the data model in Phase 2 — make it one explicit, reviewed decision, never an
+invisible default.
+
+1. **Reuse-first — check what already exists in Sigma before creating anything.** The customer may
+   have already set RLS up in Sigma; don't duplicate it.
+   - **Existing Sigma user attributes** — list them and match by name to the Looker
+     `user_attribute`s in the findings. (Manual check today: **Administration → User Attributes**
+     in the Sigma UI; reuse a matching attribute rather than creating a new one. If a list
+     endpoint becomes available, prefer it — but do not block on it; the manual check is the
+     contract.)
+   - **Existing data models with similar RLS logic** — if a Sigma DM already filters the same
+     field by the same attribute (e.g. a previously-migrated explore on the same source), reuse it
+     instead of re-implementing the filter.
+2. **Pre-fill a recommended plan.** Using the mapping table above, draft the per-finding Sigma
+   action (which user attribute, which field, `LookupUserAttributeText`/`CurrentUserAttributeText`
+   filter vs DM/element filter vs note) — reusing the existing Sigma attributes/DMs found in step 1.
+3. **One consolidated confirm / edit / skip.** Present the full plan and let the user, in a SINGLE
+   decision: **confirm** it as drafted, **edit** any mapping (e.g. point at a different existing
+   attribute, change a field), or **skip** porting RLS entirely (they may enforce it elsewhere in
+   Sigma). No per-rule nagging.
+4. **Always record the outcome.** For every finding, note **ported / reused / skipped** in the
+   migration summary (Phase 4 output) so any skipped RLS is **visible, never silent** — a reviewer
+   can see exactly which Looker restriction was carried over, reused, or deliberately dropped.
+
+Then proceed to Phase 2. Apply the confirmed plan as part of the DM build: create/reuse the Sigma
+user attribute(s), and add the row filter(s) to the data model (or element) — `access_filter` and
+user-attribute `sql_always_where` → `LookupUserAttributeText`/`CurrentUserAttributeText` row
+filters; static `sql_always_where` → a plain DM/element filter; `access_grant` → the recorded note.
+
 ---
 
 ## Phase 2 — Convert the LookML semantic model
@@ -247,8 +312,10 @@ shapes so you recognize a regression:
 - **Table-calc grain/sort** for window functions (rank / offset / percentile) → review.
 - **`merged_results`** → a DM join or a Custom SQL element (follow `merge_result_id` to the
   source queries; >2 sources or non-equi joins → manual + warn).
-- **Not yet converted:** NDT (`explore_source`), PDT `datagroup`/`persist_for`, `many_to_many`,
-  `access_filter`.
+- **Not yet converted:** NDT (`explore_source`), PDT `datagroup`/`persist_for`, `many_to_many`.
+- **RLS (`access_filter` / `sql_always_where` / `access_grant`)** — detected at discovery
+  (Phase 1d) and decided ONCE at the Phase 1.5 gate; the converter emits an `access_filter` RLS
+  note + `CurrentUserAttributeText()` stub. Never silently dropped — the outcome is recorded.
 
 > **`metric()` returns "Missing Metric" in MCP SQL** — a known Sigma quirk, not a conversion
 > bug. Verify metric values via the **raw aggregate** (`Sum(...)`, `CountDistinct(...)`), not via
@@ -396,6 +463,12 @@ key metrics, and per-tile.
 GREEN only when all three match. The validated run produced **exact** parity to the cent —
 region revenue (West 38906.82 / South 31650.98 / NE 21587.52 / MW 14966.20 / null 3231.23 =
 $109,765.89) and the ratio metrics (AOV / margin / return) identical across Looker and Sigma.
+
+**Record the RLS outcome here.** If Phase 1d found RLS, the migration summary MUST list, per
+finding, whether it was **ported / reused / skipped** (and the Sigma user attribute + filter used)
+— so any skipped Looker restriction is visible to a reviewer, never silently dropped. (When RLS
+is active, parity-check as a representative restricted user, not only as an admin who sees all
+rows.)
 
 > **If `mcp__sigma-mcp-v2__query` errors with an auth message mid-Phase-4**, the MCP session
 > staled — re-call `mcp__sigma-mcp-v2__begin_session` and retry. Do not skip parity over a

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/detect_rls.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/detect_rls.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Phase 1 (Discover): cheap regex scan of a LookML project (and/or model JSON)
+for row-level-security (RLS) constructs, so the migration can make ONE
+consolidated, reviewed decision about porting them to Sigma — never silently
+drop RLS, never silently port a wrong mapping.
+
+NEVER SILENT, but also NEVER SLOW when there's nothing to decide:
+if no RLS construct is found, this prints NOTHING and exits 0 — the happy
+path is untouched. When hits ARE found, it emits a structured summary (and a
+recommended Sigma mapping per finding) and exits 0; pass --json for machine
+output. Exit 2 only on a usage/IO error.
+
+Looker RLS constructs detected (and their Sigma target):
+  - access_filter    (explore: maps a user_attribute → a field)
+                       → Sigma user attribute + a row filter
+                         LookupUserAttributeText(...)/CurrentUserAttributeText(...)
+  - sql_always_where (hardcoded row filter on an explore)
+                       → Sigma data-model / element filter
+  - access_grant     (model-level grant gating explores/fields/joins)
+                       → note (review; map to Sigma permissions / a filter)
+  - user_attribute   (any other reference, e.g. in a sql_always_where / Liquid)
+                       → flagged so the user_attribute is provisioned in Sigma
+
+Dependency-free (stdlib only). Mirrors the style of the other scripts here.
+
+Usage:
+    python3 detect_rls.py <lookml_dir_or_file> [<more> ...] [--json]
+    # also accepts a model JSON (e.g. from `looker_api.py raw GET
+    # /lookml_models/<model>/explores/<explore>`) — its access_filters /
+    # sql_always_where show up the same way.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+# --- regexes (line/block tolerant; LookML is whitespace-loose) -------------
+# access_filter blocks live inside an explore: access_filter { field: x  user_attribute: y }
+_ACCESS_FILTER = re.compile(r"access_filter\s*:?\s*\{(.*?)\}", re.DOTALL)
+_AF_FIELD = re.compile(r"\bfield\s*:\s*([A-Za-z0-9_.]+)")
+_AF_USERATTR = re.compile(r"\buser_attribute\s*:\s*([A-Za-z0-9_.]+)")
+# sql_always_where: <expr> ;;   (terminated by ;; or newline)
+_SQL_ALWAYS_WHERE = re.compile(r"sql_always_where\s*:\s*(.*?)(?:;;|$)", re.DOTALL | re.MULTILINE)
+# access_grant: name { user_attribute: x  allowed_values: [...] }
+_ACCESS_GRANT = re.compile(r"access_grant\s*:\s*([A-Za-z0-9_]+)\s*\{(.*?)\}", re.DOTALL)
+# any user_attribute reference (Liquid {{ _user_attributes['x'] }} or bare user_attribute: x)
+_LIQUID_USERATTR = re.compile(r"_user_attributes\s*\[\s*['\"]([^'\"]+)['\"]\s*\]")
+_BARE_USERATTR = re.compile(r"\buser_attribute\s*:\s*([A-Za-z0-9_.]+)")
+# rough explore name, so we can attribute a finding to an explore
+_EXPLORE = re.compile(r"\bexplore\s*:\s*([A-Za-z0-9_]+)\s*\{")
+
+
+def _explore_for(text, pos):
+    """Best-effort: the nearest `explore:` declared before `pos`."""
+    last = None
+    for m in _EXPLORE.finditer(text):
+        if m.start() > pos:
+            break
+        last = m.group(1)
+    return last
+
+
+def scan_text(text, source):
+    """Return a list of finding dicts for one file's text."""
+    findings = []
+    seen_userattrs = set()
+
+    for m in _ACCESS_FILTER.finditer(text):
+        body = m.group(1)
+        field = _AF_FIELD.search(body)
+        ua = _AF_USERATTR.search(body)
+        ua_name = ua.group(1) if ua else None
+        if ua_name:
+            seen_userattrs.add(ua_name)
+        findings.append({
+            "construct": "access_filter",
+            "source": source,
+            "explore": _explore_for(text, m.start()),
+            "field": field.group(1) if field else None,
+            "user_attribute": ua_name,
+            "sigma_mapping": "Sigma user attribute + row filter "
+                             "(LookupUserAttributeText/CurrentUserAttributeText) on the field",
+        })
+
+    for m in _SQL_ALWAYS_WHERE.finditer(text):
+        expr = m.group(1).strip()
+        if not expr:
+            continue
+        for ua in _LIQUID_USERATTR.findall(expr):
+            seen_userattrs.add(ua)
+        findings.append({
+            "construct": "sql_always_where",
+            "source": source,
+            "explore": _explore_for(text, m.start()),
+            "field": None,
+            "expression": expr,
+            "sigma_mapping": "Sigma data-model / element filter "
+                             "(if it references a user_attribute, use a user-attribute row filter)",
+        })
+
+    for m in _ACCESS_GRANT.finditer(text):
+        name = m.group(1)
+        body = m.group(2)
+        ua = _BARE_USERATTR.search(body)
+        ua_name = ua.group(1) if ua else None
+        if ua_name:
+            seen_userattrs.add(ua_name)
+        findings.append({
+            "construct": "access_grant",
+            "source": source,
+            "name": name,
+            "user_attribute": ua_name,
+            "sigma_mapping": "Note — review; map to Sigma permissions or a user-attribute filter "
+                             "(access_grant gates explores/fields/joins, no 1:1 Sigma analog)",
+        })
+
+    # Any remaining user_attribute references (Liquid / bare) not already captured.
+    for ua in _LIQUID_USERATTR.findall(text):
+        if ua not in seen_userattrs:
+            seen_userattrs.add(ua)
+            findings.append({
+                "construct": "user_attribute",
+                "source": source,
+                "user_attribute": ua,
+                "sigma_mapping": "Provision the matching Sigma user attribute (reuse if it exists)",
+            })
+
+    return findings
+
+
+def _iter_files(paths):
+    for p in paths:
+        if os.path.isdir(p):
+            for root, _dirs, files in os.walk(p):
+                for fn in files:
+                    if fn.endswith((".lkml", ".lookml", ".json")):
+                        yield os.path.join(root, fn)
+        elif os.path.isfile(p):
+            yield p
+        else:
+            print(f"detect_rls: no such path: {p}", file=sys.stderr)
+
+
+def scan(paths):
+    findings = []
+    for fp in _iter_files(paths):
+        try:
+            with open(fp, encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError as e:
+            print(f"detect_rls: cannot read {fp}: {e}", file=sys.stderr)
+            continue
+        # Model JSON: scan its raw text too — access_filters / sql_always_where
+        # serialize as the same keywords, so the regexes still match.
+        findings.extend(scan_text(text, os.path.relpath(fp)))
+    return findings
+
+
+def render(findings):
+    by = {}
+    for f in findings:
+        by.setdefault(f["construct"], []).append(f)
+    lines = []
+    lines.append("ROW-LEVEL SECURITY DETECTED in the Looker source — review before building.")
+    lines.append(f"  {len(findings)} finding(s) across {len(by)} construct type(s).")
+    order = ["access_filter", "sql_always_where", "access_grant", "user_attribute"]
+    for c in order:
+        items = by.get(c)
+        if not items:
+            continue
+        lines.append("")
+        lines.append(f"  {c}  ({len(items)}):")
+        for it in items:
+            bits = []
+            if it.get("explore"):
+                bits.append(f"explore={it['explore']}")
+            if it.get("field"):
+                bits.append(f"field={it['field']}")
+            if it.get("user_attribute"):
+                bits.append(f"user_attribute={it['user_attribute']}")
+            if it.get("name"):
+                bits.append(f"name={it['name']}")
+            if it.get("expression"):
+                bits.append(f"where={it['expression']}")
+            lines.append(f"    - {it['source']}: " + ("  ".join(bits) if bits else "(matched)"))
+            lines.append(f"        → {it['sigma_mapping']}")
+    lines.append("")
+    lines.append("Next: present ONE consolidated RLS decision gate (confirm / edit / skip), "
+                 "reuse existing Sigma user attributes + data models first, and record the "
+                 "outcome (ported / skipped / reused) in the migration summary.")
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Scan LookML for RLS constructs (silent if none).")
+    ap.add_argument("paths", nargs="+", help="LookML dir(s)/file(s) and/or model JSON")
+    ap.add_argument("--json", action="store_true", help="emit findings as JSON")
+    a = ap.parse_args()
+
+    findings = scan(a.paths)
+
+    # Zero-overhead happy path: nothing found → print nothing, exit clean.
+    if not findings:
+        if a.json:
+            print("[]")
+        return 0
+
+    if a.json:
+        print(json.dumps(findings, indent=2))
+    else:
+        print(render(findings))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds row-level-security (RLS) handling to the **looker-to-sigma** skill and lists the Looker plugin in the root README.

## Task 1 — RLS step
Design principle: **never silent, but never slow when there's nothing to decide.** Security silent-fail is dangerous both ways (dropping RLS = exposure; porting a wrong mapping = wrong restriction).

- **`scripts/detect_rls.py`** — stdlib-only regex scan of LookML dirs/files (and model JSON) for `access_filter`, `sql_always_where`, `access_grant`, and `user_attribute` references. Prints a structured summary + recommended Sigma mapping per finding (or `--json`), and **prints nothing / exits 0 when there's no RLS** (zero overhead on the happy path).
- **SKILL.md** — Phase 1d cheap RLS scan during discovery (silent if none), and a new **Phase 1.5 consolidated decision gate** before the Phase 2 data-model build: reuse-first check for existing Sigma user attributes / data models, a pre-filled Looker→Sigma mapping table (`access_filter` → user-attribute row filter via `LookupUserAttributeText`/`CurrentUserAttributeText`; `sql_always_where` → DM/element filter; `access_grant` → note), a single **confirm / edit / skip** decision, and the outcome (**ported / reused / skipped**) always recorded in the Phase 4 summary so skipped RLS is visible, never silent.
- **QUICKSTART.md** — one-paragraph RLS note in the Discover step.

## Task 2 — root README
Adds the `looker-to-sigma` plugin entry (install line + marketplace table row), mirroring the existing rows — bundles `looker-to-sigma` + `looker-assessment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)