### PR TITLE
Cross-tool fidelity: grouped tables, carried sorts, QS 2-up layout + runnable parity SQL

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -261,6 +261,13 @@ def main():
     }
 
     # ── tile -> Sigma element ──
+    # Looker newspaper rows are ~40px; Sigma grid rows are ~20px. Mapping them 1:1
+    # halves every tile's height — and Sigma SUPPRESSES x-axis category labels (and
+    # most y gridline labels) when the chart band is that short, so migrated bar
+    # charts rendered with NO category names (same short-band suppression seen on
+    # tableau, beads-sigma-tkkv). Scale rows 2x so tile heights land near their
+    # Looker pixel heights and axis labels render.
+    ROW_SCALE = 2
     elements, layout_items = [], []
     for el in dash["elements"]:
         # Text/markdown tiles → Sigma text element (kind: "text"). No query, no
@@ -281,7 +288,7 @@ def main():
             body = "\n\n".join(parts) if parts else (el.get("name") or title or "")
             elements.append({"id": eid, "kind": "text", "body": body})
             L = el["layout"]; c0 = L["col"] + 1; c1 = L["col"] + 1 + L["width"]
-            r0 = L["row"] + 1; r1 = L["row"] + 1 + L["height"]
+            r0 = L["row"] * ROW_SCALE + 1; r1 = r0 + L["height"] * ROW_SCALE
             layout_items.append((eid, c0, c1, r0, r1, "text"))
             continue
         kind = TILE_KIND.get(el["tileType"])
@@ -293,6 +300,7 @@ def main():
         ds = [f for f in el["fields"] if not is_measure(f)]
         eid = sid()
         base = {"id": eid, "kind": kind, "name": el["name"], "source": {"elementId": "m-master", "kind": "table"}}
+        field2cid = {}   # "view.field" -> tile column id (for sorts: resolution)
 
         if kind == "kpi-chart":
             vf = formula_for(ms[0], ex) if ms else "Count()"
@@ -329,10 +337,12 @@ def main():
             xid = sid("x"); xf = ds[0] if ds else (el["fields"][0] if el["fields"] else None)
             cols.append({"id": xid, "formula": formula_for(xf, ex) if xf else "Count()",
                          "name": (col_display(xf, ex) if xf else None) or "Group"})
+            if xf: field2cid[xf] = xid
             for mf in (ms or []):
                 yid = sid("y")
                 cols.append(apply_fmt({"id": yid, "formula": formula_for(mf, ex), "name": disp(leaf(mf))}, mf))
                 ymids.append(yid)
+                field2cid[mf] = yid
                 _warn_count(mf, el)
             if not ymids:
                 yid = sid("y"); cols.append({"id": yid, "formula": "Count()", "name": "Count"}); ymids.append(yid)
@@ -364,17 +374,30 @@ def main():
             ]
             base["value"] = {"id": valid}      # donut/pie use value.id (KPI uses value.columnId)
             base["color"] = {"id": catid}
+            if catf: field2cid[catf] = catid
+            if valf: field2cid[valf] = valid
             if valf: _warn_count(valf, el)
             if el["tileType"] == "looker_donut_multiples":
                 warnings.append(f"tile '{el['name']}': donut_multiples → single donut sliced by "
                                 f"'{leaf(catf) if catf else 'category'}'; the per-multiple dimension is dropped — review in Sigma")
         elif kind == "table":
-            cols = []
+            cols, gids, cids = [], [], []
             for f in el["fields"] + (el.get("pivots") or []):
                 tcol = {"id": sid("c"), "formula": formula_for(f, ex), "name": disp(leaf(f))}
-                if is_measure(f): apply_fmt(tcol, f); _warn_count(f, el)
+                if is_measure(f):
+                    apply_fmt(tcol, f); _warn_count(f, el); cids.append(tcol["id"])
+                else:
+                    gids.append(tcol["id"])
                 cols.append(tcol)
+                field2cid[f] = tcol["id"]
             base["columns"] = cols
+            # A Looker table tile is an AGGREGATING query (group by dims, aggregate
+            # measures). Without `groupings` a Sigma table with dim + Sum(...) columns
+            # renders one row per SOURCE row (no roll-up). Verified shape (hand-PATCH
+            # round-trip): groupings:[{id, groupBy:[dim col ids], calculations:[measure
+            # col ids]}].
+            if gids and cids:
+                base["groupings"] = [{"id": sid("g"), "groupBy": gids, "calculations": cids}]
             if el.get("pivots"):
                 warnings.append(f"tile '{el['name']}': pivot {el['pivots']} flattened to columns — "
                                 f"rebuild as a Sigma pivot-table for true cross-tab")
@@ -387,11 +410,39 @@ def main():
                 continue
             col = next((c for c in base["columns"] if c["name"] == d), None)
             if not col:
-                col = {"id": sid("c"), "formula": f"[{a.master_name}/{d}]", "name": d}
+                # filter-only field: the tile filters by it but doesn't display it —
+                # carry it hidden so the filter works without adding a visible column.
+                col = {"id": sid("c"), "formula": f"[{a.master_name}/{d}]", "name": d, "hidden": True}
                 base["columns"].append(col)
             vals = [v.strip() for v in str(val).split(",") if v.strip()]
             base.setdefault("filters", []).append(
                 {"id": sid("f"), "columnId": col["id"], "kind": "list", "mode": "include", "values": vals})
+        # tile sorts: -> Sigma sort. Verified shapes (live POST + readback + render,
+        # 2026-06-10):
+        #   bar/line/area/scatter : xAxis.sort  = {by: <colId>, direction}
+        #   pie/donut             : color.sort  = {by: <colId>, direction}
+        #   UNGROUPED table       : element sort = [{columnId, direction}]
+        #   GROUPED table         : groupings[0].sort = [{columnId, direction}] —
+        #     element-level sort on a grouped table 400s with "Sort column not found"
+        #     for BOTH groupBy and calculation column ids; nesting the sort inside the
+        #     grouping entry is the shape that posts, round-trips, and orders groups.
+        for si, s in enumerate(el.get("sorts") or []):
+            toks = str(s).split()
+            sf = toks[0]
+            direction = "descending" if (len(toks) > 1 and toks[1].lower().startswith("desc")) else "ascending"
+            cid = field2cid.get(sf)
+            if not cid:
+                warnings.append(f"tile '{el['name']}': sort field '{sf}' not among the tile's columns — sort skipped")
+                continue
+            if kind in ("bar-chart", "area-chart", "line-chart", "scatter-chart"):
+                if si == 0: base.setdefault("xAxis", {})["sort"] = {"by": cid, "direction": direction}
+            elif kind in ("pie-chart", "donut-chart"):
+                if si == 0: base.setdefault("color", {})["sort"] = {"by": cid, "direction": direction}
+            elif kind == "table":
+                if base.get("groupings"):
+                    base["groupings"][0].setdefault("sort", []).append({"columnId": cid, "direction": direction})
+                else:
+                    base.setdefault("sort", []).append({"columnId": cid, "direction": direction})
         # Looker table calcs (dynamic_fields) → Sigma formula columns
         for dyn in (el.get("dynamicFields") or []):
             if not isinstance(dyn, dict):
@@ -412,9 +463,9 @@ def main():
             base.setdefault("columns", []).append({"id": sid("tc"), "formula": sig.strip(), "name": label})
         elements.append(base)
 
-        # newspaper -> 24-col grid
+        # newspaper -> 24-col grid (rows scaled — see ROW_SCALE above)
         L = el["layout"]; c0 = L["col"] + 1; c1 = L["col"] + 1 + L["width"]
-        r0 = L["row"] + 1; r1 = L["row"] + 1 + L["height"]
+        r0 = L["row"] * ROW_SCALE + 1; r1 = r0 + L["height"] * ROW_SCALE
         layout_items.append((eid, c0, c1, r0, r1, kind))
 
     # ── controls from dashboard filters ──

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/post_dm.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/post_dm.py
@@ -34,6 +34,50 @@ def api(method, path, body=None):
         return raw  # YAML/text
 
 
+def drop_join_key_passthroughs(spec):
+    """Guard: drop derived-view columns that pass a relationship's OWN join key across
+    the join (formula [Base/REL_NAME/<target key col>]). A cross-element passthrough of
+    a join key compiles to type "error" in Sigma (the base element already carries that
+    value; Sigma degrades the ref on readback). The MCP lookml converter's denormalized
+    element can still emit one — strip it here with a WARN before POSTing."""
+    rel_keys = {}   # relationship name -> set of target-key DISPLAY names
+    elements = [e for p in spec.get("pages", []) for e in (p.get("elements") or [])]
+    by_id = {e.get("id"): e for e in elements}
+    for el in elements:
+        for rel in (el.get("relationships") or []):
+            tgt = by_id.get(rel.get("targetElementId")) or {}
+            tcols = {c.get("id"): c for c in (tgt.get("columns") or [])}
+            names = rel_keys.setdefault(rel.get("name") or "", set())
+            for k in (rel.get("keys") or []):
+                c = tcols.get(k.get("targetColumnId"))
+                if not c:
+                    continue
+                d = c.get("name")
+                if not d:
+                    m = re.match(r"\[([^\]]+)\]$", c.get("formula") or "")
+                    if m:
+                        d = m.group(1).split("/")[-1]
+                if d:
+                    names.add(d)
+    for el in elements:
+        cols = el.get("columns") or []
+        kept = []
+        for c in cols:
+            m = re.match(r"\[([^/\]]+)/([^/\]]+)/([^\]]+)\]$", c.get("formula") or "")
+            if m and m.group(3) in rel_keys.get(m.group(2), set()):
+                print(f"WARN: dropping join-key passthrough column {c.get('id')} "
+                      f"({c.get('formula')}) on element {el.get('name') or el.get('id')} — "
+                      f"cross-element passthrough of a join key compiles to type=error in Sigma",
+                      file=sys.stderr)
+                if el.get("order"):
+                    el["order"] = [o for o in el["order"] if o != c.get("id")]
+                continue
+            kept.append(c)
+        if len(kept) != len(cols):
+            el["columns"] = kept
+    return spec
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("spec")
@@ -41,6 +85,7 @@ def main():
     a = ap.parse_args()
 
     spec = json.load(open(a.spec))
+    spec = drop_join_key_passthroughs(spec)
 
     # rewrite every connectionId (placeholder or short prefix) to the full UUID
     if FULL_CONN:

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -269,11 +269,9 @@ unless opts[:skip_layout]
         if layout_xml.empty?
           warn "[FAIL] gate 4/4: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
-          warn "       dashboard grid. Build a layout and PUT it:"
-          warn "         ruby scripts/build-dashboard-layout.rb \\"
-          warn "           --layout #{opts[:tab]}/dashboard-layout.json \\"
-          warn "           --wb-ids #{opts[:tab]}/wb-ids.json \\"
-          warn "           --out #{opts[:tab]}/layout.xml"
+          warn "       dashboard grid. Rebuild the layout with this skill's layout"
+          warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
+          warn "       then PUT it:"
           warn "         ruby scripts/put-layout.rb --workbook #{wb_id} \\"
           warn "           --layout #{opts[:tab]}/layout.xml"
           warn "       See beads-sigma-bw3."
@@ -291,9 +289,8 @@ unless opts[:skip_layout]
           non_data_stack_pages.each do |pid, col, n|
             warn "         page=#{pid.inspect}: #{n} elements all at gridColumn=#{col.inspect}"
           end
-          warn "       Build a real layout and PUT it:"
-          warn "         ruby scripts/build-dashboard-layout.rb --layout #{opts[:tab]}/dashboard-layout.json \\"
-          warn "           --wb-ids #{opts[:tab]}/wb-ids.json --out #{opts[:tab]}/layout.xml"
+          warn "       Rebuild the layout with this skill's layout builder (see SKILL.md —"
+          warn "       layout phase) into #{opts[:tab]}/layout.xml, then PUT it:"
           warn "         ruby scripts/put-layout.rb --workbook #{wb_id} --layout #{opts[:tab]}/layout.xml"
           warn "       See beads-sigma-bw3."
           exit 6

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/sigma-build-gotchas.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/sigma-build-gotchas.md
@@ -93,6 +93,15 @@ list in the hub — graft onto a **UI-created native sheet** instead.
 - **pivot-table**: `rowsBy` + `columnsBy` (`[{id}]`) + `values` (see feedback_sigma_pivot_rowsby_columnsby).
 - KPIs need ≥5 grid-rows of height or the title clips.
 
+## Sorting a GROUPED table — sort lives INSIDE the grouping (verified 2026-06-10)
+Element-level `sort:[{columnId,direction}]` works only on UNGROUPED tables. On a table
+with `groupings`, the POST 400s with `Sort column not found` for **both** groupBy and
+calculation column ids. The shape that posts, round-trips on GET (gains `nulls:
+"connection-default"`), and actually orders the groups is the sort nested in the
+grouping entry:
+`groupings: [{id, groupBy: [...], calculations: [...], sort: [{columnId: <calc or dim col id>, direction: "descending"}]}]`.
+Charts keep using `xAxis.sort: {by, direction}` / pie-donut `color.sort`.
+
 ## Excluding a null/unmatched group — element list-filter
 To drop a null dimension bucket (e.g. fact rows whose FK didn't match a dim under a
 LEFT JOIN), add an element filter (verified shape):

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -21,20 +21,57 @@ master={"id":"m-ofv","name":"OFV","kind":"table","source":{"dataModelId":DM,"ele
 def kpi(name,formula,fmt):
     c=nid()+"-v"; return {"id":nid(),"kind":"kpi-chart","name":name,"source":{"elementId":"m-ofv","kind":"table"},
         "columns":[{"id":c,"formula":formula,"name":name,"format":NUM(fmt)}],"value":{"columnId":c}}
-def chart(kind,name,dimf,dimn,measures):
-    x=nid()+"-x"; cols=[{"id":x,"formula":dimf,"name":dimn}]; ymids=[]
+# Qlik's associative model hides unmatched/null dimension keys (a LEFT-JOIN miss never
+# shows as a row in a Qlik straight table). Sigma keeps those rows, so a faithful
+# migration excludes them on the TABLE element (NOT on the master — an element filter on
+# a shared SOURCE element propagates into every chart that sources it). Deliberate
+# choice: set QLIK_KEEP_UNMATCHED=1 to keep the null rows instead (warehouse-faithful).
+KEEP_UNMATCHED=os.environ.get("QLIK_KEEP_UNMATCHED","")=="1"
+
+def chart(kind,name,dimf,dimn,measures,sort=None):
+    """sort: optional ("<measure or dim display name>", "ascending"|"descending") carried
+    from the Qlik object definition (qDimensionInfo qSortCriterias / measure qSortBy in
+    the discover output's charts.json). None = Sigma default ordering."""
+    x=nid()+"-x"; cols=[{"id":x,"formula":dimf,"name":dimn}]; ymids=[]; byname={dimn:x}
     for mf,mn,fmt in measures:
-        y=nid()+"-y"; cols.append({"id":y,"formula":mf,"name":mn,"format":NUM(fmt)}); ymids.append(y)
+        y=nid()+"-y"; cols.append({"id":y,"formula":mf,"name":mn,"format":NUM(fmt)}); ymids.append(y); byname[mn]=y
     el={"id":nid(),"kind":kind,"name":name,"source":{"elementId":"m-ofv","kind":"table"},
         "columns":cols,"xAxis":{"columnId":x},"yAxis":{"columnIds":ymids}}
+    if sort and sort[0] in byname:
+        el["xAxis"]["sort"]={"by":byname[sort[0]],"direction":sort[1]}
     # value labels on bar/pie/donut (Sigma defaults them OFF); lines stay clean
     if kind in ("bar-chart","pie-chart","donut-chart"): el["dataLabel"]={"labels":"shown"}
     return el
-def table(name,dims,measures):
-    cols=[]; 
-    for f,n in dims: cols.append({"id":nid(),"formula":f,"name":n})
-    for f,n,fmt in measures: cols.append({"id":nid(),"formula":f,"name":n,"format":NUM(fmt)})
-    return {"id":nid(),"kind":"table","name":name,"source":{"elementId":"m-ofv","kind":"table"},"columns":cols}
+def table(name,dims,measures,sort=None,exclude_null_dim=None):
+    """A Qlik straight table is an AGGREGATING element: without a `groupings` array a
+    Sigma table with dim + Sum(...) columns renders ONE ROW PER SOURCE ROW (refs/
+    sigma-build-gotchas.md "Aggregating elements need an explicit dimension→measure
+    declaration"). groupBy = the dim column ids, calculations = the measure column ids.
+
+    sort: optional ("<col display name>", "ascending"|"descending") carried from the
+      Qlik object definition where it provides one (qSortCriterias/qSortBy in the
+      discover output). Verified shape (live POST+readback 2026-06-10): a GROUPED
+      table rejects element-level `sort` ("Sort column not found") -- the sort must
+      nest INSIDE the grouping entry: groupings[0].sort=[{columnId,direction}].
+    exclude_null_dim: display name of a dim whose null/unmatched rows to drop (the
+      associative-model behavior — see KEEP_UNMATCHED above). Emits a hidden boolean
+      calc column + the gotchas-documented element list-filter
+      filters:[{columnId, kind:"list", mode:"include", values:[true]}]."""
+    cols=[]; gids=[]; cids=[]; byname={}; byform={}
+    for f,n in dims:
+        i=nid(); cols.append({"id":i,"formula":f,"name":n}); gids.append(i); byname[n]=i; byform[n]=f
+    for f,n,fmt in measures:
+        i=nid(); cols.append({"id":i,"formula":f,"name":n,"format":NUM(fmt)}); cids.append(i); byname[n]=i
+    el={"id":nid(),"kind":"table","name":name,"source":{"elementId":"m-ofv","kind":"table"},
+        "columns":cols,"groupings":[{"id":nid()+"-g","groupBy":gids,"calculations":cids}]}
+    if sort and sort[0] in byname:
+        el["groupings"][0]["sort"]=[{"columnId":byname[sort[0]],"direction":sort[1]}]
+    if exclude_null_dim and not KEEP_UNMATCHED and exclude_null_dim in byform:
+        b=nid()+"-nn"
+        cols.append({"id":b,"formula":"Not(IsNull(%s))"%byform[exclude_null_dim],
+                     "name":"%s Matched"%exclude_null_dim,"hidden":True})
+        el["filters"]=[{"id":nid()+"-f","columnId":b,"kind":"list","mode":"include","values":[True]}]
+    return el
 
 overview=[
  kpi("Net Revenue","Sum([OFV/Net Revenue])","$,.0f"),
@@ -44,8 +81,11 @@ overview=[
  chart("line-chart","Revenue & Profit by Month","[OFV/Month Number]","Month",
        [("Sum([OFV/Net Revenue])","Net Revenue","$,.0f"),("Sum([OFV/Net Profit])","Net Profit","$,.0f")]),
  chart("bar-chart","Net Revenue by Customer Segment","[OFV/Customer Segment]","Segment",[("Sum([OFV/Net Revenue])","Net Revenue","$,.0f")]),
+ # Qlik hides the unmatched-store rows (associative model) and the source table reads
+ # best by revenue — group by the dims, sort desc, drop the null-store bucket.
  table("Store Performance",[("[OFV/Store Name]","Store"),("[OFV/Store Region]","Region")],
-       [("Sum([OFV/Net Revenue])","Net Revenue","$,.0f"),("CountDistinct([OFV/Order Id])","Orders",",.0f")]),
+       [("Sum([OFV/Net Revenue])","Net Revenue","$,.0f"),("CountDistinct([OFV/Order Id])","Orders",",.0f")],
+       sort=("Net Revenue","descending"),exclude_null_dim="Store"),
 ]
 spec={"name":"Retail Orders — Overview (from Qlik)","folderId":FOLDER,"schemaVersion":1,
   "pages":[{"id":"page-data","name":"Data","elements":[master]},

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
@@ -113,11 +113,22 @@ def main():
         oid, qtype = o.get("qId"), o.get("qType")
         props = qlik("app", "object", "properties", oid, "-a", a.app, *ctx) or {}
         hc = props.get("qHyperCubeDef", {})
+        # Carry the object's sort definition so the workbook build can reproduce it:
+        # per-dimension qSortCriterias (qSortByNumeric/qSortByAscii/qSortByExpression),
+        # per-measure qSortBy, and the column precedence (qInterColumnSortOrder).
+        # Empty lists/{} mean "Qlik default" — the builder should only emit a Sigma
+        # sort (xAxis.sort / element sort:[{columnId,direction}]) when one is present.
+        sort = {
+            "interColumnSortOrder": hc.get("qInterColumnSortOrder") or [],
+            "dimensions": [ (dd.get("qDef", {}).get("qSortCriterias") or []) for dd in hc.get("qDimensions", []) ],
+            "measures":   [ (mm.get("qSortBy") or {}) for mm in hc.get("qMeasures", []) ],
+        }
         charts.append({
             "id": oid, "vizType": qtype,
             "title": (props.get("qMetaDef") or {}).get("title") or (props.get("title")),
             "dimensions": [ (dd.get("qDef", {}).get("qFieldDefs") or [dd.get("qLibraryId")]) for dd in hc.get("qDimensions", []) ],
             "measures":   [ (mm.get("qDef", {}).get("qDef") or mm.get("qLibraryId")) for mm in hc.get("qMeasures", []) ],
+            "sort": sort,
         })
     json.dump(charts, open(os.path.join(a.out, "charts.json"), "w"), indent=2)
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -269,11 +269,9 @@ unless opts[:skip_layout]
         if layout_xml.empty?
           warn "[FAIL] gate 4/4: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
-          warn "       dashboard grid. Build a layout and PUT it:"
-          warn "         ruby scripts/build-dashboard-layout.rb \\"
-          warn "           --layout #{opts[:tab]}/dashboard-layout.json \\"
-          warn "           --wb-ids #{opts[:tab]}/wb-ids.json \\"
-          warn "           --out #{opts[:tab]}/layout.xml"
+          warn "       dashboard grid. Rebuild the layout with this skill's layout"
+          warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
+          warn "       then PUT it:"
           warn "         ruby scripts/put-layout.rb --workbook #{wb_id} \\"
           warn "           --layout #{opts[:tab]}/layout.xml"
           warn "       See beads-sigma-bw3."
@@ -291,9 +289,8 @@ unless opts[:skip_layout]
           non_data_stack_pages.each do |pid, col, n|
             warn "         page=#{pid.inspect}: #{n} elements all at gridColumn=#{col.inspect}"
           end
-          warn "       Build a real layout and PUT it:"
-          warn "         ruby scripts/build-dashboard-layout.rb --layout #{opts[:tab]}/dashboard-layout.json \\"
-          warn "           --wb-ids #{opts[:tab]}/wb-ids.json --out #{opts[:tab]}/layout.xml"
+          warn "       Rebuild the layout with this skill's layout builder (see SKILL.md —"
+          warn "       layout phase) into #{opts[:tab]}/layout.xml, then PUT it:"
           warn "         ruby scripts/put-layout.rb --workbook #{wb_id} --layout #{opts[:tab]}/layout.xml"
           warn "       See beads-sigma-bw3."
           exit 6

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
@@ -32,13 +32,22 @@ v2e = map['visualToElement']             # QS VisualId -> Sigma element id
 GRID = 36.0                              # QuickSight max grid width (fallback only)
 SIG = 24                                 # Sigma grid width
 
-# QuickSight does NOT use a fixed 36-column grid. A sheet's effective grid width is
-# whatever the widest row of tiles adds up to — commonly 12, 18, 24, or 36 depending
-# on how the author sized things. Scaling every layout by a hardcoded 36 squeezes a
-# 12-wide D4 into the left third of the Sigma page. Infer the real width as the max
-# (ColumnIndex + ColumnSpan) across the sheet's elements, so relative widths + the
-# overall span are preserved when we scale to Sigma's 24 columns.
-def infer_grid_width(els)
+# QuickSight does NOT use a fixed 36-column grid when indices are EXPLICIT. A sheet's
+# effective grid width is whatever the widest row of tiles adds up to — commonly 12,
+# 18, 24, or 36 depending on how the author sized things. Scaling every layout by a
+# hardcoded 36 squeezes a 12-wide D4 into the left third of the Sigma page. Infer the
+# real width as the max row edge (ColumnIndex + ColumnSpan — i.e. the per-row span sum
+# of the widest row) across the sheet's elements, so relative widths + the overall
+# span are preserved when we scale to Sigma's 24 columns.
+#
+# SPANS-ONLY layouts (auto-flow GridLayout: ColumnSpan but no ColumnIndex) are a
+# DIFFERENT case: QS auto-flows those on its full 36-column canvas, so the canvas IS
+# 36. Taking max(span) as the width here collapsed a uniform-18-span sheet (2-up on
+# the QS canvas) into a full-width single-column stack (every 18-span tile scaled to
+# 18/18 = full width) — beads-sigma-vvus. Spans-only callers must pass
+# spans_only: true to get the fixed 36 canvas.
+def infer_grid_width(els, spans_only: false)
+  return GRID if spans_only
   edges = els.map { |e| (e['ColumnIndex'] || 0) + (e['ColumnSpan'] || 0) }
   w = edges.compact.max.to_f
   w >= 1 ? w : GRID
@@ -85,7 +94,7 @@ def layout_sheet(sheet, v2e, eids_for_sheet)
         placed << [eid, c0, c1, r0, r1]
       end
     else
-      grid_w = infer_grid_width(els); grid_w = GRID if grid_w <= 0
+      grid_w = infer_grid_width(els, spans_only: true); grid_w = GRID if grid_w <= 0
       col = 0; row = 1; row_h = 0
       els.each do |e|
         eid = v2e[e['ElementId']]; next unless eid && eids_for_sheet.include?(eid)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -228,6 +228,71 @@ def field_id(f)
    f['CategoricalDimensionField'] || f['DateDimensionField'] || {})['FieldId']
 end
 
+# ---- QS SortConfiguration -> Sigma sort (beads-sigma-xvjl) -------------------
+# QuickSight sorts live under ChartConfiguration.SortConfiguration, e.g.
+#   { "CategorySort": [ { "FieldSort":  { "FieldId": "...", "Direction": "DESC" } },
+#                       { "ColumnSort": { "SortBy": { "Column": { "ColumnName": ... } },
+#                                         "Direction": "ASC", "AggregationFunction": {...} } } ] }
+# (bar/line/pie use CategorySort; TableVisual uses RowSort.) Resolve the sorted field
+# to the Sigma column built for the visual and emit the verified Sigma shapes:
+#   bar/line/area/combo/scatter : xAxis.sort  = { by: <colId>, direction: }
+#   pie/donut                   : color.sort  = { by: <colId>, direction: }
+#   table                       : sort        = [{ columnId:, direction: }]
+# (pivot-table columnsBy/rowsBy sorts are NOT spec-supported — skipped with a warning.)
+
+# Every FieldId -> raw ColumnName mapping in the visual's field wells.
+def fid_to_colname(field_wells)
+  map = {}
+  walk = lambda do |o|
+    if o.is_a?(Hash)
+      if o['FieldId'] && (cn = o.dig('Column', 'ColumnName'))
+        map[o['FieldId']] = cn
+      end
+      o.each_value { |v| walk.call(v) }
+    elsif o.is_a?(Array)
+      o.each { |v| walk.call(v) }
+    end
+  end
+  walk.call(field_wells || {})
+  map
+end
+
+# Apply a visual's SortConfiguration to the built Sigma element (mutates el).
+def apply_qs_sorts(el, inner, kind, title, warnings)
+  cc = inner['ChartConfiguration'] || {}
+  sc = cc['SortConfiguration']
+  return unless sc.is_a?(Hash) && !sc.empty?
+  entries = sc.values.find { |v| v.is_a?(Array) && !v.empty? } # CategorySort / RowSort / ...
+  return unless entries
+  if kind == 'pivot-table'
+    warnings << { 'visual' => title, 'type' => 'SortConfiguration',
+                  'reason' => 'pivot-table sorts are not spec-expressible in Sigma (columnsBy/rowsBy sort rejected) — set in the UI' }
+    return
+  end
+  fidmap = fid_to_colname(cc['FieldWells'])
+  entries.each_with_index do |entry, i|
+    fs = entry['FieldSort']; cs = entry['ColumnSort']
+    raw = fs ? fidmap[fs['FieldId']] : cs&.dig('SortBy', 'Column', 'ColumnName')
+    dir = ((fs || cs || {})['Direction'].to_s.upcase == 'DESC') ? 'descending' : 'ascending'
+    next unless raw
+    # column names on the element: calc fields keep the raw name, physical cols are disp()'d
+    col = (el['columns'] || []).find { |c| c['name'] == disp(raw) || c['name'] == raw }
+    unless col
+      warnings << { 'visual' => title, 'type' => 'SortConfiguration',
+                    'reason' => "sort field '#{raw}' is not among the visual's Sigma columns — sort skipped" }
+      next
+    end
+    case kind
+    when 'bar-chart', 'line-chart', 'area-chart', 'combo-chart', 'scatter-chart'
+      (el['xAxis'] ||= {})['sort'] = { 'by' => col['id'], 'direction' => dir } if i.zero?
+    when 'pie-chart', 'donut-chart'
+      (el['color'] ||= {})['sort'] = { 'by' => col['id'], 'direction' => dir } if i.zero?
+    when 'table'
+      (el['sort'] ||= []) << { 'columnId' => col['id'], 'direction' => dir }
+    end
+  end
+end
+
 # Translate a QuickSight TableVisual ConditionalFormatting block into Sigma
 # `conditionalFormats` (D19). Supported QS -> Sigma mappings (verified spec-expressible
 # + round-tripping via /v2/workbooks/spec, 2026-06-06):
@@ -646,6 +711,8 @@ defn['Sheets'].each_with_index do |sh, sheet_idx|
                         'region' => { 'id' => did, 'regionType' => region_type_for(geo[0][1]) })
       end
     end
+    # carry the visual's QS SortConfiguration (CategorySort/RowSort) when present
+    apply_qs_sorts(el, inner, kind, title, build_warnings) if el
     elements << el if el
   end
   # one Sigma page per QS sheet (skip a sheet that produced zero elements)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
@@ -153,7 +153,9 @@ if opts[:emit]
   puts "  database: #{opts[:db] || '(override if dataset path is incomplete)'}"
   puts "  schema:   #{opts[:schema] || '(override if dataset path is incomplete)'}"
   puts
-  puts "Save the returned model, then: ruby scripts/convert-model.rb --fixup --in <model>.json --discover-dir #{dir} --out dm-spec.json"
+  # --folder-id is REQUIRED by --fixup (POST /v2/dataModels/spec rejects specs without
+  # folderId) — print it in the next-step command so the agent doesn't hit the abort.
+  puts "Save the returned model, then: ruby scripts/convert-model.rb --fixup --in <model>.json --discover-dir #{dir} --folder-id #{opts[:folder] || '<SIGMA_FOLDER_ID>'} --out dm-spec.json"
   exit 0
 end
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/phase6-parity-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/phase6-parity-quicksight.rb
@@ -66,24 +66,26 @@ rescue JSON::ParserError
   YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
 end
 
-# Resolve the (dim, val) column display names for a chart element, by kind.
-# Returns [dim_name, val_name] (dim_name nil for KPI) or nil if not plannable.
+# Resolve the (dim, val) columns for a chart element, by kind. Returns
+# [[dim_id, dim_name], [val_id, val_name]] (dim pair nil for KPI) or nil if not
+# plannable. The IDs matter: sigma-mcp-v2 workbook queries resolve COLUMN IDS, not
+# display labels — SQL emitted against display names fails to resolve.
 def chart_columns(el)
   cols = el['columns'] || []
   by_id = cols.each_with_object({}) { |c, h| h[c['id']] = c['name'] }
   case el['kind']
   when 'kpi-chart'
     vid = el.dig('value', 'columnId') || el.dig('value', 'id')
-    by_id[vid] && [nil, by_id[vid]]
+    by_id[vid] && [nil, [vid, by_id[vid]]]
   when 'pie-chart', 'donut-chart'
     did = el.dig('color', 'id') || el.dig('color', 'columnId')
     vid = el.dig('value', 'id') || el.dig('value', 'columnId')
-    by_id[did] && by_id[vid] ? [by_id[did], by_id[vid]] : nil
+    by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
   else # bar-chart, line-chart, combo-chart, scatter-chart, ...
     did = el.dig('xAxis', 'columnId')
     vid = Array(el.dig('yAxis', 'columnIds')).first
     vid = vid['columnId'] if vid.is_a?(Hash) # combo dual-axis object form
-    by_id[did] && by_id[vid] ? [by_id[did], by_id[vid]] : nil
+    by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
   end
 end
 
@@ -103,10 +105,12 @@ if !opts[:finalize]
   Array(spec['pages']).each do |page|
     Array(page['elements']).each do |el|
       next unless el['kind'].to_s.end_with?('-chart')
-      names = chart_columns(el)
-      next unless names
+      pairs = chart_columns(el)
+      next unless pairs
       charts << { 'chart' => el['name'], 'sigma_element_id' => el['id'],
-                  'kind' => el['kind'], 'sigma_columns' => names.compact,
+                  'kind' => el['kind'],
+                  'sigma_columns' => pairs.compact.map { |id_name| id_name[1] },
+                  'sigma_column_ids' => pairs.compact.map { |id_name| id_name[0] },
                   'workbook_id' => opts[:wb] }
     end
   end
@@ -129,11 +133,14 @@ if !opts[:finalize]
   puts 'KPI charts: a single row [[null, <value>]].'
   puts ''
   charts.each_with_index do |c, i|
-    cols = c['sigma_columns']
-    sql = if cols.length >= 2
-            %(SELECT "#{cols[0]}" AS dim, "#{cols[1]}" AS val FROM "workbook"."#{c['sigma_element_id']}" ORDER BY dim NULLS FIRST)
+    # Query by COLUMN ID (sigma-mcp-v2 can't resolve display labels in workbook
+    # queries); the display names ride along in a trailing SQL comment for readability.
+    ids = c['sigma_column_ids']
+    names = c['sigma_columns']
+    sql = if ids.length >= 2
+            %(SELECT "#{ids[0]}" AS dim, "#{ids[1]}" AS val FROM "workbook"."#{c['sigma_element_id']}" ORDER BY dim NULLS FIRST -- dim: #{names[0]}, val: #{names[1]})
           else
-            %(SELECT "#{cols[0]}" AS val FROM "workbook"."#{c['sigma_element_id']}")
+            %(SELECT "#{ids[0]}" AS val FROM "workbook"."#{c['sigma_element_id']}" -- val: #{names[0]})
           end
     puts "  [#{i + 1}/#{charts.length}] #{c['chart']} (#{c['kind']})"
     puts "    mcp__sigma-mcp-v2__query  type=workbook  workbookId=#{opts[:wb]}"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -269,11 +269,9 @@ unless opts[:skip_layout]
         if layout_xml.empty?
           warn "[FAIL] gate 4/4: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
-          warn "       dashboard grid. Build a layout and PUT it:"
-          warn "         ruby scripts/build-dashboard-layout.rb \\"
-          warn "           --layout #{opts[:tab]}/dashboard-layout.json \\"
-          warn "           --wb-ids #{opts[:tab]}/wb-ids.json \\"
-          warn "           --out #{opts[:tab]}/layout.xml"
+          warn "       dashboard grid. Rebuild the layout with this skill's layout"
+          warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
+          warn "       then PUT it:"
           warn "         ruby scripts/put-layout.rb --workbook #{wb_id} \\"
           warn "           --layout #{opts[:tab]}/layout.xml"
           warn "       See beads-sigma-bw3."
@@ -291,9 +289,8 @@ unless opts[:skip_layout]
           non_data_stack_pages.each do |pid, col, n|
             warn "         page=#{pid.inspect}: #{n} elements all at gridColumn=#{col.inspect}"
           end
-          warn "       Build a real layout and PUT it:"
-          warn "         ruby scripts/build-dashboard-layout.rb --layout #{opts[:tab]}/dashboard-layout.json \\"
-          warn "           --wb-ids #{opts[:tab]}/wb-ids.json --out #{opts[:tab]}/layout.xml"
+          warn "       Rebuild the layout with this skill's layout builder (see SKILL.md —"
+          warn "       layout phase) into #{opts[:tab]}/layout.xml, then PUT it:"
           warn "         ruby scripts/put-layout.rb --workbook #{wb_id} --layout #{opts[:tab]}/layout.xml"
           warn "       See beads-sigma-bw3."
           exit 6


### PR DESCRIPTION
## What

Cross-tool fidelity fixes across qlik / looker / quicksight (+ the vendored gate in tableau/powerbi), each E2E-validated against live Sigma (org tj-wells-1989).

### Qlik (bead 7dgd)
- `build-sigma-workbook.py` `table()` now emits the gotchas-required `groupings` (groupBy dims + calculations measures) — the Store Performance table rolls up to store grain instead of rendering 653 raw rows.
- Null/unmatched-key exclusion on the store dim (Qlik associative behavior): hidden `Not(IsNull(...))` bool column + element list-filter `values:[true]`. Deliberate choice — `QLIK_KEEP_UNMATCHED=1` keeps the rows (warehouse-faithful).
- Sort plumbing on `chart()`/`table()`; store table sorted Net Revenue desc. **New verified shape:** a grouped table 400s on element-level `sort` ("Sort column not found") — the sort must nest inside the grouping entry: `groupings[0].sort=[{columnId,direction}]`. Documented in `refs/sigma-build-gotchas.md`.
- `qlik-discover.py` captures per-chart `qSortCriterias` / `qSortBy` / `qInterColumnSortOrder` into charts.json so builds can carry source sorts.

### Looker (beads 0m79 + f972 partial)
- `build_workbook.py`: (a) `groupings` for table tiles; (b) filter-only fields carried `hidden: true`; (c) tile `sorts:` carried → `xAxis.sort` / `color.sort` / element sort / `groupings[0].sort`; (d) **bar x-axis label fix**: Looker newspaper rows (~40px) were mapped 1:1 onto Sigma grid rows (~20px) — every tile rendered half-height and Sigma suppresses x-axis category labels on short chart bands (same family as beads-sigma-tkkv). `ROW_SCALE=2` restores the heights; labels render.
- `post_dm.py`: WARN-and-drop guard for the MCP lookml converter's join-key passthrough column on the denorm element (cross-element passthrough of a join key compiles to `type=error`). The emitter is the MCP converter's local `buildDerivedElements` in `lookml.ts`, not this repo — hence a guard here.

### QuickSight (beads vvus + xvjl)
- `build-quicksight-layout.rb`: spans-only GridLayouts use QS's fixed 36-col canvas (taking `max(span)` collapsed uniform-18-span sheets into a full-width stack). Explicit-index inference unchanged.
- `phase6-parity-quicksight.rb` PASS 1 emits SQL with **column IDs** resolved from the spec (sigma-mcp-v2 can't resolve display labels); display names ride in a trailing SQL comment.
- `assert-phase6-ran.rb` gate-4 fix-it text made converter-generic; applied byte-identically to all 3 vendored copies — md5 `c46eb5465ba9faa563ac4689d6f10657` for tableau/powerbi/quicksight.
- `convert-model.rb --emit-mcp` next-step command now includes `--folder-id`.
- `build-workbook-from-quicksight.rb` carries QS `SortConfiguration` (CategorySort/RowSort; FieldSort + ColumnSort) into the spec; pivot sorts warned (not spec-expressible).

## E2E (all VISQA2*, KEPT)
| Tool | Objects | Verdict |
|---|---|---|
| Qlik (live app ec9a73e3, read-only) | DM `50957489` + wb `e4c9a64f` | Store table 14 grouped rows, desc by revenue, null bucket excluded; parity exact 110,342.75 / 648 / 62.4147%; PNG read |
| QuickSight (bundled fixture) | DM `dc468d95` + wb `3b156081` | 2-up layout straight from the script, parity 5/5 strict, `assert-phase6-ran.rb` exit 0, no hand-fix; PNG read |
| Looker (offline fixture) | DM `f2f33b41` + wb `4d942f1c` | Channel Summary grouped (3 rows) + sorted desc from the script; bar shows category labels; join-key guard fired (0 error columns); parity exact 110,342.75 / 648 / 170.28; PNG read |

PNGs: `~/migration-visual-qa/{qlik2,looker2,quicksight2}/` with OBJECTS.txt inventories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)