### PR TITLE
thoughtspot-to-sigma: final-wave overhaul (m5se, wgvv, zvn0, f972-TS)

### DIFF
--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/QUICKSTART.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/QUICKSTART.md
@@ -25,9 +25,12 @@ python3 scripts/ts_discover.py <LIVEBOARD_ID> LIVEBOARD   # viz chart types + li
 
 ## 3. Convert the model
 Feed the model's TML to the **`convert_thoughtspot_to_sigma`** MCP tool (or point
-`CONVERTER_PATH` at a `sigma-data-model-mcp` build for the scripted path). It emits
-a Sigma data model with a denormalized **"<root> View"** element that surfaces
-joined-dim columns — the workbook master reads from it.
+`CONVERTER_PATH` at a `sigma-data-model-mcp` build for the one-shot path). With
+neither, `migrate.py` writes `<workdir>/convert-request.json` (the exact MCP
+arguments) and exits 3 — call the tool, save its JSON output, and re-run with
+`--converted <file>`. The converter emits a Sigma data model with a denormalized
+**"<root> View"** element that surfaces joined-dim columns — the workbook master
+reads from it. Rules: `refs/model-conversion-rules.md`.
 
 Before POSTing, run the **DM-reuse check** (SKILL.md step 2.5): `ts-dm-signature.py`
 + `find-or-pick-dm.rb --auto-pick` score the org's existing data models against the
@@ -36,18 +39,28 @@ is skipped.
 
 ## 4. Migrate (model → DM → its Liveboards → layout)
 ```bash
-python3 scripts/migrate.py --model <TS_MODEL_ID>            # all Liveboards on the model
-python3 scripts/migrate.py --model <ID> --liveboard <LB_ID> # just one
+python3 scripts/migrate.py --model <TS_MODEL_ID> --workdir /tmp/ts-run   # all Liveboards on the model
+python3 scripts/migrate.py --model <ID> --liveboard <LB_ID> --workdir /tmp/ts-run  # just one
+# offline (no TS access): --model-tml fixtures/retail-analytics-model.tml \
+#                         --liveboard-tml fixtures/retail-analytics-liveboard.tml
 ```
 This converts + POSTs the DM, discovers the denorm element, derives the column
 resolver from the model TML, rebuilds each Liveboard's visualizations as Sigma
-elements (KPI/bar/line/pie/pivot/table + search-query filters), and applies a grid
-layout. Output ids → `~/thoughtspot-migration/migrate_out.json`.
+elements (KPI/bar/line/pie/pivot/table + search-query filters + sorts), and maps
+the Liveboard's own `layout.tiles` geometry onto Sigma's grid. Workbooks/pages
+take the Liveboard's display name (`--name` adds a prefix to the DM + workbooks).
+Output ids → `<workdir>/migrate_out.json`.
 
-## 5. Verify parity
-Query the model in ThoughtSpot (`ts_lib.searchdata`) and the Sigma workbook
-elements (Sigma v2 query); values match to the cent. Re-apply layout last if you
-edit a workbook spec (a bare PUT wipes `spec.layout`).
+## 5. Verify parity (hard gate)
+```bash
+ruby scripts/phase6-parity-thoughtspot.rb --workdir /tmp/ts-run --workbook-id <wb>  # PASS 1: plan
+# … fetch ACTUAL (mcp__sigma-mcp-v2__query) + EXPECTED (ts_lib.searchdata / warehouse) …
+ruby scripts/phase6-parity-thoughtspot.rb --workdir /tmp/ts-run --finalize          # PASS 2: sentinel
+ruby scripts/assert-phase6-ran.rb --workdir /tmp/ts-run --workbook-id <wb>          # must exit 0
+```
+Re-apply layout last if you edit a workbook spec (a bare PUT wipes `spec.layout`).
+Workbook RENAMES go through `PATCH /v2/files/{id}` — `PATCH /v2/workbooks/{id}`
+silently no-ops.
 
 ## Assess first (optional)
 `thoughtspot-assessment/scripts/scan.py` inventories the instance, ranks a

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -23,10 +23,36 @@ context (curl uses the system store and works).
 ```
 export TS_HOST TS_TOKEN SIGMA_BASE_URL SIGMA_API_TOKEN \
        SIGMA_CONNECTION_ID SIGMA_FOLDER_ID TS_DB TS_SCHEMA
-python3 scripts/migrate.py --model <TS_MODEL_ID> [--liveboard <ID> ...] [--name PREFIX]
+python3 scripts/migrate.py --model <TS_MODEL_ID> [--liveboard <ID> ...] \
+       [--name PREFIX] [--workdir DIR]
 ```
-`migrate.py` runs the whole pipeline with **no hardcoded ids** and migrates every
-Liveboard that reads the model (or just the `--liveboard` ones).
+`migrate.py` runs the whole pipeline with **no hardcoded ids or paths** and
+migrates every Liveboard that reads the model (or just the `--liveboard` ones).
+All artifacts (manifest, TML, parity files) land in `--workdir`
+(default `$TS_WORKDIR` or `./ts-migration`, created if missing). `--name` is a
+prefix applied to BOTH the data model and every workbook; workbooks and pages
+are named after the Liveboard's **display name** (resolved from its TML, never
+the UUID).
+
+**Converter paths** (no unvendored build required):
+- `CONVERTER_PATH` set (a local `sigma-data-model-mcp` `build/thoughtspot.js`)
+  → fully scripted one-shot via `convert_model.mjs`.
+- `CONVERTER_PATH` unset → **MCP fallback**: migrate.py writes
+  `<workdir>/model.tml` + `<workdir>/convert-request.json` (the exact
+  `mcp__sigma-data-model__convert_thoughtspot_to_sigma` arguments), prints the
+  instructions, and exits 3. Call the MCP tool, save its JSON output to
+  `<workdir>/converted.json`, and re-run the same command with
+  `--converted <workdir>/converted.json` to continue the pipeline.
+
+**Offline mode** (no live ThoughtSpot needed): `--model-tml <file>` +
+`--liveboard-tml <file>` read exported TML from disk — `fixtures/` ships a real
+exported pair (`retail-analytics-model.tml` + `retail-analytics-liveboard.tml`,
+the CSA.TJ retail star) so the full convert→post→build→layout path can be
+exercised end-to-end without a TS trial:
+```
+python3 scripts/migrate.py --model-tml fixtures/retail-analytics-model.tml \
+  --liveboard-tml fixtures/retail-analytics-liveboard.tml --workdir /tmp/ts-offline
+```
 
 ## Pipeline (what migrate.py does)
 1. **Discover** — `ts_discover.py [<id> <type>]` lists models + Liveboards or
@@ -53,15 +79,27 @@ Liveboard that reads the model (or just the `--liveboard` ones).
    name; Sigma auto-colors from the measure). No native Sigma kind for funnel /
    waterfall / treemap / heat-map / sankey → those fall back to bar-chart (flagged
    in the assessment). All chart kinds verified live (POST→readback) 2026-06-07.
-   Search-query filters (`[Col]='v'`) → element list-filters.
+   Search-query filters (`[Col]='v'`) → element list-filters. TML **sorts**
+   (`sort by [Col]` tokens + `client_state` sortInfo) carry into the specs, and
+   table column ORDER follows the answer's `ordered_column_ids` (never the
+   alphabetical `answer_columns` or the chart's `chart_columns`).
    Aggregate formulas (`sum(x)/sum(y)`, `sqrt(sum())`) become DM **metrics**; column
    formats come from the TML `format_pattern`/`currency_type`. KPI value uses
    `{"columnId": c}`; donut `value`/`color` use `{"id": c}`; grouped tables need
-   `groupings:[{groupBy, calculations}]`.
-5. **Layout** — `apply_layouts.py` applies a clean grid (KPIs top row, charts
-   2-wide) as the **LAST** write (a bare spec PUT wipes layout).
-6. **Parity** — query the model via `ts_lib.searchdata` (ground truth) vs the
-   Sigma workbook elements (v2 query MCP); values match to the cent.
+   `groupings:[{groupBy, calculations}]`. Full spec shapes:
+   **`refs/liveboard-to-workbook.md`** (charts) + **`refs/model-conversion-rules.md`** (DM).
+5. **Layout** — `apply_layouts.py` maps the Liveboard's OWN `layout.tiles`
+   geometry (x/y/w/h on ThoughtSpot's 12-col grid) onto Sigma's 24-col grid
+   (cols ×2, rows ×ROW_SCALE min 2 so axis/KPI labels render), as the **LAST**
+   write (a bare spec PUT wipes layout). Falls back to a clean auto grid when
+   the TML has no tiles.
+6. **Parity (HARD GATE)** — `phase6-parity-thoughtspot.rb` two-pass: PASS 1
+   reads the workbook spec and emits per-chart fetch instructions (Sigma ACTUAL
+   via `mcp__sigma-mcp-v2__query`; EXPECTED via `ts_lib.searchdata` ground
+   truth, or warehouse SQL when offline); PASS 2 `--finalize` runs
+   `verify-parity.rb` and writes the `parity-final.json` sentinel. Then run
+   `ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <wb>` —
+   it must **exit 0** before declaring the migration GREEN.
 
 ## Step 2.5 — Reuse an existing DM? (between convert and POST — mirrors tableau Phase 1.5 / powerbi Phase 3.5)
 
@@ -89,8 +127,17 @@ you export for `migrate.py`). Decision:
 - **Score < 0.6** → POST new and TELL the user no reusable DM was found.
 
 ## Scripts
-- `migrate.py` — **canonical entry**: model → DM → migrate its Liveboards (parameterized)
-- `convert_model.mjs` — model TML → Sigma DM spec (imports the built converter)
+- `migrate.py` — **canonical entry**: model → DM → migrate its Liveboards
+  (parameterized: `--workdir`, `--name` prefix, `--converted` MCP output,
+  offline `--model-tml`/`--liveboard-tml`)
+- `convert_model.mjs` — model TML → Sigma DM spec (imports a local converter
+  build via `CONVERTER_PATH`; without one, migrate.py emits the MCP request instead)
+- `phase6-parity-thoughtspot.rb` — parity orchestrator (two-pass; writes the
+  `parity-final.json` sentinel) + `verify-parity.rb` (comparator)
+- `assert-phase6-ran.rb` — **hard gate** (vendored byte-identical from
+  quicksight-to-sigma): parity ran + PASS, no orphan workbooks, no `type=error`
+  columns, layout applied. Run with `--workdir <dir> --workbook-id <wb>`; exit 0
+  required before GREEN
 - `ts-dm-signature.py` — step 2.5: model TML → DM-reuse signature for `find-or-pick-dm.rb`
 - `find-or-pick-dm.rb` — step 2.5: scan existing Sigma DMs, recommend reuse (0.7·column +
   0.2·table + 0.1·metric overlap; `--auto-pick` w/ tie-window). Shared vendor-neutral copy
@@ -98,9 +145,12 @@ you export for `migrate.py`). Decision:
 - `ts_lib.py` — ThoughtSpot REST v2 (whoami/search/export_tml/import_tml/searchdata)
 - `ts_discover.py` — inventory / per-object summary
 - `ts_common.py` — `build_resolver` (from model TML), viz↔element mappers, format/currency mapping
-- `apply_layouts.py` — grid layout pass (run last)
+- `apply_layouts.py` — layout pass (run LAST): TML tile geometry → Sigma 24-col
+  grid, auto-grid fallback; `--workdir` reads the manifest
 - `compare.py` — visual + structural compare (TS viz PNG vs Sigma element PNG → HTML)
-- `ts_screenshot.py` — per-viz PNG export from ThoughtSpot (report/liveboard)
+- `ts_screenshot.py` — per-viz PNG export from ThoughtSpot; detects blank /
+  connection-error placeholder renders (near-uniform image or non-PNG error
+  body) and reports them as ✗ failures, never ✓
 - `gap-scout.md` + `scout-validate.py` + `learned-rules.py` — formula gap-scout (validate + persist unhandled-TML translations)
 - `get-token.sh` — Sigma token; `get-ts-token.sh` — ThoughtSpot Trusted-Auth service token
 
@@ -108,11 +158,25 @@ you export for `migrate.py`). Decision:
 The CSA.TJ retail star (ORDER_FACT + 5 dims) → ThoughtSpot model "Retail Analytics"
 → converted Sigma DM (6-table star + Order Fact View) → 11 themed Liveboards
 migrated to 11 Sigma workbooks, parity exact (Net Revenue 108,797.85; by-category,
-region, quarter all match to the cent). See `~/thoughtspot-migration/migration_manifest.json`.
+region, quarter all match to the cent). Per-run ids land in `<workdir>/migrate_out.json`.
+
+## Reference docs & fixtures
+- `refs/model-conversion-rules.md` — model TML → DM rules (joins/formulas/display
+  names/formats, TS_DB/TS_SCHEMA fqn gotcha, MCP request shape)
+- `refs/liveboard-to-workbook.md` — workbook spec shapes (KPI `{columnId}` vs
+  donut `{id}`, groupings, pivot rowsBy/columnsBy, sorts, layout geometry math,
+  rename gotcha)
+- `fixtures/` — real exported TML pair from the team2 trial
+  (`retail-analytics-model.tml` 6-table star + `retail-analytics-liveboard.tml`
+  5-viz Liveboard with layout.tiles) — drives the offline mode above and the
+  converter's regression diet.
 
 ## Notes
 - `convert_thoughtspot_to_sigma` is the converter (MCP github.com/twells89/sigma-data-model-mcp
   + browser sigma-data-model-manager) — keep both in lockstep.
+- **Rename gotcha**: `PATCH /v2/workbooks/{id}` silently no-ops for renames
+  (200, name unchanged) — rename via `PATCH /v2/files/{id} {"name": …}`
+  (delete and unarchive are files-side too).
 - TML export embeds raw control chars in JSON → parse with `json.loads(..., strict=False)`.
 - System/sample objects are FORBIDDEN to export (only own content).
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/fixtures/retail-analytics-liveboard.tml
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/fixtures/retail-analytics-liveboard.tml
@@ -1,0 +1,226 @@
+guid: a4e9c7c6-c4e4-49ab-bcf6-013b1ebf42a5
+liveboard:
+  name: Retail Analytics (TS Fixture)
+  description: "Migration fixture — KPI, column, line, pie, table over Retail Analytics model"
+  visualizations:
+  - id: Viz_1
+    answer:
+      name: Total Net Revenue
+      tables:
+      - id: Retail Analytics
+        name: Retail Analytics
+        fqn: d09e27fd-414e-4378-a148-c061da79d8e4
+      search_query: "[Net Revenue]"
+      answer_columns:
+      - name: Total Net Revenue
+      table:
+        table_columns:
+        - column_id: Total Net Revenue
+          headline_aggregation: SUM
+        ordered_column_ids:
+        - Total Net Revenue
+        client_state: ""
+        client_state_v2: "{\"tableVizPropVersion\": \"V1\",\"columnProperties\": [{\"columnId\": \"Total Net Revenue\",\"columnProperty\": {}}]}"
+      chart:
+        type: KPI
+        chart_columns:
+        - column_id: Total Net Revenue
+        axis_configs:
+        - x:
+          - Total Net Revenue
+          "y":
+          - Total Net Revenue
+        client_state: ""
+        client_state_v2: "{\"version\": \"V4DOT2\",\"chartProperties\": {\"gridLines\": {},\"responsiveLayoutPreference\": \"USER_PREFERRED_ON\",\"chartSpecific\": {\"dataFieldArea\": \"column\"}},\"columnProperties\": [{\"columnId\": \"Total Net Revenue\",\"columnProperty\": {}}],\"axisProperties\": [{\"id\": \"377d8e1a-7beb-40af-a39d-6394be0375bb\",\"properties\": {\"axisType\": \"Y\",\"linkedColumns\": [\"Total Net Revenue\"],\"isOpposite\": false}},{\"id\": \"6aa9acb9-4e99-427d-bcdd-c04ea6d65997\",\"properties\": {\"axisType\": \"X\",\"linkedColumns\": [\"Total Net Revenue\"]}}]}"
+      display_mode: CHART_MODE
+    viz_guid: 5f56140a-4fb0-4e70-a65e-0c2826b7197e
+  - id: Viz_2
+    answer:
+      name: Net Revenue by Category
+      tables:
+      - id: Retail Analytics
+        name: Retail Analytics
+        fqn: d09e27fd-414e-4378-a148-c061da79d8e4
+      search_query: "[Category] [Net Revenue]"
+      answer_columns:
+      - name: Category
+      - name: Total Net Revenue
+      table:
+        table_columns:
+        - column_id: Category
+          headline_aggregation: COUNT_DISTINCT
+        - column_id: Total Net Revenue
+          headline_aggregation: SUM
+        ordered_column_ids:
+        - Category
+        - Total Net Revenue
+        client_state: ""
+        client_state_v2: "{\"tableVizPropVersion\": \"V1\",\"columnProperties\": [{\"columnId\": \"Category\",\"columnProperty\": {}},{\"columnId\": \"Total Net Revenue\",\"columnProperty\": {}}]}"
+      chart:
+        type: COLUMN
+        chart_columns:
+        - column_id: Category
+        - column_id: Total Net Revenue
+        axis_configs:
+        - x:
+          - Category
+          "y":
+          - Total Net Revenue
+        client_state: ""
+        client_state_v2: "{\"version\": \"V4DOT2\",\"chartProperties\": {\"gridLines\": {},\"responsiveLayoutPreference\": \"USER_PREFERRED_ON\",\"chartSpecific\": {\"dataFieldArea\": \"column\"}},\"columnProperties\": [{\"columnId\": \"Total Net Revenue\",\"columnProperty\": {}},{\"columnId\": \"Category\",\"columnProperty\": {}}],\"axisProperties\": [{\"id\": \"692c3228-b6e1-4bc7-80af-a418c6f4684d\",\"properties\": {\"axisType\": \"Y\",\"linkedColumns\": [\"Total Net Revenue\"],\"isOpposite\": false}},{\"id\": \"4312cff6-d545-4038-84e8-0057b8d01eac\",\"properties\": {\"axisType\": \"X\",\"linkedColumns\": [\"Category\"]}}]}"
+      display_mode: CHART_MODE
+    viz_guid: 2f3a1ee8-be25-450d-902e-de1a75b9e498
+  - id: Viz_3
+    answer:
+      name: Net Revenue by Month
+      tables:
+      - id: Retail Analytics
+        name: Retail Analytics
+        fqn: d09e27fd-414e-4378-a148-c061da79d8e4
+      search_query: "[Month Name] [Net Revenue]"
+      answer_columns:
+      - name: Month Name
+      - name: Total Net Revenue
+      table:
+        table_columns:
+        - column_id: Month Name
+          headline_aggregation: COUNT_DISTINCT
+        - column_id: Total Net Revenue
+          headline_aggregation: SUM
+        ordered_column_ids:
+        - Month Name
+        - Total Net Revenue
+        client_state: ""
+        client_state_v2: "{\"tableVizPropVersion\": \"V1\",\"columnProperties\": [{\"columnId\": \"Month Name\",\"columnProperty\": {}},{\"columnId\": \"Total Net Revenue\",\"columnProperty\": {}}]}"
+      chart:
+        type: LINE
+        chart_columns:
+        - column_id: Month Name
+        - column_id: Total Net Revenue
+        axis_configs:
+        - x:
+          - Month Name
+          "y":
+          - Total Net Revenue
+        client_state: ""
+        client_state_v2: "{\"version\": \"V4DOT2\",\"chartProperties\": {\"gridLines\": {},\"responsiveLayoutPreference\": \"USER_PREFERRED_ON\",\"chartSpecific\": {\"dataFieldArea\": \"column\"}},\"columnProperties\": [{\"columnId\": \"Month Name\",\"columnProperty\": {}},{\"columnId\": \"Total Net Revenue\",\"columnProperty\": {}}],\"axisProperties\": [{\"id\": \"74d0646f-48b8-48f0-a379-b4e042bb4f03\",\"properties\": {\"axisType\": \"Y\",\"linkedColumns\": [\"Total Net Revenue\"],\"isOpposite\": false}},{\"id\": \"aa3f12ec-fabf-4db1-a25e-5e0306d751cf\",\"properties\": {\"axisType\": \"X\",\"linkedColumns\": [\"Month Name\"]}}]}"
+      display_mode: CHART_MODE
+    viz_guid: 222a545b-a5b5-4618-b96d-22f118528aab
+  - id: Viz_4
+    answer:
+      name: Net Revenue by Customer Segment
+      tables:
+      - id: Retail Analytics
+        name: Retail Analytics
+        fqn: d09e27fd-414e-4378-a148-c061da79d8e4
+      search_query: "[Customer Segment] [Net Revenue]"
+      answer_columns:
+      - name: Customer Segment
+      - name: Total Net Revenue
+      table:
+        table_columns:
+        - column_id: Customer Segment
+          headline_aggregation: COUNT_DISTINCT
+        - column_id: Total Net Revenue
+          headline_aggregation: SUM
+        ordered_column_ids:
+        - Customer Segment
+        - Total Net Revenue
+        client_state: ""
+        client_state_v2: "{\"tableVizPropVersion\": \"V1\",\"columnProperties\": [{\"columnId\": \"Customer Segment\",\"columnProperty\": {}},{\"columnId\": \"Total Net Revenue\",\"columnProperty\": {}}]}"
+      chart:
+        type: PIE
+        chart_columns:
+        - column_id: Customer Segment
+        - column_id: Total Net Revenue
+        axis_configs:
+        - x:
+          - Customer Segment
+          "y":
+          - Total Net Revenue
+        client_state: ""
+        client_state_v2: "{\"version\": \"V4DOT2\",\"chartProperties\": {\"gridLines\": {},\"responsiveLayoutPreference\": \"USER_PREFERRED_ON\",\"chartSpecific\": {\"dataFieldArea\": \"column\"}},\"columnProperties\": [{\"columnId\": \"Customer Segment\",\"columnProperty\": {\"dataLabels\": true}},{\"columnId\": \"Total Net Revenue\",\"columnProperty\": {\"dataLabels\": true}}],\"axisProperties\": [{\"id\": \"54f2918a-b558-4345-8a46-2a797ca4b7c3\",\"properties\": {\"axisType\": \"Y\",\"linkedColumns\": [\"Total Net Revenue\"],\"isOpposite\": false}},{\"id\": \"0c8b7814-4c4a-47f0-9aa5-0d5e9dd8d3b5\",\"properties\": {\"axisType\": \"X\",\"linkedColumns\": [\"Customer Segment\"]}}]}"
+      display_mode: CHART_MODE
+    viz_guid: ccf2096b-5321-4f95-adcc-f0a7f78ce116
+  - id: Viz_5
+    answer:
+      name: Region Performance
+      tables:
+      - id: Retail Analytics
+        name: Retail Analytics
+        fqn: d09e27fd-414e-4378-a148-c061da79d8e4
+      search_query: "[Region] [Net Revenue] [Gross Profit]"
+      answer_columns:
+      - name: Region
+      - name: Total Gross Profit
+      - name: Total Net Revenue
+      table:
+        table_columns:
+        - column_id: Region
+          headline_aggregation: COUNT_DISTINCT
+        - column_id: Total Gross Profit
+          headline_aggregation: SUM
+        - column_id: Total Net Revenue
+          headline_aggregation: SUM
+        ordered_column_ids:
+        - Region
+        - Total Net Revenue
+        - Total Gross Profit
+        client_state: ""
+        client_state_v2: "{\"tableVizPropVersion\": \"V1\",\"columnProperties\": [{\"columnId\": \"Region\",\"columnProperty\": {}},{\"columnId\": \"Total Net Revenue\",\"columnProperty\": {}},{\"columnId\": \"Total Gross Profit\",\"columnProperty\": {}}]}"
+      chart:
+        type: ADVANCED_COLUMN
+        chart_columns:
+        - column_id: Region
+        - column_id: Total Gross Profit
+        - column_id: Total Net Revenue
+        client_state: ""
+        client_state_v2: "{\"version\": \"V4DOT2\",\"chartProperties\": {\"gridLines\": {},\"responsiveLayoutPreference\": \"USER_PREFERRED_ON\",\"chartSpecific\": {\"dataFieldArea\": \"column\"}},\"columnProperties\": [{\"columnId\": \"Region\",\"columnProperty\": {}},{\"columnId\": \"Total Net Revenue\",\"columnProperty\": {}},{\"columnId\": \"Total Gross Profit\",\"columnProperty\": {}}],\"axisProperties\": [{\"id\": \"590ebb18-a971-4803-abe7-54a6657d71dd\",\"properties\": {\"axisType\": \"Y\",\"linkedColumns\": [\"Total Net Revenue\"],\"isOpposite\": false}},{\"id\": \"5f1b517a-19b8-4737-a22b-7f64bdaad289\",\"properties\": {\"axisType\": \"Y\",\"linkedColumns\": [\"Total Gross Profit\"],\"isOpposite\": true}},{\"id\": \"a40a91df-ea58-4416-b7f2-791d99744d64\",\"properties\": {\"axisType\": \"X\",\"linkedColumns\": [\"Region\"]}}]}"
+        custom_chart_config:
+        - key: basic
+          dimensions:
+          - key: x-axis
+            axes:
+            - type: FLAT
+              column: Region
+            mode: AXIS_DRIVEN
+          - key: y-axis
+            axes:
+            - type: MERGED
+              columns:
+              - Total Net Revenue
+              - Total Gross Profit
+            mode: AXIS_DRIVEN
+          - key: slice-with-color
+            mode: AXIS_DRIVEN
+          - key: trellis-by
+            mode: AXIS_DRIVEN
+      display_mode: TABLE_MODE
+    viz_guid: b77f0de5-b5fc-4b9a-bef4-d8982f9e6d08
+  layout:
+    tiles:
+    - visualization_id: Viz_1
+      x: 0
+      "y": 0
+      height: 4
+      width: 3
+    - visualization_id: Viz_2
+      x: 3
+      "y": 0
+      height: 8
+      width: 6
+    - visualization_id: Viz_3
+      x: 0
+      "y": 8
+      height: 8
+      width: 6
+    - visualization_id: Viz_4
+      x: 6
+      "y": 8
+      height: 8
+      width: 6
+    - visualization_id: Viz_5
+      x: 0
+      "y": 16
+      height: 8
+      width: 12

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/fixtures/retail-analytics-model.tml
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/fixtures/retail-analytics-model.tml
@@ -1,0 +1,338 @@
+guid: d09e27fd-414e-4378-a148-c061da79d8e4
+model:
+  name: Retail Analytics
+  model_tables:
+  - name: ORDER_FACT
+    fqn: 7ccc4d3c-eb28-463e-bf74-790c67129a9e
+    joins:
+    - with: CUSTOMER_DIM
+      'on': '[ORDER_FACT::CUSTOMER_KEY] = [CUSTOMER_DIM::CUSTOMER_KEY]'
+      type: LEFT_OUTER
+      cardinality: MANY_TO_ONE
+    - with: DATE_DIM
+      'on': '[ORDER_FACT::ORDER_DATE_KEY] = [DATE_DIM::DATE_KEY]'
+      type: LEFT_OUTER
+      cardinality: MANY_TO_ONE
+    - with: PRODUCT_DIM
+      'on': '[ORDER_FACT::PRODUCT_KEY] = [PRODUCT_DIM::PRODUCT_KEY]'
+      type: LEFT_OUTER
+      cardinality: MANY_TO_ONE
+    - with: PROMO_DIM
+      'on': '[ORDER_FACT::PROMO_KEY] = [PROMO_DIM::PROMO_KEY]'
+      type: LEFT_OUTER
+      cardinality: MANY_TO_ONE
+    - with: STORE_DIM
+      'on': '[ORDER_FACT::ORDER_STORE_KEY] = [STORE_DIM::STORE_KEY]'
+      type: LEFT_OUTER
+      cardinality: MANY_TO_ONE
+  - name: CUSTOMER_DIM
+    fqn: 988bb03f-c374-4216-b77d-69fb188d47ca
+  - name: PRODUCT_DIM
+    fqn: ce0b9665-b271-487e-86e4-74d208178876
+  - name: STORE_DIM
+    fqn: 83b78191-f7d6-41f4-8bf2-5485e3b1ede1
+  - name: DATE_DIM
+    fqn: 774ac78d-f650-4d9b-b0cb-3b874eb8465d
+  - name: PROMO_DIM
+    fqn: bd078b70-2dcf-47fe-aa60-39f693cc5ad4
+  formulas:
+  - id: formula_Avg Order Value
+    name: Avg Order Value
+    expr: safe_divide ( [ORDER_FACT::GROSS_REVENUE] , [ORDER_FACT::QUANTITY_ORDERED] )
+  - id: formula_Channel Group
+    name: Channel Group
+    expr: if ( [ORDER_FACT::ORDER_CHANNEL] in { "EMAIL" , "SMS" } ) then "Digital Direct" else if ( [ORDER_FACT::ORDER_CHANNEL] in { "STORE" } ) then "In-Store" else "Other"
+  - id: formula_Gross Margin Pct
+    name: Gross Margin Pct
+    expr: if ( [ORDER_FACT::GROSS_REVENUE] > 0 ) then [ORDER_FACT::GROSS_PROFIT] / [ORDER_FACT::GROSS_REVENUE] else 0
+  - id: formula_Order Count
+    name: Order Count
+    expr: count ( [ORDER_FACT::ORDER_ID] )
+  columns:
+  - name: Order ID
+    column_id: ORDER_FACT::ORDER_ID
+    properties:
+      column_type: ATTRIBUTE
+  - name: Order Channel
+    column_id: ORDER_FACT::ORDER_CHANNEL
+    properties:
+      column_type: ATTRIBUTE
+  - name: Order Status
+    column_id: ORDER_FACT::ORDER_STATUS
+    properties:
+      column_type: ATTRIBUTE
+  - name: Ship Method
+    column_id: ORDER_FACT::SHIP_METHOD
+    properties:
+      column_type: ATTRIBUTE
+  - name: Is First Order
+    column_id: ORDER_FACT::IS_FIRST_ORDER
+    properties:
+      column_type: ATTRIBUTE
+  - name: Is Returned
+    column_id: ORDER_FACT::IS_RETURNED
+    properties:
+      column_type: ATTRIBUTE
+  - name: Is Cancelled
+    column_id: ORDER_FACT::IS_CANCELLED
+    properties:
+      column_type: ATTRIBUTE
+  - name: Customer Key
+    column_id: ORDER_FACT::CUSTOMER_KEY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Product Key
+    column_id: ORDER_FACT::PRODUCT_KEY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Order Store Key
+    column_id: ORDER_FACT::ORDER_STORE_KEY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Order Date Key
+    column_id: ORDER_FACT::ORDER_DATE_KEY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Promo Key
+    column_id: ORDER_FACT::PROMO_KEY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Gross Revenue
+    column_id: ORDER_FACT::GROSS_REVENUE
+    properties:
+      column_type: MEASURE
+      aggregation: SUM
+  - name: Net Revenue
+    column_id: ORDER_FACT::NET_REVENUE
+    properties:
+      column_type: MEASURE
+      aggregation: SUM
+  - name: Gross Profit
+    column_id: ORDER_FACT::GROSS_PROFIT
+    properties:
+      column_type: MEASURE
+      aggregation: SUM
+  - name: Discount Amount
+    column_id: ORDER_FACT::DISCOUNT_AMOUNT
+    properties:
+      column_type: MEASURE
+      aggregation: SUM
+  - name: Quantity Ordered
+    column_id: ORDER_FACT::QUANTITY_ORDERED
+    properties:
+      column_type: MEASURE
+      aggregation: SUM
+  - name: Quantity Returned
+    column_id: ORDER_FACT::QUANTITY_RETURNED
+    properties:
+      column_type: MEASURE
+      aggregation: SUM
+  - name: Days To Ship
+    column_id: ORDER_FACT::DAYS_TO_SHIP
+    properties:
+      column_type: MEASURE
+      aggregation: AVERAGE
+  - name: Customer Key (Customer)
+    column_id: CUSTOMER_DIM::CUSTOMER_KEY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Customer ID
+    column_id: CUSTOMER_DIM::CUSTOMER_ID
+    properties:
+      column_type: ATTRIBUTE
+  - name: First Name
+    column_id: CUSTOMER_DIM::FIRST_NAME
+    properties:
+      column_type: ATTRIBUTE
+  - name: Last Name
+    column_id: CUSTOMER_DIM::LAST_NAME
+    properties:
+      column_type: ATTRIBUTE
+  - name: Customer Segment
+    column_id: CUSTOMER_DIM::CUSTOMER_SEGMENT
+    properties:
+      column_type: ATTRIBUTE
+  - name: Loyalty Tier
+    column_id: CUSTOMER_DIM::LOYALTY_TIER
+    properties:
+      column_type: ATTRIBUTE
+  - name: Region
+    column_id: CUSTOMER_DIM::REGION
+    properties:
+      column_type: ATTRIBUTE
+  - name: State
+    column_id: CUSTOMER_DIM::STATE
+    properties:
+      column_type: ATTRIBUTE
+  - name: Acquisition Channel
+    column_id: CUSTOMER_DIM::ACQUISITION_CHANNEL
+    properties:
+      column_type: ATTRIBUTE
+  - name: Is Active
+    column_id: CUSTOMER_DIM::IS_ACTIVE
+    properties:
+      column_type: ATTRIBUTE
+  - name: Lifetime Revenue
+    column_id: CUSTOMER_DIM::LIFETIME_REVENUE
+    properties:
+      column_type: MEASURE
+      aggregation: SUM
+  - name: Lifetime Order Count
+    column_id: CUSTOMER_DIM::LIFETIME_ORDER_COUNT
+    properties:
+      column_type: MEASURE
+      aggregation: SUM
+  - name: Product Key (Product)
+    column_id: PRODUCT_DIM::PRODUCT_KEY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Product ID
+    column_id: PRODUCT_DIM::PRODUCT_ID
+    properties:
+      column_type: ATTRIBUTE
+  - name: Product Name
+    column_id: PRODUCT_DIM::PRODUCT_NAME
+    properties:
+      column_type: ATTRIBUTE
+  - name: Category
+    column_id: PRODUCT_DIM::CATEGORY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Subcategory
+    column_id: PRODUCT_DIM::SUBCATEGORY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Brand
+    column_id: PRODUCT_DIM::BRAND
+    properties:
+      column_type: ATTRIBUTE
+  - name: Unit Cost
+    column_id: PRODUCT_DIM::UNIT_COST
+    properties:
+      column_type: MEASURE
+      aggregation: AVERAGE
+  - name: Unit Price
+    column_id: PRODUCT_DIM::UNIT_PRICE
+    properties:
+      column_type: MEASURE
+      aggregation: AVERAGE
+  - name: Store Key
+    column_id: STORE_DIM::STORE_KEY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Store ID
+    column_id: STORE_DIM::STORE_ID
+    properties:
+      column_type: ATTRIBUTE
+  - name: Store Name
+    column_id: STORE_DIM::STORE_NAME
+    properties:
+      column_type: ATTRIBUTE
+  - name: Store Type
+    column_id: STORE_DIM::STORE_TYPE
+    properties:
+      column_type: ATTRIBUTE
+  - name: City
+    column_id: STORE_DIM::CITY
+    properties:
+      column_type: ATTRIBUTE
+  - name: State (Store)
+    column_id: STORE_DIM::STATE
+    properties:
+      column_type: ATTRIBUTE
+  - name: Region (Store)
+    column_id: STORE_DIM::REGION
+    properties:
+      column_type: ATTRIBUTE
+  - name: District
+    column_id: STORE_DIM::DISTRICT
+    properties:
+      column_type: ATTRIBUTE
+  - name: Square Footage
+    column_id: STORE_DIM::SQUARE_FOOTAGE
+    properties:
+      column_type: MEASURE
+      aggregation: AVERAGE
+  - name: Annual Lease Cost
+    column_id: STORE_DIM::ANNUAL_LEASE_COST
+    properties:
+      column_type: MEASURE
+      aggregation: SUM
+  - name: Date Key
+    column_id: DATE_DIM::DATE_KEY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Full Date
+    column_id: DATE_DIM::FULL_DATE
+    properties:
+      column_type: ATTRIBUTE
+  - name: Year
+    column_id: DATE_DIM::YEAR
+    properties:
+      column_type: ATTRIBUTE
+  - name: Quarter
+    column_id: DATE_DIM::QUARTER
+    properties:
+      column_type: ATTRIBUTE
+  - name: Month Number
+    column_id: DATE_DIM::MONTH_NUMBER
+    properties:
+      column_type: ATTRIBUTE
+  - name: Month Name
+    column_id: DATE_DIM::MONTH_NAME
+    properties:
+      column_type: ATTRIBUTE
+  - name: Day Of Week
+    column_id: DATE_DIM::DAY_OF_WEEK
+    properties:
+      column_type: ATTRIBUTE
+  - name: Promo Key (Promo)
+    column_id: PROMO_DIM::PROMO_KEY
+    properties:
+      column_type: ATTRIBUTE
+  - name: Promo ID
+    column_id: PROMO_DIM::PROMO_ID
+    properties:
+      column_type: ATTRIBUTE
+  - name: Promo Name
+    column_id: PROMO_DIM::PROMO_NAME
+    properties:
+      column_type: ATTRIBUTE
+  - name: Promo Type
+    column_id: PROMO_DIM::PROMO_TYPE
+    properties:
+      column_type: ATTRIBUTE
+  - name: Channel
+    column_id: PROMO_DIM::CHANNEL
+    properties:
+      column_type: ATTRIBUTE
+  - name: Target Segment
+    column_id: PROMO_DIM::TARGET_SEGMENT
+    properties:
+      column_type: ATTRIBUTE
+  - name: Discount Pct
+    column_id: PROMO_DIM::DISCOUNT_PCT
+    properties:
+      column_type: MEASURE
+      aggregation: AVERAGE
+  - name: Gross Margin Pct
+    formula_id: formula_Gross Margin Pct
+    properties:
+      column_type: MEASURE
+  - name: Channel Group
+    formula_id: formula_Channel Group
+    properties:
+      column_type: ATTRIBUTE
+  - name: Avg Order Value
+    formula_id: formula_Avg Order Value
+    properties:
+      column_type: MEASURE
+  - name: Order Count
+    formula_id: formula_Order Count
+    properties:
+      column_type: MEASURE
+  properties:
+    is_bypass_rls: false
+    join_progressive: false
+    spotter_config:
+      is_spotter_enabled: true

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/liveboard-to-workbook.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/liveboard-to-workbook.md
@@ -1,0 +1,96 @@
+# ThoughtSpot Liveboard → Sigma workbook — spec shapes
+
+The exact Sigma workbook-spec shapes the builder (`ts_common.py` /
+`migrate.py`) emits, all live-verified (POST → readback). Get these wrong and
+Sigma either 400s at POST or **silently degrades** (pivot collapses to one
+cell, KPI fails validation only at POST, sorts dropped).
+
+## Chart-kind map
+
+| ThoughtSpot | Sigma | Notes |
+|---|---|---|
+| KPI | `kpi-chart` | value is `{"columnId": c}` — NOT `{"id": c}` |
+| COLUMN / BAR / STACKED_* | `bar-chart` | `orientation` enum is `"horizontal"`-only; omit for vertical |
+| LINE | `line-chart` | |
+| PIE / DONUT | `donut-chart` | TS renders pies as donuts; `value`/`color` use `{"id": c}` — NOT `{"columnId": c}` |
+| AREA / STACKED_AREA | `area-chart` | |
+| SCATTER / BUBBLE | `scatter-chart` | two measures x/y + optional category `color` |
+| LINE_COLUMN | `combo-chart` | first measure bare string in `yAxis.columnIds`, rest `{"columnId", "type": "line"}` |
+| GEO_AREA / GEO_BUBBLE | `region-map` | `region: {id, regionType}`; regionType inferred from the geo field name |
+| PIVOT_TABLE | `pivot-table` | see below |
+| TABLE / ADVANCED_COLUMN | grouped `table` | see below |
+| funnel / waterfall / treemap / heat-map / sankey | `bar-chart` fallback | flagged in the assessment |
+
+## The asymmetric column-ref shapes (the #1 trap)
+
+- **KPI**: `"value": {"columnId": cid}` (kpis.md docs are stale; `{id}` fails at POST,
+  validate-spec misses it).
+- **Donut/pie**: `"value": {"id": vid}, "color": {"id": cid}` (the opposite convention).
+- **Pivot**: `rowsBy`/`columnsBy` are arrays of **`{id}` objects**, `values` is an
+  array of **bare column-id strings**. Omitting rowsBy/columnsBy silently collapses
+  the pivot to a single grand-total cell.
+- **Grouped table**: `"groupings": [{"id", "groupBy": [dimId], "calculations": [measureIds]}]`.
+
+## Column ORDER (tables)
+
+Use the answer's **`table.ordered_column_ids`** for column order — `answer_columns`
+is alphabetical and `chart.chart_columns` follows the chart axes, both of which
+scramble multi-measure tables. (`ts_common.parse_ts_viz` reorders by
+`ordered_column_ids`; the converter's chart_columns order is wrong for tables.)
+
+## Sorts
+
+TML sorts come from `sort by [Col] desc/asc` tokens in `search_query` and
+`sortInfo` entries in `client_state(_v2)` (`ts_common.parse_sorts`). Verified
+Sigma shapes (same as looker-to-sigma, live POST + readback + render):
+
+- bar/line/area/scatter/combo: `xAxis.sort = {by: <colId>, direction}`
+- pie/donut: `color.sort = {by: <colId>, direction}`
+- ungrouped table: element-level `sort = [{columnId, direction}]`
+- grouped table: `groupings[0].sort = [{columnId, direction}]` — element-level
+  sort on a grouped table 400s with "Sort column not found".
+
+## Master-element pattern
+
+Each workbook gets a "Data" page with one master `table` sourced from the DM's
+denormalized View (`source: {dataModelId, elementId, kind: "data-model"}`);
+every chart sources `{elementId: <master id>, kind: "table"}` and references
+columns as `[<master name>/<friendly>]`. Never put an element filter / top-N cap
+on the master — it propagates into every chart that sources it.
+
+## Layout: TML tiles → Sigma grid
+
+`liveboard.layout.tiles[]` carries `{visualization_id, x, y, width, height}` on a
+**12-column** grid. Sigma layout is XML on a **24-column** grid:
+
+- columns: ×2 → `gridColumn="{x*2+1} / {(x+width)*2+1}"`
+- rows: ×`ROW_SCALE` (min **2**) → `gridRow="{y*RS+1} / {(y+height)*RS+1}"`.
+  1:1 rows make bands too short: Sigma suppresses axis category labels and hides
+  KPI titles below ~5 grid rows (~150px) — same fix as looker's `ROW_SCALE=2`.
+
+Apply layout as the **LAST** write — a bare spec PUT wipes `spec.layout`
+(strip `workbookId/url/ownerId/created*/updated*/latestDocumentVersion` before
+the PUT; see `apply_layouts.py`).
+
+## Rename gotcha
+
+`PATCH /v2/workbooks/{id}` **silently no-ops for renames** (200, name unchanged).
+Rename through the files API instead:
+
+```
+PATCH /v2/files/{workbookId}   {"name": "New Name"}
+```
+
+(Workbook delete is also files-side: `DELETE /v2/files/{id}`; and unarchive is
+`{"restore": true}`.)
+
+## Misc verified gotchas
+
+- Workbook POST/spec GET respond in **YAML** even with `Accept: application/json`
+  — parse both.
+- Show value labels on bar/donut via `dataLabel: {labels: "shown"}` (defaults OFF).
+- Search-query filters `[Col] = 'val'` → element list-filters
+  `{kind: "list", mode: include|exclude, columnId, values}`; TS lowercases string
+  literals in the query (best-effort Title Case for case-sensitive warehouses).
+- Sigma has no `IsIn` — silently errors the column and blanks the chart; use `or` chains.
+- `CountOver`/`SumOver` window functions silently error in master/DM calc columns.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/model-conversion-rules.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/model-conversion-rules.md
@@ -1,0 +1,76 @@
+# ThoughtSpot model TML → Sigma data model — conversion rules
+
+What `convert_thoughtspot_to_sigma` (MCP tool / `CONVERTER_PATH` build) does with a
+model TML, and the conventions every downstream script relies on.
+
+## Input shape (the `model:` format)
+
+ThoughtSpot exports models with:
+
+- `model_tables[]` — one entry per physical table; the **fact (root) table is the
+  one carrying `joins[]`** (joins are inline, not a separate section):
+  ```yaml
+  model_tables:
+  - name: ORDER_FACT
+    fqn: 7ccc4d3c-...            # a ThoughtSpot guid, NOT the warehouse FQN
+    joins:
+    - with: CUSTOMER_DIM
+      'on': '[ORDER_FACT::CUSTOMER_KEY] = [CUSTOMER_DIM::CUSTOMER_KEY]'
+      type: LEFT_OUTER
+      cardinality: MANY_TO_ONE
+  ```
+- `formulas[]` — `[TABLE::COL]` refs, TS functions (`safe_divide`, `if … then … else`,
+  `count`, `in { … }`).
+- `columns[]` — `column_id: TABLE::PHYSICAL_COL` (physical) or `formula_id:` (formula),
+  with `properties.column_type` (`ATTRIBUTE`/`MEASURE`), `aggregation`,
+  `format_pattern`, `currency_type`.
+
+Older worksheets use `worksheet:` + `worksheet_columns[]` with `ALIAS::column`
+separators and `table_paths` — the converter handles both.
+
+## Warehouse path: TS_DB / TS_SCHEMA are REQUIRED
+
+`model_tables[].fqn` is a ThoughtSpot guid, so the warehouse `database`/`schema`
+cannot be recovered from the TML. Pass `TS_DB` + `TS_SCHEMA` (converter args
+`database`/`schema`); the source path becomes `[TS_DB, TS_SCHEMA, <table name>]`.
+
+## Output conventions (what the scripts depend on)
+
+- **One element per table** plus a denormalized **"`<root>` View"** element that
+  surfaces joined-dim columns via cross-element refs `[<fact element>/REL/Field]`.
+  The workbook master reads from this View element. When the model has no joins
+  there is no View — fall back to the element with the most columns
+  (`migrate.py::build_dm`).
+- **Display names**: `SNAKE_CASE`/`camelCase` → Title Case with small connector
+  words (`of`, `to`, `and`, …) kept lowercase (`ts_common.sigma_display_name`
+  replicates this). On the View element, joined-dim columns get a
+  **`(TABLE)` suffix** (`Category (PRODUCT_DIM)`); fact columns don't.
+  `ts_common.build_resolver` derives the TS-name → View-name map from the model
+  TML itself — never hardcode it.
+- **Relationship keys**: the denormalized View must NOT re-surface the join key
+  column of the relationship itself — a cross-element passthrough of a join key
+  compiles to a `type: error` column in Sigma.
+- **Formulas** on the fact element keep their TS name; aggregate formulas
+  (`sum(x)/sum(y)`, `sqrt(sum(...))`) become DM **metrics**, not columns.
+- **Formats**: `format_pattern` (Java DecimalFormat, e.g. `#,##0.00`, `0.0%`) +
+  `currency_type.iso_code` map to Sigma `format` objects
+  (`ts_common.ts_format_to_sigma`). The pattern never carries a currency symbol —
+  only emit one when `currency_type` is set.
+
+## Converter invocation
+
+MCP tool `mcp__sigma-data-model__convert_thoughtspot_to_sigma`:
+`{tml_yaml, connection_id, database, schema}` (empty string = omit). Returns
+`{sigmaDataModel, stats, warnings}` (the local `CONVERTER_PATH` build returns the
+same spec under `model`) — the spec POSTs to `/v2/dataModels/spec` (add
+`folderId`). `migrate.py` emits this exact request to
+`<workdir>/convert-request.json` when no local build is configured, and resumes
+from the tool's saved output via `--converted <file>`.
+
+## Gotchas
+
+- TML export embeds raw control chars in JSON strings → `json.loads(..., strict=False)`.
+- The TS trial REST API rejects short id prefixes — use full guids.
+- System/sample objects are FORBIDDEN to export (only own content).
+- Security: `rls_rules` are detected and reported in `result.security[]`, never
+  injected into the spec — see SKILL.md "Row- & Column-Level Security".

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
@@ -1,31 +1,54 @@
 #!/usr/bin/env python3
-"""Apply a clean grid layout to migrated Sigma workbooks.
+"""Apply layout to migrated Sigma workbooks — from the Liveboard's OWN tile
+geometry when available, else a clean auto grid.
 
 Sigma stacks elements vertically unless a top-level spec.layout is set, and the
-layout must be the LAST write (a bare spec PUT wipes it). For each workbook we
-GET the spec, build a 2-page layout XML (Data page: master full-width; main
-page: KPIs across the top row, other charts in a 2-wide grid), and PUT it back.
+layout must be the LAST write (a bare spec PUT wipes it).
 
-Usage: python3 apply_layouts.py            # all workbooks in the manifest
-       python3 apply_layouts.py <wbId> ... # specific workbooks
-Env: SIGMA_BASE_URL, SIGMA_API_TOKEN
+Geometry mapping (ThoughtSpot layout.tiles → Sigma grid):
+  - ThoughtSpot Liveboards use a 12-column grid; Sigma uses 24 → scale x/width ×2.
+  - Rows: ROW_SCALE (min 2). 1:1 row mapping makes chart bands too short and
+    Sigma SUPPRESSES axis category labels / KPI titles on short bands — same
+    fix as looker-to-sigma's ROW_SCALE=2 (beads-sigma-tkkv). Override with
+    TS_ROW_SCALE (values < 2 are clamped to 2).
+
+Usage: python3 apply_layouts.py [--workdir DIR]   # all workbooks in <workdir>/migrate_out.json
+       python3 apply_layouts.py <wbId> ...        # specific workbooks (auto grid)
+Env: SIGMA_BASE_URL, SIGMA_API_TOKEN, TS_WORKDIR (default for --workdir), TS_ROW_SCALE
 """
-import json, os, ssl, sys, urllib.request, urllib.error
-SBASE = os.environ["SIGMA_BASE_URL"]; STOK = os.environ["SIGMA_API_TOKEN"]
+import argparse, json, os, ssl, sys, urllib.request, urllib.error
 _SSL = ssl._create_unverified_context()
-MANIFEST = os.path.expanduser("~/thoughtspot-migration/migration_manifest.json")
+
+TS_GRID_COLS = 12                                   # ThoughtSpot Liveboard grid
+COL_SCALE = 24 // TS_GRID_COLS                      # → Sigma's 24-col grid
+ROW_SCALE = max(2, int(os.environ.get("TS_ROW_SCALE", "2") or 2))
 
 def req(method, path, body=None):
-    r = urllib.request.Request(SBASE + path, data=(body.encode() if body else None), method=method,
-        headers={"Authorization": "Bearer " + STOK, "Accept": "application/json",
+    base = os.environ["SIGMA_BASE_URL"]; tok = os.environ["SIGMA_API_TOKEN"]
+    r = urllib.request.Request(base + path, data=(body.encode() if body else None), method=method,
+        headers={"Authorization": "Bearer " + tok, "Accept": "application/json",
                  **({"Content-Type": "application/json"} if body else {})})
     try:
         return urllib.request.urlopen(r, context=_SSL).read().decode()
     except urllib.error.HTTPError as e:
         raise RuntimeError(f"{method} {path} -> {e.code}: {e.read().decode()[:300]}")
 
+def tiles_page_xml(page_id, tiles):
+    """ThoughtSpot tile geometry → Sigma grid. tiles: [{element_id,x,y,width,height}]
+    in TS 12-col units."""
+    out = [f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">']
+    for t in tiles:
+        c0 = t["x"] * COL_SCALE + 1
+        c1 = min(t["x"] + t["width"], TS_GRID_COLS) * COL_SCALE + 1
+        r0 = t["y"] * ROW_SCALE + 1
+        r1 = (t["y"] + t["height"]) * ROW_SCALE + 1
+        out.append(f'  <LayoutElement elementId="{t["element_id"]}" gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}"/>')
+    out.append("</Page>")
+    return "\n".join(out)
+
 def page_xml(page_id, elems):
-    """KPIs across the top row (split evenly, 5 rows tall); others 2-wide, 11 rows."""
+    """Auto grid fallback (no TML geometry): KPIs across the top row (split
+    evenly, 5 rows tall); others 2-wide, 11 rows."""
     kpis = [e for e in elems if e["kind"] == "kpi-chart"]
     charts = [e for e in elems if e["kind"] not in ("kpi-chart",)]
     out = [f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">']
@@ -45,7 +68,7 @@ def page_xml(page_id, elems):
     out.append("</Page>")
     return "\n".join(out)
 
-def build_layout(spec):
+def build_layout(spec, tiles=None):
     pages = spec["pages"]
     data = next((p for p in pages if p.get("name") == "Data"), None)
     main = next((p for p in pages if p.get("name") != "Data"), None)
@@ -55,13 +78,16 @@ def build_layout(spec):
         lines.append(f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{data["id"]}">')
         lines.append(f'  <LayoutElement elementId="{mid}" gridColumn="1 / 25" gridRow="1 / 21"/>')
         lines.append('</Page>')
-    elems = [{"id": e["id"], "kind": e["kind"]} for e in main["elements"]]
-    lines.append(page_xml(main["id"], elems))
+    if tiles:
+        lines.append(tiles_page_xml(main["id"], tiles))
+    else:
+        elems = [{"id": e["id"], "kind": e["kind"]} for e in main["elements"]]
+        lines.append(page_xml(main["id"], elems))
     return "\n".join(lines) + "\n"
 
-def apply(wb):
+def apply(wb, tiles=None):
     spec = json.loads(req("GET", f"/v2/workbooks/{wb}/spec"))
-    xml = build_layout(spec)
+    xml = build_layout(spec, tiles=tiles)
     for p in spec["pages"]:
         p.pop("layout", None)
     spec["layout"] = xml
@@ -72,18 +98,27 @@ def apply(wb):
     return "workbookId" in resp
 
 def main():
-    if len(sys.argv) > 1:
-        wbs = sys.argv[1:]
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workdir", default=None, help="dir holding migrate_out.json (default $TS_WORKDIR or ./ts-migration)")
+    ap.add_argument("workbooks", nargs="*", help="specific workbook ids (auto grid; skips the manifest)")
+    a = ap.parse_args()
+    if a.workbooks:
+        jobs = [(wb, None) for wb in a.workbooks]
     else:
-        m = json.load(open(MANIFEST))
-        wbs = [r["workbook"] for r in m.values() if r.get("workbook")]
+        wd = os.path.abspath(os.path.expanduser(a.workdir or os.environ.get("TS_WORKDIR")
+                             or os.path.join(os.getcwd(), "ts-migration")))
+        manifest = os.path.join(wd, "migrate_out.json")
+        m = json.load(open(manifest))
+        results = m.get("results", m)          # new manifest nests under "results"
+        jobs = [(r["workbook"], r.get("tiles")) for r in results.values() if r.get("workbook")]
     ok = 0
-    for wb in wbs:
+    for wb, tiles in jobs:
         try:
-            apply(wb); ok += 1; print(f"✓ laid out {wb}")
+            apply(wb, tiles=tiles); ok += 1
+            print(f"✓ laid out {wb} ({'TML tiles' if tiles else 'auto grid'})")
         except Exception as e:
             print(f"✗ {wb}: {e}")
-    print(f"\n{ok}/{len(wbs)} workbooks laid out")
+    print(f"\n{ok}/{len(jobs)} workbooks laid out")
 
 if __name__ == "__main__":
     main()

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,0 +1,310 @@
+#!/usr/bin/env ruby
+# Hard gate that proves a tableau-to-sigma conversion is actually complete.
+# The subagent MUST run this script before declaring GREEN. It checks four
+# independent things — failing ANY of them blocks the GREEN declaration:
+#
+#   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
+#      → beads-sigma-4pm
+#   2. No orphan workbooks left in the customer's My Documents
+#      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
+#      cleanup ran with no failed deletes)  → beads-sigma-38a
+#   3. The live workbook's /columns endpoint shows no column with
+#      type=error (catches circular refs / runtime errors introduced
+#      AFTER the initial POST's column-type guard ran)  → beads-sigma-38a
+#   4. The workbook has a non-empty layout XML applied (catches the
+#      "elements just listed in a single column" regression where the
+#      agent forgot to PUT a layout)  → beads-sigma-bw3
+#
+# Usage:
+#   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
+#     [--workbook-id <id>]     # override; default = read from wb-ids.json
+#     [--min-pass-rate 1.0]    # default 1.0 (every chart must PASS)
+#     [--allow-extract]        # treat extract-mode as acceptable
+#     [--skip-column-check]    # skip the live /columns type=error scan
+#     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
+#                              # that genuinely want multiple workbooks)
+#     [--skip-layout-check]    # skip the layout-applied scan
+#     [--min-layout-elements N] default 2 — single-page bare-element layouts
+#                              # often have just the page wrapper; require this
+#                              # many <LayoutElement> tags
+#
+# Exit codes:
+#   0  every gate passes — conversion is allowed to declare GREEN
+#   1  parity-final.json missing (Phase 6 skipped — the regression case)
+#   2  parity-final.json exists but status=FAIL / pass-rate below min /
+#      extract-mode without --allow-extract / charts_total==0
+#   3  parity-final.json malformed
+#   4  orphan workbooks left uncleaned (beads-sigma-38a)
+#   5  live workbook has column(s) with type=error (beads-sigma-38a)
+#   6  live workbook has no layout applied — single-column fallback
+#      (beads-sigma-bw3)
+#
+# Prints a per-gate summary to stdout regardless of exit code.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2 }
+OptionParser.new do |p|
+  p.on('--tableau DIR')              { |v| opts[:tab] = v }
+  p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
+  p.on('--workbook-id ID')           { |v| opts[:wb] = v }
+  p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--allow-extract')            { opts[:allow_extract] = true }
+  p.on('--skip-column-check')        { opts[:skip_column] = true }
+  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
+  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+end.parse!
+abort('--workdir (or --tableau) required') unless opts[:tab]
+
+summary_path = File.join(opts[:tab], 'parity-final.json')
+
+unless File.exist?(summary_path)
+  warn "[FAIL] Phase 6 skipped — #{summary_path} does not exist."
+  warn "       Run: ruby scripts/phase6-parity.rb --tableau #{opts[:tab]} --workbook-id <id>"
+  warn "       then collect actuals via mcp__sigma-mcp-v2__query and re-run with --finalize."
+  warn "       See SKILL.md Phase 6. This is the hard gate (beads-sigma-4pm)."
+  exit 1
+end
+
+begin
+  summary = JSON.parse(File.read(summary_path))
+rescue JSON::ParserError => e
+  warn "[FAIL] #{summary_path} is malformed JSON: #{e.message}"
+  exit 3
+end
+
+total = summary['charts_total'].to_i
+passed = summary['charts_pass'].to_i
+status = summary['status'].to_s
+mode = summary['mode'].to_s
+
+if total <= 0
+  warn "[FAIL] parity-final.json reports charts_total=#{total} — no charts were verified."
+  warn "       This usually means auto-parity-plan.rb matched zero Tableau views."
+  warn "       Phase 6 must verify at least one chart to declare GREEN."
+  exit 2
+end
+
+if mode == 'extract' && !opts[:allow_extract]
+  warn "[FAIL] parity ran in extract-mode but --allow-extract was not passed."
+  warn "       Extract-mode permits up to ±#{((summary['extract_tol'] || 0.30) * 100).to_i}% drift —"
+  warn "       only acceptable when the source Tableau workbook has hasExtracts=true."
+  exit 2
+end
+
+pass_rate = passed.to_f / total
+if status != 'PASS' || pass_rate < opts[:min_pass_rate]
+  warn "[FAIL] parity status=#{status} pass-rate=#{(pass_rate * 100).round(1)}% (#{passed}/#{total})"
+  warn "       Required: status=PASS and pass-rate >= #{(opts[:min_pass_rate] * 100).to_i}%"
+  if (fail_names = summary['fail_names']) && !fail_names.empty?
+    warn "       Failing charts: #{fail_names.join(', ')}"
+  end
+  exit 2
+end
+
+puts "[OK] gate 1/4: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+
+# ---------------------------------------------------------------------------
+# Gate 2 — orphan workbooks (beads-sigma-38a)
+# ---------------------------------------------------------------------------
+unless opts[:skip_orphan]
+  log = File.join(opts[:tab], 'posted-workbooks.jsonl')
+  if File.exist?(log)
+    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    unique_ids = posted.map { |e| e['id'] }.uniq
+    if unique_ids.length > 1
+      marker_path = File.join(opts[:tab], 'cleanup-marker.json')
+      unless File.exist?(marker_path)
+        warn "[FAIL] gate 2/4: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "       posted-workbooks.jsonl entries:"
+        unique_ids.each { |id| warn "         - #{id}" }
+        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        warn "       See beads-sigma-38a."
+        exit 4
+      end
+      marker = JSON.parse(File.read(marker_path)) rescue {}
+      if marker['failed'] && !marker['failed'].empty?
+        warn "[FAIL] gate 2/4: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "       Orphan workbooks are still in the customer's My Documents:"
+        marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
+        exit 4
+      end
+      if marker['dry_run']
+        warn "[FAIL] gate 2/4: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+        exit 4
+      end
+      kept = marker['kept'] || '(unknown)'
+      deleted = (marker['deleted'] || []).length
+      puts "[OK] gate 2/4: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+    else
+      puts "[OK] gate 2/4: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+    end
+  else
+    puts "[OK] gate 2/4: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+  end
+else
+  puts "[SKIP] gate 2/4: --skip-orphan-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 3 — live /columns type=error scan (beads-sigma-38a)
+# Catches circular references and runtime errors that the initial post-and-
+# readback column-type guard missed because they were introduced by later
+# PUTs (layout updates, spec edits during error recovery).
+# ---------------------------------------------------------------------------
+unless opts[:skip_column]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 3/4: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 3/4: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        cols = (JSON.parse(res.body)['entries'] rescue []) || []
+        error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
+        if error_cols.any?
+          warn "[FAIL] gate 3/4: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
+          warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
+          error_cols.first(10).each do |c|
+            warn "         element=#{c['elementId']} col=#{c['columnId']} label=#{c['label'].inspect}"
+            warn "           formula: #{c['formula']}"
+          end
+          warn "       See beads-sigma-38a."
+          exit 5
+        end
+        puts "[OK] gate 3/4: #{cols.length} live columns clean (no type=error)"
+      else
+        warn "[SKIP] gate 3/4: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 3/4: --skip-column-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 4 — layout applied (beads-sigma-bw3)
+# Fetches the live workbook spec and confirms a non-empty top-level `layout`
+# XML is set, with at least --min-layout-elements <LayoutElement> tags.
+# Catches the "agent forgot to PUT a layout" regression where elements
+# render as a single-column stack instead of the dashboard grid.
+# ---------------------------------------------------------------------------
+unless opts[:skip_layout]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 4/4: no workbook ID resolvable for layout check"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 4/4: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        body = res.body.to_s
+        spec =
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+          end
+        layout_xml = spec['layout'].to_s
+        elem_count = layout_xml.scan(/<LayoutElement\b/).length
+
+        # Detect the Sigma "auto-generated single-column stack" layout that
+        # the server produces when a workbook is POSTed without a layout.
+        # Signature: every non-Data page has all its elements at the same
+        # gridColumn value (typically "1 / 13" — left half, vertically stacked).
+        # Note: per-page detection — a workbook with one element per content
+        # page is structurally fine (degenerate case, not a stack).
+        non_data_stack_pages = []
+        # Walk one page at a time using the <Page id="..."> blocks
+        layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
+          next if page_id.to_s.downcase.include?('data')
+          cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
+          elems_on_page = page_body.scan(/<LayoutElement\b/).length
+          if elems_on_page >= 2 && cols_on_page.length == 1
+            non_data_stack_pages << [page_id, cols_on_page.first, elems_on_page]
+          end
+        end
+
+        if layout_xml.empty?
+          warn "[FAIL] gate 4/4: live workbook #{wb_id} has NO top-level layout XML."
+          warn "       Elements render as a single-column stack instead of the"
+          warn "       dashboard grid. Rebuild the layout with this skill's layout"
+          warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
+          warn "       then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} \\"
+          warn "           --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        elsif elem_count < opts[:min_layout_elements]
+          warn "[FAIL] gate 4/4: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
+          warn "       The layout likely covers only the Data page — chart page is unstyled."
+          exit 6
+        elsif non_data_stack_pages.any?
+          warn "[FAIL] gate 4/4: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "       single-column stack layout (multiple elements at the same gridColumn"
+          warn "       on a non-Data page). This is what Sigma defaults to when you POST"
+          warn "       a workbook without a layout — exactly the CoCo regression."
+          non_data_stack_pages.each do |pid, col, n|
+            warn "         page=#{pid.inspect}: #{n} elements all at gridColumn=#{col.inspect}"
+          end
+          warn "       Rebuild the layout with this skill's layout builder (see SKILL.md —"
+          warn "       layout phase) into #{opts[:tab]}/layout.xml, then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        else
+          puts "[OK] gate 4/4: layout XML applied with #{elem_count} positioned element(s)"
+        end
+      else
+        warn "[SKIP] gate 4/4: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 4/4: --skip-layout-check"
+end
+
+puts "[OK] all gates pass — conversion may declare GREEN"
+exit 0

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh
@@ -5,9 +5,9 @@
 
 set -euo pipefail
 
-: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
-: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
-: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_BASE_URL:?Set SIGMA_BASE_URL (e.g. source ~/.sigma-migration/env)}"
+: "${SIGMA_CLIENT_ID:?Set SIGMA_CLIENT_ID (e.g. source ~/.sigma-migration/env)}"
+: "${SIGMA_CLIENT_SECRET:?Set SIGMA_CLIENT_SECRET (e.g. source ~/.sigma-migration/env)}"
 
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -1,50 +1,116 @@
 #!/usr/bin/env python3
 """Generalized ThoughtSpot → Sigma migration — works on ANY model, no baked ids.
 
-  python3 migrate.py --model <TS_MODEL_ID> [--liveboard <ID> ...] [--name PREFIX]
+  python3 migrate.py --model <TS_MODEL_ID> [--liveboard <ID> ...] [--name PREFIX] \
+                     [--workdir DIR] [--converted FILE]
 
-Steps: export the model's TML → convert to a Sigma data model (convert_model.mjs)
-→ POST it → discover the denormalized "<root> View" element → build a column
-resolver from the model TML → for each Liveboard that reads the model, rebuild
-its visualizations as a Sigma workbook off that element → apply a grid layout.
+Steps: export the model's TML → convert to a Sigma data model → POST it →
+discover the denormalized "<root> View" element → build a column resolver from
+the model TML → for each Liveboard that reads the model, rebuild its
+visualizations as a Sigma workbook off that element → apply the Liveboard's own
+tile geometry (layout.tiles) as the Sigma grid layout.
 
-Env (all required, no hardcoded ids):
-  TS_HOST, TS_TOKEN                         ThoughtSpot
+Converter paths (in priority order):
+  1. --converted <file>   JSON output of the `convert_thoughtspot_to_sigma`
+                          MCP tool (or a bare Sigma DM spec) — continues the
+                          pipeline without any local converter build.
+  2. CONVERTER_PATH       one-shot: a local sigma-data-model-mcp
+                          build/thoughtspot.js, run via convert_model.mjs.
+  3. neither              MCP fallback: writes <workdir>/model.tml +
+                          <workdir>/convert-request.json and prints the exact
+                          mcp__sigma-data-model__convert_thoughtspot_to_sigma
+                          call to make; save the tool's JSON output and re-run
+                          with --converted <file>. Exits 3 (not an error).
+
+Offline mode: --model-tml FILE and --liveboard-tml FILE (repeatable) read TML
+from disk instead of the live ThoughtSpot API — see fixtures/ for a real
+exported pair. No TS_HOST/TS_TOKEN needed.
+
+Env:
+  TS_HOST, TS_TOKEN                         ThoughtSpot (live mode only)
   SIGMA_BASE_URL, SIGMA_API_TOKEN           Sigma
   SIGMA_CONNECTION_ID                       warehouse connection in Sigma
   SIGMA_FOLDER_ID                           destination folder
   TS_DB, TS_SCHEMA                          warehouse db/schema for the model's tables
+  TS_WORKDIR                                default for --workdir (else ./ts-migration)
 """
-import argparse, json, os, ssl, subprocess, sys, urllib.request, urllib.error
+import argparse, json, os, re, ssl, subprocess, sys, urllib.request, urllib.error
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import yaml, ts_lib, ts_common, apply_layouts
+import yaml, ts_common, apply_layouts
 yaml.SafeLoader.add_constructor("tag:yaml.org,2002:value", lambda l, n: l.construct_scalar(n))
 
-SBASE = os.environ["SIGMA_BASE_URL"]; STOK = os.environ["SIGMA_API_TOKEN"]
-CONN = os.environ["SIGMA_CONNECTION_ID"]; FOLDER = os.environ["SIGMA_FOLDER_ID"]
 HERE = os.path.dirname(os.path.abspath(__file__))
 _SSL = ssl._create_unverified_context()
+MCP_TOOL = "mcp__sigma-data-model__convert_thoughtspot_to_sigma"
+
+def need_env(*names):
+    missing = [n for n in names if not os.environ.get(n)]
+    if missing:
+        sys.exit("missing env: " + ", ".join(missing))
+    return [os.environ[n] for n in names]
 
 def sigma(method, path, body=None):
-    r = urllib.request.Request(SBASE + path, data=(json.dumps(body).encode() if body else None),
-        method=method, headers={"Authorization": "Bearer " + STOK, "Accept": "application/json",
+    base, tok = need_env("SIGMA_BASE_URL", "SIGMA_API_TOKEN")
+    r = urllib.request.Request(base + path, data=(json.dumps(body).encode() if body else None),
+        method=method, headers={"Authorization": "Bearer " + tok, "Accept": "application/json",
         **({"Content-Type": "application/json"} if body else {})})
     try:
         return urllib.request.urlopen(r, context=_SSL).read().decode()
     except urllib.error.HTTPError as e:
         raise RuntimeError(f"Sigma {method} {path} -> {e.code}: {e.read().decode()[:300]}")
 
-def build_dm(model_tml, name):
-    """Convert the model TML and POST a Sigma data model. Returns (dmId, denormElemId, denormName)."""
-    open("/tmp/_ts_model.tml", "w").write(model_tml)
-    env = {**os.environ, "TS_DB": os.environ.get("TS_DB", ""), "TS_SCHEMA": os.environ.get("TS_SCHEMA", "")}
-    out = subprocess.run(["node", os.path.join(HERE, "convert_model.mjs"), "/tmp/_ts_model.tml"],
-                         capture_output=True, text=True, env=env)
-    if out.returncode:
-        raise RuntimeError("convert failed: " + out.stderr[-300:])
-    conv = json.loads(out.stdout)
+def resolve_workdir(arg):
+    wd = arg or os.environ.get("TS_WORKDIR") or os.path.join(os.getcwd(), "ts-migration")
+    wd = os.path.abspath(os.path.expanduser(wd))
+    os.makedirs(wd, exist_ok=True)
+    return wd
+
+def convert_model(model_tml, wd, converted_path):
+    """Return the converter output dict {model, stats?, warnings?} via one of the
+    three converter paths (see module docstring). Exits 3 on the MCP-fallback
+    pass-1 (request emitted, awaiting --converted)."""
+    if converted_path:                                   # path 1: MCP tool output
+        conv = json.load(open(converted_path))
+        if "sigmaDataModel" in conv:                     # MCP tool wraps under sigmaDataModel
+            conv = {**conv, "model": conv["sigmaDataModel"]}
+        elif "model" not in conv:                        # bare DM spec → wrap
+            conv = {"model": conv, "stats": {}, "warnings": []}
+        return conv
+    if os.environ.get("CONVERTER_PATH"):                 # path 2: local one-shot
+        tml_path = os.path.join(wd, "model.tml")
+        open(tml_path, "w").write(model_tml)
+        out = subprocess.run(["node", os.path.join(HERE, "convert_model.mjs"), tml_path],
+                             capture_output=True, text=True, env=dict(os.environ))
+        if out.returncode:
+            raise RuntimeError("convert failed: " + out.stderr[-300:])
+        return json.loads(out.stdout)
+    # path 3: MCP fallback — emit the exact conversion request and stop.
+    tml_path = os.path.join(wd, "model.tml")
+    open(tml_path, "w").write(model_tml)
+    req = {"tool": MCP_TOOL,
+           "arguments": {"tml_yaml": model_tml,
+                         "connection_id": os.environ.get("SIGMA_CONNECTION_ID", ""),
+                         "database": os.environ.get("TS_DB", ""),
+                         "schema": os.environ.get("TS_SCHEMA", "")}}
+    req_path = os.path.join(wd, "convert-request.json")
+    json.dump(req, open(req_path, "w"), indent=2)
+    print(f"""
+No local converter build (CONVERTER_PATH unset) — use the MCP converter:
+
+  1. Call the `{MCP_TOOL}` MCP tool with the arguments in
+       {req_path}
+     (tml_yaml = contents of {tml_path},
+      connection_id = $SIGMA_CONNECTION_ID, database = $TS_DB, schema = $TS_SCHEMA).
+  2. Save the tool's JSON output (the {{sigmaDataModel, stats, warnings}} object,
+     or just the model spec) to {wd}/converted.json
+  3. Re-run this command with:  --converted {wd}/converted.json
+""")
+    sys.exit(3)
+
+def build_dm(conv, name, folder):
+    """POST the converted Sigma data model. Returns (dmId, denormElemId, denormName)."""
     spec = conv["model"]; spec["name"] = name
-    res = json.loads(sigma("POST", "/v2/dataModels/spec", {"folderId": FOLDER, **spec}))
+    res = json.loads(sigma("POST", "/v2/dataModels/spec", {"folderId": folder, **spec}))
     dm = res["dataModelId"]
     # discover the denormalized "<root> View" element from the posted DM spec
     dmspec = yaml.safe_load(sigma("GET", f"/v2/dataModels/{dm}/spec"))
@@ -53,102 +119,148 @@ def build_dm(model_tml, name):
     if not denorm:
         # no joins → no denormalized view; use the base fact element (most columns).
         denorm = max(els, key=lambda e: len(e.get("columns", [])))
+    stats = conv.get("stats") or {}
     print(f"  DM {dm}  ·  denorm '{denorm['name']}' ({denorm['id']})  ·  "
-          f"{conv['stats']['relationships']} rels, {conv['stats']['elements']} elements")
+          f"{stats.get('relationships', '?')} rels, {stats.get('elements', '?')} elements")
     return dm, denorm["id"], denorm["name"]
 
-def migrate_liveboard(lb_id, dm, denorm_id, denorm_name, resolver, name):
-    edoc, err = ts_lib.export_tml(lb_id, "LIVEBOARD")
-    if err:
-        raise RuntimeError("export failed: " + err)
-    lb = yaml.safe_load(edoc)["liveboard"]
-    specs = [ps for v in lb["visualizations"] if (ps := ts_common.parse_ts_viz(v))]
-    master = ts_common.master_element(specs, resolver, dm, denorm_id, denorm_name)
-    elements = [ts_common.sigma_element(s, resolver) for s in specs]
-    spec = {"name": f"{name} (from ThoughtSpot)", "folderId": FOLDER, "schemaVersion": 1,
-            "pages": [{"id": "p-data", "name": "Data", "elements": [master]},
-                      {"id": "p-main", "name": name[:40], "elements": elements}]}
-    import re
+def post_workbook(spec, wd):
     resp = sigma("POST", "/v2/workbooks/spec", spec)
     m = re.search(r'workbookId["\s:]+([0-9a-f-]{36})', resp)
-    wb = m.group(1) if m else None
-    if not wb:
+    if not m:
         raise RuntimeError("workbook POST: " + resp[:300])
-    if wb:
-        apply_layouts.apply(wb)
-    return wb, len(specs)
+    wb = m.group(1)
+    with open(os.path.join(wd, "posted-workbooks.jsonl"), "a") as f:
+        f.write(json.dumps({"id": wb, "name": spec.get("name")}) + "\n")
+    return wb
 
-def migrate_answer(ans_id, dm, denorm_id, denorm_name, resolver, name):
+def lb_tiles(lb, viz_specs, elements):
+    """Map the Liveboard's layout.tiles (ThoughtSpot 12-col grid) to the built
+    Sigma elements, in viz order. Returns None when geometry is incomplete
+    (apply_layouts falls back to its auto grid)."""
+    by_viz = {t.get("visualization_id"): t for t in ((lb.get("layout") or {}).get("tiles") or [])}
+    tiles = []
+    for (viz_id, _), el in zip(viz_specs, elements):
+        t = by_viz.get(viz_id)
+        if not t:
+            return None
+        tiles.append({"element_id": el["id"], "x": t.get("x", 0), "y": t.get("y", 0),
+                      "width": t.get("width", 6), "height": t.get("height", 6)})
+    return tiles or None
+
+def migrate_liveboard(lb_doc, dm, denorm_id, denorm_name, resolver, prefix, fallback_name, folder, wd):
+    lb = yaml.safe_load(lb_doc)["liveboard"]
+    display = lb.get("name") or fallback_name          # never name a workbook after a UUID
+    viz_specs = [(v.get("id"), ps) for v in lb["visualizations"] if (ps := ts_common.parse_ts_viz(v))]
+    specs = [ps for _, ps in viz_specs]
+    master = ts_common.master_element(specs, resolver, dm, denorm_id, denorm_name)
+    elements = [ts_common.sigma_element(s, resolver) for s in specs]
+    spec = {"name": f"{prefix}{display} (from ThoughtSpot)", "folderId": folder, "schemaVersion": 1,
+            "pages": [{"id": "p-data", "name": "Data", "elements": [master]},
+                      {"id": "p-main", "name": display[:40], "elements": elements}]}
+    wb = post_workbook(spec, wd)
+    tiles = lb_tiles(lb, viz_specs, elements)
+    apply_layouts.apply(wb, tiles=tiles)
+    return wb, display, len(specs), tiles
+
+def migrate_answer(ans_id, dm, denorm_id, denorm_name, resolver, prefix, folder, wd):
     """A standalone Answer is a single viz — build a one-element workbook."""
+    import ts_lib
     edoc, err = ts_lib.export_tml(ans_id, "ANSWER")
     if err:
         raise RuntimeError("export failed: " + err)
-    spec_v = ts_common.parse_ts_viz({"answer": yaml.safe_load(edoc)["answer"]})
+    ans = yaml.safe_load(edoc)["answer"]
+    display = ans.get("name") or ("Answer " + ans_id[:8])
+    spec_v = ts_common.parse_ts_viz({"answer": ans})
     master = ts_common.master_element([spec_v], resolver, dm, denorm_id, denorm_name)
-    spec = {"name": f"{name} (from ThoughtSpot)", "folderId": FOLDER, "schemaVersion": 1,
+    spec = {"name": f"{prefix}{display} (from ThoughtSpot)", "folderId": folder, "schemaVersion": 1,
             "pages": [{"id": "p-data", "name": "Data", "elements": [master]},
-                      {"id": "p-main", "name": name[:40], "elements": [ts_common.sigma_element(spec_v, resolver)]}]}
-    import re
-    resp = sigma("POST", "/v2/workbooks/spec", spec)
-    m = re.search(r'workbookId["\s:]+([0-9a-f-]{36})', resp)
-    wb = m.group(1) if m else None
-    if not wb:
-        raise RuntimeError("workbook POST: " + resp[:300])
+                      {"id": "p-main", "name": display[:40], "elements": [ts_common.sigma_element(spec_v, resolver)]}]}
+    wb = post_workbook(spec, wd)
     apply_layouts.apply(wb)
-    return wb
+    return wb, display
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--model", required=True, help="ThoughtSpot model (LOGICAL_TABLE) id")
+    ap.add_argument("--model", help="ThoughtSpot model (LOGICAL_TABLE) id")
+    ap.add_argument("--model-tml", help="offline: read the model TML from a file (see fixtures/)")
     ap.add_argument("--liveboard", action="append", help="specific Liveboard id(s); default = all that read the model")
+    ap.add_argument("--liveboard-tml", action="append", help="offline: read Liveboard TML from file(s)")
     ap.add_argument("--answer", action="append", help="standalone Answer id(s) to migrate as one-element workbooks")
-    ap.add_argument("--name", default=None, help="name prefix (default: the model name)")
+    ap.add_argument("--name", default=None, help="name PREFIX applied to BOTH the data model and every workbook")
+    ap.add_argument("--workdir", default=None, help="working dir for artifacts (default $TS_WORKDIR or ./ts-migration)")
+    ap.add_argument("--converted", default=None, help="JSON output of the convert_thoughtspot_to_sigma MCP tool")
     a = ap.parse_args()
+    wd = resolve_workdir(a.workdir)
+    offline = bool(a.model_tml)
+    if not a.model and not a.model_tml:
+        ap.error("--model or --model-tml required")
 
-    model_tml, err = ts_lib.export_tml(a.model, "LOGICAL_TABLE")
-    if err:
-        sys.exit("model export failed: " + err)
+    if offline:
+        model_tml = open(a.model_tml).read()
+    else:
+        import ts_lib
+        model_tml, err = ts_lib.export_tml(a.model, "LOGICAL_TABLE")
+        if err:
+            sys.exit("model export failed: " + err)
     root = yaml.safe_load(model_tml)
     root = root.get("model") or root.get("worksheet") or root
-    model_name = a.name or root.get("name", "Migrated Model")
+    model_name = root.get("name", "Migrated Model")
+    prefix = (a.name.strip() + " ") if a.name else ""
     resolver = ts_common.build_resolver(root)
-    print(f"Model '{model_name}': {len(resolver)} resolvable columns")
+    print(f"Model '{model_name}': {len(resolver)} resolvable columns  ·  workdir {wd}")
 
-    dm, denorm_id, denorm_name = build_dm(model_tml, f"{model_name} (from ThoughtSpot)")
+    conv = convert_model(model_tml, wd, a.converted)
+    folder = need_env("SIGMA_FOLDER_ID")[0]
+    dm, denorm_id, denorm_name = build_dm(conv, f"{prefix}{model_name} (from ThoughtSpot)", folder)
 
-    # pick Liveboards: explicit, or every Liveboard that references this model name
-    if a.liveboard:
-        targets = [(x, x) for x in a.liveboard]
+    # pick Liveboards: offline TML files, explicit ids, or every Liveboard that references the model
+    targets = []                                       # (lb_doc, fallback_name)
+    if a.liveboard_tml:
+        targets = [(open(p).read(), os.path.basename(p)) for p in a.liveboard_tml]
+    elif offline:
+        pass                                           # offline with no liveboard TML → DM only
     else:
-        targets = []
-        for lb in ts_lib.search("LIVEBOARD"):
-            edoc, e = ts_lib.export_tml(lb["metadata_id"], "LIVEBOARD")
-            if e:
-                continue
-            if model_name in edoc:
-                targets.append((lb["metadata_id"], lb["metadata_name"]))
+        import ts_lib
+        if a.liveboard:
+            for lb_id in a.liveboard:
+                edoc, e = ts_lib.export_tml(lb_id, "LIVEBOARD")
+                if e:
+                    print(f"  ✗ liveboard {lb_id}: export failed: {e}"); continue
+                targets.append((edoc, lb_id))
+        else:
+            for lb in ts_lib.search("LIVEBOARD"):
+                edoc, e = ts_lib.export_tml(lb["metadata_id"], "LIVEBOARD")
+                if e:
+                    continue
+                if model_name in edoc:
+                    targets.append((edoc, lb["metadata_name"]))
     print(f"Migrating {len(targets)} Liveboard(s)…")
 
     results = {}
-    for lb_id, lb_name in targets:
+    for lb_doc, fallback in targets:
         try:
-            wb, n = migrate_liveboard(lb_id, dm, denorm_id, denorm_name, resolver, lb_name)
-            results[lb_name] = {"liveboard": lb_id, "workbook": wb, "viz": n}
-            print(f"  ✓ {lb_name[:34]:34s} WB {wb} ({n} viz)")
+            wb, display, n, tiles = migrate_liveboard(lb_doc, dm, denorm_id, denorm_name,
+                                                      resolver, prefix, fallback, folder, wd)
+            results[display] = {"workbook": wb, "viz": n, "tiles": tiles}
+            print(f"  ✓ {display[:34]:34s} WB {wb} ({n} viz, layout={'TML tiles' if tiles else 'auto grid'})")
         except Exception as ex:
-            results[lb_name] = {"error": str(ex)}
-            print(f"  ✗ {lb_name[:34]:34s} {ex}")
+            results[fallback] = {"error": str(ex)}
+            print(f"  ✗ {fallback[:34]:34s} {ex}")
     for ans_id in (a.answer or []):
         try:
-            wb = migrate_answer(ans_id, dm, denorm_id, denorm_name, resolver, "Answer " + ans_id[:8])
-            results["answer:" + ans_id] = {"answer": ans_id, "workbook": wb}
-            print(f"  ✓ answer {ans_id[:8]}  WB {wb}")
+            wb, display = migrate_answer(ans_id, dm, denorm_id, denorm_name, resolver, prefix, folder, wd)
+            results[display] = {"answer": ans_id, "workbook": wb}
+            print(f"  ✓ answer {display[:26]:26s} WB {wb}")
         except Exception as ex:
             results["answer:" + ans_id] = {"error": str(ex)}
             print(f"  ✗ answer {ans_id[:8]}  {ex}")
-    json.dump({"model": a.model, "dataModel": dm, "results": results},
-              open(os.path.expanduser("~/thoughtspot-migration/migrate_out.json"), "w"), indent=2)
-    print(f"\nDM: {dm}  ·  {sum(1 for r in results.values() if r.get('workbook'))}/{len(targets)} workbooks")
+    wbs = [r["workbook"] for r in results.values() if r.get("workbook")]
+    json.dump({"model": a.model or a.model_tml, "dataModel": dm, "results": results},
+              open(os.path.join(wd, "migrate_out.json"), "w"), indent=2)
+    if len(wbs) == 1:        # convenience for the parity gate (assert-phase6-ran.rb)
+        json.dump({"workbookId": wbs[0]}, open(os.path.join(wd, "wb-ids.json"), "w"))
+    print(f"\nDM: {dm}  ·  {len(wbs)}/{len(targets)} workbooks  ·  manifest {wd}/migrate_out.json")
 
 if __name__ == "__main__":
     main()

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/phase6-parity-thoughtspot.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/phase6-parity-thoughtspot.rb
@@ -1,0 +1,204 @@
+#!/usr/bin/env ruby
+# Parity gate (MANDATORY) — verify Sigma chart values match the ThoughtSpot source.
+#
+# The EXPECTED side comes from ThoughtSpot itself (`ts_lib.searchdata` runs the
+# viz's search query against the model — ground truth) or, when live TS access
+# is gone (offline/fixture runs), from the warehouse: compute each chart's
+# aggregation with a warehouse SQL query (mcp__sigma-mcp-v2__query
+# type=connection over the same tables the model reads). The ACTUAL side is
+# the built Sigma element. This script orchestrates both passes and writes the
+# parity-final.json sentinel that assert-phase6-ran.rb (the hard gate) requires.
+# Two-pass design mirrors quicksight's phase6-parity-quicksight.rb.
+#
+# PASS 1 — read the workbook spec, enumerate chart elements, emit per-chart
+# fetch instructions:
+#
+#   ruby scripts/phase6-parity-thoughtspot.rb --workdir <dir> --workbook-id <wb>
+#
+#   Writes <workdir>/parity-plan.json and prints, per chart:
+#     - the mcp__sigma-mcp-v2__query call for the Sigma ACTUAL rows
+#     - a reminder to fetch EXPECTED rows from ThoughtSpot (searchdata) or
+#       the warehouse with the same dimension + aggregation
+#
+#   The agent then writes two JSON files keyed by chart name, each
+#   { "<chart name>": [[dim, val], ...], ... } :
+#     <workdir>/parity-expected.json   (ThoughtSpot / warehouse ground truth)
+#     <workdir>/parity-actuals.json    (Sigma element rows)
+#   KPI charts have no dimension — use [[null, <value>]].
+#
+# PASS 2 — finalize:
+#
+#   ruby scripts/phase6-parity-thoughtspot.rb --workdir <dir> --finalize \
+#     [--expected <workdir>/parity-expected.json] \
+#     [--actuals  <workdir>/parity-actuals.json] \
+#     [--extract-mode] [--extract-tol 0.30]
+#
+#   Runs verify-parity.rb, prints the pass/fail summary, writes
+#   parity-final.txt + parity-final.json (the hard-gate sentinel).
+#
+# Plain `table` elements aren't auto-planned (no single dim/measure axis) —
+# query-verify those manually and note it in the migration report.
+
+require 'json'
+require 'optparse'
+require 'open3'
+require 'time'
+
+opts = { extract_mode: false, extract_tol: 0.30, finalize: false }
+OptionParser.new do |p|
+  p.on('--workdir DIR')          { |v| opts[:dir] = v }
+  p.on('--workbook-id ID')       { |v| opts[:wb] = v }
+  p.on('--finalize')             { opts[:finalize] = true }
+  p.on('--expected PATH')        { |v| opts[:expected] = v }
+  p.on('--actuals PATH')         { |v| opts[:actuals] = v }
+  p.on('--extract-mode')         { opts[:extract_mode] = true }
+  p.on('--extract-tol F', Float) { |v| opts[:extract_tol] = v }
+end.parse!
+abort('missing --workdir') unless opts[:dir]
+
+plan_path = File.join(opts[:dir], 'parity-plan.json')
+
+def parse_spec(body)
+  JSON.parse(body)
+rescue JSON::ParserError
+  require 'yaml'
+  require 'date'
+  YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+end
+
+# Resolve the (dim, val) columns for a chart element, by kind. Returns
+# [[dim_id, dim_name], [val_id, val_name]] (dim pair nil for KPI) or nil if not
+# plannable. The IDs matter: sigma-mcp-v2 workbook queries resolve COLUMN IDS, not
+# display labels — SQL emitted against display names fails to resolve.
+def chart_columns(el)
+  cols = el['columns'] || []
+  by_id = cols.each_with_object({}) { |c, h| h[c['id']] = c['name'] }
+  case el['kind']
+  when 'kpi-chart'
+    vid = el.dig('value', 'columnId') || el.dig('value', 'id')
+    by_id[vid] && [nil, [vid, by_id[vid]]]
+  when 'pie-chart', 'donut-chart'
+    did = el.dig('color', 'id') || el.dig('color', 'columnId')
+    vid = el.dig('value', 'id') || el.dig('value', 'columnId')
+    by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
+  else # bar-chart, line-chart, combo-chart, scatter-chart, ...
+    did = el.dig('xAxis', 'columnId')
+    vid = Array(el.dig('yAxis', 'columnIds')).first
+    vid = vid['columnId'] if vid.is_a?(Hash) # combo dual-axis object form
+    by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
+  end
+end
+
+if !opts[:finalize]
+  abort('--workbook-id required for pass 1') unless opts[:wb]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+
+  warn "Parity PASS 1: reading workbook spec #{opts[:wb]}"
+  # binary:true returns the raw body — the spec endpoint answers in YAML even
+  # when asked for JSON, so parse both.
+  raw = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec", binary: true)
+  spec = parse_spec(raw)
+  File.write(File.join(opts[:dir], 'wb-readback.json'), JSON.pretty_generate(spec))
+
+  charts = []
+  Array(spec['pages']).each do |page|
+    Array(page['elements']).each do |el|
+      next unless el['kind'].to_s.end_with?('-chart')
+      pairs = chart_columns(el)
+      next unless pairs
+      charts << { 'chart' => el['name'], 'sigma_element_id' => el['id'],
+                  'kind' => el['kind'],
+                  'sigma_columns' => pairs.compact.map { |id_name| id_name[1] },
+                  'sigma_column_ids' => pairs.compact.map { |id_name| id_name[0] },
+                  'workbook_id' => opts[:wb] }
+    end
+  end
+  abort('no plannable chart elements found in the workbook spec') if charts.empty?
+
+  File.write(plan_path, JSON.pretty_generate({ 'charts' => charts }))
+
+  puts ''
+  puts '=' * 70
+  puts 'PARITY PASS 1 — fetch ACTUAL (Sigma) and EXPECTED (ThoughtSpot/warehouse)'
+  puts '=' * 70
+  puts ''
+  puts 'For each chart: run the mcp__sigma-mcp-v2__query below for the Sigma'
+  puts 'ACTUAL rows, and fetch the EXPECTED rows from ThoughtSpot via'
+  puts 'ts_lib.searchdata (the viz search query against the model — ground'
+  puts 'truth) or, offline, by running the equivalent dimension+aggregation'
+  puts 'against the warehouse tables the model reads (type=connection query).'
+  puts "Write both files, then re-run with --finalize:"
+  puts "  #{opts[:dir]}/parity-expected.json  { \"<chart>\": [[dim, val], ...] }"
+  puts "  #{opts[:dir]}/parity-actuals.json   { \"<chart>\": [[dim, val], ...] }"
+  puts 'KPI charts: a single row [[null, <value>]].'
+  puts ''
+  charts.each_with_index do |c, i|
+    # Query by COLUMN ID (sigma-mcp-v2 can't resolve display labels in workbook
+    # queries); the display names ride along in a trailing SQL comment for readability.
+    ids = c['sigma_column_ids']
+    names = c['sigma_columns']
+    sql = if ids.length >= 2
+            %(SELECT "#{ids[0]}" AS dim, "#{ids[1]}" AS val FROM "workbook"."#{c['sigma_element_id']}" ORDER BY dim NULLS FIRST -- dim: #{names[0]}, val: #{names[1]})
+          else
+            %(SELECT "#{ids[0]}" AS val FROM "workbook"."#{c['sigma_element_id']}" -- val: #{names[0]})
+          end
+    puts "  [#{i + 1}/#{charts.length}] #{c['chart']} (#{c['kind']})"
+    puts "    mcp__sigma-mcp-v2__query  type=workbook  workbookId=#{opts[:wb]}"
+    puts "    sql=#{sql.inspect}"
+    puts ''
+  end
+  puts '=' * 70
+  exit 0
+end
+
+# PASS 2 — finalize
+abort("plan not found at #{plan_path}; run pass 1 first") unless File.exist?(plan_path)
+opts[:expected] ||= File.join(opts[:dir], 'parity-expected.json')
+opts[:actuals]  ||= File.join(opts[:dir], 'parity-actuals.json')
+abort("expected file missing: #{opts[:expected]}") unless File.exist?(opts[:expected])
+abort("actuals file missing: #{opts[:actuals]}")   unless File.exist?(opts[:actuals])
+
+plan = JSON.parse(File.read(plan_path))
+expected = JSON.parse(File.read(opts[:expected]))
+actuals  = JSON.parse(File.read(opts[:actuals]))
+
+warn "Parity PASS 2: injecting expected (#{expected.size}) + actuals (#{actuals.size}) → #{plan_path}"
+plan['charts'].each do |c|
+  c['expected'] = expected[c['chart']] if expected[c['chart']]
+  c['actual']   = { 'rows' => actuals[c['chart']] } if actuals[c['chart']]
+end
+File.write(plan_path, JSON.pretty_generate(plan))
+
+missing = plan['charts'].reject { |c| c['expected'] && c['actual'] }
+missing.each { |c| warn "WARN: no expected/actual rows supplied for #{c['chart'].inspect} — it will DIVERGE" }
+
+warn "Parity PASS 2: running verifier (#{opts[:extract_mode] ? 'extract-mode' : 'strict'})"
+verifier_args = ['ruby', File.join(__dir__, 'verify-parity.rb'), '--plan', plan_path]
+verifier_args.concat(['--extract-mode', '--extract-tol', opts[:extract_tol].to_s]) if opts[:extract_mode]
+out, err, status = Open3.capture3(*verifier_args)
+puts out
+warn err unless err.empty?
+File.write(File.join(opts[:dir], 'parity-final.txt'), out)
+
+# Hard-gate sentinel consumed by assert-phase6-ran.rb (same contract as the
+# tableau-to-sigma Phase 6 sentinel — see beads-sigma-4pm for why it exists).
+total  = plan['charts'].size
+passed = out.scan(/^PASS\s+\[[^\]]+\]\s+(.+)$/).flatten.map(&:strip)
+failed = out.scan(/^DIVERGE\s+\[[^\]]+\]\s+(.+)$/).flatten.map(&:strip)
+summary = {
+  'workbook_id'  => plan.dig('charts', 0, 'workbook_id'),
+  'ran_at'       => Time.now.utc.iso8601,
+  'mode'         => opts[:extract_mode] ? 'extract' : 'strict',
+  'extract_tol'  => opts[:extract_mode] ? opts[:extract_tol] : nil,
+  'charts_total' => total,
+  'charts_pass'  => passed.size,
+  'charts_fail'  => failed.size,
+  'pass_names'   => passed,
+  'fail_names'   => failed,
+  'status'       => (status.success? && total > 0 && passed.size == total) ? 'PASS' : 'FAIL'
+}
+summary_path = File.join(opts[:dir], 'parity-final.json')
+File.write(summary_path, JSON.pretty_generate(summary))
+warn "wrote #{summary_path} (status=#{summary['status']} #{summary['charts_pass']}/#{summary['charts_total']})"
+exit(status.success? ? 0 : 2)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
@@ -10,7 +10,7 @@ Sigma denorm element suffixes joined-table columns with the relationship name
 (e.g. "Category (PRODUCT_DIM)"). Rather than hardcode that mapping, `build_resolver`
 derives it from the model TML itself, so it works for ANY model.
 """
-import re, secrets, string
+import json, re, secrets, string
 
 SIGMA_LOWERCASE_WORDS = {'a','an','the','and','but','or','for','nor','so','yet',
                          'at','by','in','of','on','to','up','as','into','via','per'}
@@ -101,18 +101,61 @@ def ts_viz(idx, spec):
     return {"id": f"Viz_{idx}", "answer": a}
 
 # ── Migration side: parse a Liveboard viz -> {name, chart, dims, measures} ────
+def _strip_total(c):
+    return c[len("Total "):] if c.startswith("Total ") else c
+
 def parse_ts_viz(v):
     a = v.get("answer")
     if not a:
         return None
     cols = [c["name"] for c in a.get("answer_columns", [])]
-    measures = [c[len("Total "):] for c in cols if c.startswith("Total ")]
+    # Column ORDER must follow the TML's table.ordered_column_ids (the order the
+    # user arranged) — answer_columns is alphabetical, which scrambles multi-
+    # measure tables (e.g. Region Performance: Gross Profit before Net Revenue).
+    ordered = (a.get("table") or {}).get("ordered_column_ids") or []
+    if ordered:
+        known = set(cols)
+        cols = [c for c in ordered if c in known] + [c for c in cols if c not in set(ordered)]
+    measures = [_strip_total(c) for c in cols if c.startswith("Total ")]
     dims = [c for c in cols if not c.startswith("Total ")]
     ctype = (a.get("chart") or {}).get("type", "TABLE")
     if a.get("display_mode") == "TABLE_MODE":
         ctype = "TABLE"
     return {"name": a.get("name", "Viz"), "chart": ctype, "dims": dims, "measures": measures,
-            "filters": parse_filters(a.get("search_query", ""))}
+            "filters": parse_filters(a.get("search_query", "")), "sorts": parse_sorts(a)}
+
+def parse_sorts(a):
+    """Carry the answer's sorts: (1) `sort by [Col] descending` tokens in the
+    search query; (2) sortInfo entries in the table/chart client_state(_v2)
+    JSON. Returns [{"col": <model column name>, "direction": asc|desc}],
+    deduped (first wins). 'Total X' columns resolve to the measure name X."""
+    out = []
+    for m in re.finditer(r"sort\s+by\s+\[([^\]]+)\]\s*(descending|ascending)?",
+                         a.get("search_query", ""), re.I):
+        out.append({"col": _strip_total(m.group(1)),
+                    "direction": (m.group(2) or "ascending").lower()})
+    for holder in (a.get("table") or {}), (a.get("chart") or {}):
+        for key in ("client_state_v2", "client_state"):
+            raw = holder.get(key) or ""
+            if not raw.strip():
+                continue
+            try:
+                cs = json.loads(raw, strict=False)
+            except (ValueError, TypeError):
+                continue
+            for si in (cs.get("sortInfo") or []) if isinstance(cs, dict) else []:
+                col = si.get("columnId") or si.get("columnName") or si.get("name")
+                if not col:
+                    continue
+                asc = si.get("isAscending", si.get("ascending", si.get("sortAscending", True)))
+                out.append({"col": _strip_total(col),
+                            "direction": "ascending" if asc else "descending"})
+    seen, res = set(), []
+    for s in out:
+        if s["col"] in seen:
+            continue
+        seen.add(s["col"]); res.append(s)
+    return res
 
 def parse_filters(search_query):
     """Extract simple filter clauses from a ThoughtSpot search query:
@@ -170,7 +213,35 @@ def sigma_element(spec, resolver, master="OFV"):
             col_id = nid("f"); el["columns"].append({"id": col_id, "formula": f"[{master}/{e['friendly']}]", "name": f["col"]})
         el.setdefault("filters", []).append({"id": nid(), "columnId": col_id, "kind": "list",
                                              "mode": f["mode"], "values": f["values"]})
+    _apply_sorts(el, spec)
     return el
+
+def _apply_sorts(el, spec):
+    """TML sorts → Sigma. Verified shapes (looker-to-sigma build_workbook.py,
+    live POST + readback + render, 2026-06-10):
+      bar/line/area/scatter/combo : xAxis.sort  = {by: <colId>, direction}
+      pie/donut                   : color.sort  = {by: <colId>, direction}
+      UNGROUPED table             : element sort = [{columnId, direction}]
+      GROUPED table               : groupings[0].sort = [{columnId, direction}]
+        (element-level sort on a grouped table 400s with "Sort column not found")
+    """
+    for si, s in enumerate(spec.get("sorts") or []):
+        col = next((c for c in el.get("columns", [])
+                    if c.get("name") in (s["col"], "Total " + s["col"])), None)
+        if not col:
+            continue
+        d = s["direction"]; k = el.get("kind")
+        if k in ("bar-chart", "line-chart", "area-chart", "scatter-chart", "combo-chart"):
+            if si == 0 and "xAxis" in el:
+                el["xAxis"]["sort"] = {"by": col["id"], "direction": d}
+        elif k in ("pie-chart", "donut-chart"):
+            if si == 0 and "color" in el:
+                el["color"]["sort"] = {"by": col["id"], "direction": d}
+        elif k == "table":
+            if el.get("groupings"):
+                el["groupings"][0].setdefault("sort", []).append({"columnId": col["id"], "direction": d})
+            else:
+                el.setdefault("sort", []).append({"columnId": col["id"], "direction": d})
 
 def _element_core(spec, resolver, master="OFV"):
     name, chart, dims, meas = spec["name"], spec["chart"], spec["dims"], spec["measures"]

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_screenshot.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_screenshot.py
@@ -7,16 +7,52 @@ file_format PNG + visualization_identifiers → PNG bytes (per viz).
 Sigma side (counterpart): POST /v2/workbooks/{id}/export {elementId, format:{type:png,
 pixelWidth,pixelHeight}} → poll GET /v2/query/{queryId}/download). Render both, compare side by side.
 
+Blank-render guard: when the Liveboard's warehouse connection is down,
+ThoughtSpot still returns HTTP 200 with a near-uniform placeholder PNG (or an
+error body). Those are reported as ✗ failures (exit 1), never ✓.
+
 Usage:
   python3 ts_screenshot.py <LIVEBOARD_ID> [outdir]      # all viz in the liveboard
   python3 ts_screenshot.py <LIVEBOARD_ID> --viz <guid>  # one viz
-Env: TS_HOST, TS_TOKEN.
+Env: TS_HOST, TS_TOKEN, TS_WORKDIR (default outdir = <TS_WORKDIR or ./ts-migration>/png).
 """
-import os, sys, json, ssl, urllib.request, urllib.error, re
+import os, sys, json, ssl, struct, urllib.request, urllib.error, re, zlib
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import yaml, ts_lib
 yaml.SafeLoader.add_constructor("tag:yaml.org,2002:value", lambda l, n: l.construct_scalar(n))
 _SSL = ssl._create_unverified_context()
+
+def png_health(data):
+    """Heuristic blank/placeholder detection without PIL. Returns (ok, reason).
+    A connection-error placeholder renders as a (near-)uniform image: its PNG
+    filter output is almost all zero bytes after decompression. An error body
+    (JSON/HTML returned with HTTP 200) isn't a PNG at all."""
+    if len(data) < 1000:
+        return False, f"suspiciously small response ({len(data)} bytes)"
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        head = data[:120].decode("utf-8", "replace")
+        return False, "not a PNG (error body?): " + re.sub(r"\s+", " ", head)
+    pos, idat, w, h = 8, b"", 0, 0
+    while pos + 8 <= len(data):
+        ln, typ = struct.unpack(">I4s", data[pos:pos + 8])
+        chunk = data[pos + 8:pos + 8 + ln]
+        if typ == b"IHDR":
+            w, h = struct.unpack(">II", chunk[:8])
+        elif typ == b"IDAT":
+            idat += chunk
+        elif typ == b"IEND":
+            break
+        pos += 12 + ln
+    try:
+        raw = zlib.decompress(idat)
+    except zlib.error:
+        return False, "corrupt PNG (IDAT does not decompress)"
+    if not raw:
+        return False, "empty PNG payload"
+    zero_frac = raw.count(0) / len(raw)
+    if zero_frac > 0.995:
+        return False, f"near-uniform render ({zero_frac:.1%} blank) — likely a connection-error placeholder"
+    return True, f"{w}x{h}, {zero_frac:.0%} blank"
 
 def viz_png(lb_id, viz_guid, out_path):
     body = json.dumps({"metadata_identifier": lb_id, "file_format": "PNG",
@@ -25,6 +61,9 @@ def viz_png(lb_id, viz_guid, out_path):
         data=body, method="POST",
         headers={"Authorization": f"Bearer {ts_lib.TOKEN}", "Content-Type": "application/json"})
     data = urllib.request.urlopen(req, context=_SSL).read()
+    ok, reason = png_health(data)
+    if not ok:
+        raise RuntimeError(reason)
     open(out_path, "wb").write(data)
     return len(data)
 
@@ -43,19 +82,24 @@ def main():
     if len(sys.argv) < 2:
         sys.exit(__doc__)
     lb_id = sys.argv[1]
-    outdir = next((a for a in sys.argv[2:] if not a.startswith("--")), os.path.expanduser("~/thoughtspot-migration/png"))
+    default_dir = os.path.join(os.environ.get("TS_WORKDIR") or os.path.join(os.getcwd(), "ts-migration"), "png")
+    outdir = next((a for a in sys.argv[2:] if not a.startswith("--")), default_dir)
     os.makedirs(outdir, exist_ok=True)
     if "--viz" in sys.argv:
         vizzes = [(sys.argv[sys.argv.index("--viz") + 1], "viz")]
     else:
         vizzes = liveboard_vizzes(lb_id)
+    failed = 0
     for guid, name in vizzes:
         safe = re.sub(r"[^\w.-]+", "_", name)[:40]
         path = os.path.join(outdir, f"{safe}.png")
         try:
             n = viz_png(lb_id, guid, path); print(f"  ✓ {name[:40]:40s} {n} bytes -> {path}")
         except Exception as e:
+            failed += 1
             print(f"  ✗ {name[:40]:40s} {e}")
+    if failed:
+        sys.exit(f"\n{failed}/{len(vizzes)} renders FAILED (blank/placeholder renders count as failures)")
 
 if __name__ == "__main__":
     main()

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-parity.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-parity.rb
@@ -1,0 +1,195 @@
+#!/usr/bin/env ruby
+# Parity verification: compare expected (from Tableau CSVs) vs actual
+# (from Sigma queries) for each chart in a plan.
+#
+# Plan format (JSON array):
+#   [{ "chart": "...",
+#      "expected": [[dim, val], ...],
+#      "actual":   { "rows": [[dim, val], ...] },
+#      "extract":  true|false   # optional per-chart override
+#   }]
+#
+# A top-level wrapper is also accepted:
+#   { "extract": true, "charts": [ ... ] }
+# in which case `extract` propagates to every chart.
+#
+# --strict      value-exact comparison (default)
+# --extract-mode  structural comparison only — when Tableau view CSVs come from
+#                 a workbook with hasExtracts=true, the absolute values can drift
+#                 from Sigma (live warehouse) while the chart shape is correct.
+#                 Extract-mode checks:
+#                   - same number of buckets (rows)
+#                   - same set of dimension values
+#                   - same sort order on the dimension column
+#                   - measure values within `--extract-tol` relative tolerance
+#                     (default 0.30 = 30%) IF both are non-null, otherwise skipped
+#
+# Usage:
+#   ruby verify-parity.rb --plan plan.json
+#   ruby verify-parity.rb --plan plan.json --extract-mode
+#   ruby verify-parity.rb --plan plan.json --extract-mode --extract-tol 0.50
+
+require 'json'
+require 'set'
+require 'optparse'
+
+opts = { mode: :strict, tol: 0.30 }
+OptionParser.new do |p|
+  p.on('--plan P')              { |v| opts[:plan] = v }
+  p.on('--extract-mode')        {     opts[:mode] = :extract }
+  p.on('--extract-tol TOL', Float) { |v| opts[:tol] = v }
+end.parse!
+abort('--plan required') unless opts[:plan]
+
+MONTH_NUM = {
+  'january' => 1, 'february' => 2, 'march' => 3, 'april' => 4, 'may' => 5, 'june' => 6,
+  'july' => 7, 'august' => 8, 'september' => 9, 'october' => 10, 'november' => 11, 'december' => 12,
+  'jan' => 1, 'feb' => 2, 'mar' => 3, 'apr' => 4, 'jun' => 6,
+  'jul' => 7, 'aug' => 8, 'sep' => 9, 'sept' => 9, 'oct' => 10, 'nov' => 11, 'dec' => 12
+}.freeze
+
+# Canonicalize date-like dimension values so monthly buckets compare equal across
+# representations (e.g. Sigma raw SQL "2026-01-01T00:00:00.000" vs Tableau view
+# label "January 2026" both → "2026-01"). Non-date strings pass through.
+def canonicalize_dim(v)
+  return v unless v.is_a?(String)
+  s = v.strip
+  # ISO datetime, day=1, midnight → month bucket (T or space separator)
+  if (m = s.match(/\A(\d{4})-(\d{2})-01[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
+    return "#{m[1]}-#{m[2]}"
+  end
+  # ISO date, first of month → month bucket
+  if (m = s.match(/\A(\d{4})-(\d{2})-01\z/))
+    return "#{m[1]}-#{m[2]}"
+  end
+  # "January 2026" / "Jan 2026"
+  if (m = s.match(/\A([A-Za-z]+)\s+(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
+    return format('%s-%02d', m[2], mnum)
+  end
+  # Already-canonical "YYYY-MM"
+  return s if s.match?(/\A\d{4}-\d{2}\z/)
+  v
+end
+
+def round_row(row)
+  # Convert all numerics to Float-rounded so Integer 11 and Float 11.0 compare equal in the set,
+  # and canonicalize date-like dim strings so equivalent monthly buckets match.
+  row.map do |v|
+    if v.is_a?(Numeric)
+      v.to_f.round(2)
+    else
+      canonicalize_dim(v)
+    end
+  end
+end
+
+def strict_compare(exp, act)
+  exp_set = Set.new(exp.map { |r| r.first(2) })
+  act_set = Set.new(act.map { |r| r.first(2) })
+  if exp_set == act_set
+    { status: 'PASS', only_in_tableau: [], only_in_sigma: [] }
+  else
+    { status: 'DIVERGE',
+      only_in_tableau: (exp_set - act_set).to_a,
+      only_in_sigma:   (act_set - exp_set).to_a }
+  end
+end
+
+# Extract-mode: same row count + same dim set + same dim sort. Measure values
+# only flagged if they're WILDLY off (beyond extract_tol) — small drift is
+# expected because Sigma reads live warehouse while extracts are frozen snapshots.
+def extract_compare(exp, act, tol:)
+  exp_dims = exp.map { |r| r[0] }
+  act_dims = act.map { |r| r[0] }
+  exp_set  = Set.new(exp_dims)
+  act_set  = Set.new(act_dims)
+
+  notes = []
+  status = 'PASS'
+
+  if exp.size != act.size
+    status = 'DIVERGE'
+    notes << "bucket count differs: tableau=#{exp.size} sigma=#{act.size}"
+  end
+
+  unless exp_set == act_set
+    status = 'DIVERGE'
+    notes << "dim set differs: tableau-only=#{(exp_set - act_set).to_a[0..3].inspect}, sigma-only=#{(act_set - exp_set).to_a[0..3].inspect}"
+  end
+
+  # If dim sets match, check sort order on the dimension
+  if exp_set == act_set && exp_dims != act_dims
+    notes << "dim sort order differs (extract-mode flags only — not a failure)"
+  end
+
+  # Wild-divergence check on measures (10x or more drift = probably a real bug,
+  # not just extract staleness)
+  if exp.size == act.size && exp_set == act_set
+    exp_h = exp.each_with_object({}) { |r, h| h[r[0]] = r[1] }
+    act_h = act.each_with_object({}) { |r, h| h[r[0]] = r[1] }
+    big_drifts = []
+    exp_h.each do |k, v|
+      a = act_h[k]
+      next if v.nil? || a.nil?
+      next unless v.is_a?(Numeric) && a.is_a?(Numeric)
+      denom = [v.abs.to_f, a.abs.to_f, 1.0].max
+      drift = (v - a).abs.to_f / denom
+      big_drifts << [k, v, a, drift] if drift > tol
+    end
+    if big_drifts.any?
+      notes << "#{big_drifts.size} measure value(s) drift > #{(tol * 100).to_i}% — review:"
+      big_drifts.first(3).each do |k, v, a, d|
+        notes << "    #{k.inspect} tableau=#{v} sigma=#{a} drift=#{(d * 100).round}%"
+      end
+    end
+  end
+
+  { status: status, notes: notes,
+    only_in_tableau: (exp_set - act_set).to_a,
+    only_in_sigma:   (act_set - exp_set).to_a }
+end
+
+raw = JSON.parse(File.read(opts[:plan]))
+default_extract = false
+if raw.is_a?(Hash) && raw['charts']
+  default_extract = !!raw['extract']
+  plan = raw['charts']
+else
+  plan = raw
+end
+
+# Top-level --extract-mode overrides default
+mode_forced = opts[:mode] == :extract
+
+results = plan.map do |p|
+  exp = (p['expected'] || []).map { |r| round_row(r) }
+  act = (p.dig('actual', 'rows') || []).map { |r| round_row(r) }
+
+  this_extract = if p.key?('extract')
+                   p['extract']
+                 elsif mode_forced
+                   true
+                 else
+                   default_extract
+                 end
+
+  result = this_extract ? extract_compare(exp, act, tol: opts[:tol]) : strict_compare(exp, act)
+  result.merge(chart: p['chart'], extract: this_extract)
+end
+
+results.each do |r|
+  tag = r[:extract] ? '[extract]' : '[strict] '
+  printf "%-7s  %s  %s\n", r[:status], tag, r[:chart]
+  if r[:status] != 'PASS' || (r[:notes] && r[:notes].any?)
+    Array(r[:notes]).each { |n| puts "    #{n}" }
+    if r[:only_in_tableau].any? || r[:only_in_sigma].any?
+      puts "    Tableau-only: #{r[:only_in_tableau].inspect[0..200]}"
+      puts "    Sigma-only:   #{r[:only_in_sigma].inspect[0..200]}"
+    end
+  end
+end
+
+failed = results.count { |r| r[:status] != 'PASS' }
+puts '---'
+puts "#{results.size - failed}/#{results.size} pass" + (mode_forced ? '  (extract-mode)' : '')
+exit(failed.zero? ? 0 : 1)


### PR DESCRIPTION
Final-wave overhaul of the thoughtspot-to-sigma skill. Closes beads m5se, wgvv, zvn0, and the ThoughtSpot part of f972.

## Fixes

1. **Converter dependency (m5se)** — `migrate.py` no longer requires an unvendored `sigma-data-model-mcp` build. With `CONVERTER_PATH` unset it writes `<workdir>/model.tml` + `convert-request.json` (the exact `mcp__sigma-data-model__convert_thoughtspot_to_sigma` arguments), prints instructions, exits 3; the pipeline resumes with `--converted <file>` (accepts the tool's `{sigmaDataModel,...}` wrapper or a bare spec). The local-build one-shot still works.
2. **Hardcoded paths (m5se)** — `migrate.py` + `apply_layouts.py` (+ `ts_screenshot.py`) parameterized with `--workdir` (default `./ts-migration` or `$TS_WORKDIR`), created if missing.
3. **--liveboard UUID naming (m5se)** — workbook/page names come from the Liveboard's TML display name; `--name` is a prefix applied to BOTH the DM and every workbook.
4. **Layout geometry (zvn0)** — `apply_layouts.py` maps the TML's `layout.tiles` x/y/w/h (TS 12-col grid) onto Sigma's 24-col grid: cols ×2, rows ×`ROW_SCALE` clamped ≥2 (looker's ROW_SCALE=2 prior art — short bands suppress axis/KPI labels). Auto-grid fallback when the TML has no tiles.
5. **Rename gotcha (zvn0)** — `PATCH /v2/workbooks/{id}` silently no-ops for renames; documented `PATCH /v2/files/{id}` in SKILL.md + refs.
6. **Blank renders (zvn0)** — `ts_screenshot.py` detects connection-error placeholder renders (near-uniform PNG via IDAT zero-fraction, or non-PNG error body) and reports ✗ / exit 1, never ✓.
7. **refs/ + fixtures/ (wgvv)** — `refs/model-conversion-rules.md` + `refs/liveboard-to-workbook.md` (KPI `{columnId}` vs donut `{id}`, groupings, pivot rowsBy/columnsBy, sorts, layout math, rename gotcha); `fixtures/` ships the real exported Retail Analytics model + Liveboard TML pair from the live team2 trial; offline path (`--model-tml`/`--liveboard-tml`) documented in SKILL.md. `get-token.sh` no longer references the nonexistent setup.rb.
8. **Scripted parity gate (wgvv)** — `phase6-parity-thoughtspot.rb` (two-pass, quicksight pattern, writes the `parity-final.json` sentinel) + vendored `verify-parity.rb` + **byte-identical** `assert-phase6-ran.rb` (md5 `c46eb5465ba9faa563ac4689d6f10657`, matches quicksight's copy).
9. **Sort carry (f972 TS)** — TML sorts (`sort by [...]` tokens + client_state sortInfo) carried into the verified Sigma sort shapes; table column ORDER now follows `ordered_column_ids` (fixes Region Performance column scrambling from alphabetical `answer_columns`).

## E2E evidence

- **Live (MCP fallback path)**: Retail Analytics (model d09e27fd, Liveboard a4e9c7c6) re-converted via pass-1 exit 3 → real MCP tool call → `--converted` resume. DM `78462e9d`, WB `7b4ed8d5` "VISQA3 TS Retail Analytics (TS Fixture) (from ThoughtSpot)" — **KEPT** for review.
- **Parity**: 4/4 charts strict PASS (Net Revenue 110,342.75 to the cent); `assert-phase6-ran.rb` exit 0 (all 4 gates).
- **Layout**: PNG at `~/migration-visual-qa/thoughtspot3/visqa3-ts-retail.png` — small KPI top-left (not a full-width banner), bar top-right, line + donut middle row, full-width Region Performance table with Region | Net Revenue | Gross Profit order, matching the TS tile arrangement.
- **Offline (local-build path)**: full run from the new fixtures with NO TS credentials — gate exit 0, identical values; scratch DM + workbook deleted.
- **Blank-render detection verified live**: the trial's warehouse connection is currently broken (invalid JWT) and ThoughtSpot returns placeholder renders — the new ts_screenshot flags 5/5 as failures (exit 1) where the old code printed ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)