### PR TITLE
looker-to-sigma: Looker source render + number-format carry-through + gap scout

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -57,9 +57,14 @@ offline-only path that normalizes into the same contract.
 | `scripts/convert_dm.mjs` | **Phase 2:** run `convertLookMLToSigma` against a directory of `.lkml` files for one explore → a Sigma DM spec JSON. Bypasses the deployed MCP build (see the converter-build gotcha below). Env: `LOOKML_DIR`, `CONVERTER_SRC`; args `<exploreName> <out.json>`. |
 | `scripts/post_dm.py` | **Phase 2:** POST a DM spec to `/v2/dataModels/spec` (auto-finds a writable folder, swaps in the full connection UUID). Env: `SIGMA_API_TOKEN`, `SIGMA_BASE_URL`, `SIGMA_CONNECTION_ID`; args `<spec.json>`. |
 | `scripts/build_workbook.py` | **Phase 3:** dashboard contract + the explore's view `.lkml` files → a Sigma `/v2/workbooks/spec` body (hidden Data page + master table, one element per tile, controls from filters, newspaper→24-col layout XML). Generates locally; does **not** POST. Handles ratio measures, joined-col `Field (alias)` naming, table calcs, pivot-flatten + warn. Layout: a top control bar (row 0), a full-width strip of **tall** KPI tiles (height ≥ 6 so titles render), then the remaining tiles shifted down. |
-| `scripts/sigma-export-png.py` | **Phase 4 (visual QA):** render a posted workbook page or element to PNG via `POST /v2/workbooks/{id}/export` → poll `GET /v2/query/{queryId}/download`. For side-by-side layout/render checks against the source Looker dashboard (catches hidden KPI titles, orphaned filters, overlaps that a numeric parity check can't). Reads `$SIGMA_BASE_URL`/`$SIGMA_API_TOKEN`. `python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png` (or `--element <id>`). |
+| `scripts/looker-render-dashboard.py` | **Phase 4 (visual QA — SOURCE side):** render a LIVE Looker dashboard to PNG via the Looker render API (`POST /render_tasks/dashboards/{id}/png` → poll `GET /render_tasks/{task_id}` until `success` → `GET .../results`). Pairs with `sigma-export-png.py` for source-vs-migrated side-by-side. Reuses `looker_api.py` `~/.looker/looker.ini` auth. `python3 looker-render-dashboard.py <dashboard_id> [out.png] [--w 1200 --h 1600]`. |
+| `scripts/sigma-export-png.py` | **Phase 4 (visual QA — MIGRATED side):** render a posted workbook page or element to PNG via `POST /v2/workbooks/{id}/export` → poll `GET /v2/query/{queryId}/download`. For side-by-side layout/render checks against the source Looker dashboard render (catches hidden KPI titles, orphaned filters, overlaps, bare-number vs `$`/`%` formats that a numeric parity check can't). Reads `$SIGMA_BASE_URL`/`$SIGMA_API_TOKEN`. `python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png` (or `--element <id>`). |
 | `scripts/build_looker_dashboard.py` | **TEST-FIXTURE BUILDER (not a migration step).** Builds the "Orders Overview" UDD on `csa_thelook` via the Looker API (4 KPIs + line/column/bar/pie + grid, 3 filters wired via `result_maker.filterables.listen`). |
 | `scripts/build_looker_dashboard2.py` | **TEST-FIXTURE BUILDER (not a migration step).** Builds the "Orders Deep Dive" UDD — area, pivot, table-calcs, scatter, donut, text tile — the harder dashboard surface for the converter. |
+| `scripts/gap-scout.md` | **Gap scout (converter gaps):** runbook for the main agent — when/how to spawn a scout subagent for a LookML construct the converter can't translate, the LookML→Sigma candidate table, and the opt-in issue-filing flow. Read before spawning. |
+| `scripts/scout-validate.py` | **Gap scout:** validate a candidate Sigma formula against a real DM element (throwaway test workbook → check column type ≠ `error` → delete), persist a win to `~/.looker-to-sigma/learned-rules.yaml`, or return an opt-in `escalation` block on failure. Also a quick "does this formula resolve?" check for Phase-4 validation. Reads `$SIGMA_BASE_URL`/`$SIGMA_API_TOKEN`. |
+| `scripts/learned-rules.py` | **Gap scout:** loader for the customer-local `learned-rules.yaml` (`load()`/`apply()`); applied to LookML measure expressions before the converter/WARN fallback. Home = `~/.looker-to-sigma` (override `LOOKER_TO_SIGMA_HOME`). |
+| `scripts/escalate-gap.py` | **Gap scout (shared, identical across all migration skills):** opt-in GitHub-issue filer — category→repo routing, dedupe (open issues + beads), converter-repo mirroring, bead cross-link. **Dry-run by default; files only with `--yes`.** Requires `gh`. |
 
 > **Test-fixture builders vs migration scripts.** `build_looker_dashboard.py` /
 > `build_looker_dashboard2.py` **author** Looker dashboards (migration *targets*); they are
@@ -483,6 +488,15 @@ Newspaper layout math (a single arithmetic transform, no spatial heuristic):
   these; `dynamic_fields` arrives JSON-parsed from discovery.)
 - **count on a joined view** → `CountDistinct` using that view's primary key (base-view counts
   stay `Count()`).
+- **Number formats carry through.** A LookML measure's `value_format_name` (`usd`, `usd_0`,
+  `percent_0/1/2`, `decimal_0/1/2`, …) or custom `value_format` mask becomes the Sigma column
+  `format` object — `{kind: "number", formatString: "<d3-format>"}` — on the tile's value /
+  KPI-value / chart-measure / measure-table column. So a `usd` measure renders `$110,342.75`
+  (not bare `110,342.75`) and a `percent_1` measure renders `12.3%`. `build_workbook.py`'s
+  `build_field_index` captures each measure's format and `apply_fmt` attaches it; custom masks are
+  best-effort (currency symbol / thousands separator / decimals / percent). Counts and dimensions
+  get no format (raw). Without this the side-by-side render (Phase 4a) shows bare numbers where
+  Looker showed `$`/`%`.
 
 ### 3c. POST the workbook + verify
 
@@ -509,23 +523,29 @@ GREEN only when all three match. The validated run produced **exact** parity to 
 region revenue (West 38906.82 / South 31650.98 / NE 21587.52 / MW 14966.20 / null 3231.23 =
 $109,765.89) and the ratio metrics (AOV / margin / return) identical across Looker and Sigma.
 
-### 4a. Visual QA — render the workbook to PNG and eyeball it
+### 4a. Visual QA — render BOTH dashboards to PNG and eyeball them side-by-side
 
 Numbers tying out is necessary but not sufficient — a workbook can be GREEN on parity yet look
-broken (hidden KPI titles, orphaned filters, overlapping tiles, the wrong chart kind). After
-POSTing, render the dashboard page to a PNG and inspect it side-by-side against the source Looker
-dashboard:
+broken (hidden KPI titles, orphaned filters, overlapping tiles, the wrong chart kind, bare numbers
+where Looker showed `$`/`%`). After POSTing, render **both** the Looker source dashboard and the
+migrated Sigma workbook to PNG and inspect them side-by-side:
 
 ```bash
+# (1) SOURCE — render the live Looker dashboard (reads ~/.looker/looker.ini)
+python3 scripts/looker-render-dashboard.py <dashboardId> /tmp/<name>/looker-<dash>.png
+
+# (2) MIGRATED — render the Sigma workbook page
 bash -c 'eval "$(scripts/get-token.sh)" && python3 scripts/sigma-export-png.py \
-  --workbook <workbookId> --page page-dash --out /tmp/<name>/<dash>.png'
+  --workbook <workbookId> --page page-dash --out /tmp/<name>/sigma-<dash>.png'
 ```
 
-Confirm visually: **KPI tile titles show** (the builder lays KPIs ≥ 6 rows tall — a `kpi-chart`
-hides its title below ~5 rows / ~150px; see `feedback_sigma_kpi_label_height.md`), the **filters
-sit in a top control bar** (not orphaned at the bottom), tiles are aligned with no large empty
-regions, and each chart kind matches Looker. Iterate on `build_workbook.py` + re-`PUT` the spec
-until the render is clean.
+Read both PNGs and compare tile-for-tile. Confirm: **KPI tile titles show** (the builder lays KPIs
+≥ 6 rows tall — a `kpi-chart` hides its title below ~5 rows / ~150px; see
+`feedback_sigma_kpi_label_height.md`), the **filters sit in a top control bar** (not orphaned at
+the bottom), tiles are aligned with no large empty regions, each chart kind matches Looker, and
+**number formats match** — if Looker shows `$176.85` the Sigma KPI must too (the builder carries
+LookML `value_format_name` / `value_format` into the tile column `format`; see Phase 3). Iterate on
+`build_workbook.py` + re-`PUT` the spec until the side-by-side render is clean.
 
 **Record the RLS outcome here.** If Phase 1d found RLS, the migration summary MUST list, per
 finding, whether it was **ported / reused / skipped** (and the Sigma user attribute + filter used)
@@ -553,6 +573,29 @@ Set expectations up front (they appear as warnings from `build_workbook.py`):
 - **KPI comparison** (`show_comparison`) → add a 2nd KPI tile or a UI delta.
 - **Pivot cross-tab** → rebuild the flattened table as a Sigma `pivot-table` in the UI.
 - **Per-tile refresh intervals** → Sigma has workbook-level scheduled refresh only — drop + warn.
+
+---
+
+## Gap scout — when the converter can't translate a LookML construct
+
+When `convert_lookml_to_sigma` only approximates or drops a LookML measure/construct (a ratio /
+`${measure}`-ref measure, a `type: percentile`, a filtered count, a Liquid `{% parameter %}`
+measure), spawn the **gap scout** subagent to find a Sigma formula that resolves on the live site,
+then persist it so the next dashboard reuses it. The full runbook (when to spawn, the spawn
+prompt, the LookML→Sigma candidate table, opt-in issue filing) is in **`scripts/gap-scout.md`** —
+read it before spawning.
+
+- `scripts/scout-validate.py` validates a candidate against a real DM element (builds a throwaway
+  test workbook, checks the column's resolved type, deletes it) and persists a win to
+  `~/.looker-to-sigma/learned-rules.yaml` (`scripts/learned-rules.py` loads + applies it).
+- On failure it returns an `escalation` block. Filing a GitHub issue is **opt-in /
+  confirm-before-file** — run `escalation.dry_run_cmd` (files nothing; drafts the issue + dedupes),
+  show the user, and only run `escalation.file_cmd` (`escalate-gap.py … --yes`) if they accept.
+  LookML construct gaps are **converter** gaps and mirror to both converter repos with a bead.
+
+This is also a lightweight way to **validate a migrated DM/workbook**: point `scout-validate.py`
+at the denorm element to confirm a suspect formula resolves (no `type:error` column) before
+declaring Phase 4 green.
 
 ---
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -28,9 +28,68 @@ TILE_KIND = {
 }
 AGG = {"average": "Avg", "sum": "Sum", "min": "Min", "max": "Max", "median": "Median"}
 
+# ── LookML value_format_name / value_format -> Sigma column format ──────────
+# Sigma columns carry an optional `format` object — for numbers:
+#   {"kind": "number", "formatString": "<d3-format>"}  (see sigma-workbooks
+#   reference/specification/formatting.md). LookML measures declare their display
+#   via a named format (`value_format_name`) or a custom Excel-style mask
+#   (`value_format`). Map the common named formats to d3 format strings; fall
+#   back to a best-effort translation of a custom mask.
+VALUE_FORMAT_NAME_MAP = {
+    "usd":          "$,.2f",
+    "usd_0":        "$,.0f",
+    "gbp":          "£,.2f",
+    "gbp_0":        "£,.0f",
+    "eur":          "€,.2f",
+    "eur_0":        "€,.0f",
+    "percent_0":    ",.0%",
+    "percent_1":    ",.1%",
+    "percent_2":    ",.2%",
+    "percent_3":    ",.3%",
+    "percent_4":    ",.4%",
+    "decimal_0":    ",.0f",
+    "decimal_1":    ",.1f",
+    "decimal_2":    ",.2f",
+    "decimal_3":    ",.3f",
+    "decimal_4":    ",.4f",
+    "id":           "d",            # plain integer, no thousands separator
+}
+
+def custom_value_format_to_d3(mask):
+    """Best-effort translate a LookML custom value_format (Excel-style mask) to a
+    d3 format string. Handles the common shapes: currency prefix, thousands
+    separator, fixed decimals, and percent. Returns None if nothing recognizable."""
+    if not mask: return None
+    m = mask.strip().strip('"')
+    is_pct = m.endswith("%")
+    sym = ""
+    if m[:1] in "$£€¥": sym = m[0]
+    has_thousands = "," in m
+    dec = 0
+    dm = re.search(r"\.(0+|#+)", m)        # ".00" or ".##" -> 2 decimals
+    if dm: dec = len(dm.group(1))
+    thou = "," if has_thousands else ""
+    if is_pct:
+        return f"{thou}.{dec}%"
+    if sym or has_thousands or dec:
+        return f"{sym}{thou}.{dec}f"
+    return None
+
+def sigma_format_for(value_format_name, value_format):
+    """Resolve a LookML measure's format -> a Sigma column `format` object (or None)."""
+    fs = None
+    if value_format_name:
+        fs = VALUE_FORMAT_NAME_MAP.get(value_format_name.strip().lower())
+    if fs is None and value_format:
+        fs = custom_value_format_to_d3(value_format)
+    if not fs: return None
+    return {"kind": "number", "formatString": fs}
+
+
 # ── parse view files: classify fields as measure (agg + base col) or dimension ──
 def build_field_index(view_files):
-    measures = {}   # "view.field" -> (agg_type, base_display_or_None)
+    measures = {}   # "view.field" -> (agg_type, base_display_or_None, sql)
+    formats = {}    # "view.field" -> Sigma format dict (or None)
     dims = set()    # "view.field"
     view_pk = {}    # "view" -> primary-key dimension name
     for path in view_files:
@@ -63,8 +122,14 @@ def build_field_index(view_files):
                 ref = re.search(r"\$\{(?:TABLE\}\.)?(\w+)\}?", s)  # ${dim} or ${TABLE}.col
                 r2 = re.search(r"\$\{TABLE\}\.(\w+)", s)
                 base = disp((r2 or ref).group(1)) if (r2 or ref) else None
-            measures[f"{view}.{name}"] = (mtype, base, (sqlm.group(1).strip() if sqlm else ""))
-    return measures, dims, view_pk
+            key = f"{view}.{name}"
+            measures[key] = (mtype, base, (sqlm.group(1).strip() if sqlm else ""))
+            # capture the measure's display format (named or custom mask)
+            vfn = re.search(r"value_format_name:\s*(\w+)", block)
+            vf = re.search(r'value_format:\s*"([^"]*)"', block)
+            fmt = sigma_format_for(vfn.group(1) if vfn else None, vf.group(1) if vf else None)
+            if fmt: formats[key] = fmt
+    return measures, dims, view_pk, formats
 
 def main():
     ap = argparse.ArgumentParser()
@@ -80,8 +145,20 @@ def main():
     a = ap.parse_args()
 
     dash = json.load(open(a.contract))
-    measures, dims, view_pk = build_field_index(sorted(glob.glob(os.path.join(a.views, "*.view.lkml"))))
+    measures, dims, view_pk, formats = build_field_index(sorted(glob.glob(os.path.join(a.views, "*.view.lkml"))))
     warnings = []
+
+    def fmt_for(f):
+        """Sigma column `format` dict for a measure field (or None). Ratio
+        measures inherit their own value_format if declared; else best-effort
+        percent for ratio-typed measures left unset."""
+        return formats.get(f)
+    def apply_fmt(col, f):
+        """Attach a Sigma number format to a tile column if the LookML measure
+        declared one. Mutates+returns col for chaining."""
+        ff = fmt_for(f)
+        if ff: col["format"] = ff
+        return col
 
     def is_measure(f): return f in measures
     def is_ratio(f):
@@ -220,7 +297,9 @@ def main():
         if kind == "kpi-chart":
             vf = formula_for(ms[0], ex) if ms else "Count()"
             cid = sid("v")
-            base["columns"] = [{"id": cid, "formula": vf, "name": el["name"]}]
+            col = {"id": cid, "formula": vf, "name": el["name"]}
+            if ms: apply_fmt(col, ms[0])      # carry LookML value_format -> Sigma $/%/decimals
+            base["columns"] = [col]
             base["value"] = {"columnId": cid}
             if ms: _warn_count(ms[0], el)
             if el.get("showComparison"):
@@ -231,10 +310,13 @@ def main():
             xf = ms[0] if ms else None
             yf = ms[1] if len(ms) > 1 else None
             xid, yid, cols = sid("x"), sid("y"), []
-            cols.append({"id": xid, "formula": formula_for(xf, ex) if xf else "Count()",
-                         "name": disp(leaf(xf)) if xf else "X"})
-            cols.append({"id": yid, "formula": formula_for(yf, ex) if yf else "Count()",
-                         "name": disp(leaf(yf)) if yf else "Y"})
+            xcol = {"id": xid, "formula": formula_for(xf, ex) if xf else "Count()",
+                    "name": disp(leaf(xf)) if xf else "X"}
+            ycol = {"id": yid, "formula": formula_for(yf, ex) if yf else "Count()",
+                    "name": disp(leaf(yf)) if yf else "Y"}
+            if xf: apply_fmt(xcol, xf)
+            if yf: apply_fmt(ycol, yf)
+            cols.append(xcol); cols.append(ycol)
             base["columns"] = cols
             base["xAxis"] = {"columnId": xid}; base["yAxis"] = {"columnIds": [yid]}
             if ds:
@@ -248,7 +330,8 @@ def main():
             cols.append({"id": xid, "formula": formula_for(xf, ex) if xf else "Count()",
                          "name": (col_display(xf, ex) if xf else None) or "Group"})
             for mf in (ms or []):
-                yid = sid("y"); cols.append({"id": yid, "formula": formula_for(mf, ex), "name": disp(leaf(mf))})
+                yid = sid("y")
+                cols.append(apply_fmt({"id": yid, "formula": formula_for(mf, ex), "name": disp(leaf(mf))}, mf))
                 ymids.append(yid)
                 _warn_count(mf, el)
             if not ymids:
@@ -271,11 +354,13 @@ def main():
             catf = el["pivots"][0] if el["pivots"] else (ds[0] if ds else (el["fields"][0] if el["fields"] else None))
             valf = ms[0] if ms else None
             catid = sid("cat"); valid = sid("val")
+            valcol = {"id": valid, "formula": formula_for(valf, ex) if valf else "Count()",
+                      "name": (disp(leaf(valf)) if valf else "Count")}
+            if valf: apply_fmt(valcol, valf)
             base["columns"] = [
                 {"id": catid, "formula": formula_for(catf, ex) if catf else "Count()",
                  "name": (col_display(catf, ex) if catf else None) or "Category"},
-                {"id": valid, "formula": formula_for(valf, ex) if valf else "Count()",
-                 "name": (disp(leaf(valf)) if valf else "Count")},
+                valcol,
             ]
             base["value"] = {"id": valid}      # donut/pie use value.id (KPI uses value.columnId)
             base["color"] = {"id": catid}
@@ -286,8 +371,9 @@ def main():
         elif kind == "table":
             cols = []
             for f in el["fields"] + (el.get("pivots") or []):
-                cols.append({"id": sid("c"), "formula": formula_for(f, ex), "name": disp(leaf(f))})
-                if is_measure(f): _warn_count(f, el)
+                tcol = {"id": sid("c"), "formula": formula_for(f, ex), "name": disp(leaf(f))}
+                if is_measure(f): apply_fmt(tcol, f); _warn_count(f, el)
+                cols.append(tcol)
             base["columns"] = cols
             if el.get("pivots"):
                 warnings.append(f"tile '{el['name']}': pivot {el['pivots']} flattened to columns — "

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/escalate-gap.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/escalate-gap.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""escalate-gap — opt-in GitHub-issue filer for gap-scout escalations.
+
+Shared across every migration skill (vendored identically into each plugin's
+scripts/). When the gap scout can't find a working Sigma translation for a
+source feature, the main agent offers the user the *option* to open a tracking
+issue in the appropriate repo. This script is what turns that "yes" into filed
+issues — with dedupe, repo routing, converter-repo mirroring, and a cross-linked
+bead.
+
+DESIGN: opt-in, never automatic.
+  - Default (no --yes): DRY RUN. Prints the drafted issue(s), the target repo(s),
+    and any existing open issues/beads that already cover this gap. Files NOTHING.
+    This is what the agent shows the user.
+  - With --yes: actually files. Skips any repo where dedupe already found a match
+    (unless --force).
+
+ROUTING (category -> repos):
+  converter  -> twells89/sigma-data-model-manager + twells89/sigma-data-model-mcp
+               (a source expression the *converter* failed to translate — the
+                browser tool and the MCP must stay in sync, so mirror to both)
+  builder    -> twells89/sigma-migration-skills   (workbook/DM spec builder gap)
+  skill      -> twells89/sigma-migration-skills   (skill-logic / discovery gap)
+
+Usage (dry-run draft the agent shows the user):
+  python3 scout/escalate-gap.py \
+    --skill tableau-to-sigma --category converter \
+    --feature WINDOW_AVG --description 'moving average over SUM' \
+    --source-pattern 'WINDOW_AVG(SUM([...]))' \
+    --template-attempted 'MovingAvg(Sum([Master/\\1]), -10, 10)' \
+    --test-formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+    --sigma-response '<failing column type / error json>' \
+    --example-from 'Sales.twb line 412' \
+    --escalation-yaml ~/.tableau-to-sigma/escalations/window_avg.yaml
+
+Then, only if the user says yes, the agent re-runs the same command with --yes.
+
+Requires `gh` on PATH and authed for the target repos. `bd` (beads) optional.
+Exit codes: 0 = ok (drafted or filed), 3 = nothing fileable / gh missing on --yes.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+ROUTES = {
+    "converter": ["twells89/sigma-data-model-manager", "twells89/sigma-data-model-mcp"],
+    "builder":   ["twells89/sigma-migration-skills"],
+    "skill":     ["twells89/sigma-migration-skills"],
+}
+BEADS_DIR = os.path.expanduser("~/.beads-sigma")
+
+
+def have(cmd):
+    return shutil.which(cmd) is not None
+
+
+def run(args, **kw):
+    """Run a command, return (ok, stdout, stderr)."""
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, **kw)
+        return p.returncode == 0, p.stdout.strip(), p.stderr.strip()
+    except Exception as e:  # noqa: BLE001
+        return False, "", str(e)
+
+
+def build_issue(a):
+    title = f"{a.skill} gap: {a.feature}" + (f" ({a.description})" if a.description else "")
+    body = []
+    body.append(f"**Skill:** `{a.skill}`")
+    body.append(f"**Gap category:** `{a.category}`")
+    body.append(f"**Feature:** `{a.feature}`")
+    if a.description:
+        body.append(f"**Description:** {a.description}")
+    if a.source_pattern:
+        body.append(f"**Source pattern:** `{a.source_pattern}`")
+    if a.template_attempted:
+        body.append(f"**Sigma template attempted:** `{a.template_attempted}`")
+    if a.test_formula:
+        body.append(f"**Test formula POSTed:** `{a.test_formula}`")
+    if a.sigma_response:
+        body.append(f"**Sigma response:**\n```\n{a.sigma_response}\n```")
+    body.append(f"**Example source:** {a.example_from or '(not provided)'}")
+    if a.escalation_yaml:
+        body.append(f"**Local escalation record:** `{a.escalation_yaml}`")
+    body.append("\n_Filed via the gap-scout opt-in escalation flow (`escalate-gap.py`)._")
+    return title, "\n\n".join(body)
+
+
+def labels_for(a):
+    return ["gap-scout-escalation", a.skill, f"category:{a.category}"]
+
+
+def ensure_labels(repo, labels):
+    """Best-effort: create labels so `gh issue create --label` won't fail."""
+    for lab in labels:
+        run(["gh", "label", "create", lab, "--repo", repo, "--force"])
+
+
+def find_dupes(repo, feature, skill):
+    """Return list of {number,title,url} open issues that look like this gap."""
+    ok, out, _ = run([
+        "gh", "issue", "list", "--repo", repo, "--state", "open",
+        "--label", "gap-scout-escalation", "--search", feature,
+        "--json", "number,title,url",
+    ])
+    if not ok or not out:
+        return []
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return []
+    feat = feature.lower()
+    return [i for i in items if feat in (i.get("title", "").lower())]
+
+
+def find_bead_dupe(feature):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    ok, out, _ = run(["bd", "list", "--json"], cwd=BEADS_DIR)
+    if not ok or not out:
+        return None
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return None
+    rows = items if isinstance(items, list) else items.get("issues", items.get("beads", []))
+    feat = feature.lower()
+    for b in rows or []:
+        if feat in (str(b.get("title", "")) + str(b.get("summary", ""))).lower():
+            return b.get("id") or b.get("bead_id")
+    return None
+
+
+def create_bead(title, body, skill, category):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    labels = f"sigma-converter,{skill},gap-scout-escalation,category:{category}"
+    ok, out, _ = run([
+        "bd", "create", title, "--priority", "2", "--labels", labels,
+        "--description", body, "--silent",
+    ], cwd=BEADS_DIR)
+    return out.strip() if ok else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--feature", required=True)
+    ap.add_argument("--category", default="converter", choices=list(ROUTES))
+    ap.add_argument("--description", default="")
+    ap.add_argument("--source-pattern", default="")
+    ap.add_argument("--template-attempted", default="")
+    ap.add_argument("--test-formula", default="")
+    ap.add_argument("--sigma-response", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--escalation-yaml", default="")
+    ap.add_argument("--extra-repo", action="append", default=[],
+                    help="additional target repo(s), repeatable")
+    ap.add_argument("--yes", action="store_true",
+                    help="actually file. Without it: dry-run, prints the draft only.")
+    ap.add_argument("--force", action="store_true",
+                    help="file even if a matching open issue already exists")
+    ap.add_argument("--no-beads", action="store_true")
+    a = ap.parse_args()
+
+    repos = list(dict.fromkeys(ROUTES[a.category] + a.extra_repo))
+    title, body = build_issue(a)
+    labels = labels_for(a)
+
+    # Dedupe scan (read-only) up front so the agent can show it to the user.
+    gh_ok = have("gh")
+    dupes = {r: (find_dupes(r, a.feature, a.skill) if gh_ok else []) for r in repos}
+    bead_dupe = None if a.no_beads else find_bead_dupe(a.feature)
+
+    if not a.yes:
+        # DRY RUN — this is what the agent presents to the user.
+        out = {
+            "mode": "draft",
+            "would_file_in": repos,
+            "labels": labels,
+            "title": title,
+            "body": body,
+            "existing_issues": {r: d for r, d in dupes.items() if d},
+            "existing_bead": bead_dupe,
+            "gh_available": gh_ok,
+            "next_step": "re-run with --yes to file (skips repos already covered)",
+        }
+        print(json.dumps(out, indent=2))
+        return 0
+
+    # --yes: actually file.
+    if not gh_ok:
+        print(json.dumps({"status": "error", "error": "gh not on PATH; cannot file"}))
+        return 3
+
+    # Bead first (authoritative tracker), so its id can be embedded in issues.
+    bead_id = bead_dupe
+    if bead_id is None and not a.no_beads:
+        bead_id = create_bead(title, body, a.skill, a.category)
+    issue_body = body + (f"\n\n**Bead:** `{bead_id}`" if bead_id else "")
+
+    filed, skipped = [], []
+    for repo in repos:
+        if dupes.get(repo) and not a.force:
+            skipped.append({"repo": repo, "existing": dupes[repo]})
+            continue
+        ensure_labels(repo, labels)
+        ok, out, err = run([
+            "gh", "issue", "create", "--repo", repo,
+            "--title", title, "--body", issue_body,
+            "--label", ",".join(labels),
+        ])
+        if ok:
+            filed.append({"repo": repo, "url": out.strip()})
+        else:
+            # retry once without labels (in case label creation was denied)
+            ok2, out2, err2 = run([
+                "gh", "issue", "create", "--repo", repo,
+                "--title", title, "--body", issue_body,
+            ])
+            if ok2:
+                filed.append({"repo": repo, "url": out2.strip(), "note": "filed without labels"})
+            else:
+                filed.append({"repo": repo, "error": err or err2})
+
+    # Cross-link mirrored issues to each other.
+    urls = [f["url"] for f in filed if f.get("url")]
+    if len(urls) > 1:
+        for f in filed:
+            if not f.get("url"):
+                continue
+            others = [u for u in urls if u != f["url"]]
+            num = f["url"].rstrip("/").split("/")[-1]
+            link_body = issue_body + "\n\n**Mirrored to:** " + ", ".join(others)
+            run(["gh", "issue", "edit", num, "--repo", f["repo"], "--body", link_body])
+
+    # Cross-link the bead back to the filed issue urls.
+    if bead_id and urls and have("bd"):
+        run(["bd", "update", bead_id, "--description",
+             issue_body + "\n\nFiled issues: " + ", ".join(urls)], cwd=BEADS_DIR)
+
+    print(json.dumps({
+        "status": "filed",
+        "filed": filed,
+        "skipped_existing": skipped,
+        "bead_id": bead_id,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/gap-scout.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/gap-scout.md
@@ -1,0 +1,112 @@
+# gap-scout subagent — guide for the main agent (Looker → Sigma)
+
+When `convert_lookml_to_sigma` / `scout-validate.py` flags a **LookML construct** with no clean
+Sigma rewrite (a measure the converter could only approximate or had to drop), spawn a separate
+subagent — the "gap scout" — to find a Sigma translation that works against the live Sigma site,
+then persist it so future conversions apply it automatically.
+
+Validated translations go to `~/.looker-to-sigma/learned-rules.yaml` (customer HOME, not the
+skill repo). `scripts/learned-rules.py` loads them; the build step applies them before falling
+back to a WARN.
+
+## When to spawn
+
+For each LookML field the converter buckets as **restructure** or **no-equivalent** (the
+`CONVERTER-FINDINGS.md` BUG3–BUG9 class — things that emit a literal `${...}`, a `0` where a
+`1.0` belonged, a bogus `CountIf`, or a phantom column):
+
+| LookML construct | Candidate Sigma approach to try |
+|---|---|
+| **ratio measure** (`type: number`, sql references other `${measure}`s, e.g. AOV = revenue/orders) | substitute each `${measure}` with its Sigma agg formula: `Sum([Master/Net Revenue]) / NullIf(CountDistinct([Master/Order Id]), 0)`; preserve `1.0 *` and `NULLIF`→`NullIf` |
+| **filtered measure** (`type: sum`/`count` + `filters:`) | `SumIf([Master/Col], <cond>)` / `CountIf(<cond>)` built from the `filters:` block |
+| `type: percentile` / `type: percentile_distinct` | `Percentile([Master/Col], p/100)` (NOT `CountIf`) |
+| `type: median` | `Median([Master/Col])` |
+| **Liquid `{% parameter %}` measure** | a workbook **control** + an `If`/`Switch` on the control value — usually a Phase 5 UI wiring; scout the static fallback |
+| **`type: count` on a joined view** | `CountDistinct([Master/<that view's PK>])` (a plain `Count()` counts fact rows, not the joined entity) |
+| **table calc** (`dynamic_fields`: `running_total`, `pct_of_total`, `offset`) | `CumulativeSum` / `GrandTotal` denominator / `Lag` in a date- or category-grouped element |
+| **`sql_distance` / `sql` with warehouse-specific funcs** | translate the SQL via `convert_sql_to_sigma_formula`, else escalate |
+| **`access_filter` / `sql_always_where` (RLS)** | a `CurrentUserAttributeText(...)` calc col + element filter (see Phase 1.5 / `apply_sigma_rls.py`) — usually handled there, escalate only if the predicate has no Sigma analog |
+
+Spawn ONE scout per distinct construct; run them in parallel.
+
+## How to spawn (from the main agent)
+
+Use the Agent tool, `subagent_type: 'general-purpose'`. Self-contained prompt:
+
+```
+You are a translation scout for a Looker→Sigma migration. Propose a Sigma formula that
+replaces a LookML measure/construct, validate it against the live Sigma API, and persist the rule.
+
+INPUTS
+- LookML construct/pattern: <e.g. "ratio_measure" or "percentile">
+- Sample LookML from the view(s): <2-5 real measure blocks, with type:/sql:/filters:>
+- Sigma data-model id: <dm-id>
+- Sigma denorm element id: <element-id>   (the joined "Order Fact"-style element)
+- Sigma folder id: <folder-id>
+
+PROCEDURE
+1. Read refs/dashboard-contract.md + the sibling sigma-workbooks spec (function-context rules:
+   window funcs error in grouping-table calc cols; CumulativeSum/DateLookback need a
+   date-grouped element; CountOver/SumOver fail in DM/master calc cols — see memory).
+2. Propose ONE candidate Sigma formula referencing columns as [Master/<Display Name>]
+   (joined-view cols carry the alias suffix, e.g. [Master/Region (customer_dim)]).
+3. Validate + persist:
+     eval "$(scripts/get-token.sh)"   # SIGMA_API_TOKEN
+     python3 scripts/scout-validate.py \
+       --formula '<candidate with REAL [Master/Col] names>' \
+       --feature '<construct>' --pattern '<LookML regex; capture field refs>' \
+       --template '<Sigma template using \1, \2>' \
+       --hint '<post-publish caveat, e.g. "needs a date-grouped element">' \
+       --description '<one-line>' --example-from '<measure name>' \
+       --data-model-id <dm-id> --element-id <element-id> --folder-id <folder-id> \
+       --home ~/.looker-to-sigma   [--kind table]
+4. Parse JSON: status=validated → done; status=error → retry (≤3). After the last
+   failed attempt the result carries an `escalation.dry_run_cmd` / `escalation.file_cmd`
+   and the gap is left as a WARN. Do NOT file anything yourself — see "Opt-in issue
+   filing" below.
+
+OUTPUT
+One paragraph: construct, candidate, status, and — if escalated — the
+`escalation.dry_run_cmd` so the main agent can offer the user a tracking issue.
+The validator auto-deletes its test workbook.
+```
+
+## Opt-in issue filing (escalations)
+
+Filing a GitHub issue is **opt-in and confirm-before-file** — never automatic.
+When `scout-validate.py` returns `status=error`, its `escalation` block carries
+ready-to-run commands for the shared `escalate-gap.py` filer. The main agent:
+
+1. Runs `escalation.dry_run_cmd` — files NOTHING; prints the drafted issue, the
+   target repo(s), and any existing open issues/beads that already cover the gap.
+2. Shows the user that draft and asks whether to open the issue.
+3. Only if the user says yes, runs `escalation.file_cmd` (the same command + `--yes`).
+
+LookML construct gaps are **converter** gaps, so they mirror to both converter repos
+(`sigma-data-model-manager` + `sigma-data-model-mcp`) with a cross-link and a bead as the
+authoritative tracker. (A workbook-builder gap — e.g. a layout / format / tile-mapping miss in
+`build_workbook.py` — uses `--category builder`, which routes to `sigma-migration-skills`.)
+See `scripts/escalate-gap.py`.
+
+## What the scout depends on
+
+- `scripts/scout-validate.py` — builds a throwaway test workbook (Master from the DM element
+  + a column using the candidate), checks the column's resolved type via
+  `/v2/workbooks/{id}/elements/{el}/columns`, persists on success, deletes the test workbook.
+- `scripts/learned-rules.py` — loader (`load(home="~/.looker-to-sigma")` + `apply()`).
+- `scripts/escalate-gap.py` — shared opt-in issue filer: category→repo routing, dedupe
+  (open issues + beads), converter-repo mirroring, bead cross-link. Dry-run by default;
+  files only with `--yes`. Identical copy across all migration skills.
+
+## File locations (CRITICAL)
+
+| File | Path | Why |
+|---|---|---|
+| Learned rules | `~/.looker-to-sigma/learned-rules.yaml` | Customer home; `git pull` can't clobber |
+| Override (CI/sandbox) | `$LOOKER_TO_SIGMA_HOME` | points loader + validator elsewhere |
+
+## Why a separate subagent
+
+- **Context isolation** — verbose Sigma POST/readback stays out of the main conversion's context (matters for clustered multi-dashboard migrations).
+- **Bounded budget** — ≤3 attempts per gap; failures stay WARNs, never block the migration.
+- **Compounds** — validated rules persist locally and auto-apply to the next dashboard; strong ones can be promoted into the converter (`src/lookml.ts`).

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/learned-rules.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/learned-rules.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""learned-rules — load + apply gap-scout translation rules (Looker → Sigma).
+
+Rules live in the customer's HOME (`~/.looker-to-sigma/learned-rules.yaml`), NOT the
+skill repo — so `git pull` of the skill never clobbers what a customer's scout has
+discovered, and wins persist across every dashboard they migrate. Override the dir
+with the `LOOKER_TO_SIGMA_HOME` env var. (Identical loader to the sibling Qlik/Power BI
+copies; only the default home + env var differ.)
+
+The conversion build step imports this and calls `apply()` on each LookML measure
+expression before falling back to the converter / a WARN line.
+
+    from learned_rules import load, apply
+    rules = load(home="~/.looker-to-sigma")
+    sigma_formula, hint = apply(rules, lookml_expr)   # (None, None) if no rule matches
+"""
+import os, re, yaml
+
+def home_dir(home=None, env=None):
+    if home: return os.path.expanduser(home)
+    if env and os.environ.get(env): return os.path.expanduser(os.environ[env])
+    return os.path.expanduser("~/.looker-to-sigma")
+
+def load(home=None, env="LOOKER_TO_SIGMA_HOME"):
+    path = os.path.join(home_dir(home, env), "learned-rules.yaml")
+    if not os.path.exists(path): return []
+    doc = yaml.safe_load(open(path)) or {}
+    return doc.get("rules", [])
+
+def apply(rules, expr):
+    """Return (translated_formula, hint) for the first matching rule, else (None, None)."""
+    for r in rules:
+        pat = r.get("source_pattern") or r.get("tableau_pattern") or r.get("dax_pattern")
+        tmpl = r.get("sigma_template")
+        if not pat or not tmpl: continue
+        m = re.search(pat, expr, re.IGNORECASE)
+        if m:
+            out = tmpl
+            for i, g in enumerate(m.groups(), start=1):
+                out = out.replace("\\%d" % i, g or "").replace("CAP%d" % i, g or "")
+            return out, r.get("hint", "")
+    return None, None
+
+if __name__ == "__main__":
+    import sys, json
+    rules = load(home=(sys.argv[2] if len(sys.argv) > 2 else None))
+    expr = sys.argv[1] if len(sys.argv) > 1 else ""
+    out, hint = apply(rules, expr)
+    print(json.dumps({"input": expr, "translated": out, "hint": hint, "rules_loaded": len(rules)}, indent=2))

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/looker-render-dashboard.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/looker-render-dashboard.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""looker-render-dashboard.py — render a LIVE Looker dashboard to PNG via the
+Looker render API, for Phase 4 SOURCE-vs-MIGRATED side-by-side visual QA.
+
+Pairs with sigma-export-png.py: render the Looker SOURCE dashboard here and the
+migrated Sigma workbook there, then eyeball them together to catch layout /
+chart-kind / formatting drift a numeric parity check can't see.
+
+Flow (Looker API 4.0):
+  POST /render_tasks/dashboards/{id}/png?width=&height=  {body: {dashboard_style,...}}
+       -> {id: <task_id>, status: "created"|"enqueued_for_query"...}
+  GET  /render_tasks/{task_id}                            poll until status=="success"
+       (status "failure" -> bail with the task's status_detail)
+  GET  /render_tasks/{task_id}/results                    -> raw PNG bytes
+
+Reuses looker_api.py's ~/.looker/looker.ini auth (fresh login per call). The
+render endpoints return binary, so this fetches the bytes directly rather than
+through looker_api.call() (which json-decodes).
+
+Usage:
+  python3 looker-render-dashboard.py <dashboard_id> [out.png] [--w 1200 --h 1600]
+"""
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# Reuse the looker.ini auth + login from the sibling client.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import looker_api  # noqa: E402
+
+
+def _req(method, url, tok, verify, body=None, accept=None):
+    """Raw request returning (status, bytes, content_type). No json decode."""
+    data = None
+    headers = {"Authorization": "Bearer " + tok}
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    if accept:
+        headers["Accept"] = accept
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, context=looker_api._ctx(verify), timeout=120) as r:
+            return r.status, r.read(), r.headers.get("Content-Type", "")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(), e.headers.get("Content-Type", "")
+
+
+def render(dashboard_id, out_path, width, height, fmt="png", timeout_s=180):
+    base, tok, verify = looker_api.login()
+
+    # 1. kick off the render task
+    create_url = (f"{base}/render_tasks/dashboards/{dashboard_id}/{fmt}"
+                  f"?width={width}&height={height}")
+    code, raw, _ = _req("POST", create_url, tok, verify,
+                        body={"dashboard_style": "tiled"})
+    if code not in (200, 201):
+        sys.exit(f"render create POST {code}: {raw[:400].decode('utf-8', 'replace')}")
+    task = json.loads(raw.decode())
+    task_id = task.get("id")
+    if not task_id:
+        sys.exit(f"no render task id in response: {raw[:400].decode('utf-8','replace')}")
+    print(f"[looker] render task {task_id} created (dashboard {dashboard_id})")
+
+    # 2. poll the task until success (re-login each poll: looker_api logs in fresh,
+    #    and a render can outlive a single short-lived bearer)
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        base, tok, verify = looker_api.login()
+        code, raw, _ = _req("GET", f"{base}/render_tasks/{task_id}", tok, verify)
+        if code != 200:
+            sys.exit(f"render poll GET {code}: {raw[:400].decode('utf-8','replace')}")
+        st = json.loads(raw.decode())
+        status = st.get("status")
+        if status == "success":
+            break
+        if status == "failure":
+            sys.exit(f"render failed: {st.get('status_detail') or st}")
+        time.sleep(3)
+    else:
+        sys.exit(f"render task {task_id} did not finish within {timeout_s}s")
+
+    # 3. download the rendered bytes
+    base, tok, verify = looker_api.login()
+    code, content, ct = _req("GET", f"{base}/render_tasks/{task_id}/results",
+                             tok, verify, accept="image/png")
+    if code != 200 or not content:
+        sys.exit(f"render results GET {code} ({ct}): {content[:400].decode('utf-8','replace')}")
+    with open(out_path, "wb") as f:
+        f.write(content)
+    print(f"[looker] {len(content)} bytes -> {out_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dashboard_id")
+    ap.add_argument("out", nargs="?", default=None,
+                    help="output PNG path (default: /tmp/looker-dashboard-<id>.png)")
+    ap.add_argument("--w", type=int, default=1200, help="render width px")
+    ap.add_argument("--h", type=int, default=1600, help="render height px")
+    a = ap.parse_args()
+    out = a.out or f"/tmp/looker-dashboard-{a.dashboard_id}.png"
+    render(a.dashboard_id, out, a.w, a.h)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/scout-validate.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/scout-validate.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""scout-validate — gap-scout validation primitive (Looker → Sigma).
+
+Validates a candidate Sigma formula against a real data-model element by building a
+throwaway test workbook, checking the column resolves (type != "error"), and — on
+success — persisting the rule to the customer-local learned-rules.yaml. Generic across
+skills via --home (this copy defaults to the Looker home; identical shape to the
+sibling Qlik/Power BI copies so the shared escalate-gap.py flow works unchanged).
+
+Use it when `convert_lookml_to_sigma` flags a LookML construct with no clean Sigma
+rewrite — a ratio/`${measure}`-ref measure, a `type: percentile`, a Liquid
+`{% parameter %}` measure, a multi-hop `${TABLE}`-vs-join reference — to confirm a
+candidate Sigma formula actually resolves on the live site before persisting it.
+
+    python3 scout-validate.py \
+      --formula '1.0 * (Sum([Master/Net Revenue])) / NullIf((CountDistinct([Master/Order Id])), 0)' \
+      --data-model-id <dm> --element-id <denorm-elem-id> --folder-id <folder> \
+      --feature 'ratio_measure' --pattern '\\$\\{(\\w+)\\}' \
+      --template 'Sum([Master/\\1]) / NullIf(...)' --hint 'ratio of two measures' \
+      --description 'LookML ratio measure -> Sigma agg/agg' --home ~/.looker-to-sigma
+
+Env: SIGMA_BASE_URL, SIGMA_API_TOKEN (eval get-token.sh first).
+Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the test workbook.
+"""
+import json, os, sys, urllib.request, argparse, datetime, re
+
+BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
+def api(method, path, body=None, accept_json=True):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE+path, data=data, method=method,
+        headers={"Authorization":"Bearer "+TOK, "Content-Type":"application/json",
+                 **({"Accept":"application/json"} if accept_json else {})})
+    try:
+        r = urllib.request.urlopen(req); return r.status, r.read().decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+
+def dm_element_master_columns(dm_id, el_id):
+    """Read the DM spec, find the element, return (elementName, [displayName,...])."""
+    st, body = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    spec = json.loads(body)
+    for pg in spec.get("pages", []):
+        for el in pg.get("elements", []):
+            if el.get("id") == el_id:
+                src = el.get("source", {})
+                name = el.get("name") or ("Custom SQL" if src.get("kind")=="sql"
+                       else (src.get("path",["Element"])[-1] if src.get("kind")=="warehouse-table" else "Element"))
+                cols = []
+                for c in el.get("columns", []):
+                    dn = c.get("name") or re.sub(r'.*/', '', c.get("formula","").strip("[]"))
+                    cols.append(dn)
+                return name, cols
+    raise SystemExit("element not found in DM spec")
+
+def build_escalation(a, err):
+    """Record the gap locally and return opt-in escalate-gap.py commands.
+
+    Filing a tracking issue is NOT automatic: the main agent runs dry_run_cmd
+    (drafts the issue + dedupes against open issues/beads), shows the user, and
+    runs file_cmd only if they accept. Source-formula gaps are converter gaps."""
+    import shlex
+    skill = (a.skill or os.path.basename(os.path.normpath(a.home)).lstrip("."))
+    esc_dir = os.path.join(a.home, "escalations"); os.makedirs(esc_dir, exist_ok=True)
+    slug = re.sub(r"[^a-z0-9]+", "-", a.feature.lower()).strip("-") or "gap"
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    esc_path = os.path.join(esc_dir, f"{ts}-{slug}.yaml")
+    payload = {"feature": a.feature, "description": a.description,
+               "source_pattern": a.pattern, "sigma_template_attempted": a.template,
+               "test_formula": a.formula, "example_from": a.example_from,
+               "error_column": err, "escalated_at": ts}
+    try:
+        import yaml; yaml.safe_dump(payload, open(esc_path, "w"), sort_keys=False)
+    except Exception:
+        json.dump(payload, open(esc_path, "w"), indent=2)
+    filer = os.path.join(os.path.dirname(os.path.abspath(__file__)), "escalate-gap.py")
+    cmd = ["python3", filer, "--skill", skill, "--category", "converter",
+           "--feature", a.feature, "--description", a.description or "",
+           "--source-pattern", a.pattern or "", "--template-attempted", a.template or "",
+           "--test-formula", a.formula, "--sigma-response", json.dumps(err)[:1500],
+           "--example-from", a.example_from or "", "--escalation-yaml", esc_path]
+    dry = " ".join(shlex.quote(c) for c in cmd)
+    return {"note": "Gap recorded locally. Filing a tracking issue is opt-in — run "
+                    "dry_run_cmd, show the user, then file_cmd only if they accept.",
+            "escalation_yaml": esc_path, "dry_run_cmd": dry, "file_cmd": dry + " --yes"}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    for f in ["formula","data-model-id","element-id","feature"]:
+        ap.add_argument("--"+f, required=True)
+    ap.add_argument("--folder-id", required=True)
+    ap.add_argument("--pattern"); ap.add_argument("--template")
+    ap.add_argument("--hint", default=""); ap.add_argument("--description", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--kind", default="kpi-chart", choices=["kpi-chart","table"])
+    ap.add_argument("--home", default=os.path.expanduser("~/.looker-to-sigma"))
+    ap.add_argument("--skill", default="", help="skill name for issue routing (default: derived from --home)")
+    a = ap.parse_args()
+
+    elem_name, cols = dm_element_master_columns(a.data_model_id, a.element_id)
+    master = {"id":"m","name":"Master","kind":"table",
+              "source":{"dataModelId":a.data_model_id,"elementId":a.element_id,"kind":"data-model"},
+              "columns":[{"id":f"mc{i}","name":c,"formula":f"[{elem_name}/{c}]"} for i,c in enumerate(cols)]}
+    if a.kind == "kpi-chart":
+        test = {"id":"scout","kind":"kpi-chart","name":"scout","source":{"elementId":"m","kind":"table"},
+                "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}],"value":{"id":"sc"}}
+    else:
+        test = {"id":"scout","kind":"table","name":"scout","source":{"elementId":"m","kind":"table"},
+                "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}]}
+    spec = {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id,"schemaVersion":1,
+            "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    st, body = api("POST","/v2/workbooks/spec",spec)
+    wb = None
+    try: wb = json.loads(body).get("workbookId")
+    except Exception: pass
+    if not wb:
+        m = re.search(r'workbookId:\s*(\S+)', body)
+        if m: wb = m.group(1)
+    result = {"feature":a.feature,"formula":a.formula,"workbook_id":wb}
+    if not wb:
+        print(json.dumps({**result,"status":"error","error":"POST failed: "+body[:200]})); return
+    # check the test column's type
+    st2, cbody = api("GET", f"/v2/workbooks/{wb}/elements/scout/columns")
+    err = None
+    try:
+        colsout = json.loads(cbody)
+        entries = colsout.get("entries", colsout) if isinstance(colsout, dict) else colsout
+        for c in (entries or []):
+            t = (c.get("type") or {})
+            if (t.get("type") or t) == "error" or "error" in str(t).lower():
+                err = c
+    except Exception as e:
+        err = {"parse": str(e), "raw": cbody[:200]}
+    status = "error" if err else "validated"
+    # persist on success
+    if status == "validated":
+        if a.pattern and a.template:
+            os.makedirs(a.home, exist_ok=True)
+            import yaml
+            rp = os.path.join(a.home, "learned-rules.yaml")
+            doc = yaml.safe_load(open(rp)) if os.path.exists(rp) else None
+            doc = doc or {"rules":[]}
+            doc["rules"].append({"feature":a.feature,"description":a.description,
+                "source_pattern":a.pattern,"sigma_template":a.template,"hint":a.hint,
+                "validated_at":datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "validated_workbook":wb,"example_from":a.example_from,"confidence":"validated"})
+            yaml.safe_dump(doc, open(rp,"w"), sort_keys=False)
+            result["persisted_to"] = rp
+    else:
+        # opt-in escalation: record the gap locally + hand back ready-to-run filer cmds
+        result["error_column"] = err
+        result["escalation"] = build_escalation(a, err)
+    # cleanup test workbook
+    api("DELETE", f"/v2/files/{wb}")
+    print(json.dumps({**result,"status":status}, indent=2))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three additions to the `looker-to-sigma` skill.

## Task 1 — Looker source render for side-by-side QA
`scripts/looker-render-dashboard.py` exports a live Looker dashboard to PNG via the Looker render API (`POST /render_tasks/dashboards/{id}/png` → poll `GET /render_tasks/{task_id}` → `GET .../results`), reusing `looker_api.py` auth. Pairs with the existing `sigma-export-png.py` so Phase 4 visual QA renders **both** the Looker source and the migrated Sigma workbook for a tile-for-tile comparison. SKILL.md Phase 4a updated to show the side-by-side.
**Live-verified:** rendered dashboard 8 ("Orders Overview") — real dashboard image (KPIs, line/bar/pie, grid).

## Task 2 — carry number formats into migrated tiles
`build_workbook.py` `build_field_index` now captures each measure's `value_format_name` / custom `value_format`; `apply_fmt` attaches a Sigma column `format` ({kind:number, formatString}) to KPI/chart/table value columns. Maps `usd`→`$,.2f`, `usd_0`→`$,.0f`, `percent_n`→`,.n%`, `decimal_n`→`,.nf`; custom masks best-effort.
**Live-verified:** rebuilt the Orders Overview workbook against a freshly converted DM, POSTed, rendered — KPIs now show **$110,342.75** (Net Revenue) and **$170.28** (AOV) instead of bare numbers; counts (Orders 648, Units 1,473) stay unformatted. Temp DM + workbook cleaned up.

## Task 3 — gap scout
The skill lacked the gap-scout layer every sibling has. Added (mirrors the Power BI Python variant):
- `gap-scout.md` — runbook with a LookML→Sigma candidate table (ratio measures, percentile, filtered counts, Liquid `{% parameter %}`, table calcs, RLS).
- `scout-validate.py` — validate a candidate against a DM element (throwaway test workbook → type check → delete), persist wins to `~/.looker-to-sigma/learned-rules.yaml`.
- `escalate-gap.py` — shared opt-in GitHub-issue filer (identical copy; routes converter gaps to both converter repos). Dry-run by default.
- `learned-rules.py` — loader (home `~/.looker-to-sigma`, env `LOOKER_TO_SIGMA_HOME`).
Escalation is opt-in / confirm-before-file. SKILL.md gained a gap-scout section + script-index rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)