### PR TITLE
tableau-to-sigma final-wave polish: tile-census gate, relative-date current, layout rename/row-scale, User-agg calcs, sort carry

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # Hard gate that proves a tableau-to-sigma conversion is actually complete.
-# The subagent MUST run this script before declaring GREEN. It checks four
+# The subagent MUST run this script before declaring GREEN. It checks five
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
@@ -14,6 +14,12 @@
 #   4. The workbook has a non-empty layout XML applied (catches the
 #      "elements just listed in a single column" regression where the
 #      agent forgot to PUT a layout)  → beads-sigma-bw3
+#   5. Tile census — parity-final.json's `tile_census` field (emitted by the
+#      converter's phase6 finalize when a dashboard zone tree is available)
+#      shows no unexplained dashboard zones without a matching chart in the
+#      parity plan. Catches the "empty view CSV silently dropped a tile and
+#      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
+#      (with a note) when the converter doesn't emit a census.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -27,6 +33,9 @@
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
+#     [--allow-missing-tiles N] default 0 — tolerate up to N unmatched dashboard
+#                              # zones in the tile census (for legitimately
+#                              # unbuildable zones; name them in your report)
 #
 # Exit codes:
 #   0  every gate passes — conversion is allowed to declare GREEN
@@ -38,6 +47,8 @@
 #   5  live workbook has column(s) with type=error (beads-sigma-38a)
 #   6  live workbook has no layout applied — single-column fallback
 #      (beads-sigma-bw3)
+#   7  tile census shows unexplained unmatched dashboard zones beyond
+#      --allow-missing-tiles (bead gjhe)
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -46,7 +57,8 @@ require 'net/http'
 require 'uri'
 require 'optparse'
 
-opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2 }
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
+         allow_missing_tiles: 0 }
 OptionParser.new do |p|
   p.on('--tableau DIR')              { |v| opts[:tab] = v }
   p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
@@ -57,6 +69,7 @@ OptionParser.new do |p|
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
   p.on('--skip-layout-check')        { opts[:skip_layout] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+  p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -106,7 +119,7 @@ if status != 'PASS' || pass_rate < opts[:min_pass_rate]
   exit 2
 end
 
-puts "[OK] gate 1/4: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+puts "[OK] gate 1/5: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
 
 # ---------------------------------------------------------------------------
 # Gate 2 — orphan workbooks (beads-sigma-38a)
@@ -119,7 +132,7 @@ unless opts[:skip_orphan]
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
       unless File.exist?(marker_path)
-        warn "[FAIL] gate 2/4: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "[FAIL] gate 2/5: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
         warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
@@ -128,27 +141,27 @@ unless opts[:skip_orphan]
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
       if marker['failed'] && !marker['failed'].empty?
-        warn "[FAIL] gate 2/4: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "[FAIL] gate 2/5: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
       if marker['dry_run']
-        warn "[FAIL] gate 2/4: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "[FAIL] gate 2/5: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
         warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
         exit 4
       end
       kept = marker['kept'] || '(unknown)'
       deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/4: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      puts "[OK] gate 2/5: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
     else
-      puts "[OK] gate 2/4: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+      puts "[OK] gate 2/5: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end
   else
-    puts "[OK] gate 2/4: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+    puts "[OK] gate 2/5: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/4: --skip-orphan-check"
+  puts "[SKIP] gate 2/5: --skip-orphan-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -168,12 +181,12 @@ unless opts[:skip_column]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 3/4: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts "[SKIP] gate 3/5: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 3/4: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+      warn "[SKIP] gate 3/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
       req = Net::HTTP::Get.new(uri)
@@ -185,7 +198,7 @@ unless opts[:skip_column]
         cols = (JSON.parse(res.body)['entries'] rescue []) || []
         error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
         if error_cols.any?
-          warn "[FAIL] gate 3/4: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "[FAIL] gate 3/5: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
           warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
           warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
           error_cols.first(10).each do |c|
@@ -195,14 +208,14 @@ unless opts[:skip_column]
           warn "       See beads-sigma-38a."
           exit 5
         end
-        puts "[OK] gate 3/4: #{cols.length} live columns clean (no type=error)"
+        puts "[OK] gate 3/5: #{cols.length} live columns clean (no type=error)"
       else
-        warn "[SKIP] gate 3/4: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 3/5: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 3/4: --skip-column-check"
+  puts "[SKIP] gate 3/5: --skip-column-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -223,12 +236,12 @@ unless opts[:skip_layout]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 4/4: no workbook ID resolvable for layout check"
+    puts "[SKIP] gate 4/5: no workbook ID resolvable for layout check"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 4/4: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+      warn "[SKIP] gate 4/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
       req = Net::HTTP::Get.new(uri)
@@ -267,7 +280,7 @@ unless opts[:skip_layout]
         end
 
         if layout_xml.empty?
-          warn "[FAIL] gate 4/4: live workbook #{wb_id} has NO top-level layout XML."
+          warn "[FAIL] gate 4/5: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
           warn "       dashboard grid. Rebuild the layout with this skill's layout"
           warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
@@ -277,12 +290,12 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         elsif elem_count < opts[:min_layout_elements]
-          warn "[FAIL] gate 4/4: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "[FAIL] gate 4/5: layout XML has only #{elem_count} <LayoutElement> tag(s);"
           warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
           warn "       The layout likely covers only the Data page — chart page is unstyled."
           exit 6
         elsif non_data_stack_pages.any?
-          warn "[FAIL] gate 4/4: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "[FAIL] gate 4/5: live workbook #{wb_id} has Sigma's auto-generated"
           warn "       single-column stack layout (multiple elements at the same gridColumn"
           warn "       on a non-Data page). This is what Sigma defaults to when you POST"
           warn "       a workbook without a layout — exactly the CoCo regression."
@@ -295,15 +308,48 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         else
-          puts "[OK] gate 4/4: layout XML applied with #{elem_count} positioned element(s)"
+          puts "[OK] gate 4/5: layout XML applied with #{elem_count} positioned element(s)"
         end
       else
-        warn "[SKIP] gate 4/4: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 4/5: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 4/4: --skip-layout-check"
+  puts "[SKIP] gate 4/5: --skip-layout-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 5 — tile census (bead gjhe)
+# parity-final.json's `tile_census` field compares the source dashboard's
+# chart-zone count against the charts that made it into the parity plan.
+# Catches the empty-view-CSV escape where the builder silently emits N-1
+# charts and parity still reports PASS (every chart it knows about passes —
+# it just doesn't know about the dropped one).
+# ---------------------------------------------------------------------------
+census = summary['tile_census']
+if census.nil?
+  puts "[SKIP] gate 5/5: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+else
+  zones     = census['zones_total'].to_i
+  built     = census['charts_built'].to_i
+  unmatched = census['zones_unmatched'].to_i
+  names     = Array(census['unmatched_zone_names'])
+  if unmatched > opts[:allow_missing_tiles]
+    warn "[FAIL] gate 5/5: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    names.each { |n| warn "         - #{n}" }
+    warn "       A zone that rendered in the source dashboard has NO matching chart in the"
+    warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
+    warn "       (re-fetch the view data and rebuild), or the tile was renamed without"
+    warn "       passing --rename to phase6-parity.rb / build-dashboard-layout.rb."
+    warn "       If #{unmatched} zone(s) are legitimately unbuildable, re-run with"
+    warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
+    exit 7
+  elsif unmatched > 0
+    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+  else
+    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # Hard gate that proves a tableau-to-sigma conversion is actually complete.
-# The subagent MUST run this script before declaring GREEN. It checks four
+# The subagent MUST run this script before declaring GREEN. It checks five
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
@@ -14,6 +14,12 @@
 #   4. The workbook has a non-empty layout XML applied (catches the
 #      "elements just listed in a single column" regression where the
 #      agent forgot to PUT a layout)  → beads-sigma-bw3
+#   5. Tile census — parity-final.json's `tile_census` field (emitted by the
+#      converter's phase6 finalize when a dashboard zone tree is available)
+#      shows no unexplained dashboard zones without a matching chart in the
+#      parity plan. Catches the "empty view CSV silently dropped a tile and
+#      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
+#      (with a note) when the converter doesn't emit a census.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -27,6 +33,9 @@
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
+#     [--allow-missing-tiles N] default 0 — tolerate up to N unmatched dashboard
+#                              # zones in the tile census (for legitimately
+#                              # unbuildable zones; name them in your report)
 #
 # Exit codes:
 #   0  every gate passes — conversion is allowed to declare GREEN
@@ -38,6 +47,8 @@
 #   5  live workbook has column(s) with type=error (beads-sigma-38a)
 #   6  live workbook has no layout applied — single-column fallback
 #      (beads-sigma-bw3)
+#   7  tile census shows unexplained unmatched dashboard zones beyond
+#      --allow-missing-tiles (bead gjhe)
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -46,7 +57,8 @@ require 'net/http'
 require 'uri'
 require 'optparse'
 
-opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2 }
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
+         allow_missing_tiles: 0 }
 OptionParser.new do |p|
   p.on('--tableau DIR')              { |v| opts[:tab] = v }
   p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
@@ -57,6 +69,7 @@ OptionParser.new do |p|
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
   p.on('--skip-layout-check')        { opts[:skip_layout] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+  p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -106,7 +119,7 @@ if status != 'PASS' || pass_rate < opts[:min_pass_rate]
   exit 2
 end
 
-puts "[OK] gate 1/4: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+puts "[OK] gate 1/5: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
 
 # ---------------------------------------------------------------------------
 # Gate 2 — orphan workbooks (beads-sigma-38a)
@@ -119,7 +132,7 @@ unless opts[:skip_orphan]
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
       unless File.exist?(marker_path)
-        warn "[FAIL] gate 2/4: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "[FAIL] gate 2/5: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
         warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
@@ -128,27 +141,27 @@ unless opts[:skip_orphan]
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
       if marker['failed'] && !marker['failed'].empty?
-        warn "[FAIL] gate 2/4: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "[FAIL] gate 2/5: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
       if marker['dry_run']
-        warn "[FAIL] gate 2/4: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "[FAIL] gate 2/5: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
         warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
         exit 4
       end
       kept = marker['kept'] || '(unknown)'
       deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/4: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      puts "[OK] gate 2/5: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
     else
-      puts "[OK] gate 2/4: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+      puts "[OK] gate 2/5: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end
   else
-    puts "[OK] gate 2/4: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+    puts "[OK] gate 2/5: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/4: --skip-orphan-check"
+  puts "[SKIP] gate 2/5: --skip-orphan-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -168,12 +181,12 @@ unless opts[:skip_column]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 3/4: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts "[SKIP] gate 3/5: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 3/4: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+      warn "[SKIP] gate 3/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
       req = Net::HTTP::Get.new(uri)
@@ -185,7 +198,7 @@ unless opts[:skip_column]
         cols = (JSON.parse(res.body)['entries'] rescue []) || []
         error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
         if error_cols.any?
-          warn "[FAIL] gate 3/4: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "[FAIL] gate 3/5: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
           warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
           warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
           error_cols.first(10).each do |c|
@@ -195,14 +208,14 @@ unless opts[:skip_column]
           warn "       See beads-sigma-38a."
           exit 5
         end
-        puts "[OK] gate 3/4: #{cols.length} live columns clean (no type=error)"
+        puts "[OK] gate 3/5: #{cols.length} live columns clean (no type=error)"
       else
-        warn "[SKIP] gate 3/4: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 3/5: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 3/4: --skip-column-check"
+  puts "[SKIP] gate 3/5: --skip-column-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -223,12 +236,12 @@ unless opts[:skip_layout]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 4/4: no workbook ID resolvable for layout check"
+    puts "[SKIP] gate 4/5: no workbook ID resolvable for layout check"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 4/4: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+      warn "[SKIP] gate 4/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
       req = Net::HTTP::Get.new(uri)
@@ -267,7 +280,7 @@ unless opts[:skip_layout]
         end
 
         if layout_xml.empty?
-          warn "[FAIL] gate 4/4: live workbook #{wb_id} has NO top-level layout XML."
+          warn "[FAIL] gate 4/5: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
           warn "       dashboard grid. Rebuild the layout with this skill's layout"
           warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
@@ -277,12 +290,12 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         elsif elem_count < opts[:min_layout_elements]
-          warn "[FAIL] gate 4/4: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "[FAIL] gate 4/5: layout XML has only #{elem_count} <LayoutElement> tag(s);"
           warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
           warn "       The layout likely covers only the Data page — chart page is unstyled."
           exit 6
         elsif non_data_stack_pages.any?
-          warn "[FAIL] gate 4/4: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "[FAIL] gate 4/5: live workbook #{wb_id} has Sigma's auto-generated"
           warn "       single-column stack layout (multiple elements at the same gridColumn"
           warn "       on a non-Data page). This is what Sigma defaults to when you POST"
           warn "       a workbook without a layout — exactly the CoCo regression."
@@ -295,15 +308,48 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         else
-          puts "[OK] gate 4/4: layout XML applied with #{elem_count} positioned element(s)"
+          puts "[OK] gate 4/5: layout XML applied with #{elem_count} positioned element(s)"
         end
       else
-        warn "[SKIP] gate 4/4: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 4/5: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 4/4: --skip-layout-check"
+  puts "[SKIP] gate 4/5: --skip-layout-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 5 — tile census (bead gjhe)
+# parity-final.json's `tile_census` field compares the source dashboard's
+# chart-zone count against the charts that made it into the parity plan.
+# Catches the empty-view-CSV escape where the builder silently emits N-1
+# charts and parity still reports PASS (every chart it knows about passes —
+# it just doesn't know about the dropped one).
+# ---------------------------------------------------------------------------
+census = summary['tile_census']
+if census.nil?
+  puts "[SKIP] gate 5/5: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+else
+  zones     = census['zones_total'].to_i
+  built     = census['charts_built'].to_i
+  unmatched = census['zones_unmatched'].to_i
+  names     = Array(census['unmatched_zone_names'])
+  if unmatched > opts[:allow_missing_tiles]
+    warn "[FAIL] gate 5/5: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    names.each { |n| warn "         - #{n}" }
+    warn "       A zone that rendered in the source dashboard has NO matching chart in the"
+    warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
+    warn "       (re-fetch the view data and rebuild), or the tile was renamed without"
+    warn "       passing --rename to phase6-parity.rb / build-dashboard-layout.rb."
+    warn "       If #{unmatched} zone(s) are legitimately unbuildable, re-run with"
+    warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
+    exit 7
+  elsif unmatched > 0
+    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+  else
+    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -58,7 +58,7 @@ which calc translation, which layout) — not orchestration.
 | `scripts/put-layout.rb` | Apply a layout XML to an existing workbook (strips read-only fields) |
 | `scripts/auto-parity-plan.rb` | Phase 6a: auto-build a parity plan by matching Sigma chart elements to Tableau view CSVs (with `--rename` for renamed tiles). Output → `/tmp/<name>/parity-plan.json` wrapped as `{ extract, charts: [...] }` |
 | `scripts/verify-parity.rb` | Phase 6c: diff expected (Tableau) vs actual (Sigma) per chart. `--extract-mode` switches to structural comparison (bucket count + dim set + sort) with value-drift tolerance for hasExtracts=true workbooks |
-| `scripts/assert-phase6-ran.rb` | **Conversion hard gate (3 gates)** — exits 0 only when ALL three pass: (1) Phase 6 ran and parity-final.json shows status=PASS at the required rate, (2) no uncleaned orphan workbooks (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows a successful non-dry-run cleanup), (3) the live workbook's `/columns` endpoint shows no column with `type=error` (catches circular refs / runtime errors introduced after the initial POST's column-type guard). Exits 1 for missing parity sentinel, 2 for parity FAIL / extract-mode-without-flag / charts_total==0, 4 for uncleaned orphans (beads-sigma-38a), 5 for live type=error columns (beads-sigma-38a). Subagent flows MUST call this as their final step. |
+| `scripts/assert-phase6-ran.rb` | **Conversion hard gate (5 gates)** — exits 0 only when ALL five pass: (1) Phase 6 ran and parity-final.json shows status=PASS at the required rate, (2) no uncleaned orphan workbooks (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows a successful non-dry-run cleanup), (3) the live workbook's `/columns` endpoint shows no column with `type=error` (catches circular refs / runtime errors introduced after the initial POST's column-type guard), (4) a non-empty top-level layout XML is applied (beads-sigma-bw3), (5) tile census — parity-final.json's `tile_census` shows no unexplained dashboard zones without a matching chart (catches the empty-view-CSV N-1-charts escape, bead gjhe; `--allow-missing-tiles N` for legitimately unbuildable zones). Exits 1 for missing parity sentinel, 2 for parity FAIL / extract-mode-without-flag / charts_total==0, 4 for uncleaned orphans, 5 for live type=error columns, 6 for missing layout, 7 for census failure. Subagent flows MUST call this as their final step. |
 | `scripts/cleanup-orphan-workbooks.rb` | Delete orphan workbooks left by spec-iteration retries. Reads `<workdir>/posted-workbooks.jsonl`, keeps the most-recent ID, deletes the rest via `DELETE /v2/files/{id}`. Writes `cleanup-marker.json` so the hard gate can confirm cleanup ran (and wasn't `--dry-run`). Idempotent (404 on delete is treated as success). See beads-sigma-38a. |
 | `scripts/build-dashboard-layout.rb` | **MANDATORY in Phase 5d** (dashboard-fidelity mode) — auto-build the Sigma layout XML from the parsed Tableau zone tree (`dashboard-layout.json`) + the workbook readback IDs (`wb-ids.json`). Positions each chart at the grid cell derived from its zone's x/y/w/h%. Without this step, the workbook PUTs without a top-level layout and Sigma renders elements as a single-column stack — see `assert-phase6-ran.rb` gate 4 (beads-sigma-bw3). |
 | `scripts/export-chart-png.rb` | Phase 6d (visual): export PNG screenshots of every chart in the converted Sigma workbook via `/v2/workbooks/{wb}/export` → `/v2/query/{q}/download`. Catches visual regressions CSV value parity can miss (silently-dropped log scale, missing data labels, wrong chart kind, palette drift). Output: per-element PNGs + `_manifest.json`. Pair with the Tableau MCP `get-view-image` to side-by-side compare source vs target. |
@@ -1121,6 +1121,11 @@ ruby scripts/build-dashboard-layout.rb \
   --layout /tmp/<name>/dashboard-layout.json \
   --wb-ids /tmp/<name>/wb-ids.json \
   --out /tmp/<name>/layout.xml
+# If any chart tile was renamed from its Tableau title, pass the same
+# --rename "Tableau name=Sigma name" pairs you give the parity scripts —
+# otherwise the renamed tile silently drops out of the layout (bead ddbq).
+# Row heights are scaled 1.5x by default (--row-scale) so Sigma doesn't
+# suppress axis/pie labels on short tiles (bead tkkv); proportions are kept.
 
 ruby scripts/put-layout.rb \
   --workbook <workbookId> \
@@ -1130,7 +1135,10 @@ ruby scripts/put-layout.rb \
 `build-dashboard-layout.rb` walks the dashboard's zones, converts each
 zone's `x_pct`/`y_pct`/`w_pct`/`h_pct` into Sigma 24-column grid spans,
 and stretches adjacent tiles to fill empty columns where Tableau had
-legend/filter shelves Sigma doesn't render. This is the dashboard-fidelity
+legend/filter shelves Sigma doesn't render. Band heights are multiplied by
+`--row-scale` (default 1.5 — Tableau zone ratios mapped 1:1 onto a 32-row
+page produce tiles short enough that Sigma suppresses axis and pie labels;
+1.43× was the empirically sufficient minimum, looker's builder uses 2×). This is the dashboard-fidelity
 path — chart positions mirror the source PNG.
 
 **Hand-rolled path — page-per-worksheet OR when zone parsing fails:**
@@ -1258,7 +1266,7 @@ ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name>
 # add --allow-extract when running parity in extract-mode
 ```
 
-The gate checks four independent things and rejects on any failure:
+The gate checks five independent things and rejects on any failure:
 
 1. **Phase 6 ran** — `parity-final.json` exists with status=PASS at the
    required rate.
@@ -1278,6 +1286,15 @@ The gate checks four independent things and rejects on any failure:
    `<LayoutElement>` tags. Catches the CoCo regression where the agent
    forgot to PUT a layout and Sigma rendered every tile as a
    single-column stack instead of the dashboard grid.
+5. **Tile census** — reads `tile_census` from `parity-final.json`
+   (emitted by `phase6-parity.rb --finalize` when
+   `dashboard-layout.json` is present): "X zones, Y charts built,
+   Z unmatched". Rejects when any source dashboard zone has no
+   matching chart in the parity plan — the empty-view-CSV escape
+   where the builder silently emitted N-1 charts and every other
+   gate still passed (bead gjhe). Renamed tiles must be explained
+   via `--rename` on `phase6-parity.rb`; legitimately unbuildable
+   zones via `--allow-missing-tiles N` (name them in your report).
 
 Exit 0 means the conversion is allowed to declare GREEN. Any other exit
 code means downgrade to YELLOW (parity skipped or incomplete, orphans
@@ -1308,6 +1325,8 @@ ruby scripts/auto-parity-plan.rb \
   --workbook-id <sigma-workbook-id> \
   --out /tmp/<name>/parity-plan.json
 ```
+
+On `--finalize`, `phase6-parity.rb` also writes a `tile_census` field into `parity-final.json` (zones vs charts built vs unmatched, read from `dashboard-layout.json`) — gate 5 of `assert-phase6-ran.rb` fails on unmatched zones.
 
 The output is wrapped as `{ "extract": <bool>, "charts": [...] }` — the `extract` flag is set automatically from `get-workbook.json`'s `hasExtracts` field when the workbook itself is extract-backed. If a Sigma chart was renamed from its Tableau title (e.g., the pie tile renamed from "Order Channel vs Ship Method" → "Orders by Category"), pass `--rename "Order Channel vs Ship Method=Orders by Category"` so the auto-matcher pairs them.
 
@@ -1368,18 +1387,7 @@ If the customer expects Tableau-extract numbers to match Sigma-live numbers exac
 | Empty result / column resolves as `error` | `mcp__sigma-mcp-v2__describe` on the element; type `error` means the formula failed to compile (often `IsIn`, unsupported window function, or missing-column ref) |
 | Numbers consistently within ±X% across all buckets | Extract drift — switch to `--extract-mode` if the source workbook has `hasExtracts: true` |
 
-### 6b. Triage divergences
-
-| Symptom | Likely cause |
-|---|---|
-| Numbers wrong by a constant factor | Aggregation mismatch (Sum vs Avg vs CountDistinct) |
-| Wrong dimension values | `[Master/...]` formula references the wrong column |
-| Date axis has 24 buckets where Tableau shows 12 | Cross-year month rollup — see `refs/column-gotchas.md` |
-| Sigma chart shows extra dim values Tableau never displays | Missed Phase 2.5 filter — apply the filter as `date-range`/`list`/`top-n` |
-| Bucket values differ but ratios match | Wrong source column — see Phase 3 "Translate Tableau calc fields here". A `Customer Value Tier` Tableau calc-derived from `Lifetime Revenue` must NOT be replaced by a warehouse `LOYALTY_TIER` column |
-| Empty result / column resolves as `error` | `mcp__sigma-mcp-v2__describe` on the element; type `error` means the formula failed to compile (often `IsIn`, unsupported window function, or missing-column ref) |
-
-### 6c. Trust the CSV, not the dashboard caption
+#### Trust the CSV, not the dashboard caption
 
 A Tableau dashboard's chart title is hardcoded text on the dashboard, not derived from
 the underlying view. When a Tableau author replaces a chart's data without updating the
@@ -1387,7 +1395,7 @@ title, the caption lies. **The view's `get-view-data` CSV is the source of truth
 build the Sigma chart against the CSV's actual columns and pick a truthful Sigma name,
 even if it disagrees with what's printed above the bars in Tableau.
 
-### 6d. Phantom `--metric-["..."]` columns
+#### Phantom `--metric-["..."]` columns
 
 `mcp__sigma-mcp-v2__query` with `type="workbook"` appends synthetic columns of the form
 `--metric-["<colId>"]` whose values look like `Column "X.--metric-[...]" does not exist.`.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/data-model-spec.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/data-model-spec.md
@@ -35,7 +35,7 @@ POST /v2/dataModels/spec
   "source": {
     "connectionId": "<connection-id>",
     "kind": "warehouse-table",
-    "path": ["SCHEMA", "CATALOG", "TABLE_NAME"]
+    "path": ["DATABASE", "SCHEMA", "TABLE_NAME"]
   },
   "columns": [
     {"id": "col-sales", "name": "Sales", "formula": "[TABLE_NAME/SALES]"}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # Hard gate that proves a tableau-to-sigma conversion is actually complete.
-# The subagent MUST run this script before declaring GREEN. It checks four
+# The subagent MUST run this script before declaring GREEN. It checks five
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
@@ -14,6 +14,12 @@
 #   4. The workbook has a non-empty layout XML applied (catches the
 #      "elements just listed in a single column" regression where the
 #      agent forgot to PUT a layout)  → beads-sigma-bw3
+#   5. Tile census — parity-final.json's `tile_census` field (emitted by the
+#      converter's phase6 finalize when a dashboard zone tree is available)
+#      shows no unexplained dashboard zones without a matching chart in the
+#      parity plan. Catches the "empty view CSV silently dropped a tile and
+#      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
+#      (with a note) when the converter doesn't emit a census.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -27,6 +33,9 @@
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
+#     [--allow-missing-tiles N] default 0 — tolerate up to N unmatched dashboard
+#                              # zones in the tile census (for legitimately
+#                              # unbuildable zones; name them in your report)
 #
 # Exit codes:
 #   0  every gate passes — conversion is allowed to declare GREEN
@@ -38,6 +47,8 @@
 #   5  live workbook has column(s) with type=error (beads-sigma-38a)
 #   6  live workbook has no layout applied — single-column fallback
 #      (beads-sigma-bw3)
+#   7  tile census shows unexplained unmatched dashboard zones beyond
+#      --allow-missing-tiles (bead gjhe)
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -46,7 +57,8 @@ require 'net/http'
 require 'uri'
 require 'optparse'
 
-opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2 }
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
+         allow_missing_tiles: 0 }
 OptionParser.new do |p|
   p.on('--tableau DIR')              { |v| opts[:tab] = v }
   p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
@@ -57,6 +69,7 @@ OptionParser.new do |p|
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
   p.on('--skip-layout-check')        { opts[:skip_layout] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+  p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -106,7 +119,7 @@ if status != 'PASS' || pass_rate < opts[:min_pass_rate]
   exit 2
 end
 
-puts "[OK] gate 1/4: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+puts "[OK] gate 1/5: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
 
 # ---------------------------------------------------------------------------
 # Gate 2 — orphan workbooks (beads-sigma-38a)
@@ -119,7 +132,7 @@ unless opts[:skip_orphan]
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
       unless File.exist?(marker_path)
-        warn "[FAIL] gate 2/4: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "[FAIL] gate 2/5: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
         warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
@@ -128,27 +141,27 @@ unless opts[:skip_orphan]
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
       if marker['failed'] && !marker['failed'].empty?
-        warn "[FAIL] gate 2/4: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "[FAIL] gate 2/5: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
       if marker['dry_run']
-        warn "[FAIL] gate 2/4: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "[FAIL] gate 2/5: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
         warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
         exit 4
       end
       kept = marker['kept'] || '(unknown)'
       deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/4: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      puts "[OK] gate 2/5: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
     else
-      puts "[OK] gate 2/4: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+      puts "[OK] gate 2/5: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end
   else
-    puts "[OK] gate 2/4: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+    puts "[OK] gate 2/5: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/4: --skip-orphan-check"
+  puts "[SKIP] gate 2/5: --skip-orphan-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -168,12 +181,12 @@ unless opts[:skip_column]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 3/4: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts "[SKIP] gate 3/5: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 3/4: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+      warn "[SKIP] gate 3/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
       req = Net::HTTP::Get.new(uri)
@@ -185,7 +198,7 @@ unless opts[:skip_column]
         cols = (JSON.parse(res.body)['entries'] rescue []) || []
         error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
         if error_cols.any?
-          warn "[FAIL] gate 3/4: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "[FAIL] gate 3/5: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
           warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
           warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
           error_cols.first(10).each do |c|
@@ -195,14 +208,14 @@ unless opts[:skip_column]
           warn "       See beads-sigma-38a."
           exit 5
         end
-        puts "[OK] gate 3/4: #{cols.length} live columns clean (no type=error)"
+        puts "[OK] gate 3/5: #{cols.length} live columns clean (no type=error)"
       else
-        warn "[SKIP] gate 3/4: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 3/5: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 3/4: --skip-column-check"
+  puts "[SKIP] gate 3/5: --skip-column-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -223,12 +236,12 @@ unless opts[:skip_layout]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 4/4: no workbook ID resolvable for layout check"
+    puts "[SKIP] gate 4/5: no workbook ID resolvable for layout check"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 4/4: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+      warn "[SKIP] gate 4/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
       req = Net::HTTP::Get.new(uri)
@@ -267,7 +280,7 @@ unless opts[:skip_layout]
         end
 
         if layout_xml.empty?
-          warn "[FAIL] gate 4/4: live workbook #{wb_id} has NO top-level layout XML."
+          warn "[FAIL] gate 4/5: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
           warn "       dashboard grid. Rebuild the layout with this skill's layout"
           warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
@@ -277,12 +290,12 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         elsif elem_count < opts[:min_layout_elements]
-          warn "[FAIL] gate 4/4: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "[FAIL] gate 4/5: layout XML has only #{elem_count} <LayoutElement> tag(s);"
           warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
           warn "       The layout likely covers only the Data page — chart page is unstyled."
           exit 6
         elsif non_data_stack_pages.any?
-          warn "[FAIL] gate 4/4: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "[FAIL] gate 4/5: live workbook #{wb_id} has Sigma's auto-generated"
           warn "       single-column stack layout (multiple elements at the same gridColumn"
           warn "       on a non-Data page). This is what Sigma defaults to when you POST"
           warn "       a workbook without a layout — exactly the CoCo regression."
@@ -295,15 +308,48 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         else
-          puts "[OK] gate 4/4: layout XML applied with #{elem_count} positioned element(s)"
+          puts "[OK] gate 4/5: layout XML applied with #{elem_count} positioned element(s)"
         end
       else
-        warn "[SKIP] gate 4/4: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 4/5: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 4/4: --skip-layout-check"
+  puts "[SKIP] gate 4/5: --skip-layout-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 5 — tile census (bead gjhe)
+# parity-final.json's `tile_census` field compares the source dashboard's
+# chart-zone count against the charts that made it into the parity plan.
+# Catches the empty-view-CSV escape where the builder silently emits N-1
+# charts and parity still reports PASS (every chart it knows about passes —
+# it just doesn't know about the dropped one).
+# ---------------------------------------------------------------------------
+census = summary['tile_census']
+if census.nil?
+  puts "[SKIP] gate 5/5: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+else
+  zones     = census['zones_total'].to_i
+  built     = census['charts_built'].to_i
+  unmatched = census['zones_unmatched'].to_i
+  names     = Array(census['unmatched_zone_names'])
+  if unmatched > opts[:allow_missing_tiles]
+    warn "[FAIL] gate 5/5: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    names.each { |n| warn "         - #{n}" }
+    warn "       A zone that rendered in the source dashboard has NO matching chart in the"
+    warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
+    warn "       (re-fetch the view data and rebuild), or the tile was renamed without"
+    warn "       passing --rename to phase6-parity.rb / build-dashboard-layout.rb."
+    warn "       If #{unmatched} zone(s) are legitimately unbuildable, re-run with"
+    warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
+    exit 7
+  elsif unmatched > 0
+    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+  else
+    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -110,33 +110,41 @@ DATE_TRUNC = {
   'Hour-Trunc'   => 'hour'
 }.freeze
 
-# Tableau "this year/quarter/month" (relative-date first=0,last=0) → explicit
-# [startDate, endDate] bounds for the CURRENT period. Returns [nil, nil] for
-# periods we don't bound (caller falls back to a pass-through relative filter).
+# Tableau relative-date offset window (first-period..last-period, in periods
+# relative to now — e.g. first=-2,last=0 = "last 3 months") → explicit
+# [startDate, endDate] bounds. Returns [nil, nil] for periods we don't bound
+# (caller falls back to a pass-through relative filter).
 #
-# Why bounds and not Sigma `mode: relative`/`current`: a relative/current date
-# filter only applies at UI render time — it does NOT filter the chart-data SQL
-# (Phase 6 parity showed every relative-date chart returning unfiltered data).
-# Hardcoded bounds apply at query time AND on the UI. Trade-off: the filter
-# "freezes" — it must be refreshed when the period rolls over.
-def current_period_bounds(period, now = Time.now)
+# NOTE (bead z135, 2026-06-10): this is only the FALLBACK for offset windows.
+# "This <period>" (first=0,last=0) filters are emitted as Sigma
+# `mode: "current"` + `unit: <period>` — E2E re-verified that mode:current DOES
+# filter the chart-data SQL when the control's `filters` target wiring is
+# present, so the old hardcode-the-bounds workaround (which froze the filter
+# and broke at period rollover) is no longer used for current-period filters.
+def relative_period_bounds(period, first = 0, last = 0, now = Time.now)
+  first = first.to_i
+  last  = last.to_i
   case period.to_s.downcase
   when 'year'
-    ["#{now.year}-01-01T00:00:00Z", "#{now.year}-12-31T23:59:59Z"]
+    ["#{now.year + first}-01-01T00:00:00Z", "#{now.year + last}-12-31T23:59:59Z"]
   when 'quarter'
-    q       = ((now.month - 1) / 3) + 1
-    start_m = (q - 1) * 3 + 1
-    end_m   = start_m + 2
-    end_day = Date.new(now.year, end_m, -1).day
-    ["#{now.year}-#{start_m.to_s.rjust(2, '0')}-01T00:00:00Z",
-     "#{now.year}-#{end_m.to_s.rjust(2, '0')}-#{end_day.to_s.rjust(2, '0')}T23:59:59Z"]
+    q0 = Date.new(now.year, ((now.month - 1) / 3) * 3 + 1, 1)
+    s  = q0 >> (3 * first)
+    e  = (q0 >> (3 * last + 3)) - 1
+    [s.strftime('%Y-%m-%dT00:00:00Z'), e.strftime('%Y-%m-%dT23:59:59Z')]
   when 'month'
-    last = Date.new(now.year, now.month, -1).day
-    [now.strftime('%Y-%m-01T00:00:00Z'),
-     now.strftime("%Y-%m-#{last.to_s.rjust(2, '0')}T23:59:59Z")]
+    m0 = Date.new(now.year, now.month, 1)
+    s  = m0 >> first
+    e  = (m0 >> (last + 1)) - 1
+    [s.strftime('%Y-%m-%dT00:00:00Z'), e.strftime('%Y-%m-%dT23:59:59Z')]
   else
     [nil, nil]
   end
+end
+
+# Back-compat alias — current period only.
+def current_period_bounds(period, now = Time.now)
+  relative_period_bounds(period, 0, 0, now)
 end
 
 def render_agg(agg, master_col_ref)
@@ -146,6 +154,55 @@ def render_agg(agg, master_col_ref)
   else
     "#{agg}(#{master_col_ref})"
   end
+end
+
+# Tableau "User"-aggregated calc fields (derivation=User) are already-aggregated
+# expressions like `SUM([Returns]) / COUNT([Order Id])` — wrapping them in
+# another Sum() against a master column that doesn't exist emits an
+# unresolvable `Sum([Master/X])` (bead k3kk). Decompose the Tableau formula
+# directly into a Sigma formula against the master table instead. Returns nil
+# when the formula contains anything beyond simple aggregates + arithmetic
+# (the caller falls back and warns loudly).
+USER_AGG_FN = {
+  'SUM' => 'Sum', 'AVG' => 'Avg', 'MIN' => 'Min', 'MAX' => 'Max',
+  'MEDIAN' => 'Median'
+}.freeze
+
+def translate_user_agg_formula(formula, mmap, columns_by_guid = {})
+  s = formula.to_s.gsub(/\s+/, ' ').strip
+  return nil if s.empty?
+  # Resolve Tableau-internal GUID refs ([d3b60b0e-…]) to their captions first —
+  # worksheet calc formulas reference columns by GUID, not caption.
+  s = s.gsub(/\[([0-9a-f\-]{36})\]/i) do
+    info = columns_by_guid[Regexp.last_match(1)]
+    info && info['caption'] ? "[#{info['caption']}]" : "[#{Regexp.last_match(1)}]"
+  end
+  # IIF(c, t, e) → If(c, t, e) so guarded ratios (divide-by-zero protection)
+  # survive the decomposition.
+  s = s.gsub(/\bIIF\s*\(/i, 'If(')
+  out = s.gsub(/\b(SUM|AVG|MIN|MAX|MEDIAN|COUNTD|COUNT)\s*\(\s*\[([^\]]+)\]\s*\)/i) do
+    agg = Regexp.last_match(1).upcase
+    col = Regexp.last_match(2)
+    m   = map_column(col, mmap)
+    ref = "[Master/#{m ? m['name'] : col}]"
+    case agg
+    when 'COUNT'  then "CountIf(IsNotNull(#{ref}))"
+    when 'COUNTD' then "CountDistinct(#{ref})"
+    else "#{USER_AGG_FN[agg]}(#{ref})"
+    end
+  end
+  # ZN(expr) → Coalesce(expr, 0). One nesting level of parens is enough for
+  # ZN(Sum([x]))-style wrappers; loop to handle repeated occurrences.
+  while out =~ /\bZN\s*\(((?:[^()]|\([^()]*(?:\([^()]*\)[^()]*)*\))*)\)/i
+    out = out.sub(Regexp.last_match(0), "Coalesce(#{Regexp.last_match(1)}, 0)")
+  end
+  # Validate: after stripping translated calls + refs, only arithmetic glue may
+  # remain — otherwise the formula has constructs we can't safely auto-emit.
+  residue = out.dup
+  residue.gsub!(/\[Master\/[^\]]+\]/, '1')
+  residue.gsub!(/\b(Sum|Avg|Min|Max|Median|CountDistinct|CountIf|IsNotNull|Coalesce|If)\b/, '')
+  return nil unless residue =~ %r{\A[\s()+\-*/.,\d!=<>]*\z}
+  out
 end
 
 # Translate the Tableau column reference inside aggregations dict to a clean key
@@ -166,6 +223,25 @@ def map_column(header, mmap)
     return info if Regexp.new(pat).match?(h)
   end
   nil
+end
+
+# Resolve which Sigma column a Tableau <sort column="..."> targets: the chart's
+# dim or its measure. Tableau sort columns look like
+# `[federated.X].[none:REGION:nk]` or `[sum:NET_REVENUE:qk]` — pull the middle
+# token of the last bracket segment and fuzzy-match against the dim names.
+# A sort on the dim itself = alphabetic/natural dim sort; anything else
+# (field sort on the measure, unresolvable) sorts by the measure, which was
+# the previous hardcoded behaviour.
+def sort_target_column_id(sort_info, dim, dim_hdr, dim_col_id, meas_col_id)
+  raw   = sort_info['column'].to_s
+  inner = raw[/\[([^\[\]]+)\]\z/, 1].to_s
+  token = (inner.split(':')[1] || inner).downcase.gsub(/\W+/, '')
+  return meas_col_id if token.empty?
+  dim_keys = [dim && dim['name'], dim_hdr].compact
+                                          .map { |x| x.to_s.downcase.gsub(/\W+/, '') }
+                                          .reject(&:empty?)
+  return dim_col_id if dim_keys.any? { |k| token == k || token.include?(k) || k.include?(token) }
+  meas_col_id
 end
 
 # Pick the best aggregation for a header. CSV headers often hint at the
@@ -778,9 +854,23 @@ layout.each do |dash|
       next
     end
     rows = CSV.read(csv_path)
-    next if rows.empty?
+    if rows.empty?
+      # LOUD on purpose (bead gjhe): an empty/0-byte view CSV used to silently
+      # drop the zone — the dashboard shipped with N-1 charts and every gate
+      # still passed because the missing chart never entered the parity plan.
+      warnings << "ZONE DROPPED: '#{cap}' — view CSV at #{csv_path} is EMPTY (0 bytes / 0 rows) " \
+                  "but the zone exists in the dashboard. NO Sigma chart was built for it. " \
+                  "Re-fetch the view data (fetch-view-data.rb) or build the chart by hand — " \
+                  "the Phase-6 tile census will report this zone as unmatched."
+      next
+    end
     headers = rows.shift
-    next unless headers.length >= 2
+    if headers.length < 2
+      warnings << "ZONE DROPPED: '#{cap}' — view CSV has only #{headers.length} column(s); " \
+                  "need dim + measure. NO Sigma chart was built for this zone — " \
+                  "the Phase-6 tile census will report it as unmatched."
+      next
+    end
 
     dim_hdr  = headers[0]
     meas_hdr = headers[1]
@@ -813,6 +903,28 @@ layout.each do |dash|
     agg_label ||= infer_csv_agg(meas_hdr)
     agg_label ||= 'Sum'
     sigma_agg = SIGMA_AGG[agg_label] || 'Sum'
+
+    # derivation=User → the measure IS a Tableau calc field that's already
+    # aggregated (typically a ratio like SUM(a)/COUNT(b)). Wrapping it in
+    # Sum([Master/X]) is unresolvable when no master column carries the ratio —
+    # decompose the calc formula into a direct Sigma formula instead (bead k3kk).
+    user_agg_formula = nil
+    if agg_label == 'User' && meas['formula'].nil?
+      norm = ->(x) { x.to_s.gsub(/^\[|\]$/, '').strip.downcase }
+      user_calc = (z['calculations'] || []).find do |c|
+        n = norm.call(c['name'])
+        !n.empty? && (n == norm.call(meas['name']) || n == norm.call(meas_hdr) ||
+                      norm.call(meas_hdr).include?(n))
+      end
+      user_agg_formula = user_calc &&
+                         translate_user_agg_formula(user_calc['formula'], mmap,
+                                                    meta['columns_by_guid'] || {})
+      if user_agg_formula
+        warnings << "'#{cap}' measure '#{meas['name']}' is a Tableau User-aggregated calc — emitted its decomposed Sigma formula directly: #{user_agg_formula[0..140]}"
+      else
+        warnings << "'#{cap}' measure '#{meas['name']}' has Tableau aggregation=User but its calc formula could not be auto-decomposed — falling back to Sum([Master/#{meas['name']}]), which is UNRESOLVABLE unless the master carries that column; translate the ratio by hand (add a `formula` to its master-columns.json entry)"
+      end
+    end
 
     # Decide if the dimension is a date that needs DateTrunc. The parser's
     # aggregations dict surfaces Month-Trunc / Year-Trunc / etc. on the date col.
@@ -849,6 +961,8 @@ layout.each do |dash|
     # wrap the master-table column with the Sigma aggregator picked above.
     measure_formula = if meas['formula']
                         meas['formula']
+                      elsif user_agg_formula
+                        user_agg_formula
                       else
                         render_agg(sigma_agg, "[Master/#{meas['name']}]")
                       end
@@ -1009,9 +1123,37 @@ layout.each do |dash|
       end
     end
 
-    if kind == 'pie-chart' || kind == 'donut-chart'
+    if kind == 'table'
+      # Tableau text-table → Sigma grouped ("level") table. WITHOUT `groupings`,
+      # a table with dim + Sum(...) columns renders one row per SOURCE row (no
+      # roll-up). And on a grouped table the sort MUST nest inside the grouping
+      # entry — element-level sort 400s with "Sort column not found" (verified
+      # shape, see qlik-to-sigma refs/sigma-build-gotchas.md; bead f972).
+      grouping = {
+        'id'           => "g-#{el_id}",
+        'groupBy'      => [dim_col_obj['id']],
+        'calculations' => [meas_col_obj['id']]
+      }
+      if z['sort']
+        dir = z.dig('sort', 'direction').to_s
+        grouping['sort'] = [{
+          'columnId'  => sort_target_column_id(z['sort'], dim, dim_hdr, dim_col_obj['id'], meas_col_obj['id']),
+          'direction' => (dir =~ /desc/i) ? 'descending' : 'ascending'
+        }]
+        warnings << "'#{cap}' Tableau sort carried into groupings[0].sort (grouped-table sorts must nest inside the grouping — element-level sort 400s)"
+      end
+      element['groupings'] = [grouping]
+    elsif kind == 'pie-chart' || kind == 'donut-chart'
       element['color'] = { 'id' => dim_col_obj['id'] }
       element['value'] = { 'id' => meas_col_obj['id'] }
+      if z['sort']
+        dir = z.dig('sort', 'direction').to_s
+        element['color']['sort'] = {
+          'by'        => sort_target_column_id(z['sort'], dim, dim_hdr, dim_col_obj['id'], meas_col_obj['id']),
+          'direction' => (dir =~ /desc/i) ? 'descending' : 'ascending'
+        }
+        warnings << "'#{cap}' Tableau sort carried into pie color.sort"
+      end
     else
       # Breaking-change-2026-05-21: xAxis takes singular `columnId` (string),
       # yAxis takes plural `columnIds` (array on the object — NOT array of
@@ -1024,7 +1166,10 @@ layout.each do |dash|
       if z['sort']
         dir = z.dig('sort', 'direction').to_s
         sigma_dir = (dir =~ /desc/i) ? 'descending' : 'ascending'
-        x_axis['sort'] = { 'by' => meas_col_obj['id'], 'direction' => sigma_dir }
+        x_axis['sort'] = {
+          'by'        => sort_target_column_id(z['sort'], dim, dim_hdr, dim_col_obj['id'], meas_col_obj['id']),
+          'direction' => sigma_dir
+        }
       end
       element['xAxis'] = x_axis
       # Combo-chart: yAxis.columnIds is a mixed array — bare strings default to
@@ -1119,26 +1264,36 @@ layout.each do |dash|
         }
       when 'relative-date'
         # Tableau first-period=0, last-period=0 + period-type=year means
-        # "this <period>". Emit explicit current-period bounds — `mode: relative`
-        # does NOT filter the chart-data SQL (same lesson the shared-filter path
-        # learned; see current_period_bounds). Falls back to pass-through
-        # relative for periods we don't bound (week/day).
-        period = (f['period_type'] || 'year').downcase
-        start_d, end_d = current_period_bounds(period)
-        if start_d
+        # "this <period>" → Sigma mode:"current" + unit:<period>. E2E
+        # re-verified 2026-06-10 (bead z135) that mode:current filters the
+        # chart-data SQL — it rolls over automatically instead of freezing.
+        # Offset windows (first/last ≠ 0, e.g. "last 3 months") fall back to
+        # explicit between-bounds (frozen — re-run to refresh).
+        period   = (f['period_type'] || 'year').downcase
+        inc_null = (f['include_null'].to_s == 'true' ? 'always' : 'never')
+        if f['first_period'].to_i.zero? && f['last_period'].to_i.zero?
           el_filters << {
-            'columnId' => m['id'], 'kind' => 'date-range', 'mode' => 'between',
-            'startDate' => start_d, 'endDate' => end_d,
-            'includeNulls' => (f['include_null'].to_s == 'true' ? 'always' : 'never')
+            'columnId' => m['id'], 'kind' => 'date-range', 'mode' => 'current',
+            'unit' => period, 'includeNulls' => inc_null
           }
-          warnings << "'#{cap}' relative-date '#{period}' → element filter mode:between current-#{period} (#{start_d[0..9]}..#{end_d[0..9]}); re-run next #{period} to refresh"
+          warnings << "'#{cap}' relative-date 'this #{period}' → element filter mode:current unit:#{period} (rolls over automatically; verified to filter chart-data SQL, bead z135)"
         else
-          el_filters << {
-            'columnId' => m['id'], 'kind' => 'date-range', 'mode' => 'relative',
-            'unit' => period, 'count' => 1,
-            'includeNulls' => (f['include_null'].to_s == 'true' ? 'always' : 'never')
-          }
-          warnings << "'#{cap}' relative-date '#{period}' kept as mode:relative (no current-period bounds for '#{period}') — verify it filters the SQL"
+          start_d, end_d = relative_period_bounds(period, f['first_period'], f['last_period'])
+          if start_d
+            el_filters << {
+              'columnId' => m['id'], 'kind' => 'date-range', 'mode' => 'between',
+              'startDate' => start_d, 'endDate' => end_d,
+              'includeNulls' => inc_null
+            }
+            warnings << "'#{cap}' relative-date window #{f['first_period']}..#{f['last_period']} #{period}s → element filter mode:between (#{start_d[0..9]}..#{end_d[0..9]}); FROZEN — re-run to refresh"
+          else
+            el_filters << {
+              'columnId' => m['id'], 'kind' => 'date-range', 'mode' => 'relative',
+              'unit' => period, 'count' => 1,
+              'includeNulls' => inc_null
+            }
+            warnings << "'#{cap}' relative-date '#{period}' kept as mode:relative (no bounds computable for '#{period}') — verify it filters the SQL"
+          end
         end
       when 'number-range'
         el_filters << {
@@ -1340,35 +1495,38 @@ if opts[:auto_controls]
         'columnId' => m['id']
       }]
     when 'relative-date'
-      # Tableau "this year" / "this month" / "this quarter" → translate to
-      # Sigma `mode: between` with hardcoded startDate/endDate. The previously-
-      # tried `mode: current, unit: <period>` only applies at UI render time —
-      # it does NOT filter Sigma's chart-data SQL queries (Phase 6 parity
-      # showed every relative-date chart returning unfiltered data). Hardcoded
-      # dates apply at query time AND on the UI. Trade-off: filter "freezes"
-      # — next year someone must update it manually. The mirror of v4's
-      # reference workbook.
+      # Tableau "this year" / "this month" / "this quarter" → Sigma date-range
+      # control with `mode: "current"` + `unit: <period>`. E2E re-verified
+      # 2026-06-10 (bead z135): mode:current DOES filter the chart-data SQL
+      # when the control's `filters` target wiring is present — the earlier
+      # "render-time only" finding that drove hardcoded between-bounds was
+      # wrong, and the hardcoded dates froze the filter (broke at rollover).
+      # mode:between is kept ONLY for genuinely fixed/offset windows
+      # (first/last period ≠ 0, e.g. "last 3 months"), which Sigma has no
+      # verified rolling-control shape for yet.
       spec['controlType'] = 'date-range'
-      spec['mode']        = 'between'
       period = (f['period_type'] || 'year').downcase
-      start_d, end_d = current_period_bounds(period)
-      unless start_d
-        # Fallback: pass-through current+unit; agent updates manually
-        spec['mode'] = 'current'
-        spec['unit'] = period
-        spec['filters'] = [{
-          'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
-          'columnId' => m['id']
-        }]
-        next
-      end
-      spec['startDate'] = start_d
-      spec['endDate']   = end_d
       spec['filters'] = [{
         'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
         'columnId' => m['id']
       }]
-      warnings << "shared filter '#{cap}' relative-date '#{period}' → emitted as mode:between with hardcoded current-#{period} dates (#{start_d[0..9]}..#{end_d[0..9]}). Re-run next #{period} to refresh."
+      if f['first_period'].to_i.zero? && f['last_period'].to_i.zero?
+        spec['mode'] = 'current'
+        spec['unit'] = period
+        warnings << "shared filter '#{cap}' relative-date 'this #{period}' → date-range control mode:current unit:#{period} (rolls over automatically; no frozen dates)"
+      else
+        start_d, end_d = relative_period_bounds(period, f['first_period'], f['last_period'])
+        if start_d
+          spec['mode']      = 'between'
+          spec['startDate'] = start_d
+          spec['endDate']   = end_d
+          warnings << "shared filter '#{cap}' relative-date window #{f['first_period']}..#{f['last_period']} #{period}s → mode:between (#{start_d[0..9]}..#{end_d[0..9]}); FROZEN — re-run to refresh"
+        else
+          spec['mode'] = 'current'
+          spec['unit'] = period
+          warnings << "shared filter '#{cap}' relative-date '#{period}' window not boundable — emitted mode:current unit:#{period}; verify the window manually"
+        end
+      end
     when 'number-range'
       spec['controlType'] = 'range-slider'
       spec['filters'] = [{

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -21,7 +21,19 @@
 #
 # Optional:
 #   --page-cols N    Sigma grid columns (default 24)
-#   --page-rows N    visible rows (default 32)
+#   --page-rows N    visible rows BEFORE row scaling (default 32)
+#   --row-scale F    multiply the chart band's row count (default 1.5).
+#                    Tableau zone h% mapped 1:1 onto a 32-row Sigma page makes
+#                    tiles too short — Sigma suppresses axis labels / pie slice
+#                    labels below ~5-6 grid rows (bead tkkv; the looker builder
+#                    uses ROW_SCALE=2, tableau E2E found 1.43× sufficient —
+#                    default 1.5 preserves proportions while clearing the
+#                    label-suppression threshold). Pass --row-scale 1 to get
+#                    the old un-scaled mapping.
+#   --rename PAIR    "Tableau name=Sigma name" (repeatable) — same flag as the
+#                    parity scripts. A chart tile renamed during conversion
+#                    otherwise fails the zone→element name match and silently
+#                    drops out of the layout (bead ddbq).
 #   --chart-y0 PCT   top of the chart band as Tableau %  (default 29.7)
 #   --chart-y1 PCT   bottom of the chart band as Tableau % (default 100.0)
 #   --chart-row0 N   first grid row of the chart band     (default 6)
@@ -29,18 +41,30 @@
 require 'json'
 require 'optparse'
 
-opts = { page_cols: 24, page_rows: 32, chart_y0: 29.7, chart_y1: 100.0, chart_row0: 6 }
+opts = { page_cols: 24, page_rows: 32, row_scale: 1.5, chart_y0: 29.7,
+         chart_y1: 100.0, chart_row0: 6, renames: {} }
 OptionParser.new do |p|
   p.on('--layout PATH')        { |v| opts[:layout] = v }
   p.on('--wb-ids PATH')        { |v| opts[:wb_ids] = v }
   p.on('--out PATH')           { |v| opts[:out] = v }
   p.on('--page-cols N',  Integer) { |v| opts[:page_cols] = v }
   p.on('--page-rows N',  Integer) { |v| opts[:page_rows] = v }
+  p.on('--row-scale F',  Float, 'row-height multiplier (default 1.5; min label-safe ~1.43)') { |v| opts[:row_scale] = v }
+  p.on('--rename PAIR', 'Tableau-name=Sigma-name (repeat) — matches the parity scripts\' flag') do |v|
+    from, to = v.split('=', 2)
+    abort("--rename expects 'Tableau name=Sigma name', got #{v.inspect}") if from.nil? || to.nil? || from.empty? || to.empty?
+    opts[:renames][from] = to
+  end
   p.on('--chart-y0 PCT', Float)   { |v| opts[:chart_y0] = v }
   p.on('--chart-y1 PCT', Float)   { |v| opts[:chart_y1] = v }
   p.on('--chart-row0 N', Integer) { |v| opts[:chart_row0] = v }
 end.parse!
 %i[layout wb_ids out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+
+# Row scaling (bead tkkv): scale the page's row count so each chart band tile
+# gets proportionally more rows. Title (rows 1-3) and controls (rows 3-6) keep
+# their fixed positions; only the chart band [chart_row0..page_rows] stretches.
+opts[:page_rows] = (opts[:page_rows] * opts[:row_scale]).round if opts[:row_scale] != 1.0
 
 dash_layout = JSON.parse(File.read(opts[:layout]))
 wb_ids      = JSON.parse(File.read(opts[:wb_ids]))
@@ -101,8 +125,12 @@ end
 
 # Compute initial positions
 chart_layouts = chart_zones.map do |z|
-  el = els_by_name[z['caption']]
-  warn "WARN: no Sigma element matched zone caption #{z['caption'].inspect}" if el.nil?
+  lookup_name = opts[:renames][z['caption']] || z['caption']
+  el = els_by_name[lookup_name]
+  if el.nil?
+    warn "WARN: no Sigma element matched zone caption #{z['caption'].inspect}" \
+         "#{lookup_name == z['caption'] ? " — if the tile was renamed, pass --rename #{z['caption'].inspect}'=<Sigma name>'" : " (renamed to #{lookup_name.inspect})"} — tile DROPPED from layout"
+  end
   next nil unless el
   c1, c2, r1, r2 = chart_pos(z, opts)
   { el_id: el['id'], c1: c1, c2: c2, r1: r1, r2: r2 }
@@ -149,4 +177,4 @@ end
 lines << '</Page>'
 
 File.write(opts[:out], lines.join("\n") + "\n")
-puts "wrote #{opts[:out]} (#{chart_layouts.length} charts, #{ctl_els.length} controls, gap-closing applied)"
+puts "wrote #{opts[:out]} (#{chart_layouts.length} charts, #{ctl_els.length} controls, gap-closing applied, row-scale #{opts[:row_scale]}× → #{opts[:page_rows]} rows)"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
@@ -42,6 +42,7 @@ OptionParser.new do |p|
   p.on('--extract-mode')         { opts[:extract_mode] = true }
   p.on('--extract-tol F', Float) { |v| opts[:extract_tol] = v }
   p.on('--rename PAIR', 'Tableau-name=Sigma-name (repeat)') { |v| opts[:renames] << v }
+  p.on('--dashboard-layout PATH', 'parse-twb-layout output for the tile census (default <tableau-dir>/dashboard-layout.json)') { |v| opts[:dash_layout] = v }
   p.on('--finalize')             { opts[:finalize] = true }
   p.on('--actuals PATH', 'JSON: { "<chart name>": [[dim, val], ...] } — for --finalize') { |v| opts[:actuals] = v }
 end.parse!
@@ -144,6 +145,40 @@ summary_path = File.join(opts[:tab], 'parity-final.json')
 total = plan['charts'].size
 passed_chart_names = out.scan(/^PASS\s+\[[^\]]+\]\s+(.+)$/).flatten
 failed_chart_names = out.scan(/^DIVERGE\s+\[[^\]]+\]\s+(.+)$/).flatten
+
+# ---- Tile census (bead gjhe) ------------------------------------------------
+# Compare the Tableau dashboard's chart-zone count against the charts that made
+# it into the parity plan. A zone that rendered in the source dashboard but has
+# no matching Sigma chart (empty view CSV silently dropped the tile, or an
+# unexplained rename) used to slip through every gate — the workbook shipped
+# with N-1 charts and parity still reported PASS. assert-phase6-ran.rb gate 5
+# fails on unmatched zones unless --allow-missing-tiles explains them.
+tile_census = nil
+dash_layout_path = opts[:dash_layout] || File.join(opts[:tab], 'dashboard-layout.json')
+if File.exist?(dash_layout_path)
+  dash_layout = JSON.parse(File.read(dash_layout_path)) rescue nil
+  if dash_layout.is_a?(Array)
+    zone_names = dash_layout.flat_map { |d| d['zones'] || [] }
+                            .select { |zz| zz['kind'] == 'chart' && !zz['caption'].to_s.strip.empty? }
+                            .map { |zz| zz['caption'].strip }
+                            .uniq
+    norm = ->(s) { s.to_s.downcase.gsub(/[^a-z0-9]/, '') }
+    matched = plan['charts'].flat_map { |c| [c['tableau_view'], c['chart']] }.compact.map(&norm)
+    unmatched = zone_names.reject { |zn| matched.include?(norm.call(zn)) }
+    tile_census = {
+      'zones_total'          => zone_names.size,
+      'charts_built'         => plan['charts'].size,
+      'zones_unmatched'      => unmatched.size,
+      'unmatched_zone_names' => unmatched
+    }
+    warn "tile census: #{zone_names.size} dashboard zone(s), #{plan['charts'].size} chart(s) in parity plan, #{unmatched.size} unmatched" \
+         "#{unmatched.any? ? " — UNMATCHED: #{unmatched.join(', ')}" : ''}"
+  else
+    warn "tile census skipped: #{dash_layout_path} is not a parse-twb-layout array"
+  end
+else
+  warn "tile census skipped: no dashboard layout at #{dash_layout_path} (pass --dashboard-layout to enable)"
+end
 summary = {
   'workbook_id'  => plan.dig('charts', 0, 'workbook_id') ||
                     (File.exist?(File.join(opts[:tab], 'wb-readback.json')) ?
@@ -158,6 +193,7 @@ summary = {
   'fail_names'   => failed_chart_names,
   'status'       => (status.success? && total > 0 && passed_chart_names.size == total) ? 'PASS' : 'FAIL'
 }
+summary['tile_census'] = tile_census if tile_census
 File.write(summary_path, JSON.pretty_generate(summary))
 warn "wrote #{summary_path} (status=#{summary['status']} #{summary['charts_pass']}/#{summary['charts_total']})"
 exit(status.success? ? 0 : 2)


### PR DESCRIPTION
Final-wave fixes for `tableau-to-sigma`, all from today's E2E evidence and each re-verified with a fresh live conversion ("VISQA3 Tableau Orders Overview", Orders Conversion Test dashboard, datasource 2e62b914, org tj-wells-1989).

## Fixes

| # | Bead | Fix |
|---|---|---|
| 1 | gjhe (P0) | **Empty-view-CSV gate escape.** Builder now emits a loud `ZONE DROPPED` WARN naming the zone; `phase6-parity.rb --finalize` writes a `tile_census` field (`zones_total` / `charts_built` / `zones_unmatched` + names) into `parity-final.json`; `assert-phase6-ran.rb` gains **gate 5/5** (exit 7) failing on unexplained unmatched zones, with `--allow-missing-tiles N` escape. Vendored identically to powerbi/quicksight (md5-equal, gate self-skips without a census). |
| 2 | z135 | **Relative-date controls.** `--auto-controls` emits `mode:"current"` + correct `unit` for Tableau "this <period>" filters (controls AND element filters); frozen `between` bounds only for offset windows via generalized `relative_period_bounds`. |
| 3 | ddbq | **`--rename` on `build-dashboard-layout.rb`** (repeatable, same flag shape as the parity scripts) so renamed tiles stay in the layout. |
| 4 | k3kk | **User-aggregated calc fields** decomposed directly into Sigma formulas (GUID→caption via `columns_by_guid`, SUM/COUNT/COUNTD/ZN/IIF, aggregate-only validation) instead of unresolvable `Sum([Master/X])`. |
| 5 | tkkv | **Row heights**: `--row-scale` (default **1.5×**, looker prior art 2×, E2E minimum 1.43×) so Sigma stops suppressing axis/pie labels on short tiles; proportions preserved. |
| 6 | i3wk | **Doc nits**: SKILL.md duplicate 6b/6c/6d renumbered (dup triage table removed, two subsections folded under 6e); `refs/data-model-spec.md` path example corrected to `["DATABASE", "SCHEMA", "TABLE_NAME"]`. |
| 7 | f972 | **Sort carry**: Tableau `<sort>` resolves dim-vs-measure target; grouped tables nest sort in `groupings[0].sort` (verified shape from qlik refs), pies use `color.sort`, charts keep `xAxis.sort`; plain tables gain `groupings` roll-up. |

## E2E (live)

- Fresh conversion hit the real, reproducibly-empty Monthly-Revenue-Trend view CSV (Tableau returns 200/`text/csv`/0 bytes): builder printed the loud WARN, census reported **"6 zones, 5 built, 1 unmatched — Monthly Revenue Trend"**, gate failed **exit 7** while parity itself said 5/5 PASS (the exact prior escape).
- View data recovered via VDS (`query-datasource`), chart rebuilt **by the script** (DateTrunc month + auto log-scale yAxis), re-run: **6/6 strict parity, census 0 unmatched, all 5 gates green**.
- Date control rendered "**This year (2026)**" from `mode:current` emitted by the script — no hand patch.
- Page PNG exported at 1.5× row-scale: all axis labels, data labels, and pie labels render without hand-scaling; layout mirrors the Tableau dashboard (3-tile top row, small/wide/small bottom row).
- `assert-phase6-ran.rb` md5-identical across tableau / powerbi / quicksight: `058fb32a9a6dc12f440df6bc4b0c3cd0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)