### PR TITLE
Phase E (opt-in) — Enhancement Phase for tableau-to-sigma + powerbi-to-sigma (bead zb7h)

### DIFF
--- a/docs/phase-schema.md
+++ b/docs/phase-schema.md
@@ -38,7 +38,7 @@ has been edited since).
 | C7 Layout | within Phase 5 (5c/5d layout passes) | Phase 5d — Layout | within Phase 4 (build-sigma-workbook.py) | Phase 6 — Layout | within Phase 3 (newspaper layout) | within Phase 3 (apply-layout.mjs) | Pipeline step 5 — Layout (LAST write) |
 | C8 Parity hard gate | Phase 6 — Verify (hard-gated by assert-phase6-ran.rb) | Phase 6 — Verify (mandatory) | Phase 5 — Parity (hard gate) | Phase 7 — Parity (hard gate) | Phase 4 — Verify parity (3-way, MANDATORY) | Phase 4 — Verify parity (hard gate) | Pipeline step 6 — Parity |
 | C9 Security/RLS | "Security: RLS/CLS" section (unnumbered) | "Security: RLS/CLS" section | "Security: RLS/CLS" section | "Security: RLS/CLS" section | Phase 1d scan + Phase 1.5 RLS decision gate (before building) | "Security: RLS/CLS" section | "Security: RLS/CLS" section |
-| C10 Enhance | post-Phase-6 polish (demo-skill Phase 5 Enhance arc) | Phase 7 — Bookmarks → per-bookmark workbooks (optional) | — | — | Phase 5 — Enhance (UI-only features) | — | — |
+| C10 Enhance | **Phase E (opt-in)** — `--enhance` on migrate-tableau.rb (shared enhance-scan/apply engine) | **Phase E (opt-in)** — `--enhance` on migrate-powerbi.rb (same shared engine) + Phase 7 Bookmarks | — | — | Phase 5 — Enhance (UI-only features) | — | — |
 
 Notes:
 
@@ -52,3 +52,13 @@ Notes:
   that cross-reference and add a row here.
 - Regression-test converter changes against `corpus/` (see corpus/README.md)
   before relying on a live tenant.
+- **Phase E (C10) is OPT-IN ONLY and shared.** tableau-to-sigma and
+  powerbi-to-sigma vendor a byte-identical engine
+  (`scripts/enhance-scan.rb` + `scripts/enhance-apply.rb` — md5 discipline,
+  same as escalate-gap.py) triggered exclusively by `--enhance` on their
+  one-command orchestrators. It never runs in batch/headless without the
+  flag; nothing applies without `--enhance-accept`; it clones the
+  parity-verified workbook ("<name> — Enhanced") and never touches the 1:1
+  artifact; every applied item is gated by a parity-unchanged spot-check
+  that auto-reverts on divergence. Other skills should adopt the same
+  vendored engine + flag convention when they grow a Phase E.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/QUICKSTART.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/QUICKSTART.md
@@ -123,9 +123,20 @@ ruby scripts/migrate-powerbi.rb \
   --pbir   /path/to/Report.json \
   --connection <SIGMA_CONN_UUID> --database <DB> --schema <SCHEMA> \
   --ref-dm <referenceDataModelId> \
-  [--name "Sales Overview (from Power BI)"] [--folder <id>] [--yes]
+  [--name "Sales Overview (from Power BI)"] [--folder <id>] [--yes] \
+  [--enhance [--enhance-accept all-low-risk]]   # Phase E (opt-in, default OFF)
 # exit 0 = done (parity pass) · 10 = decisions needed · 3 = parity fail
+# exit 14 = parity PASS + Phase E proposals pending --enhance-accept
 ```
+
+**Phase E (opt-in) — Enhance.** After parity passes, `--enhance` scans the source
+signals + built workbook and proposes trial-validated enhancements (period-comparison
+KPIs, grain switcher restoring the PBI date drill, selection controls, map
+restoration, null-label/freshness polish). Nothing is applied without
+`--enhance-accept`; accepted items land on a **clone** named "<name> — Enhanced"
+(the parity workbook is never touched), one at a time, each gated by an
+untouched-element parity spot-check that auto-reverts on any shift. See the
+SKILL.md "Phase E (opt-in) — Enhance" section.
 
 **Phase-by-phase** (`scripts/run.sh`, or drive the scripts directly) when you want to
 inspect or hand-tune each stage. The phases:

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -102,6 +102,67 @@ python3 scripts/build-bookmark-workbooks.py --signals $WORK/signals.json \
 - Validated 2026-06-02 on Retail Trends: Overview(8)/KPIs-Only(3)/Trend-Spotlight(1) → 3 workbooks, screenshot-verified.
 - `build-bookmark-workbooks.py` is **shared** (lives in `tableau-to-sigma/scripts`, symlinked here) and **vendor-neutral**: `--build-script` selects the signals→workbook builder; a normalized state's `filters: {col:[vals]}` is baked as a `list` filter (`{columnId, kind:list, mode:include, values}`) onto the Data-page **master** so every chart inherits it (page-filter semantics — verified end-to-end). Tableau's analog (Custom Views) feeds the same builder via `tableau-to-sigma/scripts/extract-custom-views.py` — note: Tableau REST exposes custom-view *metadata* only, not filter *values* (opaque state), so Tableau filter recovery needs the view-data-diff technique.
 
+## Phase E (opt-in) — Enhance
+
+**OFF by default, everywhere.** Phase E never runs in batch/headless mode
+without the explicit `--enhance` flag on `migrate-powerbi.rb`, and it only
+ever starts from a **parity-verified** workbook (Phase 6 PASS). It is powered
+by the shared engine vendored byte-identically into the covered plugins
+(`scripts/enhance-scan.rb` + `scripts/enhance-apply.rb` — md5 discipline,
+same as `escalate-gap.py`).
+
+```bash
+ruby scripts/migrate-powerbi.rb ... --yes \
+  --enhance                       # scan only → exit 14 with proposals
+# present each candidate to the user (one AskUserQuestion checklist), then:
+ruby scripts/migrate-powerbi.rb ... --yes \
+  --enhance --enhance-accept all-low-risk    # or: id1,id2,...
+```
+
+The contract (trial-validated, 2026-06-10):
+
+1. **Clone-first.** `enhance-apply.rb` GETs the parity workbook's spec and
+   POSTs it as `"<name> — Enhanced"`. The 1:1 parity artifact is **never
+   written** (the report records its `updatedAt` before/after as proof).
+2. **Scan-then-propose.** `enhance-scan.rb` reads source signals (workdir
+   artifacts: `signals.json`, `freshness.json`) + the built spec + live
+   element exports, and emits `enhancements.json` — each candidate
+   `{id, category, evidence, proposed, risk, verdict_hint, patch}`.
+   **Nothing applies without acceptance**: interactive runs present a per-item
+   checklist (AskUserQuestion); headless runs pass `--enhance-accept id1,id2`
+   or `--enhance-accept all-low-risk`.
+3. **Apply + parity-unchanged gate.** Accepted items apply **one at a time**
+   to the clone; after each, 2-3 untouched elements are spot-queried on the
+   clone AND the original at the same instant (live-drift-proof) — any shift
+   auto-reverts that item and flags it in `enhance-report.json`
+   (applied/skipped/reverted + evidence).
+
+Detector catalog (trial-validated; nothing speculative):
+
+- **comparison-enrichment** — date-grouped master + revenue-like measure →
+  latest-period KPI + delta-% KPI pair. KPI value columns INLINE the full
+  `Sum(If(D = Max(D), v, Null))` expression — cross-column aggregate refs
+  silently misevaluate in kpi-charts.
+- **interactivity-recovery** — (a) list **selection controls** on
+  reasonable-cardinality dims wired to the shared master (empty default =
+  identical render); (b) **grain switcher** — segmented control + DateTrunc
+  switch restoring the PBI date-hierarchy drill intent, default = parity
+  grain; (c) **drill switcher** — segmented control + `If()` dimension switch
+  where a finer dim exists (medium risk: heuristic hierarchy pairing);
+  (d) **map restoration** — an `azureMap`/`filledMap` visual the migration
+  approximated as a bar → point-map with `Switch()` centroid synthesis
+  (medium risk: centroids must be filled into the patch before apply).
+- **fidelity-polish** — null-bucket labeling (`Coalesce → "No <Dim>"`),
+  month/date axis canonicalization (`MakeDate`; medium risk on multi-year
+  sources — intentionally un-pools), stale-source freshness note (time-boxed
+  wording, fed by the Phase 2.5 freshness preflight), title corrections from
+  source captions.
+
+**Descoped — emitted as propose-in-UI notes, never spec changes** (all
+trial-proven spec-unsupported): DM-metric promotion (metric refs don't resolve
+through a workbook table), chart-as-filter (`useAsFilter` silently dropped on
+readback), pie percent labels (`valueFormat:'percent'` silently dropped).
+
 ## Reverse direction — author INTO Power BI
 The Fabric API is symmetric: `POST .../semanticModels` (TMSL parts) + `POST .../reports` (PBIR) create live items. Same device-code token (`user_impersonation` covers writes). Needs a Fabric-capacity workspace. See `scripts/fabric-auth-check.py` for the write-capability/capacity check.
 
@@ -117,6 +178,8 @@ The conversion is script-driven (mirrors `tableau-to-sigma/scripts/`). `scripts/
 | `convert-model.rb` | 2–3 convert/post | MODE A prints the exact `convert_powerbi_to_sigma` MCP call for a `model.bim`; MODE B takes the converter output and applies the 3 fixups (schemaVersion + folderId/ownerId via a ref-DM harvest + base-element names) → postable DM spec. |
 | `build-workbook-from-pbir.rb` | 4 build | `signals.json` + a `master-map.json` → full workbook spec + 24-col layout XML. Applies the measure-translation patterns in `refs/measure-patterns.md`; **line charts default to a single series** (`beads-sigma-c07`) unless PBI bound a Series/Legend role. **Carries the PBI visual sort** (`f972` — PBIR `query.sortDefinition` / classic `prototypeQuery.OrderBy` → chart `xAxis.sort`/`color.sort`; grouped table → `groupings[0].sort` — element-level sort is rejected on grouped tables). Analog of `build-charts-from-signals.rb`. |
 | `phase6-parity-pbi.rb` | 7 parity | executeQueries(DAX) adapter: `--emit-dax` runs the PBI side and writes the parity plan's `expected` rows; `--finalize` injects Sigma actuals and runs the shared `verify-parity.rb`. The PBI analog of Tableau's view-CSV parity adapter. |
+| `enhance-scan.rb` | E scan (opt-in) | **Phase E part 1 — SCAN (read-only).** Source signals + built spec + live element exports → `enhancements.json` candidates `{id, category, evidence, proposed, risk, verdict_hint, patch}` + descoped propose-in-UI notes. Shared Phase-E engine, vendored byte-identical across plugins (md5 discipline). |
+| `enhance-apply.rb` | E apply (opt-in) | **Phase E part 2 — APPLY (accept-only, clone-first).** Clones the parity workbook as `"<name> — Enhanced"` (1:1 artifact never written), applies ONLY `--accept`-ed candidates one at a time, each gated by an untouched-element clone-vs-original spot-check (auto-revert on shift). Writes `enhance-report.json`. Byte-identical twin of the tableau copy. |
 
 The agent authors one PBI-specific artifact: `master-map.json` (maps each PBI Entity → a Data-page master element and each `Entity.Field` queryRef → `{ref, agg}`), which encodes the DM element ids + DAX-measure→Sigma-aggregator decisions. Everything else is mechanical.
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
@@ -1,0 +1,392 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# enhance-apply.rb — Phase E (opt-in) shared engine, part 2 of 2: APPLY.
+#
+# CLONE-FIRST, ACCEPT-ONLY, PARITY-GATED application of enhancements.json
+# candidates produced by enhance-scan.rb:
+#   1. CLONE: GET the parity-verified workbook's spec and POST it as
+#      "<name> — Enhanced". The 1:1 parity artifact is NEVER written.
+#   2. ACCEPT: only candidates named in --accept (id list) or matching
+#      --accept all-low-risk are applied. Everything else is recorded as
+#      skipped. Candidates whose patch carries unmet 'needs' (e.g. map
+#      centroids) are skipped with the reason, never half-applied.
+#   3. APPLY ONE AT A TIME with a parity-unchanged gate: after each item,
+#      spot-query 2-3 UNTOUCHED elements on the clone AND the same elements
+#      on the original simultaneously; any divergence (clone != original at
+#      the same instant — live-drift-proof, the trial's lesson) auto-REVERTS
+#      that item and flags it. enhance-report.json records
+#      applied/skipped/reverted with evidence.
+#
+# This file is the SHARED Phase-E engine, vendored byte-identical into every
+# covered plugin (md5 discipline — same as escalate-gap.py).
+#
+# Usage:
+#   ruby scripts/enhance-apply.rb --workbook-id <parityWorkbookId> \
+#     --enhancements <enhancements.json> \
+#     --accept all-low-risk | --accept id1,id2,... \
+#     [--name '<clone name>'] [--out enhance-report.json] [--probes N]
+#
+# Exit codes: 0 = done (clone created; accepted items applied or cleanly
+# reverted; parity-unchanged gate green); 2 = nothing accepted; 3 = the
+# parity-unchanged gate could not be restored (clone left for inspection,
+# report says so); other = error.
+
+require 'json'
+require 'yaml'
+require 'time'
+require 'date'
+require 'optparse'
+
+HERE = __dir__
+$LOAD_PATH.unshift File.expand_path('lib', HERE)
+require 'sigma_rest'
+
+opts = { probes: 3 }
+OptionParser.new do |o|
+  o.on('--workbook-id ID')   { |v| opts[:wb] = v }
+  o.on('--enhancements P')   { |v| opts[:enh] = File.expand_path(v) }
+  o.on('--accept LIST')      { |v| opts[:accept] = v }
+  o.on('--name NAME')        { |v| opts[:name] = v }
+  o.on('--out PATH')         { |v| opts[:out] = File.expand_path(v) }
+  o.on('--probes N', Integer) { |v| opts[:probes] = v }
+end.parse!
+abort 'missing --workbook-id' unless opts[:wb]
+abort 'missing --enhancements' unless opts[:enh] && File.exist?(opts[:enh])
+abort 'missing --accept (id list or all-low-risk) — nothing applies without explicit acceptance' unless opts[:accept]
+
+ORIG_WB = opts[:wb]
+enh = JSON.parse(File.read(opts[:enh]))
+OUT = opts[:out] || File.join(File.dirname(opts[:enh]), 'enhance-report.json')
+
+candidates = enh['candidates'] || []
+accepted_ids =
+  if opts[:accept].strip.casecmp?('all-low-risk')
+    candidates.select { |c| c['risk'].to_s == 'low' }.map { |c| c['id'] }
+  else
+    opts[:accept].split(',').map(&:strip).reject(&:empty?)
+  end
+unknown = accepted_ids - candidates.map { |c| c['id'] }
+abort "FATAL: --accept names unknown candidate id(s): #{unknown.join(', ')}" if unknown.any?
+
+accepted = candidates.select { |c| accepted_ids.include?(c['id']) }
+skipped  = candidates.reject { |c| accepted_ids.include?(c['id']) }
+                     .map { |c| { 'id' => c['id'], 'risk' => c['risk'], 'reason' => 'not accepted' } }
+if accepted.empty?
+  puts 'enhance-apply: no candidate accepted — nothing to do (no clone created).'
+  File.write(OUT, JSON.pretty_generate(
+    'workbook_id' => ORIG_WB, 'status' => 'nothing-accepted',
+    'applied' => [], 'skipped' => skipped, 'reverted' => [],
+    'descoped_notes' => enh['descoped_notes'] || []))
+  exit 2
+end
+
+READONLY_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt
+                   documentVersion latestDocumentVersion].freeze
+
+def clean(spec)
+  s = JSON.parse(JSON.generate(spec))
+  READONLY_KEYS.each { |k| s.delete(k) }
+  s
+end
+
+# Sigma's workbook POST/PUT responses can come back as YAML — parse leniently.
+def lenient(body)
+  return body if body.is_a?(Hash)
+  YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) rescue nil
+end
+
+def export_rows(wb, element_id, timeout: 75)
+  res = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: { 'elementId' => element_id, 'format' => { 'type' => 'json' } }.to_json)
+  qid = res.is_a?(Hash) ? res['queryId'] : nil
+  return nil unless qid
+  deadline = Time.now + timeout
+  while Time.now < deadline
+    body = (Sigma.request(:get, "/v2/query/#{qid}/download", binary: true) rescue nil)
+    if body && !body.strip.empty?
+      parsed = (JSON.parse(body) rescue nil)
+      return parsed if parsed.is_a?(Array)
+      return parsed['rows'] if parsed.is_a?(Hash) && parsed['rows'].is_a?(Array)
+      lines = body.each_line.map { |l| (JSON.parse(l) rescue nil) }.compact
+      return lines unless lines.empty?
+    end
+    sleep 2
+  end
+  nil
+rescue StandardError
+  nil
+end
+
+# Order-insensitive, float-tolerant normalization for row comparison.
+def norm_rows(rows)
+  return nil unless rows.is_a?(Array)
+  rows.map do |r|
+    r.transform_values { |v| v.is_a?(Numeric) ? v.to_f.round(4) : v }
+  end.sort_by { |r| JSON.generate(r.sort.to_h) }
+end
+
+# ---------------------------------------------------------------------------
+# Layout helper: append a LayoutElement to the bottom of a page's grid block.
+# ---------------------------------------------------------------------------
+def add_layout!(spec, page_id, element_id, grid_column, height, same_row_start = nil)
+  xml = spec['layout'].to_s
+  return nil if xml.empty? || page_id.nil?
+  m = xml.match(%r{(<Page\b[^>]*\bid="#{Regexp.escape(page_id)}"[^>]*>)(.*?)(</Page>)}m)
+  return nil unless m
+  block = m[2]
+  max_end = block.scan(/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/).flatten.map(&:to_i).max || 1
+  row_start = same_row_start || max_end
+  entry = %(  <LayoutElement elementId="#{element_id}" gridColumn="#{grid_column}" gridRow="#{row_start} / #{row_start + height}"/>\n)
+  spec['layout'] = xml.sub(m[0], "#{m[1]}#{block}#{entry}#{m[3]}")
+  row_start
+end
+
+def find_element(spec, element_id)
+  (spec['pages'] || []).each do |p|
+    (p['elements'] || []).each { |e| return [p, e] if e['id'] == element_id }
+  end
+  nil
+end
+
+# Apply one candidate's patch to a working spec (in place). Returns a
+# human-readable description, or raises with the reason it cannot apply.
+def apply_patch!(spec, cand)
+  patch = cand['patch']
+  raise 'candidate has no machine patch (propose-in-UI only)' unless patch.is_a?(Hash)
+  if patch['needs'] && (patch[patch['needs']].nil? || patch[patch['needs']].empty?)
+    raise "patch needs '#{patch['needs']}' filled in before apply (see candidate.proposed)"
+  end
+  case patch['op']
+  when 'add_elements'
+    page = (spec['pages'] || []).find { |p| p['id'] == patch['page_id'] } ||
+           (spec['pages'] || []).reject { |p| p['id'] == 'page-data' }.first
+    raise 'target page not found' unless page
+    row_anchor = {}
+    Array(patch['elements']).each do |el|
+      raise "element id #{el['id']} already exists" if find_element(spec, el['id'])
+      (page['elements'] ||= []) << el
+    end
+    Array(patch['layout']).each do |l|
+      anchor = l['same_row_as'] && row_anchor[l['same_row_as']]
+      placed = add_layout!(spec, page['id'], l['element_id'], l['grid_column'], l['height'] || 4, anchor)
+      row_anchor[l['element_id']] = placed if placed
+    end
+    "added #{Array(patch['elements']).size} element(s) to page #{page['id']}"
+  when 'set_column_formula'
+    _pg, el = find_element(spec, patch['element_id'])
+    raise "element #{patch['element_id']} not found" unless el
+    col = (el['columns'] || []).find { |c| c['id'] == patch['column_id'] }
+    raise "column #{patch['column_id']} not found on #{patch['element_id']}" unless col
+    col['formula'] = patch['formula']
+    "set #{patch['element_id']}/#{patch['column_id']} formula"
+  when 'rename_element'
+    _pg, el = find_element(spec, patch['element_id'])
+    raise "element #{patch['element_id']} not found" unless el
+    el['name'] = patch['name']
+    "renamed #{patch['element_id']} -> '#{patch['name']}'"
+  when 'add_control_and_rewire'
+    pg, el = find_element(spec, patch.dig('rewire', 'element_id'))
+    raise "element #{patch.dig('rewire', 'element_id')} not found" unless el
+    col = (el['columns'] || []).find { |c| c['id'] == patch.dig('rewire', 'column_id') }
+    raise 'rewire column not found' unless col
+    raise "control id #{patch.dig('control', 'id')} already exists" if find_element(spec, patch.dig('control', 'id'))
+    (pg['elements'] ||= []) << patch['control']
+    col['formula'] = patch.dig('rewire', 'formula')
+    Array(patch['layout']).each do |l|
+      add_layout!(spec, pg['id'], l['element_id'], l['grid_column'], l['height'] || 3)
+    end
+    "added control #{patch.dig('control', 'controlId')} + rewired #{el['id']}"
+  when 'set_element_prop'
+    _pg, el = find_element(spec, patch['element_id'])
+    raise "element #{patch['element_id']} not found" unless el
+    el[patch['prop']] = patch['value']
+    "set #{patch['element_id']}.#{patch['prop']}"
+  when 'replace_with_point_map'
+    pg, el = find_element(spec, patch['element_id'])
+    raise "element #{patch['element_id']} not found" unless el
+    geo = patch['geo_column']
+    cents = patch['centroids'] || {}
+    raise 'centroids empty' if cents.empty?
+    sw = lambda do |idx, default|
+      args = cents.flat_map { |val, ll| ["\"#{val}\"", ll[idx].to_s] }.join(', ')
+      "Switch([#{geo}], #{args}, #{default})"
+    end
+    geo_ref = patch['geo_ref'] ||
+              (el['columns'] || []).map { |c| c['formula'] }.find { |f| f.to_s =~ /\/#{Regexp.escape(geo)}\]\z/ }
+    raise 'cannot resolve a geo column reference' unless geo_ref
+    map_el = {
+      'id' => "map-phasee-#{el['id']}"[0, 40], 'kind' => 'point-map',
+      'source' => el['source'],
+      'columns' => [
+        { 'id' => 'map-phasee-geo', 'formula' => geo_ref, 'name' => geo },
+        { 'id' => 'map-phasee-lat', 'formula' => sw.call(0, '39'), 'name' => 'Lat' },
+        { 'id' => 'map-phasee-lng', 'formula' => sw.call(1, '-98'), 'name' => 'Long' },
+        { 'id' => 'map-phasee-val', 'formula' => patch['value_formula'],
+          'name' => patch['value_name'] || 'Value' }
+      ],
+      'latitude' => { 'id' => 'map-phasee-lat' }, 'longitude' => { 'id' => 'map-phasee-lng' },
+      'size' => { 'id' => 'map-phasee-val' },
+      'color' => { 'by' => 'category', 'column' => 'map-phasee-geo' },
+      'name' => "#{el['name']} (map restored)"
+    }
+    pg['elements'].delete(el)
+    pg['elements'] << map_el
+    spec['layout'] = spec['layout'].to_s.gsub(/elementId="#{Regexp.escape(el['id'])}"/,
+                                              %(elementId="#{map_el['id']}"))
+    "replaced #{el['id']} with point-map #{map_el['id']}"
+  else
+    raise "unknown patch op #{patch['op'].inspect}"
+  end
+end
+
+# Element ids a candidate touches (so probes only use UNTOUCHED elements).
+def touched_ids(cand)
+  p = cand['patch'] || {}
+  ids = [p['element_id'], p.dig('rewire', 'element_id')]
+  ids += Array(p['elements']).map { |e| e['id'] }
+  ids += [p['control'] && p['control']['id']]
+  ids.compact.uniq
+end
+
+# ---------------------------------------------------------------------------
+# 1. CLONE — the 1:1 parity artifact is never touched.
+# ---------------------------------------------------------------------------
+orig_meta_before = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}")
+orig_spec = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}/spec")
+abort "FATAL: cannot read spec of #{ORIG_WB}" unless orig_spec.is_a?(Hash) && orig_spec['pages']
+clone_name = opts[:name] || "#{orig_spec['name']} — Enhanced"
+
+clone_spec = clean(orig_spec)
+clone_spec['name'] = clone_name
+post = lenient(Sigma.request(:post, '/v2/workbooks/spec',
+                             body: JSON.generate(clone_spec), binary: true))
+clone_id = post.is_a?(Hash) && (post['workbookId'] || post['id'])
+abort "FATAL: clone POST returned no workbookId: #{post.inspect[0, 300]}" unless clone_id
+puts "enhance-apply: clone '#{clone_name}' = #{clone_id} (original #{ORIG_WB} untouched)"
+
+# ---------------------------------------------------------------------------
+# 2. Pick probe elements (untouched by ANY accepted item) + baseline check.
+# ---------------------------------------------------------------------------
+all_touched = accepted.flat_map { |c| touched_ids(c) }
+viz_kinds = %w[bar-chart line-chart area-chart pie-chart combo-chart scatter-chart kpi-chart table pivot-table]
+probe_pool = (orig_spec['pages'] || []).reject { |p| p['id'] == 'page-data' }
+                                       .flat_map { |p| p['elements'] || [] }
+                                       .select { |e| viz_kinds.include?(e['kind']) }
+                                       .reject { |e| all_touched.include?(e['id']) }
+probes = probe_pool.first(opts[:probes]).map { |e| e['id'] }
+abort 'FATAL: no untouched element available as a parity probe' if probes.empty?
+puts "   parity probes (untouched elements): #{probes.join(', ')}"
+
+# clone-vs-original at (near) the same instant: live-drift-proof comparison.
+def probe_pair(clone_id, orig_id, probes)
+  probes.to_h do |el|
+    [el, { 'clone' => norm_rows(export_rows(clone_id, el)),
+           'orig' => norm_rows(export_rows(orig_id, el)) }]
+  end
+end
+
+def probe_diffs(pair)
+  pair.reject { |_el, v| v['clone'] && v['orig'] && v['clone'] == v['orig'] }.keys
+end
+
+baseline = probe_pair(clone_id, ORIG_WB, probes)
+bad = probe_diffs(baseline)
+abort "FATAL: clone baseline already diverges from original on #{bad.join(', ')} — aborting before any change" if bad.any?
+puts "   baseline: clone == original on #{probes.size}/#{probes.size} probe(s)"
+
+# ---------------------------------------------------------------------------
+# 3. Apply accepted items ONE AT A TIME with the parity-unchanged gate.
+# ---------------------------------------------------------------------------
+def put_spec(wb, spec)
+  lenient(Sigma.request(:put, "/v2/workbooks/#{wb}/spec",
+                        body: JSON.generate(spec), binary: true))
+end
+
+current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+applied = []
+reverted = []
+gate_green = true
+
+accepted.each do |cand|
+  print "   [#{cand['id']}] "
+  prev = JSON.parse(JSON.generate(current))
+  begin
+    desc = apply_patch!(current, cand)
+  rescue StandardError => e
+    skipped << { 'id' => cand['id'], 'risk' => cand['risk'], 'reason' => "not applied: #{e.message}" }
+    current = prev
+    puts "SKIP (#{e.message})"
+    next
+  end
+  begin
+    put_spec(clone_id, current)
+  rescue StandardError => e
+    current = prev
+    (put_spec(clone_id, current) rescue nil) # restore server state if the PUT half-landed
+    reverted << { 'id' => cand['id'], 'reason' => "PUT rejected: #{e.message.to_s.gsub(/\s+/, ' ')[0, 200]}" }
+    puts 'REVERTED (PUT rejected)'
+    next
+  end
+  # parity-unchanged gate: untouched probes, clone vs original, same instant.
+  pair = probe_pair(clone_id, ORIG_WB, probes)
+  diffs = probe_diffs(pair)
+  if diffs.any?
+    current = prev
+    begin
+      put_spec(clone_id, current)
+      recheck = probe_diffs(probe_pair(clone_id, ORIG_WB, probes))
+      gate_green &&= recheck.empty?
+    rescue StandardError
+      gate_green = false
+    end
+    reverted << { 'id' => cand['id'],
+                  'reason' => "parity-unchanged gate: untouched element(s) #{diffs.join(', ')} shifted vs original" }
+    puts "REVERTED (probes shifted: #{diffs.join(', ')})"
+  else
+    applied << { 'id' => cand['id'], 'category' => cand['category'], 'change' => desc,
+                 'evidence' => cand['evidence'] }
+    puts "APPLIED (#{desc}; #{probes.size} probe(s) unchanged)"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# 4. Final report.
+# ---------------------------------------------------------------------------
+final_pair = probe_pair(clone_id, ORIG_WB, probes)
+final_ok = probe_diffs(final_pair).empty?
+gate_green &&= final_ok
+orig_meta_after = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}")
+orig_untouched = orig_meta_before['updatedAt'] == orig_meta_after['updatedAt']
+
+report = {
+  'workbook_id' => ORIG_WB,
+  'workbook_name' => orig_spec['name'],
+  'clone_id' => clone_id,
+  'clone_name' => clone_name,
+  'clone_url' => (lenient(post) || {})['url'],
+  'accepted' => accepted_ids,
+  'applied' => applied,
+  'skipped' => skipped,
+  'reverted' => reverted,
+  'descoped_notes' => enh['descoped_notes'] || [],
+  'parity_unchanged_gate' => {
+    'probe_elements' => probes,
+    'method' => 'clone-vs-original simultaneous JSON exports (live-drift-proof), after every item',
+    'green' => gate_green
+  },
+  'original_untouched' => {
+    'updatedAt_before' => orig_meta_before['updatedAt'],
+    'updatedAt_after' => orig_meta_after['updatedAt'],
+    'unchanged' => orig_untouched
+  },
+  'finished_at' => Time.now.utc.iso8601
+}
+File.write(OUT, JSON.pretty_generate(report))
+
+puts
+puts "enhance-apply: #{applied.size} applied, #{skipped.size} skipped, #{reverted.size} reverted"
+puts "   clone: '#{clone_name}' (#{clone_id})"
+puts "   parity-unchanged gate: #{gate_green ? 'GREEN' : 'NOT GREEN (see report)'}; original untouched: #{orig_untouched}"
+puts "   report -> #{OUT}"
+exit(gate_green ? 0 : 3)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-scan.rb
@@ -1,0 +1,701 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# enhance-scan.rb — Phase E (opt-in) shared engine, part 1 of 2: SCAN.
+#
+# Reads source-migration signals (workdir artifacts) + the PARITY-VERIFIED
+# built workbook (live spec + element data exports) and emits
+# enhancements.json: a list of candidate enhancements, each with
+#   {id, category, evidence, proposed, risk, verdict_hint, patch}
+# NOTHING here writes to Sigma — scan is strictly read-only. Application is
+# enhance-apply.rb's job, and ONLY for explicitly accepted candidates.
+#
+# This file is the SHARED Phase-E engine, vendored byte-identical into every
+# covered plugin (md5 discipline — same as escalate-gap.py). Keep it
+# tool-agnostic: per-source behavior keys off --source + which workdir
+# artifacts exist, never off the plugin it happens to live in.
+#
+# The detector catalog is TRIAL-VALIDATED (2026-06-10 prototype trials on
+# tableau/qlik/powerbi migrations) — nothing speculative:
+#   1. comparison-enrichment  date-grouped master -> prior-period KPI pair
+#      (the verified Sum(If(D = Max(D), v, Null)) inline shape; KPI value
+#      columns must INLINE the full expression — cross-column aggregate refs
+#      silently misevaluate).
+#   2. interactivity-recovery
+#      (a) selection controls — list controls on reasonable-cardinality dims
+#          wired to the shared master (qlik-trial pattern; empty default =>
+#          untouched render identical).
+#      (b) grain switcher — segmented control + DateTrunc switch on a
+#          date-grouped chart (PBI-trial pattern; default == parity grain).
+#      (c) drill switcher — segmented control + If() dimension switch where a
+#          finer dimension exists on the master (tableau-trial pattern).
+#      (d) map restoration (PBI) — azureMap-approximated-as-bar -> point-map
+#          with Switch() centroid synthesis when geo-ish columns exist
+#          (PBI-trial verified shape; centroids must be supplied at apply).
+#   3. fidelity-polish — null-bucket labeling (Coalesce -> "No <Dim>"),
+#      month/date axis canonicalization (MakeDate), stale-source freshness
+#      note (time-boxed wording), title corrections from source captions.
+#   DESCOPED (trial-proven spec-unsupported; emitted as propose-in-UI NOTES,
+#   never spec changes): DM-metric promotion (metric refs don't resolve
+#   through a workbook table layer), chart-as-filter (useAsFilter silently
+#   dropped on readback), pie percent labels (valueFormat:'percent' silently
+#   dropped).
+#
+# Usage:
+#   ruby scripts/enhance-scan.rb --workbook-id <parityWorkbookId> \
+#     --workdir <migration workdir> [--source tableau|powerbi|qlik|...] \
+#     [--out enhancements.json] [--max-exports N]
+#
+# Env: SIGMA_BASE_URL + SIGMA_CLIENT_ID/SECRET (lib/sigma_rest.rb bootstraps
+# from ~/.sigma-migration/env when unset).
+
+require 'json'
+require 'csv'
+require 'time'
+require 'digest'
+require 'optparse'
+
+HERE = __dir__
+$LOAD_PATH.unshift File.expand_path('lib', HERE)
+require 'sigma_rest'
+
+opts = { max_exports: 12 }
+OptionParser.new do |o|
+  o.on('--workbook-id ID')  { |v| opts[:wb] = v }
+  o.on('--workdir DIR')     { |v| opts[:workdir] = File.expand_path(v) }
+  o.on('--source NAME')     { |v| opts[:source] = v }
+  o.on('--out PATH')        { |v| opts[:out] = File.expand_path(v) }
+  o.on('--max-exports N', Integer) { |v| opts[:max_exports] = v }
+end.parse!
+abort 'missing --workbook-id' unless opts[:wb]
+WB = opts[:wb]
+WORKDIR = opts[:workdir]
+OUT = opts[:out] || (WORKDIR ? File.join(WORKDIR, 'enhancements.json') : 'enhancements.json')
+
+def jread(path)
+  return nil unless path && File.exist?(path)
+  JSON.parse(File.read(path))
+rescue StandardError
+  nil
+end
+
+# Infer the source tool from workdir artifacts when --source is not given.
+source = opts[:source]
+if source.nil? && WORKDIR
+  source = if File.exist?(File.join(WORKDIR, 'signals.json')) then 'powerbi'
+           elsif File.exist?(File.join(WORKDIR, 'dashboard-layout.json')) ||
+                 File.exist?(File.join(WORKDIR, 'calc-fields.json')) then 'tableau'
+           end
+end
+source ||= 'unknown'
+
+# ---------------------------------------------------------------------------
+# Load the live spec + export element data (read-only).
+# ---------------------------------------------------------------------------
+spec = Sigma.request(:get, "/v2/workbooks/#{WB}/spec")
+abort "FATAL: could not read spec for workbook #{WB}" unless spec.is_a?(Hash) && spec['pages']
+wb_name = spec['name'].to_s
+
+VIZ_KINDS = %w[bar-chart line-chart area-chart pie-chart combo-chart scatter-chart].freeze
+pages = spec['pages'] || []
+data_page = pages.find { |p| p['id'] == 'page-data' } || pages.find { |p| p['name'].to_s =~ /\bdata\b/i }
+dash_pages = pages - [data_page].compact
+viz = dash_pages.flat_map { |p| (p['elements'] || []).map { |e| [p, e] } }
+                .select { |(_p, e)| VIZ_KINDS.include?(e['kind']) }
+controls = dash_pages.flat_map { |p| p['elements'] || [] }.select { |e| e['kind'] == 'control' }
+masters = data_page ? (data_page['elements'] || []) : []
+master_by_id = masters.to_h { |e| [e['id'], e] }
+
+# Export an element's data rows via the REST export API (JSON). Best-effort.
+def export_rows(wb, element_id, timeout: 75)
+  res = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: { 'elementId' => element_id, 'format' => { 'type' => 'json' } }.to_json)
+  qid = res.is_a?(Hash) ? res['queryId'] : nil
+  return nil unless qid
+  deadline = Time.now + timeout
+  while Time.now < deadline
+    body = (Sigma.request(:get, "/v2/query/#{qid}/download", binary: true) rescue nil)
+    if body && !body.strip.empty?
+      parsed = (JSON.parse(body) rescue nil)
+      return parsed if parsed.is_a?(Array)
+      return parsed['rows'] if parsed.is_a?(Hash) && parsed['rows'].is_a?(Array)
+      lines = body.each_line.map { |l| (JSON.parse(l) rescue nil) }.compact
+      return lines unless lines.empty?
+    end
+    sleep 2
+  end
+  nil
+rescue StandardError
+  nil
+end
+
+# Per-element data cache (each viz exported at most once; capped).
+rows_by_el = {}
+exported = 0
+viz.each do |(_pg, el)|
+  break if exported >= opts[:max_exports]
+  rows_by_el[el['id']] = export_rows(WB, el['id'])
+  exported += 1
+end
+
+# ---------------------------------------------------------------------------
+# Spec-navigation helpers.
+# ---------------------------------------------------------------------------
+def col_by_id(el, cid)
+  (el['columns'] || []).find { |c| c['id'] == cid }
+end
+
+# The categorical/x column of a viz element.
+def x_col(el)
+  cid = el.dig('xAxis', 'columnId') || el.dig('color', 'id') || el.dig('category', 'id')
+  cid && col_by_id(el, cid)
+end
+
+# The first value/measure column.
+def y_col(el)
+  cid = Array(el.dig('yAxis', 'columnIds')).first || el.dig('value', 'id') || el.dig('value', 'columnId')
+  cid = cid['columnId'] if cid.is_a?(Hash)
+  cid && col_by_id(el, cid)
+end
+
+# A bare single-ref formula like "[Master/Region]" -> ['Master', 'Region'].
+def bare_ref(formula)
+  m = formula.to_s.strip.match(/\A\[([^\]]+)\]\z/)
+  return nil unless m
+  parts = m[1].split('/')
+  return nil if parts.size < 2
+  [parts[0..-2].join('/'), parts[-1]]
+end
+
+def norm(s)
+  s.to_s.downcase.gsub(/[^a-z0-9]/, '')
+end
+
+# Pull the value for a viz row matching a column display name (export keys are
+# display names, sometimes suffixed).
+def row_val(row, colname)
+  return row[colname] if row.key?(colname)
+  k = row.keys.find { |kk| norm(kk) == norm(colname) }
+  k && row[k]
+end
+
+DATEISH = /\b(date|month|year|week|quarter|day)\b/i
+MEASUREISH = /revenue|sales|amount|profit|margin|net|gross|total|spend|cost|price|hours|count|orders|quantity|qty|units|headcount/i
+
+candidates = []
+descoped = []
+
+# ---------------------------------------------------------------------------
+# 1. comparison-enrichment — prior-period KPI pair on the best date-grouped
+#    chart. Verified shape: KPI value column INLINES the full conditional
+#    aggregate (Sum(If(D = Max(D), v, Null))) — never references sibling
+#    aggregate columns (they silently misevaluate in kpi-chart).
+# ---------------------------------------------------------------------------
+comparison_target = nil
+viz.sort_by { |(_p, e)| e['kind'] == 'line-chart' ? 0 : 1 }.each do |(_pg, el)|
+  xc = x_col(el)
+  yc = y_col(el)
+  next unless xc && yc
+  next unless yc['formula'].to_s =~ /\ASum\((.+)\)\z/m
+  inner_v = Regexp.last_match(1)
+  next unless (yc['name'].to_s =~ MEASUREISH) || (yc['formula'].to_s =~ MEASUREISH)
+  xf = xc['formula'].to_s
+  d_expr = nil
+  unit = nil
+  if (m = xf.match(/\ADateTrunc\(\s*"(\w+)"\s*,\s*(.+)\)\z/m))
+    unit = m[1]
+    d_expr = xf
+  elsif xc['name'].to_s =~ DATEISH || xf =~ DATEISH
+    # Derive a usable month-grain date expression over the same source:
+    # a real date column on the ref prefix, else MakeDate(Year, Month, 1).
+    ref = bare_ref(xf)
+    src_el = master_by_id[el.dig('source', 'elementId')]
+    prefix = ref ? ref[0] : (src_el && src_el['name'])
+    src_cols = src_el ? (src_el['columns'] || []).map { |c| c['name'].to_s } : []
+    date_col = src_cols.find { |n| n =~ /\bdate\b/i && n !~ /\bkey\b/i }
+    year_col = src_cols.find { |n| n =~ /\byear\b/i }
+    month_col = src_cols.find { |n| n =~ /\bmonth\b/i && n !~ /name/i }
+    if prefix && date_col
+      d_expr = "DateTrunc(\"month\", [#{prefix}/#{date_col}])"
+      unit = 'month'
+    elsif prefix && year_col && month_col
+      d_expr = "DateTrunc(\"month\", MakeDate([#{prefix}/#{year_col}], [#{prefix}/#{month_col}], 1))"
+      unit = 'month'
+    end
+  end
+  next unless d_expr && unit
+  comparison_target = { el: el, inner_v: inner_v, d: d_expr, unit: unit,
+                        measure: yc['name'].to_s, fmt: yc['format'] }
+  break
+end
+
+if comparison_target
+  t = comparison_target
+  el = t[:el]
+  cur = "Sum(If(#{t[:d]} = Max(#{t[:d]}), #{t[:inner_v]}, Null))"
+  prev = "Sum(If(#{t[:d]} = DateAdd(\"#{t[:unit]}\", -1, Max(#{t[:d]})), #{t[:inner_v]}, Null))"
+  page_id = dash_pages.find { |p| (p['elements'] || []).any? { |e| e['id'] == el['id'] } }&.dig('id') ||
+            dash_pages.first&.dig('id')
+  kpi_cur = {
+    'id' => 'el-phasee-kpi-current', 'kind' => 'kpi-chart',
+    'name' => "Latest #{t[:unit].capitalize} #{t[:measure]}",
+    'source' => el['source'],
+    'columns' => [{ 'id' => 'phasee-kpi-cur-val', 'name' => "Latest #{t[:unit].capitalize} #{t[:measure]}",
+                    'formula' => cur }.merge(t[:fmt] ? { 'format' => t[:fmt] } : {})],
+    'value' => { 'columnId' => 'phasee-kpi-cur-val' }
+  }
+  kpi_delta = {
+    'id' => 'el-phasee-kpi-delta', 'kind' => 'kpi-chart',
+    'name' => "#{t[:measure]} vs prior #{t[:unit]}",
+    'source' => el['source'],
+    'columns' => [{ 'id' => 'phasee-kpi-delta-val', 'name' => "#{t[:measure]} Δ vs prior #{t[:unit]}",
+                    'formula' => "((#{cur}) - (#{prev})) / (#{prev})",
+                    'format' => { 'kind' => 'number', 'formatString' => '+,.1%' } }],
+    'value' => { 'columnId' => 'phasee-kpi-delta-val' }
+  }
+  candidates << {
+    'id' => 'comparison-kpi-pair',
+    'category' => 'comparison-enrichment',
+    'evidence' => "'#{el['name']}' (#{el['kind']}) groups #{t[:measure]} by a date expression " \
+                  "(#{t[:d][0, 90]}); the dashboard has no period-over-period context. " \
+                  'Trial-verified pattern: latest-period KPI + delta-% KPI, full expression inlined ' \
+                  '(KPI cross-column aggregate refs silently misevaluate).',
+    'proposed' => "Add 2 KPI tiles sourcing the same element: 'Latest #{t[:unit].capitalize} " \
+                  "#{t[:measure]}' and '#{t[:measure]} vs prior #{t[:unit]}' (delta %). Purely additive — " \
+                  'no existing element changes.',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'add_elements', 'page_id' => page_id,
+                 'elements' => [kpi_cur, kpi_delta],
+                 'layout' => [{ 'element_id' => 'el-phasee-kpi-current', 'grid_column' => '1 / 13', 'height' => 6 },
+                              { 'element_id' => 'el-phasee-kpi-delta', 'grid_column' => '13 / 25', 'height' => 6,
+                                'same_row_as' => 'el-phasee-kpi-current' }] }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 2a. selection controls — list controls on reasonable-cardinality dims wired
+#     to the shared master (qlik-trial verified shape). Empty default values
+#     => untouched render is identical, so this is low risk.
+# ---------------------------------------------------------------------------
+existing_ctrl_cols = controls.flat_map { |c| Array(c['filters']).map { |f| f['columnId'] } }
+                             .compact
+sel_seen = {}
+viz.each do |(_pg, el)|
+  break if candidates.count { |c| c['id'].start_with?('interactivity-selection-') } >= 3
+  xc = x_col(el)
+  next unless xc
+  ref = bare_ref(xc['formula'])
+  next unless ref
+  next if xc['name'].to_s =~ DATEISH
+  src_eid = el.dig('source', 'elementId')
+  master = master_by_id[src_eid]
+  next unless master
+  # shared master: at least 2 viz source it (the propagation that makes one
+  # control filter the whole dashboard).
+  next unless viz.count { |(_p, e)| e.dig('source', 'elementId') == src_eid } >= 2
+  leaf = ref[1]
+  mcol = (master['columns'] || []).find { |c| c['name'].to_s == leaf } ||
+         (master['columns'] || []).find { |c| norm(c['name']) == norm(leaf) }
+  next unless mcol
+  next if sel_seen[mcol['id']]
+  next if existing_ctrl_cols.include?(mcol['id']) # already has a control
+  rows = rows_by_el[el['id']]
+  card = rows ? rows.map { |r| row_val(r, xc['name'].to_s) }.uniq.size : nil
+  next if card && (card < 2 || card > 50)
+  sel_seen[mcol['id']] = true
+  cid = "PhaseE#{leaf.gsub(/[^A-Za-z0-9]/, '')}Filter"
+  ctrl = {
+    'id' => "ctrl-phasee-#{Digest::SHA1.hexdigest(mcol['id'])[0, 6]}",
+    'kind' => 'control', 'controlId' => cid, 'name' => leaf,
+    'controlType' => 'list', 'mode' => 'include', 'selectionMode' => 'multiple',
+    'values' => [],
+    'source' => { 'kind' => 'source',
+                  'source' => { 'kind' => 'table', 'elementId' => master['id'] },
+                  'columnId' => mcol['id'] },
+    'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => master['id'] },
+                    'columnId' => mcol['id'] }]
+  }
+  candidates << {
+    'id' => "interactivity-selection-#{norm(leaf)}",
+    'category' => 'interactivity-recovery',
+    'evidence' => "'#{leaf}' is a chart dimension#{card ? " with #{card} member(s)" : ''} on the shared " \
+                  "master '#{master['name']}' (#{viz.count { |(_p, e)| e.dig('source', 'elementId') == src_eid }} " \
+                  'charts source it) and has no filter control. A list control on the shared source ' \
+                  'filters every consumer (verified propagation pattern).',
+    'proposed' => "Add a '#{leaf}' list control bound to the master column. Default = no selection, " \
+                  'so the untouched render is identical.',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'add_elements',
+                 'page_id' => dash_pages.first&.dig('id'),
+                 'elements' => [ctrl],
+                 'layout' => [{ 'element_id' => ctrl['id'], 'grid_column' => '1 / 9', 'height' => 3 }] }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 2b. grain switcher — segmented control + DateTrunc switch (PBI-trial shape).
+#     Default value == the parity grain, so element data is unchanged until a
+#     user switches — low risk.
+# ---------------------------------------------------------------------------
+viz.each do |(pg, el)|
+  xc = x_col(el)
+  next unless xc
+  m = xc['formula'].to_s.match(/\ADateTrunc\(\s*"(year|quarter|month|week|day)"\s*,\s*(.+)\)\z/m)
+  next unless m
+  cur_unit = m[1]
+  inner = m[2]
+  grains = %w[Year Quarter Month]
+  grains << cur_unit.capitalize unless grains.include?(cur_unit.capitalize)
+  cid = "PhaseEGrain#{Digest::SHA1.hexdigest(el['id'])[0, 4]}"
+  new_f = "If([#{cid}] = \"Year\", DateTrunc(\"year\", #{inner}), " \
+          "If([#{cid}] = \"Quarter\", DateTrunc(\"quarter\", #{inner}), " \
+          "DateTrunc(\"#{cur_unit}\", #{inner})))"
+  ctrl = {
+    'id' => "ctrl-phasee-grain-#{Digest::SHA1.hexdigest(el['id'])[0, 6]}",
+    'kind' => 'control', 'controlId' => cid, 'name' => "#{el['name']} grain",
+    'controlType' => 'segmented',
+    'source' => { 'kind' => 'manual', 'valueType' => 'text',
+                  'values' => grains, 'labels' => grains.map { nil } },
+    'value' => cur_unit.capitalize
+  }
+  candidates << {
+    'id' => "interactivity-grain-#{el['id']}",
+    'category' => 'interactivity-recovery',
+    'evidence' => "'#{el['name']}' is hard-grouped to DateTrunc(\"#{cur_unit}\") — the source's date " \
+                  'drill/hierarchy affordance was frozen at one grain by the migration. Segmented ' \
+                  'control + DateTrunc switch is the trial-verified spec-persistable equivalent.',
+    'proposed' => "Add a segmented '#{grains.join('/')}' grain control (default #{cur_unit.capitalize} " \
+                  '= parity grain, so data is unchanged at default) and wire the x-axis through it.',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'add_control_and_rewire', 'page_id' => pg['id'],
+                 'control' => ctrl,
+                 'rewire' => { 'element_id' => el['id'], 'column_id' => xc['id'], 'formula' => new_f },
+                 'layout' => [{ 'element_id' => ctrl['id'], 'grid_column' => '17 / 25', 'height' => 3 }] }
+  }
+  break # one grain switcher per workbook is plenty for the opt-in pass
+end
+
+# ---------------------------------------------------------------------------
+# 2c. drill switcher — segmented control + If() dimension switch where a finer
+#     dimension exists on the master (tableau-trial pattern). Medium risk: it
+#     rewrites the chart's category formula (default reproduces the parity
+#     grouping, but the hierarchy pairing is heuristic — confirm before apply).
+# ---------------------------------------------------------------------------
+HIERARCHY = {
+  'region' => %w[state province],
+  'state' => %w[city county],
+  'category' => ['sub-category', 'subcategory', 'sub category', 'product name'],
+  'department' => %w[team role title],
+  'country' => %w[state region city]
+}.freeze
+viz.each do |(pg, el)|
+  next if candidates.any? { |c| c['id'].start_with?('interactivity-drill-') }
+  xc = x_col(el)
+  next unless xc
+  ref = bare_ref(xc['formula'])
+  next unless ref
+  prefix, leaf = ref
+  finer_names = HIERARCHY[leaf.downcase.strip]
+  next unless finer_names
+  src_el = master_by_id[el.dig('source', 'elementId')]
+  next unless src_el
+  finer = (src_el['columns'] || []).map { |c| c['name'].to_s }
+                                   .find { |n| finer_names.include?(n.downcase.strip) }
+  next unless finer
+  cid = "PhaseELevel#{Digest::SHA1.hexdigest(el['id'])[0, 4]}"
+  new_f = "If([#{cid}] = \"#{finer}\", [#{prefix}/#{finer}], [#{prefix}/#{leaf}])"
+  ctrl = {
+    'id' => "ctrl-phasee-drill-#{Digest::SHA1.hexdigest(el['id'])[0, 6]}",
+    'kind' => 'control', 'controlId' => cid, 'name' => "#{el['name']} level",
+    'controlType' => 'segmented',
+    'source' => { 'kind' => 'manual', 'valueType' => 'text',
+                  'values' => [leaf, finer], 'labels' => [nil, nil] },
+    'value' => leaf
+  }
+  candidates << {
+    'id' => "interactivity-drill-#{el['id']}",
+    'category' => 'interactivity-recovery',
+    'evidence' => "'#{el['name']}' groups by '#{leaf}' and the master also exposes the finer " \
+                  "'#{finer}' — users of the source clearly analyze below #{leaf} level, but Sigma's " \
+                  'spec has no native drill/hierarchy field (UI-only). Segmented control + If() switch ' \
+                  'is the trial-verified spec equivalent.',
+    'proposed' => "Add a '#{leaf}/#{finer}' segmented control (default #{leaf} reproduces the parity " \
+                  'grouping) and switch the category formula through it.',
+    'risk' => 'medium',
+    'verdict_hint' => 'confirm — rewrites the chart category formula; hierarchy pairing is heuristic',
+    'patch' => { 'op' => 'add_control_and_rewire', 'page_id' => pg['id'],
+                 'control' => ctrl,
+                 'rewire' => { 'element_id' => el['id'], 'column_id' => xc['id'], 'formula' => new_f },
+                 'layout' => [{ 'element_id' => ctrl['id'], 'grid_column' => '9 / 17', 'height' => 3 }] }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 2d. map restoration (PBI-trial shape) — a source map visual that the
+#     migration approximated as a bar/table, where geo-ish columns exist.
+#     point-map with Switch() centroid synthesis; the centroid table must be
+#     supplied at apply time (patch.needs='centroids'), so this is never
+#     auto-applied by all-low-risk.
+# ---------------------------------------------------------------------------
+signals = WORKDIR && jread(File.join(WORKDIR, 'signals.json'))
+if signals
+  map_visuals = (signals['pages'] || []).flat_map { |p| p['visuals'] || [] }
+                                        .select { |v| v['visual_type'].to_s =~ /azureMap|filledMap|shapeMap|^map$/i }
+  map_visuals.each do |mv|
+    title = (mv['title'] || mv['visual_id']).to_s
+    approx = viz.map(&:last).find { |e| norm(e['name']) == norm(title) } ||
+             viz.map(&:last).find { |e| !title.empty? && norm(e['name']).include?(norm(title)) }
+    src_el = approx && master_by_id[approx.dig('source', 'elementId')]
+    geo_cols = src_el ? (src_el['columns'] || []).map { |c| c['name'].to_s }
+                                                 .select { |n| n =~ /\b(city|state|zip|postal|country|region|lat|latitude|lon|lng|longitude|location)\b/i } : []
+    candidates << {
+      'id' => "interactivity-map-#{norm(title)[0, 24]}",
+      'category' => 'interactivity-recovery',
+      'evidence' => "Source visual '#{title}' is a #{mv['visual_type']} (map), but the migration " \
+                    "approximated it as #{approx ? "'#{approx['name']}' (#{approx['kind']})" : 'a non-map element (no name match found in the built workbook)'}." \
+                    "#{geo_cols.any? ? " Geo-ish columns available on the source element: #{geo_cols.join(', ')}." : ' No geo-ish columns detected on the matched element.'}",
+      'proposed' => 'Restore as a Sigma point-map (trial-verified shape: latitude/longitude/size ' \
+                    'bindings persist on readback) with Switch()-synthesized centroids per geo value. ' \
+                    "Requires a centroid table {value: [lat, lng]} filled into the patch before apply" \
+                    "#{geo_cols.any? ? " (geo column: #{geo_cols.first})" : ''}.",
+      'risk' => 'medium',
+      'verdict_hint' => 'confirm — needs centroid synthesis; present to the user with the geo column list',
+      'patch' => (approx && geo_cols.any? ? {
+        'op' => 'replace_with_point_map', 'needs' => 'centroids',
+        'element_id' => approx['id'], 'page_id' => (dash_pages.find { |p| (p['elements'] || []).any? { |e| e['id'] == approx['id'] } } || {})['id'],
+        'geo_column' => geo_cols.first, 'source' => approx['source'],
+        'geo_ref' => "[#{src_el['name']}/#{geo_cols.first}]",
+        'value_formula' => (y_col(approx) || {})['formula'],
+        'value_name' => (y_col(approx) || {})['name'],
+        'centroids' => {}
+      } : nil)
+    }
+  end
+end
+
+# ---------------------------------------------------------------------------
+# 3a. null-bucket labeling — a categorical axis with a null bucket renders a
+#     blank label; Coalesce -> "No <Dim>" (label-only; values unchanged).
+# ---------------------------------------------------------------------------
+viz.each do |(_pg, el)|
+  xc = x_col(el)
+  rows = rows_by_el[el['id']]
+  next unless xc && rows.is_a?(Array) && rows.any?
+  next unless bare_ref(xc['formula']) # only bare dim refs (don't stack onto switches)
+  next if xc['name'].to_s =~ DATEISH
+  null_rows = rows.select { |r| v = row_val(r, xc['name'].to_s); v.nil? || v.to_s.strip.empty? }
+  next if null_rows.empty?
+  label = "No #{xc['name']}"
+  candidates << {
+    'id' => "polish-null-label-#{el['id']}",
+    'category' => 'fidelity-polish',
+    'evidence' => "'#{el['name']}' has #{null_rows.size} null '#{xc['name']}' bucket(s) — Sigma renders " \
+                  'a blank category label, leaving the bar/slice unexplained (export-verified).',
+    'proposed' => "Wrap the category as Coalesce(#{xc['formula']}, \"#{label}\") — label only; " \
+                  'bucket values unchanged.',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'set_column_formula', 'element_id' => el['id'], 'column_id' => xc['id'],
+                 'formula' => "Coalesce(#{xc['formula']}, \"#{label}\")" }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 3a2. value-label polish — the source tool shows data labels by default on
+#      small categorical charts; a migrated bar/pie with NO dataLabel config
+#      reads bare. dataLabel:{labels:'shown'} is the verified persisting shape
+#      (valueFormat:'percent' is NOT — see the descoped notes). Additive-config
+#      only; values untouched.
+viz.each do |(_pg, el)|
+  next unless %w[bar-chart pie-chart line-chart].include?(el['kind'])
+  next if el['dataLabel']
+  rows = rows_by_el[el['id']]
+  next if rows.is_a?(Array) && rows.size > 24 # labels unreadable on dense charts
+  candidates << {
+    'id' => "polish-data-labels-#{el['id']}",
+    'category' => 'fidelity-polish',
+    'evidence' => "'#{el['name']}' (#{el['kind']}#{rows.is_a?(Array) ? ", #{rows.size} bucket(s)" : ''}) has no " \
+                  'dataLabel config — source-tool defaults show value labels on small categorical charts.',
+    'proposed' => "Set dataLabel:{labels:'shown'} (trial-verified persisting shape; percent styling is " \
+                  'UI-only and stays descoped).',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'set_element_prop', 'element_id' => el['id'],
+                 'prop' => 'dataLabel', 'value' => { 'labels' => 'shown' } }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 3b. month/date axis canonicalization — a chart grouped by a bare month
+#     NUMBER (1..12) reads as integers and pools across years; MakeDate(Year,
+#     Month, 1) restores a true date axis. Medium risk: on a multi-year source
+#     this intentionally un-pools the series (trial-validated divergence).
+# ---------------------------------------------------------------------------
+viz.each do |(_pg, el)|
+  xc = x_col(el)
+  rows = rows_by_el[el['id']]
+  next unless xc && rows.is_a?(Array) && rows.any?
+  next unless xc['name'].to_s =~ /\bmonth\b/i && xc['name'].to_s !~ /name/i
+  vals = rows.map { |r| row_val(r, xc['name'].to_s) }.compact
+  next if vals.empty?
+  next unless vals.all? { |v| v.to_s =~ /\A\d+(\.0+)?\z/ && v.to_f.between?(1, 12) }
+  ref = bare_ref(xc['formula'])
+  next unless ref
+  prefix, = ref
+  src_el = master_by_id[el.dig('source', 'elementId')]
+  year_col = src_el && (src_el['columns'] || []).map { |c| c['name'].to_s }.find { |n| n =~ /\byear\b/i }
+  next unless year_col
+  candidates << {
+    'id' => "polish-date-axis-#{el['id']}",
+    'category' => 'fidelity-polish',
+    'evidence' => "'#{el['name']}' x-axis is a bare month NUMBER (export shows #{vals.uniq.size} integer " \
+                  "bucket(s) in 1..12) — reads as 1,2,3 and pools all years into 12 buckets. Master exposes " \
+                  "'#{year_col}'.",
+    'proposed' => "x-axis -> MakeDate([#{prefix}/#{year_col}], #{xc['formula']}, 1): true date axis " \
+                  '(Jan 2026 style). NOTE: on a multi-year source this correctly UN-POOLS the series ' \
+                  '(intended divergence on this element only).',
+    'risk' => 'medium',
+    'verdict_hint' => 'confirm — changes this element\'s own buckets if the source spans multiple years',
+    'patch' => { 'op' => 'set_column_formula', 'element_id' => el['id'], 'column_id' => xc['id'],
+                 'formula' => "MakeDate([#{prefix}/#{year_col}], #{xc['formula']}, 1)" }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 3c. stale-source freshness note — a frozen source snapshot (Tableau extract /
+#     stale PBI import) means Sigma (live) WILL show different numbers. A
+#     time-boxed text note heads that off. Purely additive — low risk.
+# ---------------------------------------------------------------------------
+fresh_note = nil
+if WORKDIR
+  state = jread(File.join(WORKDIR, 'migrate-state.json'))
+  freshness = jread(File.join(WORKDIR, 'freshness.json'))
+  if freshness && freshness['staleDays'].to_f >= 1
+    last = freshness.dig('lastSuccessfulRefresh', 'endTime')
+    fresh_note = "**Migration note (as of #{Time.now.utc.strftime('%Y-%m-%d')})** — the source " \
+                 "Power BI dataset was last refreshed #{last} (~#{freshness['staleDays'].to_f.ceil} day(s) " \
+                 'before migration). This workbook queries the warehouse **live**, so totals here are ' \
+                 'expected to run ahead of the frozen source snapshot.'
+  elsif state && state['extract_mode']
+    fresh_note = "**Migration note (as of #{Time.now.utc.strftime('%Y-%m-%d')})** — the source Tableau " \
+                 'workbook reads a frozen EXTRACT snapshot. This workbook queries the warehouse ' \
+                 '**live**, so totals here are expected to drift ahead of the extract until it is refreshed.'
+  end
+end
+if fresh_note
+  candidates << {
+    'id' => 'polish-freshness-note',
+    'category' => 'fidelity-polish',
+    'evidence' => 'Source is a frozen snapshot (extract/import) while Sigma reads the live warehouse — ' \
+                  'the classic "numbers don\'t match" support ticket. Time-boxed wording so the note ' \
+                  'ages gracefully.',
+    'proposed' => 'Add a small text element stating the source snapshot age and that Sigma is live.',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
+                 'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
+                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                 'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 3d. title corrections — the source dashboard's VISIBLE caption differs from
+#     the element name the migration carried over (stale worksheet name).
+#     Conservative: only when a caption and an element pair off unambiguously.
+# ---------------------------------------------------------------------------
+if WORKDIR
+  captions = [] # [{caption, ref_name}]
+  dl = jread(File.join(WORKDIR, 'dashboard-layout.json'))
+  if dl
+    zones = dl.is_a?(Array) ? dl.flat_map { |d| d['zones'] || [] } : (dl['zones'] || [])
+    zones.select { |z| z['kind'] == 'chart' }.each do |z|
+      cap = z['caption'].to_s.strip
+      refn = (z['view_ref'] || z['view'] || z['name']).to_s.strip
+      captions << { 'caption' => cap, 'ref' => refn } unless cap.empty? || refn.empty?
+    end
+  elsif signals
+    (signals['pages'] || []).flat_map { |p| p['visuals'] || [] }.each do |v|
+      cap = v['title'].to_s.strip
+      captions << { 'caption' => cap, 'ref' => cap } unless cap.empty?
+    end
+  end
+  el_names = viz.map(&:last).map { |e| e['name'].to_s }
+  captions.each do |c|
+    next if c['caption'].casecmp?(c['ref'])                       # caption == worksheet name: nothing stale
+    next if el_names.any? { |n| norm(n) == norm(c['caption']) }   # an element already carries the caption
+    target = viz.map(&:last).find { |e| norm(e['name']) == norm(c['ref']) }
+    next unless target
+    candidates << {
+      'id' => "polish-title-#{target['id']}",
+      'category' => 'fidelity-polish',
+      'evidence' => "Source dashboard's visible title is '#{c['caption']}' but the migrated element is " \
+                    "named '#{target['name']}' (stale internal worksheet/visual name).",
+      'proposed' => "Rename element to '#{c['caption']}'.",
+      'risk' => 'low',
+      'verdict_hint' => 'apply',
+      'patch' => { 'op' => 'rename_element', 'element_id' => target['id'], 'name' => c['caption'] }
+    }
+  end
+end
+
+# ---------------------------------------------------------------------------
+# DESCOPED — trial-proven spec-unsupported. Emitted as propose-in-UI notes
+# only; enhance-apply NEVER applies these.
+# ---------------------------------------------------------------------------
+if viz.any? { |(_p, e)| e['kind'] == 'pie-chart' }
+  descoped << {
+    'id' => 'descoped-pie-percent-labels',
+    'note' => 'Pie/donut percent labels: dataLabel.valueFormat:"percent" is SILENTLY DROPPED on spec ' \
+              'readback (trial-proven, same class as trellis/tooltip). Value labels persist; percent ' \
+              'style must be set in the Sigma UI.',
+    'evidence' => "#{viz.count { |(_p, e)| e['kind'] == 'pie-chart' }} pie-chart element(s) present."
+  }
+end
+dm_sourced = masters.any? { |m| m.dig('source', 'kind') == 'data-model' } ||
+             viz.any? { |(_p, e)| e.dig('source', 'kind') == 'data-model' }
+inline_aggs = viz.count { |(_p, e)| (y_col(e) || {})['formula'].to_s =~ /\A(Sum|Avg|Count|CountDistinct|Min|Max)\(/ }
+if dm_sourced && inline_aggs.positive?
+  descoped << {
+    'id' => 'descoped-dm-metric-promotion',
+    'note' => 'DM metric promotion: charts re-implement aggregate formulas inline, but DM metrics are ' \
+              'NOT referenceable from a chart through an intermediate workbook table ([Master/Metric] -> ' \
+              '"Dependency not found"; bare [Metric] compiles to a silent error column — trial-proven). ' \
+              'Promote in the DM and rebind in the Sigma UI if governance requires it.',
+    'evidence' => "#{inline_aggs} chart(s) carry inline aggregate formulas over a data-model source."
+  }
+end
+shared_masters = viz.group_by { |(_p, e)| e.dig('source', 'elementId') }.select { |_k, v| v.size >= 2 }
+if shared_masters.any?
+  descoped << {
+    'id' => 'descoped-chart-as-filter',
+    'note' => 'Chart-as-filter (cross-filter on click): useAsFilter/crossFilter spec fields are accepted ' \
+              'by PUT but silently DROPPED on readback (trial-proven; UI-only). Enable "Use as filter" in ' \
+              'the Sigma UI. List controls on the shared master already give equivalent dashboard-wide filtering.',
+    'evidence' => "#{shared_masters.values.sum(&:size)} chart(s) share #{shared_masters.size} master source(s)."
+  }
+end
+
+# ---------------------------------------------------------------------------
+# Emit.
+# ---------------------------------------------------------------------------
+out = {
+  'workbook_id' => WB,
+  'workbook_name' => wb_name,
+  'source' => source,
+  'scanned_at' => Time.now.utc.iso8601,
+  'elements_scanned' => viz.size,
+  'elements_exported' => rows_by_el.count { |_k, v| v },
+  'candidates' => candidates,
+  'descoped_notes' => descoped
+}
+File.write(OUT, JSON.pretty_generate(out))
+
+puts "enhance-scan: #{candidates.size} candidate(s), #{descoped.size} descoped note(s) -> #{OUT}"
+candidates.each do |c|
+  puts format('  [%-6s] %-38s %s', c['risk'], c['id'], c['proposed'].to_s.gsub(/\s+/, ' ')[0, 100])
+end
+descoped.each { |d| puts format('  [note ] %-38s %s', d['id'], d['note'].to_s.gsub(/\s+/, ' ')[0, 100]) }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -47,7 +47,15 @@
 # MCP tool yourself and resume with --converter-out <its result JSON> — the
 # default route on machines without a local build.
 #
-# Exit codes: 0 = done (parity pass); 10 = decisions needed (OPEN QUESTIONS); 3 = parity fail; other = error.
+# Phase E (OPT-IN) — Enhance: pass --enhance to run the shared enhancement
+# engine AFTER parity passes: enhance-scan.rb emits candidates; nothing applies
+# without --enhance-accept <ids|all-low-risk> (without it the run stops at exit
+# 14 with the proposals); enhance-apply.rb then clones the parity workbook
+# ("<name> — Enhanced") and applies accepted items one at a time under a
+# parity-unchanged gate. Default = OFF everywhere.
+#
+# Exit codes: 0 = done (parity pass); 10 = decisions needed (OPEN QUESTIONS); 3 = parity fail;
+# 14 = parity PASS + Phase E proposals pending acceptance (re-run with --enhance-accept); other = error.
 require 'json'
 require 'optparse'
 require 'fileutils'
@@ -85,6 +93,12 @@ OptionParser.new do |o|
   o.on('--workspace ID')       { |v| opts[:ws] = v }
   o.on('--dataset ID')         { |v| opts[:dataset] = v }
   o.on('--skip-freshness')     {     opts[:skip_fresh] = true }
+  # Phase E (opt-in) — Enhance. NEVER runs without --enhance; with --enhance
+  # but no --enhance-accept the run stops at exit 14 with the scan proposals
+  # (present them per-item to the human, e.g. AskUserQuestion), then re-run
+  # with --enhance-accept <id,id,...> or 'all-low-risk'.
+  o.on('--enhance')            {     opts[:enhance] = true }
+  o.on('--enhance-accept L')   { |v| opts[:enhance_accept] = v }
 end.parse!
 
 abort 'missing --tmsl' unless opts[:tmsl]
@@ -176,13 +190,22 @@ FileUtils.mkdir_p(pbir_dir)
 bundle = JSON.parse(File.read(opts[:pbir]))
 exploded = 0
 bundle.each do |part, payload|
-  next unless part.start_with?('definition') # skip report.json/.platform legacy keys
+  next unless part.start_with?('definition/') # the exploded-PBIR parts only
   fp = File.join(pbir_dir, part)
   FileUtils.mkdir_p(File.dirname(fp))
   File.write(fp, payload.is_a?(String) ? payload : JSON.pretty_generate(payload))
   exploded += 1
 end
-abort "FATAL: PBIR bundle has no definition/ parts — is this an exploded PBIR? keys=#{bundle.keys.first(3)}" if exploded.zero?
+# bead anlb (orchestrator parity with run.sh): a fetched definition may be the
+# CLASSIC single report.json (top-level sections[]) instead of exploded PBIR
+# parts. Branch to extract-report-classic.py — same signals.json schema out.
+classic_rj = nil
+if exploded.zero? && bundle.key?('report.json')
+  classic_rj = File.join(pbir_dir, 'report.json')
+  payload = bundle['report.json']
+  File.write(classic_rj, payload.is_a?(String) ? payload : JSON.pretty_generate(payload))
+end
+abort "FATAL: PBIR bundle has no definition/ parts and no classic report.json — keys=#{bundle.keys.first(3)}" if exploded.zero? && classic_rj.nil?
 
 signals_path = File.join(WORK, 'signals.json')
 # bead 7o01: Python resolution — --python / PBI_PY, else a bootstrapped venv
@@ -191,7 +214,12 @@ signals_path = File.join(WORK, 'signals.json')
 PY = opts[:python] || ENV['PBI_PY'] ||
      [File.join(WORK, '.venv', 'bin', 'python'), '/tmp/pbiauth/bin/python']
        .find { |p| File.exist?(p) } || 'python3'
-run!([PY, File.join(HERE, 'extract-pbir.py'), '--pbir-dir', pbir_dir, '--out', signals_path])
+if classic_rj
+  puts '   classic single report.json detected — branching to extract-report-classic.py'
+  run!([PY, File.join(HERE, 'extract-report-classic.py'), '--report-json', classic_rj, '--out', signals_path])
+else
+  run!([PY, File.join(HERE, 'extract-pbir.py'), '--pbir-dir', pbir_dir, '--out', signals_path])
+end
 signals = JSON.parse(File.read(signals_path))
 
 # TMSL model summary + import/DirectQuery mode.
@@ -812,6 +840,31 @@ if ti_elements.any?
   end
 end
 
+# bead anlb (continued) — CLASSIC-report queryRef normalization. The legacy
+# report.json binds measures as "Sum(Entity.Col)" / "Count(Entity.Col)" and
+# date hierarchies as "Entity.Col.Variation.Date Hierarchy.<Level>". Neither
+# key shape exists in the Entity.Field map derived above (which uses the
+# converter's Title-Case display names), so those bindings fell through to a
+# literal bracketed ref -> silent error-typed column. Resolve both shapes via
+# a case/underscore-insensitive lookup against the existing map.
+norm_key = ->(k) { k.to_s.downcase.gsub(/[^a-z0-9.]/, '') }
+fm_norm = {}
+field_map.each { |k, v| fm_norm[norm_key.call(k)] ||= v }
+agg_names = { 'sum' => 'Sum', 'avg' => 'Avg', 'average' => 'Avg', 'min' => 'Min', 'max' => 'Max',
+              'count' => 'Count', 'countnonnull' => 'Count', 'distinctcount' => 'CountDistinct' }
+all_visuals.flat_map { |v| (v['bindings'] || {}).values.flatten }.uniq.each do |r|
+  next if r.nil? || field_map.key?(r)
+  if (m = r.match(/\A([A-Za-z ]+)\((.+)\)\z/)) && agg_names[m[1].downcase.delete(' ')]
+    base = fm_norm[norm_key.call(m[2])]
+    next unless base && base['ref'].to_s =~ /\A\[[^\]]+\]\z/
+    field_map[r] = base.merge('ref' => "#{agg_names[m[1].downcase.delete(' ')]}(#{base['ref']})", 'agg' => nil)
+  elsif (m = r.match(/\A(.+?)\.Variation\..*\.(Year|Quarter|Month|Week|Day)\z/i))
+    base = fm_norm[norm_key.call(m[1])]
+    next unless base && base['ref'].to_s =~ /\A\[[^\]]+\]\z/
+    field_map[r] = base.merge('ref' => "DateTrunc(\"#{m[2].downcase}\", #{base['ref']})", 'agg' => nil)
+  end
+end
+
 master_map = { 'masters' => masters, 'fields' => field_map }
 mmap_path = File.join(WORK, 'master-map.json')
 File.write(mmap_path, JSON.pretty_generate(master_map))
@@ -1009,6 +1062,52 @@ else
 end
 
 # ---------------------------------------------------------------------------
+# Phase E (OPT-IN) — Enhance. Runs ONLY with --enhance AND a parity PASS:
+# enhancements clone a PARITY-VERIFIED workbook, never an unproven one.
+# Clone-first / scan-then-propose / accept-only / parity-unchanged-gated —
+# see enhance-scan.rb + enhance-apply.rb (the shared Phase-E engine).
+# ---------------------------------------------------------------------------
+enhance_line = nil
+if opts[:enhance] && !parity_ok
+  enhance_line = 'SKIPPED — parity not green (Phase E only clones a parity-verified workbook)'
+elsif opts[:enhance]
+  puts
+  puts '── Phase E (opt-in) · Enhance ──'
+  enh_path = File.join(WORK, 'enhancements.json')
+  e_out, e_st = Open3.capture2e(ENV.to_h, 'ruby', File.join(HERE, 'enhance-scan.rb'),
+                                '--workbook-id', wb_id, '--workdir', WORK,
+                                '--source', 'powerbi', '--out', enh_path)
+  e_out.each_line { |l| puts "   #{l.rstrip}" }
+  if !e_st.success?
+    enhance_line = 'scan FAILED (migration itself passed parity; see output above)'
+  elsif opts[:enhance_accept].nil?
+    cands = (JSON.parse(File.read(enh_path))['candidates'] rescue [])
+    puts
+    puts '==================== PHASE E PROPOSALS (acceptance required) ===================='
+    puts "#{cands.size} enhancement candidate(s) in #{enh_path}. NOTHING has been applied —"
+    puts 'present each candidate to the human (interactive: one AskUserQuestion checklist),'
+    puts 'then re-run this exact command adding:'
+    puts "  --enhance --enhance-accept <id,id,...>   # or: --enhance-accept all-low-risk"
+    puts '================================================================================='
+    exit 14
+  else
+    a_out, a_st = Open3.capture2e(ENV.to_h, 'ruby', File.join(HERE, 'enhance-apply.rb'),
+                                  '--workbook-id', wb_id, '--enhancements', enh_path,
+                                  '--accept', opts[:enhance_accept],
+                                  '--out', File.join(WORK, 'enhance-report.json'))
+    a_out.each_line { |l| puts "   #{l.rstrip}" }
+    rep = (JSON.parse(File.read(File.join(WORK, 'enhance-report.json'))) rescue {})
+    enhance_line = if a_st.success?
+                     "clone #{rep['clone_id']} '#{rep['clone_name']}': " \
+                     "#{(rep['applied'] || []).size} applied, #{(rep['skipped'] || []).size} skipped, " \
+                     "#{(rep['reverted'] || []).size} reverted; parity-unchanged gate GREEN"
+                   else
+                     "apply NOT GREEN (exit #{a_st.exitstatus}) — see enhance-report.json"
+                   end
+  end
+end
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 puts
@@ -1021,5 +1120,6 @@ if fresh_ok
   puts "freshness   : PBI last refresh #{fresh_ok['endTime']} (#{stale_days} days ago)" \
        "#{freshness['credsSuspect'] ? ' — REFRESH FAILING (creds)' : ''}"
 end
+puts "ENHANCE     : #{enhance_line}" if enhance_line
 puts '======================================='
 exit(parity_ok ? 0 : 3)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/QUICKSTART.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/QUICKSTART.md
@@ -328,6 +328,16 @@ ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name>
 
 Exit 0 means the conversion may declare GREEN. Any non-zero exit means downgrade to YELLOW or RED with a documented reason.
 
+**Phase E (opt-in) — Enhance.** Once everything is GREEN you can opt into the
+enhancement pass: add `--enhance` to the `migrate-tableau.rb --finalize` command to
+scan for trial-validated upgrades (period-comparison KPIs, selection controls, grain
+and drill switchers, null-label/title/freshness polish). The scan stops with exit
+`14` and a proposal list; nothing is applied until you re-run with
+`--enhance-accept all-low-risk` (or an explicit id list). Accepted items land on a
+**clone** named "<name> — Enhanced" — the parity-verified workbook is never touched —
+and every applied item is gated by an untouched-element spot-check that auto-reverts
+on any shift. See the SKILL.md "Phase E (opt-in) — Enhance" section.
+
 ![Footer](assets/sigma_footer.png)
 <!-- END OF SECTION -->
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -46,8 +46,11 @@ wherever agent judgment is genuinely required. Exit codes: `10` = OPEN QUESTIONS
 (re-run with `--yes`/`--answers`), `11` = ❌-unhandled gap-scan features (close via
 gap-scout or `--force`), `12` = pass 1 done, parity PENDING (collect mcp-v2 actuals,
 then `--finalize`), `4` = DM posted but the workbook layer needs the agent path,
-`3` = a gate failed, `0` = ALL gates green (only reachable via `--finalize`).
+`3` = a gate failed, `14` = migration GREEN + Phase E proposals pending
+acceptance, `0` = ALL gates green (only reachable via `--finalize`).
 DM-reuse defaults to BUILD NEW — candidates are printed; `--reuse-dm` opts in.
+Optional `--enhance [--enhance-accept <ids|all-low-risk>]` runs Phase E
+(opt-in) after all gates are green — see the Phase E section below.
 
 **Still manual by design (the orchestrator stops and tells you):**
 - **Parity actuals** — Sigma has no synchronous chart-data REST endpoint; the
@@ -118,6 +121,8 @@ which calc translation, which layout) — not orchestration.
 | `scripts/scan-customer-style.rb` | Phase 0c: sample N recent workbooks in the customer's Sigma org and aggregate style signals (color palettes, number-format strings, layout grids, chart-kind mix, dataLabel preference, element naming case, density). Lets the converter emit specs that match house conventions instead of generic defaults. |
 | `scripts/dev/phase-timer.sh` | **Dev / profiling only — do NOT source in customer conversions.** Source helper for phase timing when iterating on the skill itself; emits `▶`/`■` log lines per phase and a `phase-timings.json` summary. Only invoke when the user explicitly asks for timing data ("time it", "where did the minutes go", "profile"). Usage: `phase_start "<name>"` / `phase_end` around each phase, `phase_report` at the end. **Across multiple Bash tool-call blocks**, export `PHASE_TIMINGS_TMP=<path>` BEFORE the first source so the helper appends across blocks. |
 | `scripts/lib/layout.rb` | Layout-XML helpers (`gc`, `le`, `page_xml`, `assemble`) — `require`'d by per-workbook layout configs |
+| `scripts/enhance-scan.rb` | **Phase E (opt-in) part 1 — SCAN (read-only).** Source signals + built spec + live element exports → `enhancements.json` candidates `{id, category, evidence, proposed, risk, verdict_hint, patch}` + descoped propose-in-UI notes. Shared Phase-E engine, vendored byte-identical across plugins (md5 discipline). |
+| `scripts/enhance-apply.rb` | **Phase E (opt-in) part 2 — APPLY (accept-only, clone-first).** Clones the parity workbook as `"<name> — Enhanced"` (1:1 artifact never written), applies ONLY `--accept`-ed candidates one at a time, each gated by an untouched-element clone-vs-original spot-check (auto-revert on shift). Writes `enhance-report.json`. Shared engine, byte-identical twin of the tableau/powerbi copy. |
 
 ---
 
@@ -1485,6 +1490,68 @@ When to escalate to a visual check rather than just CSV parity:
 > **Known render-vs-spec drift on log-scale axes.** A `yAxis.format.scale: {type: "log"}` spec persists correctly via PUT/GET, and the interactive Sigma UI renders log-scaled. The Phase 6f PNG export endpoint, however, renders the y-axis linearly (verified 2026-05-24 on OCT v2's Monthly Trend export). This is a render-side limitation of the export endpoint, not a converter regression — confirm log behavior in the live workbook before downgrading parity. When the source Tableau chart had a log axis and the Sigma PNG shows linear, note YELLOW with `error_summary: "log-axis export-renders-linear"` and link the live workbook URL; do NOT re-emit the chart spec.
 
 ---
+
+## Phase E (opt-in) — Enhance
+
+**OFF by default, everywhere.** Phase E never runs in batch/headless mode
+without the explicit `--enhance` flag, and it only ever starts from a
+**parity-verified** workbook (all Phase 6 gates green). It is powered by the
+shared engine vendored byte-identically into the covered plugins
+(`scripts/enhance-scan.rb` + `scripts/enhance-apply.rb` — md5 discipline,
+same as `escalate-gap.py`).
+
+```bash
+# at --finalize, after gates are green:
+ruby scripts/migrate-tableau.rb --workbook "<name>" --finalize \
+  --actuals <workdir>/parity-actuals.json \
+  --enhance                       # scan only → exit 14 with proposals
+# present each candidate to the user (one AskUserQuestion checklist), then:
+ruby scripts/migrate-tableau.rb --workbook "<name>" --finalize \
+  --actuals <workdir>/parity-actuals.json \
+  --enhance --enhance-accept all-low-risk    # or: id1,id2,...
+```
+
+The contract (trial-validated, 2026-06-10):
+
+1. **Clone-first.** `enhance-apply.rb` GETs the parity workbook's spec and
+   POSTs it as `"<name> — Enhanced"`. The 1:1 parity artifact is **never
+   written** (the report records its `updatedAt` before/after as proof).
+2. **Scan-then-propose.** `enhance-scan.rb` reads source signals (workdir
+   artifacts: `calc-fields.json`, `dashboard-layout.json`, `migrate-state.json`,
+   view CSVs) + the built spec + live element exports, and emits
+   `enhancements.json` — each candidate `{id, category, evidence, proposed,
+   risk, verdict_hint, patch}`. **Nothing applies without acceptance**:
+   interactive runs present a per-item checklist (AskUserQuestion); headless
+   runs pass `--enhance-accept id1,id2` or `--enhance-accept all-low-risk`.
+3. **Apply + parity-unchanged gate.** Accepted items apply **one at a time**
+   to the clone; after each, 2-3 untouched elements are spot-queried on the
+   clone AND the original at the same instant (live-drift-proof) — any shift
+   auto-reverts that item and flags it in `enhance-report.json`
+   (applied/skipped/reverted + evidence).
+
+Detector catalog (trial-validated; nothing speculative):
+
+- **comparison-enrichment** — date-grouped master + revenue-like measure →
+  latest-period KPI + delta-% KPI pair. KPI value columns INLINE the full
+  `Sum(If(D = Max(D), v, Null))` expression — cross-column aggregate refs
+  silently misevaluate in kpi-charts.
+- **interactivity-recovery** — (a) list **selection controls** on
+  reasonable-cardinality dims wired to the shared master (empty default =
+  identical render); (b) **grain switcher** — segmented control + DateTrunc
+  switch, default = parity grain; (c) **drill switcher** — segmented control +
+  `If()` dimension switch where a finer dim exists (medium risk: heuristic
+  hierarchy pairing); (d) **map restoration** (PBI signals) — point-map with
+  `Switch()` centroid synthesis (medium risk: centroids must be filled into
+  the patch before apply).
+- **fidelity-polish** — null-bucket labeling (`Coalesce → "No <Dim>"`),
+  month/date axis canonicalization (`MakeDate`; medium risk on multi-year
+  sources — intentionally un-pools), stale-source freshness note (time-boxed
+  wording), title corrections from source captions.
+
+**Descoped — emitted as propose-in-UI notes, never spec changes** (all
+trial-proven spec-unsupported): DM-metric promotion (metric refs don't resolve
+through a workbook table), chart-as-filter (`useAsFilter` silently dropped on
+readback), pie percent labels (`valueFormat:'percent'` silently dropped).
 
 ## Troubleshooting
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
@@ -1,0 +1,392 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# enhance-apply.rb — Phase E (opt-in) shared engine, part 2 of 2: APPLY.
+#
+# CLONE-FIRST, ACCEPT-ONLY, PARITY-GATED application of enhancements.json
+# candidates produced by enhance-scan.rb:
+#   1. CLONE: GET the parity-verified workbook's spec and POST it as
+#      "<name> — Enhanced". The 1:1 parity artifact is NEVER written.
+#   2. ACCEPT: only candidates named in --accept (id list) or matching
+#      --accept all-low-risk are applied. Everything else is recorded as
+#      skipped. Candidates whose patch carries unmet 'needs' (e.g. map
+#      centroids) are skipped with the reason, never half-applied.
+#   3. APPLY ONE AT A TIME with a parity-unchanged gate: after each item,
+#      spot-query 2-3 UNTOUCHED elements on the clone AND the same elements
+#      on the original simultaneously; any divergence (clone != original at
+#      the same instant — live-drift-proof, the trial's lesson) auto-REVERTS
+#      that item and flags it. enhance-report.json records
+#      applied/skipped/reverted with evidence.
+#
+# This file is the SHARED Phase-E engine, vendored byte-identical into every
+# covered plugin (md5 discipline — same as escalate-gap.py).
+#
+# Usage:
+#   ruby scripts/enhance-apply.rb --workbook-id <parityWorkbookId> \
+#     --enhancements <enhancements.json> \
+#     --accept all-low-risk | --accept id1,id2,... \
+#     [--name '<clone name>'] [--out enhance-report.json] [--probes N]
+#
+# Exit codes: 0 = done (clone created; accepted items applied or cleanly
+# reverted; parity-unchanged gate green); 2 = nothing accepted; 3 = the
+# parity-unchanged gate could not be restored (clone left for inspection,
+# report says so); other = error.
+
+require 'json'
+require 'yaml'
+require 'time'
+require 'date'
+require 'optparse'
+
+HERE = __dir__
+$LOAD_PATH.unshift File.expand_path('lib', HERE)
+require 'sigma_rest'
+
+opts = { probes: 3 }
+OptionParser.new do |o|
+  o.on('--workbook-id ID')   { |v| opts[:wb] = v }
+  o.on('--enhancements P')   { |v| opts[:enh] = File.expand_path(v) }
+  o.on('--accept LIST')      { |v| opts[:accept] = v }
+  o.on('--name NAME')        { |v| opts[:name] = v }
+  o.on('--out PATH')         { |v| opts[:out] = File.expand_path(v) }
+  o.on('--probes N', Integer) { |v| opts[:probes] = v }
+end.parse!
+abort 'missing --workbook-id' unless opts[:wb]
+abort 'missing --enhancements' unless opts[:enh] && File.exist?(opts[:enh])
+abort 'missing --accept (id list or all-low-risk) — nothing applies without explicit acceptance' unless opts[:accept]
+
+ORIG_WB = opts[:wb]
+enh = JSON.parse(File.read(opts[:enh]))
+OUT = opts[:out] || File.join(File.dirname(opts[:enh]), 'enhance-report.json')
+
+candidates = enh['candidates'] || []
+accepted_ids =
+  if opts[:accept].strip.casecmp?('all-low-risk')
+    candidates.select { |c| c['risk'].to_s == 'low' }.map { |c| c['id'] }
+  else
+    opts[:accept].split(',').map(&:strip).reject(&:empty?)
+  end
+unknown = accepted_ids - candidates.map { |c| c['id'] }
+abort "FATAL: --accept names unknown candidate id(s): #{unknown.join(', ')}" if unknown.any?
+
+accepted = candidates.select { |c| accepted_ids.include?(c['id']) }
+skipped  = candidates.reject { |c| accepted_ids.include?(c['id']) }
+                     .map { |c| { 'id' => c['id'], 'risk' => c['risk'], 'reason' => 'not accepted' } }
+if accepted.empty?
+  puts 'enhance-apply: no candidate accepted — nothing to do (no clone created).'
+  File.write(OUT, JSON.pretty_generate(
+    'workbook_id' => ORIG_WB, 'status' => 'nothing-accepted',
+    'applied' => [], 'skipped' => skipped, 'reverted' => [],
+    'descoped_notes' => enh['descoped_notes'] || []))
+  exit 2
+end
+
+READONLY_KEYS = %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt
+                   documentVersion latestDocumentVersion].freeze
+
+def clean(spec)
+  s = JSON.parse(JSON.generate(spec))
+  READONLY_KEYS.each { |k| s.delete(k) }
+  s
+end
+
+# Sigma's workbook POST/PUT responses can come back as YAML — parse leniently.
+def lenient(body)
+  return body if body.is_a?(Hash)
+  YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) rescue nil
+end
+
+def export_rows(wb, element_id, timeout: 75)
+  res = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: { 'elementId' => element_id, 'format' => { 'type' => 'json' } }.to_json)
+  qid = res.is_a?(Hash) ? res['queryId'] : nil
+  return nil unless qid
+  deadline = Time.now + timeout
+  while Time.now < deadline
+    body = (Sigma.request(:get, "/v2/query/#{qid}/download", binary: true) rescue nil)
+    if body && !body.strip.empty?
+      parsed = (JSON.parse(body) rescue nil)
+      return parsed if parsed.is_a?(Array)
+      return parsed['rows'] if parsed.is_a?(Hash) && parsed['rows'].is_a?(Array)
+      lines = body.each_line.map { |l| (JSON.parse(l) rescue nil) }.compact
+      return lines unless lines.empty?
+    end
+    sleep 2
+  end
+  nil
+rescue StandardError
+  nil
+end
+
+# Order-insensitive, float-tolerant normalization for row comparison.
+def norm_rows(rows)
+  return nil unless rows.is_a?(Array)
+  rows.map do |r|
+    r.transform_values { |v| v.is_a?(Numeric) ? v.to_f.round(4) : v }
+  end.sort_by { |r| JSON.generate(r.sort.to_h) }
+end
+
+# ---------------------------------------------------------------------------
+# Layout helper: append a LayoutElement to the bottom of a page's grid block.
+# ---------------------------------------------------------------------------
+def add_layout!(spec, page_id, element_id, grid_column, height, same_row_start = nil)
+  xml = spec['layout'].to_s
+  return nil if xml.empty? || page_id.nil?
+  m = xml.match(%r{(<Page\b[^>]*\bid="#{Regexp.escape(page_id)}"[^>]*>)(.*?)(</Page>)}m)
+  return nil unless m
+  block = m[2]
+  max_end = block.scan(/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/).flatten.map(&:to_i).max || 1
+  row_start = same_row_start || max_end
+  entry = %(  <LayoutElement elementId="#{element_id}" gridColumn="#{grid_column}" gridRow="#{row_start} / #{row_start + height}"/>\n)
+  spec['layout'] = xml.sub(m[0], "#{m[1]}#{block}#{entry}#{m[3]}")
+  row_start
+end
+
+def find_element(spec, element_id)
+  (spec['pages'] || []).each do |p|
+    (p['elements'] || []).each { |e| return [p, e] if e['id'] == element_id }
+  end
+  nil
+end
+
+# Apply one candidate's patch to a working spec (in place). Returns a
+# human-readable description, or raises with the reason it cannot apply.
+def apply_patch!(spec, cand)
+  patch = cand['patch']
+  raise 'candidate has no machine patch (propose-in-UI only)' unless patch.is_a?(Hash)
+  if patch['needs'] && (patch[patch['needs']].nil? || patch[patch['needs']].empty?)
+    raise "patch needs '#{patch['needs']}' filled in before apply (see candidate.proposed)"
+  end
+  case patch['op']
+  when 'add_elements'
+    page = (spec['pages'] || []).find { |p| p['id'] == patch['page_id'] } ||
+           (spec['pages'] || []).reject { |p| p['id'] == 'page-data' }.first
+    raise 'target page not found' unless page
+    row_anchor = {}
+    Array(patch['elements']).each do |el|
+      raise "element id #{el['id']} already exists" if find_element(spec, el['id'])
+      (page['elements'] ||= []) << el
+    end
+    Array(patch['layout']).each do |l|
+      anchor = l['same_row_as'] && row_anchor[l['same_row_as']]
+      placed = add_layout!(spec, page['id'], l['element_id'], l['grid_column'], l['height'] || 4, anchor)
+      row_anchor[l['element_id']] = placed if placed
+    end
+    "added #{Array(patch['elements']).size} element(s) to page #{page['id']}"
+  when 'set_column_formula'
+    _pg, el = find_element(spec, patch['element_id'])
+    raise "element #{patch['element_id']} not found" unless el
+    col = (el['columns'] || []).find { |c| c['id'] == patch['column_id'] }
+    raise "column #{patch['column_id']} not found on #{patch['element_id']}" unless col
+    col['formula'] = patch['formula']
+    "set #{patch['element_id']}/#{patch['column_id']} formula"
+  when 'rename_element'
+    _pg, el = find_element(spec, patch['element_id'])
+    raise "element #{patch['element_id']} not found" unless el
+    el['name'] = patch['name']
+    "renamed #{patch['element_id']} -> '#{patch['name']}'"
+  when 'add_control_and_rewire'
+    pg, el = find_element(spec, patch.dig('rewire', 'element_id'))
+    raise "element #{patch.dig('rewire', 'element_id')} not found" unless el
+    col = (el['columns'] || []).find { |c| c['id'] == patch.dig('rewire', 'column_id') }
+    raise 'rewire column not found' unless col
+    raise "control id #{patch.dig('control', 'id')} already exists" if find_element(spec, patch.dig('control', 'id'))
+    (pg['elements'] ||= []) << patch['control']
+    col['formula'] = patch.dig('rewire', 'formula')
+    Array(patch['layout']).each do |l|
+      add_layout!(spec, pg['id'], l['element_id'], l['grid_column'], l['height'] || 3)
+    end
+    "added control #{patch.dig('control', 'controlId')} + rewired #{el['id']}"
+  when 'set_element_prop'
+    _pg, el = find_element(spec, patch['element_id'])
+    raise "element #{patch['element_id']} not found" unless el
+    el[patch['prop']] = patch['value']
+    "set #{patch['element_id']}.#{patch['prop']}"
+  when 'replace_with_point_map'
+    pg, el = find_element(spec, patch['element_id'])
+    raise "element #{patch['element_id']} not found" unless el
+    geo = patch['geo_column']
+    cents = patch['centroids'] || {}
+    raise 'centroids empty' if cents.empty?
+    sw = lambda do |idx, default|
+      args = cents.flat_map { |val, ll| ["\"#{val}\"", ll[idx].to_s] }.join(', ')
+      "Switch([#{geo}], #{args}, #{default})"
+    end
+    geo_ref = patch['geo_ref'] ||
+              (el['columns'] || []).map { |c| c['formula'] }.find { |f| f.to_s =~ /\/#{Regexp.escape(geo)}\]\z/ }
+    raise 'cannot resolve a geo column reference' unless geo_ref
+    map_el = {
+      'id' => "map-phasee-#{el['id']}"[0, 40], 'kind' => 'point-map',
+      'source' => el['source'],
+      'columns' => [
+        { 'id' => 'map-phasee-geo', 'formula' => geo_ref, 'name' => geo },
+        { 'id' => 'map-phasee-lat', 'formula' => sw.call(0, '39'), 'name' => 'Lat' },
+        { 'id' => 'map-phasee-lng', 'formula' => sw.call(1, '-98'), 'name' => 'Long' },
+        { 'id' => 'map-phasee-val', 'formula' => patch['value_formula'],
+          'name' => patch['value_name'] || 'Value' }
+      ],
+      'latitude' => { 'id' => 'map-phasee-lat' }, 'longitude' => { 'id' => 'map-phasee-lng' },
+      'size' => { 'id' => 'map-phasee-val' },
+      'color' => { 'by' => 'category', 'column' => 'map-phasee-geo' },
+      'name' => "#{el['name']} (map restored)"
+    }
+    pg['elements'].delete(el)
+    pg['elements'] << map_el
+    spec['layout'] = spec['layout'].to_s.gsub(/elementId="#{Regexp.escape(el['id'])}"/,
+                                              %(elementId="#{map_el['id']}"))
+    "replaced #{el['id']} with point-map #{map_el['id']}"
+  else
+    raise "unknown patch op #{patch['op'].inspect}"
+  end
+end
+
+# Element ids a candidate touches (so probes only use UNTOUCHED elements).
+def touched_ids(cand)
+  p = cand['patch'] || {}
+  ids = [p['element_id'], p.dig('rewire', 'element_id')]
+  ids += Array(p['elements']).map { |e| e['id'] }
+  ids += [p['control'] && p['control']['id']]
+  ids.compact.uniq
+end
+
+# ---------------------------------------------------------------------------
+# 1. CLONE — the 1:1 parity artifact is never touched.
+# ---------------------------------------------------------------------------
+orig_meta_before = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}")
+orig_spec = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}/spec")
+abort "FATAL: cannot read spec of #{ORIG_WB}" unless orig_spec.is_a?(Hash) && orig_spec['pages']
+clone_name = opts[:name] || "#{orig_spec['name']} — Enhanced"
+
+clone_spec = clean(orig_spec)
+clone_spec['name'] = clone_name
+post = lenient(Sigma.request(:post, '/v2/workbooks/spec',
+                             body: JSON.generate(clone_spec), binary: true))
+clone_id = post.is_a?(Hash) && (post['workbookId'] || post['id'])
+abort "FATAL: clone POST returned no workbookId: #{post.inspect[0, 300]}" unless clone_id
+puts "enhance-apply: clone '#{clone_name}' = #{clone_id} (original #{ORIG_WB} untouched)"
+
+# ---------------------------------------------------------------------------
+# 2. Pick probe elements (untouched by ANY accepted item) + baseline check.
+# ---------------------------------------------------------------------------
+all_touched = accepted.flat_map { |c| touched_ids(c) }
+viz_kinds = %w[bar-chart line-chart area-chart pie-chart combo-chart scatter-chart kpi-chart table pivot-table]
+probe_pool = (orig_spec['pages'] || []).reject { |p| p['id'] == 'page-data' }
+                                       .flat_map { |p| p['elements'] || [] }
+                                       .select { |e| viz_kinds.include?(e['kind']) }
+                                       .reject { |e| all_touched.include?(e['id']) }
+probes = probe_pool.first(opts[:probes]).map { |e| e['id'] }
+abort 'FATAL: no untouched element available as a parity probe' if probes.empty?
+puts "   parity probes (untouched elements): #{probes.join(', ')}"
+
+# clone-vs-original at (near) the same instant: live-drift-proof comparison.
+def probe_pair(clone_id, orig_id, probes)
+  probes.to_h do |el|
+    [el, { 'clone' => norm_rows(export_rows(clone_id, el)),
+           'orig' => norm_rows(export_rows(orig_id, el)) }]
+  end
+end
+
+def probe_diffs(pair)
+  pair.reject { |_el, v| v['clone'] && v['orig'] && v['clone'] == v['orig'] }.keys
+end
+
+baseline = probe_pair(clone_id, ORIG_WB, probes)
+bad = probe_diffs(baseline)
+abort "FATAL: clone baseline already diverges from original on #{bad.join(', ')} — aborting before any change" if bad.any?
+puts "   baseline: clone == original on #{probes.size}/#{probes.size} probe(s)"
+
+# ---------------------------------------------------------------------------
+# 3. Apply accepted items ONE AT A TIME with the parity-unchanged gate.
+# ---------------------------------------------------------------------------
+def put_spec(wb, spec)
+  lenient(Sigma.request(:put, "/v2/workbooks/#{wb}/spec",
+                        body: JSON.generate(spec), binary: true))
+end
+
+current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+applied = []
+reverted = []
+gate_green = true
+
+accepted.each do |cand|
+  print "   [#{cand['id']}] "
+  prev = JSON.parse(JSON.generate(current))
+  begin
+    desc = apply_patch!(current, cand)
+  rescue StandardError => e
+    skipped << { 'id' => cand['id'], 'risk' => cand['risk'], 'reason' => "not applied: #{e.message}" }
+    current = prev
+    puts "SKIP (#{e.message})"
+    next
+  end
+  begin
+    put_spec(clone_id, current)
+  rescue StandardError => e
+    current = prev
+    (put_spec(clone_id, current) rescue nil) # restore server state if the PUT half-landed
+    reverted << { 'id' => cand['id'], 'reason' => "PUT rejected: #{e.message.to_s.gsub(/\s+/, ' ')[0, 200]}" }
+    puts 'REVERTED (PUT rejected)'
+    next
+  end
+  # parity-unchanged gate: untouched probes, clone vs original, same instant.
+  pair = probe_pair(clone_id, ORIG_WB, probes)
+  diffs = probe_diffs(pair)
+  if diffs.any?
+    current = prev
+    begin
+      put_spec(clone_id, current)
+      recheck = probe_diffs(probe_pair(clone_id, ORIG_WB, probes))
+      gate_green &&= recheck.empty?
+    rescue StandardError
+      gate_green = false
+    end
+    reverted << { 'id' => cand['id'],
+                  'reason' => "parity-unchanged gate: untouched element(s) #{diffs.join(', ')} shifted vs original" }
+    puts "REVERTED (probes shifted: #{diffs.join(', ')})"
+  else
+    applied << { 'id' => cand['id'], 'category' => cand['category'], 'change' => desc,
+                 'evidence' => cand['evidence'] }
+    puts "APPLIED (#{desc}; #{probes.size} probe(s) unchanged)"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# 4. Final report.
+# ---------------------------------------------------------------------------
+final_pair = probe_pair(clone_id, ORIG_WB, probes)
+final_ok = probe_diffs(final_pair).empty?
+gate_green &&= final_ok
+orig_meta_after = Sigma.request(:get, "/v2/workbooks/#{ORIG_WB}")
+orig_untouched = orig_meta_before['updatedAt'] == orig_meta_after['updatedAt']
+
+report = {
+  'workbook_id' => ORIG_WB,
+  'workbook_name' => orig_spec['name'],
+  'clone_id' => clone_id,
+  'clone_name' => clone_name,
+  'clone_url' => (lenient(post) || {})['url'],
+  'accepted' => accepted_ids,
+  'applied' => applied,
+  'skipped' => skipped,
+  'reverted' => reverted,
+  'descoped_notes' => enh['descoped_notes'] || [],
+  'parity_unchanged_gate' => {
+    'probe_elements' => probes,
+    'method' => 'clone-vs-original simultaneous JSON exports (live-drift-proof), after every item',
+    'green' => gate_green
+  },
+  'original_untouched' => {
+    'updatedAt_before' => orig_meta_before['updatedAt'],
+    'updatedAt_after' => orig_meta_after['updatedAt'],
+    'unchanged' => orig_untouched
+  },
+  'finished_at' => Time.now.utc.iso8601
+}
+File.write(OUT, JSON.pretty_generate(report))
+
+puts
+puts "enhance-apply: #{applied.size} applied, #{skipped.size} skipped, #{reverted.size} reverted"
+puts "   clone: '#{clone_name}' (#{clone_id})"
+puts "   parity-unchanged gate: #{gate_green ? 'GREEN' : 'NOT GREEN (see report)'}; original untouched: #{orig_untouched}"
+puts "   report -> #{OUT}"
+exit(gate_green ? 0 : 3)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-scan.rb
@@ -1,0 +1,701 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# enhance-scan.rb — Phase E (opt-in) shared engine, part 1 of 2: SCAN.
+#
+# Reads source-migration signals (workdir artifacts) + the PARITY-VERIFIED
+# built workbook (live spec + element data exports) and emits
+# enhancements.json: a list of candidate enhancements, each with
+#   {id, category, evidence, proposed, risk, verdict_hint, patch}
+# NOTHING here writes to Sigma — scan is strictly read-only. Application is
+# enhance-apply.rb's job, and ONLY for explicitly accepted candidates.
+#
+# This file is the SHARED Phase-E engine, vendored byte-identical into every
+# covered plugin (md5 discipline — same as escalate-gap.py). Keep it
+# tool-agnostic: per-source behavior keys off --source + which workdir
+# artifacts exist, never off the plugin it happens to live in.
+#
+# The detector catalog is TRIAL-VALIDATED (2026-06-10 prototype trials on
+# tableau/qlik/powerbi migrations) — nothing speculative:
+#   1. comparison-enrichment  date-grouped master -> prior-period KPI pair
+#      (the verified Sum(If(D = Max(D), v, Null)) inline shape; KPI value
+#      columns must INLINE the full expression — cross-column aggregate refs
+#      silently misevaluate).
+#   2. interactivity-recovery
+#      (a) selection controls — list controls on reasonable-cardinality dims
+#          wired to the shared master (qlik-trial pattern; empty default =>
+#          untouched render identical).
+#      (b) grain switcher — segmented control + DateTrunc switch on a
+#          date-grouped chart (PBI-trial pattern; default == parity grain).
+#      (c) drill switcher — segmented control + If() dimension switch where a
+#          finer dimension exists on the master (tableau-trial pattern).
+#      (d) map restoration (PBI) — azureMap-approximated-as-bar -> point-map
+#          with Switch() centroid synthesis when geo-ish columns exist
+#          (PBI-trial verified shape; centroids must be supplied at apply).
+#   3. fidelity-polish — null-bucket labeling (Coalesce -> "No <Dim>"),
+#      month/date axis canonicalization (MakeDate), stale-source freshness
+#      note (time-boxed wording), title corrections from source captions.
+#   DESCOPED (trial-proven spec-unsupported; emitted as propose-in-UI NOTES,
+#   never spec changes): DM-metric promotion (metric refs don't resolve
+#   through a workbook table layer), chart-as-filter (useAsFilter silently
+#   dropped on readback), pie percent labels (valueFormat:'percent' silently
+#   dropped).
+#
+# Usage:
+#   ruby scripts/enhance-scan.rb --workbook-id <parityWorkbookId> \
+#     --workdir <migration workdir> [--source tableau|powerbi|qlik|...] \
+#     [--out enhancements.json] [--max-exports N]
+#
+# Env: SIGMA_BASE_URL + SIGMA_CLIENT_ID/SECRET (lib/sigma_rest.rb bootstraps
+# from ~/.sigma-migration/env when unset).
+
+require 'json'
+require 'csv'
+require 'time'
+require 'digest'
+require 'optparse'
+
+HERE = __dir__
+$LOAD_PATH.unshift File.expand_path('lib', HERE)
+require 'sigma_rest'
+
+opts = { max_exports: 12 }
+OptionParser.new do |o|
+  o.on('--workbook-id ID')  { |v| opts[:wb] = v }
+  o.on('--workdir DIR')     { |v| opts[:workdir] = File.expand_path(v) }
+  o.on('--source NAME')     { |v| opts[:source] = v }
+  o.on('--out PATH')        { |v| opts[:out] = File.expand_path(v) }
+  o.on('--max-exports N', Integer) { |v| opts[:max_exports] = v }
+end.parse!
+abort 'missing --workbook-id' unless opts[:wb]
+WB = opts[:wb]
+WORKDIR = opts[:workdir]
+OUT = opts[:out] || (WORKDIR ? File.join(WORKDIR, 'enhancements.json') : 'enhancements.json')
+
+def jread(path)
+  return nil unless path && File.exist?(path)
+  JSON.parse(File.read(path))
+rescue StandardError
+  nil
+end
+
+# Infer the source tool from workdir artifacts when --source is not given.
+source = opts[:source]
+if source.nil? && WORKDIR
+  source = if File.exist?(File.join(WORKDIR, 'signals.json')) then 'powerbi'
+           elsif File.exist?(File.join(WORKDIR, 'dashboard-layout.json')) ||
+                 File.exist?(File.join(WORKDIR, 'calc-fields.json')) then 'tableau'
+           end
+end
+source ||= 'unknown'
+
+# ---------------------------------------------------------------------------
+# Load the live spec + export element data (read-only).
+# ---------------------------------------------------------------------------
+spec = Sigma.request(:get, "/v2/workbooks/#{WB}/spec")
+abort "FATAL: could not read spec for workbook #{WB}" unless spec.is_a?(Hash) && spec['pages']
+wb_name = spec['name'].to_s
+
+VIZ_KINDS = %w[bar-chart line-chart area-chart pie-chart combo-chart scatter-chart].freeze
+pages = spec['pages'] || []
+data_page = pages.find { |p| p['id'] == 'page-data' } || pages.find { |p| p['name'].to_s =~ /\bdata\b/i }
+dash_pages = pages - [data_page].compact
+viz = dash_pages.flat_map { |p| (p['elements'] || []).map { |e| [p, e] } }
+                .select { |(_p, e)| VIZ_KINDS.include?(e['kind']) }
+controls = dash_pages.flat_map { |p| p['elements'] || [] }.select { |e| e['kind'] == 'control' }
+masters = data_page ? (data_page['elements'] || []) : []
+master_by_id = masters.to_h { |e| [e['id'], e] }
+
+# Export an element's data rows via the REST export API (JSON). Best-effort.
+def export_rows(wb, element_id, timeout: 75)
+  res = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: { 'elementId' => element_id, 'format' => { 'type' => 'json' } }.to_json)
+  qid = res.is_a?(Hash) ? res['queryId'] : nil
+  return nil unless qid
+  deadline = Time.now + timeout
+  while Time.now < deadline
+    body = (Sigma.request(:get, "/v2/query/#{qid}/download", binary: true) rescue nil)
+    if body && !body.strip.empty?
+      parsed = (JSON.parse(body) rescue nil)
+      return parsed if parsed.is_a?(Array)
+      return parsed['rows'] if parsed.is_a?(Hash) && parsed['rows'].is_a?(Array)
+      lines = body.each_line.map { |l| (JSON.parse(l) rescue nil) }.compact
+      return lines unless lines.empty?
+    end
+    sleep 2
+  end
+  nil
+rescue StandardError
+  nil
+end
+
+# Per-element data cache (each viz exported at most once; capped).
+rows_by_el = {}
+exported = 0
+viz.each do |(_pg, el)|
+  break if exported >= opts[:max_exports]
+  rows_by_el[el['id']] = export_rows(WB, el['id'])
+  exported += 1
+end
+
+# ---------------------------------------------------------------------------
+# Spec-navigation helpers.
+# ---------------------------------------------------------------------------
+def col_by_id(el, cid)
+  (el['columns'] || []).find { |c| c['id'] == cid }
+end
+
+# The categorical/x column of a viz element.
+def x_col(el)
+  cid = el.dig('xAxis', 'columnId') || el.dig('color', 'id') || el.dig('category', 'id')
+  cid && col_by_id(el, cid)
+end
+
+# The first value/measure column.
+def y_col(el)
+  cid = Array(el.dig('yAxis', 'columnIds')).first || el.dig('value', 'id') || el.dig('value', 'columnId')
+  cid = cid['columnId'] if cid.is_a?(Hash)
+  cid && col_by_id(el, cid)
+end
+
+# A bare single-ref formula like "[Master/Region]" -> ['Master', 'Region'].
+def bare_ref(formula)
+  m = formula.to_s.strip.match(/\A\[([^\]]+)\]\z/)
+  return nil unless m
+  parts = m[1].split('/')
+  return nil if parts.size < 2
+  [parts[0..-2].join('/'), parts[-1]]
+end
+
+def norm(s)
+  s.to_s.downcase.gsub(/[^a-z0-9]/, '')
+end
+
+# Pull the value for a viz row matching a column display name (export keys are
+# display names, sometimes suffixed).
+def row_val(row, colname)
+  return row[colname] if row.key?(colname)
+  k = row.keys.find { |kk| norm(kk) == norm(colname) }
+  k && row[k]
+end
+
+DATEISH = /\b(date|month|year|week|quarter|day)\b/i
+MEASUREISH = /revenue|sales|amount|profit|margin|net|gross|total|spend|cost|price|hours|count|orders|quantity|qty|units|headcount/i
+
+candidates = []
+descoped = []
+
+# ---------------------------------------------------------------------------
+# 1. comparison-enrichment — prior-period KPI pair on the best date-grouped
+#    chart. Verified shape: KPI value column INLINES the full conditional
+#    aggregate (Sum(If(D = Max(D), v, Null))) — never references sibling
+#    aggregate columns (they silently misevaluate in kpi-chart).
+# ---------------------------------------------------------------------------
+comparison_target = nil
+viz.sort_by { |(_p, e)| e['kind'] == 'line-chart' ? 0 : 1 }.each do |(_pg, el)|
+  xc = x_col(el)
+  yc = y_col(el)
+  next unless xc && yc
+  next unless yc['formula'].to_s =~ /\ASum\((.+)\)\z/m
+  inner_v = Regexp.last_match(1)
+  next unless (yc['name'].to_s =~ MEASUREISH) || (yc['formula'].to_s =~ MEASUREISH)
+  xf = xc['formula'].to_s
+  d_expr = nil
+  unit = nil
+  if (m = xf.match(/\ADateTrunc\(\s*"(\w+)"\s*,\s*(.+)\)\z/m))
+    unit = m[1]
+    d_expr = xf
+  elsif xc['name'].to_s =~ DATEISH || xf =~ DATEISH
+    # Derive a usable month-grain date expression over the same source:
+    # a real date column on the ref prefix, else MakeDate(Year, Month, 1).
+    ref = bare_ref(xf)
+    src_el = master_by_id[el.dig('source', 'elementId')]
+    prefix = ref ? ref[0] : (src_el && src_el['name'])
+    src_cols = src_el ? (src_el['columns'] || []).map { |c| c['name'].to_s } : []
+    date_col = src_cols.find { |n| n =~ /\bdate\b/i && n !~ /\bkey\b/i }
+    year_col = src_cols.find { |n| n =~ /\byear\b/i }
+    month_col = src_cols.find { |n| n =~ /\bmonth\b/i && n !~ /name/i }
+    if prefix && date_col
+      d_expr = "DateTrunc(\"month\", [#{prefix}/#{date_col}])"
+      unit = 'month'
+    elsif prefix && year_col && month_col
+      d_expr = "DateTrunc(\"month\", MakeDate([#{prefix}/#{year_col}], [#{prefix}/#{month_col}], 1))"
+      unit = 'month'
+    end
+  end
+  next unless d_expr && unit
+  comparison_target = { el: el, inner_v: inner_v, d: d_expr, unit: unit,
+                        measure: yc['name'].to_s, fmt: yc['format'] }
+  break
+end
+
+if comparison_target
+  t = comparison_target
+  el = t[:el]
+  cur = "Sum(If(#{t[:d]} = Max(#{t[:d]}), #{t[:inner_v]}, Null))"
+  prev = "Sum(If(#{t[:d]} = DateAdd(\"#{t[:unit]}\", -1, Max(#{t[:d]})), #{t[:inner_v]}, Null))"
+  page_id = dash_pages.find { |p| (p['elements'] || []).any? { |e| e['id'] == el['id'] } }&.dig('id') ||
+            dash_pages.first&.dig('id')
+  kpi_cur = {
+    'id' => 'el-phasee-kpi-current', 'kind' => 'kpi-chart',
+    'name' => "Latest #{t[:unit].capitalize} #{t[:measure]}",
+    'source' => el['source'],
+    'columns' => [{ 'id' => 'phasee-kpi-cur-val', 'name' => "Latest #{t[:unit].capitalize} #{t[:measure]}",
+                    'formula' => cur }.merge(t[:fmt] ? { 'format' => t[:fmt] } : {})],
+    'value' => { 'columnId' => 'phasee-kpi-cur-val' }
+  }
+  kpi_delta = {
+    'id' => 'el-phasee-kpi-delta', 'kind' => 'kpi-chart',
+    'name' => "#{t[:measure]} vs prior #{t[:unit]}",
+    'source' => el['source'],
+    'columns' => [{ 'id' => 'phasee-kpi-delta-val', 'name' => "#{t[:measure]} Δ vs prior #{t[:unit]}",
+                    'formula' => "((#{cur}) - (#{prev})) / (#{prev})",
+                    'format' => { 'kind' => 'number', 'formatString' => '+,.1%' } }],
+    'value' => { 'columnId' => 'phasee-kpi-delta-val' }
+  }
+  candidates << {
+    'id' => 'comparison-kpi-pair',
+    'category' => 'comparison-enrichment',
+    'evidence' => "'#{el['name']}' (#{el['kind']}) groups #{t[:measure]} by a date expression " \
+                  "(#{t[:d][0, 90]}); the dashboard has no period-over-period context. " \
+                  'Trial-verified pattern: latest-period KPI + delta-% KPI, full expression inlined ' \
+                  '(KPI cross-column aggregate refs silently misevaluate).',
+    'proposed' => "Add 2 KPI tiles sourcing the same element: 'Latest #{t[:unit].capitalize} " \
+                  "#{t[:measure]}' and '#{t[:measure]} vs prior #{t[:unit]}' (delta %). Purely additive — " \
+                  'no existing element changes.',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'add_elements', 'page_id' => page_id,
+                 'elements' => [kpi_cur, kpi_delta],
+                 'layout' => [{ 'element_id' => 'el-phasee-kpi-current', 'grid_column' => '1 / 13', 'height' => 6 },
+                              { 'element_id' => 'el-phasee-kpi-delta', 'grid_column' => '13 / 25', 'height' => 6,
+                                'same_row_as' => 'el-phasee-kpi-current' }] }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 2a. selection controls — list controls on reasonable-cardinality dims wired
+#     to the shared master (qlik-trial verified shape). Empty default values
+#     => untouched render is identical, so this is low risk.
+# ---------------------------------------------------------------------------
+existing_ctrl_cols = controls.flat_map { |c| Array(c['filters']).map { |f| f['columnId'] } }
+                             .compact
+sel_seen = {}
+viz.each do |(_pg, el)|
+  break if candidates.count { |c| c['id'].start_with?('interactivity-selection-') } >= 3
+  xc = x_col(el)
+  next unless xc
+  ref = bare_ref(xc['formula'])
+  next unless ref
+  next if xc['name'].to_s =~ DATEISH
+  src_eid = el.dig('source', 'elementId')
+  master = master_by_id[src_eid]
+  next unless master
+  # shared master: at least 2 viz source it (the propagation that makes one
+  # control filter the whole dashboard).
+  next unless viz.count { |(_p, e)| e.dig('source', 'elementId') == src_eid } >= 2
+  leaf = ref[1]
+  mcol = (master['columns'] || []).find { |c| c['name'].to_s == leaf } ||
+         (master['columns'] || []).find { |c| norm(c['name']) == norm(leaf) }
+  next unless mcol
+  next if sel_seen[mcol['id']]
+  next if existing_ctrl_cols.include?(mcol['id']) # already has a control
+  rows = rows_by_el[el['id']]
+  card = rows ? rows.map { |r| row_val(r, xc['name'].to_s) }.uniq.size : nil
+  next if card && (card < 2 || card > 50)
+  sel_seen[mcol['id']] = true
+  cid = "PhaseE#{leaf.gsub(/[^A-Za-z0-9]/, '')}Filter"
+  ctrl = {
+    'id' => "ctrl-phasee-#{Digest::SHA1.hexdigest(mcol['id'])[0, 6]}",
+    'kind' => 'control', 'controlId' => cid, 'name' => leaf,
+    'controlType' => 'list', 'mode' => 'include', 'selectionMode' => 'multiple',
+    'values' => [],
+    'source' => { 'kind' => 'source',
+                  'source' => { 'kind' => 'table', 'elementId' => master['id'] },
+                  'columnId' => mcol['id'] },
+    'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => master['id'] },
+                    'columnId' => mcol['id'] }]
+  }
+  candidates << {
+    'id' => "interactivity-selection-#{norm(leaf)}",
+    'category' => 'interactivity-recovery',
+    'evidence' => "'#{leaf}' is a chart dimension#{card ? " with #{card} member(s)" : ''} on the shared " \
+                  "master '#{master['name']}' (#{viz.count { |(_p, e)| e.dig('source', 'elementId') == src_eid }} " \
+                  'charts source it) and has no filter control. A list control on the shared source ' \
+                  'filters every consumer (verified propagation pattern).',
+    'proposed' => "Add a '#{leaf}' list control bound to the master column. Default = no selection, " \
+                  'so the untouched render is identical.',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'add_elements',
+                 'page_id' => dash_pages.first&.dig('id'),
+                 'elements' => [ctrl],
+                 'layout' => [{ 'element_id' => ctrl['id'], 'grid_column' => '1 / 9', 'height' => 3 }] }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 2b. grain switcher — segmented control + DateTrunc switch (PBI-trial shape).
+#     Default value == the parity grain, so element data is unchanged until a
+#     user switches — low risk.
+# ---------------------------------------------------------------------------
+viz.each do |(pg, el)|
+  xc = x_col(el)
+  next unless xc
+  m = xc['formula'].to_s.match(/\ADateTrunc\(\s*"(year|quarter|month|week|day)"\s*,\s*(.+)\)\z/m)
+  next unless m
+  cur_unit = m[1]
+  inner = m[2]
+  grains = %w[Year Quarter Month]
+  grains << cur_unit.capitalize unless grains.include?(cur_unit.capitalize)
+  cid = "PhaseEGrain#{Digest::SHA1.hexdigest(el['id'])[0, 4]}"
+  new_f = "If([#{cid}] = \"Year\", DateTrunc(\"year\", #{inner}), " \
+          "If([#{cid}] = \"Quarter\", DateTrunc(\"quarter\", #{inner}), " \
+          "DateTrunc(\"#{cur_unit}\", #{inner})))"
+  ctrl = {
+    'id' => "ctrl-phasee-grain-#{Digest::SHA1.hexdigest(el['id'])[0, 6]}",
+    'kind' => 'control', 'controlId' => cid, 'name' => "#{el['name']} grain",
+    'controlType' => 'segmented',
+    'source' => { 'kind' => 'manual', 'valueType' => 'text',
+                  'values' => grains, 'labels' => grains.map { nil } },
+    'value' => cur_unit.capitalize
+  }
+  candidates << {
+    'id' => "interactivity-grain-#{el['id']}",
+    'category' => 'interactivity-recovery',
+    'evidence' => "'#{el['name']}' is hard-grouped to DateTrunc(\"#{cur_unit}\") — the source's date " \
+                  'drill/hierarchy affordance was frozen at one grain by the migration. Segmented ' \
+                  'control + DateTrunc switch is the trial-verified spec-persistable equivalent.',
+    'proposed' => "Add a segmented '#{grains.join('/')}' grain control (default #{cur_unit.capitalize} " \
+                  '= parity grain, so data is unchanged at default) and wire the x-axis through it.',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'add_control_and_rewire', 'page_id' => pg['id'],
+                 'control' => ctrl,
+                 'rewire' => { 'element_id' => el['id'], 'column_id' => xc['id'], 'formula' => new_f },
+                 'layout' => [{ 'element_id' => ctrl['id'], 'grid_column' => '17 / 25', 'height' => 3 }] }
+  }
+  break # one grain switcher per workbook is plenty for the opt-in pass
+end
+
+# ---------------------------------------------------------------------------
+# 2c. drill switcher — segmented control + If() dimension switch where a finer
+#     dimension exists on the master (tableau-trial pattern). Medium risk: it
+#     rewrites the chart's category formula (default reproduces the parity
+#     grouping, but the hierarchy pairing is heuristic — confirm before apply).
+# ---------------------------------------------------------------------------
+HIERARCHY = {
+  'region' => %w[state province],
+  'state' => %w[city county],
+  'category' => ['sub-category', 'subcategory', 'sub category', 'product name'],
+  'department' => %w[team role title],
+  'country' => %w[state region city]
+}.freeze
+viz.each do |(pg, el)|
+  next if candidates.any? { |c| c['id'].start_with?('interactivity-drill-') }
+  xc = x_col(el)
+  next unless xc
+  ref = bare_ref(xc['formula'])
+  next unless ref
+  prefix, leaf = ref
+  finer_names = HIERARCHY[leaf.downcase.strip]
+  next unless finer_names
+  src_el = master_by_id[el.dig('source', 'elementId')]
+  next unless src_el
+  finer = (src_el['columns'] || []).map { |c| c['name'].to_s }
+                                   .find { |n| finer_names.include?(n.downcase.strip) }
+  next unless finer
+  cid = "PhaseELevel#{Digest::SHA1.hexdigest(el['id'])[0, 4]}"
+  new_f = "If([#{cid}] = \"#{finer}\", [#{prefix}/#{finer}], [#{prefix}/#{leaf}])"
+  ctrl = {
+    'id' => "ctrl-phasee-drill-#{Digest::SHA1.hexdigest(el['id'])[0, 6]}",
+    'kind' => 'control', 'controlId' => cid, 'name' => "#{el['name']} level",
+    'controlType' => 'segmented',
+    'source' => { 'kind' => 'manual', 'valueType' => 'text',
+                  'values' => [leaf, finer], 'labels' => [nil, nil] },
+    'value' => leaf
+  }
+  candidates << {
+    'id' => "interactivity-drill-#{el['id']}",
+    'category' => 'interactivity-recovery',
+    'evidence' => "'#{el['name']}' groups by '#{leaf}' and the master also exposes the finer " \
+                  "'#{finer}' — users of the source clearly analyze below #{leaf} level, but Sigma's " \
+                  'spec has no native drill/hierarchy field (UI-only). Segmented control + If() switch ' \
+                  'is the trial-verified spec equivalent.',
+    'proposed' => "Add a '#{leaf}/#{finer}' segmented control (default #{leaf} reproduces the parity " \
+                  'grouping) and switch the category formula through it.',
+    'risk' => 'medium',
+    'verdict_hint' => 'confirm — rewrites the chart category formula; hierarchy pairing is heuristic',
+    'patch' => { 'op' => 'add_control_and_rewire', 'page_id' => pg['id'],
+                 'control' => ctrl,
+                 'rewire' => { 'element_id' => el['id'], 'column_id' => xc['id'], 'formula' => new_f },
+                 'layout' => [{ 'element_id' => ctrl['id'], 'grid_column' => '9 / 17', 'height' => 3 }] }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 2d. map restoration (PBI-trial shape) — a source map visual that the
+#     migration approximated as a bar/table, where geo-ish columns exist.
+#     point-map with Switch() centroid synthesis; the centroid table must be
+#     supplied at apply time (patch.needs='centroids'), so this is never
+#     auto-applied by all-low-risk.
+# ---------------------------------------------------------------------------
+signals = WORKDIR && jread(File.join(WORKDIR, 'signals.json'))
+if signals
+  map_visuals = (signals['pages'] || []).flat_map { |p| p['visuals'] || [] }
+                                        .select { |v| v['visual_type'].to_s =~ /azureMap|filledMap|shapeMap|^map$/i }
+  map_visuals.each do |mv|
+    title = (mv['title'] || mv['visual_id']).to_s
+    approx = viz.map(&:last).find { |e| norm(e['name']) == norm(title) } ||
+             viz.map(&:last).find { |e| !title.empty? && norm(e['name']).include?(norm(title)) }
+    src_el = approx && master_by_id[approx.dig('source', 'elementId')]
+    geo_cols = src_el ? (src_el['columns'] || []).map { |c| c['name'].to_s }
+                                                 .select { |n| n =~ /\b(city|state|zip|postal|country|region|lat|latitude|lon|lng|longitude|location)\b/i } : []
+    candidates << {
+      'id' => "interactivity-map-#{norm(title)[0, 24]}",
+      'category' => 'interactivity-recovery',
+      'evidence' => "Source visual '#{title}' is a #{mv['visual_type']} (map), but the migration " \
+                    "approximated it as #{approx ? "'#{approx['name']}' (#{approx['kind']})" : 'a non-map element (no name match found in the built workbook)'}." \
+                    "#{geo_cols.any? ? " Geo-ish columns available on the source element: #{geo_cols.join(', ')}." : ' No geo-ish columns detected on the matched element.'}",
+      'proposed' => 'Restore as a Sigma point-map (trial-verified shape: latitude/longitude/size ' \
+                    'bindings persist on readback) with Switch()-synthesized centroids per geo value. ' \
+                    "Requires a centroid table {value: [lat, lng]} filled into the patch before apply" \
+                    "#{geo_cols.any? ? " (geo column: #{geo_cols.first})" : ''}.",
+      'risk' => 'medium',
+      'verdict_hint' => 'confirm — needs centroid synthesis; present to the user with the geo column list',
+      'patch' => (approx && geo_cols.any? ? {
+        'op' => 'replace_with_point_map', 'needs' => 'centroids',
+        'element_id' => approx['id'], 'page_id' => (dash_pages.find { |p| (p['elements'] || []).any? { |e| e['id'] == approx['id'] } } || {})['id'],
+        'geo_column' => geo_cols.first, 'source' => approx['source'],
+        'geo_ref' => "[#{src_el['name']}/#{geo_cols.first}]",
+        'value_formula' => (y_col(approx) || {})['formula'],
+        'value_name' => (y_col(approx) || {})['name'],
+        'centroids' => {}
+      } : nil)
+    }
+  end
+end
+
+# ---------------------------------------------------------------------------
+# 3a. null-bucket labeling — a categorical axis with a null bucket renders a
+#     blank label; Coalesce -> "No <Dim>" (label-only; values unchanged).
+# ---------------------------------------------------------------------------
+viz.each do |(_pg, el)|
+  xc = x_col(el)
+  rows = rows_by_el[el['id']]
+  next unless xc && rows.is_a?(Array) && rows.any?
+  next unless bare_ref(xc['formula']) # only bare dim refs (don't stack onto switches)
+  next if xc['name'].to_s =~ DATEISH
+  null_rows = rows.select { |r| v = row_val(r, xc['name'].to_s); v.nil? || v.to_s.strip.empty? }
+  next if null_rows.empty?
+  label = "No #{xc['name']}"
+  candidates << {
+    'id' => "polish-null-label-#{el['id']}",
+    'category' => 'fidelity-polish',
+    'evidence' => "'#{el['name']}' has #{null_rows.size} null '#{xc['name']}' bucket(s) — Sigma renders " \
+                  'a blank category label, leaving the bar/slice unexplained (export-verified).',
+    'proposed' => "Wrap the category as Coalesce(#{xc['formula']}, \"#{label}\") — label only; " \
+                  'bucket values unchanged.',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'set_column_formula', 'element_id' => el['id'], 'column_id' => xc['id'],
+                 'formula' => "Coalesce(#{xc['formula']}, \"#{label}\")" }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 3a2. value-label polish — the source tool shows data labels by default on
+#      small categorical charts; a migrated bar/pie with NO dataLabel config
+#      reads bare. dataLabel:{labels:'shown'} is the verified persisting shape
+#      (valueFormat:'percent' is NOT — see the descoped notes). Additive-config
+#      only; values untouched.
+viz.each do |(_pg, el)|
+  next unless %w[bar-chart pie-chart line-chart].include?(el['kind'])
+  next if el['dataLabel']
+  rows = rows_by_el[el['id']]
+  next if rows.is_a?(Array) && rows.size > 24 # labels unreadable on dense charts
+  candidates << {
+    'id' => "polish-data-labels-#{el['id']}",
+    'category' => 'fidelity-polish',
+    'evidence' => "'#{el['name']}' (#{el['kind']}#{rows.is_a?(Array) ? ", #{rows.size} bucket(s)" : ''}) has no " \
+                  'dataLabel config — source-tool defaults show value labels on small categorical charts.',
+    'proposed' => "Set dataLabel:{labels:'shown'} (trial-verified persisting shape; percent styling is " \
+                  'UI-only and stays descoped).',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'set_element_prop', 'element_id' => el['id'],
+                 'prop' => 'dataLabel', 'value' => { 'labels' => 'shown' } }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 3b. month/date axis canonicalization — a chart grouped by a bare month
+#     NUMBER (1..12) reads as integers and pools across years; MakeDate(Year,
+#     Month, 1) restores a true date axis. Medium risk: on a multi-year source
+#     this intentionally un-pools the series (trial-validated divergence).
+# ---------------------------------------------------------------------------
+viz.each do |(_pg, el)|
+  xc = x_col(el)
+  rows = rows_by_el[el['id']]
+  next unless xc && rows.is_a?(Array) && rows.any?
+  next unless xc['name'].to_s =~ /\bmonth\b/i && xc['name'].to_s !~ /name/i
+  vals = rows.map { |r| row_val(r, xc['name'].to_s) }.compact
+  next if vals.empty?
+  next unless vals.all? { |v| v.to_s =~ /\A\d+(\.0+)?\z/ && v.to_f.between?(1, 12) }
+  ref = bare_ref(xc['formula'])
+  next unless ref
+  prefix, = ref
+  src_el = master_by_id[el.dig('source', 'elementId')]
+  year_col = src_el && (src_el['columns'] || []).map { |c| c['name'].to_s }.find { |n| n =~ /\byear\b/i }
+  next unless year_col
+  candidates << {
+    'id' => "polish-date-axis-#{el['id']}",
+    'category' => 'fidelity-polish',
+    'evidence' => "'#{el['name']}' x-axis is a bare month NUMBER (export shows #{vals.uniq.size} integer " \
+                  "bucket(s) in 1..12) — reads as 1,2,3 and pools all years into 12 buckets. Master exposes " \
+                  "'#{year_col}'.",
+    'proposed' => "x-axis -> MakeDate([#{prefix}/#{year_col}], #{xc['formula']}, 1): true date axis " \
+                  '(Jan 2026 style). NOTE: on a multi-year source this correctly UN-POOLS the series ' \
+                  '(intended divergence on this element only).',
+    'risk' => 'medium',
+    'verdict_hint' => 'confirm — changes this element\'s own buckets if the source spans multiple years',
+    'patch' => { 'op' => 'set_column_formula', 'element_id' => el['id'], 'column_id' => xc['id'],
+                 'formula' => "MakeDate([#{prefix}/#{year_col}], #{xc['formula']}, 1)" }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 3c. stale-source freshness note — a frozen source snapshot (Tableau extract /
+#     stale PBI import) means Sigma (live) WILL show different numbers. A
+#     time-boxed text note heads that off. Purely additive — low risk.
+# ---------------------------------------------------------------------------
+fresh_note = nil
+if WORKDIR
+  state = jread(File.join(WORKDIR, 'migrate-state.json'))
+  freshness = jread(File.join(WORKDIR, 'freshness.json'))
+  if freshness && freshness['staleDays'].to_f >= 1
+    last = freshness.dig('lastSuccessfulRefresh', 'endTime')
+    fresh_note = "**Migration note (as of #{Time.now.utc.strftime('%Y-%m-%d')})** — the source " \
+                 "Power BI dataset was last refreshed #{last} (~#{freshness['staleDays'].to_f.ceil} day(s) " \
+                 'before migration). This workbook queries the warehouse **live**, so totals here are ' \
+                 'expected to run ahead of the frozen source snapshot.'
+  elsif state && state['extract_mode']
+    fresh_note = "**Migration note (as of #{Time.now.utc.strftime('%Y-%m-%d')})** — the source Tableau " \
+                 'workbook reads a frozen EXTRACT snapshot. This workbook queries the warehouse ' \
+                 '**live**, so totals here are expected to drift ahead of the extract until it is refreshed.'
+  end
+end
+if fresh_note
+  candidates << {
+    'id' => 'polish-freshness-note',
+    'category' => 'fidelity-polish',
+    'evidence' => 'Source is a frozen snapshot (extract/import) while Sigma reads the live warehouse — ' \
+                  'the classic "numbers don\'t match" support ticket. Time-boxed wording so the note ' \
+                  'ages gracefully.',
+    'proposed' => 'Add a small text element stating the source snapshot age and that Sigma is live.',
+    'risk' => 'low',
+    'verdict_hint' => 'apply',
+    'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
+                 'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
+                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                 'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
+  }
+end
+
+# ---------------------------------------------------------------------------
+# 3d. title corrections — the source dashboard's VISIBLE caption differs from
+#     the element name the migration carried over (stale worksheet name).
+#     Conservative: only when a caption and an element pair off unambiguously.
+# ---------------------------------------------------------------------------
+if WORKDIR
+  captions = [] # [{caption, ref_name}]
+  dl = jread(File.join(WORKDIR, 'dashboard-layout.json'))
+  if dl
+    zones = dl.is_a?(Array) ? dl.flat_map { |d| d['zones'] || [] } : (dl['zones'] || [])
+    zones.select { |z| z['kind'] == 'chart' }.each do |z|
+      cap = z['caption'].to_s.strip
+      refn = (z['view_ref'] || z['view'] || z['name']).to_s.strip
+      captions << { 'caption' => cap, 'ref' => refn } unless cap.empty? || refn.empty?
+    end
+  elsif signals
+    (signals['pages'] || []).flat_map { |p| p['visuals'] || [] }.each do |v|
+      cap = v['title'].to_s.strip
+      captions << { 'caption' => cap, 'ref' => cap } unless cap.empty?
+    end
+  end
+  el_names = viz.map(&:last).map { |e| e['name'].to_s }
+  captions.each do |c|
+    next if c['caption'].casecmp?(c['ref'])                       # caption == worksheet name: nothing stale
+    next if el_names.any? { |n| norm(n) == norm(c['caption']) }   # an element already carries the caption
+    target = viz.map(&:last).find { |e| norm(e['name']) == norm(c['ref']) }
+    next unless target
+    candidates << {
+      'id' => "polish-title-#{target['id']}",
+      'category' => 'fidelity-polish',
+      'evidence' => "Source dashboard's visible title is '#{c['caption']}' but the migrated element is " \
+                    "named '#{target['name']}' (stale internal worksheet/visual name).",
+      'proposed' => "Rename element to '#{c['caption']}'.",
+      'risk' => 'low',
+      'verdict_hint' => 'apply',
+      'patch' => { 'op' => 'rename_element', 'element_id' => target['id'], 'name' => c['caption'] }
+    }
+  end
+end
+
+# ---------------------------------------------------------------------------
+# DESCOPED — trial-proven spec-unsupported. Emitted as propose-in-UI notes
+# only; enhance-apply NEVER applies these.
+# ---------------------------------------------------------------------------
+if viz.any? { |(_p, e)| e['kind'] == 'pie-chart' }
+  descoped << {
+    'id' => 'descoped-pie-percent-labels',
+    'note' => 'Pie/donut percent labels: dataLabel.valueFormat:"percent" is SILENTLY DROPPED on spec ' \
+              'readback (trial-proven, same class as trellis/tooltip). Value labels persist; percent ' \
+              'style must be set in the Sigma UI.',
+    'evidence' => "#{viz.count { |(_p, e)| e['kind'] == 'pie-chart' }} pie-chart element(s) present."
+  }
+end
+dm_sourced = masters.any? { |m| m.dig('source', 'kind') == 'data-model' } ||
+             viz.any? { |(_p, e)| e.dig('source', 'kind') == 'data-model' }
+inline_aggs = viz.count { |(_p, e)| (y_col(e) || {})['formula'].to_s =~ /\A(Sum|Avg|Count|CountDistinct|Min|Max)\(/ }
+if dm_sourced && inline_aggs.positive?
+  descoped << {
+    'id' => 'descoped-dm-metric-promotion',
+    'note' => 'DM metric promotion: charts re-implement aggregate formulas inline, but DM metrics are ' \
+              'NOT referenceable from a chart through an intermediate workbook table ([Master/Metric] -> ' \
+              '"Dependency not found"; bare [Metric] compiles to a silent error column — trial-proven). ' \
+              'Promote in the DM and rebind in the Sigma UI if governance requires it.',
+    'evidence' => "#{inline_aggs} chart(s) carry inline aggregate formulas over a data-model source."
+  }
+end
+shared_masters = viz.group_by { |(_p, e)| e.dig('source', 'elementId') }.select { |_k, v| v.size >= 2 }
+if shared_masters.any?
+  descoped << {
+    'id' => 'descoped-chart-as-filter',
+    'note' => 'Chart-as-filter (cross-filter on click): useAsFilter/crossFilter spec fields are accepted ' \
+              'by PUT but silently DROPPED on readback (trial-proven; UI-only). Enable "Use as filter" in ' \
+              'the Sigma UI. List controls on the shared master already give equivalent dashboard-wide filtering.',
+    'evidence' => "#{shared_masters.values.sum(&:size)} chart(s) share #{shared_masters.size} master source(s)."
+  }
+end
+
+# ---------------------------------------------------------------------------
+# Emit.
+# ---------------------------------------------------------------------------
+out = {
+  'workbook_id' => WB,
+  'workbook_name' => wb_name,
+  'source' => source,
+  'scanned_at' => Time.now.utc.iso8601,
+  'elements_scanned' => viz.size,
+  'elements_exported' => rows_by_el.count { |_k, v| v },
+  'candidates' => candidates,
+  'descoped_notes' => descoped
+}
+File.write(OUT, JSON.pretty_generate(out))
+
+puts "enhance-scan: #{candidates.size} candidate(s), #{descoped.size} descoped note(s) -> #{OUT}"
+candidates.each do |c|
+  puts format('  [%-6s] %-38s %s', c['risk'], c['id'], c['proposed'].to_s.gsub(/\s+/, ' ')[0, 100])
+end
+descoped.each { |d| puts format('  [note ] %-38s %s', d['id'], d['note'].to_s.gsub(/\s+/, ' ')[0, 100]) }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -53,11 +53,20 @@
 #     --finalize --actuals <WORKDIR>/parity-actuals.json \
 #     [--allow-missing-tiles N]   # explain legitimately unbuildable zones
 #
+# Phase E (OPT-IN) — Enhance: pass --enhance (pass 1 or --finalize) to run the
+# shared enhancement engine AFTER all gates are green: enhance-scan.rb emits
+# candidates; nothing applies without --enhance-accept <ids|all-low-risk>
+# (without it the run stops at exit 14 with the proposals); enhance-apply.rb
+# then clones the parity workbook ("<name> — Enhanced") and applies accepted
+# items one at a time under a parity-unchanged gate. Default = OFF everywhere.
+#
 # Exit codes: 0 = done (ALL gates green — only possible via --finalize);
 # 10 = decisions needed (OPEN QUESTIONS printed, NO Sigma objects created);
 # 11 = gap scan found ❌-unhandled features (re-run with --force to accept);
 # 12 = pass 1 complete, parity PENDING (run the printed MCP queries, then
 #      re-run with --finalize --actuals);
+# 14 = migration GREEN + Phase E proposals pending acceptance (re-run
+#      --finalize with --enhance --enhance-accept ...);
 # 3 = parity/guard fail; 4 = workbook layer needs the agent path; other = error.
 require 'json'
 require 'csv'
@@ -98,6 +107,12 @@ OptionParser.new do |o|
   o.on('--finalize')         {     opts[:finalize] = true }
   o.on('--actuals PATH')     { |v| opts[:actuals] = File.expand_path(v) }
   o.on('--allow-missing-tiles N', Integer) { |v| opts[:allow_missing_tiles] = v }
+  # Phase E (opt-in) — Enhance. NEVER runs without --enhance; with --enhance
+  # but no --enhance-accept the run stops at exit 14 with the scan proposals
+  # (present them per-item to the human, e.g. AskUserQuestion), then re-run
+  # --finalize with --enhance-accept <id,id,...> or 'all-low-risk'.
+  o.on('--enhance')          {     opts[:enhance] = true }
+  o.on('--enhance-accept L') { |v| opts[:enhance_accept] = v }
 end.parse!
 
 abort 'missing --workbook or --workbook-id' unless opts[:wb_name] || opts[:wb_id]
@@ -220,6 +235,52 @@ if opts[:finalize]
   end
 
   all_green = p6st.success? && clst.success? && gst.success?
+
+  # ---------------------------------------------------------------------------
+  # Phase E (OPT-IN) — Enhance. Runs ONLY when --enhance was passed (here or on
+  # pass 1) AND every gate above is green: enhancements clone a PARITY-VERIFIED
+  # workbook, never an unproven one. Clone-first / scan-then-propose /
+  # accept-only / parity-unchanged-gated — see enhance-scan.rb + enhance-apply.rb.
+  # ---------------------------------------------------------------------------
+  enhance_requested = opts[:enhance] || state['enhance_requested']
+  enhance_line = nil
+  if enhance_requested && !all_green
+    enhance_line = 'SKIPPED — gates not green (Phase E only clones a parity-verified workbook)'
+  elsif enhance_requested
+    puts
+    puts '── Phase E (opt-in) · Enhance ──'
+    enh_path = File.join(WORK, 'enhancements.json')
+    _, est = sigma_run!(['ruby', File.join(HERE, 'enhance-scan.rb'),
+                         '--workbook-id', wb_id, '--workdir', WORK,
+                         '--source', 'tableau', '--out', enh_path], allow_fail: true)
+    if !est.success?
+      enhance_line = 'scan FAILED (migration itself is green; see output above)'
+    elsif opts[:enhance_accept].nil?
+      cands = (JSON.parse(File.read(enh_path))['candidates'] rescue [])
+      puts
+      puts '==================== PHASE E PROPOSALS (acceptance required) ===================='
+      puts "#{cands.size} enhancement candidate(s) in #{enh_path}. NOTHING has been applied —"
+      puts 'present each candidate to the human (interactive: one AskUserQuestion checklist),'
+      puts 'then re-run this exact --finalize command adding:'
+      puts "  --enhance --enhance-accept <id,id,...>   # or: --enhance-accept all-low-risk"
+      puts '================================================================================='
+      exit 14
+    else
+      _, ast = sigma_run!(['ruby', File.join(HERE, 'enhance-apply.rb'),
+                           '--workbook-id', wb_id, '--enhancements', enh_path,
+                           '--accept', opts[:enhance_accept],
+                           '--out', File.join(WORK, 'enhance-report.json')], allow_fail: true)
+      rep = (JSON.parse(File.read(File.join(WORK, 'enhance-report.json'))) rescue {})
+      enhance_line = if ast.success?
+                       "clone #{rep['clone_id']} '#{rep['clone_name']}': " \
+                       "#{(rep['applied'] || []).size} applied, #{(rep['skipped'] || []).size} skipped, " \
+                       "#{(rep['reverted'] || []).size} reverted; parity-unchanged gate GREEN"
+                     else
+                       "apply NOT GREEN (exit #{ast.exitstatus}) — see enhance-report.json"
+                     end
+    end
+  end
+
   pf = (JSON.parse(File.read(File.join(WORK, 'parity-final.json'))) rescue {})
   puts
   puts '================ RESULT ================'
@@ -227,6 +288,7 @@ if opts[:finalize]
   puts "workbookId  : #{wb_id}"
   puts "PARITY      : #{pf['status'] || '?'} (#{pf['charts_pass']}/#{pf['charts_total']} charts#{state['extract_mode'] ? ', extract-mode' : ''})"
   puts "GATES       : phase6=#{p6st.success? ? 'PASS' : 'FAIL'} cleanup=#{clst.success? ? 'PASS' : 'FAIL'} assert-phase6-ran=#{gst.success? ? 'PASS' : "FAIL(#{gst.exitstatus})"}"
+  puts "ENHANCE     : #{enhance_line}" if enhance_line
   puts "STATUS      : #{all_green ? 'GREEN' : 'NOT GREEN'}"
   puts '======================================='
   exit(all_green ? 0 : 3)
@@ -950,7 +1012,8 @@ end
 # Persist resume state for --finalize (pass 2) BEFORE stopping.
 state = { 'workbook_id' => wb_id, 'data_model_id' => dm_id,
           'extract_mode' => !!has_extracts, 'workbook_name' => display_wb_name,
-          'reused_dm' => !!reuse_dm_id, 'pass1_at' => Time.now.utc.iso8601 }
+          'reused_dm' => !!reuse_dm_id, 'pass1_at' => Time.now.utc.iso8601,
+          'enhance_requested' => !!opts[:enhance] }
 File.write(File.join(WORK, 'migrate-state.json'), JSON.pretty_generate(state))
 
 unless structural_ok
@@ -981,5 +1044,6 @@ finalize_cmd = "  ruby scripts/migrate-tableau.rb #{opts[:wb_id] ? "--workbook-i
 puts finalize_cmd
 puts '(--finalize runs phase6 finalize + orphan cleanup + the census-aware'
 puts ' assert-phase6-ran hard gate; exit 0 there is the ONLY green exit.)'
+puts 'PHASE E     : requested (--enhance) — runs at --finalize AFTER all gates are green' if opts[:enhance]
 puts '=================================================================='
 exit 12


### PR DESCRIPTION
## What

Adds the opt-in **Enhancement Phase (Phase E)** — design validated by the 3 prototype trials (tableau / qlik / powerbi, 2026-06-10). The trial protocol is the spec.

### Shared engine (vendored byte-identical, md5 discipline)
- `scripts/enhance-scan.rb` — **SCAN (read-only)**: source signals (workdir artifacts) + built spec + live element exports → `enhancements.json`: candidates `{id, category, evidence, proposed, risk, verdict_hint, patch}` + descoped propose-in-UI notes.
- `scripts/enhance-apply.rb` — **APPLY (accept-only, clone-first)**: clones the parity workbook as `"<name> — Enhanced"` (1:1 artifact never written — `updatedAt` before/after recorded as proof); applies accepted items **one at a time**, each gated by an untouched-element **clone-vs-original simultaneous-export** spot-check (live-drift-proof) that auto-reverts on any shift; writes `enhance-report.json`.

md5 of vendored copies (identical across both plugins):
- `enhance-scan.rb` = `aa51633775d6976f24d6e0d5e9650cc9`
- `enhance-apply.rb` = `2f2b8a618a7f97f82f0a96d098027763`

### Trimmed, trial-validated detector catalog (nothing speculative)
1. **comparison-enrichment** — date-grouped master + revenue-like measure → latest-period KPI + delta-% KPI pair; full `Sum(If(D = Max(D), v, Null))` expression INLINED (KPI cross-column aggregate refs silently misevaluate).
2. **interactivity-recovery** — (a) list selection controls on the shared master (empty default = identical render); (b) grain switcher (segmented + DateTrunc switch, default = parity grain); (c) drill switcher (segmented + If() dim switch, medium risk); (d) PBI map restoration (azureMap-as-bar → point-map with Switch centroid synthesis; medium risk, centroids required at apply).
3. **fidelity-polish** — null-bucket `Coalesce → "No <Dim>"`, MakeDate axis canonicalization (medium on multi-year — intentional un-pool), time-boxed stale-source freshness note, title corrections, `dataLabel:{labels:shown}`.

**Descoped (notes only, never spec changes; all trial-proven spec-unsupported):** DM-metric promotion, chart-as-filter (`useAsFilter` dropped on readback), pie percent labels (`valueFormat:'percent'` dropped).

### Orchestrator wiring — default OFF everywhere
- `migrate-tableau.rb --enhance [--enhance-accept ids|all-low-risk]` — Phase E runs at `--finalize` ONLY after all gates are green; without `--enhance-accept` → **exit 14** with the proposal list (present per-item via AskUserQuestion, then re-run).
- `migrate-powerbi.rb` — same flags + exit-14 contract after a parity PASS. Also fixes the one-command path for **classic single-report.json** reports (branches to `extract-report-classic.py`, matching `run.sh`) and adds classic queryRef normalization (`Sum(Entity.Col)`, `Entity.Col.Variation.Date Hierarchy.<Level>`) — these previously error-typed.
- Docs: SKILL.md Phase E sections + scripts-table rows, QUICKSTART notes, `docs/phase-schema.md` C10 row + shared-engine note.

## Live E2E (tj-wells-1989; both pairs KEPT)

**Tableau "Orders Conversion Test"** (datasource 2e62b914, conn bc0319f8, via the documented designed stops: exit 4 → `--master-col`, master CY filter, manual trend-tile rebuild + `--allow-missing-tiles 1`):
- Parity workbook `64e78398` "PHASEE Tableau Orders Conversion Test" — **5/5 strict parity, all gates GREEN** (DM `d38588ac`).
- Clone `0e022d3b` "… — Enhanced": scan 7 candidates + 3 descoped notes → **6 applied** (comparison KPI pair: Latest Month Gross Revenue $6,806 / −59.6% vs prior month — both verified; 3 selection controls; grain switcher; "No Region" null label), 1 skipped (medium drill switcher), **0 reverted**; parity-unchanged gate **GREEN**; original untouched (updatedAt unchanged).

**Power BI classic "EMPLOYEE DASHBOARD"** (My-workspace, cached token):
- Parity workbook `c480df21` "PHASEE PBI Employee Dashboard" — **PARITY PASS** (98 cols, 0 error-typed; 3 freshness deltas all STALE-EXPLAINED, source 11.7 days stale) (DM `71586466`).
- Scan proposed exactly the trial pattern: **grain switcher** (restores the PBI date-hierarchy drill; default Year = parity grain), **labels polish** (`dataLabel:{labels:shown}`), 3 selection controls, freshness note, and the **azureMap restoration candidate evidence-checked** (medium risk, `needs: centroids` — correctly NOT auto-applied by all-low-risk).
- Clone `a38f0d1b` "… — Enhanced": **6 applied / 1 skipped (map) / 0 reverted**; parity-unchanged gate **GREEN**; original untouched.

PNG proof read + archived at `~/migration-visual-qa/phase-e/` ({tableau,pbi}-{parity,enhanced}.png + both enhancements.json/enhance-report.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)