### PR TITLE
Container-based layouts in all migration layout builders (bead jzsf)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
@@ -1,71 +1,130 @@
 #!/usr/bin/env node
-// apply-layout.mjs — give a migrated Cognos workbook a CLEAN dashboard grid.
+// apply-layout.mjs — give a migrated Cognos workbook a CLEAN container-banded
+// dashboard grid (layout-playbook.md, verified 2026-06-10).
 //
-// Sigma auto-arrange stacks every element at the SAME height (KPIs as tall as tables,
-// charts squished) — so for any multi-element page we write an explicit 24-col layout:
-// controls in a top row, then content stacked full-width with per-kind heights. Layout
-// elementIds must match the POSTED (reassigned) ids, so this GETs the readback spec first.
+// Sigma auto-arrange stacks every element at the SAME height (KPIs as tall as
+// tables, charts squished). Flat LayoutElement lists also produce dead zones /
+// detached controls — so every multi-element page is grouped into full-width
+// BAND CONTAINERS:
+//   1. header band — dark, full-width, page/workbook title text
+//   2. control band — controls side-by-side (global filters)
+//   3. KPI band(s) — runs of kpi-charts as rows of up to 3 TALL tiles (Sigma
+//      hides the KPI title below ~5 grid rows)
+//   4. chart rows — consecutive charts paired 2-across, even heights
+//   5. tables / maps / pivots — full-width band each
+// Spec side each band needs a `kind: container` placeholder element; layout
+// side a <GridContainer> (NOT <LayoutElement type="grid">, which silently
+// drops children) whose child <LayoutElement>s use CONTAINER-RELATIVE
+// coordinates (rows restart at 1). Layout elementIds must match the POSTED
+// (reassigned) ids, so this GETs the readback spec first.
 //
 // Usage:
 //   eval "$(scripts/get-token.sh)"
 //   node scripts/apply-layout.mjs --workbook <workbookId>
 //
-// Idempotent. Run it as the last step of the build/verify phase.
+// Idempotent (band elements are re-derived each run). Run it as the last step
+// of the build/verify phase.
 import { api, parseArgs } from './lib/sigma-rest.mjs';
 
 const a = parseArgs(process.argv.slice(2));
 if (!a.workbook) { console.error('need --workbook <workbookId>'); process.exit(2); }
 
-// per-kind row-unit heights (24-col grid; rows are "auto" so spans set relative size)
-const H = (k) => k === 'control' ? 2
-  : k === 'kpi-chart' ? 6
-  : k.endsWith('-chart') ? 10
-  : (k.endsWith('-map') || k === 'pivot-table' || k === 'table') ? 12
-  : k === 'text' ? 3 : 10;
+const HEADER_STYLE = { backgroundColor: '#0F172A', borderRadius: 'round' };
+const HDR_H = 3;   // header band height (grid rows)
+const CTRL_H = 3;  // control band height
+const KPI_H = 6;   // KPI tile height — >= 5 so the title renders
+const CHART_H = 11; // paired chart row height
+// full-width per-kind heights for non-chart content
+const H = (k) => (k.endsWith('-map') || k === 'pivot-table' || k === 'table') ? 12
+  : k === 'text' ? 3 : 11;
 
-function pageLayout(page) {
-  const els = (page.elements || []).filter((e) => e.id);
-  if (els.length < 2) return null; // single element → auto-arrange is fine
+const le = (id, c0, c1, r0, r1) =>
+  `  <LayoutElement elementId="${id}" gridColumn="${c0} / ${c1}" gridRow="${r0} / ${r1}"/>`;
+const gcXml = (id, r0, r1, inner) =>
+  `<GridContainer elementId="${id}" type="grid" gridColumn="1 / 25" gridRow="${r0} / ${r1}" ` +
+  `gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">\n${inner}\n</GridContainer>`;
+
+const isChart = (k) => k.endsWith('-chart') && k !== 'kpi-chart';
+
+function pageLayout(page, fallbackTitle) {
+  // strip band elements injected by a previous run (idempotency)
+  page.elements = (page.elements || []).filter((e) =>
+    !(String(e.id || '').startsWith('band-') && (e.kind === 'container' || e.kind === 'text')));
+  const els = page.elements.filter((e) => e.id);
+  if (!els.length) return null;
+  const pfx = `band-${page.id}`;
+  const bandEls = [];   // container/header spec elements to inject
+  const bands = [];     // page-level GridContainer XML blocks
+  let row = 1;
+
+  // (1) header band
+  const title = page.name || fallbackTitle || 'Dashboard';
+  bandEls.push({ id: `${pfx}-hdr`, kind: 'container', style: { ...HEADER_STYLE } });
+  bandEls.push({ id: `${pfx}-hdrtext`, kind: 'text',
+                 body: `# <span style="color: #FFFFFF">${title}</span>` });
+  bands.push(gcXml(`${pfx}-hdr`, row, row + HDR_H, le(`${pfx}-hdrtext`, 1, 25, 1, 1 + HDR_H)));
+  row += HDR_H;
+
+  // (2) control band: up to 4 across per row, one container for all of them
   const controls = els.filter((e) => e.kind === 'control');
   const content = els.filter((e) => e.kind !== 'control');
-  const lines = [];
-  let row = 1;
-  // controls: up to 4 across the top
-  controls.forEach((c, i) => {
+  if (controls.length) {
+    const lines = [];
     const perRow = Math.min(controls.length, 4);
     const span = Math.floor(24 / perRow);
-    const col0 = 1 + (i % perRow) * span;
-    const r = row + Math.floor(i / perRow) * H('control');
-    const col1 = (i % perRow === perRow - 1) ? 25 : col0 + span;
-    lines.push(`  <LayoutElement elementId="${c.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('control')}"/>`);
-  });
-  if (controls.length) row += Math.ceil(controls.length / 4) * H('control');
-  // content: stacked full-width, per-kind heights (clean, no overlap, right proportions).
-  // Exception: RUNS of consecutive kpi-charts lay out as rows of up to 3 TALL tiles
-  // (a KPI panel) — full-width singles waste a page and Sigma hides the KPI title
-  // below ~5 grid rows, so never shrink them either.
+    controls.forEach((c, i) => {
+      const col0 = 1 + (i % perRow) * span;
+      const col1 = (i % perRow === perRow - 1) ? 25 : col0 + span;
+      const r = 1 + Math.floor(i / perRow) * CTRL_H;
+      lines.push(le(c.id, col0, col1, r, r + CTRL_H));
+    });
+    const h = Math.ceil(controls.length / perRow) * CTRL_H;
+    bandEls.push({ id: `${pfx}-ctl`, kind: 'container' });
+    bands.push(gcXml(`${pfx}-ctl`, row, row + h, lines.join('\n')));
+    row += h;
+  }
+
+  // (3..5) content bands
+  let bandN = 0;
+  const pushBand = (h, lines) => {
+    bandN += 1;
+    const cid = `${pfx}-${bandN}`;
+    bandEls.push({ id: cid, kind: 'container' });
+    bands.push(gcXml(cid, row, row + h, lines.join('\n')));
+    row += h;
+  };
   for (let i = 0; i < content.length; i++) {
     const e = content[i];
     if (e.kind === 'kpi-chart') {
+      // KPI panel: the whole run in ONE band container, rows of up to 3 TALL tiles
       let j = i; while (j < content.length && content[j].kind === 'kpi-chart') j++;
       const run = content.slice(i, j);
       const perRow = Math.min(run.length, 3);
       const span = Math.floor(24 / perRow);
-      run.forEach((k, n) => {
+      const lines = run.map((k, n) => {
         const col0 = 1 + (n % perRow) * span;
         const col1 = (n % perRow === perRow - 1) ? 25 : col0 + span;
-        const r = row + Math.floor(n / perRow) * H('kpi-chart');
-        lines.push(`  <LayoutElement elementId="${k.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('kpi-chart')}"/>`);
+        const r = 1 + Math.floor(n / perRow) * KPI_H;
+        return le(k.id, col0, col1, r, r + KPI_H);
       });
-      row += Math.ceil(run.length / perRow) * H('kpi-chart');
+      pushBand(Math.ceil(run.length / perRow) * KPI_H, lines);
       i = j - 1;
       continue;
     }
-    const h = H(e.kind);
-    lines.push(`  <LayoutElement elementId="${e.id}" gridColumn="1 / 25" gridRow="${row} / ${row + h}"/>`);
-    row += h;
+    if (isChart(e.kind) && i + 1 < content.length && isChart(content[i + 1].kind)) {
+      // chart row: two charts side-by-side, even heights (the 2x2 grid pattern)
+      pushBand(CHART_H, [le(e.id, 1, 13, 1, 1 + CHART_H),
+                         le(content[i + 1].id, 13, 25, 1, 1 + CHART_H)]);
+      i += 1;
+      continue;
+    }
+    // lone chart / table / map / pivot / text: full-width band
+    const h = isChart(e.kind) ? CHART_H : H(e.kind);
+    pushBand(h, [le(e.id, 1, 25, 1, 1 + h)]);
   }
-  return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${page.id}">\n${lines.join('\n')}\n</Page>`;
+
+  page.elements = page.elements.concat(bandEls);
+  return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${page.id}">\n${bands.join('\n')}\n</Page>`;
 }
 
 const got = await api('GET', `/v2/workbooks/${a.workbook}/spec`);
@@ -74,8 +133,13 @@ const spec = got.json;
 // The layout is a SINGLE top-level `spec.layout` XML holding one <Page> block per page
 // (NOT pages[].layout — that's silently dropped). Strip read-only fields before the PUT.
 const pageBlocks = [];
-for (const p of spec.pages || []) { delete p.layout; const xml = pageLayout(p); if (xml) pageBlocks.push(xml); }
-if (!pageBlocks.length) { console.log('no multi-element pages — nothing to lay out'); process.exit(0); }
+for (const p of spec.pages || []) {
+  delete p.layout;
+  if ((p.name || '') === 'Data') continue; // hidden master page — auto-arrange is fine
+  const xml = pageLayout(p, spec.name);
+  if (xml) pageBlocks.push(xml);
+}
+if (!pageBlocks.length) { console.log('no layoutable pages — nothing to lay out'); process.exit(0); }
 spec.layout = `<?xml version="1.0" encoding="utf-8"?>\n${pageBlocks.join('\n')}`;
 for (const k of ['workbookId', 'url', 'ownerId', 'createdBy', 'updatedBy', 'createdAt', 'updatedAt', 'latestDocumentVersion', 'documentVersion']) delete spec[k];
 if (a.folder && !spec.folderId) spec.folderId = a.folder;
@@ -83,9 +147,10 @@ if (a.folder && !spec.folderId) spec.folderId = a.folder;
 const put = await api('PUT', `/v2/workbooks/${a.workbook}/spec`, spec);
 if (!put.ok) { console.error(`PUT failed (HTTP ${put.status}): ${put.text.slice(0, 400)}`); process.exit(1); }
 
-// verify the layout survived readback
+// verify the layout (containers included) survived readback
 const rb = await api('GET', `/v2/workbooks/${a.workbook}/spec`);
-const ok = /<LayoutElement/.test(rb.json?.layout || '');
+const rbLayout = rb.json?.layout || '';
+const ok = /<LayoutElement/.test(rbLayout) && /<GridContainer/.test(rbLayout);
 console.log(JSON.stringify({ workbookId: a.workbook, pagesLaidOut: pageBlocks.length, layoutOnReadback: ok }, null, 2));
-if (!ok) { console.error('FAIL: layout did not survive readback (check elementId matches)'); process.exit(1); }
-console.error(`clean layout applied (${pageBlocks.length} page block(s))`);
+if (!ok) { console.error('FAIL: container layout did not survive readback (check elementId matches — a GridContainer with an unknown elementId is silently dropped)'); process.exit(1); }
+console.error(`container-banded layout applied (${pageBlocks.length} page block(s))`);

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -268,10 +268,15 @@ unless opts[:skip_layout]
         # gridColumn value (typically "1 / 13" — left half, vertically stacked).
         # Note: per-page detection — a workbook with one element per content
         # page is structurally fine (degenerate case, not a stack).
+        # Container-banded pages (<GridContainer> bands per layout-playbook.md)
+        # are exempt: full-width band containers (and single-chart rows inside
+        # them) legitimately share gridColumn="1 / 25" — that is deliberate
+        # banding, not the auto-stack regression.
         non_data_stack_pages = []
         # Walk one page at a time using the <Page id="..."> blocks
         layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
           next if page_id.to_s.downcase.include?('data')
+          next if page_body.include?('<GridContainer')
           cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
           elems_on_page = page_body.scan(/<LayoutElement\b/).length
           if elems_on_page >= 2 && cols_on_page.length == 1

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -697,77 +697,109 @@ def main():
             warnings.append(f"filter '{flt['name']}': could not bind to a master column")
         controls.append(ctrl)
 
-    # ── layout finalize: top control bar, tall titled KPIs, downshifted tiles ──
-    # The raw newspaper→grid math (above) honors Looker's pixel positions, but two
-    # Looker→Sigma quirks need fixing for a tidy, readable dashboard:
-    #   1. Sigma kpi-chart HIDES its title (the element name / measure label) when
-    #      the tile is shorter than ~5 grid rows / ~150px — Looker KPIs are usually
-    #      2-3 rows tall, so every title vanishes (bare floating numbers). Fix: lay
-    #      KPIs as a full-width strip of equal, TALL tiles (height >= 6).
-    #      See memory feedback_sigma_kpi_label_height.md.
-    #   2. Dashboard controls (filters) carry no layout, so they orphan at the
-    #      bottom-left. Looker shows filters at the TOP. Fix: a control row at row 0
-    #      and shift every tile DOWN by that row's height.
+    # ── layout finalize: container bands (layout-playbook.md, 2026-06-10) ──
+    # The raw newspaper→grid math (above) honors Looker's pixel positions; the
+    # final layout groups everything into full-width band CONTAINERS instead of
+    # a flat LayoutElement list (flat layouts produce dead zones / detached
+    # controls). Spec side: one `kind: container` placeholder element per band
+    # plus a header text; layout side: <GridContainer> (NOT <LayoutElement
+    # type="grid">, which silently drops children) whose child <LayoutElement>s
+    # use CONTAINER-RELATIVE coordinates (rows restart at 1). Band order:
+    #   1. header band — dark, full-width, dashboard title (rows 1-3)
+    #   2. control band — dashboard filters side-by-side (Looker shows them top)
+    #   3. KPI band — full-width strip of equal TALL tiles (>= 6 rows so the
+    #      title renders; see memory feedback_sigma_kpi_label_height.md)
+    #   4. chart row bands — newspaper rows clustered by row overlap, original
+    #      columns/heights preserved inside each band
     GRID = 24
-    CTRL_H = 3                 # control-bar height (grid rows)
+    HDR_H = 3                  # header band height (grid rows)
+    CTRL_H = 3                 # control-band height (grid rows)
     KPI_H = 6                  # KPI tile height — >= 5 so the title renders
+    HEADER_STYLE = {"backgroundColor": "#0F172A", "borderRadius": "round"}
+    page_id = "page-dash"
 
-    # (a) Top control bar: lay controls side-by-side across row 0, evenly. Each
-    #     control needs a layout entry so it docks at the top instead of orphaning.
-    ctrl_items = []
+    def _le(eid, c0, c1, r0, r1):
+        return f'  <LayoutElement elementId="{eid}" gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}"/>'
+
+    def _gc(cid, r0, r1, inner):
+        return (f'<GridContainer elementId="{cid}" type="grid" gridColumn="1 / 25" '
+                f'gridRow="{r0} / {r1}" gridTemplateColumns="repeat(24, 1fr)" '
+                f'gridTemplateRows="auto">\n{inner}\n</GridContainer>')
+
+    band_els, band_xml = [], []   # spec placeholder elements / page-level XML
+    page_row = 1
+
+    # (1) header band
+    band_els.append({"id": "band-hdr", "kind": "container", "style": dict(HEADER_STYLE)})
+    band_els.append({"id": "band-hdrtext", "kind": "text",
+                     "body": f'# <span style="color: #FFFFFF">{dash["title"]}</span>'})
+    band_xml.append(_gc("band-hdr", page_row, page_row + HDR_H,
+                        _le("band-hdrtext", 1, GRID + 1, 1, 1 + HDR_H)))
+    page_row += HDR_H
+
+    # (2) control band: dashboard-global filters side-by-side in one container
     if controls:
         n = len(controls)
         cw = max(1, GRID // n)
-        x = 1
+        x, inner = 1, []
         for i, c in enumerate(controls):
             c1 = (x + cw) if i < n - 1 else (GRID + 1)   # last fills to the edge
-            ctrl_items.append((c["id"], x, c1, 1, 1 + CTRL_H, "control"))
+            inner.append(_le(c["id"], x, c1, 1, 1 + CTRL_H))
             x = c1
-    ctrl_h = CTRL_H if controls else 0
+        band_els.append({"id": "band-ctl", "kind": "container"})
+        band_xml.append(_gc("band-ctl", page_row, page_row + CTRL_H, "\n".join(inner)))
+        page_row += CTRL_H
 
-    # (b) KPI strip: pull every KPI out of its Looker position and lay them as one
-    #     full-width row of equal, TALL tiles directly under the control bar — this
-    #     is the only reliable way to keep their titles visible.
+    # (3) KPI band: pull every KPI out of its Looker position into one strip of
+    #     equal, TALL tiles — the only reliable way to keep their titles visible.
     kpi_ids = [e for (e, *_rest, k) in layout_items if k == "kpi-chart"]
     other_items = [it for it in layout_items if it[5] != "kpi-chart"]
-    new_items = list(ctrl_items)
-    kpi_row0 = 1 + ctrl_h
     if kpi_ids:
         n = len(kpi_ids)
         kw = max(1, GRID // n)
-        x = 1
+        x, inner = 1, []
         for i, e in enumerate(kpi_ids):
             c1 = (x + kw) if i < n - 1 else (GRID + 1)   # last fills to the edge
-            new_items.append((e, x, c1, kpi_row0, kpi_row0 + KPI_H, "kpi-chart"))
+            inner.append(_le(e, x, c1, 1, 1 + KPI_H))
             x = c1
-    kpi_h = KPI_H if kpi_ids else 0
+        band_els.append({"id": "band-kpi", "kind": "container"})
+        band_xml.append(_gc("band-kpi", page_row, page_row + KPI_H, "\n".join(inner)))
+        page_row += KPI_H
 
-    # (c) Shift all remaining tiles DOWN below the control bar + KPI strip, by the
-    #     amount their original top-row sat above the first non-KPI tile (so we
-    #     close the gap the KPIs left and never overlap the bars). Preserve their
-    #     relative vertical order and columns from the newspaper math.
-    body_off = ctrl_h + kpi_h
-    top = min((r0 for (_e, _c0, _c1, r0, _r1, _k) in other_items), default=1)
-    for (e, c0, c1, r0, r1, k) in other_items:
-        h = r1 - r0
-        nr0 = (r0 - top) + 1 + body_off
-        new_items.append((e, c0, c1, nr0, nr0 + h, k))
-    layout_items = new_items
+    # (4) chart row bands: cluster the remaining newspaper tiles into horizontal
+    #     bands by row overlap; one container per band, children relative.
+    bands = []
+    for it in sorted(other_items, key=lambda i: (i[3], i[1])):
+        if bands and it[3] < bands[-1]["r1"]:
+            bands[-1]["items"].append(it)
+            bands[-1]["r1"] = max(bands[-1]["r1"], it[4])
+        else:
+            bands.append({"r0": it[3], "r1": it[4], "items": [it]})
+    TABLE_MAX_H = 12   # table tiles sized to content, not the Looker tile box —
+                       # an over-tall table band renders as a giant dead tile
+                       # (layout-playbook.md rule 4)
+    for bi, b in enumerate(bands, 1):
+        cid = f"band-row-{bi}"
+        band_els.append({"id": cid, "kind": "container"})
+        h = b["r1"] - b["r0"]
+        if all(k == "table" for (*_g, k) in b["items"]) and h > TABLE_MAX_H:
+            h = TABLE_MAX_H
+        inner = "\n".join(_le(e, c0, c1, min(r0 - b["r0"], h - 1) + 1, min(r1 - b["r0"], h) + 1)
+                          for (e, c0, c1, r0, r1, _k) in b["items"])
+        band_xml.append(_gc(cid, page_row, page_row + h, inner))
+        page_row += h
 
     # ── layout XML (single top-level field; 24-col grid) ──
-    page_id = "page-dash"
-    les = "\n".join(f'  <LayoutElement elementId="{e}" gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}"/>'
-                    for (e, c0, c1, r0, r1, _k) in layout_items)
     layout_xml = ('<?xml version="1.0" encoding="utf-8"?>\n'
                   f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">\n'
-                  f'{les}\n</Page>')
+                  + "\n".join(band_xml) + '\n</Page>')
 
     spec = {
         "name": f"{dash['title']} (from Looker)", "folderId": a.folder_id, "schemaVersion": 1,
         "layout": layout_xml,
         "pages": [
             {"id": "page-data", "name": "Data", "elements": []},  # filled below
-            {"id": page_id, "name": dash["title"], "elements": controls + elements},
+            {"id": page_id, "name": dash["title"], "elements": controls + elements + band_els},
         ],
     }
     master_elements = [{

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -234,7 +234,9 @@ class SourceEval:
     def measure_value(self, field, rows, depth=0):
         if depth > 4 or field not in self.measures:
             return None
-        mtype, base, sql = self.measures[field]
+        # build_field_index emits 4-tuples (mtype, base, sql, filters) — take the
+        # first three (the filters slot was added for filtered-measure tiles).
+        mtype, base, sql = self.measures[field][:3]
         view = field.split(".")[0]
         if mtype in ("number",) or re.search(r"\$\{(\w+)\}", sql or ""):
             # ratio / composite: substitute each ${measure} component recursively

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -268,10 +268,15 @@ unless opts[:skip_layout]
         # gridColumn value (typically "1 / 13" — left half, vertically stacked).
         # Note: per-page detection — a workbook with one element per content
         # page is structurally fine (degenerate case, not a stack).
+        # Container-banded pages (<GridContainer> bands per layout-playbook.md)
+        # are exempt: full-width band containers (and single-chart rows inside
+        # them) legitimately share gridColumn="1 / 25" — that is deliberate
+        # banding, not the auto-stack regression.
         non_data_stack_pages = []
         # Walk one page at a time using the <Page id="..."> blocks
         layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
           next if page_id.to_s.downcase.include?('data')
+          next if page_body.include?('<GridContainer')
           cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
           elems_on_page = page_body.scan(/<LayoutElement\b/).length
           if elems_on_page >= 2 && cols_on_page.length == 1

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -48,6 +48,8 @@
 
 require 'json'
 require 'optparse'
+require_relative 'lib/layout'
+include SigmaLayout
 
 opts = {}
 OptionParser.new do |p|
@@ -652,9 +654,14 @@ col_for = ->(x, w, pw) {
   [[cs, 1].max, [ce, 25].min]
 }
 ROW_UNIT = 30.0
+# Container-banded pages (layout-playbook.md): the PBI canvas regions cluster
+# into horizontal row bands, each band a full-width <GridContainer> whose
+# children keep the canvas-derived geometry (container-relative rows). Every
+# page gets a dark header band carrying the page title; the matching
+# `kind: container` / header-text spec elements are appended to the page below.
 pages_xml = signals['pages'].map do |pg|
   pw = pg['page_w'] || 1280
-  les = pg['visuals'].flat_map do |v|
+  items = pg['visuals'].flat_map do |v|
     cs, ce = col_for.call(v['x'], v['w'], pw)
     rs = (v['y'] / ROW_UNIT).floor + 1
     re = ((v['y'] + v['h']) / ROW_UNIT).floor + 1
@@ -684,14 +691,19 @@ pages_xml = signals['pages'].map do |pg|
         sre = rs + ((r + 1) * rspan.to_f / nrow).round
         sce = scs + 1 if sce <= scs
         sre = srs + 1 if sre <= srs
-        %(  <LayoutElement elementId="#{base}-k#{i}" gridColumn="#{scs} / #{sce}" gridRow="#{srs} / #{sre}"/>)
+        ["#{base}-k#{i}", scs, sce, srs, sre]
       end
     else
-      [%(  <LayoutElement elementId="#{base}" gridColumn="#{cs} / #{ce}" gridRow="#{rs} / #{re}"/>)]
+      [[base, cs, ce, rs, re]]
     end
-  end.join("\n")
-  %(<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="page-#{pg['page_id']}">\n#{les}\n</Page>)
-end.join("\n")
+  end
+  page_id = "page-#{pg['page_id']}"
+  next nil if items.empty?
+  xml, extra = banded_page(page_id, items, title: pg['page_title'])
+  page_spec = content_pages.find { |p| p['id'] == page_id }
+  page_spec['elements'] = page_spec['elements'] + extra if page_spec
+  xml
+end.compact.join("\n")
 layout_xml = %(<?xml version="1.0" encoding="utf-8"?>\n#{pages_xml}\n)
 
 spec = {

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout.rb
@@ -1,6 +1,16 @@
 # Layout-XML helpers. require'd by per-workbook layout configs.
+#
+# Container-based layouts (layout-playbook.md, verified 2026-06-10):
+#   - spec side: a `kind: container` placeholder element per band
+#     (container_el / header_text_el below build those spec objects)
+#   - layout side: a <GridContainer> (NOT <LayoutElement type="grid">, which
+#     silently drops children) whose child <LayoutElement>s use
+#     CONTAINER-RELATIVE coordinates (rows restart at 1).
 module SigmaLayout
   module_function
+
+  HEADER_STYLE = { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' }.freeze
+  HEADER_ROWS  = 3 # header band height in grid rows
 
   def gc(eid, c0, c1, r0, r1, inner)
     "<GridContainer elementId=\"#{eid}\" type=\"grid\" " \
@@ -19,5 +29,81 @@ module SigmaLayout
 
   def assemble(*pages)
     %(<?xml version="1.0" encoding="utf-8"?>\n) + pages.join("\n")
+  end
+
+  # ---- container-layout helpers --------------------------------------------
+
+  # Spec-side placeholder for a band container.
+  def container_el(id, style = nil)
+    el = { 'id' => id, 'kind' => 'container' }
+    el['style'] = style if style
+    el
+  end
+
+  # Spec-side page-title text element (white text over the dark header band).
+  def header_text_el(id, title)
+    { 'id' => id, 'kind' => 'text',
+      'body' => %(# <span style="color: #FFFFFF">#{title}</span>) }
+  end
+
+  # Header band XML: dark full-width container at the top of the page wrapping
+  # the title text (child coordinates are container-relative).
+  def header_band_xml(container_id, text_id, rows: HEADER_ROWS)
+    gc(container_id, 1, 25, 1, 1 + rows, le(text_id, 1, 25, 1, 1 + rows))
+  end
+
+  # Cluster placed items into horizontal bands by row overlap. Items are
+  # [eid, c0, c1, r0, r1, *rest] tuples with PAGE-ABSOLUTE rows. Returns an
+  # array of bands (each an array of items), top-to-bottom.
+  def cluster_bands(items)
+    bands = []
+    items.sort_by { |i| [i[3], i[1]] }.each do |it|
+      if bands.any? && it[3] < bands.last[:r1]
+        bands.last[:items] << it
+        bands.last[:r1] = [bands.last[:r1], it[4]].max
+      else
+        bands << { r0: it[3], r1: it[4], items: [it] }
+      end
+    end
+    bands.map { |b| b[:items] }
+  end
+
+  # One band of items -> a full-width GridContainer spanning the band's row
+  # range at page level, children re-emitted with CONTAINER-RELATIVE rows.
+  # row_offset shifts the container's page-level position (e.g. +3 when a
+  # header band was prepended above the original geometry).
+  def band_container_xml(cid, items, row_offset: 0)
+    r0 = items.map { |i| i[3] }.min
+    r1 = items.map { |i| i[4] }.max
+    inner = items.map { |i| le(i[0], i[1], i[2], i[3] - r0 + 1, i[4] - r0 + 1) }.join("\n")
+    gc(cid, 1, 25, r0 + row_offset, r1 + row_offset, inner)
+  end
+
+  # Full container-banded page: header band + one container per row band.
+  # Returns [page_xml_string, extra_spec_elements] — the caller must add the
+  # extra elements (containers + header text) to the page's spec `elements`
+  # (directly, or via put-layout.rb's <layout>.elements.json sidecar).
+  # `title` of nil/empty skips the header band (e.g. when the caller bands an
+  # existing title text element explicitly).
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}")
+    extra = []
+    children = []
+    offset = 0
+    if title && !title.to_s.empty?
+      hdr_id = "#{id_prefix}-hdr"
+      txt_id = "#{id_prefix}-hdrtext"
+      extra << container_el(hdr_id, HEADER_STYLE.dup)
+      extra << header_text_el(txt_id, title)
+      children << header_band_xml(hdr_id, txt_id)
+      offset = HEADER_ROWS
+    end
+    top = items.map { |i| i[3] }.min
+    offset += (1 - top) if top # first band starts right under the header
+    cluster_bands(items).each_with_index do |band, i|
+      cid = "#{id_prefix}-#{i + 1}"
+      extra << container_el(cid)
+      children << band_container_xml(cid, band, row_offset: offset)
+    end
+    [page_xml(page_id, *children), extra]
   end
 end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/put-layout.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/put-layout.rb
@@ -2,8 +2,17 @@
 # GET a workbook spec, replace per-page layouts with a single top-level layout
 # XML (provided), strip read-only fields, PUT back.
 #
+# Container layouts: a <GridContainer> in the layout XML must be paired with a
+# `kind: container` placeholder element in the spec (else it is silently
+# dropped — layout-playbook.md). Layout builders that emit GridContainers
+# write a sidecar `<layout>.elements.json` ({pageId: [element, ...]}) next to
+# the layout XML; this script injects those elements (containers + header
+# text) into the matching pages before the PUT. Pass --elements to override
+# the sidecar path. Injection is idempotent (existing element ids are kept).
+#
 # Usage:
-#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml>
+#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml> \
+#     [--elements <elements.json>]
 
 require 'net/http'
 require 'uri'
@@ -16,6 +25,7 @@ opts = {}
 OptionParser.new do |p|
   p.on('--workbook ID') { |v| opts[:wb] = v }
   p.on('--layout PATH') { |v| opts[:layout] = v }
+  p.on('--elements PATH', 'spec elements to inject (default: <layout>.elements.json if present)') { |v| opts[:elements] = v }
 end.parse!
 %i[wb layout].each { |k| abort("missing --#{k}") unless opts[k] }
 
@@ -39,6 +49,28 @@ abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
 spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec").body)
 spec['pages'].each { |p| p.delete('layout') }
 spec['layout'] = xml
+
+# Inject container/header-text spec elements (see header comment).
+elements_path = opts[:elements] || "#{opts[:layout]}.elements.json"
+if File.exist?(elements_path)
+  inject = JSON.parse(File.read(elements_path))
+  injected = 0
+  inject.each do |page_id, els|
+    page = spec['pages'].find { |p| p['id'] == page_id }
+    unless page
+      warn "WARN: elements sidecar references unknown page #{page_id.inspect} — skipped"
+      next
+    end
+    page['elements'] ||= []
+    existing = page['elements'].map { |e| e['id'] }
+    els.each do |el|
+      next if existing.include?(el['id'])
+      page['elements'] << el
+      injected += 1
+    end
+  end
+  puts "injected #{injected} container/header element(s) from #{elements_path}"
+end
 %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
 
 resp = http(:put, "/v2/workbooks/#{opts[:wb]}/spec", JSON.pretty_generate(spec))

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/batch-migrate.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/batch-migrate.py
@@ -9,8 +9,10 @@ For each app, builds a Sigma workbook (reusing an existing data model) with an O
 Demonstrates tenant-scale migration. Reuses DM/denorm element (set below) since the demo apps
 share data; for distinct apps, discover per-app and build per-app specs.
 
-Includes `auto_layout()` — the reusable layout heuristic (KPIs across the top row, other
-charts in a 2-wide grid below) returning the 24-col grid XML a workbook PUT expects.
+Includes `auto_layout()` — the reusable layout heuristic (header band + KPI band + chart
+rows, each a <GridContainer> band per layout-playbook.md) returning (24-col grid XML,
+container/header spec elements). The spec elements MUST be in the POSTed spec or the
+GridContainers are silently dropped.
 """
 import json, os, sys, urllib.request, subprocess, re, argparse
 
@@ -25,24 +27,35 @@ def post(p,b):
     except urllib.error.HTTPError as e: print("HTTP",e.code,e.read().decode()[:400],file=sys.stderr); return None
 N=lambda f:{"kind":"number","formatString":f}
 
-def auto_layout(page_id, elems):
-    """elems: ordered list of {id, kind}. KPIs → top row (split evenly); others → 2-wide grid below."""
+def auto_layout(page_id, elems, title="Overview"):
+    """elems: ordered list of {id, kind}. Header band + KPI band + chart rows, each a
+    full-width GridContainer (children container-relative). Returns (xml, extra_spec_elements)."""
     kpis=[e for e in elems if e["kind"]=="kpi-chart"]; charts=[e for e in elems if e["kind"]!="kpi-chart"]
-    lines=[f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">']
+    def le(eid,c0,c1,r0,r1): return f'  <LayoutElement elementId="{eid}" gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}"/>'
+    def gc(cid,r0,r1,inner):
+        return (f'<GridContainer elementId="{cid}" type="grid" gridColumn="1 / 25" gridRow="{r0} / {r1}" '
+                f'gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">\n{inner}\n</GridContainer>')
+    extra=[{"id":"band-hdr","kind":"container","style":{"backgroundColor":"#0F172A","borderRadius":"round"}},
+           {"id":"band-hdrtext","kind":"text","body":f'# <span style="color: #FFFFFF">{title}</span>'}]
+    bands=[gc("band-hdr",1,4,le("band-hdrtext",1,25,1,4))]
+    row=4
     if kpis:
-        w=24//len(kpis)
+        w=24//len(kpis); inner=[]
         for i,e in enumerate(kpis):
             c0=1+i*w; c1=(c0+w) if i<len(kpis)-1 else 25
-            lines.append(f'  <LayoutElement elementId="{e["id"]}" gridColumn="{c0} / {c1}" gridRow="1 / 6"/>')
-    row=6
-    for i in range(0,len(charts),2):
-        pair=charts[i:i+2]
+            inner.append(le(e["id"],c0,c1,1,6))
+        extra.append({"id":"band-kpi","kind":"container"})
+        bands.append(gc("band-kpi",row,row+5,"\n".join(inner))); row+=5
+    for n,i in enumerate(range(0,len(charts),2),1):
+        pair=charts[i:i+2]; inner=[]
         for j,e in enumerate(pair):
             c0=1 if j==0 else 13; c1=13 if (j==0 and len(pair)>1) else 25
-            lines.append(f'  <LayoutElement elementId="{e["id"]}" gridColumn="{c0} / {c1}" gridRow="{row} / {row+11}"/>')
-        row+=11
-    lines.append("</Page>")
-    return '<?xml version="1.0" encoding="utf-8"?>\n'+"\n".join(lines)
+            inner.append(le(e["id"],c0,c1,1,12))
+        cid=f"band-row-{n}"; extra.append({"id":cid,"kind":"container"})
+        bands.append(gc(cid,row,row+11,"\n".join(inner))); row+=11
+    xml=(f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">\n'
+         +"\n".join(bands)+'\n</Page>')
+    return '<?xml version="1.0" encoding="utf-8"?>\n'+xml, extra
 
 def build(app_name):
     O=lambda c:"[OFV/%s]"%c
@@ -58,14 +71,14 @@ def build(app_name):
            ch(1,"bar-chart","Net Revenue by Category",O("Category"),"Category","Sum(%s)"%O("Net Revenue")),
            ch(2,"line-chart","Net Revenue by Month",O("Month Number"),"Month","Sum(%s)"%O("Net Revenue")),
            ch(3,"bar-chart","Net Revenue by Region",O("Store Region"),"Region","Sum(%s)"%O("Net Revenue"))]
+    xml,extra=auto_layout("pg-ov",[{"id":e["id"],"kind":e["kind"]} for e in elems],title=app_name)
     spec={"name":f"{app_name} → Sigma","folderId":FOLDER,"schemaVersion":1,
-          "pages":[{"id":"pg-data","name":"Data","elements":[master]},{"id":"pg-ov","name":"Overview","elements":elems}]}
+          "pages":[{"id":"pg-data","name":"Data","elements":[master]},{"id":"pg-ov","name":"Overview","elements":elems+extra}]}
     res=post("/v2/workbooks/spec",spec)
     if not res: return None
     wb=re.search(r'workbookId:\s*(\S+)',res)
     wb=wb.group(1) if wb else None
     if wb:
-        xml=auto_layout("pg-ov",[{"id":e["id"],"kind":e["kind"]} for e in elems])
         lf="/tmp/_lay_%s.xml"%wb; open(lf,"w").write(xml)
         subprocess.run(["ruby",PUTLAYOUT,"--workbook",wb,"--layout",lf],capture_output=True)
     return wb

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -241,10 +241,64 @@ def build_element(c, resolve, warnings):
     if kind == "bar-chart": el["dataLabel"] = {"labels": "shown"}
     return el
 
+# ---- container-banded layout (layout-playbook.md, verified 2026-06-10) -----
+# Spec side: a `kind: container` placeholder element per band (+ a header text
+# element). Layout side: <GridContainer> (NOT <LayoutElement type="grid">,
+# which silently drops children) wrapping <LayoutElement>s whose coordinates
+# are CONTAINER-RELATIVE (rows restart at 1).
+HEADER_STYLE = {"backgroundColor": "#0F172A", "borderRadius": "round"}
+HEADER_ROWS = 3
+
+def _le(eid, c0, c1, r0, r1):
+    return f'  <LayoutElement elementId="{eid}" gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}"/>'
+
+def _gc(cid, c0, c1, r0, r1, inner):
+    return (f'<GridContainer elementId="{cid}" type="grid" gridColumn="{c0} / {c1}" '
+            f'gridRow="{r0} / {r1}" gridTemplateColumns="repeat(24, 1fr)" '
+            f'gridTemplateRows="auto">\n{inner}\n</GridContainer>')
+
+def _cluster_bands(items):
+    """Cluster [eid,c0,c1,r0,r1] items into horizontal bands by row overlap."""
+    bands = []
+    for it in sorted(items, key=lambda i: (i[3], i[1])):
+        if bands and it[3] < bands[-1]["r1"]:
+            bands[-1]["items"].append(it)
+            bands[-1]["r1"] = max(bands[-1]["r1"], it[4])
+        else:
+            bands.append({"r0": it[3], "r1": it[4], "items": [it]})
+    return [b["items"] for b in bands]
+
+def banded_page(page_id, items, title, id_prefix=None):
+    """Header band + one full-width GridContainer per row band, children
+    container-relative. Returns (page_xml, extra_spec_elements)."""
+    pfx = id_prefix or f"band-{page_id}"
+    extra, children = [], []
+    offset = 0
+    if title:
+        hdr, txt = f"{pfx}-hdr", f"{pfx}-hdrtext"
+        extra.append({"id": hdr, "kind": "container", "style": dict(HEADER_STYLE)})
+        extra.append({"id": txt, "kind": "text",
+                      "body": f'# <span style="color: #FFFFFF">{title}</span>'})
+        children.append(_gc(hdr, 1, 25, 1, 1 + HEADER_ROWS, _le(txt, 1, 25, 1, 1 + HEADER_ROWS)))
+        offset = HEADER_ROWS
+    if items:
+        offset += 1 - min(i[3] for i in items)  # first band starts under the header
+    for n, band in enumerate(_cluster_bands(items), 1):
+        cid = f"{pfx}-{n}"
+        extra.append({"id": cid, "kind": "container"})
+        r0 = min(i[3] for i in band); r1 = max(i[4] for i in band)
+        inner = "\n".join(_le(i[0], i[1], i[2], i[3] - r0 + 1, i[4] - r0 + 1) for i in band)
+        children.append(_gc(cid, 1, 25, r0 + offset, r1 + offset, inner))
+    body = "\n".join(children)
+    return (f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" '
+            f'gridTemplateRows="auto" id="{page_id}">\n{body}\n</Page>', extra)
+
 def grid_layout(page_id, sheet, placed):
-    """Map the Qlik sheet cell grid onto Sigma's 24-col grid (1-based lines)."""
+    """Map the Qlik sheet cell grid onto Sigma's 24-col grid, then wrap each
+    cell-grid row in a band container (relative proportions preserved).
+    Returns (page_xml, extra_spec_elements)."""
     qcols = sheet.get("columns") or 24
-    lines = [f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">']
+    items = []
     for cell, el in placed:
         c0 = round(cell["col"] * 24 / qcols) + 1
         c1 = round((cell["col"] + cell["colspan"]) * 24 / qcols) + 1
@@ -252,29 +306,28 @@ def grid_layout(page_id, sheet, placed):
         r1 = (cell["row"] + cell["rowspan"]) * ROW_SCALE + 1
         if el["kind"] == "kpi-chart" and (r1 - r0) < KPI_MIN_ROWS:
             r1 = r0 + KPI_MIN_ROWS
-        lines.append(f'  <LayoutElement elementId="{el["id"]}" gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}"/>')
-    lines.append("</Page>")
-    return "\n".join(lines)
+        items.append([el["id"], c0, c1, r0, r1])
+    return banded_page(page_id, items, sheet.get("title"))
 
-def auto_layout(page_id, elems):
-    """Fallback when no layout.json: KPIs across the top, charts 2-wide below."""
+def auto_layout(page_id, elems, title=None):
+    """Fallback when no layout.json: header band, KPI strip band, then chart
+    rows 2-wide — each a container. Returns (page_xml, extra_spec_elements)."""
     kpis = [e for e in elems if e["kind"] == "kpi-chart"]
     charts = [e for e in elems if e["kind"] != "kpi-chart"]
-    lines = [f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">']
+    items, row = [], 1
     if kpis:
         w = 24 // len(kpis)
         for i, e in enumerate(kpis):
             c0 = 1 + i * w; c1 = c0 + w if i < len(kpis) - 1 else 25
-            lines.append(f'  <LayoutElement elementId="{e["id"]}" gridColumn="{c0} / {c1}" gridRow="1 / 6"/>')
-    row = 6
+            items.append([e["id"], c0, c1, 1, 6])
+        row = 6
     for i in range(0, len(charts), 2):
         pair = charts[i:i + 2]
         for j, e in enumerate(pair):
             c0 = 1 if j == 0 else 13; c1 = 13 if (j == 0 and len(pair) > 1) else 25
-            lines.append(f'  <LayoutElement elementId="{e["id"]}" gridColumn="{c0} / {c1}" gridRow="{row} / {row + 11}"/>')
+            items.append([e["id"], c0, c1, row, row + 11])
         row += 11
-    lines.append("</Page>")
-    return "\n".join(lines)
+    return banded_page(page_id, items, title or "Overview")
 
 def main():
     ap = argparse.ArgumentParser()
@@ -330,8 +383,9 @@ def main():
                                       "measures": c.get("measures") or [],
                                       "nullSuppression": c.get("dimNullSuppression") or []}})
             if not elems: continue
-            pages.append({"id": pid, "name": sheet["title"], "elements": elems})
-            layout_pages.append(grid_layout(pid, sheet, placed))
+            xml, extra = grid_layout(pid, sheet, placed)
+            pages.append({"id": pid, "name": sheet["title"], "elements": elems + extra})
+            layout_pages.append(xml)
     else:
         # no sheet layout discovered — build every dim+measure chart, auto-layout
         pid, elems = "pg-1", []
@@ -346,8 +400,9 @@ def main():
                                   "dims": [(d[0] if isinstance(d, list) else d) for d in (c.get("dimensions") or [])],
                                   "measures": c.get("measures") or [],
                                   "nullSuppression": c.get("dimNullSuppression") or []}})
-        pages.append({"id": pid, "name": "Overview", "elements": elems})
-        layout_pages.append(auto_layout(pid, [{"id": e["id"], "kind": e["kind"]} for e in elems]))
+        xml, extra = auto_layout(pid, [{"id": e["id"], "kind": e["kind"]} for e in elems])
+        pages.append({"id": pid, "name": "Overview", "elements": elems + extra})
+        layout_pages.append(xml)
 
     spec = {"name": a.name, "schemaVersion": 1, "pages": pages}
     if a.folder: spec["folderId"] = a.folder

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/layout.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/layout.rb
@@ -1,6 +1,16 @@
 # Layout-XML helpers. require'd by per-workbook layout configs.
+#
+# Container-based layouts (layout-playbook.md, verified 2026-06-10):
+#   - spec side: a `kind: container` placeholder element per band
+#     (container_el / header_text_el below build those spec objects)
+#   - layout side: a <GridContainer> (NOT <LayoutElement type="grid">, which
+#     silently drops children) whose child <LayoutElement>s use
+#     CONTAINER-RELATIVE coordinates (rows restart at 1).
 module SigmaLayout
   module_function
+
+  HEADER_STYLE = { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' }.freeze
+  HEADER_ROWS  = 3 # header band height in grid rows
 
   def gc(eid, c0, c1, r0, r1, inner)
     "<GridContainer elementId=\"#{eid}\" type=\"grid\" " \
@@ -19,5 +29,81 @@ module SigmaLayout
 
   def assemble(*pages)
     %(<?xml version="1.0" encoding="utf-8"?>\n) + pages.join("\n")
+  end
+
+  # ---- container-layout helpers --------------------------------------------
+
+  # Spec-side placeholder for a band container.
+  def container_el(id, style = nil)
+    el = { 'id' => id, 'kind' => 'container' }
+    el['style'] = style if style
+    el
+  end
+
+  # Spec-side page-title text element (white text over the dark header band).
+  def header_text_el(id, title)
+    { 'id' => id, 'kind' => 'text',
+      'body' => %(# <span style="color: #FFFFFF">#{title}</span>) }
+  end
+
+  # Header band XML: dark full-width container at the top of the page wrapping
+  # the title text (child coordinates are container-relative).
+  def header_band_xml(container_id, text_id, rows: HEADER_ROWS)
+    gc(container_id, 1, 25, 1, 1 + rows, le(text_id, 1, 25, 1, 1 + rows))
+  end
+
+  # Cluster placed items into horizontal bands by row overlap. Items are
+  # [eid, c0, c1, r0, r1, *rest] tuples with PAGE-ABSOLUTE rows. Returns an
+  # array of bands (each an array of items), top-to-bottom.
+  def cluster_bands(items)
+    bands = []
+    items.sort_by { |i| [i[3], i[1]] }.each do |it|
+      if bands.any? && it[3] < bands.last[:r1]
+        bands.last[:items] << it
+        bands.last[:r1] = [bands.last[:r1], it[4]].max
+      else
+        bands << { r0: it[3], r1: it[4], items: [it] }
+      end
+    end
+    bands.map { |b| b[:items] }
+  end
+
+  # One band of items -> a full-width GridContainer spanning the band's row
+  # range at page level, children re-emitted with CONTAINER-RELATIVE rows.
+  # row_offset shifts the container's page-level position (e.g. +3 when a
+  # header band was prepended above the original geometry).
+  def band_container_xml(cid, items, row_offset: 0)
+    r0 = items.map { |i| i[3] }.min
+    r1 = items.map { |i| i[4] }.max
+    inner = items.map { |i| le(i[0], i[1], i[2], i[3] - r0 + 1, i[4] - r0 + 1) }.join("\n")
+    gc(cid, 1, 25, r0 + row_offset, r1 + row_offset, inner)
+  end
+
+  # Full container-banded page: header band + one container per row band.
+  # Returns [page_xml_string, extra_spec_elements] — the caller must add the
+  # extra elements (containers + header text) to the page's spec `elements`
+  # (directly, or via put-layout.rb's <layout>.elements.json sidecar).
+  # `title` of nil/empty skips the header band (e.g. when the caller bands an
+  # existing title text element explicitly).
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}")
+    extra = []
+    children = []
+    offset = 0
+    if title && !title.to_s.empty?
+      hdr_id = "#{id_prefix}-hdr"
+      txt_id = "#{id_prefix}-hdrtext"
+      extra << container_el(hdr_id, HEADER_STYLE.dup)
+      extra << header_text_el(txt_id, title)
+      children << header_band_xml(hdr_id, txt_id)
+      offset = HEADER_ROWS
+    end
+    top = items.map { |i| i[3] }.min
+    offset += (1 - top) if top # first band starts right under the header
+    cluster_bands(items).each_with_index do |band, i|
+      cid = "#{id_prefix}-#{i + 1}"
+      extra << container_el(cid)
+      children << band_container_xml(cid, band, row_offset: offset)
+    end
+    [page_xml(page_id, *children), extra]
   end
 end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/put-layout.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/put-layout.rb
@@ -2,8 +2,17 @@
 # GET a workbook spec, replace per-page layouts with a single top-level layout
 # XML (provided), strip read-only fields, PUT back.
 #
+# Container layouts: a <GridContainer> in the layout XML must be paired with a
+# `kind: container` placeholder element in the spec (else it is silently
+# dropped — layout-playbook.md). Layout builders that emit GridContainers
+# write a sidecar `<layout>.elements.json` ({pageId: [element, ...]}) next to
+# the layout XML; this script injects those elements (containers + header
+# text) into the matching pages before the PUT. Pass --elements to override
+# the sidecar path. Injection is idempotent (existing element ids are kept).
+#
 # Usage:
-#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml>
+#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml> \
+#     [--elements <elements.json>]
 
 require 'net/http'
 require 'uri'
@@ -16,6 +25,7 @@ opts = {}
 OptionParser.new do |p|
   p.on('--workbook ID') { |v| opts[:wb] = v }
   p.on('--layout PATH') { |v| opts[:layout] = v }
+  p.on('--elements PATH', 'spec elements to inject (default: <layout>.elements.json if present)') { |v| opts[:elements] = v }
 end.parse!
 %i[wb layout].each { |k| abort("missing --#{k}") unless opts[k] }
 
@@ -39,6 +49,28 @@ abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
 spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec").body)
 spec['pages'].each { |p| p.delete('layout') }
 spec['layout'] = xml
+
+# Inject container/header-text spec elements (see header comment).
+elements_path = opts[:elements] || "#{opts[:layout]}.elements.json"
+if File.exist?(elements_path)
+  inject = JSON.parse(File.read(elements_path))
+  injected = 0
+  inject.each do |page_id, els|
+    page = spec['pages'].find { |p| p['id'] == page_id }
+    unless page
+      warn "WARN: elements sidecar references unknown page #{page_id.inspect} — skipped"
+      next
+    end
+    page['elements'] ||= []
+    existing = page['elements'].map { |e| e['id'] }
+    els.each do |el|
+      next if existing.include?(el['id'])
+      page['elements'] << el
+      injected += 1
+    end
+  end
+  puts "injected #{injected} container/header element(s) from #{elements_path}"
+end
 %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
 
 resp = http(:put, "/v2/workbooks/#{opts[:wb]}/spec", JSON.pretty_generate(spec))

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -268,10 +268,15 @@ unless opts[:skip_layout]
         # gridColumn value (typically "1 / 13" — left half, vertically stacked).
         # Note: per-page detection — a workbook with one element per content
         # page is structurally fine (degenerate case, not a stack).
+        # Container-banded pages (<GridContainer> bands per layout-playbook.md)
+        # are exempt: full-width band containers (and single-chart rows inside
+        # them) legitimately share gridColumn="1 / 25" — that is deliberate
+        # banding, not the auto-stack regression.
         non_data_stack_pages = []
         # Walk one page at a time using the <Page id="..."> blocks
         layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
           next if page_id.to_s.downcase.include?('data')
+          next if page_body.include?('<GridContainer')
           cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
           elems_on_page = page_body.scan(/<LayoutElement\b/).length
           if elems_on_page >= 2 && cols_on_page.length == 1

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
@@ -174,6 +174,7 @@ end
 sheet_pages = map['sheetPages']
 sheets = defn['Sheets'] || []
 pages_xml = []
+sidecar = {}   # pageId -> container/header spec elements (put-layout.rb injects)
 total_placed = 0
 
 if sheet_pages && !sheet_pages.empty?
@@ -184,9 +185,14 @@ if sheet_pages && !sheet_pages.empty?
     eids_for_sheet = (sheet['Visuals'] || []).map { |v| _t, inner = v.first; v2e[inner['VisualId']] }.compact.to_set
     placed, src = layout_sheet(sheet, v2e, eids_for_sheet)
     total_placed += placed.size
-    children = placed.map { |eid, c0, c1, r0, r1| le(eid, c0, c1, r0, r1) }
-    pages_xml << page_xml(sp['pageId'], *children)
-    STDERR.puts "layout: page \"#{sp['name']}\" (#{sp['pageId']}) <- QS sheet[#{idx}] #{src}: #{placed.size} element(s)"
+    next if placed.empty?
+    # Container-banded page (layout-playbook.md): header band with the QS sheet
+    # name, then one full-width GridContainer per row band — the QS 36-col row
+    # geometry is preserved INSIDE each band (container-relative coordinates).
+    xml, extra = banded_page(sp['pageId'], placed, title: sp['name'] || sheet['Name'])
+    pages_xml << xml
+    sidecar[sp['pageId']] = extra
+    STDERR.puts "layout: page \"#{sp['name']}\" (#{sp['pageId']}) <- QS sheet[#{idx}] #{src}: #{placed.size} element(s), #{extra.size - 2} chart band(s) + header"
     placed.each { |eid, c0, c1, r0, r1| STDERR.puts "  #{eid}  col #{c0}-#{c1}  row #{r0}-#{r1}" }
   end
 else
@@ -194,11 +200,13 @@ else
   all_eids = v2e.values.to_set
   placed, src = layout_sheet(sheets[0] || {}, v2e, all_eids)
   total_placed += placed.size
-  children = placed.map { |eid, c0, c1, r0, r1| le(eid, c0, c1, r0, r1) }
-  pages_xml << page_xml(map['dashPageId'], *children)
-  STDERR.puts "layout: #{placed.size} elements mapped from QuickSight #{src} (legacy single-page)"
+  xml, extra = banded_page(map['dashPageId'], placed, title: (sheets[0] || {})['Name'] || 'Dashboard')
+  pages_xml << xml
+  sidecar[map['dashPageId']] = extra
+  STDERR.puts "layout: #{placed.size} elements mapped from QuickSight #{src} (legacy single-page; container bands)"
 end
 
 data_page = page_xml('page-data', le(map['masterElementId'], 1, 25, 1, 15))
 File.write(opts[:out], assemble(data_page, *pages_xml))
-STDERR.puts "layout: #{total_placed} elements across #{pages_xml.size} page(s) -> #{opts[:out]}"
+File.write("#{opts[:out]}.elements.json", JSON.pretty_generate(sidecar))
+STDERR.puts "layout: #{total_placed} elements across #{pages_xml.size} page(s) -> #{opts[:out]} (+ .elements.json sidecar)"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout.rb
@@ -1,6 +1,16 @@
 # Layout-XML helpers. require'd by per-workbook layout configs.
+#
+# Container-based layouts (layout-playbook.md, verified 2026-06-10):
+#   - spec side: a `kind: container` placeholder element per band
+#     (container_el / header_text_el below build those spec objects)
+#   - layout side: a <GridContainer> (NOT <LayoutElement type="grid">, which
+#     silently drops children) whose child <LayoutElement>s use
+#     CONTAINER-RELATIVE coordinates (rows restart at 1).
 module SigmaLayout
   module_function
+
+  HEADER_STYLE = { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' }.freeze
+  HEADER_ROWS  = 3 # header band height in grid rows
 
   def gc(eid, c0, c1, r0, r1, inner)
     "<GridContainer elementId=\"#{eid}\" type=\"grid\" " \
@@ -19,5 +29,81 @@ module SigmaLayout
 
   def assemble(*pages)
     %(<?xml version="1.0" encoding="utf-8"?>\n) + pages.join("\n")
+  end
+
+  # ---- container-layout helpers --------------------------------------------
+
+  # Spec-side placeholder for a band container.
+  def container_el(id, style = nil)
+    el = { 'id' => id, 'kind' => 'container' }
+    el['style'] = style if style
+    el
+  end
+
+  # Spec-side page-title text element (white text over the dark header band).
+  def header_text_el(id, title)
+    { 'id' => id, 'kind' => 'text',
+      'body' => %(# <span style="color: #FFFFFF">#{title}</span>) }
+  end
+
+  # Header band XML: dark full-width container at the top of the page wrapping
+  # the title text (child coordinates are container-relative).
+  def header_band_xml(container_id, text_id, rows: HEADER_ROWS)
+    gc(container_id, 1, 25, 1, 1 + rows, le(text_id, 1, 25, 1, 1 + rows))
+  end
+
+  # Cluster placed items into horizontal bands by row overlap. Items are
+  # [eid, c0, c1, r0, r1, *rest] tuples with PAGE-ABSOLUTE rows. Returns an
+  # array of bands (each an array of items), top-to-bottom.
+  def cluster_bands(items)
+    bands = []
+    items.sort_by { |i| [i[3], i[1]] }.each do |it|
+      if bands.any? && it[3] < bands.last[:r1]
+        bands.last[:items] << it
+        bands.last[:r1] = [bands.last[:r1], it[4]].max
+      else
+        bands << { r0: it[3], r1: it[4], items: [it] }
+      end
+    end
+    bands.map { |b| b[:items] }
+  end
+
+  # One band of items -> a full-width GridContainer spanning the band's row
+  # range at page level, children re-emitted with CONTAINER-RELATIVE rows.
+  # row_offset shifts the container's page-level position (e.g. +3 when a
+  # header band was prepended above the original geometry).
+  def band_container_xml(cid, items, row_offset: 0)
+    r0 = items.map { |i| i[3] }.min
+    r1 = items.map { |i| i[4] }.max
+    inner = items.map { |i| le(i[0], i[1], i[2], i[3] - r0 + 1, i[4] - r0 + 1) }.join("\n")
+    gc(cid, 1, 25, r0 + row_offset, r1 + row_offset, inner)
+  end
+
+  # Full container-banded page: header band + one container per row band.
+  # Returns [page_xml_string, extra_spec_elements] — the caller must add the
+  # extra elements (containers + header text) to the page's spec `elements`
+  # (directly, or via put-layout.rb's <layout>.elements.json sidecar).
+  # `title` of nil/empty skips the header band (e.g. when the caller bands an
+  # existing title text element explicitly).
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}")
+    extra = []
+    children = []
+    offset = 0
+    if title && !title.to_s.empty?
+      hdr_id = "#{id_prefix}-hdr"
+      txt_id = "#{id_prefix}-hdrtext"
+      extra << container_el(hdr_id, HEADER_STYLE.dup)
+      extra << header_text_el(txt_id, title)
+      children << header_band_xml(hdr_id, txt_id)
+      offset = HEADER_ROWS
+    end
+    top = items.map { |i| i[3] }.min
+    offset += (1 - top) if top # first band starts right under the header
+    cluster_bands(items).each_with_index do |band, i|
+      cid = "#{id_prefix}-#{i + 1}"
+      extra << container_el(cid)
+      children << band_container_xml(cid, band, row_offset: offset)
+    end
+    [page_xml(page_id, *children), extra]
   end
 end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/put-layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/put-layout.rb
@@ -2,8 +2,17 @@
 # GET a workbook spec, replace per-page layouts with a single top-level layout
 # XML (provided), strip read-only fields, PUT back.
 #
+# Container layouts: a <GridContainer> in the layout XML must be paired with a
+# `kind: container` placeholder element in the spec (else it is silently
+# dropped — layout-playbook.md). Layout builders that emit GridContainers
+# write a sidecar `<layout>.elements.json` ({pageId: [element, ...]}) next to
+# the layout XML; this script injects those elements (containers + header
+# text) into the matching pages before the PUT. Pass --elements to override
+# the sidecar path. Injection is idempotent (existing element ids are kept).
+#
 # Usage:
-#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml>
+#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml> \
+#     [--elements <elements.json>]
 
 require 'net/http'
 require 'uri'
@@ -16,6 +25,7 @@ opts = {}
 OptionParser.new do |p|
   p.on('--workbook ID') { |v| opts[:wb] = v }
   p.on('--layout PATH') { |v| opts[:layout] = v }
+  p.on('--elements PATH', 'spec elements to inject (default: <layout>.elements.json if present)') { |v| opts[:elements] = v }
 end.parse!
 %i[wb layout].each { |k| abort("missing --#{k}") unless opts[k] }
 
@@ -39,6 +49,28 @@ abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
 spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec").body)
 spec['pages'].each { |p| p.delete('layout') }
 spec['layout'] = xml
+
+# Inject container/header-text spec elements (see header comment).
+elements_path = opts[:elements] || "#{opts[:layout]}.elements.json"
+if File.exist?(elements_path)
+  inject = JSON.parse(File.read(elements_path))
+  injected = 0
+  inject.each do |page_id, els|
+    page = spec['pages'].find { |p| p['id'] == page_id }
+    unless page
+      warn "WARN: elements sidecar references unknown page #{page_id.inspect} — skipped"
+      next
+    end
+    page['elements'] ||= []
+    existing = page['elements'].map { |e| e['id'] }
+    els.each do |el|
+      next if existing.include?(el['id'])
+      page['elements'] << el
+      injected += 1
+    end
+  end
+  puts "injected #{injected} container/header element(s) from #{elements_path}"
+end
 %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
 
 resp = http(:put, "/v2/workbooks/#{opts[:wb]}/spec", JSON.pretty_generate(spec))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -268,10 +268,15 @@ unless opts[:skip_layout]
         # gridColumn value (typically "1 / 13" — left half, vertically stacked).
         # Note: per-page detection — a workbook with one element per content
         # page is structurally fine (degenerate case, not a stack).
+        # Container-banded pages (<GridContainer> bands per layout-playbook.md)
+        # are exempt: full-width band containers (and single-chart rows inside
+        # them) legitimately share gridColumn="1 / 25" — that is deliberate
+        # banding, not the auto-stack regression.
         non_data_stack_pages = []
         # Walk one page at a time using the <Page id="..."> blocks
         layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
           next if page_id.to_s.downcase.include?('data')
+          next if page_body.include?('<GridContainer')
           cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
           elems_on_page = page_body.scan(/<LayoutElement\b/).length
           if elems_on_page >= 2 && cols_on_page.length == 1

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -40,6 +40,8 @@
 
 require 'json'
 require 'optparse'
+require_relative 'lib/layout'
+include SigmaLayout
 
 opts = { page_cols: 24, page_rows: 32, row_scale: 1.5, chart_y0: 29.7,
          chart_y1: 100.0, chart_row0: 6, renames: {} }
@@ -148,33 +150,59 @@ rows.each_value do |row_charts|
   end
 end
 
-# Render
-lines = ['<?xml version="1.0" encoding="utf-8"?>']
-lines << %(<Page type="grid" gridTemplateColumns="repeat(#{opts[:page_cols]}, 1fr)" gridTemplateRows="auto" id="page-data">)
-lines << %(  <LayoutElement elementId="#{master_el['id']}" gridColumn="1 / #{opts[:page_cols] + 1}" gridRow="1 / 21"/>)
-lines << '</Page>'
+# Render — container-banded page (layout-playbook.md): header band + control
+# band + one full-width GridContainer per chart row, children container-relative.
+data_page_xml = page_xml('page-data',
+                         le(master_el['id'], 1, opts[:page_cols] + 1, 1, 21))
 
-lines << %(<Page type="grid" gridTemplateColumns="repeat(#{opts[:page_cols]}, 1fr)" gridTemplateRows="auto" id="#{overview['id']}">)
+children = []
+extra_els = []
+ov_prefix = "band-#{overview['id']}"
+
+# Header band: reuse the spec's existing title text if present, else add one
+# (sidecar) named after the overview page.
+hdr_id = "#{ov_prefix}-hdr"
+extra_els << container_el(hdr_id, HEADER_STYLE.dup)
 if title_el
-  lines << %(  <LayoutElement elementId="#{title_el['id']}" gridColumn="1 / #{opts[:page_cols] + 1}" gridRow="1 / 3"/>)
+  children << header_band_xml(hdr_id, title_el['id'])
+else
+  txt_id = "#{ov_prefix}-hdrtext"
+  extra_els << header_text_el(txt_id, overview['name'])
+  children << header_band_xml(hdr_id, txt_id)
 end
 
-# Distribute controls evenly across the top row (cols 1, 1+W, 1+2W, ... where W = total/n)
+# Control band: dashboard-global controls side-by-side in one container
+# directly under the header.
 n = ctl_els.length
+ctl_rows = 0
 if n > 0
+  ctl_rows = 3
   col_width = (opts[:page_cols].to_f / n).round
-  ctl_els.each_with_index do |c, i|
+  inner = ctl_els.each_with_index.map do |c, i|
     col_start = 1 + i * col_width
     col_end   = i == n - 1 ? opts[:page_cols] + 1 : col_start + col_width
-    lines << %(  <LayoutElement elementId="#{c['id']}" gridColumn="#{col_start} / #{col_end}" gridRow="3 / 6"/>)
-  end
+    le(c['id'], col_start, col_end, 1, 1 + ctl_rows)
+  end.join("\n")
+  ctl_id = "#{ov_prefix}-ctl"
+  extra_els << container_el(ctl_id)
+  children << gc(ctl_id, 1, opts[:page_cols] + 1, 1 + HEADER_ROWS, 1 + HEADER_ROWS + ctl_rows, inner)
 end
 
-chart_layouts.each do |c|
-  lines << %(  <LayoutElement elementId="#{c[:el_id]}" gridColumn="#{c[:c1]} / #{c[:c2]}" gridRow="#{c[:r1]} / #{c[:r2]}"/>)
+# Chart bands: cluster the zone-derived positions into row bands (preserving
+# the Tableau geometry within each band) and shift the whole chart area so the
+# first band starts right under the header + control bands.
+chart_items = chart_layouts.map { |c| [c[:el_id], c[:c1], c[:c2], c[:r1], c[:r2]] }
+bands = cluster_bands(chart_items)
+content_start = 1 + HEADER_ROWS + ctl_rows
+band_offset = bands.empty? ? 0 : content_start - bands.first.map { |i| i[3] }.min
+bands.each_with_index do |band, i|
+  cid = "#{ov_prefix}-#{i + 1}"
+  extra_els << container_el(cid)
+  children << band_container_xml(cid, band, row_offset: band_offset)
 end
 
-lines << '</Page>'
-
-File.write(opts[:out], lines.join("\n") + "\n")
-puts "wrote #{opts[:out]} (#{chart_layouts.length} charts, #{ctl_els.length} controls, gap-closing applied, row-scale #{opts[:row_scale]}× → #{opts[:page_rows]} rows)"
+File.write(opts[:out], assemble(data_page_xml, page_xml(overview['id'], *children)) + "\n")
+File.write("#{opts[:out]}.elements.json", JSON.pretty_generate({ overview['id'] => extra_els }))
+puts "wrote #{opts[:out]} (#{chart_layouts.length} charts in #{bands.length} band container(s), " \
+     "#{ctl_els.length} controls, header band, gap-closing applied, row-scale #{opts[:row_scale]}× → #{opts[:page_rows]} rows)"
+puts "wrote #{opts[:out]}.elements.json (#{extra_els.length} container/header spec element(s) — put-layout.rb injects these)"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout.rb
@@ -1,6 +1,16 @@
 # Layout-XML helpers. require'd by per-workbook layout configs.
+#
+# Container-based layouts (layout-playbook.md, verified 2026-06-10):
+#   - spec side: a `kind: container` placeholder element per band
+#     (container_el / header_text_el below build those spec objects)
+#   - layout side: a <GridContainer> (NOT <LayoutElement type="grid">, which
+#     silently drops children) whose child <LayoutElement>s use
+#     CONTAINER-RELATIVE coordinates (rows restart at 1).
 module SigmaLayout
   module_function
+
+  HEADER_STYLE = { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' }.freeze
+  HEADER_ROWS  = 3 # header band height in grid rows
 
   def gc(eid, c0, c1, r0, r1, inner)
     "<GridContainer elementId=\"#{eid}\" type=\"grid\" " \
@@ -19,5 +29,81 @@ module SigmaLayout
 
   def assemble(*pages)
     %(<?xml version="1.0" encoding="utf-8"?>\n) + pages.join("\n")
+  end
+
+  # ---- container-layout helpers --------------------------------------------
+
+  # Spec-side placeholder for a band container.
+  def container_el(id, style = nil)
+    el = { 'id' => id, 'kind' => 'container' }
+    el['style'] = style if style
+    el
+  end
+
+  # Spec-side page-title text element (white text over the dark header band).
+  def header_text_el(id, title)
+    { 'id' => id, 'kind' => 'text',
+      'body' => %(# <span style="color: #FFFFFF">#{title}</span>) }
+  end
+
+  # Header band XML: dark full-width container at the top of the page wrapping
+  # the title text (child coordinates are container-relative).
+  def header_band_xml(container_id, text_id, rows: HEADER_ROWS)
+    gc(container_id, 1, 25, 1, 1 + rows, le(text_id, 1, 25, 1, 1 + rows))
+  end
+
+  # Cluster placed items into horizontal bands by row overlap. Items are
+  # [eid, c0, c1, r0, r1, *rest] tuples with PAGE-ABSOLUTE rows. Returns an
+  # array of bands (each an array of items), top-to-bottom.
+  def cluster_bands(items)
+    bands = []
+    items.sort_by { |i| [i[3], i[1]] }.each do |it|
+      if bands.any? && it[3] < bands.last[:r1]
+        bands.last[:items] << it
+        bands.last[:r1] = [bands.last[:r1], it[4]].max
+      else
+        bands << { r0: it[3], r1: it[4], items: [it] }
+      end
+    end
+    bands.map { |b| b[:items] }
+  end
+
+  # One band of items -> a full-width GridContainer spanning the band's row
+  # range at page level, children re-emitted with CONTAINER-RELATIVE rows.
+  # row_offset shifts the container's page-level position (e.g. +3 when a
+  # header band was prepended above the original geometry).
+  def band_container_xml(cid, items, row_offset: 0)
+    r0 = items.map { |i| i[3] }.min
+    r1 = items.map { |i| i[4] }.max
+    inner = items.map { |i| le(i[0], i[1], i[2], i[3] - r0 + 1, i[4] - r0 + 1) }.join("\n")
+    gc(cid, 1, 25, r0 + row_offset, r1 + row_offset, inner)
+  end
+
+  # Full container-banded page: header band + one container per row band.
+  # Returns [page_xml_string, extra_spec_elements] — the caller must add the
+  # extra elements (containers + header text) to the page's spec `elements`
+  # (directly, or via put-layout.rb's <layout>.elements.json sidecar).
+  # `title` of nil/empty skips the header band (e.g. when the caller bands an
+  # existing title text element explicitly).
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}")
+    extra = []
+    children = []
+    offset = 0
+    if title && !title.to_s.empty?
+      hdr_id = "#{id_prefix}-hdr"
+      txt_id = "#{id_prefix}-hdrtext"
+      extra << container_el(hdr_id, HEADER_STYLE.dup)
+      extra << header_text_el(txt_id, title)
+      children << header_band_xml(hdr_id, txt_id)
+      offset = HEADER_ROWS
+    end
+    top = items.map { |i| i[3] }.min
+    offset += (1 - top) if top # first band starts right under the header
+    cluster_bands(items).each_with_index do |band, i|
+      cid = "#{id_prefix}-#{i + 1}"
+      extra << container_el(cid)
+      children << band_container_xml(cid, band, row_offset: offset)
+    end
+    [page_xml(page_id, *children), extra]
   end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/put-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/put-layout.rb
@@ -2,8 +2,17 @@
 # GET a workbook spec, replace per-page layouts with a single top-level layout
 # XML (provided), strip read-only fields, PUT back.
 #
+# Container layouts: a <GridContainer> in the layout XML must be paired with a
+# `kind: container` placeholder element in the spec (else it is silently
+# dropped — layout-playbook.md). Layout builders that emit GridContainers
+# write a sidecar `<layout>.elements.json` ({pageId: [element, ...]}) next to
+# the layout XML; this script injects those elements (containers + header
+# text) into the matching pages before the PUT. Pass --elements to override
+# the sidecar path. Injection is idempotent (existing element ids are kept).
+#
 # Usage:
-#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml>
+#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml> \
+#     [--elements <elements.json>]
 
 require 'net/http'
 require 'uri'
@@ -16,6 +25,7 @@ opts = {}
 OptionParser.new do |p|
   p.on('--workbook ID') { |v| opts[:wb] = v }
   p.on('--layout PATH') { |v| opts[:layout] = v }
+  p.on('--elements PATH', 'spec elements to inject (default: <layout>.elements.json if present)') { |v| opts[:elements] = v }
 end.parse!
 %i[wb layout].each { |k| abort("missing --#{k}") unless opts[k] }
 
@@ -39,6 +49,28 @@ abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
 spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec").body)
 spec['pages'].each { |p| p.delete('layout') }
 spec['layout'] = xml
+
+# Inject container/header-text spec elements (see header comment).
+elements_path = opts[:elements] || "#{opts[:layout]}.elements.json"
+if File.exist?(elements_path)
+  inject = JSON.parse(File.read(elements_path))
+  injected = 0
+  inject.each do |page_id, els|
+    page = spec['pages'].find { |p| p['id'] == page_id }
+    unless page
+      warn "WARN: elements sidecar references unknown page #{page_id.inspect} — skipped"
+      next
+    end
+    page['elements'] ||= []
+    existing = page['elements'].map { |e| e['id'] }
+    els.each do |el|
+      next if existing.include?(el['id'])
+      page['elements'] << el
+      injected += 1
+    end
+  end
+  puts "injected #{injected} container/header element(s) from #{elements_path}"
+end
 %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
 
 resp = http(:put, "/v2/workbooks/#{opts[:wb]}/spec", JSON.pretty_generate(spec))

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
@@ -33,42 +33,87 @@ def req(method, path, body=None):
     except urllib.error.HTTPError as e:
         raise RuntimeError(f"{method} {path} -> {e.code}: {e.read().decode()[:300]}")
 
-def tiles_page_xml(page_id, tiles):
-    """ThoughtSpot tile geometry → Sigma grid. tiles: [{element_id,x,y,width,height}]
-    in TS 12-col units."""
-    out = [f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">']
+# ---- container-banded layout (layout-playbook.md, verified 2026-06-10) -----
+# Spec side: a `kind: container` placeholder element per band + a header text
+# element. Layout side: <GridContainer> (NOT <LayoutElement type="grid">, which
+# silently drops children) wrapping <LayoutElement>s with CONTAINER-RELATIVE
+# coordinates (rows restart at 1).
+HEADER_STYLE = {"backgroundColor": "#0F172A", "borderRadius": "round"}
+HEADER_ROWS = 3
+
+def _le(eid, c0, c1, r0, r1):
+    return f'  <LayoutElement elementId="{eid}" gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}"/>'
+
+def _gc(cid, r0, r1, inner):
+    return (f'<GridContainer elementId="{cid}" type="grid" gridColumn="1 / 25" '
+            f'gridRow="{r0} / {r1}" gridTemplateColumns="repeat(24, 1fr)" '
+            f'gridTemplateRows="auto">\n{inner}\n</GridContainer>')
+
+def banded_page(page_id, items, title):
+    """items: [eid, c0, c1, r0, r1] page-absolute. Header band + one container
+    per row band (children relative; relative TS proportions preserved inside).
+    Returns (page_xml, extra_spec_elements)."""
+    extra, children = [], []
+    extra.append({"id": "band-hdr", "kind": "container", "style": dict(HEADER_STYLE)})
+    extra.append({"id": "band-hdrtext", "kind": "text",
+                  "body": f'# <span style="color: #FFFFFF">{title}</span>'})
+    children.append(_gc("band-hdr", 1, 1 + HEADER_ROWS, _le("band-hdrtext", 1, 25, 1, 1 + HEADER_ROWS)))
+    offset = HEADER_ROWS + (1 - min(i[3] for i in items) if items else 0)
+    bands = []
+    for it in sorted(items, key=lambda i: (i[3], i[1])):
+        if bands and it[3] < bands[-1]["r1"]:
+            bands[-1]["items"].append(it)
+            bands[-1]["r1"] = max(bands[-1]["r1"], it[4])
+        else:
+            bands.append({"r0": it[3], "r1": it[4], "items": [it]})
+    for n, b in enumerate(bands, 1):
+        cid = f"band-{n}"
+        extra.append({"id": cid, "kind": "container"})
+        inner = "\n".join(_le(i[0], i[1], i[2], i[3] - b["r0"] + 1, i[4] - b["r0"] + 1)
+                          for i in b["items"])
+        children.append(_gc(cid, b["r0"] + offset, b["r1"] + offset, inner))
+    body = "\n".join(children)
+    return (f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" '
+            f'gridTemplateRows="auto" id="{page_id}">\n{body}\n</Page>', extra)
+
+def tiles_items(tiles, kinds=None):
+    """ThoughtSpot tile geometry → Sigma grid items (TS 12-col units → 24).
+    KPI tiles are padded to >= 5 grid rows (Sigma hides the KPI title below
+    that — layout-playbook.md)."""
+    items = []
     for t in tiles:
         c0 = t["x"] * COL_SCALE + 1
         c1 = min(t["x"] + t["width"], TS_GRID_COLS) * COL_SCALE + 1
         r0 = t["y"] * ROW_SCALE + 1
         r1 = (t["y"] + t["height"]) * ROW_SCALE + 1
-        out.append(f'  <LayoutElement elementId="{t["element_id"]}" gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}"/>')
-    out.append("</Page>")
-    return "\n".join(out)
+        if (kinds or {}).get(t["element_id"]) == "kpi-chart" and r1 - r0 < 5:
+            r1 = r0 + 5
+        items.append([t["element_id"], c0, c1, r0, r1])
+    return items
 
-def page_xml(page_id, elems):
-    """Auto grid fallback (no TML geometry): KPIs across the top row (split
-    evenly, 5 rows tall); others 2-wide, 11 rows."""
+def auto_items(elems):
+    """Auto grid fallback (no TML geometry): KPI strip (5+ rows, titles render),
+    then charts 2-wide, 11 rows."""
     kpis = [e for e in elems if e["kind"] == "kpi-chart"]
     charts = [e for e in elems if e["kind"] not in ("kpi-chart",)]
-    out = [f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{page_id}">']
+    items, row = [], 1
     if kpis:
         w = 24 // len(kpis)
         for i, e in enumerate(kpis):
             c0 = 1 + i * w; c1 = (c0 + w) if i < len(kpis) - 1 else 25
-            out.append(f'  <LayoutElement elementId="{e["id"]}" gridColumn="{c0} / {c1}" gridRow="1 / 6"/>')
-    row = 6
+            items.append([e["id"], c0, c1, 1, 6])
+        row = 6
     for i in range(0, len(charts), 2):
         pair = charts[i:i + 2]
         for j, e in enumerate(pair):
             c0 = 1 if j == 0 else 13
             c1 = 13 if (j == 0 and len(pair) > 1) else 25
-            out.append(f'  <LayoutElement elementId="{e["id"]}" gridColumn="{c0} / {c1}" gridRow="{row} / {row+11}"/>')
+            items.append([e["id"], c0, c1, row, row + 11])
         row += 11
-    out.append("</Page>")
-    return "\n".join(out)
+    return items
 
 def build_layout(spec, tiles=None):
+    """Returns (layout_xml, main_page, extra_spec_elements)."""
     pages = spec["pages"]
     data = next((p for p in pages if p.get("name") == "Data"), None)
     main = next((p for p in pages if p.get("name") != "Data"), None)
@@ -79,15 +124,23 @@ def build_layout(spec, tiles=None):
         lines.append(f'  <LayoutElement elementId="{mid}" gridColumn="1 / 25" gridRow="1 / 21"/>')
         lines.append('</Page>')
     if tiles:
-        lines.append(tiles_page_xml(main["id"], tiles))
+        items = tiles_items(tiles, kinds={e["id"]: e.get("kind") for e in main["elements"]})
     else:
-        elems = [{"id": e["id"], "kind": e["kind"]} for e in main["elements"]]
-        lines.append(page_xml(main["id"], elems))
-    return "\n".join(lines) + "\n"
+        elems = [{"id": e["id"], "kind": e["kind"]} for e in main["elements"]
+                 if e.get("kind") != "container" and not str(e.get("id", "")).startswith("band-")]
+        items = auto_items(elems)
+    title = main.get("name") or spec.get("name") or "Dashboard"
+    page, extra = banded_page(main["id"], items, title)
+    lines.append(page)
+    return "\n".join(lines) + "\n", main, extra
 
 def apply(wb, tiles=None):
     spec = json.loads(req("GET", f"/v2/workbooks/{wb}/spec"))
-    xml = build_layout(spec, tiles=tiles)
+    xml, main, extra = build_layout(spec, tiles=tiles)
+    # idempotent: drop previously-injected band elements, then add this run's
+    main["elements"] = [e for e in main["elements"]
+                        if not (str(e.get("id", "")).startswith("band-")
+                                and e.get("kind") in ("container", "text"))] + extra
     for p in spec["pages"]:
         p.pop("layout", None)
     spec["layout"] = xml

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -268,10 +268,15 @@ unless opts[:skip_layout]
         # gridColumn value (typically "1 / 13" — left half, vertically stacked).
         # Note: per-page detection — a workbook with one element per content
         # page is structurally fine (degenerate case, not a stack).
+        # Container-banded pages (<GridContainer> bands per layout-playbook.md)
+        # are exempt: full-width band containers (and single-chart rows inside
+        # them) legitimately share gridColumn="1 / 25" — that is deliberate
+        # banding, not the auto-stack regression.
         non_data_stack_pages = []
         # Walk one page at a time using the <Page id="..."> blocks
         layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
           next if page_id.to_s.downcase.include?('data')
+          next if page_body.include?('<GridContainer')
           cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
           elems_on_page = page_body.scan(/<LayoutElement\b/).length
           if elems_on_page >= 2 && cols_on_page.length == 1


### PR DESCRIPTION
## What

Ports the verified container-layout recipe (`~/migration-visual-qa/enhance-trial/layout-playbook.md`, live-verified 2026-06-10) into **every** migration plugin's layout builder. Pages are no longer flat `<LayoutElement>` lists (the source of dead zones / detached controls); they are banded:

1. **Header band** — dark (`#0F172A`, `borderRadius: round`) full-width container with the page/workbook title (white `#` heading), added unless the spec already has a title text (tableau reuses its existing one).
2. **Control band** — global filters side-by-side in one container.
3. **KPI band** — tall tiles (≥5 rows so titles render).
4. **Chart row bands** — one full-width `<GridContainer>` per row, children with **container-relative** coordinates; source-tool geometry (Tableau zones, PBI canvas, QS 36-col grid, Qlik cell grid, Looker newspaper, TS TML tiles) preserved *inside* each band.

Contract per the playbook: each `<GridContainer>` needs a matching `kind: container` spec element or it is **silently dropped** — every builder now provides those (directly in the spec it generates, via the GET→PUT cycle, or via a new `<layout>.elements.json` sidecar that `put-layout.rb` injects).

## Per-builder changes

| Builder | Change |
|---|---|
| tableau `build-dashboard-layout.rb` | zone bands → header + control band + per-row containers; keeps `--row-scale`/`--rename`; emits sidecar |
| powerbi `build-workbook-from-pbir.rb` | canvas regions → row bands (slicers band with adjacent charts by geometry); title → header band; containers embedded at POST |
| quicksight `build-quicksight-layout.rb` | 36-col rows → band containers; sheet-name header; sidecar |
| qlik `build-sigma-workbook.py` (+ `batch-migrate.py` local heuristic) | cell-grid rows wrapped in containers, proportions kept; KPI strip = KPI band; sheet-title header |
| looker `build_workbook.py` | header + control + KPI bands, newspaper rows clustered into chart bands; table-only bands capped at 12 rows |
| thoughtspot `apply_layouts.py` | TML tile rows → band containers (KPI tiles padded to ≥5 rows); banded auto-grid fallback; idempotent spec-element injection |
| cognos `apply-layout.mjs` | header + control band + KPI panel + charts paired 2-across per row container; readback now asserts GridContainers survived |

## Shared plumbing (vendored copies byte-identical, md5-verified)

- `lib/layout.rb` ×4 (tableau/powerbi/quicksight/qlik-vendor): band clustering, `banded_page`, container/header spec-element helpers — `5b4c178280de6b76adb02a78726847b3`
- `put-layout.rb` ×4: `--elements` / auto-detected `<layout>.elements.json` sidecar injection — `28769dd7d30c07ac27f3710a8a4076c0`
- `assert-phase6-ran.rb` ×5 (tableau/powerbi/quicksight/looker/thoughtspot): gate-4 stack heuristic exempts pages containing `<GridContainer>` (full-width band containers legitimately share `gridColumn="1 / 25"`) — `fb082da46127debec345971acbcca7c3`

Also fixes a pre-existing crash in `migrate-looker.py` offline parity (`measure_value` unpacked 3 values from the 4-tuple `build_field_index` now emits).

## E2E (org tj-wells-1989 — all layouts from the scripts, zero hand-fixes, workbooks KEPT)

- **CONT Looker** `c4a5329b` — `migrate-looker.py` (skilltest-orders fixtures): parity 5/5 strict, `assert-phase6-ran` all gates green (gate 4 passed on the container layout)
- **CONT QuickSight Orders Overview** `4ff7508f` — `migrate-quicksight.rb --from-fixtures` (conn bc0319f8, folder "QuickSight Migrations"): parity 5/5 strict, hard gate green, sidecar injection verified on readback
- **CONT Cognos GO sales performance** `5153d9e4` — `migrate-cognos.mjs` fixtures (conn cb2f5180): `assert-parity` GREEN 20/20 (expected derived from the synthetic source tables + report filter semantics)

Full-page PNGs exported to `~/migration-visual-qa/containers/` and reviewed: header band present, even chart rows, controls adjacent/banded, no dead zones.

Tableau / PBI / qlik / TS builders validated via synthetic + fixture dry-runs (XML + spec-element output inspected); qlik retail-orders fixture dry-run produced 40 GridContainers across 5 sheet pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)