### PR TITLE
One-command orchestrators: cognos-to-sigma + tableau-to-sigma (bead ns7c)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -24,6 +24,49 @@ of emitting wrong logic.
 
 ---
 
+## One command (orchestrated path)
+
+```bash
+node scripts/migrate-cognos.mjs \
+  --module <module.json> --report <report.xml> \
+  --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID> \
+  [--database CSA --schema TJ] [--name '<prefix>'] \
+  [--reuse-dm [ID]] [--expected expected.json] [--yes]
+```
+
+Chains every phase below in one process: module convert → DM-reuse scan
+(candidates printed; default BUILD NEW, `--reuse-dm` opts in) → DM
+post-and-readback (hard gate) → report convert `--dm` → remap → workbook
+post-and-readback (hard gate) → apply-layout (readback-verified) → parity.
+Inputs are the exported module JSON + report XML (Phase 0 / `cognos-discover.sh`
+gets them from a live CA). `--name` prefixes both the DM and workbook names.
+
+Parity is two-pass when `--expected` isn't supplied up front: pass 1 auto-exports
+every element to CSV via the Sigma REST export API → `<workdir>/sigma-actuals.json`
+(keys `"<Element>/<Column>" = sum`, `"<Element>/rows" = count`), prints the
+`assert-parity --plan` mcp-v2 query list, then exits 10 with resume instructions.
+Build `expected.json` from the **Cognos** report's numbers (same keys, subset ok)
+and resume:
+
+```bash
+node scripts/migrate-cognos.mjs --resume --out <workdir> --expected expected.json
+```
+
+Exit codes: `0` = PARITY GREEN (`assert-parity --check` passed — the only green
+exit); `10` = stopped for human input (OPEN QUESTIONS or expected values needed;
+state saved); `3` = built but parity RED; anything else = a gate failed. A
+freshness banner prints before any side-by-side: Sigma queries the LIVE
+warehouse while `expected.json` is a Cognos snapshot — re-capture before calling
+drift a bug.
+
+**Still manual by design (the orchestrator stops and tells you):** the expected
+parity numbers (they must come from the Cognos report — never invented),
+flagged-expression rework (gap-scout), and RLS porting (`security.json` →
+`apply_sigma_rls.py`, see "Security" — detected rules are surfaced at the
+checkpoint, never silently ported or dropped).
+
+---
+
 ## Prerequisites
 
 - **Cognos Analytics 11.1+** REST access (on-prem or CA on Cloud). Base path is

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+// migrate-cognos.mjs — ONE-COMMAND orchestrator for the cognos-to-sigma
+// pipeline: module convert → DM-reuse check → DM post (gated) → report convert
+// → remap → workbook post (gated) → layout → parity. Mirrors qlik-to-sigma's
+// migrate-qlik.rb: every phase prints a visible header + concise result, the
+// genuine human decision points surface as a structured OPEN QUESTIONS block
+// (exit 10) instead of being silently auto-resolved, and the hard gates
+// (post-and-readback error-column scan, apply-layout readback, assert-parity
+// --check) are NEVER bypassed — the command fails when a gate fails.
+//
+// This script does NOT re-implement any phase — it chains the per-phase pieces
+// (each independently usable):
+//   converter/cli.ts          (Phase 1 — module.json → Sigma DM spec;
+//                              Phase 4 — report.xml → Sigma workbook spec)
+//   cognos-dm-signature.py + find-or-pick-dm.rb
+//                             (Phase 2 — DM-reuse scan; default BUILD NEW,
+//                              candidates printed, --reuse-dm opts in)
+//   post-and-readback.mjs     (Phase 3 DM + Phase 5 workbook — POST + the
+//                              error-typed-column hard gate)
+//   remap-wb-to-dm-ids.mjs    (Phase 4 — placeholder elementIds → real DM ids)
+//   apply-layout.mjs          (Phase 6 — clean 24-col grid; readback-verified)
+//   assert-parity.mjs         (Phase 7 — --plan emits the per-element query
+//                              list; --check is the GREEN gate)
+//
+// Parity is two-pass: pass 1 auto-exports every workbook element to CSV via
+// the Sigma REST export API and writes sigma-actuals.json (keys
+// "<Element>/<Column>" = column sum, "<Element>/rows" = row count), prints the
+// assert-parity --plan query list (mcp-v2 alternative), then exits 10 with
+// resume instructions. The EXPECTED numbers must come from the Cognos report —
+// they cannot be invented here. Resume with:
+//   node scripts/migrate-cognos.mjs --resume --out <WORKDIR> --expected expected.json
+// or run end-to-end in one shot when expected.json already exists:
+//   ... --expected expected.json
+//
+// Usage:
+//   node scripts/migrate-cognos.mjs \
+//     --module <module.json> --report <report.xml> \
+//     --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID> \
+//     [--database CSA] [--schema TJ] [--name '<prefix for DM/workbook names>'] \
+//     [--out DIR] [--expected expected.json] [--tol 0.01] \
+//     [--reuse-dm [dataModelId]]   # opt IN to DM reuse (default: build new;
+//                                  # bare flag = use the picker's recommendation)
+//     [--skip-reuse-scan]          # don't scan existing DMs at all
+//     [--answers '<json>'] [--yes] # resolve the OPEN QUESTIONS block
+//     [--resume]                   # jump to parity against the posted ids in
+//                                  # <out>/migrate-state.json
+//     [--dry-run]                  # convert only; no Sigma POSTs
+//
+// Exit codes: 0 = PARITY GREEN; 10 = stopped for human input (open questions
+// or expected-values needed — state saved, resume supported); 3 = built but
+// parity RED; other = error / gate failure.
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CONV = join(HERE, '..', 'converter');
+
+// ---------------------------------------------------------------------------
+// args
+// ---------------------------------------------------------------------------
+const argv = process.argv.slice(2);
+const opt = {};
+for (let i = 0; i < argv.length; i++) {
+  if (!argv[i].startsWith('--')) continue;
+  const k = argv[i].slice(2);
+  const next = argv[i + 1];
+  opt[k] = (next == null || next.startsWith('--')) ? true : (i++, next);
+}
+const die = (m, code = 1) => { console.error(`FATAL: ${m}`); process.exit(code); };
+
+if (!opt.resume) {
+  if (!opt.module) die('missing --module <module.json>');
+  if (!opt.report) die('missing --report <report.xml>');
+  if (!opt.connection) die('missing --connection');
+  if (!opt.folder && !opt['dry-run']) die('missing --folder (post-and-readback requires one)');
+}
+const slug = basename((opt.module || opt.out || 'cognos')).replace(/\.[^.]+$/, '').replace(/[^A-Za-z0-9_-]/g, '-');
+const WORK = resolve(opt.out || join(homedir(), 'cognos-migration', slug));
+mkdirSync(WORK, { recursive: true });
+const statePath = join(WORK, 'migrate-state.json');
+const TOL = Number(opt.tol ?? 0.01);
+
+const TOTAL = 7;
+const hdr = (n, t) => console.log(`\n── Phase ${n}/${TOTAL} · ${t} ──`);
+const line = (m) => console.log(`   ${m}`);
+
+// ---------------------------------------------------------------------------
+// Sigma env bootstrap — same path as the per-phase scripts: get-token.sh
+// (which itself falls back to ~/.sigma-migration/env). All children inherit.
+// ---------------------------------------------------------------------------
+function sigmaLogin() {
+  if (process.env.SIGMA_API_TOKEN && process.env.SIGMA_BASE_URL) return;
+  const r = spawnSync('bash', ['-c',
+    `[ -f "$HOME/.sigma-migration/env" ] && . "$HOME/.sigma-migration/env"; ` +
+    `eval "$('${join(HERE, 'get-token.sh')}')" && env | grep '^SIGMA_'`], { encoding: 'utf8' });
+  if (r.status !== 0) die(`Sigma token bootstrap failed:\n${r.stderr || r.stdout}`);
+  for (const l of r.stdout.split('\n')) {
+    const m = l.match(/^(SIGMA_[A-Z_]+)=(.*)$/);
+    if (m) process.env[m[1]] = m[2];
+  }
+  if (!process.env.SIGMA_API_TOKEN) die('get-token.sh did not yield SIGMA_API_TOKEN');
+}
+
+// Run a child, stream output indented; hard-fail unless allowFail.
+function run(cmd, args, { allowFail = false, capture = false, cwd = undefined } = {}) {
+  const r = spawnSync(cmd, args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, cwd });
+  const out = (r.stdout || '') + (r.stderr || '');
+  if (!capture && out.trim()) out.split('\n').forEach((l) => l.trim() && console.log('   ' + l));
+  if (r.status !== 0 && !allowFail) die(`command failed (${r.status}): ${cmd} ${args.join(' ')}\n${capture ? out : ''}`);
+  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+// Minimal Sigma REST (for the parity auto-export only — builders go through the
+// per-phase scripts).
+async function api(method, path, body) {
+  const base = process.env.SIGMA_BASE_URL.replace(/\/$/, '');
+  const res = await fetch(base + path, {
+    method,
+    headers: { Authorization: `Bearer ${process.env.SIGMA_API_TOKEN}`, 'Content-Type': 'application/json' },
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json = null; try { json = JSON.parse(text); } catch { /* csv/yaml */ }
+  return { status: res.status, ok: res.ok, text, json };
+}
+
+// Tiny CSV parser (quoted fields, no embedded newlines-in-quotes edge beyond basic).
+function parseCsv(text) {
+  const rows = [];
+  let row = [], field = '', inQ = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQ) {
+      if (c === '"') { if (text[i + 1] === '"') { field += '"'; i++; } else inQ = false; }
+      else field += c;
+    } else if (c === '"') inQ = true;
+    else if (c === ',') { row.push(field); field = ''; }
+    else if (c === '\n') { row.push(field); rows.push(row); row = []; field = ''; }
+    else if (c !== '\r') field += c;
+  }
+  if (field !== '' || row.length) { row.push(field); rows.push(row); }
+  return rows.filter((r) => r.length > 1 || (r.length === 1 && r[0] !== ''));
+}
+
+const numish = (s) => {
+  if (s == null) return null;
+  const t = String(s).replace(/[$,%\s]/g, '');
+  return /^-?\d+(\.\d+)?$/.test(t) ? Number(t) : null;
+};
+
+// ---------------------------------------------------------------------------
+// Parity (Phase 7) — shared by the straight-through path and --resume.
+// ---------------------------------------------------------------------------
+async function runParity(state) {
+  hdr(7, 'Parity');
+
+  // SOURCE-FRESHNESS banner BEFORE any side-by-side (pattern requirement):
+  // Cognos report numbers are a snapshot of whenever the report was last run /
+  // captured; Sigma queries the LIVE warehouse.
+  console.log('   ── SOURCE FRESHNESS (read this before any side-by-side) ──');
+  if (state.moduleFile && existsSync(state.moduleFile)) {
+    const mt = statSync(state.moduleFile).mtime;
+    const days = ((Date.now() - mt.getTime()) / 86400e3).toFixed(1);
+    line(`Cognos module export captured ${mt.toISOString()} (~${days} day(s) ago).`);
+  }
+  line('Sigma queries the LIVE warehouse; expected.json reflects the Cognos report AS CAPTURED.');
+  line('If the source tables changed since capture, deltas are STALENESS, not conversion errors —');
+  line('re-run the Cognos report (or re-query the source DB) before calling a divergence a bug.');
+
+  // Auto-actuals: export every data-bearing workbook element to CSV via REST
+  // and aggregate to "<Element>/<Column>"=sum + "<Element>/rows"=count.
+  const els = (state.wbElements || []).filter((e) => !['control', 'text'].includes(String(e.kind)));
+  line('');
+  line(`exporting ${els.length} element(s) for Sigma actuals…`);
+  const actuals = {};
+  for (const e of els) {
+    const post = await api('POST', `/v2/workbooks/${state.workbookId}/export`,
+      { elementId: e.id, format: { type: 'csv' } });
+    const qid = post.json?.queryId;
+    if (!qid) { line(`WARN: export request failed for '${e.name}' (HTTP ${post.status})`); continue; }
+    let body = null;
+    const deadline = Date.now() + 240e3;
+    while (Date.now() < deadline) {
+      const dl = await api('GET', `/v2/query/${qid}/download`);
+      if (dl.ok && dl.text && dl.text.trim()) { body = dl.text; break; }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    if (!body) { line(`WARN: export never became ready for '${e.name}'`); continue; }
+    const rows = parseCsv(body);
+    const headers = rows[0] || [];
+    const data = rows.slice(1);
+    actuals[`${e.name}/rows`] = data.length;
+    headers.forEach((h, ci) => {
+      const vals = data.map((r) => numish(r[ci])).filter((v) => v != null);
+      if (vals.length === data.length && data.length > 0) {
+        actuals[`${e.name}/${h}`] = Number(vals.reduce((a, b) => a + b, 0).toFixed(6));
+      }
+    });
+    line(`'${e.name}': ${data.length} row(s), ${headers.length} col(s)`);
+  }
+  const actualsPath = join(WORK, 'sigma-actuals.json');
+  writeFileSync(actualsPath, JSON.stringify(actuals, null, 2));
+  line(`Sigma actuals → ${actualsPath} (${Object.keys(actuals).length} key(s))`);
+
+  // The per-element query list (mcp-v2 alternative / drill-down path).
+  console.log('');
+  run('node', [join(HERE, 'assert-parity.mjs'), '--plan', '--type', 'workbook', '--id', state.workbookId]);
+
+  const expectedPath = opt.expected ? resolve(opt.expected) : state.expectedPath;
+  if (!expectedPath || !existsSync(expectedPath)) {
+    console.log('\n==================== PARITY INPUT NEEDED ====================');
+    console.log('Sigma actuals are exported. The EXPECTED numbers must come from the');
+    console.log('Cognos report (run it, or query the source DB) — they cannot be');
+    console.log('derived here. Write expected.json using the SAME keys as');
+    console.log(`${actualsPath}`);
+    console.log('(subset is fine — every key present is checked), then resume:');
+    console.log(`  node scripts/migrate-cognos.mjs --resume --out ${WORK} --expected expected.json`);
+    console.log('=============================================================');
+    state.actualsPath = actualsPath;
+    writeFileSync(statePath, JSON.stringify(state, null, 2));
+    console.log('\n================ RESULT (parity pending) ================');
+    console.log(`dataModelId : ${state.dataModelId}`);
+    console.log(`workbookId  : ${state.workbookId}`);
+    console.log('PARITY      : PENDING — expected.json needed (see above)');
+    console.log('=========================================================');
+    process.exit(10);
+  }
+
+  const actualArg = opt.actuals ? resolve(opt.actuals) : actualsPath;
+  const chk = run('node', [join(HERE, 'assert-parity.mjs'), '--check',
+    '--actual', actualArg, '--expected', expectedPath, '--tol', String(TOL)], { allowFail: true });
+  const green = chk.status === 0;
+  console.log('\n================ RESULT ================');
+  console.log(`dataModelId : ${state.dataModelId}${state.reusedDm ? '  (REUSED existing DM)' : ''}`);
+  console.log(`workbookId  : ${state.workbookId}`);
+  console.log(`PARITY      : ${green ? 'GREEN' : 'RED'} (assert-parity --check, tol ±${TOL * 100}%)`);
+  if (state.securityRules) console.log(`security    : ${state.securityRules} RLS rule(s) detected — NOT auto-ported; run apply_sigma_rls.py (see SKILL.md "Security")`);
+  console.log('========================================');
+  process.exit(green ? 0 : 3);
+}
+
+// ---------------------------------------------------------------------------
+// --resume: parity-only against saved state.
+// ---------------------------------------------------------------------------
+if (opt.resume) {
+  if (!existsSync(statePath)) die(`--resume: no state at ${statePath} (pass --out <workdir>)`);
+  const state = JSON.parse(readFileSync(statePath, 'utf8'));
+  if (!state.workbookId) die('--resume: state has no workbookId (the build never completed)');
+  sigmaLogin();
+  console.log(`resuming parity for workbook ${state.workbookId} (state: ${statePath})`);
+  await runParity(state);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — Convert the Data Module → Sigma DM spec (converter/cli.ts).
+// ---------------------------------------------------------------------------
+hdr(1, 'Convert data module');
+if (!existsSync(join(CONV, 'node_modules'))) {
+  line('converter deps missing — running npm install (once)…');
+  run('npm', ['install', '--silent'], { cwd: CONV });
+}
+const modulePath = resolve(opt.module);
+const reportPath = resolve(opt.report);
+const db = opt.database || 'CSA';
+const schema = opt.schema || 'TJ';
+const securityPath = join(WORK, 'security.json');
+const conv = spawnSync('node', ['--import', 'tsx/esm', join(CONV, 'cli.ts'), modulePath,
+  '--connection', opt.connection, '--database', db, '--schema', schema,
+  '--security-out', securityPath],
+  { encoding: 'utf8', cwd: CONV, maxBuffer: 64 * 1024 * 1024 });
+if (conv.status !== 0) die(`module converter failed:\n${conv.stderr}`);
+const dmSpec = JSON.parse(conv.stdout);
+const dmPath = join(WORK, 'dm.json');
+writeFileSync(dmPath, JSON.stringify(dmSpec, null, 2));
+const convWarnings = conv.stderr.split('\n').filter((l) => l.trim().startsWith('!')).map((l) => l.replace(/^\s*!\s*/, ''));
+const statsLine = (conv.stderr.match(/stats: (\{.*\})/) || [])[1];
+const securityDetected = existsSync(securityPath) ? JSON.parse(readFileSync(securityPath, 'utf8')) : [];
+line(`module '${dmSpec.name || basename(modulePath)}' → DM spec (${statsLine || 'no stats'}); ${convWarnings.length} warning(s)`);
+if (securityDetected.length) line(`SECURITY: ${securityDetected.length} rule(s) detected → ${securityPath} (ported AFTER post via apply_sigma_rls.py — never silently)`);
+
+const namePrefix = typeof opt.name === 'string' ? opt.name : null;
+const dmName = namePrefix ? `${namePrefix} ${dmSpec.name || 'Cognos DM'}` : (dmSpec.name || `Cognos DM ${slug}`);
+
+// ---------------------------------------------------------------------------
+// Phase 2 — DM-reuse scan (find-or-pick-dm). Default = BUILD NEW; candidates
+// are printed so a human can opt in with --reuse-dm.
+// ---------------------------------------------------------------------------
+hdr(2, 'DM-reuse scan');
+let reuseDmId = null;
+let match = null;
+if (opt['skip-reuse-scan'] || opt['dry-run']) {
+  line(opt['dry-run'] ? 'dry-run — skipping the org DM scan' : 'skipped (--skip-reuse-scan)');
+} else {
+  sigmaLogin();
+  const sigPath = join(WORK, 'dm-signature.json');
+  run('python3', [join(HERE, 'cognos-dm-signature.py'), '--dm-spec', dmPath, '--out', sigPath]);
+  const matchPath = join(WORK, 'dm-match.json');
+  run('ruby', [join(HERE, 'find-or-pick-dm.rb'), '--workbook-signature', sigPath, '--out', matchPath],
+    { allowFail: true }); // exit 1 = no candidate ≥ min-score (normal)
+  match = existsSync(matchPath) ? JSON.parse(readFileSync(matchPath, 'utf8')) : {};
+  const cands = (match.candidates || []).slice(0, 3);
+  if (cands.length) {
+    line(`top candidate(s) — default is BUILD NEW; pass --reuse-dm to opt in:`);
+    cands.forEach((c) => line(`  score ${(c.score ?? 0).toFixed(2)}  ${c.dm_id}  '${c.dm_name}'`));
+  } else {
+    line('no existing DM covers this module — building new');
+  }
+  if (opt['reuse-dm']) {
+    reuseDmId = typeof opt['reuse-dm'] === 'string' ? opt['reuse-dm'] : (match.recommended_dm_id || null);
+    if (!reuseDmId) die(`--reuse-dm: picker found no candidate ≥ min-score (top: ${cands[0] ? cands[0].score : 'none'}); pass an explicit --reuse-dm <dataModelId> or drop the flag to build new`, 1);
+    line(`REUSING data model ${reuseDmId} (Phase 3 skipped). Inherited columns/metrics/RLS come with it.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DECISIONS CHECKPOINT — genuine human questions ONLY (mechanical POST / remap
+// / layout / parity are never asked about).
+// ---------------------------------------------------------------------------
+const questions = [];
+for (const w of convWarnings) {
+  questions.push({
+    id: 'expression_flagged', severity: 'review', detail: w,
+    options: ['proceed (construct flagged, placeholder/warning kept — close via gap-scout later)',
+      'abort and re-author manually'],
+    default: 'proceed (construct flagged, placeholder/warning kept — close via gap-scout later)',
+  });
+}
+if (securityDetected.length) {
+  questions.push({
+    id: 'security_detected', severity: 'required',
+    detail: `${securityDetected.length} Cognos security filter(s) detected. They are NOT auto-ported — after the model posts, run scripts/apply_sigma_rls.py --from-security ${securityPath} --dm-id <id> (see SKILL.md "Security"). Skipping leaves ALL rows visible to everyone.`,
+    options: ['proceed (port security via apply_sigma_rls.py after the post)',
+      'abort until security is designed'],
+    default: 'proceed (port security via apply_sigma_rls.py after the post)',
+  });
+}
+let answers = null;
+if (opt.answers) { try { answers = JSON.parse(opt.answers); } catch { die('--answers is not valid JSON'); } }
+if (questions.length && !opt.yes && !answers) {
+  console.log('\n==================== OPEN QUESTIONS ====================');
+  console.log(JSON.stringify({
+    status: 'decisions_needed',
+    module: dmSpec.name || basename(modulePath),
+    phases_completed: ['1 Convert', '2 DM-reuse scan'],
+    note: 'Deterministic mechanical steps (POST, remap, layout, parity) are NOT asked about. ' +
+      "Re-run with --yes to accept all defaults, or --answers '{\"<id>\":\"<choice>\"}' to override.",
+    open_questions: questions,
+  }, null, 2));
+  console.log('========================================================');
+  console.log(`\n${questions.length} decision(s) need a human. No Sigma objects were created.`);
+  process.exit(10);
+}
+if (questions.length) {
+  line(`decisions auto-resolved (${opt.yes ? '--yes: defaults' : '--answers supplied'}):`);
+  for (const q of questions) {
+    const chosen = (answers && answers[q.id]) || q.default;
+    line(`  - ${q.id}: ${chosen}`);
+    if (String(chosen).startsWith('abort')) {
+      console.log(`   '${q.id}' answered abort — stopping before any Sigma object is created.`);
+      process.exit(10);
+    }
+  }
+} else line('no open questions — running straight through');
+
+if (opt['dry-run']) {
+  hdr(3, 'Build data model');
+  line(`DRY RUN: DM spec → ${dmPath} (no POST)`);
+  hdr(4, 'Convert report');
+  const rconv = spawnSync('node', ['--import', 'tsx/esm', join(CONV, 'cli.ts'), reportPath, '--dm', 'DRY-RUN'],
+    { encoding: 'utf8', cwd: CONV, maxBuffer: 64 * 1024 * 1024 });
+  if (rconv.status !== 0) die(`report converter failed:\n${rconv.stderr}`);
+  writeFileSync(join(WORK, 'wb.json'), rconv.stdout);
+  line(`DRY RUN: workbook spec → ${join(WORK, 'wb.json')} (placeholder DM id, no remap/POST)`);
+  console.log('\n================ RESULT (dry run) ================');
+  console.log(`specs       : ${WORK}`);
+  console.log('==================================================');
+  process.exit(0);
+}
+
+sigmaLogin();
+const state = { workdir: WORK, moduleFile: modulePath, reportFile: reportPath,
+  securityRules: securityDetected.length || 0 };
+
+// ---------------------------------------------------------------------------
+// Phase 3 — POST the data model + readback (HARD GATE: error-typed columns).
+// ---------------------------------------------------------------------------
+hdr(3, 'Build data model');
+const dmMapPath = join(WORK, 'dm-map.json');
+let dmId;
+if (reuseDmId) {
+  dmId = reuseDmId;
+  state.reusedDm = true;
+  line(`reusing data model ${dmId} — no POST (remap matches the report to ITS elements by name)`);
+} else {
+  run('node', [join(HERE, 'post-and-readback.mjs'), '--type', 'datamodel', '--spec', dmPath,
+    '--folder', opt.folder, '--name', dmName, '--out', dmMapPath]);
+  dmId = JSON.parse(readFileSync(dmMapPath, 'utf8')).dataModelId;
+}
+state.dataModelId = dmId;
+line(`dataModelId = ${dmId}`);
+writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+// ---------------------------------------------------------------------------
+// Phase 4 — Convert the report → workbook spec, remap to the real DM ids.
+// ---------------------------------------------------------------------------
+hdr(4, 'Convert report + remap');
+const rconv = spawnSync('node', ['--import', 'tsx/esm', join(CONV, 'cli.ts'), reportPath, '--dm', dmId],
+  { encoding: 'utf8', cwd: CONV, maxBuffer: 64 * 1024 * 1024 });
+if (rconv.status !== 0) die(`report converter failed:\n${rconv.stderr}`);
+const wbSpec = JSON.parse(rconv.stdout);
+const rWarnings = rconv.stderr.split('\n').filter((l) => l.trim().startsWith('!')).map((l) => l.replace(/^\s*!\s*/, ''));
+const rStats = (rconv.stderr.match(/stats: (\{.*\})/) || [])[1];
+const wbPath = join(WORK, 'wb.json');
+writeFileSync(wbPath, JSON.stringify(wbSpec, null, 2));
+line(`report → workbook spec (${rStats || 'no stats'}); ${rWarnings.length} warning(s)`);
+rWarnings.forEach((w) => line(`  ! ${w}`));
+const wbRemapped = join(WORK, 'wb.remapped.json');
+run('node', [join(HERE, 'remap-wb-to-dm-ids.mjs'), '--wb', wbPath, '--dm-id', dmId, '--out', wbRemapped]);
+
+// ---------------------------------------------------------------------------
+// Phase 5 — POST the workbook + readback (HARD GATE: error-typed columns).
+// ---------------------------------------------------------------------------
+hdr(5, 'Build workbook');
+const wbName = namePrefix ? `${namePrefix} ${wbSpec.name || 'Cognos report'}` : (wbSpec.name || `Cognos report ${slug}`);
+const wbMapPath = join(WORK, 'wb-map.json');
+run('node', [join(HERE, 'post-and-readback.mjs'), '--type', 'workbook', '--spec', wbRemapped,
+  '--folder', opt.folder, '--name', wbName, '--out', wbMapPath]);
+const wbMap = JSON.parse(readFileSync(wbMapPath, 'utf8'));
+state.workbookId = wbMap.workbookId;
+state.wbElements = wbMap.elements || [];
+line(`workbookId = ${state.workbookId} (${state.wbElements.length} element(s), 0 error columns)`);
+writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+// ---------------------------------------------------------------------------
+// Phase 6 — Layout (HARD GATE: apply-layout verifies the grid survives readback;
+// per SKILL.md layout cleanliness is part of parity).
+// ---------------------------------------------------------------------------
+hdr(6, 'Layout');
+run('node', [join(HERE, 'apply-layout.mjs'), '--workbook', state.workbookId]);
+
+// ---------------------------------------------------------------------------
+// Phase 7 — Parity.
+// ---------------------------------------------------------------------------
+state.expectedPath = opt.expected ? resolve(opt.expected) : null;
+writeFileSync(statePath, JSON.stringify(state, null, 2));
+await runParity(state);

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -23,6 +23,56 @@ that mirrors the Tableau dashboard layout as closely as possible.
 
 ---
 
+## One command (orchestrated path)
+
+```bash
+eval "$(scripts/get-token.sh)"
+# PASS 1 — discover → gap gate → DM-reuse scan → DM → workbook → layout → parity plan
+ruby scripts/migrate-tableau.rb \
+  --workbook "<name>" --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID> \
+  [--db CSA --schema TJ] [--name '<prefix>'] [--row-scale 1.5] \
+  [--reuse-dm [ID]] [--force] [--yes]
+# … run the printed mcp-v2 queries → <workdir>/parity-actuals.json …
+# PASS 2 — finalize: phase6 verify + cleanup-orphans + census-aware hard gate
+ruby scripts/migrate-tableau.rb --workbook "<name>" \
+  --finalize --actuals <workdir>/parity-actuals.json [--allow-missing-tiles N]
+```
+
+Chains the scripted spine (discover → scan-workbook-gaps → discover-columns →
+find-or-pick-dm → DM build/validate/post → build-charts-from-signals → workbook
+post-and-readback → build-dashboard-layout + put-layout → phase6-parity →
+cleanup-orphan-workbooks + assert-phase6-ran) and STOPS with exact instructions
+wherever agent judgment is genuinely required. Exit codes: `10` = OPEN QUESTIONS
+(re-run with `--yes`/`--answers`), `11` = ❌-unhandled gap-scan features (close via
+gap-scout or `--force`), `12` = pass 1 done, parity PENDING (collect mcp-v2 actuals,
+then `--finalize`), `4` = DM posted but the workbook layer needs the agent path,
+`3` = a gate failed, `0` = ALL gates green (only reachable via `--finalize`).
+DM-reuse defaults to BUILD NEW — candidates are printed; `--reuse-dm` opts in.
+
+**Still manual by design (the orchestrator stops and tells you):**
+- **Parity actuals** — Sigma has no synchronous chart-data REST endpoint; the
+  per-chart values come from `mcp__sigma-mcp-v2__query` calls the agent runs
+  between pass 1 and `--finalize`.
+- **Empty-view-CSV recovery** — a view that exports an empty CSV produces no
+  chart; surfaced at the OPEN-QUESTIONS checkpoint AND by the tile census at
+  `--finalize` (exit 7 → rebuild the chart manually or explain with
+  `--allow-missing-tiles`, naming the zones in your report).
+- **Master-level calc overrides** — when the workbook layer exits 4 naming a
+  field like `master/ship speed category`, translate the Tableau calc (see
+  `calc-fields.json`) and re-run the same command with
+  `--master-col 'Name=<Sigma formula>'`.
+- **Shared relative-date filters** — a dashboard-wide filter like
+  `'Order Date ' = this year` only surfaces as a uniform parity DIVERGE (every
+  Sigma value too big). Fix: expose the date key on the DM if the converter
+  consumed it, add a master boolean (e.g. `[Order Year] = Year(Today())`) plus a
+  master `filters: [{id, columnId, kind: list, mode: include, values: [true]}]`
+  entry — it propagates to every chart sourcing the master — then re-query and
+  re-`--finalize`. (Validated live on Orders Conversion Test, 2026-06-10.)
+- **❌-unhandled gap features** — gap-scout subagent or `--force` (degraded).
+- **DM-reuse shape preflight** — when `--reuse-dm` hits a differently-shaped DM
+  the workbook gate exits 4; run Phase 1.5b (`inspect-dm-shape.rb`) and the
+  agent path against the reused DM.
+
 ## Scripts
 
 The conversion is driven by `scripts/*.rb`. Each script encapsulates one mechanical
@@ -31,6 +81,7 @@ which calc translation, which layout) — not orchestration.
 
 | Script | Purpose |
 |---|---|
+| `scripts/migrate-tableau.rb` | **The one command** — chains the whole scripted spine (gap gate → DM-reuse scan → DM → workbook → layout → two-pass parity → cleanup + census gate) and stops with exact instructions where agent judgment is required. See "One command" above. |
 | `scripts/setup.rb` | One-time Sigma credential setup |
 | `scripts/get-token.sh` | Exchange `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` for `SIGMA_API_TOKEN` (~1h TTL) |
 | `scripts/setup-tableau.rb` | One-time Tableau PAT setup (only needed for PAT mode — see `refs/tableau-rest.md`) |

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -33,15 +33,32 @@
 #     Tableau->Sigma translator) and the workbook via the skill's own
 #     build-charts-from-signals.rb + build-workbook-spec.rb.
 #
-# Usage:
+# Usage (PASS 1 — discover → gates → DM → workbook → layout → parity plan):
 #   ruby scripts/migrate-tableau.rb \
 #     --workbook "<name>" | --workbook-id <luid> \
 #     --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID> \
 #     [--db CSA --schema TJ] [--specs <path/to/specs.rb>] \
+#     [--name '<prefix for DM/workbook names>'] [--row-scale 1.5] \
+#     [--force]               # proceed past ❌-unhandled gap-scan features
+#     [--reuse-dm [ID]]       # opt IN to DM reuse (default: build new; bare
+#                             # flag = use find-or-pick-dm's recommendation)
+#     [--skip-reuse-scan]     # don't scan existing DMs at all
 #     [--out DIR] [--answers '<json>'] [--yes]
 #
-# Exit codes: 0 = done (PARITY pass); 10 = decisions needed (OPEN QUESTIONS
-# printed, NO Sigma objects created); 3 = parity/guard fail; other = error.
+# Phase 6 parity is TWO-PASS (Sigma has no synchronous chart-data REST endpoint;
+# actuals come from mcp-v2 queries). Pass 1 ends by emitting the per-chart MCP
+# query list + exit 12. Collect the actuals, then resume (PASS 2 — finalize +
+# cleanup-orphans + the census-aware assert-phase6-ran hard gate):
+#   ruby scripts/migrate-tableau.rb --workbook "<name>" [--out DIR] \
+#     --finalize --actuals <WORKDIR>/parity-actuals.json \
+#     [--allow-missing-tiles N]   # explain legitimately unbuildable zones
+#
+# Exit codes: 0 = done (ALL gates green — only possible via --finalize);
+# 10 = decisions needed (OPEN QUESTIONS printed, NO Sigma objects created);
+# 11 = gap scan found ❌-unhandled features (re-run with --force to accept);
+# 12 = pass 1 complete, parity PENDING (run the printed MCP queries, then
+#      re-run with --finalize --actuals);
+# 3 = parity/guard fail; 4 = workbook layer needs the agent path; other = error.
 require 'json'
 require 'csv'
 require 'yaml'
@@ -66,10 +83,25 @@ OptionParser.new do |o|
   o.on('--out DIR')          { |v| opts[:out]     = File.expand_path(v) }
   o.on('--answers JSON')     { |v| opts[:answers] = v }
   o.on('--yes')              {     opts[:yes]     = true }
+  o.on('--name PREFIX')      { |v| opts[:name]    = v }
+  o.on('--force')            {     opts[:force]   = true }
+  o.on('--reuse-dm [ID]')    { |v| opts[:reuse_dm] = v || :recommended }
+  o.on('--skip-reuse-scan')  {     opts[:skip_reuse] = true }
+  o.on('--row-scale F', Float) { |v| opts[:row_scale] = v }
+  o.on('--master-col PAIR', "'Name=<Sigma formula>' — extra master column (repeatable). The resume path " \
+                            'for the exit-4 handoff when a chart dim is a master-level calc the mechanical ' \
+                            'map cannot derive (e.g. a binned/categorized dimension).') do |v|
+    nm, fx = v.split('=', 2)
+    abort "--master-col expects 'Name=<Sigma formula>', got #{v.inspect}" if nm.to_s.empty? || fx.to_s.empty?
+    (opts[:master_cols] ||= []) << [nm, fx]
+  end
+  o.on('--finalize')         {     opts[:finalize] = true }
+  o.on('--actuals PATH')     { |v| opts[:actuals] = File.expand_path(v) }
+  o.on('--allow-missing-tiles N', Integer) { |v| opts[:allow_missing_tiles] = v }
 end.parse!
 
 abort 'missing --workbook or --workbook-id' unless opts[:wb_name] || opts[:wb_id]
-abort 'missing --connection' unless opts[:conn]
+abort 'missing --connection' unless opts[:conn] || opts[:finalize]
 
 slug = (opts[:wb_name] || opts[:wb_id]).gsub(/[^A-Za-z0-9_-]/, '-').squeeze('-')
 WORK = opts[:out] || File.expand_path("~/tableau-migration/#{slug}")
@@ -134,6 +166,71 @@ def cull_failed_fields(*logs)
 end
 
 def yp(s) YAML.safe_load(s, permitted_classes: [Date, Time]) rescue {} end
+
+# ---------------------------------------------------------------------------
+# PASS 2 (--finalize) — phase6 finalize + cleanup-orphans + the census-aware
+# assert-phase6-ran hard gate. Resumes from <WORK>/migrate-state.json; phases
+# 1–5 are NOT re-run. Exit 0 here is the ONLY green exit of the orchestrator.
+# ---------------------------------------------------------------------------
+if opts[:finalize]
+  abort '--actuals required with --finalize (the parity-actuals.json you built from the MCP queries)' unless opts[:actuals]
+  state_path = File.join(WORK, 'migrate-state.json')
+  abort "FATAL: no #{state_path} — run pass 1 first (same --workbook/--out)" unless File.exist?(state_path)
+  state = JSON.parse(File.read(state_path))
+  wb_id = state['workbook_id'] or abort 'FATAL: state has no workbook_id (pass 1 never completed Phase 4)'
+
+  hdr(6, 'Parity (pass 2 — finalize)')
+  p6 = ['ruby', File.join(HERE, 'phase6-parity.rb'), '--tableau', WORK,
+        '--finalize', '--actuals', opts[:actuals]]
+  p6 += ['--extract-mode', '--extract-tol', '0.30'] if state['extract_mode']
+  _, p6st = sigma_run!(p6, allow_fail: true)
+  line "phase6-parity finalize: #{p6st.success? ? 'PASS' : "FAIL (exit #{p6st.exitstatus})"}"
+
+  # Cleanup: delete orphan workbooks from spec-iteration retries (keep the live one).
+  _, clst = sigma_run!(['ruby', File.join(HERE, 'cleanup-orphan-workbooks.rb'),
+                        '--workdir', WORK, '--keep', wb_id], allow_fail: true)
+  line 'WARN: orphan cleanup reported failures — assert-phase6-ran will gate on it' unless clst.success?
+
+  # The census-aware hard gate. NEVER bypassed — this command fails when it fails.
+  gate = ['ruby', File.join(HERE, 'assert-phase6-ran.rb'), '--tableau', WORK, '--workbook-id', wb_id]
+  gate += ['--allow-extract'] if state['extract_mode']
+  gate += ['--allow-missing-tiles', opts[:allow_missing_tiles].to_s] if opts[:allow_missing_tiles]
+  _, gst = sigma_run!(gate, allow_fail: true)
+
+  if gst.exitstatus == 7
+    census = (JSON.parse(File.read(File.join(WORK, 'parity-final.json')))['tile_census'] rescue {}) || {}
+    unmatched = census['unmatched_zone_names'] || []
+    puts
+    puts '==================== CENSUS STOP (agent action required) ===================='
+    puts "The Tableau dashboard has #{census['zones_total']} chart zone(s) but only"
+    puts "#{census['charts_built']} made it into the parity plan. Unmatched zone(s):"
+    unmatched.each { |z| puts "  - #{z}" }
+    puts ''
+    puts 'This usually means the Tableau view CSV came back EMPTY (filtered viz /'
+    puts 'export quirk) so the chart was silently dropped, or a chart was renamed.'
+    puts 'Handle each zone, then re-run this exact --finalize command:'
+    puts "  1. Re-export the view CSV (scripts/fetch-view-data.rb / MCP get-view-data"
+    puts '     with filters relaxed) into the workdir and rebuild the missing chart'
+    puts "     against DM #{state['data_model_id']} / workbook #{wb_id} (see SKILL.md),"
+    puts '     then re-run phase6-parity pass 1 + the MCP queries + --finalize; OR'
+    puts "  2. If it was a RENAME, re-run pass 1 with --rename plumbed via phase6-parity; OR"
+    puts "  3. If the zone is legitimately unbuildable, re-run --finalize with"
+    puts "     --allow-missing-tiles #{unmatched.size} and NAME the zone(s) in your report."
+    puts '============================================================================='
+  end
+
+  all_green = p6st.success? && clst.success? && gst.success?
+  pf = (JSON.parse(File.read(File.join(WORK, 'parity-final.json'))) rescue {})
+  puts
+  puts '================ RESULT ================'
+  puts "dataModelId : #{state['data_model_id']}"
+  puts "workbookId  : #{wb_id}"
+  puts "PARITY      : #{pf['status'] || '?'} (#{pf['charts_pass']}/#{pf['charts_total']} charts#{state['extract_mode'] ? ', extract-mode' : ''})"
+  puts "GATES       : phase6=#{p6st.success? ? 'PASS' : 'FAIL'} cleanup=#{clst.success? ? 'PASS' : 'FAIL'} assert-phase6-ran=#{gst.success? ? 'PASS' : "FAIL(#{gst.exitstatus})"}"
+  puts "STATUS      : #{all_green ? 'GREEN' : 'NOT GREEN'}"
+  puts '======================================='
+  exit(all_green ? 0 : 3)
+end
 
 # ---------------------------------------------------------------------------
 # Phase 1 — Discover (Tableau side). Chains tableau-discover + parse-twb-layout
@@ -203,15 +300,47 @@ if wb_luid && have_twb
 end
 
 gaps = []
+gap_report_md = nil
 if have_twb
   run!(['ruby', File.join(HERE, 'scan-workbook-gaps.rb'), twb], allow_fail: true)
   gj = Dir[File.join(WORK, '*gaps*report*.json')].first || Dir[File.join(WORK, '*gaps*.json')].first
   if gj && File.exist?(gj)
+    gap_report_md = gj.sub(/\.json$/, '.md')
     gaps = (JSON.parse(File.read(gj))['detected_features'] || []) rescue []
     bys = gaps.group_by { |g| g['status'] }.transform_values(&:size)
     line "gap scan: #{bys.map { |k, v| "#{v} #{k}" }.join(', ')}"
   end
 end
+
+# GAP-SCAN HARD GATE: ❌-unhandled features mean part of the workbook cannot be
+# migrated by this skill yet. Abort WITH the report unless the human accepts the
+# degradation explicitly via --force. (auto/hint/manual statuses flow into the
+# decisions checkpoint below instead.)
+unhandled_gaps = gaps.select { |g| g['status'].to_s == 'unhandled' }
+if unhandled_gaps.any? && !opts[:force]
+  puts
+  puts '==================== GAP-SCAN STOP ===================='
+  puts "#{unhandled_gaps.size} ❌-unhandled feature(s) detected — these do NOT migrate:"
+  unhandled_gaps.each { |g| puts "  - #{g['name']} (×#{g['count']}): #{g['blurb']}" }
+  puts ''
+  puts "Full report: #{gap_report_md || '(see workdir *gaps-report.md)'}"
+  puts 'Options: close the gap via the gap-scout subagent (scripts/gap-scout.md),'
+  puts 'restructure the workbook in Tableau, or re-run with --force to accept the'
+  puts 'degradation (the features above will be missing from the Sigma workbook).'
+  puts '======================================================='
+  puts 'No Sigma objects were created.'
+  exit 11
+elsif unhandled_gaps.any?
+  line "--force: proceeding past #{unhandled_gaps.size} ❌-unhandled feature(s) — they will NOT migrate"
+end
+
+# EMPTY-VIEW-CSV preflight (honesty stop): a view whose CSV exported 0 data rows
+# produces NO chart — the tile silently drops and the census gate stops the
+# --finalize pass. Surface it NOW as a decision instead of a surprise later.
+empty_csvs = Dir[File.join(WORK, 'views', '*.csv')].select do |c|
+  (File.readlines(c).reject { |l| l.strip.empty? }.size rescue 0) <= 1
+end.map { |c| File.basename(c, '.csv') }
+line "WARN: #{empty_csvs.size} view CSV(s) came back EMPTY: #{empty_csvs.join(', ')}" if empty_csvs.any?
 
 # ---------------------------------------------------------------------------
 # Spec generation. The DEFAULT path is MECHANICAL (no agent hand-authoring):
@@ -414,6 +543,22 @@ chart_zones.each do |z|
   end
 end
 
+# (e2) empty view CSVs — the chart for that view CANNOT be built mechanically
+#      (no headers/rows to derive columns from). Genuine human decision: recover
+#      the data or accept a missing tile (which the census gate will then stop on).
+empty_csvs.each do |v|
+  questions << {
+    'id' => 'empty_view_csv', 'severity' => 'review', 'viz' => v,
+    'detail' => "View '#{v}' exported an EMPTY CSV — its chart cannot be built mechanically and " \
+                'the tile census will stop the --finalize gate. Recover the CSV (re-export with ' \
+                'filters relaxed / MCP get-view-data) before re-running, or proceed and rebuild ' \
+                'the chart manually against the posted DM, then explain via --allow-missing-tiles.',
+    'options' => ['proceed (tile missing; rebuild manually + --allow-missing-tiles at --finalize)',
+                  'abort and recover the view CSV first'],
+    'default' => 'proceed (tile missing; rebuild manually + --allow-missing-tiles at --finalize)'
+  }
+end
+
 # (f) missing folder (DM + workbook land in My Documents).
 unless opts[:folder]
   questions << { 'id' => 'folder', 'severity' => 'required',
@@ -460,7 +605,57 @@ else
   line 'no open questions — running straight through'
 end
 
-
+# ---------------------------------------------------------------------------
+# Phase 1.6 — DM-reuse scan (find-or-pick-dm). Default = BUILD NEW; candidates
+# are printed so a human can opt in with --reuse-dm. Non-destructive.
+# ---------------------------------------------------------------------------
+hdr('1.6', 'DM-reuse scan')
+reuse_dm_id = nil
+dm_match = {}
+src_model = mechanical ? conv['model'] : (have_specs ? Specs.dm_spec : nil)
+if opts[:skip_reuse]
+  line 'skipped (--skip-reuse-scan)'
+elsif src_model.nil?
+  line 'no spec source to derive a signature from — building new'
+else
+  sig_els = (src_model['pages'] || []).flat_map { |p| p['elements'] || [] }
+  sig_tables = sig_els.map do |e|
+    s = e['source'] || {}
+    next 'CUSTOM_SQL' if s['kind'] == 'sql'
+    pth = s['path']
+    pth.is_a?(Array) ? pth.join('.').upcase : nil
+  end.compact.uniq
+  sig_cols = sig_els.flat_map { |e| (e['columns'] || []).map { |c| c['name'] } }.compact.uniq
+  sig_meas = sig_els.flat_map do |e|
+    (e['metrics'] || []).map { |m| { 'col' => m['name'], 'derivation' => m['aggregation'] || m['derivation'] } }
+  end
+  sig_path = File.join(WORK, 'workbook-signature.json')
+  File.write(sig_path, JSON.pretty_generate(
+    'tableau_workbook' => wb_name, 'warehouse_tables' => sig_tables,
+    'referenced_columns' => sig_cols, 'measures' => sig_meas))
+  match_path = File.join(WORK, 'dm-match.json')
+  sigma_run!(['ruby', File.join(HERE, 'find-or-pick-dm.rb'),
+              '--workbook-signature', sig_path, '--out', match_path],
+             allow_fail: true) # exit 1 = no candidate ≥ min-score (normal: build new)
+  dm_match = (JSON.parse(File.read(match_path)) rescue {})
+  cands = (dm_match['candidates'] || []).first(3)
+  if cands.any?
+    line 'top candidate(s) — default is BUILD NEW; pass --reuse-dm to opt in:'
+    cands.each { |c| line "  score #{format('%.2f', c['score'] || 0)}  #{c['dm_id']}  '#{c['dm_name']}'" }
+  else
+    line 'no existing DM covers this workbook — building new'
+  end
+end
+if opts[:reuse_dm]
+  reuse_dm_id = opts[:reuse_dm] == :recommended ? dm_match['recommended_dm_id'] : opts[:reuse_dm]
+  abort 'FATAL: --reuse-dm: the picker found no candidate ≥ min-score; pass an explicit ' \
+        '--reuse-dm <dataModelId> or drop the flag to build new' unless reuse_dm_id
+  line "REUSING data model #{reuse_dm_id} — Phase 3 build+POST will be skipped."
+  line "  #{dm_match['warning']}" if dm_match['warning']
+  line '  NOTE: master-column formulas are derived against the reused DM\'s readback labels;'
+  line '  if its shape differs (separate dim elements), the workbook gate will stop with the'
+  line '  agent-path handoff (exit 4) — run SKILL.md Phase 1.5b (inspect-dm-shape.rb) then.'
+end
 
 # ---------------------------------------------------------------------------
 # Phase 2 — Discover warehouse column names (per table) for the DM build.
@@ -504,13 +699,43 @@ end
 # ---------------------------------------------------------------------------
 hdr(3, 'Build data model')
 dm_spec_path = File.join(WORK, 'dm-spec.json')
-if mechanical
+dm_ids_path = File.join(WORK, 'dm-ids.json')
+if reuse_dm_id
+  # REUSE: no build, no POST. Read the existing DM back into the same id-map
+  # shape post-and-readback.rb emits (incl. per-element columnLabels — Phase 4's
+  # master derivation resolves against them).
+  $LOAD_PATH.unshift File.expand_path('lib', HERE)
+  require 'sigma_rest'
+  dm_spec_rb = Sigma.request(:get, "/v2/dataModels/#{reuse_dm_id}/spec")
+  abort "FATAL: could not read back reused DM #{reuse_dm_id} spec" unless dm_spec_rb.is_a?(Hash) && dm_spec_rb['pages']
+  cols_rb = (Sigma.request(:get, "/v2/dataModels/#{reuse_dm_id}/columns") rescue { 'entries' => [] })
+  labels_by_el = Hash.new { |h, k| h[k] = [] }
+  (cols_rb['entries'] || []).each { |c| labels_by_el[c['elementId']] << c['label'] if c['elementId'] && c['label'] }
+  dm_ids = {
+    'dataModelId' => reuse_dm_id,
+    'pages' => (dm_spec_rb['pages'] || []).map do |p|
+      { 'id' => p['id'], 'name' => p['name'],
+        'elements' => (p['elements'] || []).map do |e|
+          el = { 'id' => e['id'], 'kind' => e['kind'], 'name' => e['name'] }
+          el['columnLabels'] = labels_by_el[e['id']] if labels_by_el.key?(e['id'])
+          el
+        end }
+    end
+  }
+  File.write(dm_ids_path, JSON.pretty_generate(dm_ids))
+  dm_id = reuse_dm_id
+  dm_els = dm_ids['pages'].flat_map { |p| p['elements'] }
+  fact = dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
+  fact_eid = fact['id']
+  line "REUSED dataModelId = #{dm_id}  (fact element '#{fact['name']}' = #{fact_eid}, name-heuristic pick)"
+elsif mechanical
   # The converter output IS the DM spec (schemaVersion:1 already set). Apply the
   # mechanical fixup (resolve raw-table-name prefixes + GUID sibling refs the
   # converter left unresolved) then stamp the human-supplied folderId. No agent
   # authoring.
   dm = conv['model'] # already fixed up in Phase 1 (prefixes/GUIDs resolved, bad calcs dropped)
   dm['name'] = wb_name if dm['name'].to_s.empty?
+  dm['name'] = "#{opts[:name]} #{dm['name']}" if opts[:name]
   # Phantom-column filter (needs Phase 2's live warehouse columns): Tableau
   # virtual-connection datasources flatten dim columns into the fact and emit
   # base-column refs that don't exist in the real table. Drop them so the POST
@@ -528,41 +753,44 @@ if mechanical
   end
 else
   dm = Specs.dm_spec
+  dm['name'] = "#{opts[:name]} #{dm['name'] || wb_name}".strip if opts[:name]
 end
-dm['folderId'] = opts[:folder] if opts[:folder]
-File.write(dm_spec_path, JSON.pretty_generate(dm))
-# In mechanical mode validate-spec.rb is advisory only: it flags cross-element
-# sibling refs that Sigma actually resolves via relationships (documented
-# false-negative class — see project CLAUDE.md). The authoritative gate is the
-# live POST + readback column-type guard below (post-and-readback exits 2 on any
-# error-typed column). For hand-authored Specs, keep validation hard.
-_, dvst = run!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'datamodel', dm_spec_path],
-               allow_fail: mechanical)
-line 'DM validate-spec flagged issues (advisory in mechanical mode — live POST is the gate)' if mechanical && !dvst.success?
-dm_ids_path = File.join(WORK, 'dm-ids.json')
-sigma_run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
-            '--spec', dm_spec_path, '--out', dm_ids_path, '--workdir', WORK])
-dm_ids = JSON.parse(File.read(dm_ids_path))
-dm_id = dm_ids['dataModelId']
-dm_els = dm_ids['pages'].flat_map { |p| p['elements'] }
-if mechanical
-  # The master must source the SAME chart-ready element pick_fact chose (the
-  # derived "<Fact> View" when present). Match it into the readback by name.
-  cf = MechanicalSpecs.pick_fact(conv['model'])
-  cf_name = cf && (cf['name'] || MechanicalSpecs.elem_name(cf))
-  fact = dm_els.find { |e| e['name'] == cf_name } ||
-         dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
-else
-  fact = dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
+unless reuse_dm_id
+  dm['folderId'] = opts[:folder] if opts[:folder]
+  File.write(dm_spec_path, JSON.pretty_generate(dm))
+  # In mechanical mode validate-spec.rb is advisory only: it flags cross-element
+  # sibling refs that Sigma actually resolves via relationships (documented
+  # false-negative class — see project CLAUDE.md). The authoritative gate is the
+  # live POST + readback column-type guard below (post-and-readback exits 2 on any
+  # error-typed column). For hand-authored Specs, keep validation hard.
+  _, dvst = run!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'datamodel', dm_spec_path],
+                 allow_fail: mechanical)
+  line 'DM validate-spec flagged issues (advisory in mechanical mode — live POST is the gate)' if mechanical && !dvst.success?
+  sigma_run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
+              '--spec', dm_spec_path, '--out', dm_ids_path, '--workdir', WORK])
+  dm_ids = JSON.parse(File.read(dm_ids_path))
+  dm_id = dm_ids['dataModelId']
+  dm_els = dm_ids['pages'].flat_map { |p| p['elements'] }
+  if mechanical
+    # The master must source the SAME chart-ready element pick_fact chose (the
+    # derived "<Fact> View" when present). Match it into the readback by name.
+    cf = MechanicalSpecs.pick_fact(conv['model'])
+    cf_name = cf && (cf['name'] || MechanicalSpecs.elem_name(cf))
+    fact = dm_els.find { |e| e['name'] == cf_name } ||
+           dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
+  else
+    fact = dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
+  end
+  fact_eid = fact['id']
+  line "dataModelId = #{dm_id}  (fact element '#{fact['name']}' = #{fact_eid})"
 end
-fact_eid = fact['id']
-line "dataModelId = #{dm_id}  (fact element '#{fact['name']}' = #{fact_eid})"
 
 # ---------------------------------------------------------------------------
 # Phase 4 — Build + POST the workbook.
 # ---------------------------------------------------------------------------
 hdr(4, 'Build workbook')
 wb_spec_path = File.join(WORK, 'wb-spec.json')
+display_wb_name = opts[:name] ? "#{opts[:name]} #{wb_name}" : wb_name
 layout_xml = nil
 if mechanical
   # 1) Derive the master-map DETERMINISTICALLY from the converter fact element,
@@ -577,6 +805,14 @@ if mechanical
   derived = MechanicalSpecs.derive_master(conv_fact, fact['name'], conv_base, real_labels)
   master_columns = derived['master_columns']
   mmap = derived['mmap']
+  # Human-supplied master-calc overrides (--master-col): appended verbatim so a
+  # chart ref like [master/Ship Speed Category] resolves on the next run.
+  (opts[:master_cols] || []).each do |(nm, fx)|
+    id = "m-#{nm.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/^-|-$/, '')}"
+    master_columns.reject! { |c| c['name'].casecmp?(nm) }
+    master_columns << { 'id' => id, 'name' => nm, 'formula' => fx }
+    line "master-col override: '#{nm}' = #{fx[0, 80]}"
+  end
   mmap_path = File.join(WORK, 'master-map.json')
   File.write(mmap_path, JSON.pretty_generate(mmap))
   line "master-map: #{master_columns.size} master column(s) (fact element '#{fact['name']}', #{real_labels ? real_labels.size : 0} readback labels)"
@@ -600,11 +836,12 @@ if mechanical
 
   # 3) Assemble the workbook spec (page-data master + dashboard page).
   spec = MechanicalSpecs.build_wb_spec(
-    name: wb_name, dm_id: dm_id, fact_eid: fact_eid,
+    name: display_wb_name, dm_id: dm_id, fact_eid: fact_eid,
     master_columns: master_columns, chart_elements: chart_elements,
     folder_id: opts[:folder])
 else
   spec = Specs.wb_spec(dm_id, fact_eid)
+  spec['name'] = display_wb_name if opts[:name]
   spec['folderId'] = opts[:folder] if opts[:folder]
   layout_xml = (Specs.respond_to?(:layout_xml) ? Specs.layout_xml : nil)
 end
@@ -636,9 +873,14 @@ rescue WorkbookBuildError => e
   puts
   puts "── Mechanical path: data model built OK (dataModelId=#{dm_id}). The WORKBOOK " \
        "layer hit #{n} field(s) the mechanical path can't translate (#{names}). " \
-       "Falling back to the agent path: rebuild the workbook via the skill's " \
-       "agent-authored flow (see SKILL.md) against this DM. The data model is " \
-       "posted and ready to attach."
+       'Two ways forward:'
+  puts "   1. If the field is a MASTER-LEVEL CALC (a binned/categorized dim like 'Ship"
+  puts "      Speed Category'), translate its Tableau formula (see calc-fields.json) to"
+  puts '      a Sigma formula over master columns and re-run this exact command with:'
+  puts "        --master-col '<Name>=<Sigma formula>'   (repeatable)"
+  puts '   2. Otherwise fall back to the agent path: rebuild the workbook via the'
+  puts "      skill's agent-authored flow (see SKILL.md) against this DM."
+  puts '   The data model is posted and ready to attach either way.'
   exit 4
 end
 wb_ids = JSON.parse(File.read(wb_ids_path))
@@ -656,7 +898,8 @@ if layout_xml
   line 'layout from spec generator'
 elsif File.exist?(layout_json)
   _, lst = run!(['ruby', File.join(HERE, 'build-dashboard-layout.rb'),
-                 '--layout', layout_json, '--wb-ids', wb_ids_path, '--out', layout_path],
+                 '--layout', layout_json, '--wb-ids', wb_ids_path, '--out', layout_path,
+                 '--row-scale', (opts[:row_scale] || 1.5).to_s],
                 allow_fail: true)
   line 'WARN: layout build failed — workbook will render in default stacked order' unless lst.success?
 else
@@ -672,18 +915,17 @@ if File.exist?(layout_path)
 end
 
 # ---------------------------------------------------------------------------
-# Phase 6 — Parity. Try the skill's phase6-parity.rb; the hard signal is the
-# post-and-readback column-type guard (already enforced above with exit 2),
-# plus a live re-check of /columns for any type=error introduced by the layout PUT.
+# Phase 6 — Parity, PASS 1 of 2. Structural hard signals first (live /columns
+# type=error re-check after the layout PUT + per-chart compile check), then
+# phase6-parity.rb pass 1 builds the parity plan and emits the per-chart MCP
+# query list. VALUE parity needs the mcp-v2 actuals — this process cannot fetch
+# them (no synchronous chart-data REST endpoint), so it stops HONESTLY at exit
+# 12 with resume instructions instead of declaring a fake PASS.
 # ---------------------------------------------------------------------------
-hdr(6, 'Parity')
+hdr(6, 'Parity (pass 1 of 2)')
 require 'sigma_rest'
-p6 = ['ruby', File.join(HERE, 'phase6-parity.rb'),
-      '--tableau', WORK, '--workbook-id', wb_id]
-p6 += ['--extract-mode', '--extract-tol', '0.30'] if has_extracts
-_, p6st = sigma_run!(p6, allow_fail: true)
 
-# Independent hard signal: no live column resolves to type "error".
+# Structural hard signal: no live column resolves to type "error".
 cols = (Sigma.request(:get, "/v2/workbooks/#{wb_id}/columns") rescue { 'entries' => [] })
 err_cols = (cols['entries'] || []).select { |c| c.dig('type', 'type') == 'error' }
 total_cols = (cols['entries'] || []).size
@@ -696,22 +938,48 @@ chart_els.each do |e|
   b = (Sigma.request(:get, "/v2/workbooks/#{wb_id}/elements/#{e['id']}/query", accept: 'text/plain') rescue '')
   bad << (e['name'] || e['id']) if b.to_s =~ /Unknown column "\[|Circular column reference/
 end
-parity_ok = err_cols.empty? && bad.empty?
-if parity_ok
-  line "PARITY: PASS — #{total_cols} workbook column(s) resolve (0 error-typed); " \
-       "#{chart_els.size} chart element(s) compile clean#{p6st.success? ? '; phase6-parity PASS' : ''}"
+structural_ok = err_cols.empty? && bad.empty?
+if structural_ok
+  line "structural: PASS — #{total_cols} workbook column(s) resolve (0 error-typed); " \
+       "#{chart_els.size} chart element(s) compile clean"
 else
-  line "PARITY: FAIL — #{err_cols.size}/#{total_cols} error-typed column(s)#{bad.any? ? ", #{bad.size} chart(s) with unresolved refs (#{bad.join(', ')})" : ''}"
+  line "structural: FAIL — #{err_cols.size}/#{total_cols} error-typed column(s)#{bad.any? ? ", #{bad.size} chart(s) with unresolved refs (#{bad.join(', ')})" : ''}"
   err_cols.first(8).each { |c| line "  [#{c['elementId']}] #{c['label']}: #{c['formula']}" }
 end
 
-# ---------------------------------------------------------------------------
-# Summary.
-# ---------------------------------------------------------------------------
+# Persist resume state for --finalize (pass 2) BEFORE stopping.
+state = { 'workbook_id' => wb_id, 'data_model_id' => dm_id,
+          'extract_mode' => !!has_extracts, 'workbook_name' => display_wb_name,
+          'reused_dm' => !!reuse_dm_id, 'pass1_at' => Time.now.utc.iso8601 }
+File.write(File.join(WORK, 'migrate-state.json'), JSON.pretty_generate(state))
+
+unless structural_ok
+  puts
+  puts '================ RESULT ================'
+  puts "dataModelId : #{dm_id}"
+  puts "workbookId  : #{wb_id}"
+  puts "PARITY      : FAIL (structural — #{err_cols.size} error column(s); fix before the value pass)"
+  puts '======================================='
+  exit 3
+end
+
+# phase6-parity PASS 1: builds parity-plan.json + prints one mcp-v2 query per chart.
+p6 = ['ruby', File.join(HERE, 'phase6-parity.rb'),
+      '--tableau', WORK, '--workbook-id', wb_id]
+p6 += ['--extract-mode', '--extract-tol', '0.30'] if has_extracts
+sigma_run!(p6)
+
 puts
-puts '================ RESULT ================'
-puts "dataModelId : #{dm_id}"
+puts '================ RESULT (pass 1 — parity PENDING) ================'
+puts "dataModelId : #{dm_id}#{reuse_dm_id ? '  (REUSED existing DM)' : ''}"
 puts "workbookId  : #{wb_id}"
-puts "PARITY      : #{parity_ok ? 'PASS' : 'FAIL'} (#{total_cols} cols resolve, #{err_cols.size} error)"
-puts '======================================='
-exit(parity_ok ? 0 : 3)
+puts "structural  : PASS (#{total_cols} cols resolve, #{chart_els.size} charts compile)"
+puts 'PARITY      : PENDING — run the mcp-v2 queries printed above, save the'
+puts "              results to #{File.join(WORK, 'parity-actuals.json')}, then:"
+finalize_cmd = "  ruby scripts/migrate-tableau.rb #{opts[:wb_id] ? "--workbook-id #{opts[:wb_id]}" : "--workbook \"#{opts[:wb_name]}\""}" \
+               "#{opts[:out] ? " --out #{WORK}" : ''} \\\n    --finalize --actuals #{File.join(WORK, 'parity-actuals.json')}"
+puts finalize_cmd
+puts '(--finalize runs phase6 finalize + orphan cleanup + the census-aware'
+puts ' assert-phase6-ran hard gate; exit 0 there is the ONLY green exit.)'
+puts '=================================================================='
+exit 12


### PR DESCRIPTION
## What

ONE-COMMAND orchestrators for both skills, following the `migrate-qlik.rb` pattern: chain the scripted spine, consume pipeline artifacts, surface genuine decision points as flags/structured stops, freshness banner BEFORE parity, and hard gates that are never bypassed (the command fails when a gate fails).

### cognos-to-sigma — new `scripts/migrate-cognos.mjs`
- module convert (`converter/cli.ts`) → **DM-reuse scan** (`cognos-dm-signature.py` + `find-or-pick-dm.rb`; candidates printed, default BUILD NEW, `--reuse-dm` opt-in) → **DM post-and-readback gate** → report convert `--dm` → `remap-wb-to-dm-ids` → **workbook post-and-readback gate** → `apply-layout` (readback-verified) → **two-pass parity**.
- Parity pass 1 auto-exports every element to CSV via the Sigma REST export API (`sigma-actuals.json`, keys `"<Element>/<Column>"=sum` / `"<Element>/rows"`), prints the `assert-parity --plan` mcp-v2 query list, exits 10; resume with `--resume --expected expected.json` → `assert-parity --check` is the only GREEN exit.
- OPEN QUESTIONS checkpoint (converter warnings + detected RLS — never silently ported/dropped), `--name` plumbed to DM + workbook, source-freshness banner before any side-by-side, `--dry-run` offline smoke.

### tableau-to-sigma — `scripts/migrate-tableau.rb` completed per the pattern
- **Gap-scan hard gate**: ❌-unhandled features abort with the report (exit 11) unless `--force`.
- **Empty-view-CSV preflight** surfaced at the checkpoint (the census stop is no longer a surprise).
- **Phase 1.6 DM-reuse**: mechanical workbook signature → `find-or-pick-dm.rb`; default BUILD NEW, `--reuse-dm` wires to the existing DM via spec/columns readback.
- `--name` prefix, `--row-scale` (default 1.5) pass-through, `--master-col 'Name=<Sigma formula>'` as the resume path for the exit-4 master-calc handoff.
- **Honest two-pass Phase 6**: pass 1 = structural gates + `phase6-parity` plan + mcp-v2 query list, exit 12 (no more structural-only "PARITY PASS"); `--finalize --actuals` = phase6 finalize + `cleanup-orphan-workbooks` + census-aware `assert-phase6-ran` (exit 7 → exact census-stop instructions; `--allow-missing-tiles N` to explain). **Exit 0 is only reachable via `--finalize` with every gate green.**
- SKILL.md "One command" sections in both skills document exit codes + the honest still-manual list.

## E2E (timed, live on tj-wells-1989 — objects KEPT as VISQA4)

**Cognos** (fixtures sample-data-module + go-sales-performance, conn cb2f5180): pass 1 **63s, 0 interventions**; resume **42s** with the one by-design input (expected.json from the Cognos source) → **PARITY GREEN 14/14**, exit 0. DM `65cbfd4a`, wb `d0324e0d`, PNG at `~/migration-visual-qa/cognos4/`.

**Tableau** (live "Orders Conversion Test", ds 2e62b914, conn bc0319f8): scripted wall-clock ≈ **6m48s across 3 pass-1 runs + 2 finalizes**; every stop fired as designed — exit 10 checkpoint (5 questions incl. the empty Monthly-Revenue-Trend CSV), exit 4 master-calc handoff (resumed with `--master-col 'Ship Speed Category=…'`), census stop + parity RED exposing the Tableau shared relative-date filter (`'Order Date ' = this year`). After the documented agent fixes (re-expose ORDER_DATE_KEY on the DM, master `In Current Year` boolean + propagating master filter, hand-rebuilt trend chart): **strict parity 5/5 + all 5 assert-phase6-ran gates green, exit 0** (`--allow-missing-tiles 1` naming the empty-CSV zone). DM `09c8be53`, wb `f7d9acba`, PNG at `~/migration-visual-qa/tableau4/`.

## What genuinely can't be scripted yet
- **Parity actuals (tableau)** — no synchronous chart-data REST endpoint; mcp-v2 queries between pass 1 and `--finalize`.
- **Expected values (cognos)** — must come from the Cognos report/source; never invented.
- **Empty-view-CSV recovery** — chart rebuild is agent judgment; census gate enforces honesty.
- **Master-level calc + shared relative-date filters** — semantic translation; orchestrator stops with exact instructions and accepts `--master-col` on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)