### PR TITLE
looker-to-sigma: fix migrated workbook layout + add PNG export QA

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -56,7 +56,8 @@ offline-only path that normalizes into the same contract.
 | `scripts/apply_sigma_rls.py` | **Phase 1.5 (apply RLS):** scripted, API-driven RLS port. Reuse-first `GET /v2/user-attributes` (prints a match before creating); `--create` → `POST /v2/user-attributes`; `--assign` (+`--member-id`,`--value`) → `POST /v2/user-attributes/{id}/users`; `--field`/`--element-id` → print the verified RLS calc-col + element-filter snippet, `--apply --dm-id` → PATCH it into the DM element spec. **Read-only / plan-only by default — mutates only on an explicit `--create`/`--assign`/`--apply` flag.** Reads `$SIGMA_BASE_URL`/`$SIGMA_API_TOKEN` like `post_dm.py`. |
 | `scripts/convert_dm.mjs` | **Phase 2:** run `convertLookMLToSigma` against a directory of `.lkml` files for one explore → a Sigma DM spec JSON. Bypasses the deployed MCP build (see the converter-build gotcha below). Env: `LOOKML_DIR`, `CONVERTER_SRC`; args `<exploreName> <out.json>`. |
 | `scripts/post_dm.py` | **Phase 2:** POST a DM spec to `/v2/dataModels/spec` (auto-finds a writable folder, swaps in the full connection UUID). Env: `SIGMA_API_TOKEN`, `SIGMA_BASE_URL`, `SIGMA_CONNECTION_ID`; args `<spec.json>`. |
-| `scripts/build_workbook.py` | **Phase 3:** dashboard contract + the explore's view `.lkml` files → a Sigma `/v2/workbooks/spec` body (hidden Data page + master table, one element per tile, controls from filters, newspaper→24-col layout XML). Generates locally; does **not** POST. Handles ratio measures, joined-col `Field (alias)` naming, table calcs, pivot-flatten + warn. |
+| `scripts/build_workbook.py` | **Phase 3:** dashboard contract + the explore's view `.lkml` files → a Sigma `/v2/workbooks/spec` body (hidden Data page + master table, one element per tile, controls from filters, newspaper→24-col layout XML). Generates locally; does **not** POST. Handles ratio measures, joined-col `Field (alias)` naming, table calcs, pivot-flatten + warn. Layout: a top control bar (row 0), a full-width strip of **tall** KPI tiles (height ≥ 6 so titles render), then the remaining tiles shifted down. |
+| `scripts/sigma-export-png.py` | **Phase 4 (visual QA):** render a posted workbook page or element to PNG via `POST /v2/workbooks/{id}/export` → poll `GET /v2/query/{queryId}/download`. For side-by-side layout/render checks against the source Looker dashboard (catches hidden KPI titles, orphaned filters, overlaps that a numeric parity check can't). Reads `$SIGMA_BASE_URL`/`$SIGMA_API_TOKEN`. `python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png` (or `--element <id>`). |
 | `scripts/build_looker_dashboard.py` | **TEST-FIXTURE BUILDER (not a migration step).** Builds the "Orders Overview" UDD on `csa_thelook` via the Looker API (4 KPIs + line/column/bar/pie + grid, 3 filters wired via `result_maker.filterables.listen`). |
 | `scripts/build_looker_dashboard2.py` | **TEST-FIXTURE BUILDER (not a migration step).** Builds the "Orders Deep Dive" UDD — area, pivot, table-calcs, scatter, donut, text tile — the harder dashboard surface for the converter. |
 
@@ -507,6 +508,24 @@ key metrics, and per-tile.
 GREEN only when all three match. The validated run produced **exact** parity to the cent —
 region revenue (West 38906.82 / South 31650.98 / NE 21587.52 / MW 14966.20 / null 3231.23 =
 $109,765.89) and the ratio metrics (AOV / margin / return) identical across Looker and Sigma.
+
+### 4a. Visual QA — render the workbook to PNG and eyeball it
+
+Numbers tying out is necessary but not sufficient — a workbook can be GREEN on parity yet look
+broken (hidden KPI titles, orphaned filters, overlapping tiles, the wrong chart kind). After
+POSTing, render the dashboard page to a PNG and inspect it side-by-side against the source Looker
+dashboard:
+
+```bash
+bash -c 'eval "$(scripts/get-token.sh)" && python3 scripts/sigma-export-png.py \
+  --workbook <workbookId> --page page-dash --out /tmp/<name>/<dash>.png'
+```
+
+Confirm visually: **KPI tile titles show** (the builder lays KPIs ≥ 6 rows tall — a `kpi-chart`
+hides its title below ~5 rows / ~150px; see `feedback_sigma_kpi_label_height.md`), the **filters
+sit in a top control bar** (not orphaned at the bottom), tiles are aligned with no large empty
+regions, and each chart kind matches Looker. Iterate on `build_workbook.py` + re-`PUT` the spec
+until the render is clean.
 
 **Record the RLS outcome here.** If Phase 1d found RLS, the migration summary MUST list, per
 finding, whether it was **ported / reused / skipped** (and the Sigma user attribute + filter used)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -205,7 +205,7 @@ def main():
             elements.append({"id": eid, "kind": "text", "body": body})
             L = el["layout"]; c0 = L["col"] + 1; c1 = L["col"] + 1 + L["width"]
             r0 = L["row"] + 1; r1 = L["row"] + 1 + L["height"]
-            layout_items.append((eid, c0, c1, r0, r1))
+            layout_items.append((eid, c0, c1, r0, r1, "text"))
             continue
         kind = TILE_KIND.get(el["tileType"])
         if not kind:
@@ -329,7 +329,7 @@ def main():
         # newspaper -> 24-col grid
         L = el["layout"]; c0 = L["col"] + 1; c1 = L["col"] + 1 + L["width"]
         r0 = L["row"] + 1; r1 = L["row"] + 1 + L["height"]
-        layout_items.append((eid, c0, c1, r0, r1))
+        layout_items.append((eid, c0, c1, r0, r1, kind))
 
     # ── controls from dashboard filters ──
     controls = []
@@ -352,10 +352,67 @@ def main():
             warnings.append(f"filter '{flt['name']}': could not bind to a master column")
         controls.append(ctrl)
 
-    # ── layout XML (single top-level field; newspaper maps 1:1 to 24 cols) ──
+    # ── layout finalize: top control bar, tall titled KPIs, downshifted tiles ──
+    # The raw newspaper→grid math (above) honors Looker's pixel positions, but two
+    # Looker→Sigma quirks need fixing for a tidy, readable dashboard:
+    #   1. Sigma kpi-chart HIDES its title (the element name / measure label) when
+    #      the tile is shorter than ~5 grid rows / ~150px — Looker KPIs are usually
+    #      2-3 rows tall, so every title vanishes (bare floating numbers). Fix: lay
+    #      KPIs as a full-width strip of equal, TALL tiles (height >= 6).
+    #      See memory feedback_sigma_kpi_label_height.md.
+    #   2. Dashboard controls (filters) carry no layout, so they orphan at the
+    #      bottom-left. Looker shows filters at the TOP. Fix: a control row at row 0
+    #      and shift every tile DOWN by that row's height.
+    GRID = 24
+    CTRL_H = 3                 # control-bar height (grid rows)
+    KPI_H = 6                  # KPI tile height — >= 5 so the title renders
+
+    # (a) Top control bar: lay controls side-by-side across row 0, evenly. Each
+    #     control needs a layout entry so it docks at the top instead of orphaning.
+    ctrl_items = []
+    if controls:
+        n = len(controls)
+        cw = max(1, GRID // n)
+        x = 1
+        for i, c in enumerate(controls):
+            c1 = (x + cw) if i < n - 1 else (GRID + 1)   # last fills to the edge
+            ctrl_items.append((c["id"], x, c1, 1, 1 + CTRL_H, "control"))
+            x = c1
+    ctrl_h = CTRL_H if controls else 0
+
+    # (b) KPI strip: pull every KPI out of its Looker position and lay them as one
+    #     full-width row of equal, TALL tiles directly under the control bar — this
+    #     is the only reliable way to keep their titles visible.
+    kpi_ids = [e for (e, *_rest, k) in layout_items if k == "kpi-chart"]
+    other_items = [it for it in layout_items if it[5] != "kpi-chart"]
+    new_items = list(ctrl_items)
+    kpi_row0 = 1 + ctrl_h
+    if kpi_ids:
+        n = len(kpi_ids)
+        kw = max(1, GRID // n)
+        x = 1
+        for i, e in enumerate(kpi_ids):
+            c1 = (x + kw) if i < n - 1 else (GRID + 1)   # last fills to the edge
+            new_items.append((e, x, c1, kpi_row0, kpi_row0 + KPI_H, "kpi-chart"))
+            x = c1
+    kpi_h = KPI_H if kpi_ids else 0
+
+    # (c) Shift all remaining tiles DOWN below the control bar + KPI strip, by the
+    #     amount their original top-row sat above the first non-KPI tile (so we
+    #     close the gap the KPIs left and never overlap the bars). Preserve their
+    #     relative vertical order and columns from the newspaper math.
+    body_off = ctrl_h + kpi_h
+    top = min((r0 for (_e, _c0, _c1, r0, _r1, _k) in other_items), default=1)
+    for (e, c0, c1, r0, r1, k) in other_items:
+        h = r1 - r0
+        nr0 = (r0 - top) + 1 + body_off
+        new_items.append((e, c0, c1, nr0, nr0 + h, k))
+    layout_items = new_items
+
+    # ── layout XML (single top-level field; 24-col grid) ──
     page_id = "page-dash"
     les = "\n".join(f'  <LayoutElement elementId="{e}" gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}"/>'
-                    for (e, c0, c1, r0, r1) in layout_items)
+                    for (e, c0, c1, r0, r1, _k) in layout_items)
     layout_xml = ('<?xml version="1.0" encoding="utf-8"?>\n'
                   f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">\n'
                   f'{les}\n</Page>')

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/sigma-export-png.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/sigma-export-png.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""sigma-export-png.py — render a Sigma workbook page or element to PNG via the
+REST export API, for VISUAL QA of a migrated workbook (Phase 4: side-by-side
+against the source Looker dashboard).
+
+A PNG is more reliable than an MCP SQL query for catching LAYOUT/render problems —
+hidden KPI titles, orphaned filters, overlapping tiles, wrong chart kinds — that a
+numeric parity check can't see.
+
+POST /v2/workbooks/{id}/export {pageId|elementId, format:{type:"png",pixelWidth,pixelHeight}}
+  -> {queryId, jobComplete}; then GET /v2/query/{queryId}/download until the PNG is ready.
+
+Env: SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/get-token.sh)").
+Usage:
+  python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png
+  python3 sigma-export-png.py --workbook <id> --element <elId> --out /tmp/x.png [--w 1600 --h 900]
+"""
+import argparse, os, sys, time, requests
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook", required=True)
+    ap.add_argument("--page"); ap.add_argument("--element")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--w", type=int, default=1600); ap.add_argument("--h", type=int, default=900)
+    a = ap.parse_args()
+    base = os.environ["SIGMA_BASE_URL"]; tok = os.environ["SIGMA_API_TOKEN"]
+    h = {"Authorization": f"Bearer {tok}", "Content-Type": "application/json"}
+    fmt = {"type": "png", "pixelWidth": a.w, "pixelHeight": a.h}
+    body = {"format": fmt}
+    if a.element: body["elementId"] = a.element
+    elif a.page:  body["pageId"] = a.page
+    else: sys.exit("need --page or --element")
+    r = requests.post(f"{base}/v2/workbooks/{a.workbook}/export", headers=h, json=body)
+    if r.status_code != 200: sys.exit(f"export POST {r.status_code}: {r.text[:300]}")
+    qid = r.json()["queryId"]
+    dl = f"{base}/v2/query/{qid}/download"
+    for i in range(60):
+        g = requests.get(dl, headers={"Authorization": f"Bearer {tok}"})
+        ct = g.headers.get("Content-Type", "")
+        if g.status_code == 200 and ("image" in ct or g.content[:8] == b"\x89PNG\r\n\x1a\n"):
+            open(a.out, "wb").write(g.content)
+            print(f"[png] {len(g.content)} bytes -> {a.out}"); return
+        time.sleep(3)
+    sys.exit("timed out waiting for PNG")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Two improvements to the `looker-to-sigma` skill, verified live by re-migrating two Looker demo dashboards and rendering them to PNG.

### Task 1 — `build_workbook.py` layout quality
- **KPI titles now render.** A Sigma `kpi-chart` hides its title below ~5 grid rows / ~150px (see memory `feedback_sigma_kpi_label_height.md`). The builder previously laid KPIs at Looker's short native height, so migrated KPI tiles showed bare numbers with no measure label. Fix: lay all KPIs as a full-width strip of equal, **tall** tiles (height 6) directly under the control bar.
- **Filters are now a top control bar.** Dashboard controls carried no layout entry, so they orphaned at the bottom-left. Fix: dock them side-by-side across row 0, then shift every remaining tile down below the control bar + KPI strip (closing the gap the KPIs left) so the layout is tidy with no large empty regions.

### Task 2 — `scripts/sigma-export-png.py` (new)
Export a posted Sigma workbook page or element to PNG via `POST /v2/workbooks/{id}/export` → poll `GET /v2/query/{queryId}/download`, for Phase 4 visual QA / side-by-side against the source Looker dashboard. Mirrors the `powerbi-to-sigma` sibling's CLI + `$SIGMA_BASE_URL`/`$SIGMA_API_TOKEN` auth. Added to the SKILL.md Scripts table and a new "Phase 4a — Visual QA" section.

## Proof (live, tj-wells-1989 / CSA.TJ)
Re-fetched dashboards 8 (Orders Overview) and 9 (Orders Deep Dive), built a fresh DM + both workbooks with the fixed builder, POSTed them, and rendered each page with the new export script.

**Before:** KPI tiles = bare numbers (no "Net Revenue" label); filters stacked/orphaned at the bottom-left.

**After (confirmed visually in the exported PNGs):**
- Overview: top filter bar (Order Date / Region / Category), then 4 KPIs **with titles** (Net Revenue 110,342.75 / Orders 648 / Avg Order Value 170.28 / Units Ordered 1,473), then aligned trend / region / category / channel / top-products tiles — no gaps.
- Deep Dive: top filter bar, text tile, then aligned area / pivot-table / running-total / scatter / loyalty-pie tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)