### PR TITLE
cognos-to-sigma 1.0.0: digit-split names, working controls, KPI panel, filters, RLS parity

### DIFF
--- a/plugins/cognos-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/cognos-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "cognos-to-sigma",
   "displayName": "Cognos → Sigma",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Migrate IBM Cognos Analytics to Sigma — Data Module JSON → Sigma data model, and report-spec XML → Sigma workbook. Translates the Cognos expression DSL (total..for → window funcs, if/then/else, date/string fns) and flags what it can't (macros, running-totals, localization). Companion to the other sigma-migration-skills converters.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -17,7 +17,7 @@ cleanly; **flag what doesn't** (runtime macros, running-totals, localization) in
 of emitting wrong logic.
 
 > Read `refs/` before relying on shapes: `design-notes.md` (translation surface + scope),
-> `data-module-shape.md` + `report-spec-shape.md` (the real CA JSON/XML structures),
+> `format-shapes.md` (the real CA Data-Module JSON + report-spec XML structures),
 > `expression-dsl.md` (the Cognos-expression → Sigma-formula mapping table).
 > For the canonical Sigma data-model + workbook spec shapes, defer to the companion
 > `sigma-data-models` / `sigma-workbooks` skills.
@@ -115,19 +115,59 @@ report's numbers match the migrated Sigma workbook to the cent.
 
 ---
 
-## What's flagged, never faked
+## What converts, what's flagged (never faked)
 
-The converter emits a warning (and a readable placeholder) instead of wrong logic for:
-runtime **macros** (`#…# prompt(…,'token',…)` — dynamic column/SQL building, e.g. a
-"swap measure" picker → model as a control + `Switch`), **running-total / moving-* /
-rank / lag / lead** (window funcs with no clean single-column analog), **GetResourceString**
-(localization), composite/non-equi **joins**, and **detail/summary filters** (surfaced
-to re-create as Sigma filters). **Crosstabs → Sigma pivot-tables** (rows/columns edges →
-rowsBy/columnsBy, measure → values) and **charts (RAVE2 `<vizControl>`) → Sigma chart elements**
-(bar/column/line/area/pie/donut/combo/scatter via the slot model — see `refs/format-shapes.md`)
-and **maps (`tiledmap`) → Sigma region-map / point-map** ARE converted and live-validated.
-Only Cognos viz types with no native Sigma element (network, word-cloud, packed-bubble, treemap)
-fall back to a flagged table. Drill-through→actions and Framework Manager `.cpf` remain roadmap.
+**Converted and live-validated:**
+- **Runtime macros** (`#…# prompt(…,'token',…)` — dynamic column building, e.g. a "swap
+  measure" picker) → a Sigma **`segmented` control** (values + default recovered from the
+  report's `<selectValue>` options and `customControl` button configs) + a
+  `Switch([promptId], …)` **wired by `controlId`** (Sigma resolves control refs by
+  controlId, not display name). Both macro shapes convert: token-swap with a default
+  column AND string-concat column-ref building (`'[…CY_' + prompt('pQuarter','token') + '_Revenue]'`).
+- **Singletons → Sigma kpi-charts** (`value: {columnId}`, number format from the Cognos
+  `dataFormat`; sibling dataItem refs materialize as supporting columns). Conditional
+  up/down icon styling is NOT portable — the value is preserved and a warning names it.
+- **Detail filters → element filters**: `[Col] = literal` / `[Col] in (…)` → a `list`
+  filter; `[Col] = ?prompt?` → segmented control + hidden boolean match column +
+  `values:[true]` filter. Filter columns are added hidden when the layout didn't show them.
+- **Auto-aggregated lists → grouped tables** (`groupings: groupBy dims / calculations
+  measures`); footer `Total(...)` columns are skipped with a warning (the group already
+  aggregates — re-add via Sigma totals).
+- **Scaled currency** (`$###.#M`-style patterns) → the nearest Sigma d3 format (SI-suffix
+  `$,.3s`); percent formats → `,.N%`. **Numeric dims on a category axis** (e.g. Year) are
+  Text-cast so they bind categorically, and slot `dsSort` becomes `xAxis.sort`.
+- **Crosstabs → Sigma pivot-tables** (rows/columns edges → rowsBy/columnsBy, measure → values),
+  **charts (RAVE2 `<vizControl>`) → Sigma chart elements** (bar/column/line/area/pie/donut/
+  combo/scatter via the slot model — see `refs/format-shapes.md`) and **maps (`tiledmap`) →
+  Sigma region-map / point-map**.
+
+**Flagged with a warning (and a readable placeholder), never faked:** macros whose prompt
+value set isn't recoverable from the report, **running-total / moving-* / rank / lag / lead**
+(window funcs with no clean single-column analog), **GetResourceString** (localization),
+composite/non-equi **joins**, **summary filters** (post-aggregation), table **sort order**
+(not part of the workbook spec — apply in the UI), and Cognos viz types with no native Sigma
+element (network, word-cloud, packed-bubble, treemap → flagged table). Drill-through→actions
+and Framework Manager `.cpf` remain roadmap.
+
+## Security: Row- & Column-Level Security (RLS/CLS)
+
+Row/column security is **never silently dropped and never silently ported** — and it is handled by the **skill**, not baked into the converted model. The converter only **detects and reports** security in `result.security[]` (the CLI writes it to `security.json` and prints a loud `SECURITY:` line); it does **not** inject it into the data-model spec (a stateless converter can't create Sigma user attributes or assign members, so an injected `CurrentUserAttributeText` filter would fail-closed to 0 rows). This skill provisions + applies it after the model is posted.
+
+**What is detected for Cognos:** Data-Module **security filters** (`securityFilter` entries — top-level or per-query-subject — holding a filter expression + the CAM groups/roles they apply to). Detection is best-effort across the shape variants; **also check manually**: in the Cognos UI a data module's security filters live under the query subject's *Security filters* tab (`Properties → Security`), and Framework Manager packages carry object/data security in the `.cpf` (not parsed — inventory those by hand). Report-level security (CAM object policies on the report itself) maps to Sigma document permissions, not RLS.
+
+**Flow (only runs when security was detected or found manually — zero overhead otherwise):**
+1. **Convert + post** the data model as usual. Capture the `dataModelId` and `security.json` (write entries found manually in the same shape: `[{ "type": "row-filter", "name": …, "expression": …, "groups": […] }]`).
+2. **Gate (opt-in/out, default _Port_).** Show a plain-English summary of each detected rule + recommended Sigma mapping, then ask: **Port** (recommended) / **Customize** (review per-rule attribute/team mapping + CAM-group-to-email reconciliation) / **Skip** (migrated model shows ALL rows to everyone). Reuse-first: existing Sigma user attributes/teams are matched before creating new ones.
+3. **Provision + apply** with the shared engine:
+   ```bash
+   eval "$(scripts/get-token.sh)"
+   python3 scripts/apply_sigma_rls.py --from-security security.json --dm-id <dataModelId>            # plan only (default)
+   python3 scripts/apply_sigma_rls.py --from-security security.json --dm-id <dataModelId> --provision --apply
+   ```
+   `--provision` creates missing user attributes / teams; `--apply` PATCHes the boolean RLS calc column + fail-closed `filters` entry and the `columnSecurities` (CLS) onto the matching element.
+4. **Assign membership.** Assign per-user attribute values / team membership from the Cognos CAM group/role membership (the rule's `groups` name them; the values come from the customer's user mapping — CAM ids are usually not emails, reconcile them).
+
+**Skip is loud:** opting out leaves the migrated model with NO RLS — all rows visible to everyone. Confirm before skipping.
 
 ## Gap scout — close a flagged expression
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.ts
@@ -8,7 +8,7 @@
  *
  * Options: --connection <id> --database <DB> --schema <S> --dm <dataModelId> --pretty
  */
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { convertCognosToSigma } from './cognos.js';
@@ -41,6 +41,13 @@ const res = isReport
 const payload = isReport ? (res as any).workbook : (res as any).model;
 process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
 console.error(`\n[${isReport ? 'report→workbook' : 'module→data-model'}] stats: ${JSON.stringify(res.stats)}`);
+// Detected security (RLS) — detect-only; the skill's apply_sigma_rls.py ports it.
+const security = (res as any).security;
+if (security?.length) {
+  const out = opt('security-out', 'security.json');
+  writeFileSync(out, JSON.stringify(security, null, 2));
+  console.error(`SECURITY: ${security.length} rule(s) detected → ${out} — run scripts/apply_sigma_rls.py after posting the model (see SKILL.md "Security").`);
+}
 if (res.warnings.length) {
   console.error(`warnings (${res.warnings.length}) — translated where possible, flagged where not:`);
   res.warnings.forEach((w) => console.error('  ! ' + w));

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
@@ -425,6 +425,10 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     for (const si of findAll(L, 'sortItem')) {
       if (si['@_refDataItem']) warnings.push(`list "${qName}" sorts by "${si['@_refDataItem']}" (${si['@_sortOrder'] || 'ascending'}) — table sort isn't part of the Sigma workbook spec; apply the sort in the UI.`);
     }
+    // conditional styles on list columns (e.g. threshold-driven $K/$M/$B data formats)
+    // have no spec analog — never drop them silently.
+    const condRefs = [...new Set(findAll(L, 'conditionalStyleRef').map((c: any) => c['@_refConditionalStyle']).filter(Boolean))];
+    if (condRefs.length) warnings.push(`list "${qName}" uses conditional style(s) ${condRefs.map((r) => `"${r}"`).join(', ')} — threshold-driven formats/styles aren't portable to the Sigma spec; set a column format (e.g. $,.3s) or conditional formatting in the UI.`);
     const el: WbElement = {
       id: sigmaShortId(), kind: 'table', name: `${q.subject ? sigmaDisplayName(q.subject) + ' — ' : ''}${qName}`,
       source: dmSource(q),

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
@@ -11,13 +11,18 @@
  *   detail/summary filter                  → element filter (expression translated)
  *   aggregate / if / date DSL              → reuses translateCognosExpr (cognos.ts)
  *
- * FLAG-don't-fake: Cognos report MACROS (`# … prompt('x','token',…) … #` that build
- * SQL/column refs at runtime — e.g. a "swap measure" picker) have no clean static
- * Sigma analog; they're emitted as a Switch placeholder + a loud warning.
+ * Cognos report MACROS (`# … prompt('x','token',…) … #` that build SQL/column refs
+ * at runtime — e.g. a "swap measure" picker) ARE translated when the prompt's value
+ * set is recoverable from the report (a `<selectValue parameter=…>` and/or
+ * `customControl` button configs): they become a Sigma `segmented` control + a
+ * `Switch([promptId], value, [col], …, defaultCol)` wired by controlId. Macros whose
+ * value set can't be recovered still degrade to a flagged placeholder (never faked).
  *
- * Crosstabs → pivot-tables and charts (RAVE2 `<vizControl>`) → Sigma chart
- * elements are supported. NOT yet: drill-through→actions, conditional render
- * blocks, master-detail. Those are the research long-tail.
+ * Also converted: singletons → kpi-charts, detail filters → element filters
+ * (`?prompt?` filters → control + boolean match column), auto-aggregated lists →
+ * grouped tables (`groupings`), crosstabs → pivot-tables, charts (RAVE2
+ * `<vizControl>`) → Sigma chart elements. NOT yet: drill-through→actions,
+ * conditional render blocks, master-detail. Those are the research long-tail.
  */
 
 import { XMLParser } from 'fast-xml-parser';
@@ -35,14 +40,20 @@ const arr = (v: any): any[] => (Array.isArray(v) ? v : v == null ? [] : [v]);
 const txt = (v: any): string => (v == null ? '' : typeof v === 'object' ? (v['#text'] ?? '') : String(v));
 
 // ── workbook spec types (minimal) ────────────────────────────────────────────
-interface WbColumn { id: string; name: string; formula: string; }
-interface WbControl { id: string; kind: 'control'; controlId: string; name: string; controlType: string; }
+interface WbColumn { id: string; name: string; formula: string; format?: Record<string, any>; hidden?: boolean; }
+interface WbControl {
+  id: string; kind: 'control'; controlId: string; name: string; controlType: string;
+  source?: Record<string, any>; value?: string | null;                                     // segmented (parameter)
+}
 interface WbElement {
   id: string; kind: string; name: string; source: Record<string, any>;
   columns?: WbColumn[]; order?: string[]; filters?: any[];
+  groupings?: Array<{ id: string; groupBy: string[]; calculations: string[] }>;            // grouped table
   rowsBy?: Array<{ id: string }>; columnsBy?: Array<{ id: string }>; values?: string[];   // pivot
-  xAxis?: { columnId: string; sort?: any }; yAxis?: { columnIds: string[] };               // cartesian charts
-  value?: { id: string }; color?: any; stacking?: string; orientation?: string;            // pie/donut + bar styling
+  xAxis?: { columnId: string; sort?: { by: string; direction: string } };                  // cartesian charts
+  yAxis?: { columnIds: string[] };
+  value?: { id?: string; columnId?: string };                                              // pie/donut {id} · kpi {columnId}
+  color?: any; stacking?: string; orientation?: string;                                    // bar styling
   latitude?: { id: string }; longitude?: { id: string }; size?: { id: string };            // point-map
   region?: { id: string; regionType: string }; geography?: { id: string };                 // region-map / geography-map
 }
@@ -55,8 +66,9 @@ export interface CognosReportResult {
 export interface CognosReportOptions { dataModelId?: string; workbookName?: string; }
 
 // ── ingest ────────────────────────────────────────────────────────────────────
-interface DataItem { name: string; expression: string; }
-interface Query { name: string; subject: string; items: Map<string, DataItem>; }
+interface DataItem { name: string; expression: string; aggregate?: string; dataType?: string; }
+interface Query { name: string; subject: string; items: Map<string, DataItem>; filters: string[]; }
+interface PromptMeta { options: string[]; def?: string; valueRefs: Record<string, string>; }
 
 function findAll(node: any, tag: string, out: any[] = []): any[] {
   if (node && typeof node === 'object') {
@@ -85,17 +97,72 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     for (const di of findAll(q, 'dataItem')) {
       const dn = di['@_name']; if (!dn) continue;
       const expr = txt(di.expression);
-      items.set(dn, { name: dn, expression: expr });
+      // RS_dataType XMLAttribute (1=int, 2=decimal, 3=string …) — used to detect
+      // numeric dimensions that need a categorical (Text) axis binding.
+      const dataType = findAll(di, 'XMLAttribute').find((x: any) => x['@_name'] === 'RS_dataType')?.['@_value'];
+      items.set(dn, { name: dn, expression: expr, aggregate: di['@_aggregate'], dataType });
       const m = expr.match(/\[[^\]]+\]\.\[[^\]]+\]\.\[([^\]]+)\]\.\[[^\]]+\]/); // [C].[Module].[Subject].[Col]
       if (m && !subject) subject = m[1];
     }
-    queries.set(name, { name, subject, items });
+    const filters = findAll(q, 'detailFilter').map((f: any) => txt(f.filterExpression || f.expression)).filter(Boolean);
+    queries.set(name, { name, subject, items, filters });
   }
 
+  // 1b) prompt metadata — value set + default from the report's own widgets:
+  // <selectValue parameter="pX"> gives the option list + default selection;
+  // customControl button configs ("Parameter"/"Button label"/"Button value") give
+  // an explicit option→model-column mapping for swap-measure macros.
+  const prompts = new Map<string, PromptMeta>();
+  for (const sv of findAll(report, 'selectValue')) {
+    const p = sv['@_parameter']; if (!p) continue;
+    const meta = prompts.get(p) || { options: [], valueRefs: {} };
+    for (const o of findAll(sv, 'selectOption')) {
+      const v = o['@_useValue'];
+      if (v && !meta.options.includes(v)) meta.options.push(v);
+    }
+    const d = txt(findAll(sv, 'defaultSimpleSelection')[0]);
+    if (d && meta.def == null) meta.def = d;
+    prompts.set(p, meta);
+  }
+  for (const cc of findAll(report, 'customControl')) {
+    try {
+      const cfg = JSON.parse(txt(cc.configuration));
+      const p = cfg?.['Parameter'];
+      if (p && cfg['Button label'] && cfg['Button value']) {
+        const meta = prompts.get(p) || { options: [], valueRefs: {} };
+        meta.valueRefs[cfg['Button label']] = String(cfg['Button value']);
+        if (!meta.options.includes(cfg['Button label'])) meta.options.push(cfg['Button label']);
+        prompts.set(p, meta);
+      }
+    } catch { /* non-JSON customControl config — ignore */ }
+  }
+
+  // Prompts → Sigma SEGMENTED controls (parameters). Wired by controlId — element
+  // formulas reference `[<promptName>]`, which Sigma resolves against `controlId`
+  // (NOT the display name). A bare `list` control with no value source is unusable
+  // as a scalar (beads-sigma-fh4u) — segmented + explicit manual values is the
+  // verified working shape.
   const controls = new Map<string, WbControl>();
   const registerPrompt = (p: string) => {
-    if (!controls.has(p)) controls.set(p, { id: sigmaShortId(), kind: 'control', controlId: p, name: sigmaDisplayName(p), controlType: 'list' });
+    if (controls.has(p)) return;
+    const meta = prompts.get(p);
+    const ctrl: WbControl = {
+      id: sigmaShortId(), kind: 'control', controlId: p, name: sigmaDisplayName(p),
+      controlType: 'segmented',
+      source: { kind: 'manual', valueType: 'text', values: [...(meta?.options || [])], labels: (meta?.options || []).map(() => null) },
+      value: meta?.def ?? meta?.options?.[0] ?? null,
+    };
+    if (!meta?.options?.length) {
+      warnings.push(`prompt '${p}': no <selectValue> options found in the report — emitted an empty segmented control; add its values in Sigma.`);
+    }
+    controls.set(p, ctrl);
   };
+
+  // Translate a bare Cognos model ref string ([C].[Module].[Subject].[Col] or
+  // [Subject].[Col]) to a Sigma [Subject/Col] ref — used by the macro expansion.
+  const translateModelRef = (ref: string): string => ref
+    .replace(/\[[^\]]+\]\.\[[^\]]+\]\.\[([^\]]+)\]\.\[([^\]]+)\]/g, (_m, subj, col) => `[${sigmaDisplayName(subj)}/${sigmaDisplayName(col)}]`)
+    .replace(/\[([^\]/]+)\]\.\[([^\]]+)\]/g, (_m, subj, col) => `[${sigmaDisplayName(subj)}/${sigmaDisplayName(col)}]`);
 
   // expression translation: model refs + dataItem cross-refs + prompts + macros, then the DSL.
   const translate = (expr: string, q: Query): { formula: string; warns: string[] } => {
@@ -103,12 +170,62 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     let f = (expr || '').trim();
 
     // Cognos report MACRO ( # … # ) — dynamic SQL/column building (e.g. prompt-driven
-    // measure swap). No static Sigma analog.
+    // measure swap). Translated to control + Switch when the prompt's value set is
+    // recoverable from the report; otherwise flagged (never faked).
     if (f.startsWith('#') || /#\s*sql\s*\(|'token'/.test(f)) {
+      const norm = (s: string) => s.replace(/[\s'"]+/g, '');
+      // Pattern A — token swap with a default column:  # prompt('p','token','<colRef>') #
+      const mA = f.match(/^#\s*prompt\(\s*'([^']+)'\s*,\s*'token'\s*(?:,\s*'([^']*)')?\s*\)\s*#$/s);
+      if (mA) {
+        const [, p, defRef] = mA;
+        registerPrompt(p);
+        const meta = prompts.get(p);
+        const defaultFormula = defRef ? translateModelRef(defRef) : undefined;
+        // Which option IS the macro default? (its branch becomes the Switch fallback)
+        const defaultOption = defRef && meta
+          ? Object.keys(meta.valueRefs).find((k) => norm(meta.valueRefs[k]) === norm(defRef))
+          : undefined;
+        const branches: string[] = [];
+        for (const opt of meta?.options || []) {
+          if (opt === defaultOption) continue;
+          // option → column ref: explicit customControl mapping first, then a
+          // same-named dataItem in this query (its expression is the model ref).
+          let refFormula = meta!.valueRefs[opt] ? translateModelRef(meta!.valueRefs[opt]) : undefined;
+          if (!refFormula) {
+            const di = q.items.get(opt) || [...q.items.values()].find((d) => d.name.toLowerCase() === opt.toLowerCase());
+            if (di && !di.expression.trim().startsWith('#')) refFormula = translateModelRef(di.expression.trim());
+          }
+          if (refFormula) branches.push(`"${opt}", ${refFormula}`);
+          else warns.push(`prompt '${p}' option "${opt}" could not be mapped to a model column — left out of the Switch; add the branch manually.`);
+        }
+        if (defaultFormula && branches.length) {
+          return { formula: `Switch([${p}], ${branches.join(', ')}, ${defaultFormula})`, warns };
+        }
+        if (defaultFormula) {
+          warns.push(`prompt '${p}': no swap options resolved — emitted only the macro's default column.`);
+          return { formula: defaultFormula, warns };
+        }
+      }
+      // Pattern B — column ref built by string concat:  # '<prefix' + prompt('p','token') + 'suffix]' #
+      const mB = f.match(/^#\s*'([^']*)'\s*\+\s*prompt\(\s*'([^']+)'\s*,\s*'token'\s*\)\s*\+\s*'([^']*)'\s*#$/s);
+      if (mB) {
+        const [, pre, p, suf] = mB;
+        registerPrompt(p);
+        const meta = prompts.get(p);
+        if (meta?.options?.length) {
+          const def = meta.def && meta.options.includes(meta.def) ? meta.def : meta.options[meta.options.length - 1];
+          const branches = meta.options.filter((o) => o !== def).map((o) => `"${o}", ${translateModelRef(pre + o + suf)}`);
+          const defaultFormula = translateModelRef(pre + def + suf);
+          return { formula: branches.length ? `Switch([${p}], ${branches.join(', ')}, ${defaultFormula})` : defaultFormula, warns };
+        }
+        warns.push(`dataItem builds a column ref from prompt '${p}' but the report carries no option list for it — emitted a placeholder.`);
+        return { formula: `/* MACRO — manual: ${f.slice(0, 60)} */`, warns };
+      }
+      // Anything else (#sql(), multi-prompt concat, …) — flag, never fake.
       const promptName = (f.match(/prompt\(\s*'([^']+)'/) || [])[1];
       if (promptName) registerPrompt(promptName);
       warns.push(`dataItem uses a Cognos macro (#…#${promptName ? `, prompt '${promptName}'` : ''}) that builds the column/SQL at runtime — model it in Sigma as a control + Switch([Control], …). Emitted a placeholder.`);
-      return { formula: promptName ? `Switch([${sigmaDisplayName(promptName)}] /* map prompt tokens to columns */)` : `/* MACRO — manual: ${f.slice(0, 60)} */`, warns };
+      return { formula: promptName ? `Switch([${promptName}] /* map prompt tokens to columns */)` : `/* MACRO — manual: ${f.slice(0, 60)} */`, warns };
     }
 
     // model column ref → [Subject/Col]   (resolves against the migrated DM element)
@@ -118,8 +235,9 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     f = f.replace(/\[([^\]]+)\]\.\[([^\]]+)\]/g, (_m, subj, col) => `[${sigmaDisplayName(subj)}/${sigmaDisplayName(col)}]`);
     // dataItem cross-refs [Other Item] → [Other Item] (sibling column; keep display name)
     f = f.replace(/\[([^\]\/]+)\]/g, (whole, nm) => (q.items.has(nm) ? `[${sigmaDisplayName(nm)}]` : whole));
-    // prompt('p') standalone → control ref
-    f = f.replace(/prompt\(\s*'([^']+)'[^)]*\)/g, (_m, p) => { registerPrompt(p); return `[${sigmaDisplayName(p)}]`; });
+    // prompt('p') standalone → control ref. Sigma resolves control refs by
+    // controlId, so emit the raw prompt name (the controlId), NOT the display name.
+    f = f.replace(/prompt\(\s*'([^']+)'[^)]*\)/g, (_m, p) => { registerPrompt(p); return `[${p}]`; });
 
     // hand off arithmetic / aggregate / if / date DSL to the shared translator
     const dsl = translateCognosExpr(f, { identifier: q.subject || 'Q', items: [] } as unknown as CognosQuerySubject,
@@ -128,11 +246,136 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     return { formula: dsl.formula, warns };
   };
 
-  // 2) layout lists → table elements
+  // Cognos dataFormat → nearest Sigma column format. Scaled currency patterns
+  // ($###.#M, scale -6 etc.) map to d3 SI-prefix ('s') strings — the value renders
+  // with the magnitude suffix Sigma picks (k/M/B), the closest native analog.
+  const formatFromNode = (node: any): Record<string, any> | undefined => {
+    const cf = findAll(node, 'currencyFormat')[0];
+    const pf = findAll(node, 'percentFormat')[0];
+    const nf = findAll(node, 'numberFormat')[0];
+    const dec = (x: any, d: number) => (x?.['@_decimalSize'] != null ? Number(x['@_decimalSize']) : d);
+    const scaled = (x: any) => x?.['@_scale'] != null || /[KMB]/.test(String(x?.['@_pattern'] || ''));
+    if (cf) return { kind: 'number', formatString: scaled(cf) ? `$,.${dec(cf, 1) + 2}s` : `$,.${dec(cf, 2)}f` };
+    if (pf) return { kind: 'number', formatString: `,.${dec(pf, 0)}%` };
+    if (nf) return { kind: 'number', formatString: scaled(nf) ? `$,.${dec(nf, 1) + 2}s` : `,.${dec(nf, 2)}f` };
+    return undefined;
+  };
+
   const pages: WbPage[] = [];
   const reportPages = findAll(report.layouts || report, 'reportPage').concat(findAll(report.layouts || report, 'page'));
   const lists = findAll(report, 'list');
   const pageEls: WbElement[] = [];
+
+  // Every element sources the migrated DM element. The converter emits the query
+  // SUBJECT display name as the elementId placeholder — remap-wb-to-dm-ids.mjs
+  // rewrites it to the real posted element id.
+  const dmSource = (q: Query) => ({ kind: 'data-model', dataModelId: options.dataModelId || '<DM_ID — wire after posting the data model>', elementId: q.subject ? sigmaDisplayName(q.subject) : '<element>' });
+
+  // Per-query detail filters → Sigma element filters, applied to every element built
+  // on that query (never silently dropped). Handles:
+  //   [Col] = <literal>      → list filter, values:[literal]
+  //   [Col] in (a, b, …)     → list filter, values:[a, b, …]
+  //   [Col] = ?prompt?       → segmented control + boolean match column + list filter on [true]
+  // Anything else stays a loud warning to re-create manually.
+  const ensureFilterCol = (el: WbElement, q: Query, itemName: string): string | undefined => {
+    const di = q.items.get(itemName);
+    if (!di) return undefined;
+    const want = sigmaDisplayName(di.name);
+    const existing = (el.columns || []).find((c) => c.name === want);
+    if (existing) return existing.id;
+    const { formula, warns } = translate(di.expression, q);
+    warns.forEach((w) => warnings.push(`"${q.name}.${itemName}": ${w}`));
+    const id = sigmaShortId();
+    // hidden + not in `order` — filter plumbing, not a display column
+    (el.columns ||= []).push({ id, name: want, formula, hidden: true });
+    return id;
+  };
+  const applyQueryFilters = (el: WbElement, q: Query) => {
+    for (const fx of q.filters) {
+      const m = fx.match(/^\s*\[([^\]]+)\]\s+(in)\s*\(([^)]*)\)\s*$/i) || fx.match(/^\s*\[([^\]]+)\]\s*(=)\s*(.+?)\s*$/);
+      const fail = (why: string) => warnings.push(`filter "${fx.slice(0, 80)}" on query "${q.name}": ${why} — re-create as a Sigma element/page filter.`);
+      if (!m) { fail('not a simple =/in filter'); continue; }
+      const [, nm, op, rhs] = m;
+      if (!q.items.has(nm)) { fail(`[${nm}] is not a dataItem in the query`); continue; }
+      const colId = ensureFilterCol(el, q, nm);
+      if (!colId) { fail('filter column could not be added'); continue; }
+      const col = el.columns!.find((c) => c.id === colId)!;
+      const textCol = /^Text\(/.test(col.formula);
+      const lit = (s: string): string | number => {
+        const t = s.trim().replace(/^['"](.*)['"]$/, '$1');
+        // numeric literal → number, UNLESS the target column was Text-cast for a
+        // categorical axis — then the filter compares strings.
+        return t !== '' && /^-?[\d.]+$/.test(t) && !Number.isNaN(Number(t)) && !textCol ? Number(t) : t;
+      };
+      const prompt = rhs.trim().match(/^\?(\w+)\?$/);
+      if (prompt && op === '=') {
+        const p = prompt[1];
+        registerPrompt(p);
+        const boolId = sigmaShortId();
+        el.columns!.push({ id: boolId, name: `${col.name} = ${p}`, formula: `[${col.name}] = [${p}]`, hidden: true });
+        (el.filters ||= []).push({ id: sigmaShortId(), columnId: boolId, kind: 'list', mode: 'include', values: [true] });
+      } else if (op.toLowerCase() === 'in') {
+        const values = rhs.split(',').map((s) => lit(s)).filter((v) => v !== '');
+        (el.filters ||= []).push({ id: sigmaShortId(), columnId: colId, kind: 'list', mode: 'include', values });
+      } else if (rhs.trim().startsWith('?')) {
+        fail('unsupported prompt comparison');
+      } else {
+        (el.filters ||= []).push({ id: sigmaShortId(), columnId: colId, kind: 'list', mode: 'include', values: [lit(rhs)] });
+      }
+    }
+  };
+
+  // 2a) singletons → kpi-chart elements (beads-sigma-ir3z: these are the KPI panel —
+  // never drop them). Each <singleton refQuery><dataItemValue refDataItem> becomes a
+  // Sigma kpi-chart whose value column is the dataItem's translated formula
+  // (Sum-wrapped when row-level); sibling dataItems it references ([CYQRev]-[PYQRev])
+  // are materialized as supporting columns on the same element.
+  for (const sg of findAll(report, 'singleton')) {
+    const qName = sg['@_refQuery'];
+    const q = queries.get(qName);
+    if (!q) { warnings.push(`<singleton> "${sg['@_name']}" refQuery="${qName}" has no matching query — skipped.`); continue; }
+    const ref = findAll(sg, 'dataItemValue').map((d: any) => d['@_refDataItem']).find(Boolean);
+    const di = ref ? q.items.get(ref) : undefined;
+    if (!di) { warnings.push(`<singleton> "${sg['@_name']}" has no resolvable dataItem ("${ref}") — skipped.`); continue; }
+
+    const cols: WbColumn[] = [];
+    const idByName = new Map<string, string>();
+    const addKpiCol = (nm: string): string | undefined => {
+      if (idByName.has(nm)) return idByName.get(nm);
+      const d = q.items.get(nm);
+      if (!d) return undefined;
+      // sibling dataItems referenced by this expression first (so [X] refs resolve)
+      for (const sm of d.expression.matchAll(/\[([^\]/.]+)\]/g)) {
+        if (sm[1] !== nm && q.items.has(sm[1])) addKpiCol(sm[1]);
+      }
+      const { formula, warns } = translate(d.expression, q);
+      warns.forEach((w) => warnings.push(`"${qName}.${nm}": ${w}`));
+      // case-INSENSITIVE: translateCognosExpr re-derives bracket refs, which can
+      // lowercase non-first words ([Cyq Rev] → [Cyq rev]); Sigma resolves refs
+      // case-insensitively, but a case-sensitive check here would miss the sibling
+      // and double-aggregate (Sum over a Sum column → error column).
+      const referencesSibling = [...q.items.keys()].some((k) => k !== nm && formula.toLowerCase().includes(`[${sigmaDisplayName(k).toLowerCase()}]`));
+      const hasAgg = /\b(Sum|Avg|Min|Max|Count|CountDistinct|Median)\s*\(/.test(formula);
+      const id = sigmaShortId();
+      // a row-level formula must aggregate to render as a single KPI value;
+      // formulas over already-aggregated sibling columns stay as-is.
+      cols.push({ id, name: sigmaDisplayName(nm), formula: referencesSibling || hasAgg ? formula : `Sum(${formula})` });
+      idByName.set(nm, id);
+      return id;
+    };
+    const valId = addKpiCol(ref)!;
+    const fmt = formatFromNode(sg);
+    if (fmt) cols.find((c) => c.id === valId)!.format = fmt;
+    if (findAll(sg, 'conditionalStyleRef').length) {
+      warnings.push(`singleton "${sg['@_name']}" (${ref}) uses conditional styling (e.g. up/down KPI icons) — not portable to a Sigma kpi-chart spec; the VALUE is preserved, re-create the icon rule manually.`);
+    }
+    const el: WbElement = {
+      id: sigmaShortId(), kind: 'kpi-chart', name: di.name, source: dmSource(q),
+      columns: cols, order: cols.map((c) => c.id), value: { columnId: valId },
+    };
+    applyQueryFilters(el, q);
+    pageEls.push(el);
+  }
 
   for (const L of lists) {
     const qName = L['@_refQuery'];
@@ -141,13 +384,24 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     const colRefs: string[] = findAll(L, 'dataItemValue').map((d) => d['@_refDataItem']).filter(Boolean);
     const refs = colRefs.length ? colRefs : [...q.items.keys()];
     const columns: WbColumn[] = [];
-    const AGG: Record<string, string> = { total: 'Sum', summary: 'Sum', aggregate: 'Sum', average: 'Avg', count: 'Count', maximum: 'Max', minimum: 'Min' };
+    const AGG: Record<string, string> = { total: 'Sum', summary: 'Sum', aggregate: 'Sum', calculated: 'Sum', average: 'Avg', count: 'Count', maximum: 'Max', minimum: 'Min' };
+    // Cognos lists auto-group: non-aggregate dataItems are the grain, aggregate
+    // ('total'/'calculated'/…) dataItems are rolled up per group. Mirror that with a
+    // Sigma grouped table (beads-sigma-0xlz): dims → groupBy, measures (Agg-wrapped)
+    // → grouping calculations.
+    const isMeasureItem = (d: DataItem) => !!d.aggregate && d.aggregate !== 'none';
+    const grouped = refs.some((r) => { const d = q.items.get(r); return d && isMeasureItem(d); })
+      && refs.some((r) => { const d = q.items.get(r); return d && !isMeasureItem(d); });
+    const dimIds: string[] = [];
+    const measureIds: string[] = [];
+    const footerRefs: string[] = [];
     for (const r of refs) {
       const di = q.items.get(r);
       if (!di) {
         // layout aggregate/footer column, e.g. "Total(Revenue)" / "Summary(Revenue)" / "Average(Revenue)1"
         const m = r.match(/^(Total|Summary|Aggregate|Average|Count|Maximum|Minimum)\((.+?)\)\d*$/i);
         if (m && q.items.get(m[2])) {
+          if (grouped) { footerRefs.push(r); continue; } // grand-total footer — see warning below
           columns.push({ id: sigmaShortId(), name: sigmaDisplayName(r), formula: `${AGG[m[1].toLowerCase()]}([${sigmaDisplayName(m[2])}])` });
           continue;
         }
@@ -155,13 +409,32 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
       }
       const { formula, warns } = translate(di.expression, q);
       warns.forEach((w) => warnings.push(`"${qName}.${r}": ${w}`));
-      columns.push({ id: sigmaShortId(), name: sigmaDisplayName(di.name), formula });
+      const id = sigmaShortId();
+      if (grouped && isMeasureItem(di)) {
+        const fn = AGG[di.aggregate!.toLowerCase()] || 'Sum';
+        columns.push({ id, name: sigmaDisplayName(di.name), formula: /^\s*(Sum|Avg|Min|Max|Count|CountDistinct)\s*\(/.test(formula) ? formula : `${fn}(${formula})` });
+        measureIds.push(id);
+      } else {
+        columns.push({ id, name: sigmaDisplayName(di.name), formula });
+        if (grouped) dimIds.push(id);
+      }
     }
-    pageEls.push({
+    if (footerRefs.length) {
+      warnings.push(`list "${qName}": footer total(s) ${footerRefs.join(', ')} — the grouped Sigma table already aggregates per group; add a grand-total via the table's totals UI (a duplicate Sum column would double-aggregate).`);
+    }
+    for (const si of findAll(L, 'sortItem')) {
+      if (si['@_refDataItem']) warnings.push(`list "${qName}" sorts by "${si['@_refDataItem']}" (${si['@_sortOrder'] || 'ascending'}) — table sort isn't part of the Sigma workbook spec; apply the sort in the UI.`);
+    }
+    const el: WbElement = {
       id: sigmaShortId(), kind: 'table', name: `${q.subject ? sigmaDisplayName(q.subject) + ' — ' : ''}${qName}`,
-      source: { kind: 'data-model', dataModelId: options.dataModelId || '<DM_ID — wire after posting the data model>', elementId: q.subject ? sigmaDisplayName(q.subject) : '<element>' },
+      source: dmSource(q),
       columns, order: columns.map((c) => c.id),
-    });
+    };
+    if (grouped && dimIds.length && measureIds.length) {
+      el.groupings = [{ id: sigmaShortId(), groupBy: dimIds, calculations: measureIds }];
+    }
+    applyQueryFilters(el, q);
+    pageEls.push(el);
   }
 
   // 2b) crosstabs → pivot-table elements (rows edge → rowsBy, columns edge → columnsBy, measure → values)
@@ -188,11 +461,13 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     // Sigma pivot: rowsBy/columnsBy are {id} objects, values are bare column-id strings.
     const values = (measRefs.map((m) => mk(m, true)).filter(Boolean) as Array<{ id: string }>).map((o) => o.id);
     if (!values.length || (!rowsBy.length && !columnsBy.length)) warnings.push(`crosstab "${qName}" missing a measure or both edges — review the pivot.`);
-    pageEls.push({
+    const el: WbElement = {
       id: sigmaShortId(), kind: 'pivot-table', name: `${q.subject ? sigmaDisplayName(q.subject) + ' — ' : ''}${qName} (crosstab)`,
-      source: { kind: 'data-model', dataModelId: options.dataModelId || '<DM_ID — wire after posting the data model>', elementId: q.subject ? sigmaDisplayName(q.subject) : '<element>' },
+      source: dmSource(q),
       columns: cols, order: cols.map((c) => c.id), rowsBy, columnsBy, values,
-    });
+    };
+    applyQueryFilters(el, q);
+    pageEls.push(el);
   }
 
   // 2c) charts (RAVE2 <vizControl>) → Sigma chart elements
@@ -220,7 +495,7 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     'com.ibm.vis.packedbubble': 'packed bubble', 'com.ibm.vis.treemap': 'treemap',
   };
   const isMapViz = (t: string) => /tiledmap|choropleth|\bmap\b/.test(t);
-  const chartSource = (q: Query) => ({ kind: 'data-model', dataModelId: options.dataModelId || '<DM_ID — wire after posting the data model>', elementId: q.subject ? sigmaDisplayName(q.subject) : '<element>' });
+  const chartSource = dmSource;
 
   for (const V of findAll(report, 'vizControl')) {
     const vizType = String(V['@_type'] || '').toLowerCase();
@@ -231,26 +506,33 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
     if (!q) { warnings.push(`<vizControl> "${vizName}" (${vizType}): no resolvable query (dataStore "${dsName}") — chart skipped.`); continue; }
 
     // slot entries by id (categories / series / values / size / x / y / color)
-    const slot = (id: string): Array<{ ref: string; rollup?: string }> => {
-      const out: Array<{ ref: string; rollup?: string }> = [];
+    const slot = (id: string): Array<{ ref: string; rollup?: string; sort?: string; format?: Record<string, any> }> => {
+      const out: Array<{ ref: string; rollup?: string; sort?: string; format?: Record<string, any> }> = [];
       for (const sd of findAll(V, 'vcSlotData')) {
         if (String(sd['@_idSlot'] || '').toLowerCase() !== id) continue;
-        for (const c of findAll(sd, 'vcSlotDsColumn')) if (c['@_refDsColumn']) out.push({ ref: c['@_refDsColumn'], rollup: c['@_rollupMethod'] });
+        for (const c of findAll(sd, 'vcSlotDsColumn')) if (c['@_refDsColumn']) {
+          out.push({ ref: c['@_refDsColumn'], rollup: c['@_rollupMethod'], sort: c['@_dsSort'], format: formatFromNode(c) });
+        }
       }
       return out;
     };
     const cols: WbColumn[] = [];
     const seen = new Map<string, string>();
-    const addCol = (e: { ref: string; rollup?: string } | undefined, measure: boolean): string | undefined => {
+    const addCol = (e: { ref: string; rollup?: string; format?: Record<string, any> } | undefined, measure: boolean, categorical = false): string | undefined => {
       if (!e) return undefined;
       const di = q.items.get(e.ref);
       if (!di) { warnings.push(`chart "${vizName}" column "${e.ref}" not in query "${qName}" — skipped.`); return undefined; }
       const nm = sigmaDisplayName(di.name);
       if (seen.has(nm)) return seen.get(nm);
-      const { formula, warns } = translate(di.expression, q); warns.forEach((w) => warnings.push(`"${vizName}.${e.ref}": ${w}`));
+      let { formula, warns } = translate(di.expression, q); warns.forEach((w) => warnings.push(`"${vizName}.${e.ref}": ${w}`));
+      // A numeric dimension (e.g. Year, RS_dataType 1/2) bound to a category axis
+      // renders as a continuous axis in Sigma — cast to Text so it binds categorically.
+      if (categorical && !measure && (di.dataType === '1' || di.dataType === '2')) formula = `Text(${formula})`;
       const id = sigmaShortId();
       const fn = measure ? (ROLLUP_AGG[String(e.rollup || '').toLowerCase()] || 'Sum') : '';
-      cols.push({ id, name: nm, formula: measure ? `${fn}(${formula})` : formula });
+      const col: WbColumn = { id, name: nm, formula: measure ? `${fn}(${formula})` : formula };
+      if (e.format) col.format = e.format;
+      cols.push(col);
       seen.set(nm, id); return id;
     };
 
@@ -274,6 +556,7 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
         if (colorId) el.color = { by: 'scale', column: colorId };
         el.order = cols.map((c) => c.id);
         if (!cols.length) { warnings.push(`<vizControl> map "${vizName}" had no resolvable lat/long columns — skipped.`); continue; }
+        applyQueryFilters(el, q);
         pageEls.push(el);
       } else if (region) {
         const regId = addCol(region, false);
@@ -282,13 +565,16 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
         const el: WbElement = { id: sigmaShortId(), kind: 'region-map', name: vizName, source: chartSource(q), columns: cols, order: cols.map((c) => c.id), region: { id: regId, regionType: 'country' } };
         if (colorId) el.color = { by: 'scale', column: colorId };
         warnings.push(`chart "${vizName}" → region-map: defaulted regionType to "country" — set it to match your data (country / us-state / us-county / us-zipcode / us-cbsa / us-postal-place / ca-province).`);
+        applyQueryFilters(el, q);
         pageEls.push(el);
       } else {
         // a map with neither coordinate nor named-location slots → table fallback
         for (const c of findAll(V, 'vcSlotDsColumn')) if (c['@_refDsColumn']) addCol({ ref: c['@_refDsColumn'], rollup: c['@_rollupMethod'] }, !!c['@_rollupMethod']);
         if (!cols.length) { warnings.push(`<vizControl> map "${vizName}" (${vizType}) had no resolvable columns — skipped.`); continue; }
         warnings.push(`chart "${vizName}" is a Cognos map (${vizType}) with no lat/long or named-location slot — emitted its data as a table; add geographic columns + a map in the workbook.`);
-        pageEls.push({ id: sigmaShortId(), kind: 'table', name: `${vizName} (was map)`, source: chartSource(q), columns: cols, order: cols.map((c) => c.id) });
+        const fb: WbElement = { id: sigmaShortId(), kind: 'table', name: `${vizName} (was map)`, source: chartSource(q), columns: cols, order: cols.map((c) => c.id) };
+        applyQueryFilters(fb, q);
+        pageEls.push(fb);
       }
       continue;
     }
@@ -299,7 +585,9 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
       for (const c of findAll(V, 'vcSlotDsColumn')) if (c['@_refDsColumn']) addCol({ ref: c['@_refDsColumn'], rollup: c['@_rollupMethod'] }, !!c['@_rollupMethod']);
       if (!cols.length) { warnings.push(`<vizControl> "${vizName}" (${vizType}) had no resolvable columns — skipped.`); continue; }
       warnings.push(`chart "${vizName}" is a Cognos ${label} (${vizType}) — Sigma has no native equivalent; emitted its data as a table. Re-pick a Sigma chart in the workbook.`);
-      pageEls.push({ id: sigmaShortId(), kind: 'table', name: `${vizName} (was ${label})`, source: chartSource(q), columns: cols, order: cols.map((c) => c.id) });
+      const fb: WbElement = { id: sigmaShortId(), kind: 'table', name: `${vizName} (was ${label})`, source: chartSource(q), columns: cols, order: cols.map((c) => c.id) };
+      applyQueryFilters(fb, q);
+      pageEls.push(fb);
       continue;
     }
 
@@ -319,9 +607,12 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
       if (cId) el.color = { by: 'category', column: cId };
     } else {
       // cartesian: bar / line / area / combo
-      const xId = addCol(cats[0], false);
-      if (xId) el.xAxis = { columnId: xId };
-      if (cats.length > 1) { warnings.push(`chart "${vizName}": Cognos used ${cats.length} category levels; Sigma x-axis takes one — bound the first, kept the rest as columns.`); cats.slice(1).forEach((c) => addCol(c, false)); }
+      const xId = addCol(cats[0], false, true);
+      if (xId) {
+        el.xAxis = { columnId: xId };
+        if (cats[0]?.sort) el.xAxis.sort = { by: xId, direction: /desc/i.test(cats[0].sort) ? 'descending' : 'ascending' };
+      }
+      if (cats.length > 1) { warnings.push(`chart "${vizName}": Cognos used ${cats.length} category levels; Sigma x-axis takes one — bound the first, kept the rest as columns.`); cats.slice(1).forEach((c) => addCol(c, false, true)); }
       const yIds = [...vals, ...sizes].map((v) => addCol(v, true)).filter(Boolean) as string[];
       if (yIds.length) el.yAxis = { columnIds: yIds };
       else warnings.push(`chart "${vizName}" (${kind}) resolved no measure for the value axis — add a measure in the workbook.`);
@@ -336,6 +627,7 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
 
     el.columns = cols; el.order = cols.map((c) => c.id);
     if (!cols.length) { warnings.push(`<vizControl> "${vizName}" (${vizType}) had no resolvable slot columns — skipped.`); continue; }
+    applyQueryFilters(el, q);
     pageEls.push(el);
   }
 
@@ -343,19 +635,22 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
   const controlEls = [...controls.values()];
   pages.push({ id: sigmaShortId(), name: reportPages[0]?.['@_name'] || 'Report', elements: [...controlEls as any, ...pageEls] });
 
-  // filters → warnings (translate for reference)
-  for (const fnode of findAll(report, 'detailFilter').concat(findAll(report, 'summaryFilter'))) {
+  // detail filters are converted per element (applyQueryFilters); summary filters
+  // (post-aggregation HAVING-style) still surface as warnings to re-create.
+  for (const fnode of findAll(report, 'summaryFilter')) {
     const fexpr = txt(fnode.filterExpression || fnode.expression);
-    if (fexpr) warnings.push(`filter: "${fexpr.slice(0, 80)}" — re-create as a Sigma element/page filter.`);
+    if (fexpr) warnings.push(`summary filter: "${fexpr.slice(0, 80)}" — post-aggregation filter; re-create as a Sigma filter on the aggregated column.`);
   }
 
   const stats = {
     queries: queries.size,
     tables: pageEls.filter((e) => e.kind === 'table').length,
     pivots: pageEls.filter((e) => e.kind === 'pivot-table').length,
-    charts: pageEls.filter((e) => e.kind.endsWith('-chart')).length,
+    kpis: pageEls.filter((e) => e.kind === 'kpi-chart').length,
+    charts: pageEls.filter((e) => e.kind.endsWith('-chart') && e.kind !== 'kpi-chart').length,
     maps: pageEls.filter((e) => e.kind.endsWith('-map')).length,
     columns: pageEls.reduce((n, e) => n + (e.columns?.length || 0), 0),
+    filters: pageEls.reduce((n, e) => n + (e.filters?.length || 0), 0),
     controls: controls.size,
   };
   return {

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos.ts
@@ -56,10 +56,18 @@ export interface CognosRelationship {
   expression?: string;         // fallback: "[A].[K] = [B].[K]" (authored-fixture shape)
   cardinality?: string;
 }
+export interface CognosSecurityFilter {
+  type: string;                // 'data-module-security-filter'
+  subject?: string;            // query-subject the filter is scoped to (if known)
+  name?: string;
+  expression?: string;
+  groups?: string[];           // CAM group/role refs the filter applies to (if present)
+}
 export interface CognosModule {
   name: string;
   querySubjects: CognosQuerySubject[];
   relationships: CognosRelationship[];
+  securityFilters: CognosSecurityFilter[];
 }
 export interface CognosConvertOptions {
   connectionId?: string;
@@ -147,7 +155,33 @@ export function normalizeCognosDataModule(input: any): CognosModule {
     });
   }
 
-  return { name, querySubjects, relationships };
+  // Security filters (detect-only — see ConversionResult.security). Real CA data
+  // modules carry row-level security as `securityFilter` entries (top-level or
+  // per-query-subject) holding an expression + the CAM groups/roles it applies to.
+  // Shape tolerance: also catch plain `filter` entries explicitly marked as security.
+  const securityFilters: CognosSecurityFilter[] = [];
+  const pushSec = (sf: any, subject?: string) => {
+    if (!sf || typeof sf !== 'object') return;
+    const groups = arr(sf.securityObject || sf.member || sf.members || sf.appliesTo)
+      .map((g: any) => (typeof g === 'string' ? g : g?.searchPath || g?.ref || g?.identifier))
+      .filter(Boolean);
+    securityFilters.push({
+      type: 'data-module-security-filter',
+      subject,
+      name: sf.label || sf.identifier,
+      expression: sf.expression || sf.filterDefinition || sf.embeddedFilter?.expression,
+      ...(groups.length ? { groups } : {}),
+    });
+  };
+  for (const sf of arr(root.securityFilter || root.securityFilters)) pushSec(sf);
+  for (const qs of qsList) {
+    for (const sf of arr(qs.securityFilter || qs.securityFilters)) pushSec(sf, qs.identifier || qs.label);
+  }
+  for (const fl of arr(root.filter || root.filters)) {
+    if (fl && (lc(fl.classifier).includes('security') || arr(fl.propertyOverride).some((p: any) => lc(p).includes('security')))) pushSec(fl);
+  }
+
+  return { name, querySubjects, relationships, securityFilters };
 }
 
 // A query-subject ref may arrive as "NS.SALES_FACT" or "[NS].[SALES_FACT]" — take the tail.
@@ -293,9 +327,15 @@ export function convertCognosIR(model: CognosModule, options: CognosConvertOptio
     metrics: elements.reduce((n, e) => n + ((e as any).metrics?.length || 0), 0),
     relationships: elements.reduce((n, e) => n + (e.relationships?.length || 0), 0),
   };
+  const security = (model.securityFilters || []).map((sf) => ({ ...sf }));
+  if (security.length) {
+    warnings.push(`SECURITY: ${security.length} data-module security filter(s) detected — NOT ported into the model spec. ` +
+      `Run the skill's RLS flow (scripts/apply_sigma_rls.py) after posting the model; skipping leaves ALL rows visible to everyone.`);
+  }
   return {
     model: { name: modelName || model.name, schemaVersion: 1, pages: [{ id: sigmaShortId(), name: 'Page 1', elements }] },
     warnings, stats,
+    ...(security.length ? { security } : {}),
   };
 }
 
@@ -401,10 +441,15 @@ export function translateCognosExpr(
   f = f.replace(/\b(?:decimal|double|float|number)\s*\(\s*([^,)]+?)(?:\s*,[^)]*)?\)/gi, (_m, x) => x.trim());
   f = f.replace(/\|\|/g, '&');          // Cognos concat → Sigma concat
   f = f.replace(/\bcoalesce\s*\(/gi, 'Coalesce(');
+  // Math fns with direct Sigma analogs
+  f = f.replace(/\babs\s*\(/gi, 'Abs(').replace(/\bround\s*\(/gi, 'Round(')
+       .replace(/\bfloor\s*\(/gi, 'Floor(').replace(/\bceiling\s*\(/gi, 'Ceiling(')
+       .replace(/\bsqrt\s*\(/gi, 'Sqrt(').replace(/\bln\s*\(/gi, 'Ln(')
+       .replace(/\bmod\s*\(/gi, 'Mod(').replace(/\bpower\s*\(/gi, 'Power(');
   f = f.replace(/'([^']*)'/g, '"$1"');  // Cognos single-quoted strings → Sigma double-quoted
 
   // Unknown bareword(...) functions → warn (kept as-is for manual review)
-  const known = /\b(If|Switch|Sum|Avg|Count|CountDistinct|Min|Max|SumOver|AvgOver|CountOver|MinOver|MaxOver|DateAdd|DateDiff|DatePart|Mid|Upper|Lower|Trim|Coalesce|Text|RegexpReplace|Replace)\b/;
+  const known = /\b(If|Switch|Sum|Avg|Count|CountDistinct|Min|Max|SumOver|AvgOver|CountOver|MinOver|MaxOver|DateAdd|DateDiff|DatePart|Mid|Upper|Lower|Trim|Coalesce|Text|RegexpReplace|Replace|Abs|Round|Floor|Ceiling|Sqrt|Ln|Mod|Power)\b/;
   for (const m of f.matchAll(/\b([a-z][a-z0-9_-]*)\s*\(/gi)) {
     if (!known.test(m[1]) && !/^(and|or|not|in|like|between|then|else|end|case|when)$/i.test(m[1])) {
       warnings.push(`function "${m[1]}()" has no confirmed Sigma mapping — review/translate manually.`);

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/sigma-ids.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/sigma-ids.ts
@@ -34,13 +34,32 @@ export function sigmaInodeId(identifier: string): string {
   return `inode-${sigmaShortId(22)}/${identifier.toUpperCase()}`;
 }
 
-/** SNAKE_CASE or camelCase → "Title Case" display name */
+/**
+ * SNAKE_CASE or camelCase → "Title Case" display name.
+ *
+ * Matches Sigma's OWN derivation rule for warehouse column names (verified
+ * empirically against live DM readbacks, 2026-06-10): Sigma splits words at
+ * underscores, camelCase boundaries, AND every letter↔digit boundary — in BOTH
+ * directions. E.g. CY_Q1_REVENUE → "Cy Q 1 Revenue" (NOT "Cy Q1 Revenue"),
+ * FY2024 → "Fy 2024", PY_Q4 → "Py Q 4". Raw-column formula refs
+ * ([TABLE/Display Name]) must reproduce this exactly or the POST fails with
+ * "dependency not found" (beads-sigma-c31q).
+ */
 export function sigmaDisplayName(s: string): string {
-  // Insert underscores at camelCase boundaries so OrderDate → Order_Date
+  // Insert underscores at camelCase + letter↔digit boundaries so OrderDate →
+  // Order_Date and CY_Q1 → CY_Q_1 (Sigma splits BOTH letters→digits and
+  // digits→letters).
   const normalized = (s || '')
-    .replace(/([a-z])([A-Z])/g, '$1_$2')       // camelCase → camel_Case
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2'); // HTMLParser → HTML_Parser
-  const words = normalized.toLowerCase().split('_').filter(Boolean);
+    .replace(/([a-z])([A-Z])/g, '$1_$2')        // camelCase → camel_Case
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')  // HTMLParser → HTML_Parser
+    .replace(/([A-Za-z])([0-9])/g, '$1_$2')     // Q1 → Q_1, FY2024 → FY_2024
+    .replace(/([0-9])([A-Za-z])/g, '$1_$2');    // 2024FY → 2024_FY
+  // Split on underscores AND whitespace so the function is IDEMPOTENT:
+  // sigmaDisplayName("Cyq Rev") === "Cyq Rev". Formulas pass through the expression
+  // translator more than once, and same-element sibling refs are resolved
+  // case-SENSITIVELY by Sigma — a non-idempotent derivation ("Cyq Rev" → "Cyq rev")
+  // breaks the ref and the column compiles to type "error".
+  const words = normalized.toLowerCase().split(/[_\s]+/).filter(Boolean);
   return words.map((w, i) =>
     (i === 0 || !SIGMA_LOWERCASE_WORDS.has(w))
       ? w.charAt(0).toUpperCase() + w.slice(1)
@@ -236,6 +255,14 @@ export interface ConversionResult {
   model: SigmaDataModel;
   warnings: string[];
   stats: Record<string, number>;
+  /**
+   * Detected source-tool security rules (RLS/CLS). The converter only DETECTS
+   * and reports — it never injects security into the model spec (a stateless
+   * converter can't provision Sigma user attributes, so an injected
+   * CurrentUserAttributeText filter would fail-closed to 0 rows). The skill's
+   * apply_sigma_rls.py provisions + applies these after the model is posted.
+   */
+  security?: Array<Record<string, any>>;
 }
 
 export interface ElementResult {

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/test.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/test.ts
@@ -4,9 +4,62 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { convertCognosToSigma } from './cognos.js';
 import { convertCognosReportToSigma } from './cognos-report.js';
+import { sigmaDisplayName } from './sigma-ids.js';
 
 const FIX = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures');
 let fail = 0;
+
+// ── sigmaDisplayName must match Sigma's OWN derivation (incl. letter↔digit splits;
+// verified against live DM readbacks 2026-06-10 — beads-sigma-c31q) ──────────────
+const NAME_CASES: Array<[string, string]> = [
+  ['CY_Q1_REVENUE', 'Cy Q 1 Revenue'],   // the 16-dep-not-found case: Q1 splits to "Q 1"
+  ['PY_Q4', 'Py Q 4'],
+  ['FY2024', 'Fy 2024'],                  // letters→digits boundary, multi-digit group
+  ['REVENUE_FY2024', 'Revenue Fy 2024'],
+  ['X2024FY', 'X 2024 Fy'],               // digits→letters boundary
+  ['Sheet1_1', 'Sheet 1 1'],
+  ['GROSS_PROFIT', 'Gross Profit'],
+  ['Province_or_State', 'Province or State'],  // small words stay lowercase (not first)
+  ['Month_number', 'Month Number'],
+  ['_row_id', 'Row Id'],
+];
+for (const [input, expected] of NAME_CASES) {
+  const got = sigmaDisplayName(input);
+  if (got === expected) console.log(`✓ sigmaDisplayName(${JSON.stringify(input).padEnd(20)}) → ${JSON.stringify(got)}`);
+  else { fail++; console.log(`✗ sigmaDisplayName(${JSON.stringify(input)}) → ${JSON.stringify(got)} (expected ${JSON.stringify(expected)})`); }
+}
+
+// ── go-sales-performance regression: macro→Switch wired by controlId, segmented
+// control with values+default, KPI singletons, element filters ───────────────────
+{
+  const r = convertCognosReportToSigma(readFileSync(join(FIX, 'go-sales-performance.report.xml'), 'utf8'), { dataModelId: 'dm' });
+  const els = r.workbook.pages[0].elements as any[];
+  const ctl = (r.workbook.controls || []).find((c: any) => c.controlId === 'pColumn') as any;
+  const checks: Array<[string, boolean]> = [
+    ['pColumn control is segmented', ctl?.controlType === 'segmented'],
+    ['pColumn has explicit values', JSON.stringify(ctl?.source?.values) === JSON.stringify(['Revenue', 'Gross Profit'])],
+    ['pColumn defaults to Revenue', ctl?.value === 'Revenue'],
+    ['pQuarter control registered with Q1-Q4 + default Q4',
+      (r.workbook.controls || []).some((c: any) => c.controlId === 'pQuarter' && c.value === 'Q4' && c.source?.values?.length === 4)],
+    ['Switch wired by controlId [pColumn]',
+      els.some((e) => e.columns?.some((c: any) => /Switch\(\[pColumn\], "Gross Profit", \[Sheet 1\/Gross Profit\], \[Sheet 1\/Revenue\]\)/.test(c.formula)))],
+    ['6 KPI singletons converted', els.filter((e) => e.kind === 'kpi-chart').length === 6],
+    ['KPI value uses columnId', els.filter((e) => e.kind === 'kpi-chart').every((e) => e.value?.columnId)],
+    ['KPI macro → Switch over digit-split refs',
+      els.some((e) => e.kind === 'kpi-chart' && e.columns?.some((c: any) => c.formula.includes('[Sheet 1 1/Cy Q 1 Revenue]')))],
+    ['detail filters became element filters', r.stats.filters >= 4],
+    ['?pQuarter? filter is a boolean match column',
+      els.some((e) => e.columns?.some((c: any) => c.formula === '[Quarter Label] = [pQuarter]'))],
+    ['lists grouped', els.some((e) => e.kind === 'table' && e.groupings?.length)],
+    ['year bound categorically on the line chart',
+      els.some((e) => e.kind === 'line-chart' && e.columns?.some((c: any) => /^Text\(/.test(c.formula) && c.name === 'Year'))],
+    ['no unresolved Switch placeholders', !els.some((e) => e.columns?.some((c: any) => /map prompt tokens/.test(c.formula)))],
+  ];
+  for (const [label, ok] of checks) {
+    if (ok) console.log(`✓ go-sales: ${label}`);
+    else { fail++; console.log(`✗ go-sales: ${label}`); }
+  }
+}
 for (const f of readdirSync(FIX)) {
   try {
     if (f.endsWith('.module.json')) {
@@ -15,7 +68,7 @@ for (const f of readdirSync(FIX)) {
       console.log(`✓ ${f.padEnd(34)} module → ${r.stats.elements} elems · ${r.stats.columns} cols · ${r.stats.metrics} metrics · ${r.stats.relationships} rels`);
     } else if (f.endsWith('.report.xml')) {
       const r = convertCognosReportToSigma(readFileSync(join(FIX, f), 'utf8'), { dataModelId: 'dm' });
-      console.log(`✓ ${f.padEnd(34)} report → ${r.stats.tables} tables · ${r.stats.pivots} pivots · ${r.stats.charts} charts · ${r.stats.maps} maps · ${r.stats.columns} cols · ${r.stats.controls} controls`);
+      console.log(`✓ ${f.padEnd(34)} report → ${r.stats.tables} tables · ${r.stats.pivots} pivots · ${r.stats.kpis} kpis · ${r.stats.charts} charts · ${r.stats.maps} maps · ${r.stats.columns} cols · ${r.stats.filters} filters · ${r.stats.controls} controls`);
     }
   } catch (e: any) { fail++; console.log(`✗ ${f} — ${e.message}`); }
 }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/design-notes.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/design-notes.md
@@ -1,10 +1,12 @@
 # Cognos → Sigma — converter design notes
 
-Design sketch for a future `cognos-to-sigma` skill, parallel to the existing
-`tableau-to-sigma` converter. Not yet built. Captures the translation
-surface, hard problems, MVP scope, and what would be reusable.
+The original design sketch for the `cognos-to-sigma` skill. The converter is now
+BUILT and live-validated (`converter/` — Data Module JSON → Sigma DM, report-spec
+XML → Sigma workbook incl. crosstabs/charts/maps/KPIs/macros/filters); this doc is
+kept for the translation surface, hard problems, and reuse notes. Where it
+disagrees with `format-shapes.md` or the code, trust those.
 
-> Status: research / design only. No code yet. Last touched 2026-05-28.
+> Status: HISTORICAL design doc (converter shipped). Last touched 2026-06-10.
 
 ---
 
@@ -27,13 +29,14 @@ Schema reference: [Cognos SDK v10.2.1 Report Specification Schema Reference v10.
 
 ## API access
 
-CA 11.1+ exposes REST at `/api/v1/...`. Same surface on-prem and Cognos
-Analytics on Cloud (SaaS).
+CA 11.1+ exposes REST at **`/bi/v1/...`** (NOT `/api/v1` — that base path only serves
+`PUT /api/v1/session` for login; content sub-resources 403 on it). Same surface
+on-prem and Cognos Analytics on Cloud (SaaS).
 
-- Auth: session cookie + `X-XSRF-Token`; namespace/CAM credentials posted to `/api/v1/session`.
-- Discovery: `GET /content/{searchPath}` to list; `GET /content/{id}/items`.
-- Report spec download: `GET /content/{id}?fields=specification` — returns the report-spec XML as a string property.
-- Data module: `GET /modules/{id}` — returns the data module JSON.
+- Auth: session cookie + `X-XSRF-Token` (CAM credentials / API key via `PUT /api/v1/session`).
+- Discovery: `GET /bi/v1/objects/{id}/items?fields=defaultName,type,id`.
+- Report spec download: `GET /bi/v1/objects/{id}?fields=specification` — returns the report-spec XML as a string property.
+- Data module: `GET /bi/v1/metadata/modules/{id}` — returns the data module JSON (the plain `/modules/{id}` returns EMPTY).
 
 Working REST wrappers (use as reference, don't depend on them):
 - Python: [ykud/cognosanalyticspy](https://github.com/ykud/cognosanalyticspy) — real auth + content-tree traversal

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
@@ -40,8 +40,27 @@ function pageLayout(page) {
     lines.push(`  <LayoutElement elementId="${c.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('control')}"/>`);
   });
   if (controls.length) row += Math.ceil(controls.length / 4) * H('control');
-  // content: stacked full-width, per-kind heights (clean, no overlap, right proportions)
-  for (const e of content) {
+  // content: stacked full-width, per-kind heights (clean, no overlap, right proportions).
+  // Exception: RUNS of consecutive kpi-charts lay out as rows of up to 3 TALL tiles
+  // (a KPI panel) — full-width singles waste a page and Sigma hides the KPI title
+  // below ~5 grid rows, so never shrink them either.
+  for (let i = 0; i < content.length; i++) {
+    const e = content[i];
+    if (e.kind === 'kpi-chart') {
+      let j = i; while (j < content.length && content[j].kind === 'kpi-chart') j++;
+      const run = content.slice(i, j);
+      const perRow = Math.min(run.length, 3);
+      const span = Math.floor(24 / perRow);
+      run.forEach((k, n) => {
+        const col0 = 1 + (n % perRow) * span;
+        const col1 = (n % perRow === perRow - 1) ? 25 : col0 + span;
+        const r = row + Math.floor(n / perRow) * H('kpi-chart');
+        lines.push(`  <LayoutElement elementId="${k.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('kpi-chart')}"/>`);
+      });
+      row += Math.ceil(run.length / perRow) * H('kpi-chart');
+      i = j - 1;
+      continue;
+    }
     const h = H(e.kind);
     lines.push(`  <LayoutElement elementId="${e.id}" gridColumn="1 / 25" gridRow="${row} / ${row + h}"/>`);
     row += h;

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply_sigma_rls.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply_sigma_rls.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Phase 1.5 (RLS decision gate) — apply a Looker RLS finding to Sigma, scripted.
+
+Sigma user attributes are FULLY API-supported (confirmed live 2026-06-10):
+  - GET  /v2/user-attributes            list (reuse-first)
+  - POST /v2/user-attributes            create
+  - POST /v2/user-attributes/{id}/users assign a value to a member
+And the Sigma RLS row-filter is fully spec-expressible (NOT UI-only): a boolean
+calc column `CurrentUserAttributeText("<attr>") = [<Field>]` on the base element
+plus an element `filters` entry `{kind:list, mode:include, values:[true]}`.
+
+This script does the whole flow, REUSE-FIRST and SAFE-BY-DEFAULT:
+  1. attribute   GET /v2/user-attributes → print a match if one already exists
+                 (by name, case-insensitive) before creating anything.
+  2. provision   --create  → POST /v2/user-attributes when nothing reusable exists.
+                 --assign   → POST /v2/user-attributes/{id}/users (needs --member-id
+                 + --value) to assign the attribute value to a member.
+  3. apply       --field <DisplayName> (+ --element-id/--dm-id) → print the RLS
+                 calc-column + element-filter spec snippet; with --apply, PATCH it
+                 into the DM element's spec (GET/PUT /v2/dataModels/{id}/spec).
+
+By default this only READS and PRINTS a plan — it mutates ONLY when you pass an
+explicit --create / --assign / --apply flag. Mirrors post_dm.py: reads
+$SIGMA_BASE_URL / $SIGMA_API_TOKEN from env (eval "$(scripts/get-token.sh)").
+Dependency-free (stdlib only).
+
+Live-validated: this exact flow produced exact 3-way parity (Looker-restricted ==
+Sigma-restricted == warehouse: $38,906.82 / 220 rows, region=West).
+
+Usage:
+  eval "$(scripts/get-token.sh)"
+  # reuse-first lookup only (default, read-only):
+  python3 apply_sigma_rls.py --attr region
+  # create the attribute if missing:
+  python3 apply_sigma_rls.py --attr region --value West --create
+  # assign a value to the querying member:
+  python3 apply_sigma_rls.py --attr region --value West --member-id <id> --assign
+  # print the RLS spec snippet for a DM element (plan only):
+  python3 apply_sigma_rls.py --attr region --field Region --element-id <eid>
+  # ...and PATCH it into the DM element spec:
+  python3 apply_sigma_rls.py --attr region --field Region --element-id <eid> \
+      --dm-id <dataModelId> --apply
+
+BATCH MODE (tool-agnostic) — ingest a converter's result.security[] (architecture B:
+the converter REPORTS RLS/CLS; this script provisions + applies). Handles RLS via
+user attribute / team (CurrentUserInTeam) / email, and CLS (columnSecurities):
+  # 1) convert + POST the model (converter injects NO RLS), capture dataModelId
+  # 2) write result.security to a JSON file, then:
+  python3 apply_sigma_rls.py --from-security security.json --dm-id <dmId>            # plan only
+  python3 apply_sigma_rls.py --from-security security.json --dm-id <dmId> --provision --apply
+Elements match by name (Sigma reassigns ids on POST); CLS columns match by normalized
+name. --provision creates missing attributes/teams (assign per-user values separately).
+Works for tableau/quicksight/powerbi/thoughtspot/qlik/lookml converter output alike.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+BASE = os.environ.get("SIGMA_BASE_URL")
+TOK = os.environ.get("SIGMA_API_TOKEN")
+
+
+def api(method, path, body=None):
+    if not BASE or not TOK:
+        sys.exit("SIGMA_BASE_URL / SIGMA_API_TOKEN unset — run: eval \"$(scripts/get-token.sh)\"")
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        BASE + path, data=data, method=method,
+        headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+    except urllib.error.HTTPError as e:
+        print("HTTP", e.code, method, path, "->", e.read().decode()[:1000], file=sys.stderr)
+        raise
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw  # spec endpoints return YAML
+
+
+def _short_id(prefix="rls"):
+    """A short, deterministic-enough id for a calc column / filter."""
+    import hashlib
+    return prefix + "-" + hashlib.md5(prefix.encode() + os.urandom(4)).hexdigest()[:8]
+
+
+# --- 1. reuse-first attribute lookup --------------------------------------
+def find_attribute(name):
+    """Return the existing user-attribute entry matching `name` (case-insensitive), else None."""
+    res = api("GET", "/v2/user-attributes?limit=200")
+    entries = res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+    for e in entries:
+        if (e.get("name") or "").lower() == name.lower():
+            return e
+    return None
+
+
+def list_attributes():
+    res = api("GET", "/v2/user-attributes?limit=200")
+    return res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+
+
+# --- 3. RLS spec snippet --------------------------------------------------
+def rls_spec_snippet(attr, field, element_id):
+    """The verified row-filter shape: a boolean calc column + an element list filter showing only True."""
+    col_id = _short_id("rlscol")
+    filt_id = _short_id("rlsf")
+    calc = {
+        "id": col_id,
+        "name": f"RLS {attr}",
+        "formula": f'CurrentUserAttributeText("{attr}") = [{field}]',
+    }
+    filt = {
+        "id": filt_id,
+        "columnId": col_id,
+        "kind": "list",
+        "mode": "include",
+        "values": [True],
+    }
+    return {
+        "elementId": element_id,
+        "calcColumn": calc,
+        "filter": filt,
+        "_note": (
+            f'Add calcColumn to element "{element_id}" columns, and `filter` to that '
+            f"element's filters[]. CurrentUserAttributeText(\"{attr}\") = [{field}] is the "
+            "user-attribute mode; team mode = CurrentUserInTeam([...]); email mode = "
+            "[Email] = CurrentUserEmail()."
+        ),
+    }
+
+
+def apply_to_dm(dm_id, element_id, calc, filt):
+    """PATCH the calc column + filter into the DM element's spec (GET → mutate → PUT)."""
+    spec = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    if not isinstance(spec, dict):
+        # spec endpoints can return YAML; we can't safely mutate that here.
+        sys.exit("DM spec came back non-JSON (YAML) — cannot auto-PATCH; apply the snippet by hand.")
+    # The spec shape nests elements under the model; search for the element by id.
+    found = _inject(spec, element_id, calc, filt)
+    if not found:
+        sys.exit(f"element id {element_id} not found in DM {dm_id} spec — check --element-id")
+    res = api("PUT", f"/v2/dataModels/{dm_id}/spec", spec)
+    print("PUT /v2/dataModels/%s/spec ->" % dm_id,
+          json.dumps(res)[:300] if isinstance(res, dict) else str(res)[:300])
+
+
+def _inject(node, element_id, calc, filt):
+    """Recursively find an element dict whose id == element_id; add calc col + filter. Returns True if injected."""
+    if isinstance(node, dict):
+        if node.get("id") == element_id and ("columns" in node or "kind" in node or "source" in node):
+            cols = node.setdefault("columns", [])
+            if not any(c.get("id") == calc["id"] for c in cols if isinstance(c, dict)):
+                cols.append(calc)
+            filters = node.setdefault("filters", [])
+            filters.append(filt)
+            return True
+        for v in node.values():
+            if _inject(v, element_id, calc, filt):
+                return True
+    elif isinstance(node, list):
+        for v in node:
+            if _inject(v, element_id, calc, filt):
+                return True
+    return False
+
+
+
+# --- shared engine: teams, element/column resolution, CLS, batch from result.security ---
+def find_team(name):
+    res = api("GET", "/v2/teams?limit=500")
+    entries = res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+    for e in entries:
+        if (e.get("name") or "").lower() == name.lower():
+            return e
+    return None
+
+def ensure_team(name, do_create):
+    t = find_team(name)
+    if t:
+        print(f"  REUSE team '{name}' (id={t.get('teamId') or t.get('id')}).")
+        return t.get("teamId") or t.get("id")
+    if do_create:
+        res = api("POST", "/v2/teams", {"name": name})
+        tid = res.get("teamId") or res.get("id") if isinstance(res, dict) else None
+        print(f"  CREATED team '{name}' (id={tid}). NOTE: add members via POST /v2/teams/{tid}/members.")
+        return tid
+    print(f"  (plan: team '{name}' missing — pass --provision to create it, then add members.)")
+    return None
+
+def _walk_elements(node, out):
+    if isinstance(node, dict):
+        if node.get("id") and ("columns" in node or "kind" in node):
+            out.append(node)
+        for v in node.values():
+            _walk_elements(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            _walk_elements(v, out)
+    return out
+
+def _resolve_element(spec, element_id, element_name):
+    els = _walk_elements(spec, [])
+    for e in els:
+        if element_id and e.get("id") == element_id:
+            return e
+    for e in els:                                  # Sigma reassigns ids on POST → match by name
+        if element_name and (e.get("name") == element_name):
+            return e
+    # last resort: a path-tail match (warehouse-table element named by table)
+    for e in els:
+        path = (e.get("source") or {}).get("path") or []
+        if element_name and path and str(path[-1]).upper() == str(element_name).upper():
+            return e
+    return None
+
+def _norm(x):
+    """Normalize a column name for matching across raw/display forms (NET_PROFIT == Net Profit)."""
+    return __import__("re").sub(r"[^a-z0-9]", "", (x or "").lower())
+
+def _resolve_col_ids(element, names):
+    """Map raw-or-display column names -> live column ids (formula tail or name, normalized)."""
+    out = []
+    re = __import__("re")
+    for nm in (names or []):
+        cid = None
+        for c in (element.get("columns") or []):
+            cand = c.get("name") or ""
+            f = c.get("formula") or ""
+            m = re.match(r"^\[(?:[^\]/]+/)?([^\]]+)\]$", f)
+            if m:
+                cand = cand or m.group(1)
+                if _norm(m.group(1)) == _norm(nm): cid = c.get("id"); break
+            if _norm(cand) == _norm(nm): cid = c.get("id"); break
+        if cid: out.append(cid)
+        else: print(f"  WARN: CLS column '{nm}' not found on element — skipped.")
+    return out
+
+def apply_from_security(dm_id, security, do_apply, do_provision):
+    """Provision attrs/teams + apply RLS calc/filter and CLS for each result.security entry."""
+    spec = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    if not isinstance(spec, dict):
+        sys.exit("DM spec came back non-JSON — cannot auto-apply.")
+    applied = 0
+    def _elname(e): return e.get('name') or ((e.get('source') or {}).get('path') or ['?'])[-1]
+    for rule in security:
+        el = _resolve_element(spec, rule.get("elementId"), rule.get("elementName"))
+        if not el:
+            print(f"⚠ {rule.get('kind')} on element '{rule.get('elementName')}' — not found in DM {dm_id}; skipped."); continue
+        if rule.get("kind") == "rls" and rule.get("rls"):
+            r = rule["rls"]
+            print(f"RLS → element '{_elname(el)}': {r['formula'][:80]}")
+            for attr in (r.get("userAttributes") or []):
+                ex = find_attribute(attr)
+                if ex: print(f"  REUSE attribute '{attr}'.")
+                elif do_provision:
+                    api("POST", "/v2/user-attributes", {"name": attr, "defaultValue": {"val": "", "type": "string"}})
+                    print(f"  CREATED attribute '{attr}'. NOTE: assign per-user values via POST /v2/user-attributes/{{id}}/users.")
+                else: print(f"  (plan: attribute '{attr}' — pass --provision to create; then assign per-user values.)")
+            for team in (r.get("teams") or []):
+                ensure_team(team, do_provision)
+            calc = {"id": _short_id("rlscol"), "name": r.get("name") or "RLS", "formula": r["formula"]}
+            filt = {"id": _short_id("rlsf"), "columnId": calc["id"], "kind": "list", "mode": "include", "values": [True]}
+            if do_apply:
+                el.setdefault("columns", []).append(calc)
+                el.setdefault("filters", []).append(filt); applied += 1
+        elif rule.get("kind") == "cls" and rule.get("cls"):
+            c = rule["cls"]
+            ids = _resolve_col_ids(el, c.get("restrictedColumnNames"))
+            print(f"CLS → element '{_elname(el)}': hide {c.get('restrictedColumnNames')}")
+            if do_apply and ids:
+                el.setdefault("columnSecurities", []).append({"id": _short_id("cls"), "criteria": c.get("criteria") or {"kind": "no-one-can-view"}, "restrictedColumns": ids}); applied += 1
+    if do_apply and applied:
+        res = api("PUT", f"/v2/dataModels/{dm_id}/spec", spec)
+        print(f"PUT spec -> applied {applied} rule(s):", (json.dumps(res)[:200] if isinstance(res, dict) else str(res)[:200]))
+    elif not do_apply:
+        print("\n(plan only — pass --apply --dm-id <id> to PATCH these into the DM spec; --provision to create attributes/teams.)")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Apply a Looker RLS finding to Sigma (safe-by-default).")
+    ap.add_argument("--attr", help="Sigma user-attribute name (e.g. region)")
+    ap.add_argument("--value", help="attribute value (for --create defaultValue / --assign)")
+    ap.add_argument("--description", help="description when creating the attribute")
+    ap.add_argument("--member-id", help="Sigma memberId to assign the value to (with --assign)")
+    ap.add_argument("--field", help="DM column display name to filter on (e.g. Region) — for the RLS snippet")
+    ap.add_argument("--element-id", help="DM element id the RLS calc col + filter attach to")
+    ap.add_argument("--dm-id", help="dataModelId (with --apply, to PATCH the element spec)")
+    ap.add_argument("--create", action="store_true", help="create the user attribute if no reusable match")
+    ap.add_argument("--assign", action="store_true", help="assign --value to --member-id")
+    ap.add_argument("--apply", action="store_true", help="PATCH the RLS calc col + filter into the DM element spec")
+    ap.add_argument("--from-security", help="path to a converter result.security[] JSON (batch RLS+CLS apply)")
+    ap.add_argument("--provision", action="store_true", help="create missing user attributes / teams (with --from-security)")
+    a = ap.parse_args()
+
+    # Batch mode: ingest a converter's result.security[] and provision + apply all rules.
+    if a.from_security:
+        if not a.dm_id:
+            sys.exit("--from-security requires --dm-id (the posted data model).")
+        raw = json.load(open(a.from_security))
+        security = raw.get("security", raw) if isinstance(raw, dict) else raw
+        return apply_from_security(a.dm_id, security, a.apply, a.provision)
+
+    if not a.attr:
+        sys.exit("Provide --attr (single-rule mode) or --from-security <json> (batch mode).")
+    # --- 1. reuse-first --------------------------------------------------
+    existing = find_attribute(a.attr)
+    attr_id = None
+    if existing:
+        attr_id = existing.get("userAttributeId") or existing.get("id")
+        print(f"REUSE: user attribute '{a.attr}' already exists "
+              f"(id={attr_id}, default={existing.get('defaultValue')}) — reusing, NOT creating.")
+    else:
+        print(f"No existing Sigma user attribute named '{a.attr}'.")
+        if a.create:
+            body = {"name": a.attr}
+            if a.description:
+                body["description"] = a.description
+            if a.value is not None:
+                body["defaultValue"] = {"val": a.value, "type": "string"}
+            res = api("POST", "/v2/user-attributes", body)
+            attr_id = res.get("userAttributeId") or res.get("id") if isinstance(res, dict) else None
+            print(f"CREATED user attribute '{a.attr}' (id={attr_id}).")
+        else:
+            print("  (plan only — pass --create to create it.)")
+
+    # --- 2. assign -------------------------------------------------------
+    if a.assign:
+        if not attr_id:
+            sys.exit("--assign needs an attribute id — create/reuse it first (no id resolved).")
+        if not a.member_id or a.value is None:
+            sys.exit("--assign requires --member-id and --value.")
+        body = {"assignments": [{"userId": a.member_id, "value": {"val": a.value, "type": "string"}}]}
+        res = api("POST", f"/v2/user-attributes/{attr_id}/users", body)
+        print(f"ASSIGNED '{a.attr}'={a.value} to member {a.member_id}: "
+              + (json.dumps(res)[:200] if isinstance(res, dict) else str(res)[:200]))
+    elif a.value is not None and a.member_id:
+        print(f"  (plan: would assign '{a.attr}'={a.value} to member {a.member_id} — pass --assign.)")
+
+    # --- 3. RLS spec snippet --------------------------------------------
+    if a.field:
+        if not a.element_id:
+            print("\nNOTE: --field given without --element-id; printing the formula only.")
+            print(f'  calc column formula: CurrentUserAttributeText("{a.attr}") = [{a.field}]')
+        else:
+            snip = rls_spec_snippet(a.attr, a.field, a.element_id)
+            print("\nRLS spec snippet (verified shape — boolean calc col + element list filter on True):")
+            print(json.dumps(snip, indent=2))
+            if a.apply:
+                if not a.dm_id:
+                    sys.exit("--apply requires --dm-id.")
+                apply_to_dm(a.dm_id, a.element_id, snip["calcColumn"], snip["filter"])
+            else:
+                print("  (plan only — pass --apply --dm-id <id> to PATCH it into the DM element spec.)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/post-and-readback.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/post-and-readback.mjs
@@ -18,7 +18,8 @@ const postPath = a.type === 'datamodel' ? '/v2/dataModels/spec' : '/v2/workbooks
 const colsPath = (id) => a.type === 'datamodel' ? `/v2/dataModels/${id}/columns` : `/v2/workbooks/${id}/columns`;
 
 const spec = JSON.parse(readFileSync(a.spec, 'utf8'));
-const body = { folderId: a.folder, name: a.name || spec.name || `cognos ${a.type} ${Date.now()}`, ...spec };
+// name AFTER the spread — `{name, ...spec}` let spec.name silently override --name (beads-sigma-unff).
+const body = { folderId: a.folder, ...spec, name: a.name || spec.name || `cognos ${a.type} ${Date.now()}` };
 const post = await api('POST', postPath, body);
 const id = extractId(post, idField);
 if (!id) { console.error(`POST failed (HTTP ${post.status}): ${post.text.slice(0, 500)}`); process.exit(1); }


### PR DESCRIPTION
## What

End-to-end fixes for the `cognos-to-sigma` plugin, covering beads **c31q, fh4u, unff, ir3z, 0xlz, w94g, k6ig** + the 1.0.0 version bump. Fully E2E-validated on the bundled fixtures (`sample-data-module.module.json` + `go-sales-performance.report.xml`) against **tj-wells-1989** / conn `cb2f5180` with **ZERO manual patches**.

### Converter fixes
- **Digit-split display names (c31q, blocked DM POST):** `sigmaDisplayName` now replicates Sigma's letter↔digit boundary split in BOTH directions (`CY_Q1_REVENUE` → `Cy Q 1 Revenue`, `FY2024` → `Fy 2024`, `PY_Q4` → `Py Q 4`) and is **idempotent** (splits on whitespace too) — same-element sibling refs are case-SENSITIVE in Sigma and the old non-idempotent derivation broke them on re-translation (gate caught it: 2 error columns, fixed). Verified **empirically** against a live name-probe DM (7 digit-heavy warehouse columns incl. FY2024-style → 0 error columns, first POST) + new unit tests.
- **pColumn macro → working control (fh4u):** prompt macros emit a **`segmented` control** (values + default recovered from the report's `<selectValue>` options and `customControl` button configs) and a `Switch` **wired by `controlId`** (`Switch([pColumn], "Gross Profit", [Sheet 1/Gross Profit], [Sheet 1/Revenue])` — matches this morning's hand-verified shape). Both macro shapes convert: token-swap with default column AND string-concat ref building (`'[…CY_' + prompt('pQuarter','token') + '_Revenue]'` → Switch over the four `Cy Q n Revenue` columns). Unrecoverable macros still degrade to a flagged placeholder.
- **post-and-readback `--name` (unff):** spread-order fix — `--name` now wins over `spec.name` (live-verified: objects named `VISQA2 Cognos — …`).
- **KPI singleton panel (ir3z):** `<singleton>` → Sigma **kpi-chart** (`value:{columnId}`, Cognos `dataFormat` → Sigma number format, sibling dataItems materialized as supporting columns, Sum-wrap only for row-level formulas). Conditional up/down icons are WARNed; the values are never dropped. `apply-layout.mjs` lays consecutive KPIs as rows of 3 tall tiles.
- **Filters + prompts (0xlz):** `[Col] = lit` / `[Col] in (…)` → element `list` filters; `[Col] = ?pQuarter?` → segmented control + hidden boolean match column + `values:[true]` filter; auto-aggregated lists → **grouped tables** (`groupings`); scaled currency (`$###.#M`) → `$,.3s`; Year (numeric dim) → `Text()` cast for categorical axis binding; slot `dsSort` → `xAxis.sort`. Table sort order, footer `Total()` columns, and summary filters stay loud WARNs (never silent).
- **Dangling refs (w94g):** SKILL.md now points at `refs/format-shapes.md` (the files it referenced never existed); `design-notes.md` header un-staled (converter is shipped) and `/api/v1` → `/bi/v1`.
- **RLS layer parity (k6ig):** `scripts/apply_sigma_rls.py` vendored **byte-identical** from quicksight-to-sigma (md5 `c2f7fa6147990a4f185496c1c06e5a2e` both sides) + the same "Security: RLS/CLS" SKILL.md section as the other 6 converters. The converter best-effort **detects** data-module `securityFilter` entries → `result.security[]` (cli writes `security.json` + loud warning); manual-detection guidance documented for shapes it can't see (FM `.cpf`, UI-only tabs).
- **Version:** plugin.json `0.1.0` → `1.0.0`.

### E2E evidence (zero manual patches)
| Gate | Result |
|---|---|
| DM `post-and-readback` | exit 0 — 4 elements, **0 error columns, first POST** (digit-heavy refs resolved) |
| WB `post-and-readback` | exit 0 — 13 elements, **0 error columns** |
| `apply-layout` | `layoutOnReadback: true` |
| `assert-parity --check` | **PARITY GREEN 10/10** ±1% — revenue 7803 / GP 3120 / 12 rows / quarters 1500.75–2400.75 / Canada 2201, Germany 3001, USA 2601 |
| Control functional | Country bar = USA 800.25 / Germany 1200.25 (= warehouse Year 2023 ∧ Q4, control defaults); CYQRev KPI = $120 = Sum(CY_Q4); YtY Revenue = 25.0% = (120−96)/96 |
| PNG (read, `~/migration-visual-qa/cognos2/sigma-page1.png`) | KPI panel visible (2×3, $/% formats), both segmented controls rendered (Q4 / Revenue selected), lists grouped with plumbing columns hidden, $-formatted line axis, sorted bars |
| `npm test` | all fixtures convert + 23 new unit/regression assertions green |

Kept objects: DM `0324a74b` + WB `5c4dacd0` ("VISQA2 Cognos — …", folder Test). Scratch objects (morning VISQA pair, name-probe DM + `CSA.TJ.NAMEPROBE_DN`) deleted.

> **NOTE:** the same digit-split + macro fixes need mirroring to **sigma-data-model-mcp** and the **browser tool** — tracked separately as **bead 5nn3**; deliberately NOT attempted in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)