### PR TITLE
powerbi-to-sigma fidelity fixes: scatter grouping, YoY headline KPI, data labels, classic auto-branch, small bugs

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/QUICKSTART.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/QUICKSTART.md
@@ -124,8 +124,9 @@ inspect or hand-tune each stage. The phases:
 
 1. **Extract** (`fabric-extract.py`) — device-code → Fabric `getDefinition` →
    **TMSL** (tables, measures, calc columns, RLS, M sources) + **PBIR** (pages, visuals,
-   field bindings). Classic single-`report.json` reports are handled too
-   (`extract-report-classic.py`).
+   field bindings). Classic single-`report.json` reports are handled too:
+   `run.sh` auto-detects the legacy shape (no `definition/` folder) and branches to
+   `extract-report-classic.py`.
 2. **Translate** — `convert_powerbi_to_sigma` maps the model + DAX to a Sigma spec.
    Apply the required POST fixups (`schemaVersion`, folderId, element name).
 3. **Build the data model** — POST to `/v2/dataModels/spec`; verify every column has a
@@ -157,7 +158,7 @@ Duration: 3
 Duration: 3
 
 - **Extraction with no Entra app** — device-code + well-known client + `truststore`; works on *My workspace*.
-- **PBIR vs classic report.json** — newer reports are exploded PBIR; older ones are a single `report.json` with `sections[]` — detect and branch.
+- **PBIR vs classic report.json** — newer reports are exploded PBIR; older ones are a single `report.json` with `sections[]` — `run.sh` detects and branches automatically (`extract-report-classic.py`).
 - **Spec fixups** — three required edits before POST (`schemaVersion: 1`, real `folderId`, element `name`).
 - **Time-intelligence DAX** is translatable (not part of the (c) tail) via `DateLookback`/`CumulativeSum` on a date-grouped workbook element.
 - **Hard DAX → gap-scout sub-agent** — measures the converter buckets `b`/`c` (`RANKX`, `ALLEXCEPT`, `SUMMARIZE`, `USERELATIONSHIP`, …) are handed to a gap-scout (`scripts/gap-scout.md`): it proposes a Sigma translation, **validates it against the live Sigma API** (`scout-validate.py`), and persists the rule to `~/.powerbi-to-sigma/learned-rules.yaml` so future runs auto-apply it. When the scout hits a genuine converter gap it can **(opt-in) file a GitHub issue** so the gap gets fixed upstream — it always confirms before filing.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/measure-patterns.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/measure-patterns.md
@@ -323,6 +323,27 @@ YTD = the 2025 total). See `dax-to-sigma-coverage.md` #3.
 > element with DateLookback/CumulativeSum" instruction (bead filed). Until then,
 > the agent adds them as workbook calc columns per the recipe above.
 
+**Headline KPI from a grouped time-intel element (bead 525l).** A single-value
+PBI card bound to a time-intel measure (e.g. a "Net Revenue YoY %" headline)
+must consume the GROUPED element, which has one row per period — so a bare
+row-level ref (`[YR/Net Revenue YoY %]`, agg `nil`) is **nondeterministic**
+(null or an arbitrary period's row), and `Last(...)` depends on sort order.
+The verified deterministic form is "the latest period's value":
+
+```
+Sum(If([YR/Year] = Max([YR/Year]), [YR/Net Revenue YoY %], Null))
+```
+
+`Max([Year])` finds the latest period over the whole element, the `If` nulls
+every other row, and the `Sum` collapses to that single value. The same formula
+is also safe in a chart **grouped by** that date column (within each group
+`Max(date) = date`, so it degrades to the per-period value) — which is why
+`migrate-powerbi.rb` emits it as the field's verbatim `formula`
+(`build-workbook-from-pbir.rb`'s `measure_formula` hook) for every time-intel
+headline/YoY/PY/YTD field-map entry, covering both the KPI and date-grouped
+chart consumers. Validated live on the Retail-Trends migration (−13.58% = the
+2026 YoY, matching PBI's headline card).
+
 ## 10. Bar vs Column orientation (chart fidelity)
 
 PBI **`barChart`/`clusteredBarChart`/`stackedBarChart`** render **horizontal**;

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -96,9 +96,27 @@ def field_spec(queryref, fields, chosen_master = nil)
   fs ||= { 'master' => nil, 'ref' => "[#{queryref}]", 'agg' => nil }
   if chosen_master && fs['master'] != chosen_master && fs['alts'].is_a?(Array)
     alt = fs['alts'].find { |a| a['master'] == chosen_master }
-    return fs.merge(alt) if alt
+    if alt
+      merged = fs.merge(alt)
+      # A verbatim `formula` on the PRIMARY resolution references the primary
+      # master's columns — it is invalid on the alt's master (bead 525l). Drop it
+      # unless the alt carries its own.
+      merged.delete('formula') unless alt.key?('formula')
+      return merged
+    end
   end
   fs
+end
+
+# bead hjke(b): display-name leaf from a queryRef. Classic-report queryRefs can
+# carry the AGGREGATED form "Sum(TABLE.COL)" — a naive split('.').last leaves a
+# trailing paren ("COL)"). Unwrap any Func( ... ) wrapper(s) first, then take
+# the dotted leaf.
+def qr_leaf(qr, fallback = 'Value')
+  s = qr.to_s.strip
+  s = Regexp.last_match(1).strip while s =~ /\A[A-Za-z_][A-Za-z0-9_ ]*\(\s*(.*)\s*\)\z/
+  leaf = s.split('.').last.to_s
+  leaf.empty? ? fallback : leaf
 end
 
 # PBI numeric format string (from signals 'formats' or master-map field 'format')
@@ -194,8 +212,11 @@ def visual_master(rec, fields)
   best && best[0]
 end
 
-# Build chart element from a normalized visual record.
-def build_element(rec, fields, masters)
+# Build chart element from a normalized visual record. `extra_data` is an
+# accumulator array: branches that need a HIDDEN helper element on the Data page
+# (bead ry0n: the scatter grouped-source table) push it there; the page assembly
+# appends extra_data to the Data page's elements.
+def build_element(rec, fields, masters, extra_data = [])
   kind = SIGMA_KIND[rec['sigma_kind']] || 'bar-chart'
   vid  = rec['visual_id']
   eid  = "el-#{short(vid)}"
@@ -239,7 +260,7 @@ def build_element(rec, fields, masters)
     # filters[]. The control defines NO columns of its own — it references the
     # master's existing column id, so it both populates from and filters that col.
     qr = (b['Values'] || b['Category'] || b['Fields'] || []).first
-    colname = (qr || 'Filter').split('.').last
+    colname = qr_leaf(qr, 'Filter')
     mcols = (master && masters[master] ? (masters[master]['columns'] || []) : [])
     mcol = mcols.find { |c| c['name'] == colname } || mcols.first
     tgt = mcol ? mcol['id'] : nil
@@ -265,9 +286,9 @@ def build_element(rec, fields, masters)
       return vals.each_with_index.map do |qr, i|
         fs = field_spec(qr, fields, master)
         kid = "#{eid}-k#{i}"
-        col = { 'id' => "#{kid}-v", 'formula' => measure_formula(fs), 'name' => qr.split('.').last }
+        col = { 'id' => "#{kid}-v", 'formula' => measure_formula(fs), 'name' => qr_leaf(qr) }
         apply_fmt(col, qr, fields, vfmts)
-        e = { 'id' => kid, 'kind' => 'kpi-chart', 'name' => qr.split('.').last,
+        e = { 'id' => kid, 'kind' => 'kpi-chart', 'name' => qr_leaf(qr),
               'columns' => [col], 'value' => { 'columnId' => "#{kid}-v" } }
         e['source'] = { 'elementId' => master_id, 'kind' => 'table' } if master_id
         e
@@ -276,7 +297,7 @@ def build_element(rec, fields, masters)
     qr = vals.first
     fs = field_spec(qr, fields, master)
     cid = "#{eid}-v"
-    col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => (qr || 'Value').split('.').last }
+    col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr_leaf(qr, 'Value') }
     apply_fmt(col, qr, fields, vfmts)
     cols << col
     # KPI value binds by `columnId` (the API rejects `{id}` -> "value.columnId:
@@ -286,17 +307,28 @@ def build_element(rec, fields, masters)
   when 'bar-chart', 'line-chart', 'area-chart'
     # b['Group'] is the treemap/funnel category role (1zh9) — alias it to the dim
     # so a treemap-as-bar fallback keeps its category instead of emitting '[]'.
-    dim = (b['Category'] || b['Axis'] || b['X'] || b['Group'] || []).first
+    dim_role = (b['Category'] || b['Axis'] || b['X'] || b['Group'] || [])
+    dim = dim_role.first
+    # bead hjke(c): a PBI date-hierarchy role carries one queryRef PER LEVEL
+    # (Year/Quarter/Month/Day). The extractors keep only the ACTIVE drill level
+    # when the report records one (activeProjections / active flag); if multiple
+    # levels still arrive here we can only bind the first — warn that the drill
+    # depth was reduced so the agent can re-point the dim at the intended level.
+    if dim_role.length > 1 &&
+       dim_role.all? { |q| q.to_s =~ /hierarchy/i || q.to_s =~ /\.(Year|Quarter|Month|Week|Day|Date)\s*\z/i }
+      warn "[build-workbook] WARN visual '#{name}': date hierarchy with #{dim_role.length} levels " \
+           "reduced to '#{dim}' — deeper drill levels (#{dim_role[1..].join(', ')}) dropped."
+    end
     meas = (b['Y'] || b['Values'] || [])
     series = (b['Series'] || b['Legend'] || []).first
     dfs = field_spec(dim, fields, master)
     dcid = "#{eid}-x"
-    cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => (dim || 'Dim').split('.').last }
+    cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => qr_leaf(dim, 'Dim') }
     ycids = []
     meas.each_with_index do |qr, i|
       fs = field_spec(qr, fields, master)
       cid = "#{eid}-y#{i}"
-      col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr.split('.').last }
+      col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr_leaf(qr) }
       apply_fmt(col, qr, fields, vfmts)
       cols << col
       ycids << cid
@@ -314,15 +346,19 @@ def build_element(rec, fields, masters)
     # "normalized" = scaled to 100%). extract-pbir already maps PBI 100%-stacked
     # -> "normalized", so pass it through verbatim (bead pi8v).
     el['stacking'] = rec['stacking'] if kind == 'bar-chart' && rec['stacking']
-    # value labels on bars (Sigma defaults them OFF); line/area left clean
-    el['dataLabel'] = { 'labels' => 'shown' } if kind == 'bar-chart'
+    # bead n9u9: honor the PBI per-visual data-label signal (objects.labels show)
+    # when the extractor provided one: true -> shown, false -> omit (Sigma default
+    # is off). Verified `dataLabel:{labels:"shown"}` persists + renders for bar AND
+    # line. Back-compat when the signal is nil/absent: bar shown, line/area clean.
+    dl = rec['data_labels']
+    el['dataLabel'] = { 'labels' => 'shown' } if dl == true || (dl.nil? && kind == 'bar-chart')
     # c07: default to single series. Only split by color when PBI bound a
     # Series/Legend role. Never auto-color a line by a dimension that PBI did
     # not legend (see refs/measure-patterns.md §1 + §4).
     if series
       sfs = field_spec(series, fields, master)
       scid = "#{eid}-c"
-      cols << { 'id' => scid, 'formula' => sfs['ref'], 'name' => series.split('.').last }
+      cols << { 'id' => scid, 'formula' => sfs['ref'], 'name' => qr_leaf(series, 'Series') }
       el['color'] = { 'by' => 'category', 'column' => scid }
     end
   when 'combo-chart'
@@ -336,12 +372,12 @@ def build_element(rec, fields, masters)
     line_meas = (b['Y2'] || [])
     dfs = field_spec(dim, fields, master)
     dcid = "#{eid}-x"
-    cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => (dim || 'Dim').split('.').last }
+    cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => qr_leaf(dim, 'Dim') }
     ycids = []
     col_meas.each_with_index do |qr, i|
       fs = field_spec(qr, fields, master)
       cid = "#{eid}-y#{i}"
-      col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr.split('.').last }
+      col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr_leaf(qr) }
       apply_fmt(col, qr, fields, vfmts)
       cols << col
       ycids << cid                                   # bare string -> primary (left) bars
@@ -349,7 +385,7 @@ def build_element(rec, fields, masters)
     line_meas.each_with_index do |qr, i|
       fs = field_spec(qr, fields, master)
       cid = "#{eid}-l#{i}"
-      col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr.split('.').last }
+      col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr_leaf(qr) }
       apply_fmt(col, qr, fields, vfmts)
       cols << col
       ycids << { 'columnId' => cid, 'type' => 'line' } # object -> secondary (right) line
@@ -361,33 +397,97 @@ def build_element(rec, fields, masters)
     # color/detail. PBI scatter binds X + Y (both measures) and a Category/Details.
     xqr = (b['X'] || b['Values'] || []).first
     yqr = (b['Y'] || []).first
-    detail = (b['Category'] || b['Details'] || b['Legend'] || []).first
+    detail = (b['Category'] || b['Details'] || b['Series'] || b['Legend'] || []).first
+    sizeqr = (b['Size'] || []).first
     xfs = field_spec(xqr, fields, master); yfs = field_spec(yqr, fields, master)
-    xcid = "#{eid}-x"; ycid = "#{eid}-y"
-    cx = { 'id' => xcid, 'formula' => measure_formula(xfs), 'name' => (xqr || 'X').split('.').last }
-    cy = { 'id' => ycid, 'formula' => measure_formula(yfs), 'name' => (yqr || 'Y').split('.').last }
-    apply_fmt(cx, xqr, fields, vfmts); apply_fmt(cy, yqr, fields, vfmts)
-    cols << cx << cy
-    el['xAxis'] = { 'columnId' => xcid }
-    el['yAxis'] = { 'columnIds' => [ycid] }
-    if detail
-      dfs = field_spec(detail, fields, master)
-      dcid = "#{eid}-d"
-      cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => detail.split('.').last }
-      el['color'] = { 'by' => 'category', 'column' => dcid }
+    is_meas = ->(fs) { !(fs['agg'].to_s.empty? && fs['formula'].to_s.empty?) }
+    if is_meas.call(xfs) && detail && master_id
+      # bead ry0n: Sigma's scatter xAxis is a GROUPING axis — binding an AGGREGATE
+      # to it makes the aggregate evaluate per-row (Count -> 1) and every point
+      # collapses to x=1. Verified fix: pre-aggregate in a HIDDEN grouped source
+      # table on the Data page (dim + x/y[/size] aggregates, grouped by the dim),
+      # then point the scatter at it with ALL-RAW column refs. The detail dim MUST
+      # stay on color:{by:category} — points sharing an x merge to a null y
+      # without it.
+      dfs   = field_spec(detail, fields, master)
+      dname = qr_leaf(detail, 'Detail'); xname = qr_leaf(xqr, 'X'); yname = qr_leaf(yqr, 'Y')
+      src_id   = "#{eid}-src"
+      src_name = "Scatter Source #{short(vid)}"   # unique name: raw refs resolve [Name/Col]
+      gd = "#{src_id}-d"; gx = "#{src_id}-x"; gy = "#{src_id}-y"
+      gcols = [
+        { 'id' => gd, 'formula' => dfs['ref'], 'name' => dname },
+        apply_fmt({ 'id' => gx, 'formula' => measure_formula(xfs), 'name' => xname }, xqr, fields, vfmts),
+        apply_fmt({ 'id' => gy, 'formula' => measure_formula(yfs), 'name' => yname }, yqr, fields, vfmts)
+      ]
+      calc_ids = [gx, gy]
+      szname = nil
+      if sizeqr
+        szfs = field_spec(sizeqr, fields, master)
+        if is_meas.call(szfs)
+          szname = qr_leaf(sizeqr, 'Size')
+          # avoid a display-name collision with x/y (e.g. Size bound to the same measure)
+          szname = "#{szname} (Size)" if [dname, xname, yname].include?(szname)
+          gsz = "#{src_id}-s"
+          gcols << apply_fmt({ 'id' => gsz, 'formula' => measure_formula(szfs), 'name' => szname }, sizeqr, fields, vfmts)
+          calc_ids << gsz
+        else
+          warn "[build-workbook] WARN scatter '#{name}': Size role '#{sizeqr}' is not a measure — size DROPPED."
+        end
+      end
+      extra_data << { 'id' => src_id, 'kind' => 'table', 'name' => src_name,
+                      'source' => { 'elementId' => master_id, 'kind' => 'table' },
+                      'columns' => gcols,
+                      'groupings' => [{ 'id' => "#{src_id}-g", 'groupBy' => [gd], 'calculations' => calc_ids }],
+                      'visibleAsSource' => false }
+      el['source'] = { 'elementId' => src_id, 'kind' => 'table' }
+      dcid = "#{eid}-d"; xcid = "#{eid}-x"; ycid = "#{eid}-y"
+      cols << { 'id' => dcid, 'formula' => "[#{src_name}/#{dname}]", 'name' => dname }
+      cols << apply_fmt({ 'id' => xcid, 'formula' => "[#{src_name}/#{xname}]", 'name' => xname }, xqr, fields, vfmts)
+      cols << apply_fmt({ 'id' => ycid, 'formula' => "[#{src_name}/#{yname}]", 'name' => yname }, yqr, fields, vfmts)
+      el['xAxis'] = { 'columnId' => xcid }
+      el['yAxis'] = { 'columnIds' => [ycid] }
+      el['color'] = { 'by' => 'category', 'column' => dcid }   # REQUIRED (see above)
+      if szname
+        szcid = "#{eid}-s"
+        cols << apply_fmt({ 'id' => szcid, 'formula' => "[#{src_name}/#{szname}]", 'name' => szname }, sizeqr, fields, vfmts)
+        el['size'] = { 'id' => szcid }
+      end
+    else
+      warn "[build-workbook] WARN scatter '#{name}': measure X with no Details/Category dim — " \
+           'points will collapse to one x value.' if is_meas.call(xfs) && !detail
+      xcid = "#{eid}-x"; ycid = "#{eid}-y"
+      cx = { 'id' => xcid, 'formula' => measure_formula(xfs), 'name' => qr_leaf(xqr, 'X') }
+      cy = { 'id' => ycid, 'formula' => measure_formula(yfs), 'name' => qr_leaf(yqr, 'Y') }
+      apply_fmt(cx, xqr, fields, vfmts); apply_fmt(cy, yqr, fields, vfmts)
+      cols << cx << cy
+      el['xAxis'] = { 'columnId' => xcid }
+      el['yAxis'] = { 'columnIds' => [ycid] }
+      if detail
+        dfs = field_spec(detail, fields, master)
+        dcid = "#{eid}-d"
+        cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => qr_leaf(detail, 'Detail') }
+        el['color'] = { 'by' => 'category', 'column' => dcid }
+      end
+      warn "[build-workbook] WARN scatter '#{name}': Size role '#{(b['Size'] || []).first}' DROPPED " \
+           '(ungrouped scatter path).' if (b['Size'] || []).first
     end
+    # PBI legend.show=false -> hide the Sigma legend (the detail-on-color split
+    # otherwise surfaces a legend PBI did not show).
+    el['legend'] = { 'visibility' => 'hidden' } if rec['legend'] == false
   when 'pie-chart', 'donut-chart'
     dim = (b['Category'] || b['Legend'] || []).first
     val = (b['Values'] || b['Y'] || []).first
     dfs = field_spec(dim, fields, master); vfs = field_spec(val, fields, master)
     dcid = "#{eid}-c"; vcid = "#{eid}-v"
-    cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => (dim || 'Dim').split('.').last }
-    cv = { 'id' => vcid, 'formula' => measure_formula(vfs), 'name' => (val || 'Value').split('.').last }
+    cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => qr_leaf(dim, 'Dim') }
+    cv = { 'id' => vcid, 'formula' => measure_formula(vfs), 'name' => qr_leaf(val, 'Value') }
     apply_fmt(cv, val, fields, vfmts)
     cols << cv
     el['color'] = { 'id' => dcid }
     el['value'] = { 'id' => vcid }
-    el['dataLabel'] = { 'labels' => 'shown' }   # value labels on pie/donut slices
+    # value labels on pie/donut slices — honor an explicit PBI labels-off signal
+    # (bead n9u9); default (nil/absent) keeps the labels shown as before.
+    el['dataLabel'] = { 'labels' => 'shown' } unless rec['data_labels'] == false
   when 'table'
     # A plain table with measure columns renders FLAT/ungrouped unless it has a
     # grouping whose `calculations` lists the measure col ids (bead 14w(f)).
@@ -402,7 +502,7 @@ def build_element(rec, fields, masters)
       cid = "#{eid}-c#{i}"
       is_dim = fs['agg'].to_s.empty? && fs['formula'].to_s.empty?
       col = { 'id' => cid, 'formula' => is_dim ? fs['ref'] : measure_formula(fs),
-              'name' => qr.split('.').last }
+              'name' => qr_leaf(qr) }
       apply_fmt(col, qr, fields, vfmts) unless is_dim
       cols << col
       if is_dim
@@ -421,19 +521,19 @@ def build_element(rec, fields, masters)
     rowids = []
     rows.each_with_index do |qr, i|
       fs = field_spec(qr, fields, master); cid = "#{eid}-r#{i}"
-      cols << { 'id' => cid, 'formula' => fs['ref'], 'name' => qr.split('.').last }
+      cols << { 'id' => cid, 'formula' => fs['ref'], 'name' => qr_leaf(qr) }
       rowids << cid
     end
     colids = []
     colsby.each_with_index do |qr, i|
       fs = field_spec(qr, fields, master); cid = "#{eid}-col#{i}"
-      cols << { 'id' => cid, 'formula' => fs['ref'], 'name' => qr.split('.').last }
+      cols << { 'id' => cid, 'formula' => fs['ref'], 'name' => qr_leaf(qr) }
       colids << cid
     end
     valids = []
     vals.each_with_index do |qr, i|
       fs = field_spec(qr, fields, master); cid = "#{eid}-v#{i}"
-      col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr.split('.').last }
+      col = { 'id' => cid, 'formula' => measure_formula(fs), 'name' => qr_leaf(qr) }
       apply_fmt(col, qr, fields, vfmts)
       cols << col
       valids << cid
@@ -462,14 +562,18 @@ data_elements = masters.map do |_name, m|
   }
 end
 
+# bead ry0n: hidden helper elements (scatter grouped sources) accumulate here
+# and are appended to the Data page below.
+extra_data_elements = []
 content_pages = signals['pages'].map do |pg|
   # build_element may return one element or an array (multiRowCard -> N KPIs).
   els = pg['visuals'].flat_map do |v|
-    r = build_element(v, fields, masters)
+    r = build_element(v, fields, masters, extra_data_elements)
     r.is_a?(Array) ? r : [r]   # NB: not Array(r) — that explodes a Hash into pairs
   end
   { 'id' => "page-#{pg['page_id']}", 'name' => pg['page_title'], 'elements' => els }
 end
+data_elements += extra_data_elements
 
 # ---- 24-col grid layout (research/powerbi-visual-layout.md §4) -------------
 # Built BEFORE the spec is assembled so the layout XML can be EMBEDDED into the

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/convert-model.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/convert-model.rb
@@ -54,6 +54,16 @@ OptionParser.new do |p|
   p.on('--restructure-from-bim PATH','model.bim to scan for (b)-bucket DAX measures to auto-emit as elements') { |v| opts[:rbim] = v }
 end.parse!
 
+# bead hjke(a): a truncated/partial --connection id posts a DM whose sources
+# silently fail downstream ("Source not found" only at POST, or worse). Abort
+# early with a clear message unless it is a full UUID.
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+if opts[:conn] && opts[:conn] !~ UUID_RE
+  abort "FATAL: --connection must be a FULL Sigma connection UUID " \
+        "(8-4-4-4-12 hex, e.g. bc0319f8-1234-5678-9abc-def012345678); got #{opts[:conn].inspect}. " \
+        "List connections with GET /v2/connections."
+end
+
 # ---- MODE A: emit the MCP conversion instruction --------------------------
 if opts[:bim]
   abort('--bim not found: ' + opts[:bim]) unless File.exist?(opts[:bim])

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
@@ -121,13 +121,37 @@ def _fetch_pbir(ws, report, out_dir):
 
 
 def _role_bindings(query_state):
-    """{Role: [queryRef, ...]} from visual.query.queryState."""
+    """{Role: [queryRef, ...]} from visual.query.queryState.
+
+    bead hjke(c): a date-hierarchy role carries one projection PER LEVEL
+    (Year/Quarter/Month/Day); the drilled-to level is flagged `active`. When any
+    projection in a role carries an active flag, keep only the active one(s) so a
+    day-drilled line binds Day instead of collapsing to the first level (Year).
+    """
     out = {}
     for role, blk in (query_state or {}).items():
-        refs = [p.get("queryRef") or p.get("nativeQueryRef")
-                for p in blk.get("projections", []) if isinstance(p, dict)]
+        projs = [p for p in blk.get("projections", []) if isinstance(p, dict)]
+        active = [p for p in projs if p.get("active") is True]
+        if active and len(active) < len(projs):
+            print(f"[extract-pbir] drill: role {role} has {len(projs)} hierarchy level(s); "
+                  f"using active level only", file=sys.stderr)
+            projs = active
+        refs = [p.get("queryRef") or p.get("nativeQueryRef") for p in projs]
         out[role] = [r for r in refs if r]
     return out
+
+
+def _obj_flag(visual, key):
+    """objects.<key>[0].properties.show.expr.Literal.Value -> True/False/None.
+
+    bead n9u9 (labels) / ry0n (legend): PBI stores per-visual toggles as string
+    literals 'true'/'false'; absent means tool default -> None (callers keep
+    their back-compat behavior on None)."""
+    for item in visual.get("objects", {}).get(key, []):
+        v = item.get("properties", {}).get("show", {}).get("expr", {}).get("Literal", {}).get("Value")
+        if v is not None:
+            return str(v).strip("'").lower() == "true"
+    return None
 
 
 def _textbox_body(visual):
@@ -204,6 +228,10 @@ def extract(pbir_dir):
                 "parent_group": v.get("parentGroupName"),
                 "bindings": _role_bindings(qs),
                 "formats": formats,
+                # bead n9u9: PBI data-label toggle (objects.labels show) — true/false/None
+                "data_labels": _obj_flag(visual, "labels"),
+                # bead ry0n: PBI legend toggle (objects.legend show) — true/false/None
+                "legend": _obj_flag(visual, "legend"),
             }
             if rec["sigma_kind"] == "text":
                 rec["text"] = _textbox_body(visual)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
@@ -41,21 +41,35 @@ HBAR_TYPES = {"barChart", "clusteredBarChart", "stackedBarChart",
               "hundredPercentStackedBarChart"}
 
 # Geo/map visuals bind Series(=location dim) + Size(=measure). The bar branch of
-# the builder reads Category/Axis/X (dim) and Y/Values (measure), so remap.
+# the builder reads Category/Axis/X (dim) and Y/Values (measure), so remap —
+# but ONLY for map visuals (bead ry0n): on a scatterChart, Size is the real
+# bubble-size role and Series the legend; remapping them corrupts the scatter.
 ROLE_REMAP = {
     "Series": "Category",
     "Size": "Y",
     "Location": "Category",
     "Latitude": "Category",
 }
+MAP_TYPES = {"map", "filledMap", "shapeMap", "azureMap"}
 
 
-def _projections(sv):
+def _projections(sv, vt=None):
+    # bead hjke(c): classic configs record the drilled-to hierarchy level in
+    # singleVisual.activeProjections — prefer it over the full level list so a
+    # day-drilled line binds Day instead of collapsing to Year.
+    act = sv.get("activeProjections", {}) or {}
     out = {}
     for role, items in (sv.get("projections", {}) or {}).items():
+        a = act.get(role) or []
+        arefs = [it.get("queryRef") for it in a if isinstance(it, dict) and it.get("queryRef")]
         refs = [it.get("queryRef") for it in items if isinstance(it, dict) and it.get("queryRef")]
+        if arefs and arefs != refs:
+            print(f"[classic] drill: role {role} -> active projection {arefs} "
+                  f"(of {len(refs)} level(s))", file=sys.stderr)
+            refs = arefs
         if refs:
-            out[ROLE_REMAP.get(role, role)] = refs
+            key = ROLE_REMAP.get(role, role) if vt in MAP_TYPES else role
+            out[key] = refs
     return out
 
 
@@ -66,6 +80,16 @@ def _title(sv):
         t = props.get("text", {}).get("expr", {}).get("Literal", {}).get("Value")
         if t and show != "false":
             return t.strip("'")
+    return None
+
+
+def _obj_flag(sv, key):
+    """objects.<key>[0].properties.show.expr.Literal.Value -> True/False/None
+    (bead n9u9 data labels / ry0n legend; same shape as extract-pbir.py)."""
+    for it in sv.get("objects", {}).get(key, []):
+        v = it.get("properties", {}).get("show", {}).get("expr", {}).get("Literal", {}).get("Value")
+        if v is not None:
+            return str(v).strip("'").lower() == "true"
     return None
 
 
@@ -102,8 +126,12 @@ def extract(report):
                 "x": x or 0, "y": y or 0, "w": w or 0, "h": h or 0,
                 "z": vc.get("z", 0),
                 "parent_group": None,
-                "bindings": _projections(sv),
+                "bindings": _projections(sv, vt),
                 "formats": {},
+                # bead n9u9: PBI data-label toggle (objects.labels show) — true/false/None
+                "data_labels": _obj_flag(sv, "labels"),
+                # bead ry0n: PBI legend toggle (objects.legend show) — true/false/None
+                "legend": _obj_flag(sv, "legend"),
             }
             if rec["sigma_kind"] == "text":
                 rec["text"] = _textbox_body(sv)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -69,6 +69,12 @@ abort 'missing --tmsl' unless opts[:tmsl]
 abort "--tmsl not found: #{opts[:tmsl]}" unless opts[:tmsl] && File.exist?(opts[:tmsl])
 abort 'missing --pbir' unless opts[:pbir]
 abort "--pbir not found: #{opts[:pbir]}" unless File.exist?(opts[:pbir])
+# bead hjke(a): abort early on a truncated/partial connection id — it survives
+# all the way to the DM POST and fails there opaquely ("Source not found").
+if opts[:conn] && opts[:conn] !~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+  abort "FATAL: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); " \
+        "got #{opts[:conn].inspect}. List connections with GET /v2/connections."
+end
 
 # Local converter build (the convert_powerbi_to_sigma MCP tool, imported directly).
 MCP_DIR = ENV['PBI_MCP_DIR'] || %w[
@@ -609,14 +615,34 @@ conv_elements.each do |cel|
   mkey  = mname
   next unless masters[mkey]           # its master was built in the loop above
   mid   = masters[mkey]['id']
-  ti_elements << { 'name' => mname, 'mid' => mid, 'cols' => cols }
   # pick the headline computed column: prior-year / YTD / YoY %, falling back to
   # the last column (the converter appends the derived measure last).
   pick = cols.find { |c| c['formula'].to_s =~ /\bDateLookback\s*\(/ } ||
          cols.find { |c| c['formula'].to_s =~ /\bCumulativeSum\s*\(/ } ||
          cols.find { |c| c['name'].to_s =~ /YoY/i } || cols.last
   next unless pick
+  # bead 525l: a SINGLE-VALUE KPI bound to this measure must NOT receive a bare
+  # row-level ref (agg:nil) into the GROUPED element — Sigma evaluates an
+  # unaggregated ref over a multi-row (one-per-period) element nondeterministically
+  # (null / arbitrary row). Emit an explicit deterministic "latest period" headline
+  # formula via the builder's verbatim-formula hook (measure_formula):
+  #   Sum(If([mid/<dateCol>] = Max([mid/<dateCol>]), [mid/<col>], Null))
+  # In a chart grouped BY that date column the same formula still evaluates to the
+  # per-period value (within each group Max(date)=date), so it is safe for both
+  # the KPI and the date-grouped chart paths. The date col = the element's groupBy.
+  group_ids = (cel['groupings'] || []).flat_map { |g| g['groupBy'] || [] }
+  date_col  = cols.find { |c| group_ids.include?(c['id']) } ||
+              cols.find { |c| c['formula'].to_s =~ /\bDateTrunc\s*\(/ } ||
+              cols.find { |c| c['name'].to_s =~ /\A(Year|Quarter|Month|Week|Date|Day)\z/i }
+  headline = lambda do |colname|
+    next nil unless date_col
+    "Sum(If([#{mid}/#{date_col['name']}] = Max([#{mid}/#{date_col['name']}]), [#{mid}/#{colname}], Null))"
+  end
+  ti_elements << { 'name' => mname, 'mid' => mid, 'cols' => cols,
+                   'date' => (date_col && date_col['name']) }
   ref = { 'master' => mkey, 'ref' => "[#{mid}/#{pick['name']}]", 'agg' => nil }
+  hf = headline.call(pick['name'])
+  ref['formula'] = hf if hf
   orig = ti_orig_table[mname]
   # route both the original-table queryRef and a self-named queryRef so whichever
   # form the PBIR binding used resolves to this element.
@@ -626,6 +652,8 @@ conv_elements.each do |cel|
   cols.each do |c|
     next unless c['name'].to_s =~ /YoY|Prior Year|YTD/i
     sub = { 'master' => mkey, 'ref' => "[#{mid}/#{c['name']}]", 'agg' => nil }
+    shf = headline.call(c['name'])
+    sub['formula'] = shf if shf
     field_map["#{orig}.#{c['name']}"] ||= sub if orig
   end
   # A chart that puts a PY/YoY column next to the BASE value and the period
@@ -684,7 +712,7 @@ if ti_elements.any?
       end
     next unless shape
     # choose a target column across the emitted time-intel elements.
-    target = nil; tmid = nil; tname = nil
+    target = nil; tmid = nil; tname = nil; tdate = nil
     ti_elements.each do |te|
       cand =
         case shape
@@ -693,11 +721,17 @@ if ti_elements.any?
         when :prior then te['cols'].find { |c| c['formula'].to_s =~ /\bDateLookback\s*\(/ }
         else te['cols'].find { |c| c['formula'].to_s =~ /\b(DateLookback|CumulativeSum)\s*\(/ }
         end
-      if cand then target = cand; tmid = te['mid']; tname = te['name']; break end
+      if cand then target = cand; tmid = te['mid']; tname = te['name']; tdate = te['date']; break end
     end
     next unless target
-    field_map["#{tbl}.#{mname}"] = { 'master' => tname, 'ref' => "[#{tmid}/#{target['name']}]",
-                                     'agg' => nil }
+    entry = { 'master' => tname, 'ref' => "[#{tmid}/#{target['name']}]", 'agg' => nil }
+    # bead 525l: same headline-KPI determinism as above — a bare row-level ref on
+    # the grouped element is nondeterministic when consumed by a single-value KPI.
+    if tdate
+      entry['formula'] = "Sum(If([#{tmid}/#{tdate}] = Max([#{tmid}/#{tdate}]), " \
+                         "[#{tmid}/#{target['name']}], Null))"
+    end
+    field_map["#{tbl}.#{mname}"] = entry
   end
 end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/run.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/run.sh
@@ -64,10 +64,29 @@ START=$(stage_idx "$FROM")
 
 if [[ $START -le 1 ]]; then
   echo "== [1/7] EXTRACT PBIR =="
+  # bead anlb: a fetched definition may be the CLASSIC single report.json
+  # (top-level sections[], no definition/ dir) instead of exploded PBIR.
+  # extract-pbir.py exits non-zero on that shape — auto-branch to
+  # extract-report-classic.py instead of dying.
+  EXTRACT_OK=0
   if [[ -n "$WS" && -n "$REPORT" ]]; then
-    "$PY" "$HERE/extract-pbir.py" --workspace "$WS" --report "$REPORT" --pbir-dir "$WORK" --out "$WORK/signals.json"
-  else
-    "$PY" "$HERE/extract-pbir.py" --pbir-dir "$WORK" --out "$WORK/signals.json"
+    # the fetch half still runs (parts land in $WORK) even when the extract half fails
+    "$PY" "$HERE/extract-pbir.py" --workspace "$WS" --report "$REPORT" --pbir-dir "$WORK" --out "$WORK/signals.json" && EXTRACT_OK=1 || true
+  elif [[ -d "$WORK/definition" ]]; then
+    "$PY" "$HERE/extract-pbir.py" --pbir-dir "$WORK" --out "$WORK/signals.json" && EXTRACT_OK=1 || true
+  fi
+  if [[ $EXTRACT_OK -eq 0 ]]; then
+    RJ=""
+    for cand in "$WORK/report.json" "$WORK"/*/report.json; do
+      [[ -f "$cand" ]] && { RJ="$cand"; break; }
+    done
+    if [[ -n "$RJ" && ! -d "$WORK/definition" ]]; then
+      echo "  classic single report.json detected ($RJ) — branching to extract-report-classic.py"
+      "$PY" "$HERE/extract-report-classic.py" --report-json "$RJ" --out "$WORK/signals.json"
+    else
+      echo "  EXTRACT FAILED: no definition/ dir and no classic report.json under $WORK" >&2
+      exit 1
+    fi
   fi
 fi
 


### PR DESCRIPTION
## What

Five root-caused Power BI fidelity fixes in `plugins/powerbi-to-sigma/skills/powerbi-to-sigma/`, all live-validated:

### Fix 1 — scatter collapse (bead ry0n)
Sigma's scatter `xAxis` is a **grouping** axis, so binding the PBI X *measure* made aggregates evaluate per-row (`Count` → 1) and all points collapsed to x=1. `build-workbook-from-pbir.rb` now emits a **hidden grouped source table** on the Data page (`visibleAsSource:false`, dim + x/y[/size] aggregates, `groupings:[{groupBy:[dim], calculations:[…]}]`) and points the scatter at it with all-raw column refs. The detail dim stays on `color:{by:category}` (required — shared-x points merge to null y without it); PBI `legend.show=false` → `legend:{visibility:hidden}`; PBI Size role folds into the grouped source + `size:{id}` channel (WARN when not a measure). Helper elements plumb via an accumulator from `build_element` to the Data page.

### Fix 2 — YoY headline KPI (bead 525l)
`migrate-powerbi.rb` routed single-value KPIs to the time-intel grouped element with a bare row-level ref (`agg:nil`) — nondeterministic/null. Now emits the verified deterministic latest-period formula `Sum(If([m/Date] = Max([m/Date]), [m/Col], Null))` via the builder's verbatim-formula hook (headline pick + YoY/PY/YTD siblings + the standalone time-intel routing block). `field_spec` also drops a primary `formula` when resolving through an alt. Recipe added to `refs/measure-patterns.md` §9.

### Fix 3 — data labels plumbing (bead n9u9)
Both extractors read `visual.objects.labels[0].properties.show` → `data_labels: true/false/null` (and `objects.legend` → `legend`) per visual. Builder honors the signal for bar/line/area and pie/donut; null/absent keeps prior behavior (bar/pie shown, line clean). `dataLabel:{labels:"shown"}` verified to persist + render for bar AND line.

### Fix 4 — classic report auto-branch (bead anlb)
`run.sh` EXTRACT detects a legacy single `report.json` (no `definition/` dir) and auto-branches to `extract-report-classic.py` instead of dying. QUICKSTART updated.

### Fix 5 — small bugs (bead hjke)
(a) `convert-model.rb` + `migrate-powerbi.rb` abort early unless `--connection` is a full UUID; (b) `qr_leaf()` unwraps `Sum(TABLE.COL)` queryRefs — pie value no longer named `HOURS)`; (c) drill level: classic extractor prefers `activeProjections`, PBIR extractor honors projection `active` flags, builder WARNs when a multi-level date hierarchy is reduced. Classic `Series`/`Size` role remap now applies to map visuals only (it corrupted scatter roles).

## E2E (fresh full conversion, fixed scripts, live Fabric)

"Workforce Comp & Distribution" → **VISQA2 PBI Workforce Comp & Distribution** (DM `4d30aeef`, workbook `a2e87220`, org tj-wells-1989, kept):

- **Scatter correct straight from the pipeline** (no hand-patching): hidden grouped source emitted, 30 spread points (x up to 36), color on ROLE, legend hidden (PBI `legend.show=false` honored).
- **Labels match PBI per visual**: bar `labels=true` → value labels rendered; donut `labels=true` → shown; KPIs/table/pivot null → defaults.
- **Hard gate GREEN**: `assert-phase6-ran` — Phase 6 `11/11 charts PASS`, 30/30 live columns clean (no `type=error`), layout XML applied (13 positioned elements).
- **Parity vs PBI `executeQueries`**: extract-mode 11/11 PASS; strict spot-check is EXACT where the import cache isn't stale — e.g. Customer Service row matches to the cent across all 6 stats (`67 / $60,000 / $89,400 / $46,360 / $20,101.0138… / 15`), Mgmt Headcount exact for all 6 departments. Residual deltas (overall median 72,350 vs 73,000 etc.) are fully attributed to import-cache drift: live warehouse has +7 employees (Engineering +2, Warehouse +5; 370 vs 363); a dataset refresh to converge failed with expired Snowflake credentials on the PBI side.
- **Classic auto-branch fired live** on the legacy `EMPLOYEE DASHBOARD` report (My workspace): `classic single report.json detected — branching to extract-report-classic.py`; its `Sum(ABSENCE_RECORDS.HOURS)` pie now names the value `HOURS`, and the 4-level date-hierarchy line emits the new reduction WARN.

## Live patches (user-visible, already applied)

- **Retail Performance & Trends (from Power BI)** (`01b3487c`) `el-yoy-kpi/yoykpi-v`: `Last([YR/Net Revenue YoY %])` → `Sum(If([YR/Year] = Max([YR/Year]), [YR/Net Revenue YoY %], Null))`; renders **−13.6%** (CSV value −0.13579836). Pre-patch spec: `/tmp/wb-retail-prepatch.json`.
- **Workforce Comp & Distribution (from Power BI)** (`e12e7653`) scatter `el-0000033bb4f4`: hidden grouped table (Role/Headcount/Median Salary), raw refs, color on Role, legend hidden; renders spread points (x ≈ 5–36), not a stack at x=1. Pre-patch spec: `/tmp/wb-workforce-prepatch.json`.

Ruby `-c` and `py_compile` clean on every edited script; `bash -n` clean on run.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)