### PR TITLE
One-command orchestrators for thoughtspot-to-sigma + looker-to-sigma (ns7c) + scripted Looker parity gate (fnhy) + TS freshness preflight (fmte)

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
@@ -3,6 +3,23 @@
 End-to-end: a Looker LookML model + its dashboards (UDD or LookML-defined) → a Sigma data model
 + workbook(s), parity-verified against Looker AND the warehouse.
 
+## 0. ONE COMMAND (preferred)
+```bash
+# offline (fixtures work end-to-end):
+python3 scripts/migrate-looker.py --lookml-dir fixtures/skilltest-orders \
+    --dashboard fixtures/skilltest-orders/skilltest_orders.dashboard.lookml \
+    [--name PREFIX] [--workdir /tmp/look-run]
+# live: --dashboard-id <id> instead of --dashboard (needs ~/.looker/looker.ini)
+```
+Runs everything below — parse → RLS gate (exit 10 on findings unless `--yes`) →
+convert (exit 3 + `--converted` resume when no local converter) → DM-reuse check
+(candidates PRINTED; default build-new, reuse only via `--reuse-dm <id>`) →
+`post_dm.py` + readback → `build_workbook.py` + POST (layout inline) → freshness
+preflight → **scripted parity (`phase6-parity-looker.rb`) +
+`assert-phase6-ran.rb` hard gate**. Exit 0 = GREEN; a failed gate fails the
+command. Sigma token auto-minted from `~/.sigma-migration/env`. Steps 1–5 below
+are the manual, per-phase path.
+
 ## 1. Authenticate
 
 **Looker** (REST API 4.0). Put an API3 key in `~/.looker/looker.ini`:
@@ -86,14 +103,22 @@ Emits a `/v2/workbooks/spec` body: hidden Data page + master table, one element 
 controls from filters, newspaper→24-col layout XML. POST it to `/v2/workbooks/spec` (returns
 YAML → record `workbookId`). **POST once; PUT every later edit** (re-POST leaves orphans).
 
-## 5. Verify parity (3-way) — MANDATORY
+## 5. Verify parity (3-way) — MANDATORY (scripted hard gate)
 
-Compare at the metric grain and per tile:
+```bash
+ruby scripts/phase6-parity-looker.rb --workdir /tmp/look --workbook-id <wb>   # PASS 1: plan
+# … fetch ACTUAL (Sigma) + EXPECTED (Looker inline query / warehouse) …
+ruby scripts/phase6-parity-looker.rb --workdir /tmp/look --finalize           # PASS 2: sentinel
+ruby scripts/assert-phase6-ran.rb   --workdir /tmp/look --workbook-id <wb>    # must exit 0
+```
+(`migrate-looker.py` runs all of this automatically.) The reference comparison
+is 3-way, at the metric grain and per tile:
 - **Looker** — `POST /queries/run/json` for the explore.
 - **Sigma** — `mcp__sigma-mcp-v2__query` (raw aggregate; `metric()` returns "Missing Metric").
 - **Warehouse** — the source-of-truth `SELECT`.
 
-GREEN only when all three match (the validated run tied out to the cent).
+GREEN only when all three match (the validated run tied out to the cent) AND
+`assert-phase6-ran.rb` exits 0.
 
 ---
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -44,10 +44,55 @@ offline-only path that normalizes into the same contract.
 
 ---
 
+## ONE COMMAND (preferred): migrate-looker.py
+
+The whole pipeline — parse → **RLS gate** → convert → **DM-reuse check** → DM
+POST + readback → workbook build (layout inline) → **source-freshness
+preflight** → **scripted parity + hard gate** — as a single command (mirrors
+qlik-to-sigma's `migrate-qlik.rb` / thoughtspot's `migrate-thoughtspot.py`).
+Gates are never bypassed: the command exits non-zero if parity or
+`assert-phase6-ran.rb` fails.
+
+```bash
+# offline (.dashboard.lookml + view files; the fixture pair works end-to-end):
+python3 scripts/migrate-looker.py --lookml-dir fixtures/skilltest-orders \
+    --dashboard fixtures/skilltest-orders/skilltest_orders.dashboard.lookml \
+    [--name PREFIX] [--workdir /tmp/look-run]
+# live (UDD or LookML dashboard, ~/.looker/looker.ini configured):
+python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
+    --dashboard-id <id> [--explore <name>] [--name PREFIX] [--workdir DIR]
+```
+
+- **Decision points are flags with safe defaults, never silent:** `detect_rls.py`
+  runs first — RLS findings STOP the command (exit 10, nothing posted) until you
+  either port them via `apply_sigma_rls.py` (Phase 1.5) or re-run with `--yes`
+  (proceed WITHOUT RLS — loud + recorded). The DM-reuse check (Phase 2.5) always
+  runs and PRINTS candidates+scores; default is build-new, reuse only via an
+  explicit `--reuse-dm <id>`. The folder is auto-resolved and printed.
+- **Converter paths:** `CONVERTER_SRC` (patched `src/lookml.ts` via tsx) or
+  `CONVERTER_PATH` (`build/lookml.js`) — both auto-located; with neither, the
+  command writes `<workdir>/convert-request.json` (the exact
+  `convert_lookml_to_sigma` MCP arguments) and exits 3 — call the tool, save its
+  JSON, re-run with `--converted <file>` (mirrors thoughtspot's exit-3 design).
+- **Parity is fully scripted** (the Phase-4 gate below): ACTUAL = Sigma CSV
+  export per chart; EXPECTED = a Looker inline query (live) or a
+  SOURCE-LookML-derived re-aggregation of the master's warehouse rows (offline —
+  measure semantics from the `.view.lkml` `type:`, independent of the builder's
+  formulas). Then `phase6-parity-looker.rb --finalize` + `assert-phase6-ran.rb`
+  run automatically.
+- Exit codes: `0` GREEN · `3` MCP convert request emitted · `10` RLS decision
+  needed · `2` built but a gate FAILED. `--dry-run` = no Sigma POSTs.
+
+---
+
 ## Scripts
 
 | Script | Purpose |
 |---|---|
+| `scripts/migrate-looker.py` | **ONE-COMMAND orchestrator** (preferred entry) — chains every phase below + the scripted parity hard gate; see the section above. |
+| `scripts/phase6-parity-looker.rb` | **Phase 4 (parity gate):** two-pass orchestrator — PASS 1 reads the workbook spec → `parity-plan.json` + per-chart fetch instructions; PASS 2 `--finalize` runs `verify-parity.rb` and writes the **`parity-final.json` sentinel** the hard gate requires. Same contract as quicksight/thoughtspot/tableau. |
+| `scripts/verify-parity.rb` | **Phase 4:** the comparator (strict set-compare with date-bucket canonicalization; `--extract-mode` tolerance variant). Vendored from the shared converter copy. |
+| `scripts/assert-phase6-ran.rb` | **HARD GATE** (vendored **byte-identical** from quicksight-to-sigma — keep the md5 in lockstep): parity ran + PASS, no orphan workbooks, no `type=error` columns, layout applied. `ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <wb>` must **exit 0** before declaring GREEN. |
 | `scripts/get-token.sh` | Exchange `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` → `SIGMA_API_TOKEN` (~1h TTL). `eval "$(scripts/get-token.sh)"` |
 | `scripts/looker_api.py` | Minimal Looker REST API 4.0 client (no SDK). Reads `~/.looker/looker.ini`, logs in via `client_credentials`, exposes `L.call(method, path, body)`. CLI: `python3 looker_api.py whoami` / `get <path>` / `raw GET /lookml_models`. |
 | `scripts/fetch_looker_dashboard.py` | **Phase 1 (live):** `GET /dashboards/{id}` → the normalized contract (`refs/dashboard-contract.md`). Works for UDD AND LookML dashboards. Self-contained (reads `~/.looker/looker.ini`). `tileType` is read from `query.vis_config.type` (NOT `element.type`, which is always `"vis"`); `listen` from `result_maker.filterables`; layout from the **active** layout's components. |
@@ -540,6 +585,24 @@ applied. **POST is create-only** — every subsequent spec edit MUST use `PUT
 
 A conversion is not complete until the numbers tie out. Compare at **two grains**: the model's
 key metrics, and per-tile.
+
+### 4-pre. The scripted gate (canonical — what migrate-looker.py runs)
+
+```bash
+ruby scripts/phase6-parity-looker.rb --workdir /tmp/<name> --workbook-id <wb>   # PASS 1: plan
+# … fetch ACTUAL (Sigma CSV export / mcp__sigma-mcp-v2__query) + EXPECTED
+#   (Looker POST /queries/run/json, or the warehouse re-aggregation offline) …
+#   → write parity-expected.json + parity-actuals.json (shape: {"<chart>": [[dim,val],…]})
+ruby scripts/phase6-parity-looker.rb --workdir /tmp/<name> --finalize           # PASS 2: sentinel
+ruby scripts/assert-phase6-ran.rb   --workdir /tmp/<name> --workbook-id <wb>    # must exit 0
+```
+
+The finalize pass writes the **`parity-final.json` sentinel**; `assert-phase6-ran.rb`
+(hard gate, vendored byte-identical from quicksight-to-sigma) refuses GREEN unless
+parity ran + PASSed, no orphan workbooks were left, the live workbook has no
+`type=error` columns, and a real layout is applied. `migrate-looker.py` automates
+both fetch sides and runs the gate for you. The manual 3-way checks below remain
+the reference for what "parity" means.
 
 1. **Looker** — `POST /queries/run/json` (or `run_inline_query`) for the model/explore, e.g.
    net revenue by region.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,0 +1,356 @@
+#!/usr/bin/env ruby
+# Hard gate that proves a tableau-to-sigma conversion is actually complete.
+# The subagent MUST run this script before declaring GREEN. It checks five
+# independent things — failing ANY of them blocks the GREEN declaration:
+#
+#   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
+#      → beads-sigma-4pm
+#   2. No orphan workbooks left in the customer's My Documents
+#      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
+#      cleanup ran with no failed deletes)  → beads-sigma-38a
+#   3. The live workbook's /columns endpoint shows no column with
+#      type=error (catches circular refs / runtime errors introduced
+#      AFTER the initial POST's column-type guard ran)  → beads-sigma-38a
+#   4. The workbook has a non-empty layout XML applied (catches the
+#      "elements just listed in a single column" regression where the
+#      agent forgot to PUT a layout)  → beads-sigma-bw3
+#   5. Tile census — parity-final.json's `tile_census` field (emitted by the
+#      converter's phase6 finalize when a dashboard zone tree is available)
+#      shows no unexplained dashboard zones without a matching chart in the
+#      parity plan. Catches the "empty view CSV silently dropped a tile and
+#      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
+#      (with a note) when the converter doesn't emit a census.
+#
+# Usage:
+#   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
+#     [--workbook-id <id>]     # override; default = read from wb-ids.json
+#     [--min-pass-rate 1.0]    # default 1.0 (every chart must PASS)
+#     [--allow-extract]        # treat extract-mode as acceptable
+#     [--skip-column-check]    # skip the live /columns type=error scan
+#     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
+#                              # that genuinely want multiple workbooks)
+#     [--skip-layout-check]    # skip the layout-applied scan
+#     [--min-layout-elements N] default 2 — single-page bare-element layouts
+#                              # often have just the page wrapper; require this
+#                              # many <LayoutElement> tags
+#     [--allow-missing-tiles N] default 0 — tolerate up to N unmatched dashboard
+#                              # zones in the tile census (for legitimately
+#                              # unbuildable zones; name them in your report)
+#
+# Exit codes:
+#   0  every gate passes — conversion is allowed to declare GREEN
+#   1  parity-final.json missing (Phase 6 skipped — the regression case)
+#   2  parity-final.json exists but status=FAIL / pass-rate below min /
+#      extract-mode without --allow-extract / charts_total==0
+#   3  parity-final.json malformed
+#   4  orphan workbooks left uncleaned (beads-sigma-38a)
+#   5  live workbook has column(s) with type=error (beads-sigma-38a)
+#   6  live workbook has no layout applied — single-column fallback
+#      (beads-sigma-bw3)
+#   7  tile census shows unexplained unmatched dashboard zones beyond
+#      --allow-missing-tiles (bead gjhe)
+#
+# Prints a per-gate summary to stdout regardless of exit code.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
+         allow_missing_tiles: 0 }
+OptionParser.new do |p|
+  p.on('--tableau DIR')              { |v| opts[:tab] = v }
+  p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
+  p.on('--workbook-id ID')           { |v| opts[:wb] = v }
+  p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--allow-extract')            { opts[:allow_extract] = true }
+  p.on('--skip-column-check')        { opts[:skip_column] = true }
+  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
+  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+  p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
+end.parse!
+abort('--workdir (or --tableau) required') unless opts[:tab]
+
+summary_path = File.join(opts[:tab], 'parity-final.json')
+
+unless File.exist?(summary_path)
+  warn "[FAIL] Phase 6 skipped — #{summary_path} does not exist."
+  warn "       Run: ruby scripts/phase6-parity.rb --tableau #{opts[:tab]} --workbook-id <id>"
+  warn "       then collect actuals via mcp__sigma-mcp-v2__query and re-run with --finalize."
+  warn "       See SKILL.md Phase 6. This is the hard gate (beads-sigma-4pm)."
+  exit 1
+end
+
+begin
+  summary = JSON.parse(File.read(summary_path))
+rescue JSON::ParserError => e
+  warn "[FAIL] #{summary_path} is malformed JSON: #{e.message}"
+  exit 3
+end
+
+total = summary['charts_total'].to_i
+passed = summary['charts_pass'].to_i
+status = summary['status'].to_s
+mode = summary['mode'].to_s
+
+if total <= 0
+  warn "[FAIL] parity-final.json reports charts_total=#{total} — no charts were verified."
+  warn "       This usually means auto-parity-plan.rb matched zero Tableau views."
+  warn "       Phase 6 must verify at least one chart to declare GREEN."
+  exit 2
+end
+
+if mode == 'extract' && !opts[:allow_extract]
+  warn "[FAIL] parity ran in extract-mode but --allow-extract was not passed."
+  warn "       Extract-mode permits up to ±#{((summary['extract_tol'] || 0.30) * 100).to_i}% drift —"
+  warn "       only acceptable when the source Tableau workbook has hasExtracts=true."
+  exit 2
+end
+
+pass_rate = passed.to_f / total
+if status != 'PASS' || pass_rate < opts[:min_pass_rate]
+  warn "[FAIL] parity status=#{status} pass-rate=#{(pass_rate * 100).round(1)}% (#{passed}/#{total})"
+  warn "       Required: status=PASS and pass-rate >= #{(opts[:min_pass_rate] * 100).to_i}%"
+  if (fail_names = summary['fail_names']) && !fail_names.empty?
+    warn "       Failing charts: #{fail_names.join(', ')}"
+  end
+  exit 2
+end
+
+puts "[OK] gate 1/5: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+
+# ---------------------------------------------------------------------------
+# Gate 2 — orphan workbooks (beads-sigma-38a)
+# ---------------------------------------------------------------------------
+unless opts[:skip_orphan]
+  log = File.join(opts[:tab], 'posted-workbooks.jsonl')
+  if File.exist?(log)
+    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    unique_ids = posted.map { |e| e['id'] }.uniq
+    if unique_ids.length > 1
+      marker_path = File.join(opts[:tab], 'cleanup-marker.json')
+      unless File.exist?(marker_path)
+        warn "[FAIL] gate 2/5: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "       posted-workbooks.jsonl entries:"
+        unique_ids.each { |id| warn "         - #{id}" }
+        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        warn "       See beads-sigma-38a."
+        exit 4
+      end
+      marker = JSON.parse(File.read(marker_path)) rescue {}
+      if marker['failed'] && !marker['failed'].empty?
+        warn "[FAIL] gate 2/5: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "       Orphan workbooks are still in the customer's My Documents:"
+        marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
+        exit 4
+      end
+      if marker['dry_run']
+        warn "[FAIL] gate 2/5: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+        exit 4
+      end
+      kept = marker['kept'] || '(unknown)'
+      deleted = (marker['deleted'] || []).length
+      puts "[OK] gate 2/5: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+    else
+      puts "[OK] gate 2/5: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+    end
+  else
+    puts "[OK] gate 2/5: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+  end
+else
+  puts "[SKIP] gate 2/5: --skip-orphan-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 3 — live /columns type=error scan (beads-sigma-38a)
+# Catches circular references and runtime errors that the initial post-and-
+# readback column-type guard missed because they were introduced by later
+# PUTs (layout updates, spec edits during error recovery).
+# ---------------------------------------------------------------------------
+unless opts[:skip_column]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 3/5: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 3/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        cols = (JSON.parse(res.body)['entries'] rescue []) || []
+        error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
+        if error_cols.any?
+          warn "[FAIL] gate 3/5: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
+          warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
+          error_cols.first(10).each do |c|
+            warn "         element=#{c['elementId']} col=#{c['columnId']} label=#{c['label'].inspect}"
+            warn "           formula: #{c['formula']}"
+          end
+          warn "       See beads-sigma-38a."
+          exit 5
+        end
+        puts "[OK] gate 3/5: #{cols.length} live columns clean (no type=error)"
+      else
+        warn "[SKIP] gate 3/5: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 3/5: --skip-column-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 4 — layout applied (beads-sigma-bw3)
+# Fetches the live workbook spec and confirms a non-empty top-level `layout`
+# XML is set, with at least --min-layout-elements <LayoutElement> tags.
+# Catches the "agent forgot to PUT a layout" regression where elements
+# render as a single-column stack instead of the dashboard grid.
+# ---------------------------------------------------------------------------
+unless opts[:skip_layout]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 4/5: no workbook ID resolvable for layout check"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 4/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        body = res.body.to_s
+        spec =
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+          end
+        layout_xml = spec['layout'].to_s
+        elem_count = layout_xml.scan(/<LayoutElement\b/).length
+
+        # Detect the Sigma "auto-generated single-column stack" layout that
+        # the server produces when a workbook is POSTed without a layout.
+        # Signature: every non-Data page has all its elements at the same
+        # gridColumn value (typically "1 / 13" — left half, vertically stacked).
+        # Note: per-page detection — a workbook with one element per content
+        # page is structurally fine (degenerate case, not a stack).
+        non_data_stack_pages = []
+        # Walk one page at a time using the <Page id="..."> blocks
+        layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
+          next if page_id.to_s.downcase.include?('data')
+          cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
+          elems_on_page = page_body.scan(/<LayoutElement\b/).length
+          if elems_on_page >= 2 && cols_on_page.length == 1
+            non_data_stack_pages << [page_id, cols_on_page.first, elems_on_page]
+          end
+        end
+
+        if layout_xml.empty?
+          warn "[FAIL] gate 4/5: live workbook #{wb_id} has NO top-level layout XML."
+          warn "       Elements render as a single-column stack instead of the"
+          warn "       dashboard grid. Rebuild the layout with this skill's layout"
+          warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
+          warn "       then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} \\"
+          warn "           --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        elsif elem_count < opts[:min_layout_elements]
+          warn "[FAIL] gate 4/5: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
+          warn "       The layout likely covers only the Data page — chart page is unstyled."
+          exit 6
+        elsif non_data_stack_pages.any?
+          warn "[FAIL] gate 4/5: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "       single-column stack layout (multiple elements at the same gridColumn"
+          warn "       on a non-Data page). This is what Sigma defaults to when you POST"
+          warn "       a workbook without a layout — exactly the CoCo regression."
+          non_data_stack_pages.each do |pid, col, n|
+            warn "         page=#{pid.inspect}: #{n} elements all at gridColumn=#{col.inspect}"
+          end
+          warn "       Rebuild the layout with this skill's layout builder (see SKILL.md —"
+          warn "       layout phase) into #{opts[:tab]}/layout.xml, then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        else
+          puts "[OK] gate 4/5: layout XML applied with #{elem_count} positioned element(s)"
+        end
+      else
+        warn "[SKIP] gate 4/5: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 4/5: --skip-layout-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 5 — tile census (bead gjhe)
+# parity-final.json's `tile_census` field compares the source dashboard's
+# chart-zone count against the charts that made it into the parity plan.
+# Catches the empty-view-CSV escape where the builder silently emits N-1
+# charts and parity still reports PASS (every chart it knows about passes —
+# it just doesn't know about the dropped one).
+# ---------------------------------------------------------------------------
+census = summary['tile_census']
+if census.nil?
+  puts "[SKIP] gate 5/5: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+else
+  zones     = census['zones_total'].to_i
+  built     = census['charts_built'].to_i
+  unmatched = census['zones_unmatched'].to_i
+  names     = Array(census['unmatched_zone_names'])
+  if unmatched > opts[:allow_missing_tiles]
+    warn "[FAIL] gate 5/5: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    names.each { |n| warn "         - #{n}" }
+    warn "       A zone that rendered in the source dashboard has NO matching chart in the"
+    warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
+    warn "       (re-fetch the view data and rebuild), or the tile was renamed without"
+    warn "       passing --rename to phase6-parity.rb / build-dashboard-layout.rb."
+    warn "       If #{unmatched} zone(s) are legitimately unbuildable, re-run with"
+    warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
+    exit 7
+  elsif unmatched > 0
+    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+  else
+    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+puts "[OK] all gates pass — conversion may declare GREEN"
+exit 0

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""migrate-looker.py — ONE-COMMAND orchestrator for the looker-to-sigma
+pipeline: parse → RLS gate → convert → DM-reuse check → DM POST + readback →
+workbook build (+ layout, inline) → source-freshness preflight → scripted
+parity + HARD GATE. Mirrors qlik-to-sigma's migrate-qlik.rb: every phase prints
+a visible header + concise result, decision points are flags with safe defaults
+(never silent), and the parity gate is NEVER bypassed — the command FAILS if a
+gate fails.
+
+This script does NOT re-implement any phase — it chains the per-phase scripts:
+  parse_lookml_dashboard.py / fetch_looker_dashboard.py
+                          (Phase 1 — the normalized dashboard contract, offline
+                           .dashboard.lookml or live GET /dashboards/{id})
+  detect_rls.py           (Phase 2 — RLS gate: zero overhead when clean; when
+                           RLS IS found the command STOPS (exit 10) unless
+                           --yes — security is never silently dropped. Port it
+                           via apply_sigma_rls.py (SKILL.md Phase 1.5), then
+                           re-run.)
+  convert_dm.mjs / a local converter build / the MCP-request pattern
+                          (Phase 3 — LookML → Sigma DM spec. No shellable
+                           converter? The command writes convert-request.json —
+                           the exact mcp__sigma-data-model__convert_lookml_to_sigma
+                           arguments — and exits 3; call the tool, save its JSON,
+                           and re-run with --converted <file>. Mirrors
+                           thoughtspot's exit-3 design.)
+  lookml-dm-signature.py + find-or-pick-dm.rb
+                          (Phase 3.5 — DM-reuse check: candidates+scores
+                           PRINTED, default = build new; reuse only on an
+                           explicit --reuse-dm <id>)
+  post_dm.py              (Phase 3 — POST /v2/dataModels/spec, join-key guard
+                           included) + denorm-element readback
+  build_workbook.py       (Phase 4 — contract + view .lkml → workbook spec with
+                           the newspaper→24-col layout XML inline; POST once)
+  Phase 5 — SOURCE-FRESHNESS preflight: source mtime/live note + a warehouse
+            snapshot (master row count + max date) printed BEFORE any
+            side-by-side.
+  phase6-parity-looker.rb (Phase 6 — two-pass parity, fully scripted: ACTUAL =
+                           Sigma CSV export per chart; EXPECTED = a Looker
+                           inline query when live, or a SOURCE-LookML-derived
+                           re-aggregation of the master's warehouse rows when
+                           offline) + verify-parity.rb
+  assert-phase6-ran.rb    (HARD GATE — vendored byte-identical from
+                           quicksight-to-sigma; must exit 0 to declare GREEN)
+
+Usage (offline — fixtures, no live Looker):
+  python3 scripts/migrate-looker.py --lookml-dir fixtures/skilltest-orders \
+      --dashboard fixtures/skilltest-orders/skilltest_orders.dashboard.lookml \
+      [--name PREFIX] [--workdir DIR]
+Usage (live — ~/.looker/looker.ini configured):
+  python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
+      --dashboard-id <id> [--explore <name>] [--name PREFIX] [--workdir DIR]
+Resume after the MCP converter fallback (exit 3):
+  ... same command ... --converted <workdir>/converted.json
+Other flags:
+  --reuse-dm <dataModelId>   reuse an existing DM (skip convert+POST) — the
+                             Phase-3.5 check prints candidates; reuse is NEVER
+                             chosen silently, only via this flag
+  --skip-dm-reuse-check      skip the Phase-3.5 scan entirely
+  --folder <folderId>        Sigma folder (auto-resolved and PRINTED when unset)
+  --yes                      accept safe defaults at the RLS gate (proceed
+                             WITHOUT porting RLS — loud, recorded, never silent)
+  --dry-run                  no Sigma POSTs: contract + RLS scan + DM spec (or
+                             MCP request) + workbook spec with placeholder ids
+
+Env: SIGMA_BASE_URL + SIGMA_API_TOKEN (or SIGMA_CLIENT_ID/SECRET via
+~/.sigma-migration/env — the script mints a token), SIGMA_CONNECTION_ID,
+optional CONVERTER_SRC (src/lookml.ts, run via tsx) or CONVERTER_PATH
+(build/lookml.js) — both auto-located.
+
+Exit codes: 0 = done, all gates GREEN; 3 = MCP convert request emitted (resume
+with --converted); 10 = RLS found, decision needed (nothing posted); 2 = built
+but a parity/hard gate FAILED; other = error.
+"""
+import argparse, csv, glob, io, json, os, re, statistics, subprocess, sys, time
+import urllib.request, urllib.error
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from build_workbook import build_field_index, disp, leaf
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+T0 = time.time()
+MCP_TOOL = "mcp__sigma-data-model__convert_lookml_to_sigma"
+CONVERTER_HOMES = [os.path.expanduser(p) for p in
+                   ("~/Desktop/sigma-data-model-mcp", "~/sigma-data-model-mcp")]
+
+
+def hdr(n, total, title):
+    print(f"\n── Phase {n}/{total} · {title} ──")
+
+
+def run(cmd, env=None, cwd=None, check=True):
+    p = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd,
+                       env={**os.environ, **(env or {})})
+    out = (p.stdout or "") + (p.stderr or "")
+    for line in out.splitlines():
+        print("   " + line)
+    if check and p.returncode != 0:
+        sys.exit(f"FATAL: command failed ({p.returncode}): {' '.join(cmd)}")
+    return p.returncode, out
+
+
+def ensure_sigma_env():
+    env_file = os.path.expanduser("~/.sigma-migration/env")
+    if os.path.exists(env_file):
+        for line in open(env_file):
+            m = re.match(r"\s*export\s+(\w+)=['\"]?([^'\"\n]+)", line)
+            if m and not os.environ.get(m.group(1)):
+                os.environ[m.group(1)] = m.group(2)
+    if not os.environ.get("SIGMA_API_TOKEN") and os.environ.get("SIGMA_CLIENT_ID"):
+        p = subprocess.run(["bash", os.path.join(HERE, "get-token.sh")],
+                           capture_output=True, text=True)
+        m = re.search(r"export SIGMA_API_TOKEN=(\S+)", p.stdout or "")
+        if m:
+            os.environ["SIGMA_API_TOKEN"] = m.group(1)
+
+
+def sigma(method, path, body=None):
+    base = os.environ["SIGMA_BASE_URL"]; tok = os.environ["SIGMA_API_TOKEN"]
+    req = urllib.request.Request(base + path,
+        data=(json.dumps(body).encode() if body is not None else None), method=method,
+        headers={"Authorization": "Bearer " + tok, "Accept": "application/json",
+                 **({"Content-Type": "application/json"} if body is not None else {})})
+    try:
+        return urllib.request.urlopen(req).read().decode()
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"Sigma {method} {path} -> {e.code}: {e.read().decode()[:300]}")
+
+
+def resolve_folder(arg):
+    if arg:
+        return arg
+    if os.environ.get("SIGMA_FOLDER_ID"):
+        return os.environ["SIGMA_FOLDER_ID"]
+    files = json.loads(sigma("GET", "/v2/files?typeFilters=folder&limit=200"))
+    entries = files.get("entries") or []
+    pick = next((f for f in entries
+                 if any(k in (f.get("name") or "").upper()
+                        for k in ("LOOKER", "MIGRATION", "TEST"))),
+                entries[0] if entries else None)
+    if not pick:
+        sys.exit("FATAL: no writable folder found — pass --folder")
+    print(f"   no --folder supplied — using folder '{pick.get('name')}' ({pick['id']})")
+    return pick["id"]
+
+
+def export_csv(wb_id, element_id, timeout=240):
+    res = json.loads(sigma("POST", f"/v2/workbooks/{wb_id}/export",
+                           {"elementId": element_id, "format": {"type": "csv"}}))
+    qid = res["queryId"]
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            body = sigma("GET", f"/v2/query/{qid}/download")
+            if body and body.strip():
+                return body
+        except RuntimeError:
+            pass
+        time.sleep(2)
+    raise RuntimeError(f"CSV export of element {element_id} timed out")
+
+
+def parse_csv(body):
+    rows = list(csv.reader(io.StringIO(body)))
+    return (rows[0], rows[1:]) if rows else ([], [])
+
+
+def numify(v):
+    s = str(v).strip().replace("$", "").replace(",", "").replace("%", "")
+    try:
+        return float(s)
+    except ValueError:
+        return v
+
+
+# ── EXPECTED side (offline): re-aggregate the master's warehouse rows per the
+#    SOURCE LookML measure definitions — independent of the formulas the
+#    builder generated, so a builder bug DIVERGES instead of self-confirming. ──
+class SourceEval:
+    def __init__(self, measures, view_pk, explore, headers):
+        self.measures, self.view_pk, self.explore = measures, view_pk, explore
+        self.idx = {h: i for i, h in enumerate(headers)}
+
+    def display(self, field):
+        view = field.split(".")[0]
+        suf = "" if view == self.explore else f" ({view})"
+        if field in self.measures:
+            base = self.measures[field][1]
+            return (base + suf) if base else None
+        return disp(leaf(field)) + suf
+
+    def col_vals(self, field_display, rows, raw=False):
+        i = self.idx.get(field_display)
+        if i is None:
+            return None
+        vals = [r[i] for r in rows if str(r[i]).strip() != ""]
+        return vals if raw else [numify(v) for v in vals]
+
+    def measure_value(self, field, rows, depth=0):
+        if depth > 4 or field not in self.measures:
+            return None
+        mtype, base, sql = self.measures[field]
+        view = field.split(".")[0]
+        if mtype in ("number",) or re.search(r"\$\{(\w+)\}", sql or ""):
+            # ratio / composite: substitute each ${measure} component recursively
+            refs = {m for m in re.findall(r"\$\{(\w+)\}", sql or "")
+                    if f"{view}.{m}" in self.measures}
+            if refs:
+                expr = sql
+                for m in refs:
+                    v = self.measure_value(f"{view}.{m}", rows, depth + 1)
+                    if v is None:
+                        return None
+                    expr = expr.replace("${%s}" % m, f"({v!r})")
+                expr = re.sub(r"\$\{TABLE\}\.", "", expr)
+                expr = re.sub(r"\bNULLIF\s*\(", "NullIf(", expr, flags=re.I)
+                try:
+                    return eval(expr, {"__builtins__": {}},          # noqa: S307 — arithmetic only
+                                {"NullIf": lambda x, y: None if x == y else x})
+                except Exception:
+                    return None
+        d = self.display(field)
+        if mtype == "count":
+            if view != self.explore and self.view_pk.get(view):
+                pk = disp(self.view_pk[view]) + f" ({view})"
+                vals = self.col_vals(pk, rows, raw=True)
+                return len(set(vals)) if vals is not None else len(rows)
+            return len(rows)
+        vals = self.col_vals(d, rows, raw=(mtype == "count_distinct"))
+        if vals is None:
+            return None
+        if mtype == "count_distinct":
+            return len(set(vals))
+        nums = [v for v in vals if isinstance(v, float)]
+        return {"sum": sum, "average": statistics.fmean, "avg": statistics.fmean,
+                "min": min, "max": max,
+                "median": statistics.median}.get(mtype, sum)(nums) if nums else None
+
+
+def expected_offline(el, ev, rows):
+    """Contract element + SourceEval + master rows → [[dim, val], ...]."""
+    fields = el.get("fields") or []
+    ms = [f for f in fields if f in ev.measures]
+    ds = [f for f in fields if f not in ev.measures]
+    data = rows
+    for fld, val in (el.get("filters") or {}).items():
+        d = ev.display(fld)
+        i = ev.idx.get(d)
+        if i is None:
+            continue
+        wanted = {v.strip().casefold() for v in str(val).split(",") if v.strip()}
+        data = [r for r in data if str(r[i]).casefold() in wanted]
+    if el.get("tileType") == "looker_scatter" and len(ms) >= 2:
+        groups = {None: data}
+        if ds:
+            groups = {}
+            di = ev.idx.get(ev.display(ds[0]))
+            for r in data:
+                groups.setdefault(r[di], []).append(r)
+        return [[ev.measure_value(ms[0], rs), ev.measure_value(ms[1], rs)]
+                for rs in groups.values()]
+    if not ms:
+        return None
+    # dim field mirrors the builder/plan: pie slices come from pivots[0] or the
+    # first dimension; axis charts use the first dimension; KPI has none.
+    if el.get("tileType") in ("looker_pie", "looker_donut_multiples"):
+        catf = (el.get("pivots") or ds or [None])[0]
+    else:
+        catf = ds[0] if ds else None
+    if el.get("tileType") == "single_value" or not catf:
+        return [[None, ev.measure_value(ms[0], data)]]
+    di = ev.idx.get(ev.display(catf))
+    if di is None:
+        return None
+    groups = {}
+    for r in data:
+        groups.setdefault(r[di], []).append(r)
+    return [[d, ev.measure_value(ms[0], rs)] for d, rs in groups.items()]
+
+
+def expected_live(el):
+    """Ground truth from Looker itself: run the tile's inline query."""
+    import looker_api
+    fields = el.get("fields") or []
+    body = {"model": el.get("model"), "view": el.get("explore"), "fields": fields,
+            "filters": el.get("filters") or {}, "limit": "5000"}
+    code, res = looker_api.call("POST", "/queries/run/json", body)
+    if code != 200 or not isinstance(res, list):
+        raise RuntimeError(f"Looker inline query -> {code}: {str(res)[:200]}")
+    # last field is the measure by tile convention; dim = first other field present
+    keys = list(res[0].keys()) if res else fields
+    val_key = next((f for f in reversed(fields) if f in keys), keys[-1])
+    dim_key = next((f for f in fields if f != val_key and f in keys), None)
+    if dim_key is None:
+        return [[None, numify(res[0][val_key])]] if res else None
+    return [[r[dim_key], numify(r[val_key])] for r in res]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lookml-dir", required=True, help="LookML project dir (model + views)")
+    ap.add_argument("--dashboard", help="offline: a .dashboard.lookml file")
+    ap.add_argument("--dashboard-id", help="live: Looker dashboard id (needs ~/.looker/looker.ini)")
+    ap.add_argument("--explore", help="explore to convert (default: the contract's most-used)")
+    ap.add_argument("--name", help="name PREFIX applied to the DM and the workbook")
+    ap.add_argument("--workdir")
+    ap.add_argument("--converted", help="JSON output of the convert_lookml_to_sigma MCP tool")
+    ap.add_argument("--reuse-dm")
+    ap.add_argument("--skip-dm-reuse-check", action="store_true")
+    ap.add_argument("--folder")
+    ap.add_argument("--yes", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    a = ap.parse_args()
+    if not a.dashboard and not a.dashboard_id:
+        ap.error("--dashboard (offline .dashboard.lookml) or --dashboard-id (live) required")
+    offline = not a.dashboard_id
+    lookml_dir = os.path.abspath(os.path.expanduser(a.lookml_dir))
+    wd = os.path.abspath(os.path.expanduser(a.workdir or "./looker-migration"))
+    os.makedirs(wd, exist_ok=True)
+    prefix = (a.name.strip() + " ") if a.name else ""
+    ensure_sigma_env()
+    if not a.dry_run:
+        missing = [v for v in ("SIGMA_BASE_URL", "SIGMA_API_TOKEN") if not os.environ.get(v)]
+        if not a.reuse_dm and not os.environ.get("SIGMA_CONNECTION_ID"):
+            missing.append("SIGMA_CONNECTION_ID (full warehouse-connection UUID — NOT a short prefix)")
+        if missing:
+            sys.exit("FATAL: missing env: " + ", ".join(missing))
+    TOTAL = 6
+
+    # ── Phase 1 — Parse (the normalized dashboard contract) ──────────────────
+    hdr(1, TOTAL, "Parse")
+    contract_path = os.path.join(wd, "contract.json")
+    if offline:
+        run(["python3", os.path.join(HERE, "parse_lookml_dashboard.py"),
+             a.dashboard, "--out", contract_path])
+    else:
+        run(["python3", os.path.join(HERE, "fetch_looker_dashboard.py"),
+             a.dashboard_id, contract_path])
+    dash = json.load(open(contract_path))
+    if isinstance(dash, list):
+        dash = dash[0]
+    explores = [e.get("explore") for e in dash["elements"] if e.get("explore")]
+    explore = a.explore or (max(set(explores), key=explores.count) if explores else None)
+    views_dir = os.path.join(lookml_dir, "views")
+    if not os.path.isdir(views_dir):
+        views_dir = lookml_dir
+    view_files = sorted(glob.glob(os.path.join(views_dir, "*.view.lkml")))
+    measures, _dims, view_pk, _formats = build_field_index(view_files)
+    print(f"   '{dash['title']}': {len(dash['elements'])} tile(s), {len(dash['filters'])} filter(s), "
+          f"explore '{explore}' · {len(view_files)} view file(s), {len(measures)} measure(s) · workdir {wd}")
+
+    # ── Phase 2 — RLS gate (zero overhead when clean; LOUD when not) ─────────
+    hdr(2, TOTAL, "RLS gate (detect_rls.py)")
+    p = subprocess.run(["python3", os.path.join(HERE, "detect_rls.py"), lookml_dir, "--json"],
+                       capture_output=True, text=True)
+    findings = []
+    try:
+        parsed = json.loads(p.stdout) if p.stdout.strip() else []
+        findings = parsed.get("findings", parsed) if isinstance(parsed, dict) else parsed
+    except ValueError:
+        findings = []
+    if not findings:
+        print("   no RLS constructs found — proceeding (zero-overhead happy path)")
+    else:
+        print(f"   ⚠ {len(findings)} RLS finding(s):")
+        for f in findings[:10]:
+            print(f"     - {json.dumps(f)[:160]}")
+        json.dump(findings, open(os.path.join(wd, "rls-findings.json"), "w"), indent=2)
+        if not a.yes:
+            print("\n==================== DECISION NEEDED (RLS) ====================")
+            print("This LookML enforces row-level security. It is NEVER silently dropped")
+            print("and NEVER silently ported. Options:")
+            print("  1. Port it: run the scripted flow in SKILL.md Phase 1.5")
+            print("     (scripts/apply_sigma_rls.py — reuse-first, plan-only by default),")
+            print("     then re-run this command with --yes.")
+            print("  2. Re-run with --yes to migrate WITHOUT RLS (every row visible to")
+            print("     everyone — the outcome is recorded in rls-findings.json).")
+            print("Nothing was posted to Sigma.")
+            print("===============================================================")
+            return 10
+        print("   --yes: proceeding WITHOUT porting RLS — the migrated model shows ALL rows")
+        print("   to everyone until you run apply_sigma_rls.py (recorded in rls-findings.json)")
+
+    # ── Phase 3 — Convert (local build / patched source / MCP request) ────────
+    hdr(3, TOTAL, "Convert")
+    dm_spec_path = os.path.join(wd, "dm-spec.json")
+    conn = os.environ.get("SIGMA_CONNECTION_ID", "PLACEHOLDER_CONNECTION_ID")
+    if a.reuse_dm:
+        print(f"   --reuse-dm {a.reuse_dm} — converter skipped")
+    elif a.converted:
+        conv = json.load(open(a.converted))
+        spec = conv.get("model") or conv.get("sigmaDataModel") or conv
+        json.dump(spec, open(dm_spec_path, "w"), indent=2)
+        print(f"   using MCP converter output {a.converted} -> {dm_spec_path}")
+    else:
+        src = os.environ.get("CONVERTER_SRC") or next(
+            (os.path.join(h, "src", "lookml.ts") for h in CONVERTER_HOMES
+             if os.path.exists(os.path.join(h, "src", "lookml.ts"))
+             and os.path.exists(os.path.join(h, "node_modules", ".bin", "tsx"))), None)
+        build = os.environ.get("CONVERTER_PATH") or next(
+            (os.path.join(h, "build", "lookml.js") for h in CONVERTER_HOMES
+             if os.path.exists(os.path.join(h, "build", "lookml.js"))), None)
+        if src:
+            repo = os.path.dirname(os.path.dirname(src))
+            run(["node", "--import", "tsx/esm", os.path.join(HERE, "convert_dm.mjs"),
+                 explore, dm_spec_path],
+                env={"LOOKML_DIR": lookml_dir, "CONVERTER_SRC": src,
+                     "SIGMA_CONNECTION_ID": conn}, cwd=repo)
+        elif build:
+            shim = os.path.join(wd, "_convert_lookml.mjs")
+            files = [{"name": os.path.basename(f), "content": open(f).read()}
+                     for f in sorted(glob.glob(os.path.join(lookml_dir, "*.model.lkml"))) + view_files]
+            json.dump(files, open(os.path.join(wd, "_lookml-files.json"), "w"))
+            open(shim, "w").write(f"""// generated by migrate-looker.py — local converter build path
+import {{ readFileSync, writeFileSync }} from 'node:fs';
+import {{ convertLookMLToSigma }} from {json.dumps(build)};
+const files = JSON.parse(readFileSync({json.dumps(os.path.join(wd, "_lookml-files.json"))}, 'utf8'));
+const res = convertLookMLToSigma(files, {{ connectionId: {json.dumps(conn)},
+  exploreName: {json.dumps(explore)}, joinStrategy: 'relationships' }});
+writeFileSync({json.dumps(dm_spec_path)}, JSON.stringify(res.model, null, 2));
+console.error('stats:', JSON.stringify(res.stats));
+(res.warnings || []).forEach(w => console.error('  WARN ' + w));
+""")
+            run(["node", shim])
+        else:
+            files = [{"name": os.path.basename(f), "content": open(f).read()}
+                     for f in sorted(glob.glob(os.path.join(lookml_dir, "*.model.lkml"))) + view_files]
+            req = {"tool": MCP_TOOL,
+                   "arguments": {"files": files, "connectionId": conn,
+                                 "exploreName": explore, "joinStrategy": "relationships"}}
+            req_path = os.path.join(wd, "convert-request.json")
+            json.dump(req, open(req_path, "w"), indent=2)
+            print(f"""
+   No shellable converter (CONVERTER_SRC / CONVERTER_PATH unset) — use the MCP converter:
+     1. Call the `{MCP_TOOL}` MCP tool with the arguments in
+          {req_path}
+     2. Save the tool's JSON output to {wd}/converted.json
+     3. RE-RUN THIS COMMAND with:  --converted {wd}/converted.json""")
+            return 3
+
+    # ── Phase 3.5 — DM-reuse check (printed; default = BUILD NEW) ─────────────
+    hdr(3, TOTAL, "DM-reuse check (3.5)")
+    if a.reuse_dm:
+        print(f"   --reuse-dm {a.reuse_dm} supplied — reusing that data model (POST skipped)")
+    elif a.skip_dm_reuse_check or a.dry_run:
+        print("   skipped (--skip-dm-reuse-check / --dry-run) — building new")
+    else:
+        sig = os.path.join(wd, "dm-signature.json")
+        match_out = os.path.join(wd, "dm-match.json")
+        run(["python3", os.path.join(HERE, "lookml-dm-signature.py"),
+             "--lookml-dir", lookml_dir, "--label", dash["title"], "--out", sig])
+        rc, _ = run(["ruby", os.path.join(HERE, "find-or-pick-dm.rb"),
+                     "--workbook-signature", sig, "--out", match_out], check=False)
+        try:
+            match = json.load(open(match_out))
+            cands = match.get("candidates") or []
+            for c in cands[:5]:
+                print(f"     candidate: {c.get('dm_name')} ({c.get('dm_id')}) score={c.get('score')}")
+            if rc == 0 and cands:
+                print("   ➤ a reusable DM scored ≥ threshold — DEFAULT IS STILL BUILD-NEW. To reuse it, re-run with:")
+                print(f"       --reuse-dm {cands[0].get('dm_id')}")
+            else:
+                print("   no existing DM scores above the reuse threshold — building new")
+        except Exception as ex:
+            print(f"   DM-reuse scan unavailable ({ex}) — building new")
+
+    if a.dry_run:
+        wb_spec = os.path.join(wd, "wb-spec.json")
+        run(["python3", os.path.join(HERE, "build_workbook.py"), contract_path,
+             "--views", views_dir, "--out", wb_spec])
+        print("\n================ RESULT (dry run) ================")
+        print(f"artifacts   : {wd}  (contract, dm-spec/convert-request, wb-spec — no Sigma objects created)")
+        print("==================================================")
+        return 0
+
+    # ── Phase 4a — POST the data model + denorm readback ──────────────────────
+    hdr(4, TOTAL, "Build data model (post_dm.py + readback)")
+    folder = resolve_folder(a.folder)
+    if a.reuse_dm:
+        dm = a.reuse_dm
+    else:
+        spec = json.load(open(dm_spec_path))
+        if prefix:
+            spec["name"] = f"{prefix}{spec.get('name') or dash['title']}"
+            json.dump(spec, open(dm_spec_path, "w"), indent=2)
+        rc, out = run(["python3", os.path.join(HERE, "post_dm.py"), dm_spec_path,
+                       "--folder-id", folder])
+        m = re.search(r'dataModelId"?\s*[:=]\s*"?([0-9a-f-]{36})', out)
+        if not m:
+            sys.exit("FATAL: could not parse dataModelId from post_dm.py output")
+        dm = m.group(1)
+    import yaml
+    dmspec = yaml.safe_load(sigma("GET", f"/v2/dataModels/{dm}/spec"))
+    els = [e for pg in dmspec.get("pages", []) for e in (pg.get("elements") or [])]
+    denorm = next((e for e in els if (e.get("name") or "").endswith(" View")), None) \
+        or max(els, key=lambda e: len(e.get("columns") or []))
+    print(f"   DM {dm} · denorm '{denorm['name']}' ({denorm['id']}, "
+          f"{len(denorm.get('columns') or [])} cols) · {len(els)} element(s)")
+
+    # ── Phase 4b — Build + POST the workbook (layout XML inline) ─────────────
+    hdr(4, TOTAL, "Build workbook (4b)")
+    wb_spec_path = os.path.join(wd, "wb-spec.json")
+    run(["python3", os.path.join(HERE, "build_workbook.py"), contract_path,
+         "--views", views_dir, "--dm-id", dm, "--element-id", denorm["id"],
+         "--dm-element-name", denorm["name"], "--folder-id", folder,
+         "--out", wb_spec_path])
+    wspec = json.load(open(wb_spec_path))
+    wspec["name"] = f"{prefix}{dash['title']} (from Looker)"
+    resp = sigma("POST", "/v2/workbooks/spec", wspec)       # responds in YAML
+    m = re.search(r"workbookId[\"'\s:]+([0-9a-f-]{36})", resp)
+    if not m:
+        sys.exit("FATAL: workbook POST: " + resp[:300])
+    wb = m.group(1)
+    with open(os.path.join(wd, "posted-workbooks.jsonl"), "a") as f:
+        f.write(json.dumps({"id": wb, "name": wspec["name"]}) + "\n")
+    json.dump({"workbookId": wb}, open(os.path.join(wd, "wb-ids.json"), "w"))
+    cols = json.loads(sigma("GET", f"/v2/workbooks/{wb}/columns"))
+    entries = cols.get("entries") or []
+    errs = [c for c in entries if (c.get("type") or {}).get("type") == "error"]
+    print(f"   workbook {wb} '{wspec['name']}' · {len(entries) - len(errs)}/{len(entries)} columns resolve"
+          + (f" — {len(errs)} ERROR-typed" if errs else ""))
+    for c in errs[:6]:
+        print(f"     [{c.get('elementId')}] {c.get('label')}: {c.get('formula')}")
+
+    # ── Phase 5 — SOURCE-FRESHNESS preflight (read BEFORE any side-by-side) ───
+    hdr(5, TOTAL, "Source freshness (preflight — before parity)")
+    mh, mr = parse_csv(export_csv(wb, "m-master"))
+    print("   ── SOURCE FRESHNESS (read this before any side-by-side) ──")
+    if offline:
+        newest = max((os.path.getmtime(f) for f in view_files + [a.dashboard]), default=None)
+        print(f"   source                : offline .lkml files (newest mtime "
+              f"{time.strftime('%Y-%m-%d %H:%M', time.localtime(newest)) if newest else '?'}) — "
+              "live Looker freshness unavailable")
+    else:
+        print("   source                : live Looker — tiles query the warehouse live; EXPECTED")
+        print("                           below comes from Looker inline queries run NOW")
+    idx = {h: i for i, h in enumerate(mh)}
+    datecol = next((h for h in mh if "date" in h.lower()), None)
+    line = f"   warehouse (via Sigma) : master = {len(mr)} rows"
+    if datecol:
+        mx = max((str(r[idx[datecol]]) for r in mr if str(r[idx[datecol]]).strip()), default="?")
+        line += f", max({datecol}) = {mx}"
+    print(line)
+    print("   (Looker is live-query: a parity delta is a CONVERSION issue, not cache staleness.)")
+
+    # ── Phase 6 — Parity (two-pass, scripted) + HARD GATE ────────────────────
+    hdr(6, TOTAL, "Parity + hard gate")
+    rc, _ = run(["ruby", os.path.join(HERE, "phase6-parity-looker.rb"),
+                 "--workdir", wd, "--workbook-id", wb], check=False)
+    if rc != 0:
+        sys.exit("FATAL: parity pass 1 failed")
+    plan = json.load(open(os.path.join(wd, "parity-plan.json")))
+    by_name = {e.get("name"): e for e in dash["elements"]}
+    ev = SourceEval(measures, view_pk, explore, mh)
+    expected, actuals = {}, {}
+    for c in plan["charts"]:
+        cname = c["chart"]
+        headers, rows = parse_csv(export_csv(wb, c["sigma_element_id"]))
+        cidx = {h: i for i, h in enumerate(headers)}
+        want = c["sigma_columns"]
+        if len(want) == 1:                      # KPI
+            vi = cidx.get(want[0], 0)
+            actuals[cname] = [[None, numify(rows[0][vi])]] if rows else []
+        else:
+            di = cidx.get(want[0], 0)
+            vi = cidx.get(want[1], 1 if len(headers) > 1 else 0)
+            actuals[cname] = [[row[di], numify(row[vi])] for row in rows]
+        el = by_name.get(cname)
+        if not el:
+            print(f"   WARN: no source tile named {cname!r} in the contract — chart will DIVERGE")
+            continue
+        exp = None
+        if not offline:
+            try:
+                exp = expected_live(el)
+            except Exception as ex:
+                print(f"   WARN: Looker inline query failed for {cname!r} ({ex}); "
+                      "falling back to warehouse re-aggregation")
+        if exp is None:
+            exp = expected_offline(el, ev, mr)
+        if exp is not None:
+            expected[cname] = exp
+    json.dump(expected, open(os.path.join(wd, "parity-expected.json"), "w"), indent=2)
+    json.dump(actuals, open(os.path.join(wd, "parity-actuals.json"), "w"), indent=2)
+    rc, _ = run(["ruby", os.path.join(HERE, "phase6-parity-looker.rb"),
+                 "--workdir", wd, "--finalize"], check=False)
+    grc, _ = run(["ruby", os.path.join(HERE, "assert-phase6-ran.rb"),
+                  "--workdir", wd, "--workbook-id", wb], check=False)
+    summary = json.load(open(os.path.join(wd, "parity-final.json")))
+
+    # ── Summary ────────────────────────────────────────────────────────────────
+    green = grc == 0 and not errs
+    print("\n================ RESULT ================")
+    print(f"dataModelId : {dm}{'  (REUSED)' if a.reuse_dm else ''}")
+    print(f"workbookId  : {wb}  '{wspec['name']}'")
+    print(f"parity      : {summary['charts_pass']}/{summary['charts_total']} {summary['status']} · "
+          f"hard gate {'PASS' if grc == 0 else f'FAIL (exit {grc})'}")
+    if findings:
+        print(f"RLS         : {len(findings)} finding(s) NOT ported (recorded in rls-findings.json)")
+    print(f"PARITY      : {'GREEN' if green else 'RED'}  ·  wall-clock {time.time() - T0:.1f}s")
+    print("========================================")
+    return 0 if green else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/phase6-parity-looker.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/phase6-parity-looker.rb
@@ -1,0 +1,207 @@
+#!/usr/bin/env ruby
+# Parity gate (MANDATORY) — verify Sigma chart values match the Looker source.
+#
+# The EXPECTED side comes from Looker itself (`POST /queries/run/json` /
+# run_inline_query for the tile's explore+fields — ground truth) or, when live
+# Looker access is gone (offline/fixture runs), from the warehouse: re-aggregate
+# the master element's warehouse rows per the SOURCE LookML measure definitions
+# (type: sum / count_distinct / number-ratio …). The ACTUAL side is the built
+# Sigma element. This script orchestrates both passes and writes the
+# parity-final.json sentinel that assert-phase6-ran.rb (the hard gate) requires.
+# Two-pass design mirrors quicksight's phase6-parity-quicksight.rb /
+# thoughtspot's phase6-parity-thoughtspot.rb.
+#
+# PASS 1 — read the workbook spec, enumerate chart elements, emit per-chart
+# fetch instructions:
+#
+#   ruby scripts/phase6-parity-looker.rb --workdir <dir> --workbook-id <wb>
+#
+#   Writes <workdir>/parity-plan.json (+ wb-readback.json) and prints, per chart:
+#     - the mcp__sigma-mcp-v2__query call for the Sigma ACTUAL rows
+#     - a reminder to fetch EXPECTED rows from Looker (inline query) or the
+#       warehouse with the same dimension + aggregation
+#
+#   The agent (or scripts/migrate-looker.py, which scripts this whole flow)
+#   then writes two JSON files keyed by chart name, each
+#   { "<chart name>": [[dim, val], ...], ... } :
+#     <workdir>/parity-expected.json   (Looker / warehouse ground truth)
+#     <workdir>/parity-actuals.json    (Sigma element rows)
+#   KPI charts have no dimension — use [[null, <value>]].
+#
+# PASS 2 — finalize:
+#
+#   ruby scripts/phase6-parity-looker.rb --workdir <dir> --finalize \
+#     [--expected <workdir>/parity-expected.json] \
+#     [--actuals  <workdir>/parity-actuals.json] \
+#     [--extract-mode] [--extract-tol 0.30]
+#
+#   Runs verify-parity.rb, prints the pass/fail summary, writes
+#   parity-final.txt + parity-final.json (the hard-gate sentinel).
+#
+# Plain `table` / `text` elements aren't auto-planned (no single dim/measure
+# axis) — query-verify tables manually and note it in the migration report.
+
+require 'json'
+require 'optparse'
+require 'open3'
+require 'time'
+
+opts = { extract_mode: false, extract_tol: 0.30, finalize: false }
+OptionParser.new do |p|
+  p.on('--workdir DIR')          { |v| opts[:dir] = v }
+  p.on('--workbook-id ID')       { |v| opts[:wb] = v }
+  p.on('--finalize')             { opts[:finalize] = true }
+  p.on('--expected PATH')        { |v| opts[:expected] = v }
+  p.on('--actuals PATH')         { |v| opts[:actuals] = v }
+  p.on('--extract-mode')         { opts[:extract_mode] = true }
+  p.on('--extract-tol F', Float) { |v| opts[:extract_tol] = v }
+end.parse!
+abort('missing --workdir') unless opts[:dir]
+
+plan_path = File.join(opts[:dir], 'parity-plan.json')
+
+def parse_spec(body)
+  JSON.parse(body)
+rescue JSON::ParserError
+  require 'yaml'
+  require 'date'
+  YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+end
+
+# Resolve the (dim, val) columns for a chart element, by kind. Returns
+# [[dim_id, dim_name], [val_id, val_name]] (dim pair nil for KPI) or nil if not
+# plannable. The IDs matter: sigma-mcp-v2 workbook queries resolve COLUMN IDS, not
+# display labels — SQL emitted against display names fails to resolve.
+def chart_columns(el)
+  cols = el['columns'] || []
+  by_id = cols.each_with_object({}) { |c, h| h[c['id']] = c['name'] }
+  case el['kind']
+  when 'kpi-chart'
+    vid = el.dig('value', 'columnId') || el.dig('value', 'id')
+    by_id[vid] && [nil, [vid, by_id[vid]]]
+  when 'pie-chart', 'donut-chart'
+    did = el.dig('color', 'id') || el.dig('color', 'columnId')
+    vid = el.dig('value', 'id') || el.dig('value', 'columnId')
+    by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
+  else # bar-chart, line-chart, area-chart, combo-chart, scatter-chart, ...
+    did = el.dig('xAxis', 'columnId')
+    vid = Array(el.dig('yAxis', 'columnIds')).first
+    vid = vid['columnId'] if vid.is_a?(Hash) # combo dual-axis object form
+    by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
+  end
+end
+
+if !opts[:finalize]
+  abort('--workbook-id required for pass 1') unless opts[:wb]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+
+  warn "Parity PASS 1: reading workbook spec #{opts[:wb]}"
+  # binary:true returns the raw body — the spec endpoint answers in YAML even
+  # when asked for JSON, so parse both.
+  raw = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec", binary: true)
+  spec = parse_spec(raw)
+  File.write(File.join(opts[:dir], 'wb-readback.json'), JSON.pretty_generate(spec))
+
+  charts = []
+  Array(spec['pages']).each do |page|
+    Array(page['elements']).each do |el|
+      next unless el['kind'].to_s.end_with?('-chart')
+      pairs = chart_columns(el)
+      next unless pairs
+      charts << { 'chart' => el['name'], 'sigma_element_id' => el['id'],
+                  'kind' => el['kind'],
+                  'sigma_columns' => pairs.compact.map { |id_name| id_name[1] },
+                  'sigma_column_ids' => pairs.compact.map { |id_name| id_name[0] },
+                  'workbook_id' => opts[:wb] }
+    end
+  end
+  abort('no plannable chart elements found in the workbook spec') if charts.empty?
+
+  File.write(plan_path, JSON.pretty_generate({ 'charts' => charts }))
+
+  puts ''
+  puts '=' * 70
+  puts 'PARITY PASS 1 — fetch ACTUAL (Sigma) and EXPECTED (Looker/warehouse)'
+  puts '=' * 70
+  puts ''
+  puts 'For each chart: run the mcp__sigma-mcp-v2__query below for the Sigma'
+  puts 'ACTUAL rows, and fetch the EXPECTED rows from Looker via'
+  puts 'POST /queries/run/json (the tile\'s model/explore/fields — ground'
+  puts 'truth) or, offline, by re-aggregating the master element\'s warehouse'
+  puts 'rows per the SOURCE LookML measure definitions.'
+  puts '(scripts/migrate-looker.py automates BOTH sides of this fetch.)'
+  puts 'Write both files, then re-run with --finalize:'
+  puts "  #{opts[:dir]}/parity-expected.json  { \"<chart>\": [[dim, val], ...] }"
+  puts "  #{opts[:dir]}/parity-actuals.json   { \"<chart>\": [[dim, val], ...] }"
+  puts 'KPI charts: a single row [[null, <value>]].'
+  puts ''
+  charts.each_with_index do |c, i|
+    # Query by COLUMN ID (sigma-mcp-v2 can't resolve display labels in workbook
+    # queries); the display names ride along in a trailing SQL comment for readability.
+    ids = c['sigma_column_ids']
+    names = c['sigma_columns']
+    sql = if ids.length >= 2
+            %(SELECT "#{ids[0]}" AS dim, "#{ids[1]}" AS val FROM "workbook"."#{c['sigma_element_id']}" ORDER BY dim NULLS FIRST -- dim: #{names[0]}, val: #{names[1]})
+          else
+            %(SELECT "#{ids[0]}" AS val FROM "workbook"."#{c['sigma_element_id']}" -- val: #{names[0]})
+          end
+    puts "  [#{i + 1}/#{charts.length}] #{c['chart']} (#{c['kind']})"
+    puts "    mcp__sigma-mcp-v2__query  type=workbook  workbookId=#{opts[:wb]}"
+    puts "    sql=#{sql.inspect}"
+    puts ''
+  end
+  puts '=' * 70
+  exit 0
+end
+
+# PASS 2 — finalize
+abort("plan not found at #{plan_path}; run pass 1 first") unless File.exist?(plan_path)
+opts[:expected] ||= File.join(opts[:dir], 'parity-expected.json')
+opts[:actuals]  ||= File.join(opts[:dir], 'parity-actuals.json')
+abort("expected file missing: #{opts[:expected]}") unless File.exist?(opts[:expected])
+abort("actuals file missing: #{opts[:actuals]}")   unless File.exist?(opts[:actuals])
+
+plan = JSON.parse(File.read(plan_path))
+expected = JSON.parse(File.read(opts[:expected]))
+actuals  = JSON.parse(File.read(opts[:actuals]))
+
+warn "Parity PASS 2: injecting expected (#{expected.size}) + actuals (#{actuals.size}) → #{plan_path}"
+plan['charts'].each do |c|
+  c['expected'] = expected[c['chart']] if expected[c['chart']]
+  c['actual']   = { 'rows' => actuals[c['chart']] } if actuals[c['chart']]
+end
+File.write(plan_path, JSON.pretty_generate(plan))
+
+missing = plan['charts'].reject { |c| c['expected'] && c['actual'] }
+missing.each { |c| warn "WARN: no expected/actual rows supplied for #{c['chart'].inspect} — it will DIVERGE" }
+
+warn "Parity PASS 2: running verifier (#{opts[:extract_mode] ? 'extract-mode' : 'strict'})"
+verifier_args = ['ruby', File.join(__dir__, 'verify-parity.rb'), '--plan', plan_path]
+verifier_args.concat(['--extract-mode', '--extract-tol', opts[:extract_tol].to_s]) if opts[:extract_mode]
+out, err, status = Open3.capture3(*verifier_args)
+puts out
+warn err unless err.empty?
+File.write(File.join(opts[:dir], 'parity-final.txt'), out)
+
+# Hard-gate sentinel consumed by assert-phase6-ran.rb (same contract as the
+# tableau-to-sigma Phase 6 sentinel — see beads-sigma-4pm for why it exists).
+total  = plan['charts'].size
+passed = out.scan(/^PASS\s+\[[^\]]+\]\s+(.+)$/).flatten.map(&:strip)
+failed = out.scan(/^DIVERGE\s+\[[^\]]+\]\s+(.+)$/).flatten.map(&:strip)
+summary = {
+  'workbook_id'  => plan.dig('charts', 0, 'workbook_id'),
+  'ran_at'       => Time.now.utc.iso8601,
+  'mode'         => opts[:extract_mode] ? 'extract' : 'strict',
+  'extract_tol'  => opts[:extract_mode] ? opts[:extract_tol] : nil,
+  'charts_total' => total,
+  'charts_pass'  => passed.size,
+  'charts_fail'  => failed.size,
+  'pass_names'   => passed,
+  'fail_names'   => failed,
+  'status'       => (status.success? && total > 0 && passed.size == total) ? 'PASS' : 'FAIL'
+}
+summary_path = File.join(opts[:dir], 'parity-final.json')
+File.write(summary_path, JSON.pretty_generate(summary))
+warn "wrote #{summary_path} (status=#{summary['status']} #{summary['charts_pass']}/#{summary['charts_total']})"
+exit(status.success? ? 0 : 2)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-parity.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-parity.rb
@@ -1,0 +1,195 @@
+#!/usr/bin/env ruby
+# Parity verification: compare expected (from Tableau CSVs) vs actual
+# (from Sigma queries) for each chart in a plan.
+#
+# Plan format (JSON array):
+#   [{ "chart": "...",
+#      "expected": [[dim, val], ...],
+#      "actual":   { "rows": [[dim, val], ...] },
+#      "extract":  true|false   # optional per-chart override
+#   }]
+#
+# A top-level wrapper is also accepted:
+#   { "extract": true, "charts": [ ... ] }
+# in which case `extract` propagates to every chart.
+#
+# --strict      value-exact comparison (default)
+# --extract-mode  structural comparison only — when Tableau view CSVs come from
+#                 a workbook with hasExtracts=true, the absolute values can drift
+#                 from Sigma (live warehouse) while the chart shape is correct.
+#                 Extract-mode checks:
+#                   - same number of buckets (rows)
+#                   - same set of dimension values
+#                   - same sort order on the dimension column
+#                   - measure values within `--extract-tol` relative tolerance
+#                     (default 0.30 = 30%) IF both are non-null, otherwise skipped
+#
+# Usage:
+#   ruby verify-parity.rb --plan plan.json
+#   ruby verify-parity.rb --plan plan.json --extract-mode
+#   ruby verify-parity.rb --plan plan.json --extract-mode --extract-tol 0.50
+
+require 'json'
+require 'set'
+require 'optparse'
+
+opts = { mode: :strict, tol: 0.30 }
+OptionParser.new do |p|
+  p.on('--plan P')              { |v| opts[:plan] = v }
+  p.on('--extract-mode')        {     opts[:mode] = :extract }
+  p.on('--extract-tol TOL', Float) { |v| opts[:tol] = v }
+end.parse!
+abort('--plan required') unless opts[:plan]
+
+MONTH_NUM = {
+  'january' => 1, 'february' => 2, 'march' => 3, 'april' => 4, 'may' => 5, 'june' => 6,
+  'july' => 7, 'august' => 8, 'september' => 9, 'october' => 10, 'november' => 11, 'december' => 12,
+  'jan' => 1, 'feb' => 2, 'mar' => 3, 'apr' => 4, 'jun' => 6,
+  'jul' => 7, 'aug' => 8, 'sep' => 9, 'sept' => 9, 'oct' => 10, 'nov' => 11, 'dec' => 12
+}.freeze
+
+# Canonicalize date-like dimension values so monthly buckets compare equal across
+# representations (e.g. Sigma raw SQL "2026-01-01T00:00:00.000" vs Tableau view
+# label "January 2026" both → "2026-01"). Non-date strings pass through.
+def canonicalize_dim(v)
+  return v unless v.is_a?(String)
+  s = v.strip
+  # ISO datetime, day=1, midnight → month bucket (T or space separator)
+  if (m = s.match(/\A(\d{4})-(\d{2})-01[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
+    return "#{m[1]}-#{m[2]}"
+  end
+  # ISO date, first of month → month bucket
+  if (m = s.match(/\A(\d{4})-(\d{2})-01\z/))
+    return "#{m[1]}-#{m[2]}"
+  end
+  # "January 2026" / "Jan 2026"
+  if (m = s.match(/\A([A-Za-z]+)\s+(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
+    return format('%s-%02d', m[2], mnum)
+  end
+  # Already-canonical "YYYY-MM"
+  return s if s.match?(/\A\d{4}-\d{2}\z/)
+  v
+end
+
+def round_row(row)
+  # Convert all numerics to Float-rounded so Integer 11 and Float 11.0 compare equal in the set,
+  # and canonicalize date-like dim strings so equivalent monthly buckets match.
+  row.map do |v|
+    if v.is_a?(Numeric)
+      v.to_f.round(2)
+    else
+      canonicalize_dim(v)
+    end
+  end
+end
+
+def strict_compare(exp, act)
+  exp_set = Set.new(exp.map { |r| r.first(2) })
+  act_set = Set.new(act.map { |r| r.first(2) })
+  if exp_set == act_set
+    { status: 'PASS', only_in_tableau: [], only_in_sigma: [] }
+  else
+    { status: 'DIVERGE',
+      only_in_tableau: (exp_set - act_set).to_a,
+      only_in_sigma:   (act_set - exp_set).to_a }
+  end
+end
+
+# Extract-mode: same row count + same dim set + same dim sort. Measure values
+# only flagged if they're WILDLY off (beyond extract_tol) — small drift is
+# expected because Sigma reads live warehouse while extracts are frozen snapshots.
+def extract_compare(exp, act, tol:)
+  exp_dims = exp.map { |r| r[0] }
+  act_dims = act.map { |r| r[0] }
+  exp_set  = Set.new(exp_dims)
+  act_set  = Set.new(act_dims)
+
+  notes = []
+  status = 'PASS'
+
+  if exp.size != act.size
+    status = 'DIVERGE'
+    notes << "bucket count differs: tableau=#{exp.size} sigma=#{act.size}"
+  end
+
+  unless exp_set == act_set
+    status = 'DIVERGE'
+    notes << "dim set differs: tableau-only=#{(exp_set - act_set).to_a[0..3].inspect}, sigma-only=#{(act_set - exp_set).to_a[0..3].inspect}"
+  end
+
+  # If dim sets match, check sort order on the dimension
+  if exp_set == act_set && exp_dims != act_dims
+    notes << "dim sort order differs (extract-mode flags only — not a failure)"
+  end
+
+  # Wild-divergence check on measures (10x or more drift = probably a real bug,
+  # not just extract staleness)
+  if exp.size == act.size && exp_set == act_set
+    exp_h = exp.each_with_object({}) { |r, h| h[r[0]] = r[1] }
+    act_h = act.each_with_object({}) { |r, h| h[r[0]] = r[1] }
+    big_drifts = []
+    exp_h.each do |k, v|
+      a = act_h[k]
+      next if v.nil? || a.nil?
+      next unless v.is_a?(Numeric) && a.is_a?(Numeric)
+      denom = [v.abs.to_f, a.abs.to_f, 1.0].max
+      drift = (v - a).abs.to_f / denom
+      big_drifts << [k, v, a, drift] if drift > tol
+    end
+    if big_drifts.any?
+      notes << "#{big_drifts.size} measure value(s) drift > #{(tol * 100).to_i}% — review:"
+      big_drifts.first(3).each do |k, v, a, d|
+        notes << "    #{k.inspect} tableau=#{v} sigma=#{a} drift=#{(d * 100).round}%"
+      end
+    end
+  end
+
+  { status: status, notes: notes,
+    only_in_tableau: (exp_set - act_set).to_a,
+    only_in_sigma:   (act_set - exp_set).to_a }
+end
+
+raw = JSON.parse(File.read(opts[:plan]))
+default_extract = false
+if raw.is_a?(Hash) && raw['charts']
+  default_extract = !!raw['extract']
+  plan = raw['charts']
+else
+  plan = raw
+end
+
+# Top-level --extract-mode overrides default
+mode_forced = opts[:mode] == :extract
+
+results = plan.map do |p|
+  exp = (p['expected'] || []).map { |r| round_row(r) }
+  act = (p.dig('actual', 'rows') || []).map { |r| round_row(r) }
+
+  this_extract = if p.key?('extract')
+                   p['extract']
+                 elsif mode_forced
+                   true
+                 else
+                   default_extract
+                 end
+
+  result = this_extract ? extract_compare(exp, act, tol: opts[:tol]) : strict_compare(exp, act)
+  result.merge(chart: p['chart'], extract: this_extract)
+end
+
+results.each do |r|
+  tag = r[:extract] ? '[extract]' : '[strict] '
+  printf "%-7s  %s  %s\n", r[:status], tag, r[:chart]
+  if r[:status] != 'PASS' || (r[:notes] && r[:notes].any?)
+    Array(r[:notes]).each { |n| puts "    #{n}" }
+    if r[:only_in_tableau].any? || r[:only_in_sigma].any?
+      puts "    Tableau-only: #{r[:only_in_tableau].inspect[0..200]}"
+      puts "    Sigma-only:   #{r[:only_in_sigma].inspect[0..200]}"
+    end
+  end
+end
+
+failed = results.count { |r| r[:status] != 'PASS' }
+puts '---'
+puts "#{results.size - failed}/#{results.size} pass" + (mode_forced ? '  (extract-mode)' : '')
+exit(failed.zero? ? 0 : 1)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/QUICKSTART.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/QUICKSTART.md
@@ -3,6 +3,20 @@
 End-to-end: a ThoughtSpot model + its Liveboards → a Sigma data model + workbooks,
 parity-verified against the warehouse.
 
+## 0. ONE COMMAND (preferred)
+```bash
+export TS_HOST TS_TOKEN SIGMA_CONNECTION_ID TS_DB TS_SCHEMA   # Sigma token auto-minted from ~/.sigma-migration/env
+python3 scripts/migrate-thoughtspot.py --model <TS_MODEL_ID> [--liveboard <ID> ...] \
+    [--name PREFIX] [--workdir /tmp/ts-run]
+# offline: --model-tml fixtures/retail-analytics-model.tml --liveboard-tml fixtures/retail-analytics-liveboard.tml
+```
+Runs everything below — discover → DM-reuse check (candidates PRINTED; default
+build-new, reuse only via `--reuse-dm <id>`) → convert (exit 3 + `--converted`
+resume when no local converter build) → DM → workbooks → layout → **freshness
+preflight** → **scripted parity + `assert-phase6-ran.rb` hard gate**. Exit 0 =
+GREEN; a failed gate fails the command. Steps 1–5 below are the manual,
+per-phase path.
+
 ## 1. Authenticate
 **ThoughtSpot** (REST v2). On an SSO trial with no local password, open
 `https://<your>.thoughtspot.cloud/api/rest/2.0/auth/session/token` in the tab where

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -20,12 +20,48 @@ POST `username`+`secret_key` to `auth/token/full`. Sigma side uses
 Trials often sit behind corp TLS — the Python helpers use an unverified SSL
 context (curl uses the system store and works).
 
-## One-shot
+## ONE COMMAND (preferred): migrate-thoughtspot.py
+
+The whole pipeline — discover → DM-reuse check → convert → DM → workbooks →
+layout → **source-freshness preflight** → **scripted parity + hard gate** — as a
+single command (mirrors qlik-to-sigma's `migrate-qlik.rb`). Gates are never
+bypassed: the command exits non-zero if parity or `assert-phase6-ran.rb` fails.
+
+```bash
+export TS_HOST TS_TOKEN SIGMA_CONNECTION_ID TS_DB TS_SCHEMA   # + Sigma creds (token auto-minted from ~/.sigma-migration/env)
+python3 scripts/migrate-thoughtspot.py --model <TS_MODEL_ID> [--liveboard <ID> ...] \
+       [--name PREFIX] [--workdir DIR]
+# offline (fixtures, no TS instance):
+python3 scripts/migrate-thoughtspot.py --model-tml fixtures/retail-analytics-model.tml \
+       --liveboard-tml fixtures/retail-analytics-liveboard.tml --workdir /tmp/ts-run
+```
+
+- **Decision points are flags with safe defaults, never silent:** the DM-reuse
+  check (step 2.5) always runs and PRINTS candidates+scores; the default is
+  build-new — reuse only via an explicit `--reuse-dm <id>`. The Sigma folder is
+  auto-resolved and printed when `SIGMA_FOLDER_ID` is unset.
+- **Freshness first:** before any side-by-side it prints the TS model/Liveboard
+  modified times + a cheap `searchdata` aggregate probe vs a live warehouse
+  snapshot (offline runs note the TS side unavailable), so staleness/model drift
+  never masquerades as a conversion bug.
+- **Parity is fully scripted:** ACTUAL = Sigma CSV export per chart; EXPECTED =
+  `ts_lib.searchdata` ground truth (live) or a source-TML-derived re-aggregation
+  of the master's warehouse rows (offline — agg from the TML's own
+  `headline_aggregation`, independent of the builder). Then
+  `phase6-parity-thoughtspot.rb --finalize` + `assert-phase6-ran.rb` run
+  automatically.
+- Exit codes: `0` GREEN · `3` MCP convert request emitted (call the tool, re-run
+  with `--converted <workdir>/converted.json`) · `2` built but a gate FAILED ·
+  `10`-free (no interactive checkpoint; RLS is reported by the converter and
+  ported post-model via `apply_sigma_rls.py` as below). `--dry-run` = no Sigma
+  POSTs (discovery + reuse scan + local convert / MCP request only).
+
+## Manual phases: migrate.py (the per-phase pipeline the one-command wraps)
 ```
 export TS_HOST TS_TOKEN SIGMA_BASE_URL SIGMA_API_TOKEN \
        SIGMA_CONNECTION_ID SIGMA_FOLDER_ID TS_DB TS_SCHEMA
 python3 scripts/migrate.py --model <TS_MODEL_ID> [--liveboard <ID> ...] \
-       [--name PREFIX] [--workdir DIR]
+       [--name PREFIX] [--workdir DIR] [--reuse-dm <dataModelId>]
 ```
 `migrate.py` runs the whole pipeline with **no hardcoded ids or paths** and
 migrates every Liveboard that reads the model (or just the `--liveboard` ones).
@@ -128,9 +164,13 @@ you export for `migrate.py`). Decision:
 - **Score < 0.6** → POST new and TELL the user no reusable DM was found.
 
 ## Scripts
-- `migrate.py` — **canonical entry**: model → DM → migrate its Liveboards
-  (parameterized: `--workdir`, `--name` prefix, `--converted` MCP output,
-  offline `--model-tml`/`--liveboard-tml`)
+- `migrate-thoughtspot.py` — **ONE-COMMAND orchestrator** (preferred entry):
+  chains discovery, the DM-reuse check, `migrate.py`, the freshness preflight,
+  and the scripted parity + hard gate; exit 0 only when every gate is GREEN
+- `migrate.py` — the per-phase pipeline the one-command wraps: model → DM →
+  migrate its Liveboards (parameterized: `--workdir`, `--name` prefix,
+  `--converted` MCP output, offline `--model-tml`/`--liveboard-tml`,
+  `--reuse-dm` to skip convert+POST and build against an existing DM)
 - `convert_model.mjs` — model TML → Sigma DM spec (imports a local converter
   build via `CONVERTER_PATH`; without one, migrate.py emits the MCP request instead)
 - `phase6-parity-thoughtspot.rb` — parity orchestrator (two-pass; writes the

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""migrate-thoughtspot.py — ONE-COMMAND orchestrator for the thoughtspot-to-sigma
+pipeline: discover → DM-reuse check → convert → data model → workbooks → layout
+→ source-freshness preflight → scripted parity + HARD GATE. Mirrors
+qlik-to-sigma's migrate-qlik.rb: every phase prints a visible header + concise
+result, decision points are flags with safe defaults (never silent), and the
+parity gate is NEVER bypassed — the command FAILS if a gate fails.
+
+This script does NOT re-implement any phase — it chains the per-phase scripts:
+  ts_discover.py / ts_lib.py        (Phase 1 — TML export + freshness metadata)
+  ts-dm-signature.py + find-or-pick-dm.rb
+                                    (Phase 2 — DM-reuse check: candidates+scores
+                                     PRINTED, default = build new; reuse only on
+                                     an explicit --reuse-dm <id>)
+  migrate.py                        (Phase 3 — convert [CONVERTER_PATH one-shot,
+                                     or the exit-3 MCP-request/--converted resume]
+                                     → DM POST + denorm readback → Liveboard →
+                                     workbook build → TML-geometry layout)
+  Phase 4 — post-and-readback gate: live /columns scan (no type=error)
+  Phase 5 — SOURCE-FRESHNESS preflight (fmte): TS model/Liveboard modified time
+            + a cheap searchdata row/aggregate probe (when TS is reachable, else
+            noted unavailable) vs a live warehouse snapshot via the master
+            element — printed BEFORE any side-by-side so staleness never
+            masquerades as a conversion bug.
+  phase6-parity-thoughtspot.rb      (Phase 6 — two-pass parity, fully scripted:
+                                     ACTUAL = Sigma CSV export per chart;
+                                     EXPECTED = ts_lib.searchdata ground truth
+                                     when live, or a source-TML-derived
+                                     re-aggregation of the master's warehouse
+                                     rows when offline) + verify-parity.rb
+  assert-phase6-ran.rb              (HARD GATE — must exit 0 to declare GREEN)
+
+Usage (live):
+  python3 scripts/migrate-thoughtspot.py --model <TS_MODEL_ID> \
+      [--liveboard <ID> ...] [--name PREFIX] [--workdir DIR]
+Usage (offline — fixtures/, no TS instance):
+  python3 scripts/migrate-thoughtspot.py --model-tml fixtures/retail-analytics-model.tml \
+      --liveboard-tml fixtures/retail-analytics-liveboard.tml [--name PREFIX] [--workdir DIR]
+Resume after the MCP converter fallback (exit 3):
+  ... same command ... --converted <workdir>/converted.json
+Other flags:
+  --reuse-dm <dataModelId>   reuse an existing DM (skip convert+POST) — the
+                             Phase-2 check prints candidates; reuse is NEVER
+                             chosen silently, only via this flag
+  --skip-dm-reuse-check      skip the Phase-2 scan entirely
+  --dry-run                  no Sigma POSTs: discovery + DM-reuse scan + local
+                             convert (or the MCP convert-request) only
+
+Env: TS_HOST/TS_TOKEN (live mode), SIGMA_BASE_URL + SIGMA_API_TOKEN (or
+SIGMA_CLIENT_ID/SECRET via ~/.sigma-migration/env — the script mints a token),
+SIGMA_CONNECTION_ID, TS_DB, TS_SCHEMA, optional SIGMA_FOLDER_ID (auto-resolved
+and PRINTED when unset), optional CONVERTER_PATH (auto-located).
+
+Exit codes: 0 = done, all gates GREEN; 3 = MCP convert request emitted (resume
+with --converted); 2 = built but a parity/hard gate FAILED; other = error.
+"""
+import argparse, csv, io, json, os, re, subprocess, sys, time
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import yaml, ts_common
+import migrate  # the per-phase pipeline (sigma() REST helper reused)
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+T0 = time.time()
+
+
+def hdr(n, total, title):
+    print(f"\n── Phase {n}/{total} · {title} ──")
+
+
+def elapsed():
+    return f"{time.time() - T0:.1f}s"
+
+
+def run(cmd, env=None, check=True):
+    """Run a child script, streaming output indented. Returns (rc, captured)."""
+    p = subprocess.run(cmd, capture_output=True, text=True,
+                       env={**os.environ, **(env or {})})
+    out = (p.stdout or "") + (p.stderr or "")
+    for line in out.splitlines():
+        print("   " + line)
+    if check and p.returncode != 0:
+        sys.exit(f"FATAL: command failed ({p.returncode}): {' '.join(cmd)}")
+    return p.returncode, out
+
+
+def ensure_sigma_env():
+    """Make the command truly one-command: load ~/.sigma-migration/env and mint a
+    bearer via get-token.sh when SIGMA_API_TOKEN isn't already exported."""
+    env_file = os.path.expanduser("~/.sigma-migration/env")
+    if os.path.exists(env_file):
+        for line in open(env_file):
+            m = re.match(r"\s*export\s+(\w+)=['\"]?([^'\"\n]+)", line)
+            if m and not os.environ.get(m.group(1)):
+                os.environ[m.group(1)] = m.group(2)
+    if not os.environ.get("SIGMA_API_TOKEN") and os.environ.get("SIGMA_CLIENT_ID"):
+        p = subprocess.run(["bash", os.path.join(HERE, "get-token.sh")],
+                           capture_output=True, text=True)
+        m = re.search(r"export SIGMA_API_TOKEN=(\S+)", p.stdout or "")
+        if m:
+            os.environ["SIGMA_API_TOKEN"] = m.group(1)
+
+
+def resolve_folder():
+    """SIGMA_FOLDER_ID is a decision point — auto-resolve with a PRINTED default
+    (prefers a THOUGHTSPOT/MIGRATION/TEST folder) rather than silently failing."""
+    if os.environ.get("SIGMA_FOLDER_ID"):
+        return os.environ["SIGMA_FOLDER_ID"]
+    files = json.loads(migrate.sigma("GET", "/v2/files?typeFilters=folder&limit=200"))
+    entries = files.get("entries") or []
+    pick = next((f for f in entries
+                 if any(k in (f.get("name") or "").upper()
+                        for k in ("THOUGHTSPOT", "MIGRATION", "TEST"))),
+                entries[0] if entries else None)
+    if not pick:
+        sys.exit("FATAL: no writable folder found — set SIGMA_FOLDER_ID")
+    os.environ["SIGMA_FOLDER_ID"] = pick["id"]
+    print(f"   no SIGMA_FOLDER_ID supplied — using folder '{pick.get('name')}' ({pick['id']})")
+    return pick["id"]
+
+
+# ── Sigma CSV export (ACTUAL side of parity + the warehouse freshness probe) ──
+def export_csv(wb_id, element_id, timeout=240):
+    res = json.loads(migrate.sigma("POST", f"/v2/workbooks/{wb_id}/export",
+                                   {"elementId": element_id, "format": {"type": "csv"}}))
+    qid = res["queryId"]
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            body = migrate.sigma("GET", f"/v2/query/{qid}/download")
+            if body and body.strip():
+                return body
+        except RuntimeError:
+            pass
+        time.sleep(2)
+    raise RuntimeError(f"CSV export of element {element_id} timed out")
+
+
+def parse_csv(body):
+    rows = list(csv.reader(io.StringIO(body)))
+    return (rows[0], rows[1:]) if rows else ([], [])
+
+
+def numify(v):
+    s = str(v).strip().replace("$", "").replace(",", "").replace("%", "")
+    try:
+        return float(s)
+    except ValueError:
+        return v
+
+
+# ── EXPECTED side, derived from the SOURCE TML (independent of the builder) ──
+TS_AGG = {"SUM": lambda vs: sum(vs),
+          "AVERAGE": lambda vs: (sum(vs) / len(vs)) if vs else None,
+          "MIN": lambda vs: min(vs) if vs else None,
+          "MAX": lambda vs: max(vs) if vs else None,
+          "COUNT": lambda vs: len(vs),
+          "COUNT_DISTINCT": lambda vs: len(set(vs))}
+
+
+def viz_specs_with_aggs(lb_tml_path):
+    """Parse a Liveboard TML → {viz name: {spec, aggs}}. The per-measure agg comes
+    from the TML's own table_columns[].headline_aggregation (default SUM) — the
+    SOURCE definition, not the built Sigma formula, so a builder bug diverges."""
+    lb = yaml.safe_load(open(lb_tml_path).read())["liveboard"]
+    out = {}
+    for v in lb["visualizations"]:
+        spec = ts_common.parse_ts_viz(v)
+        if not spec:
+            continue
+        aggs = {}
+        for tc in ((v.get("answer") or {}).get("table") or {}).get("table_columns") or []:
+            base = ts_common._strip_total(tc.get("column_id", ""))
+            if tc.get("headline_aggregation"):
+                aggs[base] = tc["headline_aggregation"].upper()
+        out[spec["name"]] = {"spec": spec, "aggs": aggs}
+    return out
+
+
+def expected_offline(spec, aggs, resolver, headers, rows):
+    """Re-aggregate the master element's warehouse rows per the SOURCE viz spec."""
+    fr = lambda base: ts_common._resolve(resolver, base)["friendly"]
+    idx = {h: i for i, h in enumerate(headers)}
+    data = rows
+    for f in spec.get("filters", []):
+        col = idx.get(fr(f["col"]))
+        if col is None:
+            continue
+        vals = {str(x).casefold() for x in f["values"]}
+        keep = (lambda r: str(r[col]).casefold() in vals) if f["mode"] == "include" \
+            else (lambda r: str(r[col]).casefold() not in vals)
+        data = [r for r in data if keep(r)]
+    meas = spec["measures"][0]
+    mcol = idx.get(fr(meas))
+    if mcol is None:
+        return None
+    agg = TS_AGG.get(aggs.get(meas, "SUM"), TS_AGG["SUM"])
+    mvals = lambda rs: [numify(r[mcol]) for r in rs if str(r[mcol]).strip() != ""]
+    if not spec["dims"]:
+        return [[None, agg(mvals(data))]]
+    dcol = idx.get(fr(spec["dims"][0]))
+    if dcol is None:
+        return None
+    groups = {}
+    for r in data:
+        groups.setdefault(r[dcol], []).append(r)
+    return [[d, agg(mvals(rs))] for d, rs in groups.items()]
+
+
+def expected_live(spec, model_id):
+    """Ground truth from ThoughtSpot itself: run the viz's search tokens through
+    searchdata against the model."""
+    import ts_lib
+    q = " ".join(f"[{c}]" for c in spec["dims"] + spec["measures"])
+    for f in spec.get("filters", []):
+        q += f" [{f['col']}] {'=' if f['mode'] == 'include' else '!='} " + \
+             " ".join(f"'{v}'" for v in f["values"])
+    res = ts_lib.searchdata(q, model_id)
+    names = res["column_names"]
+    drows = res["data_rows"]
+    if not spec["dims"]:
+        return [[None, numify(drows[0][0])]] if drows else None
+    didx = names.index(spec["dims"][0]) if spec["dims"][0] in names else 0
+    meas = spec["measures"][0]
+    vidx = next((names.index(n) for n in (f"Total {meas}", meas) if n in names),
+                len(names) - 1)
+    return [[r[didx], numify(r[vidx])] for r in drows]
+
+
+def scan_modified(obj):
+    """Best-effort: find a 'modified' epoch-ms anywhere in a metadata entry."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k.lower() in ("modified", "modified_ts", "last_modified") and isinstance(v, (int, float)) and v > 1e12:
+                return time.strftime("%Y-%m-%d %H:%M UTC", time.gmtime(v / 1000))
+            r = scan_modified(v)
+            if r:
+                return r
+    elif isinstance(obj, list):
+        for it in obj:
+            r = scan_modified(it)
+            if r:
+                return r
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model")
+    ap.add_argument("--model-tml")
+    ap.add_argument("--liveboard", action="append")
+    ap.add_argument("--liveboard-tml", action="append")
+    ap.add_argument("--name")
+    ap.add_argument("--workdir")
+    ap.add_argument("--converted")
+    ap.add_argument("--reuse-dm")
+    ap.add_argument("--skip-dm-reuse-check", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    a = ap.parse_args()
+    if not a.model and not a.model_tml:
+        ap.error("--model or --model-tml required")
+    offline = bool(a.model_tml)
+    wd = migrate.resolve_workdir(a.workdir)
+    ensure_sigma_env()
+    if not a.dry_run:
+        missing = [v for v in ("SIGMA_BASE_URL", "SIGMA_API_TOKEN") if not os.environ.get(v)]
+        if not a.reuse_dm and not os.environ.get("SIGMA_CONNECTION_ID"):
+            missing.append("SIGMA_CONNECTION_ID (full warehouse-connection UUID)")
+        if missing:
+            sys.exit("FATAL: missing env: " + ", ".join(missing))
+    TOTAL = 6
+
+    # ── Phase 1 — Discover (model TML + freshness metadata) ──────────────────
+    hdr(1, TOTAL, "Discover")
+    if offline:
+        model_tml = open(a.model_tml).read()
+        print(f"   offline: model TML from {a.model_tml}")
+    else:
+        import ts_lib
+        model_tml, err = ts_lib.export_tml(a.model, "LOGICAL_TABLE")
+        if err:
+            sys.exit("model export failed: " + err)
+    open(os.path.join(wd, "model.tml"), "w").write(model_tml)
+    root = yaml.safe_load(model_tml)
+    root = root.get("model") or root.get("worksheet") or root
+    model_name = root.get("name", "Migrated Model")
+    resolver = ts_common.build_resolver(root)
+    n_lb = len(a.liveboard or a.liveboard_tml or []) or "all referencing"
+    print(f"   model '{model_name}': {len(resolver)} resolvable column(s) · {n_lb} Liveboard(s) · workdir {wd}")
+
+    freshness = {"model_modified": None, "liveboards_modified": {}}
+    if not offline:
+        try:
+            import ts_lib
+            for e in ts_lib.search("LOGICAL_TABLE"):
+                if e.get("metadata_id") == a.model:
+                    freshness["model_modified"] = scan_modified(e)
+            wanted = set(a.liveboard or [])
+            for e in ts_lib.search("LIVEBOARD"):
+                if not wanted or e.get("metadata_id") in wanted:
+                    freshness["liveboards_modified"][e.get("metadata_name")] = scan_modified(e)
+            print(f"   TS metadata: model modified {freshness['model_modified'] or '?'}")
+        except Exception as ex:
+            print(f"   TS freshness metadata unavailable: {ex}")
+    json.dump(freshness, open(os.path.join(wd, "freshness.json"), "w"), indent=2)
+
+    # ── Phase 2 — DM-reuse check (printed; default = BUILD NEW, never silent) ─
+    hdr(2, TOTAL, "DM-reuse check")
+    if a.reuse_dm:
+        print(f"   --reuse-dm {a.reuse_dm} supplied — reusing that data model (convert + POST skipped)")
+    elif a.skip_dm_reuse_check:
+        print("   --skip-dm-reuse-check — building a new data model")
+    else:
+        sig = os.path.join(wd, "dm-signature.json")
+        match_out = os.path.join(wd, "dm-match.json")
+        sig_cmd = ["python3", os.path.join(HERE, "ts-dm-signature.py"), "--tml",
+                   os.path.join(wd, "model.tml"), "--out", sig]
+        if os.environ.get("TS_DB"):
+            sig_cmd += ["--database", os.environ["TS_DB"]]
+        if os.environ.get("TS_SCHEMA"):
+            sig_cmd += ["--schema", os.environ["TS_SCHEMA"]]
+        run(sig_cmd)
+        rc, _ = run(["ruby", os.path.join(HERE, "find-or-pick-dm.rb"),
+                     "--workbook-signature", sig, "--out", match_out], check=False)
+        try:
+            match = json.load(open(match_out))
+            cands = match.get("candidates") or []
+            for c in cands[:5]:
+                print(f"     candidate: {c.get('dm_name')} ({c.get('dm_id')}) score={c.get('score')}")
+            best = cands[0] if cands else None
+            if rc == 0 and best:
+                print("   ➤ a reusable DM scored ≥ threshold — DEFAULT IS STILL BUILD-NEW. To reuse it, re-run with:")
+                print(f"       --reuse-dm {best.get('dm_id')}")
+            else:
+                print("   no existing DM scores above the reuse threshold — building new")
+        except Exception as ex:
+            print(f"   DM-reuse scan unavailable ({ex}) — building new")
+
+    # ── Phase 3 — Convert + build (migrate.py: DM POST, workbooks, layout) ────
+    hdr(3, TOTAL, "Convert + build (migrate.py)")
+    if a.dry_run:
+        conv_out = os.path.join(wd, "converted.json")
+        if os.environ.get("CONVERTER_PATH"):
+            p = subprocess.run(["node", os.path.join(HERE, "convert_model.mjs"),
+                                os.path.join(wd, "model.tml")], capture_output=True, text=True)
+            if p.returncode:
+                sys.exit("convert failed: " + p.stderr[-300:])
+            open(conv_out, "w").write(p.stdout)
+            conv = json.loads(p.stdout)
+            print(f"   DRY RUN: converted spec -> {conv_out} "
+                  f"({(conv.get('stats') or {}).get('elements', '?')} element(s), "
+                  f"{len(conv.get('warnings') or [])} warning(s))")
+        else:
+            req = {"tool": "mcp__sigma-data-model__convert_thoughtspot_to_sigma",
+                   "arguments": {"tml_yaml": model_tml,
+                                 "connection_id": os.environ.get("SIGMA_CONNECTION_ID", ""),
+                                 "database": os.environ.get("TS_DB", ""),
+                                 "schema": os.environ.get("TS_SCHEMA", "")}}
+            json.dump(req, open(os.path.join(wd, "convert-request.json"), "w"), indent=2)
+            print(f"   DRY RUN: no CONVERTER_PATH — MCP request -> {wd}/convert-request.json")
+        print("\n================ RESULT (dry run) ================")
+        print(f"artifacts   : {wd}  (no Sigma objects created)")
+        print("==================================================")
+        return 0
+    resolve_folder()
+    mig_cmd = ["python3", os.path.join(HERE, "migrate.py"), "--workdir", wd]
+    if a.model:
+        mig_cmd += ["--model", a.model]
+    if a.model_tml:
+        mig_cmd += ["--model-tml", a.model_tml]
+    for lb in a.liveboard or []:
+        mig_cmd += ["--liveboard", lb]
+    for lb in a.liveboard_tml or []:
+        mig_cmd += ["--liveboard-tml", lb]
+    if a.name:
+        mig_cmd += ["--name", a.name]
+    if a.converted:
+        mig_cmd += ["--converted", a.converted]
+    if a.reuse_dm:
+        mig_cmd += ["--reuse-dm", a.reuse_dm]
+    rc, _ = run(mig_cmd, check=False)
+    if rc == 3:
+        print("\n   ⏸ MCP converter fallback: call the MCP tool per the instructions above,")
+        print(f"     save its JSON to {wd}/converted.json, then RE-RUN THIS COMMAND with:")
+        print(f"       --converted {wd}/converted.json")
+        return 3
+    if rc != 0:
+        sys.exit(f"FATAL: migrate.py failed ({rc})")
+    out = json.load(open(os.path.join(wd, "migrate_out.json")))
+    dm = out["dataModel"]
+    wbs = [(name, r) for name, r in out["results"].items() if r.get("workbook")]
+    fails = [(name, r) for name, r in out["results"].items() if r.get("error")]
+    if not wbs:
+        sys.exit("FATAL: no workbook was built: " + json.dumps(fails))
+    print(f"   DM {dm} · {len(wbs)} workbook(s)" + (f" · {len(fails)} FAILED Liveboard(s)" if fails else ""))
+
+    # ── Phase 4 — Post-and-readback gate (live /columns: no type=error) ───────
+    hdr(4, TOTAL, "Post-and-readback gate")
+    col_errors = 0
+    for name, r in wbs:
+        cols = json.loads(migrate.sigma("GET", f"/v2/workbooks/{r['workbook']}/columns"))
+        entries = cols.get("entries") or []
+        errs = [c for c in entries if (c.get("type") or {}).get("type") == "error"]
+        col_errors += len(errs)
+        print(f"   {name[:34]:34s} {len(entries) - len(errs)}/{len(entries)} columns resolve"
+              + (f" — {len(errs)} ERROR-typed" if errs else ""))
+        for c in errs[:6]:
+            print(f"     [{c.get('elementId')}] {c.get('label')}: {c.get('formula')}")
+
+    # ── Phase 5 — SOURCE-FRESHNESS preflight (read BEFORE any side-by-side) ───
+    hdr(5, TOTAL, "Source freshness (preflight — before parity)")
+    masters = {}  # wb id -> (headers, rows)
+    print("   ── SOURCE FRESHNESS (read this before any side-by-side) ──")
+    if freshness.get("model_modified"):
+        print(f"   TS model last modified   : {freshness['model_modified']}")
+    for lname, t in (freshness.get("liveboards_modified") or {}).items():
+        print(f"   TS Liveboard modified    : {lname} — {t or '?'}")
+    if offline:
+        print("   TS instance              : unavailable (offline run) — modified-time + searchdata probe skipped")
+    probe_measure = next((c.get("name") for c in root.get("columns", [])
+                          if str(((c.get("properties") or {}).get("column_type") or "")).upper() == "MEASURE"
+                          and str(((c.get("properties") or {}).get("aggregation") or "SUM")).upper() == "SUM"), None)
+    for name, r in wbs:
+        headers, rows = parse_csv(export_csv(r["workbook"], "m-ofv"))
+        masters[r["workbook"]] = (headers, rows)
+        idx = {h: i for i, h in enumerate(headers)}
+        datecol = next((h for h in headers if "date" in h.lower()), None)
+        maxdate = max((str(row[idx[datecol]]) for row in rows if str(row[idx[datecol]]).strip()), default="?") \
+            if datecol else None
+        line = f"   warehouse (via Sigma)    : '{name[:30]}' master = {len(rows)} rows"
+        if datecol:
+            line += f", max({datecol}) = {maxdate}"
+        print(line)
+        if probe_measure and not offline and a.model:
+            fcol = idx.get(ts_common._resolve(resolver, probe_measure)["friendly"])
+            if fcol is not None:
+                wh = sum(numify(row[fcol]) for row in rows
+                         if isinstance(numify(row[fcol]), float))
+                try:
+                    import ts_lib
+                    sd = ts_lib.searchdata(f"[{probe_measure}]", a.model)
+                    tsv = numify(sd["data_rows"][0][0]) if sd.get("data_rows") else None
+                    status = "MATCH" if isinstance(tsv, float) and abs(tsv - wh) <= max(abs(tsv), abs(wh)) * 1e-6 + 1e-9 \
+                        else "DIVERGENT — investigate BEFORE reading parity as a conversion bug"
+                    print(f"   probe Total {probe_measure[:20]:20s}: TS {tsv}  vs warehouse {round(wh, 2)}  {status}")
+                except Exception as ex:
+                    print(f"   TS searchdata probe unavailable: {ex}")
+    print("   (ThoughtSpot models are usually live-query — a divergence here means the model/")
+    print("    warehouse CHANGED between export and now, or a join differs; not cache staleness.)")
+
+    # ── Phase 6 — Parity (two-pass, scripted) + HARD GATE ────────────────────
+    hdr(6, TOTAL, "Parity + hard gate")
+    model_id = a.model
+    overall = []
+    for i, (name, r) in enumerate(wbs):
+        wb = r["workbook"]
+        pdir = wd if len(wbs) == 1 else os.path.join(wd, f"parity-{i + 1}")
+        os.makedirs(pdir, exist_ok=True)
+        rc, _ = run(["ruby", os.path.join(HERE, "phase6-parity-thoughtspot.rb"),
+                     "--workdir", pdir, "--workbook-id", wb], check=False)
+        if rc != 0:
+            sys.exit(f"FATAL: parity pass 1 failed for {wb}")
+        plan = json.load(open(os.path.join(pdir, "parity-plan.json")))
+        vmap = viz_specs_with_aggs(r["lb_tml"]) if r.get("lb_tml") else {}
+        expected, actuals = {}, {}
+        for c in plan["charts"]:
+            cname = c["chart"]
+            # ACTUAL — the built Sigma chart, via CSV export
+            headers, rows = parse_csv(export_csv(wb, c["sigma_element_id"]))
+            idx = {h: i for i, h in enumerate(headers)}
+            want = c["sigma_columns"]
+            if len(want) == 1:                      # KPI
+                vi = idx.get(want[0], 0)
+                actuals[cname] = [[None, numify(rows[0][vi])]] if rows else []
+            else:
+                di, vi = idx.get(want[0], 0), idx.get(want[1], 1 if len(headers) > 1 else 0)
+                actuals[cname] = [[row[di], numify(row[vi])] for row in rows]
+            # EXPECTED — searchdata ground truth (live) or source-TML re-aggregation (offline)
+            v = vmap.get(cname)
+            if not v:
+                print(f"   WARN: no source viz named {cname!r} in the Liveboard TML — chart will DIVERGE")
+                continue
+            exp = None
+            if model_id and not offline:
+                try:
+                    exp = expected_live(v["spec"], model_id)
+                except Exception as ex:
+                    print(f"   WARN: searchdata failed for {cname!r} ({ex}); falling back to warehouse re-aggregation")
+            if exp is None:
+                mh, mr = masters[wb]
+                exp = expected_offline(v["spec"], v["aggs"], resolver, mh, mr)
+            if exp is not None:
+                expected[cname] = exp
+        json.dump(expected, open(os.path.join(pdir, "parity-expected.json"), "w"), indent=2)
+        json.dump(actuals, open(os.path.join(pdir, "parity-actuals.json"), "w"), indent=2)
+        rc, _ = run(["ruby", os.path.join(HERE, "phase6-parity-thoughtspot.rb"),
+                     "--workdir", pdir, "--finalize"], check=False)
+        grc, _ = run(["ruby", os.path.join(HERE, "assert-phase6-ran.rb"),
+                      "--workdir", pdir, "--workbook-id", wb], check=False)
+        summary = json.load(open(os.path.join(pdir, "parity-final.json")))
+        overall.append((name, wb, summary, grc))
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+    green = all(g == 0 for *_x, g in overall) and col_errors == 0
+    print("\n================ RESULT ================")
+    print(f"dataModelId : {dm}{'  (REUSED)' if out.get('dmReused') else ''}")
+    for name, wb, s, g in overall:
+        print(f"workbook    : {wb}  '{name}' — parity {s['charts_pass']}/{s['charts_total']} "
+              f"{s['status']}, hard gate {'PASS' if g == 0 else f'FAIL (exit {g})'}")
+    if fails:
+        print(f"failed lbs  : {', '.join(n for n, _ in fails)}")
+    print(f"PARITY      : {'GREEN' if green else 'RED'}  ·  wall-clock {elapsed()}")
+    print("========================================")
+    return 0 if green else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -107,22 +107,28 @@ No local converter build (CONVERTER_PATH unset) — use the MCP converter:
 """)
     sys.exit(3)
 
-def build_dm(conv, name, folder):
-    """POST the converted Sigma data model. Returns (dmId, denormElemId, denormName)."""
-    spec = conv["model"]; spec["name"] = name
-    res = json.loads(sigma("POST", "/v2/dataModels/spec", {"folderId": folder, **spec}))
-    dm = res["dataModelId"]
-    # discover the denormalized "<root> View" element from the posted DM spec
+def find_denorm(dm):
+    """Read a DM's spec back and locate the denormalized "<root> View" element.
+    Returns (denormElemId, denormName)."""
     dmspec = yaml.safe_load(sigma("GET", f"/v2/dataModels/{dm}/spec"))
     els = dmspec["pages"][0]["elements"]
     denorm = next((el for el in els if (el.get("name") or "").endswith(" View")), None)
     if not denorm:
         # no joins → no denormalized view; use the base fact element (most columns).
         denorm = max(els, key=lambda e: len(e.get("columns", [])))
+    return denorm["id"], denorm["name"]
+
+def build_dm(conv, name, folder):
+    """POST the converted Sigma data model. Returns (dmId, denormElemId, denormName)."""
+    spec = conv["model"]; spec["name"] = name
+    res = json.loads(sigma("POST", "/v2/dataModels/spec", {"folderId": folder, **spec}))
+    dm = res["dataModelId"]
+    # discover the denormalized "<root> View" element from the posted DM spec
+    denorm_id, denorm_name = find_denorm(dm)
     stats = conv.get("stats") or {}
-    print(f"  DM {dm}  ·  denorm '{denorm['name']}' ({denorm['id']})  ·  "
+    print(f"  DM {dm}  ·  denorm '{denorm_name}' ({denorm_id})  ·  "
           f"{stats.get('relationships', '?')} rels, {stats.get('elements', '?')} elements")
-    return dm, denorm["id"], denorm["name"]
+    return dm, denorm_id, denorm_name
 
 def post_workbook(spec, wd):
     resp = sigma("POST", "/v2/workbooks/spec", spec)
@@ -190,6 +196,8 @@ def main():
     ap.add_argument("--name", default=None, help="name PREFIX applied to BOTH the data model and every workbook")
     ap.add_argument("--workdir", default=None, help="working dir for artifacts (default $TS_WORKDIR or ./ts-migration)")
     ap.add_argument("--converted", default=None, help="JSON output of the convert_thoughtspot_to_sigma MCP tool")
+    ap.add_argument("--reuse-dm", default=None, help="existing Sigma dataModelId to reuse — skips convert + POST "
+                    "(decided via ts-dm-signature.py + find-or-pick-dm.rb; see SKILL.md step 2.5)")
     a = ap.parse_args()
     wd = resolve_workdir(a.workdir)
     offline = bool(a.model_tml)
@@ -203,6 +211,7 @@ def main():
         model_tml, err = ts_lib.export_tml(a.model, "LOGICAL_TABLE")
         if err:
             sys.exit("model export failed: " + err)
+    open(os.path.join(wd, "model.tml"), "w").write(model_tml)   # always persist (parity/freshness consume it)
     root = yaml.safe_load(model_tml)
     root = root.get("model") or root.get("worksheet") or root
     model_name = root.get("name", "Migrated Model")
@@ -210,9 +219,14 @@ def main():
     resolver = ts_common.build_resolver(root)
     print(f"Model '{model_name}': {len(resolver)} resolvable columns  ·  workdir {wd}")
 
-    conv = convert_model(model_tml, wd, a.converted)
     folder = need_env("SIGMA_FOLDER_ID")[0]
-    dm, denorm_id, denorm_name = build_dm(conv, f"{prefix}{model_name} (from ThoughtSpot)", folder)
+    if a.reuse_dm:
+        dm = a.reuse_dm
+        denorm_id, denorm_name = find_denorm(dm)
+        print(f"  REUSING DM {dm}  ·  denorm '{denorm_name}' ({denorm_id})  — convert + POST skipped")
+    else:
+        conv = convert_model(model_tml, wd, a.converted)
+        dm, denorm_id, denorm_name = build_dm(conv, f"{prefix}{model_name} (from ThoughtSpot)", folder)
 
     # pick Liveboards: offline TML files, explicit ids, or every Liveboard that references the model
     targets = []                                       # (lb_doc, fallback_name)
@@ -237,15 +251,21 @@ def main():
                     targets.append((edoc, lb["metadata_name"]))
     print(f"Migrating {len(targets)} Liveboard(s)…")
 
+    # persist each Liveboard TML so downstream phases (parity expected-side,
+    # freshness probe) can re-derive viz specs without re-exporting from TS
+    lbdir = os.path.join(wd, "liveboards")
+    os.makedirs(lbdir, exist_ok=True)
     results = {}
-    for lb_doc, fallback in targets:
+    for i, (lb_doc, fallback) in enumerate(targets):
+        lb_path = os.path.join(lbdir, f"lb-{i + 1}.tml")
+        open(lb_path, "w").write(lb_doc)
         try:
             wb, display, n, tiles = migrate_liveboard(lb_doc, dm, denorm_id, denorm_name,
                                                       resolver, prefix, fallback, folder, wd)
-            results[display] = {"workbook": wb, "viz": n, "tiles": tiles}
+            results[display] = {"workbook": wb, "viz": n, "tiles": tiles, "lb_tml": lb_path}
             print(f"  ✓ {display[:34]:34s} WB {wb} ({n} viz, layout={'TML tiles' if tiles else 'auto grid'})")
         except Exception as ex:
-            results[fallback] = {"error": str(ex)}
+            results[fallback] = {"error": str(ex), "lb_tml": lb_path}
             print(f"  ✗ {fallback[:34]:34s} {ex}")
     for ans_id in (a.answer or []):
         try:
@@ -256,7 +276,9 @@ def main():
             results["answer:" + ans_id] = {"error": str(ex)}
             print(f"  ✗ answer {ans_id[:8]}  {ex}")
     wbs = [r["workbook"] for r in results.values() if r.get("workbook")]
-    json.dump({"model": a.model or a.model_tml, "dataModel": dm, "results": results},
+    json.dump({"model": a.model or a.model_tml, "modelName": model_name, "dataModel": dm,
+               "dmReused": bool(a.reuse_dm), "denormElementId": denorm_id,
+               "denormName": denorm_name, "results": results},
               open(os.path.join(wd, "migrate_out.json"), "w"), indent=2)
     if len(wbs) == 1:        # convenience for the parity gate (assert-phase6-ran.rb)
         json.dump({"workbookId": wbs[0]}, open(os.path.join(wd, "wb-ids.json"), "w"))


### PR DESCRIPTION
## What

Patterned on `qlik-to-sigma/scripts/migrate-qlik.rb`: the full pipeline as ONE command per tool, chaining the existing per-phase scripts (no phase re-implemented), with hard gates that are NEVER bypassed and decision points surfaced as flags with safe defaults — never silent.

### thoughtspot-to-sigma — `scripts/migrate-thoughtspot.py` (NEW)
- Chains: discover/TML export (or offline fixtures) → **DM-reuse check** (`ts-dm-signature.py` + `find-or-pick-dm.rb`: candidates+scores printed, default **build-new**, reuse only via explicit `--reuse-dm <id>`) → `migrate.py` (CONVERTER_PATH one-shot, or the exit-3 MCP-request / `--converted` resume) → live `/columns` readback gate → **SOURCE-FRESHNESS preflight (fmte)**: TS model/Liveboard modified times + a cheap `searchdata` aggregate probe vs a live warehouse snapshot, printed BEFORE parity (offline runs note the TS side unavailable) → **scripted two-pass parity** (`phase6-parity-thoughtspot.rb`; ACTUAL = Sigma CSV export per chart, EXPECTED = `searchdata` ground truth live / source-TML re-aggregation offline using the TML's own `headline_aggregation`) → `assert-phase6-ran.rb`.
- `migrate.py`: adds `--reuse-dm`, persists `model.tml` + per-Liveboard TMLs (`lb_tml` in the manifest).
- Exit codes: 0 GREEN · 3 MCP convert request emitted (re-run with `--converted`) · 2 gate FAILED. `--dry-run` = no Sigma POSTs.

### looker-to-sigma — `scripts/migrate-looker.py` (NEW) + scripted parity gate (fnhy)
- Chains: parse (offline `.dashboard.lookml` or live `fetch_looker_dashboard.py`) → **`detect_rls.py` gate** (findings stop the command, exit 10, nothing posted — port via `apply_sigma_rls.py` or re-run `--yes`; zero overhead when clean) → convert (`CONVERTER_SRC` via tsx / `CONVERTER_PATH` build / MCP-request **exit 3 + `--converted` resume**, mirroring TS) → DM-reuse check → `post_dm.py` (join-key guard) + denorm readback → `build_workbook.py` + POST (layout inline) → freshness preflight → **NEW `phase6-parity-looker.rb`** two-pass orchestrator writing the repo-contract `parity-final.json` sentinel + vendored `verify-parity.rb` → **`assert-phase6-ran.rb` vendored byte-identical from quicksight** (`md5 058fb32a9a6dc12f440df6bc4b0c3cd0` — now 5 identical copies across plugins).
- Offline EXPECTED is **source-derived** (LookML `type:` semantics incl. recursive ratio-measure evaluation), independent of the builder's generated formulas, so a builder bug DIVERGES instead of self-confirming.

Docs: both SKILL.md + QUICKSTART.md gained the one-command path; per-phase docs kept for manual mode.

## E2E (timed, live org tj-wells-1989, conn bc0319f8)

| Run | Result | Wall-clock | Kept |
|---|---|---|---|
| Looker offline fixtures (`skilltest-orders`) | **GREEN** — parity 5/5 strict, all 5 hard gates OK | **32.7s** | WB `764973d1` "VISQA4 Looker SKILLTEST Looker Orders Pulse", DM `e85f8c65`; PNG `~/migration-visual-qa/looker4/` |
| ThoughtSpot offline fixtures (Retail Analytics) | **GREEN** — parity 4/4 strict, all gates OK | **29.2s** (scratch) / 104.1s (recorded run, slow export poll) | WB `33065f37` "Retail Analytics (TS Fixture)" under VISQA4 TS prefix, DM `39df9442`; PNG `~/migration-visual-qa/thoughtspot4/` |
| ThoughtSpot **live** (team2 trial) | **deferred** — the bearer in `~/thoughtspot-migration/.ts_env` expired (24h TTL; re-mint is interactive password entry) | — | command ready: `migrate-thoughtspot.py --model <id> --liveboard <id> --name "VISQA4 TS"` |

Parity numbers (both tools, strict to the cent): Net Revenue **$110,342.75**; Looker fixture Order Count 648 / AOV $170.28; per-dim buckets (region/category/month/segment/ship-method) all exact vs source-derived expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)