### PR TITLE
find-or-pick-dm: deterministic tie-break for same-score DM candidates

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/find-or-pick-dm.rb
@@ -297,7 +297,18 @@ candidates = dm_signatures.map do |dm|
     'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
     'raw_element_count' => dm[:raw_element_count]
   }
-end.sort_by { |c| -c['score'] }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
 
 best = candidates.first
 second = candidates[1]
@@ -309,7 +320,11 @@ second = candidates[1]
 auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
 auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
 tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
-auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && !tie_with_second
+# A same-score tie is safe to pick through when the deterministic tie-break
+# landed on an exact workbook-name match — the hazard the tie window guards
+# against is arbitrary ordering among lookalikes, which no longer applies.
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && (!tie_with_second || best_name_matches)
 
 # Standard recommend path keeps the old semantics.
 recommended_via_std  = best && best['score'] >= opts[:min_score]

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/find-or-pick-dm.rb
@@ -297,7 +297,18 @@ candidates = dm_signatures.map do |dm|
     'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
     'raw_element_count' => dm[:raw_element_count]
   }
-end.sort_by { |c| -c['score'] }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
 
 best = candidates.first
 second = candidates[1]
@@ -309,7 +320,11 @@ second = candidates[1]
 auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
 auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
 tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
-auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && !tie_with_second
+# A same-score tie is safe to pick through when the deterministic tie-break
+# landed on an exact workbook-name match — the hazard the tie window guards
+# against is arbitrary ordering among lookalikes, which no longer applies.
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && (!tie_with_second || best_name_matches)
 
 # Standard recommend path keeps the old semantics.
 recommended_via_std  = best && best['score'] >= opts[:min_score]

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/find-or-pick-dm.rb
@@ -297,7 +297,18 @@ candidates = dm_signatures.map do |dm|
     'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
     'raw_element_count' => dm[:raw_element_count]
   }
-end.sort_by { |c| -c['score'] }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
 
 best = candidates.first
 second = candidates[1]
@@ -309,7 +320,11 @@ second = candidates[1]
 auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
 auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
 tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
-auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && !tie_with_second
+# A same-score tie is safe to pick through when the deterministic tie-break
+# landed on an exact workbook-name match — the hazard the tie window guards
+# against is arbitrary ordering among lookalikes, which no longer applies.
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && (!tie_with_second || best_name_matches)
 
 # Standard recommend path keeps the old semantics.
 recommended_via_std  = best && best['score'] >= opts[:min_score]

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/find-or-pick-dm.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/find-or-pick-dm.rb
@@ -297,7 +297,18 @@ candidates = dm_signatures.map do |dm|
     'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
     'raw_element_count' => dm[:raw_element_count]
   }
-end.sort_by { |c| -c['score'] }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
 
 best = candidates.first
 second = candidates[1]
@@ -309,7 +320,11 @@ second = candidates[1]
 auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
 auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
 tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
-auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && !tie_with_second
+# A same-score tie is safe to pick through when the deterministic tie-break
+# landed on an exact workbook-name match — the hazard the tie window guards
+# against is arbitrary ordering among lookalikes, which no longer applies.
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && (!tie_with_second || best_name_matches)
 
 # Standard recommend path keeps the old semantics.
 recommended_via_std  = best && best['score'] >= opts[:min_score]

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/find-or-pick-dm.rb
@@ -297,7 +297,18 @@ candidates = dm_signatures.map do |dm|
     'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
     'raw_element_count' => dm[:raw_element_count]
   }
-end.sort_by { |c| -c['score'] }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
 
 best = candidates.first
 second = candidates[1]
@@ -309,7 +320,11 @@ second = candidates[1]
 auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
 auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
 tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
-auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && !tie_with_second
+# A same-score tie is safe to pick through when the deterministic tie-break
+# landed on an exact workbook-name match — the hazard the tie window guards
+# against is arbitrary ordering among lookalikes, which no longer applies.
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && (!tie_with_second || best_name_matches)
 
 # Standard recommend path keeps the old semantics.
 recommended_via_std  = best && best['score'] >= opts[:min_score]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/find-or-pick-dm.rb
@@ -297,7 +297,18 @@ candidates = dm_signatures.map do |dm|
     'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
     'raw_element_count' => dm[:raw_element_count]
   }
-end.sort_by { |c| -c['score'] }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
 
 best = candidates.first
 second = candidates[1]
@@ -309,7 +320,11 @@ second = candidates[1]
 auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
 auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
 tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
-auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && !tie_with_second
+# A same-score tie is safe to pick through when the deterministic tie-break
+# landed on an exact workbook-name match — the hazard the tie window guards
+# against is arbitrary ordering among lookalikes, which no longer applies.
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && (!tie_with_second || best_name_matches)
 
 # Standard recommend path keeps the old semantics.
 recommended_via_std  = best && best['score'] >= opts[:min_score]

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/find-or-pick-dm.rb
@@ -297,7 +297,18 @@ candidates = dm_signatures.map do |dm|
     'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
     'raw_element_count' => dm[:raw_element_count]
   }
-end.sort_by { |c| -c['score'] }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
 
 best = candidates.first
 second = candidates[1]
@@ -309,7 +320,11 @@ second = candidates[1]
 auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
 auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
 tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
-auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && !tie_with_second
+# A same-score tie is safe to pick through when the deterministic tie-break
+# landed on an exact workbook-name match — the hazard the tie window guards
+# against is arbitrary ordering among lookalikes, which no longer applies.
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && (!tie_with_second || best_name_matches)
 
 # Standard recommend path keeps the old semantics.
 recommended_via_std  = best && best['score'] >= opts[:min_score]


### PR DESCRIPTION
## Problem

`find-or-pick-dm.rb` sorts candidates by score only. Identical scores are common — duplicate or derived DMs sourcing the same tables/columns all tie — so ordering among ties is arbitrary, and both the standard recommendation and `--auto-pick` can land on a sprawling lookalike instead of the purpose-built twin.

Observed live (tj-wells-1989, Orders Executive Overview full conversion 2026-06-10): three identical "Orders Executive Overview" DMs (3 extra columns each) tied at 0.9 with dbt test models carrying 63 extra columns — and a dbt model won the ordering. (The run also surfaced that the stale staging copy still had the pre-fix `source.path` array bug, which masked table matching entirely; that fix is already on main — staging has been synced locally.)

## Fix

- **Deterministic tie-break**: sort by score, then exact workbook-name match, then fewest inherited extra columns.
- **Auto-pick tie window**: a same-score tie no longer blocks `--auto-pick` when the winner is an exact name match — the hazard the window guards against (arbitrary ordering among lookalikes) no longer applies in that case.
- Mirrored to all 7 plugin copies (tableau, looker, powerbi, cognos, quicksight, thoughtspot, and qlik's `scripts/vendor/`).

## Verification

Ran against the live org with the Orders Executive Overview signature: top-3 candidates are now the three name-match twins (extra_cols 3) ahead of "VISQA3 Tableau Orders" (14) and "Orders Executive Suite" (15); recommendation flips from a dbt lookalike to a twin. `ruby -c` clean on all copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)