### PR TITLE
PBI freshness preflight + QuickSight one-command orchestrator + corpus CI

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -1,0 +1,57 @@
+# Corpus regression check + repo-wide script syntax CI (bead x30b).
+#
+# Both jobs are CREDS-FREE by design: run-corpus.sh --check is pure
+# stdlib-python3 + bash (PyYAML optional — corpus_check.py has a structural
+# fallback), and the syntax job only parses files. No secrets are used or
+# needed anywhere in this workflow — keep it that way.
+#
+# Runner deps (verified): ubuntu-24.04 ships python3 (3.12), ruby (3.x) and
+# bash preinstalled — no setup-* actions required. Pinned to ubuntu-24.04
+# (not -latest) so a runner-image rollover can't silently change the
+# interpreters. Whole workflow budget: < 2 minutes (locally ~1 s + ~5 s).
+name: corpus-check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  corpus:
+    name: corpus --check (creds-free goldens)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate every corpus case against its golden
+        run: ./corpus/run-corpus.sh --check
+
+  script-syntax:
+    name: syntax-check every script (ruby -c / py_compile / bash -n)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse every tracked .rb / .py / .sh file
+        # Cheap repo-wide syntax CI: a script that doesn't even parse must
+        # never reach main. Shebang-aware for .sh files because a few scripts
+        # carry a .sh name with a ruby shebang (e.g. setup-tableau.sh).
+        run: |
+          set -uo pipefail
+          fail=0
+          while IFS= read -r f; do
+            ruby -c "$f" >/dev/null || { echo "::error file=$f::ruby syntax error"; fail=1; }
+          done < <(git ls-files '*.rb')
+          while IFS= read -r f; do
+            python3 -m py_compile "$f" || { echo "::error file=$f::python syntax error"; fail=1; }
+          done < <(git ls-files '*.py')
+          while IFS= read -r f; do
+            shebang=$(head -1 "$f")
+            case "$shebang" in
+              *ruby*)   ruby -c "$f" >/dev/null || { echo "::error file=$f::ruby syntax error"; fail=1; } ;;
+              *python*) python3 -m py_compile "$f" || { echo "::error file=$f::python syntax error"; fail=1; } ;;
+              *)        bash -n "$f" || { echo "::error file=$f::bash syntax error"; fail=1; } ;;
+            esac
+          done < <(git ls-files '*.sh')
+          echo "checked: $(git ls-files '*.rb' | wc -l) rb, $(git ls-files '*.py' | wc -l) py, $(git ls-files '*.sh' | wc -l) sh"
+          exit $fail

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -32,6 +32,16 @@ The corporate tenant blocks Entra app creation, Git integration, and XMLA (PPU).
 - **Layout**: a `.pbix` is a zip; `Report/Layout` is **UTF-16LE** JSON with per-visual `x,y,w,h` (canvas px, 1280×720 default). The model in a `.pbix` is a *binary* `DataModel` blob — NOT usable; get the model via getDefinition or a `.pbit`'s `DataModelSchema`.
 - See `refs/powerbi-visual-layout.md` for the Report/Layout & PBIR parsers and the visualType→Sigma-kind table.
 
+## Phase 2.5 — SOURCE-FRESHNESS PREFLIGHT (import-mode models, bead fmte)
+Import-mode PBI models are **frozen snapshots**; Sigma reads the LIVE warehouse. Before any parity side-by-side, capture the dataset's freshness so staleness deltas are called out UP FRONT (mirrors qlik-to-sigma Phase 1.5):
+
+```bash
+"$PY" scripts/pbi-freshness.py --workspace <wsId|me> --dataset <datasetId> \
+  --tmsl model.bim --out $WORK/freshness.json
+```
+
+Pulls the refresh history (`GET datasets/{id}/refreshes` via the cached token) — last successful refresh + **FAILED refreshes** (expired warehouse creds are the classic cause; surfaced loudly) — plus a cheap `executeQueries` row-count/max-date snapshot per table. `run.sh` runs it automatically as stage 1.5 when `--workspace`/`--dataset` are given; `migrate-powerbi.rb` runs it as Phase 1.5 (same flags). Phase 6/7 parity is then **LED by the staleness banner**, and deltas classify **MATCH / STALE-EXPLAINED / DIVERGENT — only DIVERGENT blocks** (a "Sigma shows more data" delta on a stale snapshot is explained, not a conversion error).
+
 ## Phase 3 — Convert (MCP)
 `convert_powerbi_to_sigma(model_json, connection_id, database, schema)`.
 - DAX measures → Sigma metrics. ~70% mechanical; see `refs/dax-to-sigma-coverage.md` and `fixtures/MANIFEST.md` (test oracle: 94 DAX expressions bucketed a/b/c).
@@ -103,6 +113,7 @@ The conversion is script-driven (mirrors `tableau-to-sigma/scripts/`). `scripts/
 | Script | Stage | What it does |
 |---|---|---|
 | `extract-pbir.py` | 1 extract | Fetch a report's PBIR (or parse one already on disk) → normalized `signals.json` (per-visual `sigma_kind` + role bindings + x/y/w/h). The PBI analog of `parse-twb-layout.rb`. |
+| `pbi-freshness.py` | 1.5 preflight | SOURCE-FRESHNESS: refresh history (incl. FAILED/creds-expired refreshes) + cheap executeQueries row-count/max-date snapshot → `freshness.json`. Leads the parity output; deltas classify MATCH / STALE-EXPLAINED / DIVERGENT (bead fmte). |
 | `convert-model.rb` | 2–3 convert/post | MODE A prints the exact `convert_powerbi_to_sigma` MCP call for a `model.bim`; MODE B takes the converter output and applies the 3 fixups (schemaVersion + folderId/ownerId via a ref-DM harvest + base-element names) → postable DM spec. |
 | `build-workbook-from-pbir.rb` | 4 build | `signals.json` + a `master-map.json` → full workbook spec + 24-col layout XML. Applies the measure-translation patterns in `refs/measure-patterns.md`; **line charts default to a single series** (`beads-sigma-c07`) unless PBI bound a Series/Legend role. **Carries the PBI visual sort** (`f972` — PBIR `query.sortDefinition` / classic `prototypeQuery.OrderBy` → chart `xAxis.sort`/`color.sort`; grouped table → `groupings[0].sort` — element-level sort is rejected on grouped tables). Analog of `build-charts-from-signals.rb`. |
 | `phase6-parity-pbi.rb` | 7 parity | executeQueries(DAX) adapter: `--emit-dax` runs the PBI side and writes the parity plan's `expected` rows; `--finalize` injects Sigma actuals and runs the shared `verify-parity.rb`. The PBI analog of Tableau's view-CSV parity adapter. |

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -78,6 +78,13 @@ OptionParser.new do |o|
   o.on('--mcp-dir DIR')        { |v| opts[:mcp_dir] = File.expand_path(v) }
   o.on('--converter-out PATH') { |v| opts[:cvt_out] = File.expand_path(v) }
   o.on('--python PATH')        { |v| opts[:python]  = File.expand_path(v) }
+  # bead fmte — SOURCE-FRESHNESS PREFLIGHT. --workspace/--dataset identify the
+  # LIVE semantic model (workspace id or "me" for My workspace) so Phase 1.5 can
+  # pull its refresh history + a cheap executeQueries snapshot. Optional: without
+  # them the preflight is skipped (offline TMSL+PBIR-only runs still work).
+  o.on('--workspace ID')       { |v| opts[:ws] = v }
+  o.on('--dataset ID')         { |v| opts[:dataset] = v }
+  o.on('--skip-freshness')     {     opts[:skip_fresh] = true }
 end.parse!
 
 abort 'missing --tmsl' unless opts[:tmsl]
@@ -201,6 +208,30 @@ vsumm = vkinds.map { |k, c| c > 1 ? "#{k}×#{c}" : k }.join(', ')
 puts "   model '#{name_slug}': #{tables.size} table(s), #{tables.sum { |t| (t['columns'] || []).size }} column(s), " \
      "#{all_measures.size} measure(s), mode=#{mode_summ}"
 puts "   report: #{signals['pages'].size} page(s), #{all_visuals.size} visual(s) (#{vsumm})"
+
+# --- Phase 1.5 — SOURCE-FRESHNESS PREFLIGHT (bead fmte) ---------------------
+# An import-mode PBI model is a frozen snapshot; Sigma reads the LIVE warehouse.
+# Pull the dataset's refresh history (incl. FAILED refreshes — expired warehouse
+# creds are the classic cause) + a cheap executeQueries row-count/max-date
+# snapshot NOW, so Phase 6 can lead with "source is N days stale; Sigma will
+# show more data: X vs Y" instead of explaining drift after the numbers looked
+# wrong. Best-effort: a preflight failure warns and continues.
+fresh_path = File.join(WORK, 'freshness.json')
+if opts[:ws] && opts[:dataset] && !opts[:skip_fresh] && modes.include?('import')
+  puts
+  f_out, f_st = Open3.capture2e(PY, File.join(HERE, 'pbi-freshness.py'),
+                                '--workspace', opts[:ws], '--dataset', opts[:dataset],
+                                '--tmsl', opts[:tmsl], '--out', fresh_path)
+  if f_st.success?
+    f_out.each_line { |l| puts "   #{l.rstrip}" }
+  else
+    puts "   ⚠ freshness preflight failed (continuing without it): #{f_out.lines.last.to_s.strip}"
+  end
+elsif opts[:ws] && opts[:dataset] && !opts[:skip_fresh]
+  puts "   (freshness preflight skipped — model is #{mode_summ}, not import-mode: Sigma and PBI both read live)"
+end
+freshness = File.exist?(fresh_path) ? (JSON.parse(File.read(fresh_path)) rescue {}) : {}
+stale_days = freshness['staleDays']
 
 # ---------------------------------------------------------------------------
 # Phase 2 — Convert (run convertPowerBIToSigma via a node shim)
@@ -840,19 +871,138 @@ run!(['ruby', File.join(HERE, 'put-layout.rb'), '--workbook', wb_id, '--layout',
 puts "   layout applied to workbook #{wb_id}"
 
 # ---------------------------------------------------------------------------
-# Phase 6 — Parity (formula-resolution guard + per-element row probe)
+# Phase 6 — Parity (freshness banner FIRST, then formula guard + warehouse compare)
 # ---------------------------------------------------------------------------
 hdr(6, TOTAL, 'Parity')
 require 'sigma_rest'
+require 'date'
+
+# bead fmte — the SOURCE-FRESHNESS banner LEADS the parity output (read this
+# before any side-by-side): a stale import snapshot / failed refresh explains
+# "Sigma shows more data" deltas up front instead of after they look wrong.
+fresh_ok   = freshness['lastSuccessfulRefresh']
+fresh_fail = (freshness['failures'] || []).first
+if fresh_ok || fresh_fail
+  puts '   ── SOURCE FRESHNESS (read this before any side-by-side) ──'
+  if fresh_ok
+    puts "   PBI dataset last refreshed #{fresh_ok['endTime']} (#{stale_days} days ago)"
+  end
+  if fresh_fail
+    tag = freshness['credsSuspect'] ? ' — dataset credentials look EXPIRED' : ''
+    puts "   ⚠ most recent refresh FAILURE #{fresh_fail['endTime']} (#{fresh_fail['errorCode']})#{tag}"
+  end
+  if stale_days && stale_days >= 1
+    puts "   ⚠ source is ~#{stale_days.ceil} day(s) stale — Sigma reads the LIVE warehouse and is"
+    puts '     EXPECTED to show more data. Deltas below are classified accordingly.'
+  end
+end
+
+# (1) formula-resolution guard: no column resolved to type "error".
 cols = (Sigma.request(:get, "/v2/workbooks/#{wb_id}/columns") rescue { 'entries' => [] })
 err_cols = (cols['entries'] || []).select { |c| c.dig('type', 'type') == 'error' }
 total_cols = (cols['entries'] || []).size
 chart_pages = wb_rb['pages'].reject { |p| p['id'] == 'page-data' }
 chart_els = chart_pages.flat_map { |p| (p['elements'] || []) }
-parity_ok = err_cols.empty?
-if parity_ok
-  puts "   PARITY: PASS — #{total_cols} workbook column(s) resolve (0 error-typed); " \
+
+# (2) warehouse-vs-snapshot compare (bead fmte). For every table the preflight
+# snapshotted, export the matching Data-page master element (Sigma = LIVE
+# warehouse rows) via the REST export API and classify the delta:
+#   MATCH            same row count (and max dates, when known)
+#   STALE-EXPLAINED  Sigma has MORE/newer rows — the stale/failed-refresh
+#                    snapshot explains it; NOT a conversion error
+#   DIVERGENT        Sigma has FEWER/older rows — a real problem; blocks
+norm = ->(s) { s.to_s.downcase.gsub(/[^a-z0-9]/, '') }
+export_rows = lambda do |element_id|
+  res = Sigma.request(:post, "/v2/workbooks/#{wb_id}/export",
+                      body: { 'elementId' => element_id, 'format' => { 'type' => 'json' } }.to_json)
+  qid = res.is_a?(Hash) ? res['queryId'] : nil
+  raise 'export returned no queryId' unless qid
+  deadline = Time.now + 90
+  while Time.now < deadline
+    body = (Sigma.request(:get, "/v2/query/#{qid}/download", binary: true) rescue nil)
+    if body && !body.strip.empty?
+      parsed = (JSON.parse(body) rescue nil)
+      return parsed if parsed.is_a?(Array)
+      return parsed['rows'] if parsed.is_a?(Hash) && parsed['rows'].is_a?(Array)
+      lines = body.each_line.map { |l| (JSON.parse(l) rescue nil) }.compact
+      return lines if lines.size > 1
+    end
+    sleep 2
+  end
+  raise 'export download timed out'
+end
+
+fresh_classes = []
+data_page = wb_rb['pages'].find { |p| p['id'] == 'page-data' } ||
+            wb_rb['pages'].find { |p| p['name'].to_s =~ /data/i }
+data_els = data_page ? (data_page['elements'] || []) : []
+(freshness['snapshot'] || {}).each do |table, snap|
+  pbi_rows = snap['rows']
+  next if pbi_rows.nil?
+  # match via the master-map (master key == converter element name == warehouse
+  # table for base tables; the page-data element keeps the master's id), falling
+  # back to a name match. Skip the derived "<Fact> View" join masters.
+  _mk, master = masters.find { |k, _| norm.call(k) == norm.call(table) }
+  el = (master && data_els.find { |e| e['id'] == master['id'] }) ||
+       data_els.find { |e| norm.call(e['name']) == norm.call(table) }
+  unless el
+    fresh_classes << ['SKIPPED', table, 'no matching Data-page master element']
+    next
+  end
+  if pbi_rows > 100_000
+    fresh_classes << ['SKIPPED', table, "#{pbi_rows} rows — too large for an export row-count probe"]
+    next
+  end
+  begin
+    rows = export_rows.call(el['id'])
+  rescue StandardError => e
+    fresh_classes << ['SKIPPED', table, "export failed: #{e.message[0, 80]}"]
+    next
+  end
+  wh_rows = rows.size
+  # max-date compare: match each snapshot date col to an export key by name.
+  date_note = nil
+  newer_dates = false
+  (snap['maxDates'] || {}).each do |dcol, pbi_max|
+    next if pbi_max.nil?
+    key = (rows.first || {}).keys.find { |k| norm.call(k) == norm.call(dcol) }
+    next unless key
+    wh_max = rows.map { |r| r[key] }.compact.max
+    pd = (Date.parse(pbi_max.to_s) rescue nil)
+    wd = (Date.parse(wh_max.to_s) rescue nil)
+    next unless pd && wd
+    if wd > pd
+      newer_dates = true
+      date_note = "max(#{dcol}) warehouse=#{wd} vs PBI=#{pd}"
+    end
+  end
+  stale_or_failed = (stale_days && stale_days >= 1) || freshness['credsSuspect'] ||
+                    (freshness['failures'] || []).any?
+  if wh_rows == pbi_rows && !newer_dates
+    fresh_classes << ['MATCH', table, "rows=#{wh_rows} (warehouse == PBI snapshot)"]
+  elsif wh_rows >= pbi_rows
+    why = stale_or_failed ? 'stale/failed-refresh snapshot explains it' : 'warehouse moved since the refresh'
+    delta = wh_rows - pbi_rows
+    msg = "Sigma will show more data: warehouse rows=#{wh_rows} vs PBI snapshot=#{pbi_rows}" \
+          "#{delta.positive? ? " (+#{delta})" : ''}#{date_note ? "; #{date_note}" : ''} — #{why}"
+    fresh_classes << ['STALE-EXPLAINED', table, msg]
+  else
+    fresh_classes << ['DIVERGENT', table,
+                      "warehouse rows=#{wh_rows} < PBI snapshot=#{pbi_rows} — Sigma shows LESS data " \
+                      'than the source snapshot; check the table/path mapping']
+  end
+end
+if fresh_classes.any?
+  puts '   freshness deltas (table-level, Sigma live vs PBI snapshot):'
+  fresh_classes.each { |cls, table, msg| puts format('   %-15s %s: %s', cls, table, msg) }
+end
+divergent = fresh_classes.count { |c| c[0] == 'DIVERGENT' }
+
+parity_ok = err_cols.empty? && divergent.zero?
+if err_cols.empty?
+  puts "   PARITY: #{parity_ok ? 'PASS' : 'FAIL'} — #{total_cols} workbook column(s) resolve (0 error-typed); " \
        "#{chart_els.size} chart element(s) built across #{chart_pages.size} page(s)"
+  puts "   PARITY: FAIL — #{divergent} DIVERGENT freshness delta(s) above" unless divergent.zero?
 else
   puts "   PARITY: FAIL — #{err_cols.size}/#{total_cols} column(s) resolved to type 'error':"
   err_cols.first(8).each { |c| puts "     [#{c['elementId']}] #{c['label']}: #{c['formula']}" }
@@ -865,6 +1015,11 @@ puts
 puts '================ RESULT ================'
 puts "dataModelId : #{dm_id}"
 puts "workbookId  : #{wb_id}"
-puts "PARITY      : #{parity_ok ? 'PASS' : 'FAIL'} (#{total_cols} cols resolve, #{err_cols.size} error)"
+puts "PARITY      : #{parity_ok ? 'PASS' : 'FAIL'} (#{total_cols} cols resolve, #{err_cols.size} error" \
+     "#{fresh_classes.any? ? format(', freshness: %d match / %d stale-explained / %d divergent', fresh_classes.count { |c| c[0] == 'MATCH' }, fresh_classes.count { |c| c[0] == 'STALE-EXPLAINED' }, divergent) : ''})"
+if fresh_ok
+  puts "freshness   : PBI last refresh #{fresh_ok['endTime']} (#{stale_days} days ago)" \
+       "#{freshness['credsSuspect'] ? ' — REFRESH FAILING (creds)' : ''}"
+end
 puts '======================================='
 exit(parity_ok ? 0 : 3)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi-freshness.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi-freshness.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""pbi-freshness.py — SOURCE-FRESHNESS PREFLIGHT for powerbi-to-sigma (bead fmte).
+
+Mirrors qlik-to-sigma's Phase-1.5 freshness preflight. An IMPORT-mode Power BI
+semantic model is a frozen snapshot: Sigma queries the LIVE warehouse, so any
+parity delta caused by staleness must be called out BEFORE the side-by-side,
+not discovered after the numbers look wrong.
+
+Captures, via the cached Power BI token (/tmp/pbiauth/cache.bin — see
+reference_powerbi_extraction_no_app):
+
+  1. Refresh history    GET datasets/{id}/refreshes ($top=12) — the last
+                        SUCCESSFUL refresh time (staleness clock) AND any
+                        FAILED attempts (expired warehouse credentials are the
+                        common cause: errorCode ModelRefresh_* + "credentials
+                        ... are invalid"). A failing refresh means the snapshot
+                        will only get staler — surface it loudly.
+  2. Snapshot           a cheap executeQueries per TMSL table:
+                        COUNTROWS + MAX(<date col>) (first 2 date columns) —
+                        the numbers the Phase-6 warehouse compare classifies
+                        against (MATCH / STALE-EXPLAINED / DIVERGENT).
+
+Writes <out> (freshness.json) and prints the human banner. Exit 0 even when
+the source is stale/failing (staleness is information, not an error); exit
+non-zero only when the freshness data itself could not be fetched.
+
+Usage:
+  python3 scripts/pbi-freshness.py \
+    --workspace <wsId|me> --dataset <datasetId> \
+    [--tmsl /path/model.bim|.tmsl] [--top 12] \
+    --out /tmp/pbir/freshness.json
+
+`--workspace me` (or omitted) targets My workspace (no /groups/ segment).
+Requires the msal/requests/truststore venv (run.sh bootstraps one; pass the
+interpreter explicitly or rely on /tmp/pbiauth/bin/python).
+"""
+import argparse
+import datetime
+import json
+import os
+import sys
+
+import truststore; truststore.inject_into_ssl()  # noqa: E702
+import msal
+import requests
+
+CACHE = "/tmp/pbiauth/cache.bin"
+CLIENT = "ea0616ba-638b-4df5-95b9-636659ae5121"  # well-known PBI public client
+SCOPE = ["https://analysis.windows.net/powerbi/api/.default"]
+CRED_HINTS = ("credential", "expired", "AADSTS", "authentication", "login")
+
+
+def token():
+    cache = msal.SerializableTokenCache()
+    if os.path.exists(CACHE):
+        cache.deserialize(open(CACHE).read())
+    app = msal.PublicClientApplication(
+        CLIENT, authority="https://login.microsoftonline.com/organizations",
+        token_cache=cache)
+    tok = None
+    for a in app.get_accounts():
+        r = app.acquire_token_silent(SCOPE, account=a)
+        if r and "access_token" in r:
+            tok = r["access_token"]
+            break
+    if not tok:
+        flow = app.initiate_device_flow(scopes=SCOPE)
+        print(">>> " + flow["verification_uri"] + " code " + flow["user_code"],
+              file=sys.stderr)
+        tok = app.acquire_token_by_device_flow(flow).get("access_token")
+    if cache.has_state_changed:
+        open(CACHE, "w").write(cache.serialize())
+    assert tok, "no Power BI token (device-flow failed?)"
+    return tok
+
+
+def ds_base(ws, ds):
+    if not ws or ws.lower() in ("me", "my workspace", "myworkspace"):
+        return f"https://api.powerbi.com/v1.0/myorg/datasets/{ds}"
+    return f"https://api.powerbi.com/v1.0/myorg/groups/{ws}/datasets/{ds}"
+
+
+def parse_ts(s):
+    if not s:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def tmsl_tables(path):
+    """[(table, [dateCol,...]), ...] from a TMSL model — real tables only."""
+    m = json.load(open(path))
+    m = m.get("model", m)
+    out = []
+    for t in m.get("tables", []):
+        name = t.get("name", "")
+        if name.startswith(("LocalDateTable_", "DateTableTemplate_")):
+            continue
+        dates = [c["name"] for c in t.get("columns", [])
+                 if str(c.get("dataType", "")).lower() == "datetime"
+                 and not c.get("isHidden")][:2]
+        out.append((name, dates))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workspace", default="me")
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--tmsl", help="model.bim/TMSL — enables the table snapshot")
+    ap.add_argument("--top", type=int, default=12)
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+
+    tok = token()
+    h = {"Authorization": f"Bearer {tok}"}
+    base = ds_base(a.workspace, a.dataset)
+
+    # ---- 1. refresh history -------------------------------------------------
+    r = requests.get(f"{base}/refreshes?$top={a.top}", headers=h)
+    if r.status_code != 200:
+        sys.exit(f"refresh history fetch failed: {r.status_code} {r.text[:200]}")
+    hist = r.json().get("value", [])
+    last_ok = next((e for e in hist if e.get("status") == "Completed"), None)
+    last_attempt = hist[0] if hist else None
+    failures = [e for e in hist if e.get("status") == "Failed"]
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    stale_days = None
+    ok_end = parse_ts(last_ok.get("endTime") or last_ok.get("startTime")) if last_ok else None
+    if ok_end:
+        stale_days = round((now - ok_end).total_seconds() / 86400, 1)
+
+    def fail_info(e):
+        raw = e.get("serviceExceptionJson") or ""
+        code = desc = None
+        try:
+            j = json.loads(raw)
+            code, desc = j.get("errorCode"), j.get("errorDescription")
+        except (ValueError, TypeError):
+            desc = raw[:300] or None
+        creds = any(k.lower() in (desc or "").lower() or k.lower() in (code or "").lower()
+                    for k in CRED_HINTS)
+        return {"endTime": e.get("endTime") or e.get("startTime"),
+                "refreshType": e.get("refreshType"),
+                "errorCode": code, "errorDescription": desc,
+                "credsSuspect": creds}
+
+    fail_meta = [fail_info(e) for e in failures]
+    creds_suspect = any(f["credsSuspect"] for f in fail_meta)
+
+    # ---- 2. cheap executeQueries snapshot (rows + max dates per table) ------
+    snapshot = {}
+    snapshot_err = None
+    if a.tmsl and os.path.exists(a.tmsl):
+        for table, dates in tmsl_tables(a.tmsl):
+            cols = [f'"rows", COUNTROWS(\'{table}\')']
+            cols += [f'"max:{d}", MAX(\'{table}\'[{d}])' for d in dates]
+            dax = "EVALUATE ROW(" + ", ".join(cols) + ")"
+            try:
+                q = requests.post(f"{base}/executeQueries", headers=h, json={
+                    "queries": [{"query": dax}],
+                    "serializerSettings": {"includeNulls": True}})
+                if q.status_code != 200:
+                    snapshot_err = f"{table}: executeQueries {q.status_code} {q.text[:160]}"
+                    continue
+                row = q.json()["results"][0]["tables"][0]["rows"][0]
+                ent = {"rows": row.get("[rows]"), "maxDates": {}}
+                for d in dates:
+                    ent["maxDates"][d] = row.get(f"[max:{d}]")
+                snapshot[table] = ent
+            except Exception as e:  # network/parse — snapshot is best-effort
+                snapshot_err = f"{table}: {e}"
+
+    fresh = {
+        "workspace": a.workspace, "dataset": a.dataset,
+        "fetchedAt": now.isoformat(timespec="seconds"),
+        "lastSuccessfulRefresh": last_ok and {
+            "endTime": last_ok.get("endTime") or last_ok.get("startTime"),
+            "refreshType": last_ok.get("refreshType")},
+        "staleDays": stale_days,
+        "lastAttemptStatus": last_attempt and last_attempt.get("status"),
+        "failures": fail_meta,
+        "credsSuspect": creds_suspect,
+        "snapshot": snapshot,
+        "snapshotError": snapshot_err,
+    }
+    os.makedirs(os.path.dirname(os.path.abspath(a.out)), exist_ok=True)
+    json.dump(fresh, open(a.out, "w"), indent=2)
+
+    # ---- banner -------------------------------------------------------------
+    print("⏱  SOURCE FRESHNESS (Power BI import model)")
+    if last_ok:
+        print(f"   dataset last refreshed {fresh['lastSuccessfulRefresh']['endTime']}"
+              f" ({stale_days} days ago, {fresh['lastSuccessfulRefresh']['refreshType']})")
+    else:
+        print("   no successful refresh found in history — snapshot age unknown")
+    for f in fail_meta[:2]:
+        tag = " — dataset credentials look EXPIRED; the snapshot will only get staler" \
+              if f["credsSuspect"] else ""
+        print(f"   ⚠ refresh FAILED {f['endTime']} ({f['errorCode']}){tag}")
+        if f["errorDescription"]:
+            print(f"     {f['errorDescription'][:160]}")
+    for t, ent in snapshot.items():
+        md = "  ".join(f"max({k})={str(v)[:10]}" for k, v in ent["maxDates"].items() if v)
+        print(f"   PBI snapshot: {t} rows={ent['rows']}{('  ' + md) if md else ''}")
+    if snapshot_err:
+        print(f"   (snapshot partial: {snapshot_err})")
+    if stale_days is not None and stale_days >= 1:
+        print(f"   → The import snapshot is ~{int(stale_days + 0.5)} day(s) old. Sigma queries the"
+              " LIVE warehouse and")
+        print("     will show newer data; deltas are classified MATCH / STALE-EXPLAINED /"
+              " DIVERGENT at parity.")
+    print(f"   freshness.json -> {a.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_exec.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_exec.py
@@ -18,7 +18,11 @@ if cache.has_state_changed: open(CACHE,"w").write(cache.serialize())
 assert tok, "no powerbi token"
 WS, DS = sys.argv[1], sys.argv[2]
 spec=json.load(sys.stdin)   # {name:{dax,dim_col,val_col}}
-URL=f"https://api.powerbi.com/v1.0/myorg/groups/{WS}/datasets/{DS}/executeQueries"
+# "me" / "My workspace" datasets live outside any group (no /groups/ segment).
+if WS.lower() in ("me", "myorg", "my workspace", "myworkspace"):
+    URL=f"https://api.powerbi.com/v1.0/myorg/datasets/{DS}/executeQueries"
+else:
+    URL=f"https://api.powerbi.com/v1.0/myorg/groups/{WS}/datasets/{DS}/executeQueries"
 out={}
 for name, q in spec.items():
     r=requests.post(URL, headers={"Authorization":f"Bearer {tok}"},

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
@@ -60,7 +60,41 @@ OptionParser.new do |p|
   p.on('--out-dir DIR')         { |v| opts[:outdir] = v }
   p.on('--extract-mode')        { opts[:extract] = true }
   p.on('--extract-tol F', Float){ |v| opts[:tol] = v }
+  # bead fmte — freshness.json from pbi-freshness.py. When present, the
+  # SOURCE-FRESHNESS banner leads both passes, and finalize classifies each
+  # chart MATCH / STALE-EXPLAINED / DIVERGENT (only DIVERGENT blocks).
+  p.on('--freshness PATH')      { |v| opts[:fresh] = v }
 end.parse!
+
+FRESH = if opts[:fresh] && File.exist?(opts[:fresh])
+          (JSON.parse(File.read(opts[:fresh])) rescue {})
+        else
+          {}
+        end
+
+def freshness_banner
+  ok = FRESH['lastSuccessfulRefresh']
+  fail1 = (FRESH['failures'] || []).first
+  return unless ok || fail1
+  sd = FRESH['staleDays']
+  puts '── SOURCE FRESHNESS (read this before any side-by-side) ──'
+  puts "PBI dataset last refreshed #{ok['endTime']} (#{sd} days ago)" if ok
+  if fail1
+    tag = FRESH['credsSuspect'] ? ' — dataset credentials look EXPIRED' : ''
+    puts "⚠ most recent refresh FAILURE #{fail1['endTime']} (#{fail1['errorCode']})#{tag}"
+  end
+  if sd && sd >= 1
+    puts "⚠ source is ~#{sd.ceil} day(s) stale — Sigma reads the LIVE warehouse and is"
+    puts '  EXPECTED to show more data; staleness-shaped deltas classify as STALE-EXPLAINED.'
+  end
+  puts
+end
+
+# true when the snapshot is stale enough (or refreshes are failing) for a
+# "Sigma shows more/newer data" delta to be expected rather than suspicious.
+def fresh_stale?
+  ((FRESH['staleDays'] || 0) >= 1) || FRESH['credsSuspect'] || (FRESH['failures'] || []).any?
+end
 
 HERE = File.expand_path(__dir__)
 HARNESS = File.join(HERE, 'pbi_exec.py')
@@ -89,7 +123,11 @@ HARNESS_SRC = <<~PY
   assert tok, "no powerbi token"
   WS, DS = sys.argv[1], sys.argv[2]
   spec=json.load(sys.stdin)   # {name:{dax,dim_col,val_col}}
-  URL=f"https://api.powerbi.com/v1.0/myorg/groups/{WS}/datasets/{DS}/executeQueries"
+  # "me" / "My workspace" datasets live outside any group (no /groups/ segment).
+  if WS.lower() in ("me", "myorg", "my workspace", "myworkspace"):
+      URL=f"https://api.powerbi.com/v1.0/myorg/datasets/{DS}/executeQueries"
+  else:
+      URL=f"https://api.powerbi.com/v1.0/myorg/groups/{WS}/datasets/{DS}/executeQueries"
   out={}
   for name, q in spec.items():
       r=requests.post(URL, headers={"Authorization":f"Bearer {tok}"},
@@ -134,6 +172,7 @@ if opts[:emit]
   plan = { 'extract' => opts[:extract], 'charts' => charts }
   File.write(opts[:out], JSON.pretty_generate(plan))
   warn "[phase6-pbi] wrote plan with PBI `expected` rows -> #{opts[:out]}"
+  freshness_banner # bead fmte — staleness leads, before any side-by-side
   puts "=" * 70
   puts "PHASE 6 (PBI) — collect Sigma actuals, one MCP query per chart:"
   puts "=" * 70
@@ -147,6 +186,21 @@ if opts[:emit]
   exit 0
 end
 
+# bead fmte — does this chart's delta look like "Sigma shows MORE/newer data"?
+# (extra Sigma-only buckets with none missing, or a larger Sigma total) — the
+# shape a stale import snapshot produces, as opposed to a conversion error.
+def sigma_shows_more?(exp_rows, act_rows)
+  numify = ->(v) { v.is_a?(Numeric) ? v.to_f : (v.to_s.gsub(/[$,%\s]/, '') =~ /\A-?\d+(\.\d+)?\z/ ? v.to_s.gsub(/[$,%\s]/, '').to_f : nil) }
+  exp = exp_rows || []
+  act = act_rows || []
+  exp_dims = exp.map { |r| r[0] }
+  act_dims = act.map { |r| r[0] }
+  return true if (act_dims - exp_dims).any? && (exp_dims - act_dims).empty?
+  exp_sum = exp.map { |r| numify.call(r[1]) }.compact.sum
+  act_sum = act.map { |r| numify.call(r[1]) }.compact.sum
+  act.size >= exp.size && act_sum > exp_sum
+end
+
 if opts[:finalize]
   %i[plan actuals outdir].each { |k| abort("missing --#{k}") unless opts[k] }
   plan = JSON.parse(File.read(opts[:plan]))
@@ -156,27 +210,64 @@ if opts[:finalize]
     c['actual'] = { 'rows' => a } if a
   end
   File.write(opts[:plan], JSON.pretty_generate(plan))
+  freshness_banner # bead fmte — staleness leads, before the side-by-side
   args = ['ruby', File.join(HERE, 'verify-parity.rb'), '--plan', opts[:plan]]
   args.concat(['--extract-mode', '--extract-tol', opts[:tol].to_s]) if opts[:extract]
   out, err, st = Open3.capture3(*args)
   puts out
   warn err unless err.empty?
-  # assert-phase6-ran.rb sentinel
   total = plan['charts'].size
   passed = out.scan(/^PASS\s+\[[^\]]+\]\s+(.+)$/).flatten
   failed = out.scan(/^DIVERGE\s+\[[^\]]+\]\s+(.+)$/).flatten
+
+  # bead fmte — classify every chart MATCH / STALE-EXPLAINED / DIVERGENT.
+  # A DIVERGE whose delta is "Sigma shows more/newer data" while the source is
+  # stale (or its refresh is failing) is EXPLAINED, not a conversion error.
+  # Only DIVERGENT blocks. Without --freshness, DIVERGE stays DIVERGENT.
+  classes = plan['charts'].map do |c|
+    name = c['chart']
+    cls = if passed.include?(name)
+            'MATCH'
+          elsif fresh_stale? && sigma_shows_more?(c['expected'], c.dig('actual', 'rows'))
+            'STALE-EXPLAINED'
+          else
+            'DIVERGENT'
+          end
+    [name, cls]
+  end.to_h
+  stale_expl = classes.values.count('STALE-EXPLAINED')
+  divergent  = classes.values.count('DIVERGENT')
+  if FRESH.any? || stale_expl.positive?
+    puts
+    puts 'classification (only DIVERGENT blocks):'
+    classes.each { |name, cls| puts format('  %-15s %s', cls, name) }
+    if stale_expl.positive?
+      puts "  → #{stale_expl} delta(s) are EXPLAINED by the stale PBI snapshot" \
+           "#{FRESH['credsSuspect'] ? ' (refresh failing — creds)' : ''}, not a conversion error."
+    end
+  end
+
+  status = total.positive? && divergent.zero? && (passed.size + stale_expl) == total ? 'PASS' : 'FAIL'
   summary = {
     'workbook_id' => plan.dig('charts', 0, 'workbook_id'),
     'ran_at' => Time.now.utc.iso8601,
     'source' => 'powerbi-executequeries',
     'mode' => opts[:extract] ? 'extract' : 'strict',
-    'charts_total' => total, 'charts_pass' => passed.size, 'charts_fail' => failed.size,
+    'charts_total' => total, 'charts_pass' => passed.size, 'charts_fail' => divergent,
+    'charts_stale_explained' => stale_expl,
     'pass_names' => passed, 'fail_names' => failed,
-    'status' => (st.success? && total > 0 && passed.size == total) ? 'PASS' : 'FAIL'
+    'classifications' => classes,
+    'freshness' => FRESH.empty? ? nil : {
+      'lastSuccessfulRefresh' => FRESH.dig('lastSuccessfulRefresh', 'endTime'),
+      'staleDays' => FRESH['staleDays'], 'credsSuspect' => FRESH['credsSuspect'],
+      'failures' => (FRESH['failures'] || []).size
+    },
+    'status' => status
   }
   File.write(File.join(opts[:outdir], 'parity-final.json'), JSON.pretty_generate(summary))
-  warn "[phase6-pbi] wrote parity-final.json (status=#{summary['status']} #{passed.size}/#{total})"
-  exit(st.success? ? 0 : 2)
+  warn "[phase6-pbi] wrote parity-final.json (status=#{status} " \
+       "#{passed.size} match / #{stale_expl} stale-explained / #{divergent} divergent of #{total})"
+  exit(status == 'PASS' ? 0 : 2)
 end
 
 abort('specify --emit-dax or --finalize')

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/run.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/run.sh
@@ -105,6 +105,18 @@ if [[ $START -le 1 ]]; then
       exit 1
     fi
   fi
+
+  # ---- stage 1.5: SOURCE-FRESHNESS PREFLIGHT (bead fmte) -------------------
+  # Import-mode models are frozen snapshots; Sigma reads the live warehouse.
+  # Capture the dataset's refresh history (incl. FAILED refreshes / expired
+  # creds) + a cheap executeQueries row-count/max-date snapshot NOW so the
+  # stage-7 parity is LED by the staleness banner. Best-effort: never fatal.
+  if [[ -n "$WS" && -n "$DATASET" ]]; then
+    echo "== [1.5/7] SOURCE-FRESHNESS PREFLIGHT =="
+    "$PY" "$HERE/pbi-freshness.py" --workspace "$WS" --dataset "$DATASET" \
+      ${BIM:+--tmsl "$BIM"} --out "$WORK/freshness.json" \
+      || echo "  (freshness preflight failed — continuing without it)"
+  fi
 fi
 
 if [[ $START -le 2 ]]; then
@@ -179,12 +191,17 @@ if [[ $START -le 7 ]]; then
   echo "== [7/7] PARITY (DAX vs Sigma — MCP gate) =="
   if [[ -n "$WS" && -n "$DATASET" && -f "$WORK/chart-dax.json" ]]; then
     WB_ID=$(grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' "$WORK/wb-post.txt" | head -1 || true)
+    # bead fmte: the staleness banner LEADS the parity output, and finalize
+    # classifies deltas MATCH / STALE-EXPLAINED / DIVERGENT (only DIVERGENT blocks).
+    FRESH_ARG=""
+    [[ -f "$WORK/freshness.json" ]] && FRESH_ARG="--freshness $WORK/freshness.json"
     ruby "$HERE/phase6-parity-pbi.rb" --emit-dax --workspace "$WS" --dataset "$DATASET" \
-      --chart-dax "$WORK/chart-dax.json" --workbook-id "$WB_ID" --out "$WORK/parity-plan.json"
+      --chart-dax "$WORK/chart-dax.json" --workbook-id "$WB_ID" --out "$WORK/parity-plan.json" \
+      $FRESH_ARG
     echo "  >>> GATE: collect Sigma actuals via sigma-mcp-v2 query (per chart above),"
     echo "      save to $WORK/parity-actuals.json, then:"
     echo "      ruby $HERE/phase6-parity-pbi.rb --finalize --plan $WORK/parity-plan.json \\"
-    echo "        --actuals $WORK/parity-actuals.json --out-dir $WORK"
+    echo "        --actuals $WORK/parity-actuals.json --out-dir $WORK $FRESH_ARG"
   else
     echo "  (skipped — need --workspace, --dataset, and $WORK/chart-dax.json)"
   fi

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -23,6 +23,20 @@ user-invocable: true
 
 See `refs/migration-test-slate.md` for the complexity taxonomy + 20-dashboard test slate that grounds the converter's coverage and known gaps.
 
+## One command (preferred): `scripts/migrate-quicksight.rb`
+
+The single-process orchestrator chains every phase below — discover (live AWS or `--from-fixtures <dir>`), convert (local MCP build, or `convert-model.rb --emit-mcp` gate + `--converted` resume), the **Phase 3.5 DM-reuse check** (`qs-dm-signature.py` + `find-or-pick-dm.rb`; default **build new**, attach with `--reuse-dm <id>`), fixup `--folder-id` → validate → post-and-readback, workbook build, layout, then the **two-pass Phase 7 parity** (`phase6-parity-quicksight.rb` emits the per-chart query list and gates; write `parity-expected.json` + `parity-actuals.json` and re-run the SAME command — phases 1–5 skip automatically) and the `assert-phase6-ran.rb --workdir` hard gate:
+
+```bash
+ruby scripts/migrate-quicksight.rb \
+  --analysis-id <ID> --account-id <ACCT> --region us-east-1 --profile <P> \
+  --connection <SIGMA_CONN_UUID> --folder <FOLDER_ID> \
+  [--database DB --schema SCH] [--name "My Dashboard"] [--out DIR] [--yes]
+# offline / fixtures: swap the first line for --from-fixtures fixtures/
+```
+
+Exit 0 = parity + hard gate green; exit 10 = a gate (converter MCP / parity collection / OPEN QUESTIONS) printed its exact resume command; exit 3 = parity fail. Each phase prints a visible header — it is not a black box. The per-script phases below remain the reference for running any stage by hand.
+
 ## Phase 1 — Auth
 
 **QuickSight (AWS CLI).**

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
@@ -7,20 +7,36 @@
 # block (exit 10) rather than silently auto-resolved.
 #
 # This script does NOT re-implement any phase — it chains the existing scripts:
-#   quicksight-discover.py  (Phase 1)
-#   the local sigma-data-model-mcp converter convertQuickSightToSigma (Phase 2)
-#   convert-model.rb --fixup + validate-spec.rb + post-and-readback.rb (Phase 3/DM)
-#   build-workbook-from-quicksight.rb + post-and-readback.rb (Phase 4/workbook)
-#   build-quicksight-layout.rb + put-layout.rb (Phase 5/layout)
-#   the post-and-readback column-type guard + a per-element row probe (Phase 6/parity)
+#   quicksight-discover.py [--from-fixtures]                       (Phase 1)
+#   convert-model.rb --emit-mcp → MCP gate → --converted resume,
+#     or a local sigma-data-model-mcp build via a node shim        (Phase 2)
+#   qs-dm-signature.py + find-or-pick-dm.rb (DM-reuse check)       (Phase 2.5)
+#   convert-model.rb --fixup --folder-id + validate-spec.rb
+#     + post-and-readback.rb                                       (Phase 3/DM)
+#   build-workbook-from-quicksight.rb + post-and-readback.rb       (Phase 4/workbook)
+#   build-quicksight-layout.rb (fixed 36-col inference) + put-layout.rb (Phase 5)
+#   phase6-parity-quicksight.rb two-pass (emit query list → MCP gate →
+#     --actuals/--expected resume) + assert-phase6-ran.rb --workdir (Phase 6/parity)
 #
-# Usage:
+# Usage (live):
 #   ruby scripts/migrate-quicksight.rb \
 #     --analysis-id <ID> --account-id <ACCT> --region <REGION> --profile <PROFILE> \
 #     --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID> \
+#     [--database DB --schema SCH] [--name "My Dashboard"] \
 #     [--out DIR] [--answers '<json>'] [--yes]
 #
-# Exit codes: 0 = done; 10 = decisions needed (OPEN QUESTIONS printed); other = error.
+# Usage (offline fixtures — no AWS needed):
+#   ruby scripts/migrate-quicksight.rb --from-fixtures fixtures/ \
+#     --connection <ID> --folder <ID> --database DB --schema SCH --yes
+#
+# RESUME PATTERNS (each gate prints its own exact resume command):
+#   converter MCP gate → re-run with --converted <mcp-tool-result.json>
+#   parity MCP gate    → write <out>/parity-expected.json + parity-actuals.json
+#                        (or pass --expected/--actuals) and re-run; phases 1-5
+#                        are skipped automatically when their artifacts exist.
+#
+# Exit codes: 0 = done (parity + hard gate pass); 10 = gate/decisions (printed);
+#             3 = parity fail; other = error.
 require 'json'
 require 'optparse'
 require 'fileutils'
@@ -35,27 +51,49 @@ OptionParser.new do |o|
   o.on('--account-id ID')   { |v| opts[:account]  = v }
   o.on('--region R')        { |v| opts[:region]   = v }
   o.on('--profile P')       { |v| opts[:profile]  = v }
+  o.on('--from-fixtures D') { |v| opts[:fixtures] = File.expand_path(v) }
   o.on('--connection ID')   { |v| opts[:conn]     = v }
+  o.on('--database DB')     { |v| opts[:db]       = v }
+  o.on('--schema SCH')      { |v| opts[:schema]   = v }
   o.on('--folder ID')       { |v| opts[:folder]   = v }
+  o.on('--name NAME')       { |v| opts[:name]     = v }
   o.on('--out DIR')         { |v| opts[:out]      = File.expand_path(v) }
   o.on('--answers JSON')    { |v| opts[:answers]  = v }
   o.on('--yes')             {     opts[:yes]      = true }
+  # converter MCP-gate resume: the convert_quicksight_to_sigma MCP tool result.
+  o.on('--converted PATH')  { |v| opts[:converted] = File.expand_path(v) }
+  o.on('--mcp-dir DIR')     { |v| opts[:mcp_dir]   = File.expand_path(v) }
+  # DM-reuse (Phase 2.5). Default = build new; --reuse-dm attaches to an
+  # existing DM (skips Phase 3); --skip-reuse-check skips the scan entirely.
+  o.on('--reuse-dm ID')     { |v| opts[:reuse_dm] = v }
+  o.on('--skip-reuse-check'){     opts[:skip_reuse] = true }
+  # parity MCP-gate resume inputs (defaults: <out>/parity-expected.json + parity-actuals.json).
+  o.on('--expected PATH')   { |v| opts[:expected] = File.expand_path(v) }
+  o.on('--actuals PATH')    { |v| opts[:actuals]  = File.expand_path(v) }
+  o.on('--extract-mode')    {     opts[:extract]  = true }
+  o.on('--extract-tol F', Float) { |v| opts[:tol] = v }
 end.parse!
 
-abort 'missing --analysis-id'  unless opts[:analysis]
-abort 'missing --account-id'   unless opts[:account]
-abort 'missing --connection'   unless opts[:conn]
+abort 'missing --analysis-id (or --from-fixtures)' unless opts[:analysis] || opts[:fixtures]
+abort 'missing --account-id (live discovery)' if opts[:analysis] && !opts[:fixtures] && !opts[:account]
+abort 'missing --connection' unless opts[:conn]
+if opts[:conn] !~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+  abort "FATAL: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}"
+end
 
 # Local converter build. The skill defers DM conversion to the sigma-data-model-mcp
 # `convert_quicksight_to_sigma` tool; that tool is an ESM module not loadable from a
 # plain shell, so we import its exported convertQuickSightToSigma() directly via a tiny
-# node shim. Override with QS_MCP_DIR if your checkout lives elsewhere.
-MCP_DIR = ENV['QS_MCP_DIR'] || %w[
-  /Users/tjwells/Desktop/sigma-data-model-mcp
-  /Users/tjwells/sigma-data-model-mcp
-].find { |d| File.exist?(File.join(d, 'build', 'quicksight.js')) }
+# node shim. No hardcoded developer paths (mirrors migrate-powerbi.rb): resolve from
+# --mcp-dir / QS_MCP_DIR, else probe common clone locations under $HOME. When NONE is
+# found, Phase 2 does NOT abort — it prints the convert-model.rb --emit-mcp request and
+# gates; resume with --converted <mcp tool result> (the default route without a build).
+MCP_DIR = [opts[:mcp_dir], ENV['QS_MCP_DIR'],
+           File.expand_path('~/Desktop/sigma-data-model-mcp'),
+           File.expand_path('~/sigma-data-model-mcp')]
+          .compact.find { |d| File.exist?(File.join(d, 'build', 'quicksight.js')) }
 
-name_slug = opts[:analysis].gsub(/[^A-Za-z0-9_-]/, '-')
+name_slug = (opts[:analysis] || File.basename(opts[:fixtures].to_s)).gsub(/[^A-Za-z0-9_-]/, '-')
 WORK = opts[:out] || File.expand_path("~/quicksight-migration/#{name_slug}")
 FileUtils.mkdir_p(WORK)
 
@@ -73,15 +111,40 @@ end
 
 TOTAL = 6
 
+# ---- parity-resume detection (phases 1-5 already ran; finalize only) -------
+exp_path   = opts[:expected] || File.join(WORK, 'parity-expected.json')
+act_path   = opts[:actuals]  || File.join(WORK, 'parity-actuals.json')
+wb_id_path = File.join(WORK, 'wb-id.txt')
+resume_parity = File.exist?(wb_id_path) && File.exist?(exp_path) && File.exist?(act_path)
+
+dm_id = nil
+wb_id = nil
+
+if resume_parity
+  wb_id = File.read(wb_id_path).strip
+  dm_id = (JSON.parse(File.read(File.join(WORK, 'dm-readback.json')))['dataModelId'] rescue '?')
+  puts "── resuming at Phase 6 (parity finalize) — workbook #{wb_id}, dm #{dm_id} ──"
+else
+
 # ---------------------------------------------------------------------------
-# Phase 1 — Discover
+# Phase 1 — Discover (live AWS, --from-fixtures, or reuse of a prior run)
 # ---------------------------------------------------------------------------
 hdr(1, TOTAL, 'Discover')
-disc_cmd = ['python3', File.join(HERE, 'quicksight-discover.py'),
-            '--account-id', opts[:account], '--region', opts[:region],
-            '--analysis-id', opts[:analysis], '--out-dir', WORK]
-disc_cmd += ['--profile', opts[:profile]] if opts[:profile]
-run!(disc_cmd)
+# idempotent resume: a prior run's discovery artifacts in WORK are reused
+# (the --converted gate-resume relies on this — don't re-hit AWS).
+if File.exist?(File.join(WORK, 'analysis.json')) && File.exist?(File.join(WORK, 'signals.json')) &&
+   Dir[File.join(WORK, 'datasets', '*.json')].any?
+  puts "   reusing discovery artifacts already in #{WORK}"
+elsif opts[:fixtures]
+  run!(['python3', File.join(HERE, 'quicksight-discover.py'),
+        '--from-fixtures', opts[:fixtures], '--out-dir', WORK])
+else
+  disc_cmd = ['python3', File.join(HERE, 'quicksight-discover.py'),
+              '--account-id', opts[:account], '--region', opts[:region],
+              '--analysis-id', opts[:analysis], '--out-dir', WORK]
+  disc_cmd += ['--profile', opts[:profile]] if opts[:profile]
+  run!(disc_cmd)
+end
 
 signals = JSON.parse(File.read(File.join(WORK, 'signals.json')))
 an_name = signals.dig('source', 'name') || opts[:analysis]
@@ -94,32 +157,55 @@ puts "   analysis '#{an_name}': #{signals['datasets'].size} dataset(s), " \
      "#{signals['calculatedFields'].size} calc field(s)"
 
 # ---------------------------------------------------------------------------
-# Phase 2 — Convert (run the local converter MCP function via a node shim)
+# Phase 2 — Convert. Three routes (in priority order):
+#   a) --converted <file>: the convert_quicksight_to_sigma MCP TOOL already ran
+#      (gate-resume — the default route on machines without a local build)
+#   b) a local sigma-data-model-mcp build: run it in-process via a node shim
+#   c) neither: print the exact MCP request (convert-model.rb --emit-mcp) and
+#      GATE — re-run with --converted <the tool's result JSON>.
 # ---------------------------------------------------------------------------
 hdr(2, TOTAL, 'Convert')
-abort "FATAL: cannot locate sigma-data-model-mcp build (set QS_MCP_DIR)" unless MCP_DIR
 ds_files = Dir[File.join(WORK, 'datasets', '*.json')].sort
 conv_files = [File.join(WORK, 'analysis.json')] + ds_files
 
-shim = File.join(WORK, '_convert.mjs')
-File.write(shim, <<~JS)
-  import { readFileSync, writeFileSync } from 'node:fs';
-  import { convertQuickSightToSigma } from #{File.join(MCP_DIR, 'build', 'quicksight.js').to_json};
-  const files = #{conv_files.to_json}.map(p => ({ name: p.split('/').pop(), content: readFileSync(p, 'utf8') }));
-  const out = convertQuickSightToSigma(files, {
-    connectionId: #{opts[:conn].to_json},
-    database: #{(ENV['QS_DB'] || '').to_json},
-    schema: #{(ENV['QS_SCHEMA'] || '').to_json},
-  });
-  writeFileSync(#{File.join(WORK, 'converter-out.json').to_json}, JSON.stringify(out, null, 2));
-  // emit a one-line machine summary on stderr for the orchestrator
-  const w = out.warnings || [];
-  process.stderr.write('CONVSTATS ' + JSON.stringify({ warnings: w, stats: out.stats || {} }) + '\\n');
-JS
-
-c_out, c_err, c_st = Open3.capture3('node', shim)
-puts "   converter ran (build: #{MCP_DIR})"
-abort "FATAL: converter failed:\n#{c_err}#{c_out}" unless c_st.success?
+if opts[:converted]
+  abort "FATAL: --converted not found: #{opts[:converted]}" unless File.exist?(opts[:converted])
+  FileUtils.cp(opts[:converted], File.join(WORK, 'converter-out.json')) unless
+    File.expand_path(opts[:converted]) == File.join(WORK, 'converter-out.json')
+  puts "   converter output ingested from #{opts[:converted]} (MCP-tool route)"
+elsif MCP_DIR
+  shim = File.join(WORK, '_convert.mjs')
+  File.write(shim, <<~JS)
+    import { readFileSync, writeFileSync } from 'node:fs';
+    import { convertQuickSightToSigma } from #{File.join(MCP_DIR, 'build', 'quicksight.js').to_json};
+    const files = #{conv_files.to_json}.map(p => ({ name: p.split('/').pop(), content: readFileSync(p, 'utf8') }));
+    const out = convertQuickSightToSigma(files, {
+      connectionId: #{opts[:conn].to_json},
+      database: #{(opts[:db] || ENV['QS_DB'] || '').to_json},
+      schema: #{(opts[:schema] || ENV['QS_SCHEMA'] || '').to_json},
+    });
+    writeFileSync(#{File.join(WORK, 'converter-out.json').to_json}, JSON.stringify(out, null, 2));
+    // emit a one-line machine summary on stderr for the orchestrator
+    const w = out.warnings || [];
+    process.stderr.write('CONVSTATS ' + JSON.stringify({ warnings: w, stats: out.stats || {} }) + '\\n');
+  JS
+  c_out, c_err, c_st = Open3.capture3('node', shim)
+  puts "   converter ran (build: #{MCP_DIR})"
+  abort "FATAL: converter failed:\n#{c_err}#{c_out}" unless c_st.success?
+else
+  puts '   no local sigma-data-model-mcp build found (set --mcp-dir / QS_MCP_DIR for the in-process route).'
+  puts
+  emit = ['ruby', File.join(HERE, 'convert-model.rb'), '--emit-mcp',
+          '--discover-dir', WORK, '--connection-id', opts[:conn]]
+  emit += ['--database', opts[:db]] if opts[:db]
+  emit += ['--schema', opts[:schema]] if opts[:schema]
+  run!(emit)
+  puts
+  puts '   >>> GATE: run the convert_quicksight_to_sigma MCP tool exactly as printed'
+  puts '       above, save the tool result JSON to a file, then re-run this command'
+  puts "       with --converted <that file>. No Sigma objects were created."
+  exit 10
+end
 conv = JSON.parse(File.read(File.join(WORK, 'converter-out.json')))
 conv_warnings = conv['warnings'] || []
 # The converter output is {model|sigmaDataModel, warnings, stats}. convert-model.rb
@@ -233,21 +319,79 @@ else
 end
 
 # ---------------------------------------------------------------------------
-# Phase 3 — Fixup + POST data model
+# Phase 2.5 — DM reuse check (qs-dm-signature.py + find-or-pick-dm.rb).
+# DEFAULT = BUILD NEW. The scan is informational: it surfaces a reusable
+# candidate (avoids a 4th near-identical "Orders" DM) and the exact flag to
+# attach to it (--reuse-dm <id>), but never silently reuses.
+# ---------------------------------------------------------------------------
+require 'sigma_rest' # also loads ~/.sigma-migration/env for the child scripts
+hdr('2.5', TOTAL, 'DM reuse check')
+if opts[:reuse_dm]
+  puts "   --reuse-dm #{opts[:reuse_dm]} — attaching to the existing DM (Phase 3 skipped)"
+elsif opts[:skip_reuse]
+  puts '   skipped (--skip-reuse-check) — building a new DM'
+else
+  begin
+    sig_path = File.join(WORK, 'dm-signature.json')
+    run!(['python3', File.join(HERE, 'qs-dm-signature.py'),
+          '--discover-dir', WORK, '--out', sig_path])
+    match_path = File.join(WORK, 'dm-match.json')
+    fop_out, = Open3.capture2e('ruby', File.join(HERE, 'find-or-pick-dm.rb'),
+                               '--workbook-signature', sig_path, '--out', match_path)
+    match = File.exist?(match_path) ? (JSON.parse(File.read(match_path)) rescue {}) : {}
+    best = (match['candidates'] || []).first
+    if best && best['score'].to_f >= 0.6
+      puts "   candidate: '#{best['dm_name']}' (#{best['dm_id']}) score=#{best['score']} — " \
+           "#{(best['shared_columns'] || []).size} shared column(s), #{best['extra_columns']} inherited extra(s)"
+      puts "   default = BUILD NEW. To reuse it instead, re-run with --reuse-dm #{best['dm_id']}"
+    else
+      puts '   no reusable DM found (score < threshold) — building new'
+    end
+  rescue StandardError => e
+    puts "   reuse scan failed (#{e.message[0, 80]}) — building new (the scan is advisory only)"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Fixup + POST data model (skipped when --reuse-dm attaches to one)
 # ---------------------------------------------------------------------------
 hdr(3, TOTAL, 'Build data model')
 dm_spec = File.join(WORK, 'dm-spec.json')
-fixup = ['ruby', File.join(HERE, 'convert-model.rb'), '--fixup',
-         '--in', File.join(WORK, 'converter-out.json'),
-         '--discover-dir', WORK, '--out', dm_spec]
-fixup += ['--folder-id', opts[:folder]] if opts[:folder]
-run!(fixup)
-run!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'datamodel', dm_spec])
 dm_readback = File.join(WORK, 'dm-readback.json')
-run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
-      '--spec', dm_spec, '--out', dm_readback, '--workdir', WORK])
-dm_id = JSON.parse(File.read(dm_readback))['dataModelId']
-puts "   dataModelId = #{dm_id}"
+if opts[:reuse_dm]
+  # Read the existing DM's spec back and synthesize the dm-readback artifact the
+  # workbook builder consumes (element names/ids). The spec endpoint answers in
+  # YAML even when asked for JSON — parse both.
+  raw = Sigma.request(:get, "/v2/dataModels/#{opts[:reuse_dm]}/spec", binary: true)
+  spec = begin
+    JSON.parse(raw)
+  rescue JSON::ParserError
+    require 'yaml'
+    require 'date'
+    YAML.safe_load(raw, permitted_classes: [Date, Time]) || {}
+  end
+  dm_rb = { 'dataModelId' => opts[:reuse_dm] }.merge(spec)
+  File.write(dm_readback, JSON.pretty_generate(dm_rb))
+  dm_id = opts[:reuse_dm]
+  puts "   reusing dataModelId = #{dm_id} ('#{spec['name']}') — shape preflight: " \
+       "#{(spec['pages'] || []).flat_map { |p| p['elements'] || [] }.size} element(s) read back"
+else
+  fixup = ['ruby', File.join(HERE, 'convert-model.rb'), '--fixup',
+           '--in', File.join(WORK, 'converter-out.json'),
+           '--discover-dir', WORK, '--out', dm_spec]
+  fixup += ['--folder-id', opts[:folder]] if opts[:folder]
+  run!(fixup)
+  if opts[:name]
+    j = JSON.parse(File.read(dm_spec))
+    j['name'] = "#{opts[:name]} DM"
+    File.write(dm_spec, JSON.pretty_generate(j))
+  end
+  run!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'datamodel', dm_spec])
+  run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
+        '--spec', dm_spec, '--out', dm_readback, '--workdir', WORK])
+  dm_id = JSON.parse(File.read(dm_readback))['dataModelId']
+  puts "   dataModelId = #{dm_id}"
+end
 
 # ---------------------------------------------------------------------------
 # Phase 4 — Build workbook
@@ -256,19 +400,29 @@ hdr(4, TOTAL, 'Build workbook')
 wb_spec = File.join(WORK, 'wb-spec.json')
 build = ['ruby', File.join(HERE, 'build-workbook-from-quicksight.rb'),
          '--analysis', File.join(WORK, 'analysis.json'),
-         '--dm-readback', dm_readback, '--dm-spec', dm_spec, '--out', wb_spec]
+         '--dm-readback', dm_readback, '--out', wb_spec]
+build += ['--dm-spec', dm_spec] if File.exist?(dm_spec)
 build += ['--folder-id', opts[:folder]] if opts[:folder]
 filters = File.join(WORK, 'dm-filters.json')
 build += ['--filters', filters] if File.exist?(filters)
 run!(build)
+if opts[:name]
+  j = JSON.parse(File.read(wb_spec))
+  j['name'] = opts[:name]
+  File.write(wb_spec, JSON.pretty_generate(j))
+end
 wb_readback = File.join(WORK, 'wb-readback.json')
 run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
       '--spec', wb_spec, '--out', wb_readback, '--workdir', WORK])
 wb_id = JSON.parse(File.read(wb_readback))['workbookId']
+# Phase 6 PASS 1 overwrites wb-readback.json with the live spec (no workbookId
+# key), so persist the id separately — the parity-finalize resume needs it.
+File.write(wb_id_path, wb_id)
 puts "   workbookId = #{wb_id}"
 
 # ---------------------------------------------------------------------------
-# Phase 5 — Layout
+# Phase 5 — Layout (build-quicksight-layout.rb infers the QS grid width — the
+# explicit-index 12/18/24/36-col cases — and emits the Sigma layout XML)
 # ---------------------------------------------------------------------------
 hdr(5, TOTAL, 'Layout')
 layout = File.join(WORK, 'layout.xml')
@@ -278,37 +432,57 @@ run!(['ruby', File.join(HERE, 'build-quicksight-layout.rb'),
 run!(['ruby', File.join(HERE, 'put-layout.rb'), '--workbook', wb_id, '--layout', layout])
 puts "   layout applied to workbook #{wb_id}"
 
+end # resume_parity skip of phases 1-5
+
 # ---------------------------------------------------------------------------
-# Phase 6 — Parity (self-contained: formula-resolution guard + per-element row probe)
+# Phase 6 — Parity (two-pass, hard-gated):
+#   guard  — no workbook column resolved to type "error"
+#   PASS 1 — phase6-parity-quicksight.rb emits parity-plan.json + the per-chart
+#            sigma-mcp-v2 query list, then GATES (exit 10): the agent collects
+#            Sigma ACTUAL rows + warehouse EXPECTED rows and re-runs (resume).
+#   PASS 2 — --finalize + assert-phase6-ran.rb --workdir (the hard gate).
 # ---------------------------------------------------------------------------
-hdr(6, TOTAL, 'Parity')
+hdr(6, TOTAL, 'Parity (two-pass, hard-gated)')
 require 'sigma_rest'
-# (1) formula-resolution guard: no column resolved to type "error".
-cols = Sigma.request(:get, "/v2/workbooks/#{wb_id}/columns") rescue { 'entries' => [] }
+cols = (Sigma.request(:get, "/v2/workbooks/#{wb_id}/columns") rescue { 'entries' => [] })
 err_cols = (cols['entries'] || []).select { |c| c.dig('type', 'type') == 'error' }
 total_cols = (cols['entries'] || []).size
-# (2) per-element row probe: every charted element returns >0 rows (not blank).
-wb_pages = JSON.parse(File.read(wb_readback))['pages']
-chart_els = wb_pages.reject { |p| p['id'] == 'page-data' }
-                    .flat_map { |p| (p['elements'] || []) }
-probed = 0; empty = []
-chart_els.each do |e|
-  begin
-    body = { 'elementId' => e['id'], 'limit' => 1 }.to_json
-    res = Sigma.request(:post, "/v2/workbooks/#{wb_id}/export", body: body) rescue nil
-    probed += 1
-  rescue StandardError
-    # export endpoint shape varies; row-probe is best-effort, the column guard is the hard signal
-  end
-end
-parity_ok = err_cols.empty?
-if parity_ok
-  puts "   PARITY: PASS — #{total_cols} workbook column(s) resolve (0 error-typed); " \
-       "#{chart_els.size} chart element(s) built across #{wb_pages.size} page(s)"
-else
-  puts "   PARITY: FAIL — #{err_cols.size}/#{total_cols} column(s) resolved to type 'error':"
+unless err_cols.empty?
+  puts "   GUARD FAIL — #{err_cols.size}/#{total_cols} column(s) resolved to type 'error':"
   err_cols.first(8).each { |c| puts "     [#{c['elementId']}] #{c['label']}: #{c['formula']}" }
+  exit 3
 end
+puts "   guard: #{total_cols} workbook column(s) resolve (0 error-typed)"
+
+have_parity_inputs = File.exist?(exp_path) && File.exist?(act_path)
+unless File.exist?(File.join(WORK, 'parity-plan.json')) && have_parity_inputs
+  run!(['ruby', File.join(HERE, 'phase6-parity-quicksight.rb'),
+        '--workdir', WORK, '--workbook-id', wb_id])
+end
+
+unless have_parity_inputs
+  puts
+  puts '   >>> GATE: collect the Sigma ACTUAL rows (sigma-mcp-v2 queries above) and the'
+  puts '       warehouse EXPECTED rows (same dim+aggregation, type=connection query), write'
+  puts "         #{exp_path}"
+  puts "         #{act_path}"
+  puts '       then RE-RUN THIS SAME COMMAND — phases 1-5 are skipped automatically'
+  puts '       (or pass --expected/--actuals explicitly).'
+  exit 10
+end
+
+fin = ['ruby', File.join(HERE, 'phase6-parity-quicksight.rb'),
+       '--workdir', WORK, '--finalize', '--expected', exp_path, '--actuals', act_path]
+fin += ['--extract-mode', '--extract-tol', (opts[:tol] || 0.30).to_s] if opts[:extract]
+fin_out, fin_st = Open3.capture2e(*fin)
+fin_out.each_line { |l| puts "   #{l.rstrip}" }
+parity_ok = fin_st.success?
+
+# the shared HARD GATE: parity sentinel + orphan + error-column + layout checks.
+gate_out, gate_st = Open3.capture2e('ruby', File.join(HERE, 'assert-phase6-ran.rb'),
+                                    '--workdir', WORK, '--workbook-id', wb_id)
+gate_out.each_line { |l| puts "   #{l.rstrip}" }
+gate_ok = gate_st.success?
 
 # ---------------------------------------------------------------------------
 # Summary
@@ -317,11 +491,12 @@ puts
 puts '================ RESULT ================'
 puts "dataModelId : #{dm_id}"
 puts "workbookId  : #{wb_id}"
-puts "PARITY      : #{parity_ok ? 'PASS' : 'FAIL'} (#{total_cols} cols resolve, #{err_cols.size} error)"
-wf = wb_spec.sub(/\.json$/, '') + '.warnings.json'
+puts "PARITY      : #{parity_ok ? 'PASS' : 'FAIL'} (#{total_cols} cols resolve, 0 error)"
+puts "HARD GATE   : #{gate_ok ? 'PASS' : 'FAIL'} (assert-phase6-ran)"
+wf = File.join(WORK, 'wb-spec.warnings.json')
 if File.exist?(wf)
-  wl = JSON.parse(File.read(wf))['warnings'] || []
+  wl = (JSON.parse(File.read(wf))['warnings'] rescue []) || []
   puts "warnings    : #{wl.size} (see #{wf})" unless wl.empty?
 end
 puts '======================================='
-exit(parity_ok ? 0 : 3)
+exit(parity_ok && gate_ok ? 0 : 3)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/quicksight-discover.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/quicksight-discover.py
@@ -11,6 +11,13 @@ Usage:
   python3 scripts/quicksight-discover.py \
     --account-id 153722385948 --region us-east-1 --profile pivot \
     --analysis-id orders-overview --out-dir ~/quicksight-migration/orders-overview
+
+Offline / fixture mode (no AWS account or CLI needed — drives the same
+signals.json off describe-shaped JSON files already on disk, e.g. the skill's
+fixtures/ or a customer's exported definitions):
+
+  python3 scripts/quicksight-discover.py \
+    --from-fixtures plugins/.../fixtures --out-dir /tmp/qs-orders
 """
 import argparse, json, os, subprocess, sys
 
@@ -51,23 +58,54 @@ def field_columns(inner):
     return out
 
 
+def load_fixtures(fdir):
+    """Read describe-shaped JSONs from a dir: one analysis/dashboard definition
+    (top-level "Definition") + one or more datasets (top-level "DataSet")."""
+    analysis, datasets = None, []
+    for fn in sorted(os.listdir(fdir)):
+        if not fn.endswith(".json"):
+            continue
+        try:
+            j = json.load(open(os.path.join(fdir, fn)))
+        except (ValueError, OSError):
+            continue
+        if isinstance(j, dict) and "Definition" in j:
+            analysis = j
+        elif isinstance(j, dict) and "DataSet" in j:
+            datasets.append(j)
+    if analysis is None:
+        sys.exit(f"--from-fixtures: no analysis/dashboard definition JSON (top-level 'Definition') in {fdir}")
+    return analysis, datasets
+
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--account-id", required=True)
-    ap.add_argument("--region", required=True)
+    ap.add_argument("--account-id")
+    ap.add_argument("--region")
     ap.add_argument("--profile")
-    g = ap.add_mutually_exclusive_group(required=True)
+    g = ap.add_mutually_exclusive_group()
     g.add_argument("--analysis-id")
     g.add_argument("--dashboard-id")
+    ap.add_argument("--from-fixtures", help="dir of describe-shaped JSONs — offline mode, no AWS calls")
     ap.add_argument("--out-dir", required=True)
     a = ap.parse_args()
+    offline = bool(a.from_fixtures)
+    if not offline and not (a.analysis_id or a.dashboard_id):
+        ap.error("need --analysis-id or --dashboard-id (or --from-fixtures)")
+    if not offline and not (a.account_id and a.region):
+        ap.error("--account-id and --region are required for live discovery")
 
     out = os.path.expanduser(a.out_dir)
     os.makedirs(os.path.join(out, "datasets"), exist_ok=True)
     os.makedirs(os.path.join(out, "datasources"), exist_ok=True)
 
+    fixture_ds = []
     # 1. the analysis / dashboard definition
-    if a.analysis_id:
+    if offline:
+        d, fixture_ds = load_fixtures(os.path.expanduser(a.from_fixtures))
+        src_kind = "dashboard" if d.get("DashboardId") else "analysis"
+        src_id = d.get("AnalysisId") or d.get("DashboardId") or "fixture"
+    elif a.analysis_id:
         d = aws(["describe-analysis-definition", "--analysis-id", a.analysis_id], a.account_id, a.region, a.profile)
         src_kind, src_id = "analysis", a.analysis_id
     else:
@@ -79,9 +117,16 @@ def main():
 
     # 2. datasets referenced by the definition
     ds_meta, src_arns = [], set()
+    fixture_by_id = {ds["DataSet"].get("DataSetId"): ds for ds in fixture_ds}
     for decl in defn.get("DataSetIdentifierDeclarations", []):
         ident, ds_id = decl["Identifier"], arn_id(decl["DataSetArn"])
-        ds = aws(["describe-data-set", "--data-set-id", ds_id], a.account_id, a.region, a.profile)
+        if offline:
+            ds = fixture_by_id.get(ds_id)
+            if ds is None:
+                print(f"  WARN: no fixture dataset JSON for '{ds_id}' — skipping", file=sys.stderr)
+                continue
+        else:
+            ds = aws(["describe-data-set", "--data-set-id", ds_id], a.account_id, a.region, a.profile)
         json.dump(ds, open(os.path.join(out, "datasets", ds_id + ".json"), "w"), indent=2)
         dso = ds["DataSet"]
         for ptv in (dso.get("PhysicalTableMap") or {}).values():
@@ -96,6 +141,9 @@ def main():
     src_meta = []
     for arn in sorted(src_arns):
         sid = arn_id(arn)
+        if offline:
+            src_meta.append({"dataSourceId": sid, "name": None, "type": "OFFLINE-FIXTURE"})
+            continue
         try:
             s = aws(["describe-data-source", "--data-source-id", sid], a.account_id, a.region, a.profile)
             json.dump(s, open(os.path.join(out, "datasources", sid + ".json"), "w"), indent=2)


### PR DESCRIPTION
Efficiency wave: three pieces (beads fmte part, ns7c part, x30b).

## 1. powerbi-to-sigma — SOURCE-FRESHNESS PREFLIGHT (fmte)
Mirrors qlik's freshness preflight. New `scripts/pbi-freshness.py` captures, via the cached PBI token:
- **refresh history** (`GET datasets/{id}/refreshes`) — last successful refresh + **FAILED refreshes** (expired warehouse creds called out loudly)
- a cheap **executeQueries row-count/max-date snapshot** per TMSL table

Wired into `run.sh` (stage 1.5) and `migrate-powerbi.rb` (Phase 1.5). Parity is now **LED by the staleness banner**, and deltas classify **MATCH / STALE-EXPLAINED / DIVERGENT — only DIVERGENT blocks** (both the Phase-6 table-level compare via the REST export API, and the chart-level `phase6-parity-pbi.rb --finalize --freshness`). The executeQueries harness also gained My-workspace (`--workspace me`) support.

**Live-validated:**
- EMPLOYEE DASHBOARD (My workspace): banner printed real refresh `2026-05-30T11:29:07.82Z (11.5 days ago)`; EMPLOYEES PBI snapshot 363 / max(HIRE_DATE) 2026-05-29 vs warehouse 370 / 2026-06-08 (**+7 employees**) → both chart deltas classified `STALE-EXPLAINED`, finalize exit 0.
- Workforce Comp & Distribution: banner surfaced the live **FAILED refresh 2026-06-10 (ModelRefresh_ShortMessage_ProcessingError) — Snowflake credentials invalid**.
- Full migration kept: **VISQA4 PBI Superstore Overview** (wb `9693ad75`), Phase 6 freshness-led, PARITY PASS, ~12s.

## 2. quicksight-to-sigma — one-command orchestrator (ns7c)
`migrate-quicksight.rb` now chains the CURRENT pieces end-to-end:
`discover` (live AWS **or new `--from-fixtures`** offline mode in `quicksight-discover.py`) → `convert-model --emit-mcp` gate + `--converted` resume (or local MCP build in-process) → **Phase 2.5 DM-reuse check** (`qs-dm-signature.py` + `find-or-pick-dm.rb`, default build-new, `--reuse-dm` to attach) → `fixup --folder-id` → validate → post-and-readback → build-workbook → layout → **`phase6-parity-quicksight` two-pass** (emit query list, gate, `--actuals`/`--expected` resume with automatic phase-1-5 skip via `wb-id.txt`) → **`assert-phase6-ran --workdir`** hard gate. Hardcoded developer paths removed; `--database/--schema/--name` added.

**Live-validated ONE COMMAND** on the fixtures (conn `bc0319f8`, folder "QuickSight Migrations"): **VISQA4 QS Orders Overview** (wb `997c0998`) — 5/5 strict parity PASS, all hard gates green, **137s wall-clock** including both MCP gates.

## 3. corpus CI (x30b)
`.github/workflows/corpus-check.yml` — on `pull_request` + `push` to main, creds-free:
- `corpus/run-corpus.sh --check` (stdlib python3 + bash; ~1s locally, 10/10 cases)
- repo-wide syntax CI: `ruby -c` / `py_compile` / `bash -n` over every tracked script (shebang-aware — `setup-tableau.sh` is ruby)

Pinned `ubuntu-24.04` (python3/ruby/bash preinstalled — no setup actions, no secrets). Well under the 2-minute budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)