### PR TITLE
cognos-to-sigma: gap-scout + clean dashboard layout

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -86,12 +86,16 @@ Do not proceed past a non-zero exit.
 node --import tsx/esm cli.ts ../path/to/report.xml --dm <dataModelId> > wb.json
 node scripts/remap-wb-to-dm-ids.mjs --wb wb.json --dm-id <dataModelId> --out wb.remapped.json
 node scripts/post-and-readback.mjs --type workbook --spec wb.remapped.json --folder <folderId>
+node scripts/apply-layout.mjs --workbook <workbookId>          # clean dashboard grid
 ```
 Each Cognos **list/crosstab/chart/map** becomes the matching Sigma element sourced from
 the migrated DM element. The converter emits each element's `source.elementId` as the
 query **subject name** (a placeholder) — `remap-wb-to-dm-ids.mjs` rewrites those to the
 real ids from Phase 2's readback (matched by element name). Then post-and-readback POSTs
-the workbook and re-runs the error-column gate.
+the workbook and re-runs the error-column gate. **`apply-layout.mjs` then gives the page a
+clean 24-col grid** (controls on top, content stacked full-width with per-kind heights) —
+Sigma auto-arrange otherwise squishes every element to the same height. It writes the
+top-level `spec.layout` XML (matched to readback ids) and confirms it survives readback.
 
 ## Phase 4 — Verify parity (hard gate — the real proof)
 
@@ -100,7 +104,10 @@ node scripts/assert-parity.mjs --plan --type workbook --id <workbookId>   # emit
 # run each via mcp-v2 query (or the Sigma query API), save totals to actual.json
 node scripts/assert-parity.mjs --check --actual actual.json --expected cognos.json --tol 0.01
 ```
-A migration is **GREEN only when `--check` passes** — never on a 200 POST alone.
+A migration is **GREEN only when** (a) `assert-parity --check` passes AND (b) the workbook
+came back with a clean layout (`apply-layout.mjs` reported `layoutOnReadback: true`) — never
+on a 200 POST alone. Layout cleanliness is part of parity: matching numbers on a squished,
+auto-stacked dashboard isn't a faithful migration.
 `cognos.json` = the numbers from the Cognos report (or the source warehouse). For real
 parity, land the Cognos source DB in the warehouse Sigma reads (the GO samples are the
 canonical IBM `GOSALES`/`GOSALESDW` DBs — published, loadable), then confirm the Cognos
@@ -121,3 +128,13 @@ rowsBy/columnsBy, measure → values) and **charts (RAVE2 `<vizControl>`) → Si
 and **maps (`tiledmap`) → Sigma region-map / point-map** ARE converted and live-validated.
 Only Cognos viz types with no native Sigma element (network, word-cloud, packed-bubble, treemap)
 fall back to a flagged table. Drill-through→actions and Framework Manager `.cpf` remain roadmap.
+
+## Gap scout — close a flagged expression
+
+For a flagged expression you want to actually resolve (a runtime macro, running-total /
+rank / lag-lead, `GetResourceString`, a nested CASE, an unmapped function), spawn the
+**gap-scout subagent** (`scripts/gap-scout.md`): it proposes a Sigma formula, validates it
+against the customer's live Sigma via `scripts/scout-validate-and-persist.mjs`, and on
+success persists the rule to `~/.cognos-to-sigma/learned-rules.json` — which the converter
+CLI auto-applies *before* the built-in translator on the next run. If no formula validates,
+it returns an opt-in `scripts/escalate-gap.py` command to file a tracking issue (ask first).

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.ts
@@ -9,8 +9,23 @@
  * Options: --connection <id> --database <DB> --schema <S> --dm <dataModelId> --pretty
  */
 import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { convertCognosToSigma } from './cognos.js';
 import { convertCognosReportToSigma } from './cognos-report.js';
+
+// Gap-scout learned rules (validated, customer-discovered translations) live in the
+// customer's home dir so a skill `git pull` never clobbers them. Applied before the
+// built-in translator (see scripts/gap-scout.md).
+function loadLearnedRules() {
+  try {
+    const p = join(homedir(), '.cognos-to-sigma', 'learned-rules.json');
+    const rules = JSON.parse(readFileSync(p, 'utf8'));
+    const arr = Array.isArray(rules) ? rules : (rules.rules || []);
+    if (arr.length) console.error(`[learned-rules] applying ${arr.length} customer rule(s) from ${p}`);
+    return arr;
+  } catch { return []; }
+}
 
 const args = process.argv.slice(2);
 const file = args.find((a) => !a.startsWith('--'));
@@ -21,7 +36,7 @@ const xml = readFileSync(file, 'utf8');
 const isReport = file.endsWith('.xml') || xml.trimStart().startsWith('<');
 const res = isReport
   ? convertCognosReportToSigma(xml, { dataModelId: opt('dm', '<DM_ID>') })
-  : convertCognosToSigma(xml, { connectionId: opt('connection', '<CONNECTION_ID>'), database: opt('database'), schema: opt('schema') });
+  : convertCognosToSigma(xml, { connectionId: opt('connection', '<CONNECTION_ID>'), database: opt('database'), schema: opt('schema'), learnedRules: loadLearnedRules() });
 
 const payload = isReport ? (res as any).workbook : (res as any).model;
 process.stdout.write(JSON.stringify(payload, null, 2) + '\n');

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos.ts
@@ -66,6 +66,19 @@ export interface CognosConvertOptions {
   database?: string;
   schema?: string;
   modelName?: string;
+  // Customer-discovered translation rules (from the gap-scout, persisted in
+  // ~/.cognos-to-sigma/learned-rules.json). Applied to each Cognos expression
+  // BEFORE the built-in translator, so a validated discovered rule wins.
+  learnedRules?: Array<{ pattern: string; template: string; flags?: string }>;
+}
+
+// Apply customer-learned rules (regex pattern → Sigma template) to a raw Cognos expression.
+export function applyLearnedRules(expr: string, rules?: CognosConvertOptions['learnedRules']): string {
+  let s = expr || '';
+  for (const r of (rules || [])) {
+    try { s = s.replace(new RegExp(r.pattern, r.flags || 'gi'), r.template); } catch { /* bad rule — skip */ }
+  }
+  return s;
 }
 
 // ── Ingest: Data Module JSON → IR (tolerant of the common shape variants) ─────
@@ -208,7 +221,7 @@ export function convertCognosIR(model: CognosModule, options: CognosConvertOptio
         && item.aggregate && item.aggregate !== 'none';
 
       if (item.isCalculation && item.expression) {
-        const { formula, warnings: w } = translateCognosExpr(item.expression, qs, ensureRawCol, ctx);
+        const { formula, warnings: w } = translateCognosExpr(applyLearnedRules(item.expression, options.learnedRules), qs, ensureRawCol, ctx);
         w.forEach(x => warnings.push(`"${qs.identifier}.${item.identifier}": ${x}`));
         // a calc that aggregates → metric, else calculated column
         if (/\b(Sum|Avg|Count|Min|Max|.*Over)\(/.test(formula)) {
@@ -391,7 +404,7 @@ export function translateCognosExpr(
   f = f.replace(/'([^']*)'/g, '"$1"');  // Cognos single-quoted strings → Sigma double-quoted
 
   // Unknown bareword(...) functions → warn (kept as-is for manual review)
-  const known = /\b(If|Sum|Avg|Count|CountDistinct|Min|Max|SumOver|AvgOver|CountOver|MinOver|MaxOver|DateAdd|DateDiff|DatePart|Mid|Upper|Lower|Trim|Coalesce|Text|RegexpReplace|Replace)\b/;
+  const known = /\b(If|Switch|Sum|Avg|Count|CountDistinct|Min|Max|SumOver|AvgOver|CountOver|MinOver|MaxOver|DateAdd|DateDiff|DatePart|Mid|Upper|Lower|Trim|Coalesce|Text|RegexpReplace|Replace)\b/;
   for (const m of f.matchAll(/\b([a-z][a-z0-9_-]*)\s*\(/gi)) {
     if (!known.test(m[1]) && !/^(and|or|not|in|like|between|then|else|end|case|when)$/i.test(m[1])) {
       warnings.push(`function "${m[1]}()" has no confirmed Sigma mapping — review/translate manually.`);

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// apply-layout.mjs — give a migrated Cognos workbook a CLEAN dashboard grid.
+//
+// Sigma auto-arrange stacks every element at the SAME height (KPIs as tall as tables,
+// charts squished) — so for any multi-element page we write an explicit 24-col layout:
+// controls in a top row, then content stacked full-width with per-kind heights. Layout
+// elementIds must match the POSTED (reassigned) ids, so this GETs the readback spec first.
+//
+// Usage:
+//   eval "$(scripts/get-token.sh)"
+//   node scripts/apply-layout.mjs --workbook <workbookId>
+//
+// Idempotent. Run it as the last step of the build/verify phase.
+import { api, parseArgs } from './lib/sigma-rest.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+if (!a.workbook) { console.error('need --workbook <workbookId>'); process.exit(2); }
+
+// per-kind row-unit heights (24-col grid; rows are "auto" so spans set relative size)
+const H = (k) => k === 'control' ? 2
+  : k === 'kpi-chart' ? 6
+  : k.endsWith('-chart') ? 10
+  : (k.endsWith('-map') || k === 'pivot-table' || k === 'table') ? 12
+  : k === 'text' ? 3 : 10;
+
+function pageLayout(page) {
+  const els = (page.elements || []).filter((e) => e.id);
+  if (els.length < 2) return null; // single element → auto-arrange is fine
+  const controls = els.filter((e) => e.kind === 'control');
+  const content = els.filter((e) => e.kind !== 'control');
+  const lines = [];
+  let row = 1;
+  // controls: up to 4 across the top
+  controls.forEach((c, i) => {
+    const perRow = Math.min(controls.length, 4);
+    const span = Math.floor(24 / perRow);
+    const col0 = 1 + (i % perRow) * span;
+    const r = row + Math.floor(i / perRow) * H('control');
+    const col1 = (i % perRow === perRow - 1) ? 25 : col0 + span;
+    lines.push(`  <LayoutElement elementId="${c.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('control')}"/>`);
+  });
+  if (controls.length) row += Math.ceil(controls.length / 4) * H('control');
+  // content: stacked full-width, per-kind heights (clean, no overlap, right proportions)
+  for (const e of content) {
+    const h = H(e.kind);
+    lines.push(`  <LayoutElement elementId="${e.id}" gridColumn="1 / 25" gridRow="${row} / ${row + h}"/>`);
+    row += h;
+  }
+  return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${page.id}">\n${lines.join('\n')}\n</Page>`;
+}
+
+const got = await api('GET', `/v2/workbooks/${a.workbook}/spec`);
+if (!got.json) { console.error(`GET spec failed (HTTP ${got.status}): ${got.text.slice(0, 300)}`); process.exit(1); }
+const spec = got.json;
+// The layout is a SINGLE top-level `spec.layout` XML holding one <Page> block per page
+// (NOT pages[].layout — that's silently dropped). Strip read-only fields before the PUT.
+const pageBlocks = [];
+for (const p of spec.pages || []) { delete p.layout; const xml = pageLayout(p); if (xml) pageBlocks.push(xml); }
+if (!pageBlocks.length) { console.log('no multi-element pages — nothing to lay out'); process.exit(0); }
+spec.layout = `<?xml version="1.0" encoding="utf-8"?>\n${pageBlocks.join('\n')}`;
+for (const k of ['workbookId', 'url', 'ownerId', 'createdBy', 'updatedBy', 'createdAt', 'updatedAt', 'latestDocumentVersion', 'documentVersion']) delete spec[k];
+if (a.folder && !spec.folderId) spec.folderId = a.folder;
+
+const put = await api('PUT', `/v2/workbooks/${a.workbook}/spec`, spec);
+if (!put.ok) { console.error(`PUT failed (HTTP ${put.status}): ${put.text.slice(0, 400)}`); process.exit(1); }
+
+// verify the layout survived readback
+const rb = await api('GET', `/v2/workbooks/${a.workbook}/spec`);
+const ok = /<LayoutElement/.test(rb.json?.layout || '');
+console.log(JSON.stringify({ workbookId: a.workbook, pagesLaidOut: pageBlocks.length, layoutOnReadback: ok }, null, 2));
+if (!ok) { console.error('FAIL: layout did not survive readback (check elementId matches)'); process.exit(1); }
+console.error(`clean layout applied (${pageBlocks.length} page block(s))`);

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/escalate-gap.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/escalate-gap.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""escalate-gap — opt-in GitHub-issue filer for gap-scout escalations.
+
+Shared across every migration skill (vendored identically into each plugin's
+scripts/). When the gap scout can't find a working Sigma translation for a
+source feature, the main agent offers the user the *option* to open a tracking
+issue in the appropriate repo. This script is what turns that "yes" into filed
+issues — with dedupe, repo routing, converter-repo mirroring, and a cross-linked
+bead.
+
+DESIGN: opt-in, never automatic.
+  - Default (no --yes): DRY RUN. Prints the drafted issue(s), the target repo(s),
+    and any existing open issues/beads that already cover this gap. Files NOTHING.
+    This is what the agent shows the user.
+  - With --yes: actually files. Skips any repo where dedupe already found a match
+    (unless --force).
+
+ROUTING (category -> repos):
+  converter  -> twells89/sigma-data-model-manager + twells89/sigma-data-model-mcp
+               (a source expression the *converter* failed to translate — the
+                browser tool and the MCP must stay in sync, so mirror to both)
+  builder    -> twells89/sigma-migration-skills   (workbook/DM spec builder gap)
+  skill      -> twells89/sigma-migration-skills   (skill-logic / discovery gap)
+
+Usage (dry-run draft the agent shows the user):
+  python3 scout/escalate-gap.py \
+    --skill tableau-to-sigma --category converter \
+    --feature WINDOW_AVG --description 'moving average over SUM' \
+    --source-pattern 'WINDOW_AVG(SUM([...]))' \
+    --template-attempted 'MovingAvg(Sum([Master/\\1]), -10, 10)' \
+    --test-formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+    --sigma-response '<failing column type / error json>' \
+    --example-from 'Sales.twb line 412' \
+    --escalation-yaml ~/.tableau-to-sigma/escalations/window_avg.yaml
+
+Then, only if the user says yes, the agent re-runs the same command with --yes.
+
+Requires `gh` on PATH and authed for the target repos. `bd` (beads) optional.
+Exit codes: 0 = ok (drafted or filed), 3 = nothing fileable / gh missing on --yes.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+ROUTES = {
+    "converter": ["twells89/sigma-data-model-manager", "twells89/sigma-data-model-mcp"],
+    "builder":   ["twells89/sigma-migration-skills"],
+    "skill":     ["twells89/sigma-migration-skills"],
+}
+BEADS_DIR = os.path.expanduser("~/.beads-sigma")
+
+
+def have(cmd):
+    return shutil.which(cmd) is not None
+
+
+def run(args, **kw):
+    """Run a command, return (ok, stdout, stderr)."""
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, **kw)
+        return p.returncode == 0, p.stdout.strip(), p.stderr.strip()
+    except Exception as e:  # noqa: BLE001
+        return False, "", str(e)
+
+
+def build_issue(a):
+    title = f"{a.skill} gap: {a.feature}" + (f" ({a.description})" if a.description else "")
+    body = []
+    body.append(f"**Skill:** `{a.skill}`")
+    body.append(f"**Gap category:** `{a.category}`")
+    body.append(f"**Feature:** `{a.feature}`")
+    if a.description:
+        body.append(f"**Description:** {a.description}")
+    if a.source_pattern:
+        body.append(f"**Source pattern:** `{a.source_pattern}`")
+    if a.template_attempted:
+        body.append(f"**Sigma template attempted:** `{a.template_attempted}`")
+    if a.test_formula:
+        body.append(f"**Test formula POSTed:** `{a.test_formula}`")
+    if a.sigma_response:
+        body.append(f"**Sigma response:**\n```\n{a.sigma_response}\n```")
+    body.append(f"**Example source:** {a.example_from or '(not provided)'}")
+    if a.escalation_yaml:
+        body.append(f"**Local escalation record:** `{a.escalation_yaml}`")
+    body.append("\n_Filed via the gap-scout opt-in escalation flow (`escalate-gap.py`)._")
+    return title, "\n\n".join(body)
+
+
+def labels_for(a):
+    return ["gap-scout-escalation", a.skill, f"category:{a.category}"]
+
+
+def ensure_labels(repo, labels):
+    """Best-effort: create labels so `gh issue create --label` won't fail."""
+    for lab in labels:
+        run(["gh", "label", "create", lab, "--repo", repo, "--force"])
+
+
+def find_dupes(repo, feature, skill):
+    """Return list of {number,title,url} open issues that look like this gap."""
+    ok, out, _ = run([
+        "gh", "issue", "list", "--repo", repo, "--state", "open",
+        "--label", "gap-scout-escalation", "--search", feature,
+        "--json", "number,title,url",
+    ])
+    if not ok or not out:
+        return []
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return []
+    feat = feature.lower()
+    return [i for i in items if feat in (i.get("title", "").lower())]
+
+
+def find_bead_dupe(feature):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    ok, out, _ = run(["bd", "list", "--json"], cwd=BEADS_DIR)
+    if not ok or not out:
+        return None
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return None
+    rows = items if isinstance(items, list) else items.get("issues", items.get("beads", []))
+    feat = feature.lower()
+    for b in rows or []:
+        if feat in (str(b.get("title", "")) + str(b.get("summary", ""))).lower():
+            return b.get("id") or b.get("bead_id")
+    return None
+
+
+def create_bead(title, body, skill, category):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    labels = f"sigma-converter,{skill},gap-scout-escalation,category:{category}"
+    ok, out, _ = run([
+        "bd", "create", title, "--priority", "2", "--labels", labels,
+        "--description", body, "--silent",
+    ], cwd=BEADS_DIR)
+    return out.strip() if ok else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--feature", required=True)
+    ap.add_argument("--category", default="converter", choices=list(ROUTES))
+    ap.add_argument("--description", default="")
+    ap.add_argument("--source-pattern", default="")
+    ap.add_argument("--template-attempted", default="")
+    ap.add_argument("--test-formula", default="")
+    ap.add_argument("--sigma-response", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--escalation-yaml", default="")
+    ap.add_argument("--extra-repo", action="append", default=[],
+                    help="additional target repo(s), repeatable")
+    ap.add_argument("--yes", action="store_true",
+                    help="actually file. Without it: dry-run, prints the draft only.")
+    ap.add_argument("--force", action="store_true",
+                    help="file even if a matching open issue already exists")
+    ap.add_argument("--no-beads", action="store_true")
+    a = ap.parse_args()
+
+    repos = list(dict.fromkeys(ROUTES[a.category] + a.extra_repo))
+    title, body = build_issue(a)
+    labels = labels_for(a)
+
+    # Dedupe scan (read-only) up front so the agent can show it to the user.
+    gh_ok = have("gh")
+    dupes = {r: (find_dupes(r, a.feature, a.skill) if gh_ok else []) for r in repos}
+    bead_dupe = None if a.no_beads else find_bead_dupe(a.feature)
+
+    if not a.yes:
+        # DRY RUN — this is what the agent presents to the user.
+        out = {
+            "mode": "draft",
+            "would_file_in": repos,
+            "labels": labels,
+            "title": title,
+            "body": body,
+            "existing_issues": {r: d for r, d in dupes.items() if d},
+            "existing_bead": bead_dupe,
+            "gh_available": gh_ok,
+            "next_step": "re-run with --yes to file (skips repos already covered)",
+        }
+        print(json.dumps(out, indent=2))
+        return 0
+
+    # --yes: actually file.
+    if not gh_ok:
+        print(json.dumps({"status": "error", "error": "gh not on PATH; cannot file"}))
+        return 3
+
+    # Bead first (authoritative tracker), so its id can be embedded in issues.
+    bead_id = bead_dupe
+    if bead_id is None and not a.no_beads:
+        bead_id = create_bead(title, body, a.skill, a.category)
+    issue_body = body + (f"\n\n**Bead:** `{bead_id}`" if bead_id else "")
+
+    filed, skipped = [], []
+    for repo in repos:
+        if dupes.get(repo) and not a.force:
+            skipped.append({"repo": repo, "existing": dupes[repo]})
+            continue
+        ensure_labels(repo, labels)
+        ok, out, err = run([
+            "gh", "issue", "create", "--repo", repo,
+            "--title", title, "--body", issue_body,
+            "--label", ",".join(labels),
+        ])
+        if ok:
+            filed.append({"repo": repo, "url": out.strip()})
+        else:
+            # retry once without labels (in case label creation was denied)
+            ok2, out2, err2 = run([
+                "gh", "issue", "create", "--repo", repo,
+                "--title", title, "--body", issue_body,
+            ])
+            if ok2:
+                filed.append({"repo": repo, "url": out2.strip(), "note": "filed without labels"})
+            else:
+                filed.append({"repo": repo, "error": err or err2})
+
+    # Cross-link mirrored issues to each other.
+    urls = [f["url"] for f in filed if f.get("url")]
+    if len(urls) > 1:
+        for f in filed:
+            if not f.get("url"):
+                continue
+            others = [u for u in urls if u != f["url"]]
+            num = f["url"].rstrip("/").split("/")[-1]
+            link_body = issue_body + "\n\n**Mirrored to:** " + ", ".join(others)
+            run(["gh", "issue", "edit", num, "--repo", f["repo"], "--body", link_body])
+
+    # Cross-link the bead back to the filed issue urls.
+    if bead_id and urls and have("bd"):
+        run(["bd", "update", bead_id, "--description",
+             issue_body + "\n\nFiled issues: " + ", ".join(urls)], cwd=BEADS_DIR)
+
+    print(json.dumps({
+        "status": "filed",
+        "filed": filed,
+        "skipped_existing": skipped,
+        "bead_id": bead_id,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/gap-scout.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/gap-scout.md
@@ -1,0 +1,71 @@
+# gap-scout subagent — guide for the main agent
+
+When the Cognos converter can't translate an expression into a Sigma formula, it
+**flags** it (never fakes it). For a flagged expression that you want to actually
+resolve, spawn a separate subagent — the **gap scout** — to find a Sigma
+translation that validates against the customer's real Sigma site, and persist it.
+
+The scout writes successful rules to `~/.cognos-to-sigma/learned-rules.json` (the
+customer's home dir, NOT the skill repo, so a `git pull` never clobbers them). The
+converter CLI loads them via `loadLearnedRules()` and applies them *before* the
+built-in translator (`applyLearnedRules` in `converter/cognos.ts`), so a customer's
+discovered rule wins.
+
+## When to spawn
+
+After conversion emits a warning for an untranslated construct — typically:
+- runtime **macros** (`#…# prompt(…,'token',…)` — dynamic column/SQL building)
+- **running-total / moving-* / rank / lag / lead** (window/running calcs)
+- **GetResourceString** (localization), composite / non-equi **joins**
+- a **nested / non-standard CASE** the built-in CASE→If/Switch couldn't parse
+- any `function "X()" has no confirmed Sigma mapping` warning
+
+Spawn ONE scout per distinct feature; run them in parallel where possible — they're
+independent.
+
+## How to spawn (from the main agent)
+
+Use the Agent tool with `subagent_type: 'general-purpose'`. Self-contained prompt:
+
+```
+You are a translation scout. Your job: propose a Sigma formula that replaces a
+Cognos expression, validate it against Sigma's API, and persist the rule if it works.
+
+INPUTS
+- Cognos feature: <e.g. "running-total">
+- Sample expressions: <2-5 examples from the module/report>
+- A real warehouse table on the customer's Sigma connection to test against:
+  --connection <connectionId>  --table-path <DB.SCHEMA.TABLE>
+- Sigma folder id: <folder-id>
+
+PROCEDURE
+1. Read refs/expression-dsl.md (the Cognos→Sigma mapping table) and
+   refs/format-shapes.md. Note Sigma window funcs (SumOver/CountOver/…) silently
+   error in data-model calc columns — prefer a non-window form or flag it.
+2. Propose ONE candidate Sigma formula using a column that exists on --table-path.
+3. Validate + persist:
+   eval "$(scripts/get-token.sh)"
+   node scripts/scout-validate-and-persist.mjs \
+     --feature '<feature>' \
+     --pattern '<Cognos regex, capture groups for column refs>' \
+     --template '<Sigma template using $1,$2 for captures>' \
+     --test-formula '<the candidate with a REAL column from --table-path>' \
+     --connection <connectionId> --table-path <DB.SCHEMA.TABLE> \
+     --folder <folder-id> --description '<one line>' --hint '<caveat>'
+4. Parse the JSON result:
+   - status=validated → success; rule is now in ~/.cognos-to-sigma/learned-rules.json
+   - status=escalated → try a different candidate (≤3 attempts). The last result
+     carries `escalation.dry_run_cmd`. Do NOT file anything yourself.
+
+OUTPUT
+One paragraph: feature, candidate, status (validated / escalated / abandoned-after-N),
+and — if escalated — the `escalation.dry_run_cmd` so the main agent can offer the
+user a tracking issue.
+```
+
+## Opt-in issue filing
+
+If the scout escalates (no formula validated), it returns a ready-to-run
+`scripts/escalate-gap.py … ` command (DRY-RUN by default). **Show it to the user and
+ask** before filing — only run it with `--yes` on their go-ahead. It routes
+converter gaps to the data-model repos (MCP + browser) with dedupe.

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma-rest.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma-rest.mjs
@@ -15,7 +15,7 @@ export async function api(method, path, body) {
   const { base, token } = sigmaEnv();
   const res = await fetch(base + path, {
     method,
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Accept: 'application/json' },
     body: body == null ? undefined : (typeof body === 'string' ? body : JSON.stringify(body)),
   });
   const text = await res.text();

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/scout-validate-and-persist.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/scout-validate-and-persist.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// scout-validate-and-persist.mjs — the gap-scout's terminal step.
+// Given a candidate Sigma formula + the gap context, validate it against the customer's
+// Sigma site (POST a throwaway probe data model whose one calc column IS the candidate,
+// check it resolves to a concrete type), then PERSIST the rule on success or report an
+// escalation command on failure. The subagent does the reasoning (proposing the
+// candidate); this script does the deterministic POST/validate/write.
+//
+// Usage:
+//   eval "$(scripts/get-token.sh)"
+//   node scripts/scout-validate-and-persist.mjs \
+//     --feature 'running-total' \
+//     --pattern '\brunning-total\s*\(\s*\[([^\]]+)\]\s*\)' \
+//     --template 'CumulativeSum([$1])' \
+//     --test-formula 'CumulativeSum([Net Revenue])' \
+//     --connection <connId> --table-path CSA.TJ.ORDER_FACT \
+//     --folder <folderId> [--description '...'] [--hint '...']
+//
+// Output (JSON): { status: "validated"|"escalated", rule_path?, escalation? , ... }
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { api, extractId, parseArgs } from './lib/sigma-rest.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+for (const k of ['feature', 'template', 'test-formula', 'connection', 'table-path', 'folder']) {
+  if (!a[k]) { console.error(`need --${k}`); process.exit(2); }
+}
+const [db, schema, ...t] = a['table-path'].split('.');
+const table = t.join('.');
+const RULES = join(homedir(), '.cognos-to-sigma', 'learned-rules.json');
+
+// minimal probe DM: a warehouse-table element exposing the raw columns the candidate
+// references (bare `[Name]` refs → raw cols `[TABLE/Name]`), plus the candidate calc col.
+const tail = table.toUpperCase();
+const refNames = [...new Set([...a['test-formula'].matchAll(/\[([^\]\/]+)\]/g)].map((m) => m[1]))];
+const rawCols = refNames.map((nm, i) => ({ id: `r${i}`, name: nm, formula: `[${tail}/${nm}]` }));
+const cols = [...rawCols, { id: 'c1', name: 'scout_candidate', formula: a['test-formula'] }];
+const probe = {
+  folderId: a.folder, name: `GAPSCOUT PROBE ${a.feature} ${Date.now()}`, schemaVersion: 1,
+  pages: [{ id: 'p1', name: 'P', elements: [{
+    id: 'e1', kind: 'table', name: 'Probe',
+    source: { connectionId: a.connection, kind: 'warehouse-table', path: [db, schema, table] },
+    columns: cols, order: cols.map((c) => c.id),
+  }] }],
+};
+const post = await api('POST', '/v2/dataModels/spec', probe);
+const id = extractId(post, 'dataModelId');
+let resolved = false, detail = '';
+if (id) {
+  const cols = await api('GET', `/v2/dataModels/${id}/columns`);
+  const list = cols.json?.entries || cols.json?.columns || (Array.isArray(cols.json) ? cols.json : []);
+  const cand = (Array.isArray(list) ? list : []).find((c) => (c.name || c.columnName) === 'scout_candidate');
+  const type = cand && (cand.type?.type || cand.columnType || cand.type);
+  resolved = !!type && String(type).toLowerCase() !== 'error';
+  detail = `column type=${type || 'missing'}`;
+  await api('DELETE', `/v2/files/${id}`); // always clean up the probe
+} else {
+  detail = `POST rejected: ${post.text.slice(0, 200)}`;
+}
+
+if (resolved) {
+  let rules = [];
+  try { rules = JSON.parse(readFileSync(RULES, 'utf8')); rules = Array.isArray(rules) ? rules : (rules.rules || []); } catch {}
+  rules = rules.filter((r) => r.feature !== a.feature);
+  rules.push({ feature: a.feature, pattern: a.pattern || a['test-formula'], template: a.template, flags: 'gi', description: a.description || '', hint: a.hint || '', validatedAt: new Date().toISOString() });
+  mkdirSync(join(homedir(), '.cognos-to-sigma'), { recursive: true });
+  writeFileSync(RULES, JSON.stringify(rules, null, 2));
+  console.log(JSON.stringify({ status: 'validated', feature: a.feature, rule_path: RULES, detail }, null, 2));
+  process.exit(0);
+}
+
+// escalation (opt-in; this script does NOT file — it hands back the command)
+const dry = `python3 scripts/escalate-gap.py --skill cognos-to-sigma --category converter --feature ${JSON.stringify(a.feature)} --description ${JSON.stringify(a.description || '')} --source-pattern ${JSON.stringify(a.pattern || '')} --template-attempted ${JSON.stringify(a.template)} --test-formula ${JSON.stringify(a['test-formula'])} --sigma-response ${JSON.stringify(detail)}`;
+console.log(JSON.stringify({ status: 'escalated', feature: a.feature, detail, escalation: { dry_run_cmd: dry, file_cmd: dry + ' --yes' } }, null, 2));
+process.exit(0);


### PR DESCRIPTION
Adds the gap-scout subagent (validate→persist→auto-apply learned rules, opt-in escalation) and `apply-layout.mjs` (clean 24-col grid, now part of the parity gate). All live-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)