### PR TITLE
tableau-to-sigma: fast discovery (unified 5-fetch pool) + interleaved orchestrator lanes

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -42,7 +42,12 @@ Chains the scripted spine (discover → scan-workbook-gaps → discover-columns 
 find-or-pick-dm → DM build/validate/post → build-charts-from-signals → workbook
 post-and-readback → build-dashboard-layout + put-layout → phase6-parity →
 cleanup-orphan-workbooks + assert-phase6-ran) and STOPS with exact instructions
-wherever agent judgment is genuinely required. Exit codes: `10` = OPEN QUESTIONS
+wherever agent judgment is genuinely required. Phase 1 is **interleaved**:
+Tableau discovery + gap scan run as a background lane while the pure-Sigma-side
+read-only phases (1.6 DM-reuse scan, 2 warehouse columns) run concurrently; the
+lanes join before anything consumes discovery output, so every designed
+stop/gate fires exactly as in the serial flow. A `PHASE TIMINGS` summary line
+prints at every terminal exit so the speedup stays visible. Exit codes: `10` = OPEN QUESTIONS
 (re-run with `--yes`/`--answers`), `11` = ❌-unhandled gap-scan features (close via
 gap-scout or `--force`), `12` = pass 1 done, parity PENDING (collect mcp-v2 actuals,
 then `--finalize`), `4` = DM posted but the workbook layer needs the agent path,
@@ -89,7 +94,7 @@ which calc translation, which layout) — not orchestration.
 | `scripts/get-token.sh` | Exchange `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` for `SIGMA_API_TOKEN` (~1h TTL) |
 | `scripts/setup-tableau.rb` | One-time Tableau PAT setup (only needed for PAT mode — see `refs/tableau-rest.md`) |
 | `scripts/get-tableau-token.sh` | One-shot signin → exports `TABLEAU_AUTH_TOKEN` + `TABLEAU_SITE_ID` |
-| `scripts/tableau-discover.rb` | PAT-mode Phase 1 discovery in one CLI: workbook + views + VDS metadata + GraphQL + .twb content |
+| `scripts/tableau-discover.rb` | PAT-mode Phase 1 discovery in one CLI: workbook + views + VDS metadata + GraphQL + .twb content. ONE unified fetch pool (default 5, `--pool N`, longest-job-first) with 429/timeout backoff + 401 re-mint; always writes per-task `timings.json`. Measured 61.8s → 13.7–18.9s on the 7-view reference workbook |
 | `scripts/scan-workbook-gaps.rb` | **Phase 0a (mandatory):** scan a `.twb` and emit `gaps-report.md` + `gaps.json` categorising every feature into ✅ auto / ⚠️ hint / 🛠 manual / ❌ unhandled. Run BEFORE any other phase. |
 | `scripts/gap-scout.md` | **Phase 0a-scout:** subagent prompt + protocol for resolving ❌ Unhandled gaps. Main agent spawns one scout per gap via the Agent tool. |
 | `scripts/validate-sigma-formula.rb` | Scout primitive: POST a tiny test workbook with a candidate formula, read back column types, return JSON `{ status: ok|error }`. Auto-expands the DM element's columns onto the test master so candidate refs to real data resolve. |
@@ -171,17 +176,17 @@ eval "$(scripts/get-token.sh)"
 
 ### Tableau access — two modes
 
-The skill supports two transports for Tableau-side discovery. **Prefer MCP** when
-it's available; the PAT path is a fallback.
+The skill supports two transports for Tableau-side discovery. **Prefer the
+API/PAT path** — it is dramatically faster (measured on "Orders Conversion
+Test", 7 views: **61.8s serial → 13.7–18.9s** with the unified fetch pool, zero
+rate-limiting at pool 5). The MCP is the **no-PAT fallback only** (each MCP
+fetch is a separate agent tool turn; the PAT CLI does everything in one
+process).
 
 | Mode | When to use | Setup |
 |---|---|---|
-| **MCP** | `mcp__tableau__*` tools are loaded in the session | None — host handles auth |
-| **PAT (REST)** | MCP tools not available, OR you need `.twb` content (layout-hint extraction, embedded datasources) | `ruby scripts/setup-tableau.rb` once, then `eval "$(scripts/get-tableau-token.sh)"` per session |
-
-**Detection at session start:** try `mcp__tableau__list-workbooks`. If the tool is
-loaded and responds, you're in MCP mode. If it errors with "tool not found", fall
-back to PAT mode.
+| **PAT (REST)** — preferred | A Tableau PAT is available (run `setup-tableau.rb` once). Also the only path to `.twb` content (layout-hint extraction, embedded datasources) | `ruby scripts/setup-tableau.rb` once, then `eval "$(scripts/get-tableau-token.sh)"` per session |
+| **MCP** — fallback | No PAT can be provisioned, and `mcp__tableau__*` tools are loaded in the session | None — host handles auth |
 
 **PAT mode in one command:**
 
@@ -189,22 +194,34 @@ back to PAT mode.
 eval "$(scripts/get-tableau-token.sh)"
 ruby scripts/tableau-discover.rb \
   --workbook-id <luid> \
-  --out /tmp/<name>
+  --out /tmp/<name>   # [--pool N] (default 5)
 ```
 
 Produces the same artifacts as MCP-driven Phase 1 in a single run: `get-workbook.json`,
 `workbook-content.twb`, `ds-metadata.json` + `graphql-fields.json` (VDS field list + GraphQL
-formulas), `views/*.csv` (fetched concurrently), and the dashboard PNG. Downstream scripts
-in Phases 2–6 are unchanged. Full endpoint inventory and gotchas in `refs/tableau-rest.md`.
+formulas), `views/*.csv`, the dashboard PNG, **and `timings.json`** (per-task
+start/duration/attempts — always written; it's the evidence trail for any future
+"discovery is slow" report). Downstream scripts in Phases 2–6 are unchanged.
+Full endpoint inventory and gotchas in `refs/tableau-rest.md`.
 
 `--datasource-name` / `--datasource-luid` are **optional** — the script parses the
 downloaded `.twb` for the first non-Parameters `<datasource caption='X'>` and looks it up
 on the site automatically. Pass `--no-auto-ds` to disable, or `--datasource-luid` to force
-a specific datasource when the workbook has multiple.
+a specific datasource when the workbook has multiple (`--datasource-luid` must be the
+**full UUID** — the REST filter has no prefix matching).
 
-View CSV fetches run in parallel (4 concurrent threads, with one auto-retry on 401 after a
-1.5s backoff per view — see `tableau-discover.rb` line ~145). The dashboard PNG is fetched solo
-afterward to avoid VizQL session contention.
+**How the pool works (and why 5):** every fetch after the initial workbook GET
+(.twb, VDS read-metadata, GraphQL fields, all view CSVs, dashboard PNG) goes
+through ONE shared pool of 5 threads, enqueued longest-job-first — the PNG
+render is the longest single fetch, so it starts at t≈0 and hides behind the
+CSV batch. **5 is the measured sweet spot; 8 risks long-tail stragglers** — at
+8 threads a contended VizQL session parked one CSV fetch for ~40s (56s total
+run vs. 13.7–18.9s at 5). The pool keeps 429/timeout exponential backoff and
+single-flight 401 re-mint machinery as insurance even though neither fired at
+pool 5 in validation. Also note Tableau's **~60s server-side render cache**:
+a view rendered within the last minute returns much faster, so back-to-back
+runs land at the fast end of the range and cold-cache runs at the slow end —
+don't read a 5s spread between runs as a regression.
 
 > **One signin attempt only.** Tableau Cloud invalidates a PAT after 4 consecutive failed
 > signins. `get-tableau-token.sh` runs exactly once; never wrap it in a retry loop.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -77,6 +77,8 @@ require 'open3'
 require 'date'
 require 'time'
 
+$stdout.sync = true # progress lines interleave correctly when piped/captured
+
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
 
@@ -125,6 +127,24 @@ FileUtils.mkdir_p(File.join(WORK, 'views'))
 TOTAL = 6
 def hdr(n, title) puts; puts "── Phase #{n}/#{TOTAL} · #{title} ──"; end
 def line(m) puts "   #{m}"; end
+
+# Phase-timing summary — printed at every terminal exit so the discovery
+# interleave speedup stays visible in every run (and regressions show up in
+# the first slow report instead of an investigation).
+START_T = Time.now
+PHASE_T = {}
+$t_mark = Time.now
+def mark(key)
+  now = Time.now
+  PHASE_T[key] = (PHASE_T[key] || 0.0) + (now - $t_mark)
+  $t_mark = now
+end
+def phase_summary
+  return if PHASE_T.empty?
+  puts
+  puts "PHASE TIMINGS  #{PHASE_T.map { |k, v| "#{k}=#{v.round(1)}s" }.join('  ')}  " \
+       "total=#{(Time.now - START_T).round(1)}s"
+end
 
 # Run a child command, indenting its output. token_env: prepend a fresh
 # Sigma/Tableau token via the skill's get-token scripts so long runs survive
@@ -195,22 +215,26 @@ if opts[:finalize]
   wb_id = state['workbook_id'] or abort 'FATAL: state has no workbook_id (pass 1 never completed Phase 4)'
 
   hdr(6, 'Parity (pass 2 — finalize)')
+  $t_mark = Time.now
   p6 = ['ruby', File.join(HERE, 'phase6-parity.rb'), '--tableau', WORK,
         '--finalize', '--actuals', opts[:actuals]]
   p6 += ['--extract-mode', '--extract-tol', '0.30'] if state['extract_mode']
   _, p6st = sigma_run!(p6, allow_fail: true)
   line "phase6-parity finalize: #{p6st.success? ? 'PASS' : "FAIL (exit #{p6st.exitstatus})"}"
+  mark('phase6-finalize')
 
   # Cleanup: delete orphan workbooks from spec-iteration retries (keep the live one).
   _, clst = sigma_run!(['ruby', File.join(HERE, 'cleanup-orphan-workbooks.rb'),
                         '--workdir', WORK, '--keep', wb_id], allow_fail: true)
   line 'WARN: orphan cleanup reported failures — assert-phase6-ran will gate on it' unless clst.success?
+  mark('cleanup-orphans')
 
   # The census-aware hard gate. NEVER bypassed — this command fails when it fails.
   gate = ['ruby', File.join(HERE, 'assert-phase6-ran.rb'), '--tableau', WORK, '--workbook-id', wb_id]
   gate += ['--allow-extract'] if state['extract_mode']
   gate += ['--allow-missing-tiles', opts[:allow_missing_tiles].to_s] if opts[:allow_missing_tiles]
   _, gst = sigma_run!(gate, allow_fail: true)
+  mark('assert-phase6-ran')
 
   if gst.exitstatus == 7
     census = (JSON.parse(File.read(File.join(WORK, 'parity-final.json')))['tile_census'] rescue {}) || {}
@@ -244,6 +268,7 @@ if opts[:finalize]
   # ---------------------------------------------------------------------------
   enhance_requested = opts[:enhance] || state['enhance_requested']
   enhance_line = nil
+  $t_mark = Time.now # Phase E timing starts here (mark('phaseE') at each terminal)
   if enhance_requested && !all_green
     enhance_line = 'SKIPPED — gates not green (Phase E only clones a parity-verified workbook)'
   elsif enhance_requested
@@ -264,6 +289,8 @@ if opts[:finalize]
       puts 'then re-run this exact --finalize command adding:'
       puts "  --enhance --enhance-accept <id,id,...>   # or: --enhance-accept all-low-risk"
       puts '================================================================================='
+      mark('phaseE')
+      phase_summary
       exit 14
     else
       _, ast = sigma_run!(['ruby', File.join(HERE, 'enhance-apply.rb'),
@@ -281,6 +308,7 @@ if opts[:finalize]
     end
   end
 
+  mark('phaseE') if enhance_requested
   pf = (JSON.parse(File.read(File.join(WORK, 'parity-final.json'))) rescue {})
   puts
   puts '================ RESULT ================'
@@ -291,19 +319,70 @@ if opts[:finalize]
   puts "ENHANCE     : #{enhance_line}" if enhance_line
   puts "STATUS      : #{all_green ? 'GREEN' : 'NOT GREEN'}"
   puts '======================================='
+  phase_summary
   exit(all_green ? 0 : 3)
 end
 
 # ---------------------------------------------------------------------------
-# Phase 1 — Discover (Tableau side). Chains tableau-discover + parse-twb-layout
-# + extract-calc-fields + extract-custom-sql + scan-workbook-gaps.
+# Phase 1 — Discover (Tableau side), INTERLEAVED. tableau-discover.rb (its own
+# unified 5-fetch pool) + scan-workbook-gaps run as a BACKGROUND lane; the
+# pure-Sigma-side phases (1.6 DM-reuse scan + 2 warehouse columns — read-only,
+# no Sigma objects created) run concurrently in the foreground. The lanes JOIN
+# before anything that consumes discovery output (calc fields, gap gate, view
+# CSVs, decisions checkpoint) — every designed stop/gate fires exactly as in
+# the serial flow, just sooner.
 # ---------------------------------------------------------------------------
 hdr(1, 'Discover')
+$t_mark = Time.now
+twb = File.join(WORK, 'workbook-content.twb')
 disc = ['ruby', File.join(HERE, 'tableau-discover.rb'), '--out', WORK]
 disc += opts[:wb_id] ? ['--workbook-id', opts[:wb_id]] : ['--workbook-name', opts[:wb_name]]
-run!(['bash', '-c',
-      "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && " +
-      disc.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')])
+disc_sh = disc.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')
+scan_sh = ['ruby', File.join(HERE, 'scan-workbook-gaps.rb'), twb]
+          .map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')
+disc_log = File.join(WORK, 'phase1-discover.log')
+File.write(disc_log, '')
+# Gap scan runs in the lane as soon as its input (the .twb) is ready — i.e.
+# right after discovery lands it. Scan failure is tolerated (same as before);
+# discovery failure is the lane's exit code.
+lane_cmd = "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && #{disc_sh}; rc=$?; " \
+           "if [ $rc -eq 0 ] && [ -f '#{twb}' ]; then #{scan_sh} || true; fi; exit $rc"
+lane = { started: Time.now, status: nil }
+lane[:pid] = Process.spawn('bash', '-c', lane_cmd, %i[out err] => [disc_log, 'a'])
+line "Tableau discovery + gap scan: BACKGROUND lane (pid #{lane[:pid]}, log #{File.basename(disc_log)})"
+line 'Sigma-side phases 1.6 + 2 run concurrently; lanes join before discovery output is consumed.'
+
+lane_done = lambda do
+  next true if lane[:status]
+  if (st = Process.wait2(lane[:pid], Process::WNOHANG))
+    lane[:status] = st[1]
+    lane[:ended] = Time.now
+    true
+  else
+    false
+  end
+end
+print_lane_log = lambda do
+  File.read(disc_log).each_line { |l| puts "   │ #{l.rstrip}" } if File.exist?(disc_log)
+end
+# Wait for a lane artifact (tableau-discover writes them atomically). Returns
+# false when the lane exits without producing it.
+lane_wait_for = lambda do |path, what, timeout = 600|
+  t0 = Time.now
+  until File.exist?(path)
+    if lane_done.call
+      return File.exist?(path)
+    end
+    abort "FATAL: timed out (#{timeout}s) waiting for #{what} from the discovery lane" if Time.now - t0 > timeout
+    sleep 0.1
+  end
+  true
+end
+
+unless lane_wait_for.call(File.join(WORK, 'get-workbook.json'), 'get-workbook.json')
+  print_lane_log.call
+  abort "FATAL: discovery lane exited (#{lane[:status]&.exitstatus}) before producing get-workbook.json"
+end
 
 gw = JSON.parse(File.read(File.join(WORK, 'get-workbook.json')))
 wb = gw['workbook'] || gw
@@ -315,9 +394,8 @@ views = (wb.dig('views', 'view') || [])
 views = [views] unless views.is_a?(Array)
 line "workbook '#{wb_name}' (#{wb_luid}): #{views.size} view(s)#{has_extracts ? ', hasExtracts=true' : ''}"
 
-twb = File.join(WORK, 'workbook-content.twb')
 layout_json = File.join(WORK, 'dashboard-layout.json')
-have_twb = File.exist?(twb)
+have_twb = lane_wait_for.call(twb, 'workbook-content.twb')
 if have_twb
   run!(['ruby', File.join(HERE, 'parse-twb-layout.rb'), twb, layout_json])
   dash = JSON.parse(File.read(layout_json))
@@ -332,77 +410,9 @@ else
   line 'no .twb content (MCP-only datasource?) — chart-kind/calc discovery degraded'
 end
 
-calc_path = File.join(WORK, 'calc-fields.json')
-calcs = []
-if wb_luid
-  cf = ['ruby', File.join(HERE, 'extract-calc-fields.rb'),
-        '--workbook-luid', wb_luid, '--out', calc_path]
-  cf += ['--twb', twb] if have_twb
-  _, st = run!(['bash', '-c',
-                "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && " +
-                cf.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')], allow_fail: true)
-  if File.exist?(calc_path)
-    cfj = JSON.parse(File.read(calc_path)) rescue {}
-    calcs = cfj['calcs'] || []
-    n_csql = calcs.count { |c| c['requires_custom_sql'] }
-    line "#{calcs.size} calc field(s); #{n_csql} require Custom SQL (window/LOD)"
-  end
-end
-
-custom_sql = []
-csql_path = File.join(WORK, 'custom-sql.json')
-if wb_luid && have_twb
-  csql_cmd = ['ruby', File.join(HERE, 'extract-custom-sql.rb'),
-              '--workbook-luid', wb_luid, '--twb', twb, '--out', csql_path]
-  run!(['bash', '-c',
-        "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && " +
-        csql_cmd.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')], allow_fail: true)
-  custom_sql = (JSON.parse(File.read(csql_path)) rescue []) if File.exist?(csql_path)
-  custom_sql = [] unless custom_sql.is_a?(Array)
-end
-
-gaps = []
-gap_report_md = nil
-if have_twb
-  run!(['ruby', File.join(HERE, 'scan-workbook-gaps.rb'), twb], allow_fail: true)
-  gj = Dir[File.join(WORK, '*gaps*report*.json')].first || Dir[File.join(WORK, '*gaps*.json')].first
-  if gj && File.exist?(gj)
-    gap_report_md = gj.sub(/\.json$/, '.md')
-    gaps = (JSON.parse(File.read(gj))['detected_features'] || []) rescue []
-    bys = gaps.group_by { |g| g['status'] }.transform_values(&:size)
-    line "gap scan: #{bys.map { |k, v| "#{v} #{k}" }.join(', ')}"
-  end
-end
-
-# GAP-SCAN HARD GATE: ❌-unhandled features mean part of the workbook cannot be
-# migrated by this skill yet. Abort WITH the report unless the human accepts the
-# degradation explicitly via --force. (auto/hint/manual statuses flow into the
-# decisions checkpoint below instead.)
-unhandled_gaps = gaps.select { |g| g['status'].to_s == 'unhandled' }
-if unhandled_gaps.any? && !opts[:force]
-  puts
-  puts '==================== GAP-SCAN STOP ===================='
-  puts "#{unhandled_gaps.size} ❌-unhandled feature(s) detected — these do NOT migrate:"
-  unhandled_gaps.each { |g| puts "  - #{g['name']} (×#{g['count']}): #{g['blurb']}" }
-  puts ''
-  puts "Full report: #{gap_report_md || '(see workdir *gaps-report.md)'}"
-  puts 'Options: close the gap via the gap-scout subagent (scripts/gap-scout.md),'
-  puts 'restructure the workbook in Tableau, or re-run with --force to accept the'
-  puts 'degradation (the features above will be missing from the Sigma workbook).'
-  puts '======================================================='
-  puts 'No Sigma objects were created.'
-  exit 11
-elsif unhandled_gaps.any?
-  line "--force: proceeding past #{unhandled_gaps.size} ❌-unhandled feature(s) — they will NOT migrate"
-end
-
-# EMPTY-VIEW-CSV preflight (honesty stop): a view whose CSV exported 0 data rows
-# produces NO chart — the tile silently drops and the census gate stops the
-# --finalize pass. Surface it NOW as a decision instead of a surprise later.
-empty_csvs = Dir[File.join(WORK, 'views', '*.csv')].select do |c|
-  (File.readlines(c).reject { |l| l.strip.empty? }.size rescue 0) <= 1
-end.map { |c| File.basename(c, '.csv') }
-line "WARN: #{empty_csvs.size} view CSV(s) came back EMPTY: #{empty_csvs.join(', ')}" if empty_csvs.any?
+# calc fields / custom-SQL / gap gate / empty-CSV preflight all consume
+# discovery-lane output — they run AFTER the lane join below. The spec
+# generation here only needs the .twb (already landed).
 
 # ---------------------------------------------------------------------------
 # Spec generation. The DEFAULT path is MECHANICAL (no agent hand-authoring):
@@ -430,6 +440,8 @@ mechanical = !have_specs
 conv = nil
 if mechanical
   unless have_twb
+    sleep 0.1 until lane_done.call # reap the background lane before aborting
+    print_lane_log.call
     abort <<~MSG
       FATAL: mechanical conversion needs the workbook .twb (for the data model +
       chart signals), but none was downloaded (MCP-only datasource?). Either
@@ -464,13 +476,211 @@ if mechanical
   conv_fact = MechanicalSpecs.pick_fact(conv['model'])
   conv_base = conv_fact ? MechanicalSpecs.base_of(conv['model'], conv_fact) : nil
   pre = conv_fact ? MechanicalSpecs.derive_master(conv_fact, (conv_fact['name'] || 'Order Fact'), conv_base) : { 'untranslated_metrics' => [] }
+  pre_untranslated = pre['untranslated_metrics'] || []
+  # plotted_untranslated (the CSV-header match) is computed after the lane join
+  # — it needs the view CSVs.
+end
+mark('phase1-foreground')
+
+# ---------------------------------------------------------------------------
+# Phase 1.6 — DM-reuse scan (find-or-pick-dm). Default = BUILD NEW; candidates
+# are printed so a human can opt in with --reuse-dm. Non-destructive.
+# Pure Sigma-side — runs CONCURRENTLY with the background discovery lane.
+# ---------------------------------------------------------------------------
+hdr('1.6', 'DM-reuse scan (concurrent with discovery)')
+reuse_dm_id = nil
+dm_match = {}
+src_model = mechanical ? conv['model'] : (have_specs ? Specs.dm_spec : nil)
+if opts[:skip_reuse]
+  line 'skipped (--skip-reuse-scan)'
+elsif src_model.nil?
+  line 'no spec source to derive a signature from — building new'
+else
+  sig_els = (src_model['pages'] || []).flat_map { |p| p['elements'] || [] }
+  sig_tables = sig_els.map do |e|
+    s = e['source'] || {}
+    next 'CUSTOM_SQL' if s['kind'] == 'sql'
+    pth = s['path']
+    pth.is_a?(Array) ? pth.join('.').upcase : nil
+  end.compact.uniq
+  sig_cols = sig_els.flat_map { |e| (e['columns'] || []).map { |c| c['name'] } }.compact.uniq
+  sig_meas = sig_els.flat_map do |e|
+    (e['metrics'] || []).map { |m| { 'col' => m['name'], 'derivation' => m['aggregation'] || m['derivation'] } }
+  end
+  sig_path = File.join(WORK, 'workbook-signature.json')
+  File.write(sig_path, JSON.pretty_generate(
+    'tableau_workbook' => wb_name, 'warehouse_tables' => sig_tables,
+    'referenced_columns' => sig_cols, 'measures' => sig_meas))
+  match_path = File.join(WORK, 'dm-match.json')
+  sigma_run!(['ruby', File.join(HERE, 'find-or-pick-dm.rb'),
+              '--workbook-signature', sig_path, '--out', match_path],
+             allow_fail: true) # exit 1 = no candidate ≥ min-score (normal: build new)
+  dm_match = (JSON.parse(File.read(match_path)) rescue {})
+  cands = (dm_match['candidates'] || []).first(3)
+  if cands.any?
+    line 'top candidate(s) — default is BUILD NEW; pass --reuse-dm to opt in:'
+    cands.each { |c| line "  score #{format('%.2f', c['score'] || 0)}  #{c['dm_id']}  '#{c['dm_name']}'" }
+  else
+    line 'no existing DM covers this workbook — building new'
+  end
+end
+if opts[:reuse_dm]
+  reuse_dm_id = opts[:reuse_dm] == :recommended ? dm_match['recommended_dm_id'] : opts[:reuse_dm]
+  abort 'FATAL: --reuse-dm: the picker found no candidate ≥ min-score; pass an explicit ' \
+        '--reuse-dm <dataModelId> or drop the flag to build new' unless reuse_dm_id
+  line "REUSING data model #{reuse_dm_id} — Phase 3 build+POST will be skipped."
+  line "  #{dm_match['warning']}" if dm_match['warning']
+  line '  NOTE: master-column formulas are derived against the reused DM\'s readback labels;'
+  line '  if its shape differs (separate dim elements), the workbook gate will stop with the'
+  line '  agent-path handoff (exit 4) — run SKILL.md Phase 1.5b (inspect-dm-shape.rb) then.'
+end
+mark('phase1.6-dm-scan')
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Discover warehouse column names (per table) for the DM build.
+# Pure Sigma-side — runs CONCURRENTLY with the background discovery lane.
+# ---------------------------------------------------------------------------
+hdr(2, 'Discover warehouse columns (concurrent with discovery)')
+db = opts[:db] || 'CSA'
+schema = opts[:schema] || 'TJ'
+# Table set: from the generator's DM spec when available, else inferred from the
+# datasource's logical tables.
+wh_tables =
+  if mechanical
+    (conv['model']['pages'] || []).flat_map { |p| p['elements'] || [] }
+      .select { |e| e.dig('source', 'kind') == 'warehouse-table' }
+      .map { |e| e.dig('source', 'path')&.last }.compact.uniq
+  elsif have_specs
+    Specs.dm_spec['pages'].flat_map { |p| p['elements'] }
+         .map { |e| e.dig('source', 'path')&.last }.compact.uniq
+  else
+    md = (JSON.parse(File.read(File.join(WORK, 'ds-metadata.json'))) rescue {})
+    fields = md['data'] || []
+    fields.flat_map { |f| (f['name'] || '').scan(/\b([A-Z][A-Z0-9_]*(?:_DIM|_FACT))\b/) }
+          .flatten.uniq
+  end
+wh_tables = [] if wh_tables.nil?
+if wh_tables.empty?
+  line 'no warehouse tables resolved from metadata; relying on spec generator'
+else
+  wh_tables.each do |t|
+    _, st = sigma_run!(['ruby', File.join(HERE, 'discover-columns.rb'),
+                        '--connection-id', opts[:conn],
+                        '--table-path', "#{db}.#{schema}.#{t}",
+                        '--out', File.join(WORK, "cols-#{t}.json")], allow_fail: true)
+    cj = (JSON.parse(File.read(File.join(WORK, "cols-#{t}.json"))) rescue nil)
+    n = cj && cj['columns'] ? cj['columns'].size : '?'
+    line "#{db}.#{schema}.#{t}: #{n} columns#{st.success? ? '' : ' (not in catalog — Custom SQL fallback may be needed)'}"
+  end
+end
+mark('phase2-columns')
+
+# ---------------------------------------------------------------------------
+# Phase 1 (join) — wait for the background Tableau lane, then run everything
+# that consumes its output: calc fields, custom-SQL scan, the gap-scan HARD
+# GATE, the empty-view-CSV preflight, and the plotted-untranslated check.
+# Every designed stop below is byte-identical to the serial flow.
+# ---------------------------------------------------------------------------
+puts
+puts '── Phase 1 (join) · Tableau discovery lane ──'
+sleep 0.1 until lane_done.call
+mark('join-wait')
+print_lane_log.call
+unless lane[:status].success?
+  abort "FATAL: Tableau discovery failed (exit #{lane[:status].exitstatus}) — see lane log above"
+end
+PHASE_T['phase1-lane(bg)'] = (lane[:ended] - lane[:started])
+tjs = (JSON.parse(File.read(File.join(WORK, 'timings.json'))) rescue nil)
+line "discovery lane: #{(lane[:ended] - lane[:started]).round(1)}s wall" \
+     "#{tjs ? " (tableau-discover #{tjs['total_seconds']}s, pool=#{tjs['pool']}; per-task breakdown in timings.json)" : ''}"
+
+calc_path = File.join(WORK, 'calc-fields.json')
+calcs = []
+if wb_luid
+  cf = ['ruby', File.join(HERE, 'extract-calc-fields.rb'),
+        '--workbook-luid', wb_luid, '--out', calc_path]
+  cf += ['--twb', twb] if have_twb
+  _, st = run!(['bash', '-c',
+                "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && " +
+                cf.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')], allow_fail: true)
+  if File.exist?(calc_path)
+    cfj = JSON.parse(File.read(calc_path)) rescue {}
+    calcs = cfj['calcs'] || []
+    n_csql = calcs.count { |c| c['requires_custom_sql'] }
+    line "#{calcs.size} calc field(s); #{n_csql} require Custom SQL (window/LOD)"
+  end
+end
+
+custom_sql = []
+csql_path = File.join(WORK, 'custom-sql.json')
+if wb_luid && have_twb
+  csql_cmd = ['ruby', File.join(HERE, 'extract-custom-sql.rb'),
+              '--workbook-luid', wb_luid, '--twb', twb, '--out', csql_path]
+  run!(['bash', '-c',
+        "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && " +
+        csql_cmd.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')], allow_fail: true)
+  custom_sql = (JSON.parse(File.read(csql_path)) rescue []) if File.exist?(csql_path)
+  custom_sql = [] unless custom_sql.is_a?(Array)
+end
+
+# Gap scan already ran in the discovery lane (right after the .twb landed);
+# parse its report here. Lane scan failure degrades the same way the serial
+# allow_fail run did: gaps stays empty.
+gaps = []
+gap_report_md = nil
+if have_twb
+  gj = Dir[File.join(WORK, '*gaps*report*.json')].first || Dir[File.join(WORK, '*gaps*.json')].first
+  if gj && File.exist?(gj)
+    gap_report_md = gj.sub(/\.json$/, '.md')
+    gaps = (JSON.parse(File.read(gj))['detected_features'] || []) rescue []
+    bys = gaps.group_by { |g| g['status'] }.transform_values(&:size)
+    line "gap scan: #{bys.map { |k, v| "#{v} #{k}" }.join(', ')}"
+  end
+end
+
+# GAP-SCAN HARD GATE: ❌-unhandled features mean part of the workbook cannot be
+# migrated by this skill yet. Abort WITH the report unless the human accepts the
+# degradation explicitly via --force. (auto/hint/manual statuses flow into the
+# decisions checkpoint below instead.)
+unhandled_gaps = gaps.select { |g| g['status'].to_s == 'unhandled' }
+if unhandled_gaps.any? && !opts[:force]
+  puts
+  puts '==================== GAP-SCAN STOP ===================='
+  puts "#{unhandled_gaps.size} ❌-unhandled feature(s) detected — these do NOT migrate:"
+  unhandled_gaps.each { |g| puts "  - #{g['name']} (×#{g['count']}): #{g['blurb']}" }
+  puts ''
+  puts "Full report: #{gap_report_md || '(see workdir *gaps-report.md)'}"
+  puts 'Options: close the gap via the gap-scout subagent (scripts/gap-scout.md),'
+  puts 'restructure the workbook in Tableau, or re-run with --force to accept the'
+  puts 'degradation (the features above will be missing from the Sigma workbook).'
+  puts '======================================================='
+  puts 'No Sigma objects were created.'
+  mark('phase1-join')
+  phase_summary
+  exit 11
+elsif unhandled_gaps.any?
+  line "--force: proceeding past #{unhandled_gaps.size} ❌-unhandled feature(s) — they will NOT migrate"
+end
+
+# EMPTY-VIEW-CSV preflight (honesty stop): a view whose CSV exported 0 data rows
+# produces NO chart — the tile silently drops and the census gate stops the
+# --finalize pass. Surface it NOW as a decision instead of a surprise later.
+empty_csvs = Dir[File.join(WORK, 'views', '*.csv')].select do |c|
+  (File.readlines(c).reject { |l| l.strip.empty? }.size rescue 0) <= 1
+end.map { |c| File.basename(c, '.csv') }
+line "WARN: #{empty_csvs.size} view CSV(s) came back EMPTY: #{empty_csvs.join(', ')}" if empty_csvs.any?
+
+# PLOTTED metrics whose formula did not fully translate — deferred from spec
+# generation (needs the lane's view CSVs to know what is actually charted).
+if mechanical
   csv_headers = Dir[File.join(WORK, 'views', '*.csv')].flat_map do |c|
     (CSV.read(c).first rescue nil) || []
   end.compact.map { |h| h.to_s.strip }.uniq
-  plotted_untranslated = (pre['untranslated_metrics'] || []).select do |nm|
+  plotted_untranslated = pre_untranslated.select do |nm|
     csv_headers.any? { |h| h.casecmp?(nm) || h.sub(/^(sum|avg|min|max|median|distinct count|count) of /i, '').casecmp?(nm) }
   end
 end
+mark('phase1-join')
 
 # ---------------------------------------------------------------------------
 # DECISIONS CHECKPOINT — surface the genuine human questions ONLY. Mechanical
@@ -638,7 +848,7 @@ if questions.any? && !opts[:yes] && answers.nil?
   block = {
     'status' => 'decisions_needed',
     'workbook' => wb_name,
-    'phases_completed' => ['1 Discover'],
+    'phases_completed' => ['1 Discover', '1.6 DM-reuse scan (read-only)', '2 Warehouse columns (read-only)'],
     'note' => 'Deterministic mechanical steps (DM/workbook POST, layout, parity) are NOT asked about. ' \
               'Re-run with --yes to accept all defaults, or --answers \'{"<id>":"<choice>"}\' to override.',
     'open_questions' => questions
@@ -649,6 +859,7 @@ if questions.any? && !opts[:yes] && answers.nil?
   puts '======================================================='
   puts
   puts "#{questions.size} decision(s) need a human. No Sigma objects were created."
+  phase_summary
   exit 10
 end
 
@@ -666,95 +877,7 @@ if questions.any?
 else
   line 'no open questions — running straight through'
 end
-
-# ---------------------------------------------------------------------------
-# Phase 1.6 — DM-reuse scan (find-or-pick-dm). Default = BUILD NEW; candidates
-# are printed so a human can opt in with --reuse-dm. Non-destructive.
-# ---------------------------------------------------------------------------
-hdr('1.6', 'DM-reuse scan')
-reuse_dm_id = nil
-dm_match = {}
-src_model = mechanical ? conv['model'] : (have_specs ? Specs.dm_spec : nil)
-if opts[:skip_reuse]
-  line 'skipped (--skip-reuse-scan)'
-elsif src_model.nil?
-  line 'no spec source to derive a signature from — building new'
-else
-  sig_els = (src_model['pages'] || []).flat_map { |p| p['elements'] || [] }
-  sig_tables = sig_els.map do |e|
-    s = e['source'] || {}
-    next 'CUSTOM_SQL' if s['kind'] == 'sql'
-    pth = s['path']
-    pth.is_a?(Array) ? pth.join('.').upcase : nil
-  end.compact.uniq
-  sig_cols = sig_els.flat_map { |e| (e['columns'] || []).map { |c| c['name'] } }.compact.uniq
-  sig_meas = sig_els.flat_map do |e|
-    (e['metrics'] || []).map { |m| { 'col' => m['name'], 'derivation' => m['aggregation'] || m['derivation'] } }
-  end
-  sig_path = File.join(WORK, 'workbook-signature.json')
-  File.write(sig_path, JSON.pretty_generate(
-    'tableau_workbook' => wb_name, 'warehouse_tables' => sig_tables,
-    'referenced_columns' => sig_cols, 'measures' => sig_meas))
-  match_path = File.join(WORK, 'dm-match.json')
-  sigma_run!(['ruby', File.join(HERE, 'find-or-pick-dm.rb'),
-              '--workbook-signature', sig_path, '--out', match_path],
-             allow_fail: true) # exit 1 = no candidate ≥ min-score (normal: build new)
-  dm_match = (JSON.parse(File.read(match_path)) rescue {})
-  cands = (dm_match['candidates'] || []).first(3)
-  if cands.any?
-    line 'top candidate(s) — default is BUILD NEW; pass --reuse-dm to opt in:'
-    cands.each { |c| line "  score #{format('%.2f', c['score'] || 0)}  #{c['dm_id']}  '#{c['dm_name']}'" }
-  else
-    line 'no existing DM covers this workbook — building new'
-  end
-end
-if opts[:reuse_dm]
-  reuse_dm_id = opts[:reuse_dm] == :recommended ? dm_match['recommended_dm_id'] : opts[:reuse_dm]
-  abort 'FATAL: --reuse-dm: the picker found no candidate ≥ min-score; pass an explicit ' \
-        '--reuse-dm <dataModelId> or drop the flag to build new' unless reuse_dm_id
-  line "REUSING data model #{reuse_dm_id} — Phase 3 build+POST will be skipped."
-  line "  #{dm_match['warning']}" if dm_match['warning']
-  line '  NOTE: master-column formulas are derived against the reused DM\'s readback labels;'
-  line '  if its shape differs (separate dim elements), the workbook gate will stop with the'
-  line '  agent-path handoff (exit 4) — run SKILL.md Phase 1.5b (inspect-dm-shape.rb) then.'
-end
-
-# ---------------------------------------------------------------------------
-# Phase 2 — Discover warehouse column names (per table) for the DM build.
-# ---------------------------------------------------------------------------
-hdr(2, 'Discover warehouse columns')
-db = opts[:db] || 'CSA'
-schema = opts[:schema] || 'TJ'
-# Table set: from the generator's DM spec when available, else inferred from the
-# datasource's logical tables.
-wh_tables =
-  if mechanical
-    (conv['model']['pages'] || []).flat_map { |p| p['elements'] || [] }
-      .select { |e| e.dig('source', 'kind') == 'warehouse-table' }
-      .map { |e| e.dig('source', 'path')&.last }.compact.uniq
-  elsif have_specs
-    Specs.dm_spec['pages'].flat_map { |p| p['elements'] }
-         .map { |e| e.dig('source', 'path')&.last }.compact.uniq
-  else
-    md = (JSON.parse(File.read(File.join(WORK, 'ds-metadata.json'))) rescue {})
-    fields = md['data'] || []
-    fields.flat_map { |f| (f['name'] || '').scan(/\b([A-Z][A-Z0-9_]*(?:_DIM|_FACT))\b/) }
-          .flatten.uniq
-  end
-wh_tables = [] if wh_tables.nil?
-if wh_tables.empty?
-  line 'no warehouse tables resolved from metadata; relying on spec generator'
-else
-  wh_tables.each do |t|
-    _, st = sigma_run!(['ruby', File.join(HERE, 'discover-columns.rb'),
-                        '--connection-id', opts[:conn],
-                        '--table-path', "#{db}.#{schema}.#{t}",
-                        '--out', File.join(WORK, "cols-#{t}.json")], allow_fail: true)
-    cj = (JSON.parse(File.read(File.join(WORK, "cols-#{t}.json"))) rescue nil)
-    n = cj && cj['columns'] ? cj['columns'].size : '?'
-    line "#{db}.#{schema}.#{t}: #{n} columns#{st.success? ? '' : ' (not in catalog — Custom SQL fallback may be needed)'}"
-  end
-end
+mark('decisions')
 
 # ---------------------------------------------------------------------------
 # Phase 3 — Build + POST the data model.
@@ -846,6 +969,7 @@ unless reuse_dm_id
   fact_eid = fact['id']
   line "dataModelId = #{dm_id}  (fact element '#{fact['name']}' = #{fact_eid})"
 end
+mark('phase3-dm')
 
 # ---------------------------------------------------------------------------
 # Phase 4 — Build + POST the workbook.
@@ -943,11 +1067,14 @@ rescue WorkbookBuildError => e
   puts '   2. Otherwise fall back to the agent path: rebuild the workbook via the'
   puts "      skill's agent-authored flow (see SKILL.md) against this DM."
   puts '   The data model is posted and ready to attach either way.'
+  mark('phase4-workbook')
+  phase_summary
   exit 4
 end
 wb_ids = JSON.parse(File.read(wb_ids_path))
 wb_id = wb_ids['workbookId']
 line "workbookId = #{wb_id}"
+mark('phase4-workbook')
 
 # ---------------------------------------------------------------------------
 # Phase 5 — Layout. Prefer the generator's layout_xml; else auto-build from the
@@ -975,6 +1102,7 @@ if File.exist?(layout_path)
   line(pst.success? ? "layout applied to workbook #{wb_id}" :
        'WARN: layout PUT rejected (Invalid element position) — keeping default stacked layout; charts unaffected')
 end
+mark('phase5-layout')
 
 # ---------------------------------------------------------------------------
 # Phase 6 — Parity, PASS 1 of 2. Structural hard signals first (live /columns
@@ -1023,6 +1151,8 @@ unless structural_ok
   puts "workbookId  : #{wb_id}"
   puts "PARITY      : FAIL (structural — #{err_cols.size} error column(s); fix before the value pass)"
   puts '======================================='
+  mark('phase6-pass1')
+  phase_summary
   exit 3
 end
 
@@ -1046,4 +1176,6 @@ puts '(--finalize runs phase6 finalize + orphan cleanup + the census-aware'
 puts ' assert-phase6-ran hard gate; exit 0 there is the ONLY green exit.)'
 puts 'PHASE E     : requested (--enhance) — runs at --finalize AFTER all gates are green' if opts[:enhance]
 puts '=================================================================='
+mark('phase6-pass1')
+phase_summary
 exit 12

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
-# Phase-1 discovery via the Tableau REST API. Use this when the Tableau MCP isn't available
-# (or when you want a single-command CLI that produces all Phase-1 artifacts).
+# Phase-1 discovery via the Tableau REST API. Use this when you have a PAT —
+# it is the FAST path (measured on "Orders Conversion Test": 61.8s serial →
+# 13.7–18.9s with the unified pool). The Tableau MCP is the no-PAT fallback.
 #
 # Output layout (matches what the MCP-driven Phase 1 produces):
 #   /tmp/<name>/get-workbook.json     — workbook metadata + view list
@@ -9,35 +10,56 @@
 #   /tmp/<name>/views/<viewId>.csv    — every view's data CSV
 #   /tmp/<name>/views/<viewId>.png    — dashboard view image only (skip other views by default)
 #   /tmp/<name>/workbook-content.twb  — raw .twb XML (or .twbx zip bytes)
+#   /tmp/<name>/timings.json          — per-task start/duration/attempts (ALWAYS
+#                                       written — the evidence trail for any
+#                                       future "discovery is slow" report)
+#
+# How it fetches: ONE shared thread pool (default 5, --pool N) covers EVERY
+# network task — .twb download, VDS read-metadata, GraphQL fields, all view
+# CSVs, and the dashboard PNG. Tasks are enqueued longest-job-first (PNG →
+# CSVs → twb/VDS/GraphQL) so the slow PNG render hides behind the CSV batch.
+# Only the initial workbook GET is serial (everything else needs its view
+# list). 5 is the measured sweet spot; 8+ risks long-tail stragglers (a
+# contended VizQL session can park one fetch for 40s+).
+#
+# Resilience (insurance — none of it fired in validation, keep it anyway):
+#   * 429 / 408 / 5xx / timeouts retry with exponential backoff + jitter
+#     (max 4 attempts).
+#   * 401s are re-minted single-flight by lib/tableau_rest.rb (refresh_token!);
+#     if a 401 still escapes that retry, the task wrapper re-mints once more.
 #
 # Usage:
 #   eval "$(scripts/get-tableau-token.sh)"
 #   ruby scripts/tableau-discover.rb \
 #     --workbook-name "Orders Conversion Test" \
 #     --datasource-name "ORDER_FACT (CSA.ORDER_FACT)+ (New Virtual Connection)" \
-#     --out /tmp/orders
+#     --out /tmp/orders [--pool 5]
 #
 # At least one of --workbook-id / --workbook-name is required.
-# --datasource-luid / --datasource-name are optional (skipped if neither given).
+# --datasource-luid / --datasource-name are optional (auto-detected from the
+# .twb when omitted). --datasource-luid must be the FULL UUID — the REST
+# filter has no prefix matching.
 
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'thread'
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'tableau_rest'
 
-opts = { fetch_view_images: 'dashboard-only' }
+opts = { fetch_view_images: 'dashboard-only', pool: 5 }
 OptionParser.new do |o|
   o.on('--workbook-name NAME')    { |v| opts[:workbook_name] = v }
   o.on('--workbook-id ID')        { |v| opts[:workbook_id] = v }
   o.on('--datasource-name NAME')  { |v| opts[:datasource_name] = v }
-  o.on('--datasource-luid LUID')  { |v| opts[:datasource_luid] = v }
+  o.on('--datasource-luid LUID', 'FULL datasource UUID (no prefix matching)') { |v| opts[:datasource_luid] = v }
   o.on('--no-auto-ds', 'Disable .twb-based datasource auto-detect') { opts[:no_auto_ds] = true }
   o.on('--out DIR', 'Output directory (required)') { |v| opts[:out] = v }
   o.on('--skip-images')           { opts[:fetch_view_images] = 'none' }
   o.on('--all-view-images')       { opts[:fetch_view_images] = 'all' }
   o.on('--skip-content')          { opts[:skip_content] = true }
+  o.on('--pool N', Integer, 'Fetch-pool size (default 5 — measured sweet spot)') { |v| opts[:pool] = v }
 end.parse!
 
 abort 'Missing --out' unless opts[:out]
@@ -46,150 +68,258 @@ abort 'Need --workbook-id or --workbook-name' unless opts[:workbook_id] || opts[
 FileUtils.mkdir_p(opts[:out])
 FileUtils.mkdir_p(File.join(opts[:out], 'views'))
 
-# 1. Workbook
-wb = if opts[:workbook_id]
-       Tableau.get_workbook(opts[:workbook_id])
-     else
-       hit = Tableau.find_workbook_by_name(opts[:workbook_name])
-       abort "No workbook found with name=#{opts[:workbook_name]}" unless hit
-       Tableau.get_workbook(hit['id'])
-     end
-File.write(File.join(opts[:out], 'get-workbook.json'), JSON.pretty_generate(wb))
-warn "wrote get-workbook.json  (id=#{wb['id']} views=#{wb.dig('views', 'view')&.size})"
+T0 = Time.now.to_f
+TIMINGS = []
+TIMINGS_MUTEX = Mutex.new
+LOG_MUTEX = Mutex.new
 
+def log(msg)
+  LOG_MUTEX.synchronize { warn format('[%7.3f] %s', Time.now.to_f - T0, msg) }
+end
+
+# Atomic write: downstream interleaved callers (migrate-tableau.rb) poll for
+# these artifacts while this script is still running — never let them observe
+# a half-written file.
+def atomic_write(path, bytes)
+  tmp = "#{path}.tmp.#{Process.pid}"
+  File.binwrite(tmp, bytes)
+  File.rename(tmp, path)
+end
+
+RETRYABLE = /\b(429|408|50[234])\b|Too Many Requests|timed? ?out|Timeout/i
+
+# Run one named fetch task with timing + backoff-retry. Returns task result or nil.
+def run_task(name)
+  t0 = Time.now.to_f
+  attempts = 0
+  begin
+    attempts += 1
+    result = yield
+    TIMINGS_MUTEX.synchronize do
+      TIMINGS << { 'task' => name, 'start' => (t0 - T0).round(3),
+                   'seconds' => (Time.now.to_f - t0).round(3), 'attempts' => attempts, 'ok' => true }
+    end
+    result
+  rescue Tableau::Error, Timeout::Error, Errno::ETIMEDOUT, Net::ReadTimeout, Net::OpenTimeout => e
+    msg = e.message.lines.first&.chomp || e.class.name
+    if attempts < 4 && msg =~ RETRYABLE
+      delay = (1.5 * (2**(attempts - 1))) + rand * 0.5
+      log "#{name}: retryable (#{msg[0, 80]}) — backoff #{delay.round(1)}s (attempt #{attempts})"
+      sleep delay
+      retry
+    elsif attempts < 3 && msg =~ /\b401\b/
+      # lib already retried 401 once with a refreshed token; one more explicit
+      # re-mint covers session invalidation racing across threads.
+      log "#{name}: 401 escaped lib retry — re-minting token (attempt #{attempts})"
+      (Tableau.refresh_token! rescue nil)
+      sleep 1.0 + rand * 0.5
+      retry
+    end
+    TIMINGS_MUTEX.synchronize do
+      TIMINGS << { 'task' => name, 'start' => (t0 - T0).round(3),
+                   'seconds' => (Time.now.to_f - t0).round(3), 'attempts' => attempts,
+                   'ok' => false, 'error' => msg[0, 200] }
+    end
+    log "#{name}: FAILED after #{attempts} attempt(s): #{msg[0, 120]}"
+    nil
+  end
+end
+
+# --- 1. Workbook (serial — everything else depends on the view list) --------
+wb = run_task('get-workbook') do
+  w = if opts[:workbook_id]
+        Tableau.get_workbook(opts[:workbook_id])
+      else
+        hit = Tableau.find_workbook_by_name(opts[:workbook_name])
+        abort "No workbook found with name=#{opts[:workbook_name]}" unless hit
+        Tableau.get_workbook(hit['id'])
+      end
+  atomic_write(File.join(opts[:out], 'get-workbook.json'), JSON.pretty_generate(w))
+  w
+end
+abort 'workbook fetch failed' unless wb
 views = wb.dig('views', 'view') || []
 views = [views] unless views.is_a?(Array)
+log "wrote get-workbook.json  (id=#{wb['id']} views=#{views.size})"
 
-# 2a. Download workbook content (.twb / .twbx) FIRST so we can auto-detect
-#     the primary datasource caption from it when --datasource-name is omitted.
-twb_xml = nil
+# --- 2. Build the task queue -------------------------------------------------
+queue = Queue.new
+twb_done = Queue.new # signals twb completion (for auto-ds fallback)
+
+# 2a. twb download task (.twbx auto-extract preserved from the serial version)
 unless opts[:skip_content]
-  bytes = Tableau.download_workbook_content(wb['id'])
-  if bytes.start_with?("PK\x03\x04")
-    twbx_path = File.join(opts[:out], 'workbook-content.twbx')
-    File.binwrite(twbx_path, bytes)
-    warn "wrote workbook-content.twbx  (#{bytes.bytesize} bytes)"
-
-    require 'tmpdir'
-    Dir.mktmpdir do |tmp|
-      unless system('unzip', '-o', '-q', twbx_path, '-d', tmp)
-        warn '.twbx auto-unzip failed (unzip command not available?); leaving .twbx in place'
-      else
-        inner = Dir.glob(File.join(tmp, '**', '*.twb')).first
-        if inner
-          twb_path = File.join(opts[:out], 'workbook-content.twb')
-          FileUtils.cp(inner, twb_path)
-          warn "extracted workbook-content.twb  (#{File.size(twb_path)} bytes) from .twbx"
-          twb_xml = File.read(twb_path)
-        else
-          warn '.twbx contained no inner .twb — odd'
+  queue << lambda do
+    bytes = run_task('twb-download') { Tableau.download_workbook_content(wb['id']) }
+    twb_xml = nil
+    if bytes
+      if bytes.start_with?("PK\x03\x04")
+        twbx_path = File.join(opts[:out], 'workbook-content.twbx')
+        atomic_write(twbx_path, bytes)
+        log "wrote workbook-content.twbx  (#{bytes.bytesize} bytes)"
+        require 'tmpdir'
+        Dir.mktmpdir do |tmp|
+          unless system('unzip', '-o', '-q', twbx_path, '-d', tmp)
+            log '.twbx auto-unzip failed (unzip command not available?); leaving .twbx in place'
+          else
+            inner = Dir.glob(File.join(tmp, '**', '*.twb')).first
+            if inner
+              twb_path = File.join(opts[:out], 'workbook-content.twb')
+              atomic_write(twb_path, File.binread(inner))
+              log "extracted workbook-content.twb  (#{File.size(twb_path)} bytes) from .twbx"
+              twb_xml = File.read(twb_path)
+            else
+              log '.twbx contained no inner .twb — odd'
+            end
+          end
         end
+      else
+        twb_path = File.join(opts[:out], 'workbook-content.twb')
+        atomic_write(twb_path, bytes)
+        log "wrote workbook-content.twb  (#{bytes.bytesize} bytes)"
+        twb_xml = bytes.force_encoding('UTF-8')
       end
     end
-  else
-    twb_path = File.join(opts[:out], 'workbook-content.twb')
-    File.binwrite(twb_path, bytes)
-    warn "wrote workbook-content.twb  (#{bytes.bytesize} bytes)"
-    twb_xml = bytes.force_encoding('UTF-8')
+    twb_done << twb_xml
   end
 end
 
-# 2b. Datasource metadata (VDS + GraphQL) — with .twb-based auto-detect
+# 2b. datasource metadata tasks (VDS + GraphQL) — enqueued immediately when a
+#     luid or name is supplied; otherwise chained after the twb task (the
+#     .twb-caption auto-detect needs the downloaded XML).
+ds_metadata_tasks = lambda do |ds_luid|
+  queue << lambda do
+    vds = run_task('vds-read-metadata') { Tableau.read_metadata(ds_luid) }
+    if vds
+      atomic_write(File.join(opts[:out], 'ds-metadata.json'), JSON.pretty_generate(vds))
+      log "wrote ds-metadata.json  (#{vds.dig('data')&.size || 0} fields)"
+    end
+  end
+  queue << lambda do
+    gql = run_task('graphql-fields') { Tableau.graphql_datasource_fields(ds_luid) }
+    if gql
+      atomic_write(File.join(opts[:out], 'graphql-fields.json'), JSON.pretty_generate(gql))
+      log 'wrote graphql-fields.json'
+    end
+  end
+end
+
 ds_luid = opts[:datasource_luid]
 if ds_luid.nil? && opts[:datasource_name]
-  hit = Tableau.find_datasource_by_name(opts[:datasource_name])
-  ds_luid = hit['id'] if hit
+  hit = run_task('find-datasource') { Tableau.find_datasource_by_name(opts[:datasource_name]) }
+  ds_luid = hit && hit['id']
 end
 
-if ds_luid.nil? && !opts[:no_auto_ds] && twb_xml
-  # Parse .twb for the first non-Parameters <datasource caption='X'> and try to
-  # find that datasource on the Tableau site. Strip the trailing "+ (...)" Tableau
-  # decoration that virtual-connection-backed datasources get.
-  caption = twb_xml.scan(/<datasource\s+caption='([^']+)'/).flatten
-                   .reject { |c| c == 'Parameters' }
-                   .first
-  if caption
-    bare = caption.sub(/\s*\+?\s*\(New Virtual Connection\)\s*$/i, '').strip
-    %W[#{caption} #{bare}].uniq.each do |cand|
-      hit = Tableau.find_datasource_by_name(cand)
-      if hit
-        ds_luid = hit['id']
-        opts[:datasource_name] = cand
-        warn "auto-detected datasource from .twb: #{cand.inspect} (luid=#{ds_luid})"
-        break
-      end
-    end
-    warn "could not resolve auto-detected datasource caption #{caption.inspect}; pass --datasource-luid to override" if ds_luid.nil?
-  end
+auto_ds_pending = ds_luid.nil? && !opts[:no_auto_ds] && !opts[:skip_content]
+ds_metadata_tasks.call(ds_luid) if ds_luid
+if ds_luid.nil? && !auto_ds_pending
+  warn 'no --datasource-luid/--datasource-name supplied (and auto-detect is unavailable); skipping VDS + GraphQL fetches'
 end
 
-if ds_luid
-  vds = Tableau.read_metadata(ds_luid)
-  File.write(File.join(opts[:out], 'ds-metadata.json'), JSON.pretty_generate(vds))
-  field_count = vds.dig('data')&.size || 0
-  warn "wrote ds-metadata.json  (#{field_count} fields)"
-
-  gql = Tableau.graphql_datasource_fields(ds_luid)
-  File.write(File.join(opts[:out], 'graphql-fields.json'), JSON.pretty_generate(gql))
-  warn 'wrote graphql-fields.json'
-else
-  warn 'no --datasource-luid/--datasource-name supplied (and auto-detect found nothing); skipping VDS + GraphQL fetches'
-end
-
-# 3. View CSVs — fire in parallel via threads. REST CSV endpoint handles concurrency
-#    better than MCP image fetches (which contend on VizQL sessions), but at 6+ workers
-#    we've seen 401s on Tableau Cloud. Cap at 4 and auto-retry any 401 once after a
-#    brief backoff — a second-pass solo retry recovers cleanly when contention clears.
-require 'thread'
-view_pool = Queue.new
-views.each { |v| view_pool << v }
-csv_threads = Array.new([4, views.size].min) do
-  Thread.new do
-    until view_pool.empty?
-      v = view_pool.pop(true) rescue nil
-      break unless v
-      attempts = 0
-      begin
-        attempts += 1
-        csv = Tableau.view_data(v['id'])
-        File.write(File.join(opts[:out], 'views', "#{v['id']}.csv"), csv)
-        warn "wrote views/#{v['id']}.csv  (#{v['name']})"
-      rescue Tableau::Error => e
-        msg = e.message.lines.first&.chomp || ''
-        if attempts < 2 && msg =~ /\b401\b/
-          sleep(1.5)
-          retry
-        end
-        warn "view CSV failed for #{v['name']} (#{v['id']}) after #{attempts} attempt(s): #{msg}"
-      end
-    end
-  end
-end
-csv_threads.each(&:join)
-
-# 4. View images
+# 2c. dashboard PNG task — IN THE POOL, queued BEFORE the CSVs (longest-job-
+#     first: the PNG render is the longest single fetch; starting it at t≈0
+#     hides it entirely behind the CSV batch).
 case opts[:fetch_view_images]
 when 'none'
-  warn 'skipping view images (--skip-images)'
+  log 'skipping view images (--skip-images)'
 when 'dashboard-only'
-  # Heuristic: the largest view by viewUrlName length OR the one whose name matches "overview" / "dashboard"
+  # Heuristic: the view whose name matches "overview"/"dashboard", else the longest name.
   dash = views.find { |v| v['name'] =~ /\boverview\b|\bdashboard\b/i } ||
          views.max_by { |v| (v['name'] || '').length }
   if dash
-    png = Tableau.view_image(dash['id'])
-    File.binwrite(File.join(opts[:out], 'views', "#{dash['id']}.png"), png)
-    warn "wrote views/#{dash['id']}.png  (dashboard: #{dash['name']})"
+    queue << lambda do
+      png = run_task("png:#{dash['name']}") { Tableau.view_image(dash['id']) }
+      if png
+        atomic_write(File.join(opts[:out], 'views', "#{dash['id']}.png"), png)
+        log "wrote views/#{dash['id']}.png  (dashboard: #{dash['name']}, #{png.bytesize} bytes)"
+      end
+    end
   end
 when 'all'
   views.each do |v|
-    png = Tableau.view_image(v['id'])
-    File.binwrite(File.join(opts[:out], 'views', "#{v['id']}.png"), png)
-    warn "wrote views/#{v['id']}.png  (#{v['name']})"
-  rescue Tableau::Error => e
-    warn "view PNG failed for #{v['name']} (#{v['id']}): #{e.message.lines.first&.chomp}"
+    queue << lambda do
+      png = run_task("png:#{v['name']}") { Tableau.view_image(v['id']) }
+      if png
+        atomic_write(File.join(opts[:out], 'views', "#{v['id']}.png"), png)
+        log "wrote views/#{v['id']}.png  (#{v['name']})"
+      end
+    end
   end
 end
 
-# 5. Workbook content was downloaded earlier (step 2a) so the auto-detect could see it.
+# 2d. view CSV tasks
+views.each do |v|
+  queue << lambda do
+    csv = run_task("csv:#{v['name']}") { Tableau.view_data(v['id']) }
+    if csv
+      atomic_write(File.join(opts[:out], 'views', "#{v['id']}.csv"), csv)
+      log "wrote views/#{v['id']}.csv  (#{v['name']}, #{csv.bytesize} bytes)"
+    end
+  end
+end
 
-warn 'done.'
+# --- 3. Run the pool ----------------------------------------------------------
+n_threads = [opts[:pool], queue.size + 1].min
+n_threads = 1 if n_threads < 1
+log "pool: #{n_threads} threads, #{queue.size} queued tasks#{auto_ds_pending ? ' (+VDS/GraphQL after twb auto-detect)' : ''}"
+
+# Auto-ds chain: a watcher enqueues VDS/GraphQL once the twb lands.
+watcher = nil
+unless opts[:skip_content]
+  watcher = Thread.new do
+    twb_xml = twb_done.pop
+    next unless auto_ds_pending
+    unless twb_xml
+      log 'auto-detect skipped — no .twb content; skipping VDS/GraphQL'
+      next
+    end
+    caption = twb_xml.scan(/<datasource\s+caption='([^']+)'/).flatten
+                     .reject { |c| c == 'Parameters' }
+                     .first
+    if caption
+      bare = caption.sub(/\s*\+?\s*\(New Virtual Connection\)\s*$/i, '').strip
+      found = nil
+      %W[#{caption} #{bare}].uniq.each do |cand|
+        hit = run_task("find-datasource:#{cand}") { Tableau.find_datasource_by_name(cand) }
+        if hit
+          found = hit['id']
+          log "auto-detected datasource from .twb: #{cand.inspect} (luid=#{found})"
+          break
+        end
+      end
+      ds_metadata_tasks.call(found) if found
+      log "could not resolve auto-detected datasource caption #{caption.inspect}; pass --datasource-luid to override" unless found
+    else
+      log 'auto-detect found no datasource caption in the .twb — skipping VDS/GraphQL'
+    end
+  end
+end
+
+pool = Array.new(n_threads) do
+  Thread.new do
+    loop do
+      task = begin
+               queue.pop(true)
+             rescue ThreadError
+               # queue momentarily empty — the auto-ds watcher may still add
+               # tasks; spin until it's dead AND the queue is empty.
+               if watcher && watcher.alive?
+                 sleep 0.1
+                 next
+               end
+               break
+             end
+      task.call
+    end
+  end
+end
+watcher&.join
+pool.each(&:join)
+
+# timings.json is ALWAYS written — it's the evidence trail when someone reports
+# discovery slowness later (per-task start offsets show pool occupancy; attempts
+# shows whether backoff/re-mint ever fired).
+total = (Time.now.to_f - T0).round(3)
+atomic_write(File.join(opts[:out], 'timings.json'),
+             JSON.pretty_generate('total_seconds' => total, 'pool' => opts[:pool],
+                                  'tasks' => TIMINGS.sort_by { |t| t['start'] }))
+log "done. total=#{total}s (timings.json written)"


### PR DESCRIPTION
## Fast discovery: unified 5-fetch pool + interleaved orchestrator lanes

Promotes the PROVEN fast-discovery prototype (`/tmp/speed01` spike, user-approved after the speed proof: **61.8s → 13.7–18.9s** measured on "Orders Conversion Test", zero rate-limiting at 5 threads) into the live skill.

### scripts/tableau-discover.rb
- Replaces the 4-thread-CSVs-then-serial-PNG structure with **ONE shared pool (default 5, `--pool N`)** covering every fetch: .twb, VDS read-metadata, GraphQL fields, all view CSVs, dashboard PNG. Longest-job-first (PNG → CSVs → twb/VDS/GraphQL) so the slow PNG render hides behind the CSV batch; only the initial workbook GET is serial.
- Keeps ALL existing behavior: .twbx auto-extract, .twb-caption datasource auto-detect (incl. the `(New Virtual Connection)` strip), `--datasource-luid` full-UUID requirement, output layout byte-compatible (verified — see E2E evidence).
- 429/408/5xx/timeout exponential backoff + jitter (max 4 attempts) and single-flight 401 re-mint kept as insurance (never fired in validation).
- **`timings.json` always emitted** — per-task start/duration/attempts; the evidence trail for future slowness reports.
- Artifacts written atomically (temp + rename) so the interleaved orchestrator can poll for them safely.

### scripts/migrate-tableau.rb
- Phase 1 is now **interleaved**: discovery + gap scan (as soon as its .twb input is ready) run as a background lane; the pure-Sigma-side read-only phases (1.6 find-or-pick-dm scan, 2 discover-columns) run concurrently; lanes **join before anything consumes discovery output**.
- Every designed stop/gate preserved exactly: gap-scan abort (exit 11), OPEN QUESTIONS (10), exit-4 master-col handoff, structural gate, census stop, exit codes unchanged.
- `PHASE TIMINGS` summary line printed at every terminal exit (phase: seconds) so speedups stay visible.

### SKILL.md
- Discovery section now documents **API/PAT-first** (with the measured numbers); MCP demoted to the no-PAT fallback only.
- Pool-cap rationale documented (5 = sweet spot; 8 risks long-tail stragglers — measured 56s run from one parked VizQL fetch) plus the ~60s server-side render cache (explains run-to-run spread).

### E2E evidence (live "Orders Conversion Test", org tj-wells-1989, 2026-06-11)

**Result: GREEN, exit 0** — `PARITY: PASS (5/5 charts, strict)`, all 5 gates OK, census explained (`--allow-missing-tiles 1`, zone named: Monthly Revenue Trend, rebuilt + live-verified). Kept pair: DM `e3a8d608-5f2b-4ed6-b3da-28e630d8f20e` + workbook `66f05f2d-6528-4453-b952-89598e1e6cfd` ("FASTDISC Tableau Orders Conversion Test").

**Designed stops all fired as documented**: exit-4 `--master-col` handoff for `Ship Speed Category` (resumed with the formula), OPEN-QUESTIONS auto-resolution under `--yes` (incl. the empty Monthly-Revenue-Trend CSV decision), CENSUS STOP at first `--finalize` (exit 3, instructions printed), gap scan 7 auto / 3 hint / 1 manual.

**Interleave evidence** (`PHASE TIMINGS` line from the green pass-1 run):
```
phase1-foreground=0.8s  phase1.6-dm-scan=5.9s  phase2-columns=18.0s  join-wait=8.5s
phase1-lane(bg)=33.2s   phase1-join=3.4s  decisions=0.0s  phase3-dm=3.3s
phase4-workbook=2.9s    phase5-layout=1.9s  phase6-pass1=8.6s  total=53.3s
```
The 33.2s background discovery lane overlapped 24s of Sigma-side work (DM-reuse scan + 7-table column discovery); the join waited only 8.5s.

**Phase 0–1 timing, old vs new (same day, same degraded server):** old serial discovery **109.5s** (plus two transient CSV 400s the serial path failed on; the pool run recovered all 7); new pooled discovery+gap-scan **33.6–40.7s** standalone, **30.1–33.2s** as the orchestrator lane. The ≤25s target was NOT reachable today: Tableau Cloud per-fetch latency was 20–35s (vs 10–19s during the proof) — `timings.json` shows every task `attempts=1` (zero rate-limiting) and the wall within ~1–3s of the theoretical floor (the single slowest fetch, e.g. one 34.7s CSV render). The 13.7–18.9s proof numbers are from identical pool code on a healthy server; `timings.json` is now always emitted precisely so this class of slowness is attributable on sight.

**Byte-equivalence vs the serial baseline**: `get-workbook.json`, `ds-metadata.json`, `graphql-fields.json`, `workbook-content.twb`, `workbook-content.twbx`, all view CSVs, and even the dashboard PNG were byte-identical between old-script and new-script runs.

**Live-drift note (env, not code)**: 415 pre-2026 rows ($80.5k gross) were bulk-loaded into `CSA.TJ.ORDER_FACT` overnight; the Tableau dashboard scopes every sheet with a relative-date "this year" filter, so strict parity required porting that shared filter to the Sigma master (bool calc + element filter, the verified spec shape) plus surfacing `Order Date Key` (the converter skips relationship join keys). After the port, all 5 charts matched the Tableau view CSVs EXACTLY, and the rebuilt trend matched live VDS month-by-month exactly (peak May $16,853.45). Per-chart PNGs exported to `~/migration-visual-qa/fastdisc/` and visually verified against the Tableau dashboard PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
