### PR TITLE
Phase E layout quality: derived titles, container placement for applied items, shared layout lint (gate 6)

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # Hard gate that proves a tableau-to-sigma conversion is actually complete.
-# The subagent MUST run this script before declaring GREEN. It checks five
+# The subagent MUST run this script before declaring GREEN. It checks six
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
@@ -20,6 +20,11 @@
 #      parity plan. Catches the "empty view CSV silently dropped a tile and
 #      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
 #      (with a note) when the converter doesn't emit a census.
+#   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
+#      display names, no input controls outside the GridContainer bands on a
+#      banded page, no dead zones (>25% empty grid rows between a page's
+#      first and last element). Catches the "PHASEE PBI Employee Dashboard"
+#      visual-mess regression that every data gate waved through.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -30,6 +35,9 @@
 #     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
 #                              # that genuinely want multiple workbooks)
 #     [--skip-layout-check]    # skip the layout-applied scan
+#     [--skip-layout-lint]     # skip gate 6 (layout-quality lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -49,6 +57,8 @@
 #      (beads-sigma-bw3)
 #   7  tile census shows unexplained unmatched dashboard zones beyond
 #      --allow-missing-tiles (bead gjhe)
+#   8  layout lint violations — raw-id display names / orphan controls /
+#      dead zones (gate 6; scripts/lib/layout_lint.rb)
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -68,6 +78,7 @@ OptionParser.new do |p|
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
   p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
 end.parse!
@@ -119,7 +130,7 @@ if status != 'PASS' || pass_rate < opts[:min_pass_rate]
   exit 2
 end
 
-puts "[OK] gate 1/5: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+puts "[OK] gate 1/6: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
 
 # ---------------------------------------------------------------------------
 # Gate 2 — orphan workbooks (beads-sigma-38a)
@@ -132,7 +143,7 @@ unless opts[:skip_orphan]
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
       unless File.exist?(marker_path)
-        warn "[FAIL] gate 2/5: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "[FAIL] gate 2/6: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
         warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
@@ -141,27 +152,27 @@ unless opts[:skip_orphan]
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
       if marker['failed'] && !marker['failed'].empty?
-        warn "[FAIL] gate 2/5: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "[FAIL] gate 2/6: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
       if marker['dry_run']
-        warn "[FAIL] gate 2/5: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "[FAIL] gate 2/6: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
         warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
         exit 4
       end
       kept = marker['kept'] || '(unknown)'
       deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/5: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      puts "[OK] gate 2/6: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
     else
-      puts "[OK] gate 2/5: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+      puts "[OK] gate 2/6: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end
   else
-    puts "[OK] gate 2/5: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+    puts "[OK] gate 2/6: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/5: --skip-orphan-check"
+  puts "[SKIP] gate 2/6: --skip-orphan-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -181,12 +192,12 @@ unless opts[:skip_column]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 3/5: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts "[SKIP] gate 3/6: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 3/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+      warn "[SKIP] gate 3/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
       req = Net::HTTP::Get.new(uri)
@@ -198,7 +209,7 @@ unless opts[:skip_column]
         cols = (JSON.parse(res.body)['entries'] rescue []) || []
         error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
         if error_cols.any?
-          warn "[FAIL] gate 3/5: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "[FAIL] gate 3/6: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
           warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
           warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
           error_cols.first(10).each do |c|
@@ -208,14 +219,14 @@ unless opts[:skip_column]
           warn "       See beads-sigma-38a."
           exit 5
         end
-        puts "[OK] gate 3/5: #{cols.length} live columns clean (no type=error)"
+        puts "[OK] gate 3/6: #{cols.length} live columns clean (no type=error)"
       else
-        warn "[SKIP] gate 3/5: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 3/6: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 3/5: --skip-column-check"
+  puts "[SKIP] gate 3/6: --skip-column-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -236,12 +247,12 @@ unless opts[:skip_layout]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 4/5: no workbook ID resolvable for layout check"
+    puts "[SKIP] gate 4/6: no workbook ID resolvable for layout check"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 4/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+      warn "[SKIP] gate 4/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
       req = Net::HTTP::Get.new(uri)
@@ -285,7 +296,7 @@ unless opts[:skip_layout]
         end
 
         if layout_xml.empty?
-          warn "[FAIL] gate 4/5: live workbook #{wb_id} has NO top-level layout XML."
+          warn "[FAIL] gate 4/6: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
           warn "       dashboard grid. Rebuild the layout with this skill's layout"
           warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
@@ -295,12 +306,12 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         elsif elem_count < opts[:min_layout_elements]
-          warn "[FAIL] gate 4/5: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "[FAIL] gate 4/6: layout XML has only #{elem_count} <LayoutElement> tag(s);"
           warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
           warn "       The layout likely covers only the Data page — chart page is unstyled."
           exit 6
         elsif non_data_stack_pages.any?
-          warn "[FAIL] gate 4/5: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "[FAIL] gate 4/6: live workbook #{wb_id} has Sigma's auto-generated"
           warn "       single-column stack layout (multiple elements at the same gridColumn"
           warn "       on a non-Data page). This is what Sigma defaults to when you POST"
           warn "       a workbook without a layout — exactly the CoCo regression."
@@ -313,15 +324,15 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         else
-          puts "[OK] gate 4/5: layout XML applied with #{elem_count} positioned element(s)"
+          puts "[OK] gate 4/6: layout XML applied with #{elem_count} positioned element(s)"
         end
       else
-        warn "[SKIP] gate 4/5: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 4/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 4/5: --skip-layout-check"
+  puts "[SKIP] gate 4/6: --skip-layout-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -334,14 +345,14 @@ end
 # ---------------------------------------------------------------------------
 census = summary['tile_census']
 if census.nil?
-  puts "[SKIP] gate 5/5: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+  puts "[SKIP] gate 5/6: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
 else
   zones     = census['zones_total'].to_i
   built     = census['charts_built'].to_i
   unmatched = census['zones_unmatched'].to_i
   names     = Array(census['unmatched_zone_names'])
   if unmatched > opts[:allow_missing_tiles]
-    warn "[FAIL] gate 5/5: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    warn "[FAIL] gate 5/6: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
     names.each { |n| warn "         - #{n}" }
     warn "       A zone that rendered in the source dashboard has NO matching chart in the"
     warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
@@ -351,9 +362,71 @@ else
     warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
     exit 7
   elsif unmatched > 0
-    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+    puts "[OK] gate 5/6: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
   else
-    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+    puts "[OK] gate 5/6: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 6 — layout-quality lint (scripts/lib/layout_lint.rb, shared)
+# A workbook can pass every data gate above and still ship as a visual mess:
+# raw element ids as chart titles, controls dumped loose at the page foot,
+# dead zones between elements (the "PHASEE PBI Employee Dashboard" escape).
+# This gate mechanizes those checks on the LIVE spec.
+# ---------------------------------------------------------------------------
+if opts[:skip_lint]
+  puts "[SKIP] gate 6/6: --skip-layout-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 6/6: no workbook ID resolvable for layout lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 6/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/layout_lint'
+    rescue LoadError
+      warn "[SKIP] gate 6/6: scripts/lib/layout_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(LayoutLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        violations = LayoutLint.lint(spec)
+        if violations.any?
+          warn "[FAIL] gate 6/6: layout lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the spec/layout and re-PUT (raw-id names -> derive human titles;"
+          warn "       loose controls -> place into a band/container; dead zones -> re-band the page),"
+          warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
+          exit 8
+        end
+        puts "[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones)"
+      else
+        warn "[SKIP] gate 6/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
   end
 end
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -23,8 +23,13 @@
 #   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
 #      display names, no input controls outside the GridContainer bands on a
 #      banded page, no dead zones (>25% empty grid rows between a page's
-#      first and last element). Catches the "PHASEE PBI Employee Dashboard"
-#      visual-mess regression that every data gate waved through.
+#      first and last element), no generic header-band title ("Page 1" /
+#      "Sheet 3" / "Dashboard 2" must never title a dashboard), and no
+#      under-filled band (<60% of the 24 grid columns covered; deliberate
+#      KPI bands of <=4 tiles exempt). Catches the "PHASEE PBI Employee
+#      Dashboard" visual-mess regression (and its PHASEE2 sequel: "Page 1"
+#      header + a lone small chart beside a 19-column hole) that every data
+#      gate waved through.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -422,7 +427,8 @@ else
           warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
           exit 8
         end
-        puts "[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones)"
+        puts '[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones, ' \
+             'no generic header title, no under-filled bands)'
       else
         warn "[SKIP] gate 6/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
       end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Three checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    named_elements(spec).each { |el, _pg| el_kind[el['id']] = el['kind'] }
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/layout_lint.rb
@@ -10,7 +10,7 @@
 #
 # It exists because a workbook can pass every data gate and still ship as a
 # visual mess (raw-id chart titles, controls dumped at the page foot, dead
-# zones) — the "PHASEE PBI Employee Dashboard" regression. Three checks:
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
 #
 #   (a) raw-id display names — any element display name matching a raw-id
 #       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
@@ -22,6 +22,17 @@
 #   (c) dead zones — more than 25% of a page's grid rows empty between the
 #       page's first and last positioned element (top-level layout entries).
 #       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
 #
 # API:
 #   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
@@ -32,6 +43,10 @@
 module LayoutLint
   RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
   DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
 
   module_function
 
@@ -70,10 +85,48 @@ module LayoutLint
     entries
   end
 
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
   def lint(spec)
     violations = []
     el_kind = {}
-    named_elements(spec).each { |el, _pg| el_kind[el['id']] = el['kind'] }
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
 
     # (a) raw-id display names ------------------------------------------------
     named_elements(spec).each do |el, pg|
@@ -97,6 +150,43 @@ module LayoutLint
           violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
                         '(banded page) — place it in the control band or its chart\'s container'
         end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        covered = Array.new(GRID_COLS, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+        end
+        fill = covered.count(true).to_f / GRID_COLS
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 
       # (c) dead-zone heuristic ------------------------------------------------

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -163,6 +163,39 @@ trial-proven spec-unsupported): DM-metric promotion (metric refs don't resolve
 through a workbook table), chart-as-filter (`useAsFilter` silently dropped on
 readback), pie percent labels (`valueFormat:'percent'` silently dropped).
 
+### Phase E layout placement + HARD screenshot checklist
+
+Every applied item lands in the **container system** — never appended at the
+page foot (that was the "PHASEE PBI Employee Dashboard" regression):
+
+- selection controls → the **control band** (created under the header if the
+  clone lacks one);
+- comparison KPIs → the **KPI band**;
+- grain/drill switchers → a slim row **inside the container of the chart they
+  drive**;
+- migration/freshness notes → a **slim note band directly under the header**.
+
+If the cloned parity workbook predates container layouts (no `<GridContainer>`
+in its layout), `enhance-apply.rb` **regenerates a banded layout** for the
+clone first (builder machinery, `scripts/lib/layout.rb`), then applies items.
+The finalize runs the shared layout lint (`scripts/lib/layout_lint.rb`: no
+raw-id display names, no controls outside containers, no dead zones) and
+**exits 4 on violations** — a lint-failing clone must be fixed and re-PUT
+before the run may be declared done.
+
+**HARD screenshot checklist (mandatory at finalize).** The lint is mechanical;
+your eyes are the last gate. Export the clone's **full-page PNG**
+(`scripts/sigma-export-png.py`) and verify EVERY item, listing each with
+pass/fail in your report:
+
+- [ ] every chart/control title is human-readable (no raw element ids)
+- [ ] the page has a header band (dark, full-width, page title)
+- [ ] selection controls sit together in a control band near the top
+- [ ] every control is adjacent to / inside the container of what it filters
+      (grain/drill switchers INSIDE their chart's container)
+- [ ] no orphan elements below the fold (nothing dumped at the page foot)
+- [ ] no dead zones; row heights look even across each band
+
 ## Reverse direction — author INTO Power BI
 The Fabric API is symmetric: `POST .../semanticModels` (TMSL parts) + `POST .../reports` (PBIR) create live items. Same device-code token (`user_impersonation` covers writes). Needs a Fabric-capacity workspace. See `scripts/fabric-auth-check.py` for the write-capability/capacity check.
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -179,7 +179,11 @@ If the cloned parity workbook predates container layouts (no `<GridContainer>`
 in its layout), `enhance-apply.rb` **regenerates a banded layout** for the
 clone first (builder machinery, `scripts/lib/layout.rb`), then applies items.
 The finalize runs the shared layout lint (`scripts/lib/layout_lint.rb`: no
-raw-id display names, no controls outside containers, no dead zones) and
+raw-id display names, no controls outside containers, no dead zones, no
+generic header-band title — "Page 1"/"Sheet N"/"Dashboard N" never titles a
+dashboard; the header carries the promoted source title → source display
+name → workbook name — and no band whose elements fill <60% of the grid
+columns, KPI bands of ≤4 tiles exempt) and
 **exits 4 on violations** — a lint-failing clone must be fixed and re-PUT
 before the run may be declared done.
 
@@ -189,7 +193,8 @@ your eyes are the last gate. Export the clone's **full-page PNG**
 pass/fail in your report:
 
 - [ ] every chart/control title is human-readable (no raw element ids)
-- [ ] the page has a header band (dark, full-width, page title)
+- [ ] the page has a header band (dark, full-width, carrying the SOURCE title
+      or display name — never a generic "Page 1")
 - [ ] selection controls sit together in a control band near the top
 - [ ] every control is adjacent to / inside the container of what it filters
       (grain/drill switchers INSIDE their chart's container)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # Hard gate that proves a tableau-to-sigma conversion is actually complete.
-# The subagent MUST run this script before declaring GREEN. It checks five
+# The subagent MUST run this script before declaring GREEN. It checks six
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
@@ -20,6 +20,11 @@
 #      parity plan. Catches the "empty view CSV silently dropped a tile and
 #      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
 #      (with a note) when the converter doesn't emit a census.
+#   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
+#      display names, no input controls outside the GridContainer bands on a
+#      banded page, no dead zones (>25% empty grid rows between a page's
+#      first and last element). Catches the "PHASEE PBI Employee Dashboard"
+#      visual-mess regression that every data gate waved through.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -30,6 +35,9 @@
 #     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
 #                              # that genuinely want multiple workbooks)
 #     [--skip-layout-check]    # skip the layout-applied scan
+#     [--skip-layout-lint]     # skip gate 6 (layout-quality lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -49,6 +57,8 @@
 #      (beads-sigma-bw3)
 #   7  tile census shows unexplained unmatched dashboard zones beyond
 #      --allow-missing-tiles (bead gjhe)
+#   8  layout lint violations — raw-id display names / orphan controls /
+#      dead zones (gate 6; scripts/lib/layout_lint.rb)
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -68,6 +78,7 @@ OptionParser.new do |p|
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
   p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
 end.parse!
@@ -119,7 +130,7 @@ if status != 'PASS' || pass_rate < opts[:min_pass_rate]
   exit 2
 end
 
-puts "[OK] gate 1/5: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+puts "[OK] gate 1/6: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
 
 # ---------------------------------------------------------------------------
 # Gate 2 — orphan workbooks (beads-sigma-38a)
@@ -132,7 +143,7 @@ unless opts[:skip_orphan]
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
       unless File.exist?(marker_path)
-        warn "[FAIL] gate 2/5: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "[FAIL] gate 2/6: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
         warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
@@ -141,27 +152,27 @@ unless opts[:skip_orphan]
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
       if marker['failed'] && !marker['failed'].empty?
-        warn "[FAIL] gate 2/5: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "[FAIL] gate 2/6: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
       if marker['dry_run']
-        warn "[FAIL] gate 2/5: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "[FAIL] gate 2/6: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
         warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
         exit 4
       end
       kept = marker['kept'] || '(unknown)'
       deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/5: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      puts "[OK] gate 2/6: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
     else
-      puts "[OK] gate 2/5: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+      puts "[OK] gate 2/6: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end
   else
-    puts "[OK] gate 2/5: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+    puts "[OK] gate 2/6: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/5: --skip-orphan-check"
+  puts "[SKIP] gate 2/6: --skip-orphan-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -181,12 +192,12 @@ unless opts[:skip_column]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 3/5: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts "[SKIP] gate 3/6: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 3/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+      warn "[SKIP] gate 3/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
       req = Net::HTTP::Get.new(uri)
@@ -198,7 +209,7 @@ unless opts[:skip_column]
         cols = (JSON.parse(res.body)['entries'] rescue []) || []
         error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
         if error_cols.any?
-          warn "[FAIL] gate 3/5: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "[FAIL] gate 3/6: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
           warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
           warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
           error_cols.first(10).each do |c|
@@ -208,14 +219,14 @@ unless opts[:skip_column]
           warn "       See beads-sigma-38a."
           exit 5
         end
-        puts "[OK] gate 3/5: #{cols.length} live columns clean (no type=error)"
+        puts "[OK] gate 3/6: #{cols.length} live columns clean (no type=error)"
       else
-        warn "[SKIP] gate 3/5: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 3/6: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 3/5: --skip-column-check"
+  puts "[SKIP] gate 3/6: --skip-column-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -236,12 +247,12 @@ unless opts[:skip_layout]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 4/5: no workbook ID resolvable for layout check"
+    puts "[SKIP] gate 4/6: no workbook ID resolvable for layout check"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 4/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+      warn "[SKIP] gate 4/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
       req = Net::HTTP::Get.new(uri)
@@ -285,7 +296,7 @@ unless opts[:skip_layout]
         end
 
         if layout_xml.empty?
-          warn "[FAIL] gate 4/5: live workbook #{wb_id} has NO top-level layout XML."
+          warn "[FAIL] gate 4/6: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
           warn "       dashboard grid. Rebuild the layout with this skill's layout"
           warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
@@ -295,12 +306,12 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         elsif elem_count < opts[:min_layout_elements]
-          warn "[FAIL] gate 4/5: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "[FAIL] gate 4/6: layout XML has only #{elem_count} <LayoutElement> tag(s);"
           warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
           warn "       The layout likely covers only the Data page — chart page is unstyled."
           exit 6
         elsif non_data_stack_pages.any?
-          warn "[FAIL] gate 4/5: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "[FAIL] gate 4/6: live workbook #{wb_id} has Sigma's auto-generated"
           warn "       single-column stack layout (multiple elements at the same gridColumn"
           warn "       on a non-Data page). This is what Sigma defaults to when you POST"
           warn "       a workbook without a layout — exactly the CoCo regression."
@@ -313,15 +324,15 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         else
-          puts "[OK] gate 4/5: layout XML applied with #{elem_count} positioned element(s)"
+          puts "[OK] gate 4/6: layout XML applied with #{elem_count} positioned element(s)"
         end
       else
-        warn "[SKIP] gate 4/5: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 4/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 4/5: --skip-layout-check"
+  puts "[SKIP] gate 4/6: --skip-layout-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -334,14 +345,14 @@ end
 # ---------------------------------------------------------------------------
 census = summary['tile_census']
 if census.nil?
-  puts "[SKIP] gate 5/5: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+  puts "[SKIP] gate 5/6: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
 else
   zones     = census['zones_total'].to_i
   built     = census['charts_built'].to_i
   unmatched = census['zones_unmatched'].to_i
   names     = Array(census['unmatched_zone_names'])
   if unmatched > opts[:allow_missing_tiles]
-    warn "[FAIL] gate 5/5: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    warn "[FAIL] gate 5/6: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
     names.each { |n| warn "         - #{n}" }
     warn "       A zone that rendered in the source dashboard has NO matching chart in the"
     warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
@@ -351,9 +362,71 @@ else
     warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
     exit 7
   elsif unmatched > 0
-    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+    puts "[OK] gate 5/6: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
   else
-    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+    puts "[OK] gate 5/6: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 6 — layout-quality lint (scripts/lib/layout_lint.rb, shared)
+# A workbook can pass every data gate above and still ship as a visual mess:
+# raw element ids as chart titles, controls dumped loose at the page foot,
+# dead zones between elements (the "PHASEE PBI Employee Dashboard" escape).
+# This gate mechanizes those checks on the LIVE spec.
+# ---------------------------------------------------------------------------
+if opts[:skip_lint]
+  puts "[SKIP] gate 6/6: --skip-layout-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 6/6: no workbook ID resolvable for layout lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 6/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/layout_lint'
+    rescue LoadError
+      warn "[SKIP] gate 6/6: scripts/lib/layout_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(LayoutLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        violations = LayoutLint.lint(spec)
+        if violations.any?
+          warn "[FAIL] gate 6/6: layout lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the spec/layout and re-PUT (raw-id names -> derive human titles;"
+          warn "       loose controls -> place into a band/container; dead zones -> re-band the page),"
+          warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
+          exit 8
+        end
+        puts "[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones)"
+      else
+        warn "[SKIP] gate 6/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
   end
 end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -23,8 +23,13 @@
 #   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
 #      display names, no input controls outside the GridContainer bands on a
 #      banded page, no dead zones (>25% empty grid rows between a page's
-#      first and last element). Catches the "PHASEE PBI Employee Dashboard"
-#      visual-mess regression that every data gate waved through.
+#      first and last element), no generic header-band title ("Page 1" /
+#      "Sheet 3" / "Dashboard 2" must never title a dashboard), and no
+#      under-filled band (<60% of the 24 grid columns covered; deliberate
+#      KPI bands of <=4 tiles exempt). Catches the "PHASEE PBI Employee
+#      Dashboard" visual-mess regression (and its PHASEE2 sequel: "Page 1"
+#      header + a lone small chart beside a 19-column hole) that every data
+#      gate waved through.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -422,7 +427,8 @@ else
           warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
           exit 8
         end
-        puts "[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones)"
+        puts '[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones, ' \
+             'no generic header title, no under-filled bands)'
       else
         warn "[SKIP] gate 6/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
       end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -59,6 +59,10 @@ OptionParser.new do |p|
   p.on('--out PATH')         { |v| opts[:out] = v }
   p.on('--layout-out PATH')  { |v| opts[:layout_out] = v }
   p.on('--name NAME')        { |v| opts[:name] = v }
+  # The SOURCE report/dashboard display name (e.g. "EMPLOYEE DASHBOARD") —
+  # header-band title fallback when a page has no promotable title textbox and
+  # its own name is a generic auto-name ("Page 1"). See resolve_header_title.
+  p.on('--source-title NAME') { |v| opts[:source_title] = v }
   p.on('--folder-id ID')     { |v| opts[:folder] = v }
 end.parse!
 %i[sig mmap out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
@@ -781,14 +785,17 @@ pages_xml = signals['pages'].map do |pg|
   next nil if items.empty?
   page_spec = content_pages.find { |p| p['id'] == page_id }
   # phase-e layout-quality fix: a short title TEXTBOX at the top of the source
-  # canvas becomes the header band's text (white-on-dark), instead of sitting
-  # inside band 1 with a dead zone under it. Same promotion the Phase E
-  # re-banding applies to pre-container clones.
+  # canvas becomes the header band's text (white-on-dark), MOVED out of band 1
+  # (never left behind as a dead zone). The candidate may start up to one grid
+  # row below the page's topmost element (classic-report title boxes are
+  # routinely nudged a few px down from y=0 — exact-row equality was the
+  # PHASEE2 fragility). Same promotion the Phase E re-banding applies to
+  # pre-container clones.
   top_row = items.map { |i| i[3] }.min
   hdr_vis = pg['visuals'].find do |v|
     next false unless v['sigma_kind'] == 'text' && v['text'].to_s.strip != ''
     it = items.find { |i| i[0] == "el-#{short(v['visual_id'])}" }
-    it && it[3] == top_row && (it[4] - it[3]) <= 5
+    it && it[3] <= top_row + 1 && (it[4] - it[3]) <= 5
   end
   if hdr_vis && page_spec
     hdr_eid = "el-#{short(hdr_vis['visual_id'])}"
@@ -798,7 +805,13 @@ pages_xml = signals['pages'].map do |pg|
     hdr_el['body'] = %(# <span style="color: #FFFFFF">#{hdr_vis['text']}</span>) if hdr_el
     xml, extra = banded_page(page_id, items, header_el: hdr_eid)
   else
-    xml, extra = banded_page(page_id, items, title: pg['page_title'])
+    # No promotable source title — header text falls back, in priority order,
+    # to: source page name (if not a generic auto-name) -> source report
+    # display name (--source-title) -> workbook name. NEVER "Page 1".
+    hdr_title = SigmaLayout.resolve_header_title(
+      pg['page_title'], opts[:source_title], opts[:name]
+    ) || 'Dashboard'
+    xml, extra = banded_page(page_id, items, title: hdr_title)
   end
   page_spec['elements'] = page_spec['elements'] + extra if page_spec
   xml
@@ -806,7 +819,8 @@ end.compact.join("\n")
 layout_xml = %(<?xml version="1.0" encoding="utf-8"?>\n#{pages_xml}\n)
 
 spec = {
-  'name' => opts[:name] || signals.dig('pages', 0, 'page_title') || 'Power BI Import',
+  'name' => opts[:name] || opts[:source_title] ||
+            signals.dig('pages', 0, 'page_title') || 'Power BI Import',
   'schemaVersion' => 1,
   'pages' => [{ 'id' => 'page-data', 'name' => 'Data', 'elements' => data_elements }] + content_pages,
   # bead 16i: embed the layout so the very first POST does not trigger Sigma's

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -121,6 +121,74 @@ def qr_leaf(qr, fallback = 'Value')
   leaf.empty? ? fallback : leaf
 end
 
+# ---------------------------------------------------------------------------
+# Derived element titles (phase-e layout-quality fix): classic report.json
+# visuals routinely carry NO objects.title, and the old fallback surfaced the
+# RAW visual id ("291ef87d16c50d7a3808") as the chart's display name. Derive a
+# human title from the visual's projections instead — a raw id must NEVER
+# surface as a display name (layout_lint.rb fails the build if one does).
+# ---------------------------------------------------------------------------
+
+# Humanized leaf for titles: strip agg wrappers + date-hierarchy "Variation"
+# tails, underscores -> spaces, ALL-CAPS warehouse names -> Title Case (short
+# acronyms like ZIP/ID stay upcased).
+def title_leaf(qr, fallback = nil)
+  s = qr.to_s.strip
+  # "T.COL.Variation.Date Hierarchy.Month" -> the base column "T.COL"
+  s = Regexp.last_match(1) if s =~ /\A(.+?)\.Variation\..+\z/i
+  leaf = qr_leaf(s, nil)
+  return fallback if leaf.nil? || leaf.empty?
+  words = leaf.gsub(/_+/, ' ').strip.split(/\s+/)
+  words.map { |w| w =~ /\A[A-Z0-9]+\z/ && w.length > 3 ? w.capitalize : w }.join(' ')
+end
+
+# True when a dimension queryRef is date-shaped (date hierarchy / date-named
+# column) — those visuals read better as "<Measure> Over Time".
+def dateish_qr?(qr)
+  qr.to_s =~ /variation|hierarchy|\b(date|month|year|quarter|week|day)\b/i
+end
+
+# "Absence Count by Department" / "Hours by Location" / "Hires Over Time" —
+# derived purely from the visual's role projections. Returns nil only when the
+# visual has no usable bindings (caller falls back to the kind label).
+def derived_title(rec, kind)
+  b = rec['bindings'] || {}
+  vals = b['Values'] || b['Y'] || []
+  dims = b['Category'] || b['Axis'] || b['X'] || b['Group'] || b['Rows'] || b['Fields'] || []
+  case kind
+  when 'kpi-chart'
+    title_leaf(vals.first || dims.first)
+  when 'table'
+    leaves = (b['Values'] || []).map { |q| title_leaf(q) }.compact.uniq
+    return nil if leaves.empty?
+    leaves.length > 3 ? "#{leaves.first(3).join(', ')} +#{leaves.length - 3}" : leaves.join(', ')
+  when 'pivot-table'
+    v = title_leaf(vals.first)
+    r = title_leaf((b['Rows'] || b['Category'] || []).first)
+    c = title_leaf((b['Columns'] || []).first)
+    return nil unless v
+    [v, r && "by #{r}", c && "and #{c}"].compact.join(' ')
+  when 'scatter-chart'
+    x = title_leaf((b['X'] || b['Values'] || []).first)
+    y = title_leaf((b['Y'] || []).first)
+    x && y ? "#{y} vs #{x}" : (y || x)
+  else # bar/line/area/combo/pie/donut
+    dim = dims.first || (b['Legend'] || []).first
+    v = title_leaf(vals.first || (b['Y2'] || []).first)
+    d = title_leaf(dim)
+    return v || d if v.nil? || d.nil?
+    dateish_qr?(dim) ? "#{v} Over Time" : "#{v} by #{d}"
+  end
+end
+
+# Last-resort label per Sigma kind — still human-readable, never an id.
+KIND_LABEL = {
+  'kpi-chart' => 'KPI', 'bar-chart' => 'Bar Chart', 'line-chart' => 'Line Chart',
+  'area-chart' => 'Area Chart', 'combo-chart' => 'Combo Chart',
+  'scatter-chart' => 'Scatter Plot', 'pie-chart' => 'Pie Chart',
+  'donut-chart' => 'Donut Chart', 'table' => 'Table', 'pivot-table' => 'Pivot Table'
+}.freeze
+
 # PBI numeric format string (from signals 'formats' or master-map field 'format')
 # -> Sigma column format hash. Best-effort; only emits when a format is known.
 # Sigma column format shape is { kind, formatString } (matches the converter's
@@ -268,8 +336,11 @@ def build_element(rec, fields, masters, extra_data = [])
   eid  = "el-#{short(vid)}"
   vfmts = rec['formats'] || {}
   # bead 14w(e): element name comes from the PBI visual title, not the raw id.
+  # When the source visual has no explicit title (the classic-report norm),
+  # derive one from its projections — NEVER surface the raw visual id as the
+  # display name (phase-e layout-quality fix; layout_lint.rb gates this).
   title = rec['title'].to_s.strip
-  name  = title.empty? ? vid : title
+  name  = title.empty? ? (derived_title(rec, kind) || KIND_LABEL[kind] || 'Chart') : title
 
   if kind == 'text'
     body = rec['text'] ? "## #{rec['text']}" : '## '
@@ -634,6 +705,15 @@ content_pages = signals['pages'].map do |pg|
   { 'id' => "page-#{pg['page_id']}", 'name' => pg['page_title'], 'elements' => els }
 end
 data_elements += extra_data_elements
+
+# Derived titles can collide (two untitled visuals over the same projections) —
+# suffix duplicates so every element keeps a distinct human-readable name.
+seen_names = Hash.new(0)
+content_pages.flat_map { |p| p['elements'] }.each do |el|
+  next unless el['name'].is_a?(String) && !el['name'].empty?
+  n = (seen_names[el['name']] += 1)
+  el['name'] = "#{el['name']} (#{n})" if n > 1
+end
 
 # ---- 24-col grid layout (research/powerbi-visual-layout.md §4) -------------
 # Built BEFORE the spec is assembled so the layout XML can be EMBEDDED into the

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -779,8 +779,27 @@ pages_xml = signals['pages'].map do |pg|
   end
   page_id = "page-#{pg['page_id']}"
   next nil if items.empty?
-  xml, extra = banded_page(page_id, items, title: pg['page_title'])
   page_spec = content_pages.find { |p| p['id'] == page_id }
+  # phase-e layout-quality fix: a short title TEXTBOX at the top of the source
+  # canvas becomes the header band's text (white-on-dark), instead of sitting
+  # inside band 1 with a dead zone under it. Same promotion the Phase E
+  # re-banding applies to pre-container clones.
+  top_row = items.map { |i| i[3] }.min
+  hdr_vis = pg['visuals'].find do |v|
+    next false unless v['sigma_kind'] == 'text' && v['text'].to_s.strip != ''
+    it = items.find { |i| i[0] == "el-#{short(v['visual_id'])}" }
+    it && it[3] == top_row && (it[4] - it[3]) <= 5
+  end
+  if hdr_vis && page_spec
+    hdr_eid = "el-#{short(hdr_vis['visual_id'])}"
+    items = items.reject { |i| i[0] == hdr_eid }
+    next nil if items.empty?
+    hdr_el = page_spec['elements'].find { |e| e['id'] == hdr_eid }
+    hdr_el['body'] = %(# <span style="color: #FFFFFF">#{hdr_vis['text']}</span>) if hdr_el
+    xml, extra = banded_page(page_id, items, header_el: hdr_eid)
+  else
+    xml, extra = banded_page(page_id, items, title: pg['page_title'])
+  end
   page_spec['elements'] = page_spec['elements'] + extra if page_spec
   xml
 end.compact.join("\n")

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
@@ -228,9 +228,13 @@ def ensure_banded!(spec)
     next if items.empty?
     # an existing short top text element (the dashboard's own title) becomes
     # the header band's text (recolored white for the dark band); otherwise
-    # SigmaLayout adds a header from the page name.
+    # SigmaLayout adds a header from the page name -> workbook name chain
+    # (resolve_header_title — never a generic "Page 1" auto-name). The
+    # candidate may start up to one row below the topmost element (classic
+    # title boxes are nudged a few px down; exact-row equality was the
+    # PHASEE2 fragility).
     top_row = items.map { |i| i[3] }.min
-    own_hdr = items.find { |i| i[3] == top_row && kind_of[i[0]] == 'text' && (i[4] - i[3]) <= 5 }
+    own_hdr = items.find { |i| i[3] <= top_row + 1 && kind_of[i[0]] == 'text' && (i[4] - i[3]) <= 5 }
     if own_hdr && items.length > 1
       items -= [own_hdr]
       hdr_el = (pg['elements'] || []).find { |e| e['id'] == own_hdr[0] }
@@ -241,7 +245,8 @@ def ensure_banded!(spec)
       xml, extra = SigmaLayout.banded_page(pg['id'], items, header_el: own_hdr[0],
                                            id_prefix: "band-#{pg['id']}")
     else
-      xml, extra = SigmaLayout.banded_page(pg['id'], items, title: pg['name'],
+      hdr_title = SigmaLayout.resolve_header_title(pg['name'], spec['name']) || 'Dashboard'
+      xml, extra = SigmaLayout.banded_page(pg['id'], items, title: hdr_title,
                                            id_prefix: "band-#{pg['id']}")
     end
     new_ids = (pg['elements'] || []).map { |e| e['id'] }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
@@ -27,10 +27,19 @@
 #     --accept all-low-risk | --accept id1,id2,... \
 #     [--name '<clone name>'] [--out enhance-report.json] [--probes N]
 #
+# Every applied item lands in the CONTAINER SYSTEM (see the layout-placement
+# section): controls -> control band, KPIs -> KPI band, grain/drill switchers
+# -> inside their chart's container, notes -> a slim band under the header.
+# Pre-container clones get their layout regenerated as a banded layout first.
+# The finalize runs the shared layout lint (lib/layout_lint.rb) and prints the
+# hard screenshot checklist — the agent MUST export the full-page PNG and
+# verify each item.
+#
 # Exit codes: 0 = done (clone created; accepted items applied or cleanly
-# reverted; parity-unchanged gate green); 2 = nothing accepted; 3 = the
-# parity-unchanged gate could not be restored (clone left for inspection,
-# report says so); other = error.
+# reverted; parity-unchanged gate green; layout lint clean); 2 = nothing
+# accepted; 3 = the parity-unchanged gate could not be restored (clone left
+# for inspection, report says so); 4 = layout lint violations on the clone
+# (fix + re-PUT, then re-lint); other = error.
 
 require 'json'
 require 'yaml'
@@ -127,19 +136,252 @@ def norm_rows(rows)
 end
 
 # ---------------------------------------------------------------------------
-# Layout helper: append a LayoutElement to the bottom of a page's grid block.
+# Container-aware layout placement (phase-e layout-quality fix).
+#
+# The first Phase E shipped enhancements by APPENDING <LayoutElement>s at the
+# bottom of the Page block — controls/KPIs/notes dumped below the fold, the
+# grain switcher orphaned at the foot. Every applied item now lands in the
+# container system instead:
+#   - selection controls       -> the control band (created if absent)
+#   - comparison KPIs          -> the KPI band (created if absent)
+#   - grain/drill switcher     -> INSIDE its chart's own container (slim row
+#                                 above the chart)
+#   - migration/freshness note -> a slim note band directly under the header
+# If the cloned parity workbook PREDATES container layouts (no <GridContainer>
+# in its layout), the clone's layout is REGENERATED as a banded layout first,
+# using the builder's shared container machinery (lib/layout.rb).
 # ---------------------------------------------------------------------------
-def add_layout!(spec, page_id, element_id, grid_column, height, same_row_start = nil)
-  xml = spec['layout'].to_s
-  return nil if xml.empty? || page_id.nil?
-  m = xml.match(%r{(<Page\b[^>]*\bid="#{Regexp.escape(page_id)}"[^>]*>)(.*?)(</Page>)}m)
-  return nil unless m
-  block = m[2]
-  max_end = block.scan(/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/).flatten.map(&:to_i).max || 1
-  row_start = same_row_start || max_end
-  entry = %(  <LayoutElement elementId="#{element_id}" gridColumn="#{grid_column}" gridRow="#{row_start} / #{row_start + height}"/>\n)
-  spec['layout'] = xml.sub(m[0], "#{m[1]}#{block}#{entry}#{m[3]}")
-  row_start
+require 'layout' # scripts/lib/layout.rb — SigmaLayout container machinery
+
+CTRL_BAND_PREFIX = 'phasee-ctrl-band'
+KPI_BAND_PREFIX  = 'phasee-kpi-band'
+NOTE_BAND_PREFIX = 'phasee-note-band'
+# vertical order of phasee-created bands under the header (note = slimmest,
+# closest to the header; KPIs above the charts read best below the controls)
+BAND_PRIORITY = { NOTE_BAND_PREFIX => 0, CTRL_BAND_PREFIX => 1, KPI_BAND_PREFIX => 2 }.freeze
+BAND_ROWS = { NOTE_BAND_PREFIX => 2, CTRL_BAND_PREFIX => 3, KPI_BAND_PREFIX => 6 }.freeze
+
+def page_block(spec, page_id)
+  return nil if page_id.nil?
+  spec['layout'].to_s.match(%r{(<Page\b[^>]*\bid="#{Regexp.escape(page_id)}"[^>]*>)(.*?)(</Page>)}m)
+end
+
+def replace_page_inner!(spec, page_id, new_inner)
+  m = page_block(spec, page_id) or return nil
+  spec['layout'] = spec['layout'].to_s.sub(m[0]) { "#{m[1]}#{new_inner}#{m[3]}" }
+  true
+end
+
+# Direct children of a page block: [{tag:, eid:, c0:, c1:, r0:, r1:, s:, e:,
+# head_e:, inner: (containers only)}] — byte offsets into the inner string.
+def scan_top(inner)
+  out = []
+  pos = 0
+  while (m = inner.match(%r{<(GridContainer|LayoutElement)\b[^>]*?(/>|>)}m, pos))
+    tag = m[1]
+    open_e = m.end(0)
+    ent_end = open_e
+    body = nil
+    if tag == 'GridContainer' && m[2] == '>'
+      close = inner.match(%r{</GridContainer>}m, open_e)
+      ent_end = close ? close.end(0) : open_e
+      body = close ? inner[open_e...close.begin(0)] : ''
+    end
+    head = inner[m.begin(0)...open_e]
+    out << { tag: tag, eid: head[/elementId="([^"]*)"/, 1],
+             c0: head[/gridColumn="\s*(\d+)/, 1].to_i,
+             c1: head[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+             r0: head[/gridRow="\s*(\d+)/, 1].to_i,
+             r1: head[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+             s: m.begin(0), e: ent_end, head_e: open_e, inner: body }
+    pos = ent_end
+  end
+  out
+end
+
+def set_rows(head, r0, r1)
+  head.sub(/gridRow="[^"]*"/) { %(gridRow="#{r0} / #{r1}") }
+end
+
+# Shift every top-level entry starting at/after from_row down by delta rows.
+def shift_top_rows(inner, from_row, delta)
+  res = inner.dup
+  scan_top(inner).reverse_each do |t|
+    next unless t[:r0] >= from_row
+    res[t[:s]...t[:head_e]] = set_rows(inner[t[:s]...t[:head_e]], t[:r0] + delta, t[:r1] + delta)
+  end
+  res
+end
+
+# Regenerate a banded layout for every dashboard page of a pre-container clone
+# (flat <LayoutElement> list -> header band + row-band GridContainers via the
+# builder's shared SigmaLayout machinery). No-op when containers exist.
+def ensure_banded!(spec)
+  return false if spec['layout'].to_s.include?('<GridContainer')
+  changed = false
+  (spec['pages'] || []).each do |pg|
+    next if pg['id'].to_s.downcase.include?('data')
+    m = page_block(spec, pg['id']) or next
+    kind_of = (pg['elements'] || []).to_h { |e| [e['id'], e['kind']] }
+    items = scan_top(m[2]).select { |t| t[:tag] == 'LayoutElement' }
+                          .map { |t| [t[:eid], t[:c0], t[:c1], t[:r0], t[:r1]] }
+    next if items.empty?
+    # an existing full-width-ish top text element becomes the header text;
+    # otherwise SigmaLayout adds a header from the page name.
+    top_row = items.map { |i| i[3] }.min
+    own_hdr = items.find { |i| i[3] == top_row && kind_of[i[0]] == 'text' && (i[2] - i[1]) >= 12 }
+    extra = []
+    children = []
+    offset = 0
+    hdr_id = "band-#{pg['id']}-hdr"
+    if own_hdr
+      items -= [own_hdr]
+      extra << SigmaLayout.container_el(hdr_id, SigmaLayout::HEADER_STYLE.dup)
+      children << SigmaLayout.header_band_xml(hdr_id, own_hdr[0])
+      offset = SigmaLayout::HEADER_ROWS
+      offset += (1 - items.map { |i| i[3] }.min) unless items.empty?
+      SigmaLayout.cluster_bands(items).each_with_index do |band, i|
+        cid = "band-#{pg['id']}-#{i + 1}"
+        extra << SigmaLayout.container_el(cid)
+        children << SigmaLayout.band_container_xml(cid, band, row_offset: offset)
+      end
+      xml = SigmaLayout.page_xml(pg['id'], *children)
+    else
+      xml, extra = SigmaLayout.banded_page(pg['id'], items, title: pg['name'],
+                                           id_prefix: "band-#{pg['id']}")
+    end
+    new_ids = (pg['elements'] || []).map { |e| e['id'] }
+    pg['elements'] = (pg['elements'] || []) + extra.reject { |e| new_ids.include?(e['id']) }
+    spec['layout'] = spec['layout'].to_s.sub(m[0]) { xml }
+    changed = true
+  end
+  changed
+end
+
+# Row where a new phasee band of `prefix` should start on this page: under the
+# header band (the row-1 container), below any already-created phasee band of
+# lower priority.
+def band_anchor_row(ents, prefix)
+  hdr = ents.select { |t| t[:tag] == 'GridContainer' }
+            .find { |t| t[:r0] <= 1 }
+  row = hdr ? hdr[:r1] : (ents.map { |t| t[:r0] }.min || 1)
+  ents.each do |t|
+    pfx = BAND_PRIORITY.keys.find { |p| t[:eid].to_s.start_with?(p) }
+    row = [row, t[:r1]].max if pfx && BAND_PRIORITY[pfx] < BAND_PRIORITY[prefix]
+  end
+  row
+end
+
+# Find-or-create the phasee band container for `prefix` on the page; returns
+# the band's container element id. Creates the spec-side `kind: container`
+# placeholder and shifts everything below the insertion point down.
+def ensure_band!(spec, page, prefix)
+  m = page_block(spec, page['id']) or raise "no layout block for page #{page['id']}"
+  ents = scan_top(m[2])
+  existing = ents.find { |t| t[:eid].to_s.start_with?(prefix) }
+  return existing[:eid] if existing
+  rows = BAND_ROWS[prefix]
+  cid = "#{prefix}-#{page['id']}"[0, 60]
+  anchor = band_anchor_row(ents, prefix)
+  inner = shift_top_rows(m[2], anchor, rows)
+  band = SigmaLayout.gc(cid, 1, 25, anchor, anchor + rows, '')
+  replace_page_inner!(spec, page['id'], "#{inner}\n#{band}\n")
+  (page['elements'] ||= []) << SigmaLayout.container_el(cid) unless page['elements'].any? { |e| e['id'] == cid }
+  cid
+end
+
+# Place an element INTO a band container, flowing left-to-right then wrapping
+# to a new row (growing the band + shifting the bands below it).
+def band_add!(spec, page_id, band_cid, element_id, grid_column, height)
+  m = page_block(spec, page_id) or raise "no layout block for page #{page_id}"
+  ents = scan_top(m[2])
+  band = ents.find { |t| t[:eid] == band_cid } or raise "band #{band_cid} not found"
+  c0, c1 = grid_column.to_s.scan(/\d+/).map(&:to_i)
+  c0 = 1 if c0.nil? || c0 < 1
+  c1 = [c0 + 8, 25].min if c1.nil? || c1 <= c0
+  width = c1 - c0
+  band_rows = band[:r1] - band[:r0]
+  h = [height || band_rows, band_rows].min
+  h = band_rows if h <= 0
+  kids = scan_top(band[:inner].to_s)
+  if kids.empty?
+    row = 1
+    place_c0 = c0
+  else
+    cur = kids.map { |k| k[:r0] }.max
+    cur_kids = kids.select { |k| k[:r0] == cur }
+    max_c1 = cur_kids.map { |k| k[:c1] }.max
+    if max_c1 + width <= 25
+      row = cur
+      place_c0 = max_c1
+    else
+      row = kids.map { |k| k[:r1] }.max
+      place_c0 = c0
+    end
+  end
+  grow = [row + h - 1 - band_rows, 0].max
+  entry = SigmaLayout.le(element_id, place_c0, place_c0 + width, row, row + h)
+  new_band_inner = "#{band[:inner]}\n#{entry}"
+  new_band_head = set_rows(m[2][band[:s]...band[:head_e]], band[:r0], band[:r1] + grow)
+  new_band = "#{new_band_head}#{new_band_inner}\n</GridContainer>"
+  inner = m[2].dup
+  inner[band[:s]...band[:e]] = new_band
+  inner = shift_below!(inner, band[:eid], band[:r1], grow) if grow.positive?
+  replace_page_inner!(spec, page_id, inner)
+end
+
+# After growing a band, push every OTHER top-level entry that started at/after
+# the band's old end row down by delta.
+def shift_below!(inner, except_eid, from_row, delta)
+  res = inner.dup
+  scan_top(inner).reverse_each do |t|
+    next if t[:eid] == except_eid || t[:r0] < from_row
+    res[t[:s]...t[:head_e]] = set_rows(inner[t[:s]...t[:head_e]], t[:r0] + delta, t[:r1] + delta)
+  end
+  res
+end
+
+# Place a control INSIDE the container of the chart it drives: a slim row is
+# opened at the top of that container (children shifted down), the container
+# grows, and the bands below shift. Falls back to nil when the chart has no
+# container (caller then uses the control band).
+CHART_CTRL_ROWS = 2
+def add_into_chart_container!(spec, page_id, chart_eid, ctrl_eid, grid_column)
+  m = page_block(spec, page_id) or return nil
+  ents = scan_top(m[2])
+  host = ents.find { |t| t[:tag] == 'GridContainer' && t[:inner].to_s.include?(%(elementId="#{chart_eid}")) }
+  return nil unless host
+  c0, c1 = grid_column.to_s.scan(/\d+/).map(&:to_i)
+  c0, c1 = 17, 25 if c0.nil? || c1.nil? || c1 <= c0
+  kids_shifted = shift_top_rows(host[:inner].to_s, 1, CHART_CTRL_ROWS)
+  entry = SigmaLayout.le(ctrl_eid, c0, c1, 1, 1 + CHART_CTRL_ROWS)
+  new_head = set_rows(m[2][host[:s]...host[:head_e]], host[:r0], host[:r1] + CHART_CTRL_ROWS)
+  new_host = "#{new_head}#{entry}\n#{kids_shifted}\n</GridContainer>"
+  inner = m[2].dup
+  inner[host[:s]...host[:e]] = new_host
+  inner = shift_below!(inner, host[:eid], host[:r1], CHART_CTRL_ROWS)
+  replace_page_inner!(spec, page_id, inner)
+  true
+end
+
+# Band routing per added element kind.
+def place_added_element!(spec, page, el, hint)
+  grid_column = hint && hint['grid_column']
+  height = hint && hint['height']
+  case el['kind']
+  when 'control'
+    band = ensure_band!(spec, page, CTRL_BAND_PREFIX)
+    band_add!(spec, page['id'], band, el['id'], grid_column || '1 / 9', height || BAND_ROWS[CTRL_BAND_PREFIX])
+  when 'kpi-chart'
+    band = ensure_band!(spec, page, KPI_BAND_PREFIX)
+    band_add!(spec, page['id'], band, el['id'], grid_column || '1 / 13', height || BAND_ROWS[KPI_BAND_PREFIX])
+  when 'text'
+    band = ensure_band!(spec, page, NOTE_BAND_PREFIX)
+    band_add!(spec, page['id'], band, el['id'], grid_column || '1 / 25', height || BAND_ROWS[NOTE_BAND_PREFIX])
+  else
+    band = ensure_band!(spec, page, KPI_BAND_PREFIX)
+    band_add!(spec, page['id'], band, el['id'], grid_column || '1 / 25', height || BAND_ROWS[KPI_BAND_PREFIX])
+  end
 end
 
 def find_element(spec, element_id)
@@ -162,17 +404,13 @@ def apply_patch!(spec, cand)
     page = (spec['pages'] || []).find { |p| p['id'] == patch['page_id'] } ||
            (spec['pages'] || []).reject { |p| p['id'] == 'page-data' }.first
     raise 'target page not found' unless page
-    row_anchor = {}
+    hints = Array(patch['layout']).to_h { |l| [l['element_id'], l] }
     Array(patch['elements']).each do |el|
       raise "element id #{el['id']} already exists" if find_element(spec, el['id'])
       (page['elements'] ||= []) << el
+      place_added_element!(spec, page, el, hints[el['id']])
     end
-    Array(patch['layout']).each do |l|
-      anchor = l['same_row_as'] && row_anchor[l['same_row_as']]
-      placed = add_layout!(spec, page['id'], l['element_id'], l['grid_column'], l['height'] || 4, anchor)
-      row_anchor[l['element_id']] = placed if placed
-    end
-    "added #{Array(patch['elements']).size} element(s) to page #{page['id']}"
+    "added #{Array(patch['elements']).size} element(s) into page #{page['id']}'s bands"
   when 'set_column_formula'
     _pg, el = find_element(spec, patch['element_id'])
     raise "element #{patch['element_id']} not found" unless el
@@ -190,13 +428,19 @@ def apply_patch!(spec, cand)
     raise "element #{patch.dig('rewire', 'element_id')} not found" unless el
     col = (el['columns'] || []).find { |c| c['id'] == patch.dig('rewire', 'column_id') }
     raise 'rewire column not found' unless col
-    raise "control id #{patch.dig('control', 'id')} already exists" if find_element(spec, patch.dig('control', 'id'))
-    (pg['elements'] ||= []) << patch['control']
+    ctrl = patch['control']
+    raise "control id #{ctrl['id']} already exists" if find_element(spec, ctrl['id'])
+    (pg['elements'] ||= []) << ctrl
     col['formula'] = patch.dig('rewire', 'formula')
-    Array(patch['layout']).each do |l|
-      add_layout!(spec, pg['id'], l['element_id'], l['grid_column'], l['height'] || 3)
+    # the switcher lives WITH the chart it drives: a slim row inside that
+    # chart's container (falls back to the control band when uncontainered).
+    hint = Array(patch['layout']).find { |l| l['element_id'] == ctrl['id'] } || {}
+    placed = add_into_chart_container!(spec, pg['id'], el['id'], ctrl['id'], hint['grid_column'])
+    unless placed
+      band = ensure_band!(spec, pg, CTRL_BAND_PREFIX)
+      band_add!(spec, pg['id'], band, ctrl['id'], hint['grid_column'] || '17 / 25', hint['height'] || 3)
     end
-    "added control #{patch.dig('control', 'controlId')} + rewired #{el['id']}"
+    "added control #{ctrl['controlId']} #{placed ? "inside #{el['id']}'s container" : 'to the control band'} + rewired #{el['id']}"
   when 'set_element_prop'
     _pg, el = find_element(spec, patch['element_id'])
     raise "element #{patch['element_id']} not found" unless el
@@ -304,6 +548,17 @@ def put_spec(wb, spec)
 end
 
 current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+
+# Pre-container clone? (parity workbook built before banded layouts existed.)
+# Regenerate a banded layout FIRST so every applied item has a container
+# system to land in. Layout-only change — element data untouched, so the
+# parity probes are unaffected by construction.
+if ensure_banded!(current)
+  put_spec(clone_id, current)
+  current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+  puts '   clone layout predates containers — regenerated banded layout (header + row bands)'
+end
+
 applied = []
 reverted = []
 gate_green = true
@@ -351,8 +606,20 @@ accepted.each do |cand|
 end
 
 # ---------------------------------------------------------------------------
-# 4. Final report.
+# 4. Finalize: layout lint (hard) + re-read the live layout + final report.
 # ---------------------------------------------------------------------------
+# Layout-quality lint (shared lib/layout_lint.rb, vendored byte-identical):
+# raw-id display names / controls outside containers / dead zones. The clone
+# must lint CLEAN — a parity-green visual mess is exactly the regression this
+# phase exists to prevent.
+require 'layout_lint'
+live_spec = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+lint_violations = LayoutLint.lint(live_spec)
+if lint_violations.any?
+  warn "enhance-apply FINALIZE FAIL — layout lint: #{lint_violations.size} violation(s) on the clone:"
+  lint_violations.each { |v| warn "  - #{v}" }
+end
+
 final_pair = probe_pair(clone_id, ORIG_WB, probes)
 final_ok = probe_diffs(final_pair).empty?
 gate_green &&= final_ok
@@ -375,6 +642,10 @@ report = {
     'method' => 'clone-vs-original simultaneous JSON exports (live-drift-proof), after every item',
     'green' => gate_green
   },
+  'layout_lint' => {
+    'violations' => lint_violations,
+    'green' => lint_violations.empty?
+  },
   'original_untouched' => {
     'updatedAt_before' => orig_meta_before['updatedAt'],
     'updatedAt_after' => orig_meta_after['updatedAt'],
@@ -388,5 +659,19 @@ puts
 puts "enhance-apply: #{applied.size} applied, #{skipped.size} skipped, #{reverted.size} reverted"
 puts "   clone: '#{clone_name}' (#{clone_id})"
 puts "   parity-unchanged gate: #{gate_green ? 'GREEN' : 'NOT GREEN (see report)'}; original untouched: #{orig_untouched}"
+puts "   layout lint: #{lint_violations.empty? ? 'CLEAN' : "#{lint_violations.size} violation(s) — FIX BEFORE DECLARING DONE"}"
 puts "   report -> #{OUT}"
-exit(gate_green ? 0 : 3)
+puts
+puts '──────────────── HARD SCREENSHOT CHECKLIST (Phase E finalize) ────────────────'
+puts 'The lint is mechanical; YOUR EYES are the last gate. Export the FULL-PAGE PNG'
+puts "of the clone (scripts/sigma-export-png.py --workbook #{clone_id}) and verify"
+puts 'EVERY item — list each with pass/fail in your report:'
+puts '  [ ] every chart/control title is human-readable (no raw element ids)'
+puts '  [ ] the page has a header band (dark, full-width, page title)'
+puts '  [ ] selection controls sit together in a control band near the top'
+puts '  [ ] every control is adjacent to / inside the container of what it filters'
+puts '      (grain/drill switchers INSIDE their chart\'s container)'
+puts '  [ ] no orphan elements below the fold (nothing dumped at the page foot)'
+puts '  [ ] no dead zones; row heights look even across each band'
+puts '──────────────────────────────────────────────────────────────────────────────'
+exit(lint_violations.any? ? 4 : (gate_green ? 0 : 3))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
@@ -226,26 +226,20 @@ def ensure_banded!(spec)
     items = scan_top(m[2]).select { |t| t[:tag] == 'LayoutElement' }
                           .map { |t| [t[:eid], t[:c0], t[:c1], t[:r0], t[:r1]] }
     next if items.empty?
-    # an existing full-width-ish top text element becomes the header text;
-    # otherwise SigmaLayout adds a header from the page name.
+    # an existing short top text element (the dashboard's own title) becomes
+    # the header band's text (recolored white for the dark band); otherwise
+    # SigmaLayout adds a header from the page name.
     top_row = items.map { |i| i[3] }.min
-    own_hdr = items.find { |i| i[3] == top_row && kind_of[i[0]] == 'text' && (i[2] - i[1]) >= 12 }
-    extra = []
-    children = []
-    offset = 0
-    hdr_id = "band-#{pg['id']}-hdr"
-    if own_hdr
+    own_hdr = items.find { |i| i[3] == top_row && kind_of[i[0]] == 'text' && (i[4] - i[3]) <= 5 }
+    if own_hdr && items.length > 1
       items -= [own_hdr]
-      extra << SigmaLayout.container_el(hdr_id, SigmaLayout::HEADER_STYLE.dup)
-      children << SigmaLayout.header_band_xml(hdr_id, own_hdr[0])
-      offset = SigmaLayout::HEADER_ROWS
-      offset += (1 - items.map { |i| i[3] }.min) unless items.empty?
-      SigmaLayout.cluster_bands(items).each_with_index do |band, i|
-        cid = "band-#{pg['id']}-#{i + 1}"
-        extra << SigmaLayout.container_el(cid)
-        children << SigmaLayout.band_container_xml(cid, band, row_offset: offset)
+      hdr_el = (pg['elements'] || []).find { |e| e['id'] == own_hdr[0] }
+      if hdr_el && hdr_el['body'].is_a?(String) && !hdr_el['body'].include?('color:')
+        plain = hdr_el['body'].gsub(/^#+\s*/, '').strip
+        hdr_el['body'] = %(# <span style="color: #FFFFFF">#{plain}</span>)
       end
-      xml = SigmaLayout.page_xml(pg['id'], *children)
+      xml, extra = SigmaLayout.banded_page(pg['id'], items, header_el: own_hdr[0],
+                                           id_prefix: "band-#{pg['id']}")
     else
       xml, extra = SigmaLayout.banded_page(pg['id'], items, title: pg['name'],
                                            id_prefix: "band-#{pg['id']}")

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout.rb
@@ -85,11 +85,21 @@ module SigmaLayout
   # (directly, or via put-layout.rb's <layout>.elements.json sidecar).
   # `title` of nil/empty skips the header band (e.g. when the caller bands an
   # existing title text element explicitly).
-  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}")
+  # `header_el`: an EXISTING text element id to wrap as the header band's text
+  # (e.g. the source dashboard's own title textbox — phase-e layout-quality
+  # fix: a short title text left inside band 1 reads as a dead zone). It must
+  # NOT also appear in `items`; the caller should recolor its body for the
+  # dark band (see header_text_el's white span).
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}", header_el: nil)
     extra = []
     children = []
     offset = 0
-    if title && !title.to_s.empty?
+    if header_el
+      hdr_id = "#{id_prefix}-hdr"
+      extra << container_el(hdr_id, HEADER_STYLE.dup)
+      children << header_band_xml(hdr_id, header_el)
+      offset = HEADER_ROWS
+    elsif title && !title.to_s.empty?
       hdr_id = "#{id_prefix}-hdr"
       txt_id = "#{id_prefix}-hdrtext"
       extra << container_el(hdr_id, HEADER_STYLE.dup)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout.rb
@@ -11,6 +11,24 @@ module SigmaLayout
 
   HEADER_STYLE = { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' }.freeze
   HEADER_ROWS  = 3 # header band height in grid rows
+  GRID_COLS    = 24 # page/container grid width (gridTemplateColumns repeat(24))
+  MIN_BAND_FILL = 0.60 # a band must fill >=60% of the grid columns (lint parity)
+  # Generic auto-names (Sigma page names / source section names) that must
+  # NEVER become a header-band title — "Page 1" / "Sheet 3" / "Dashboard 2".
+  GENERIC_TITLE = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+
+  # True when a candidate header title is a generic auto-name.
+  def generic_title?(s)
+    s.to_s.strip.match?(GENERIC_TITLE)
+  end
+
+  # First usable header-band title from a priority-ordered candidate list:
+  # skips nil/empty and generic auto-names ("Page 1" etc). Callers pass, in
+  # order: promoted source title -> source dashboard/report display name ->
+  # workbook name. Returns nil when nothing usable remains (caller decides).
+  def resolve_header_title(*candidates)
+    candidates.map { |c| c.to_s.strip }.find { |c| !c.empty? && !generic_title?(c) }
+  end
 
   def gc(eid, c0, c1, r0, r1, inner)
     "<GridContainer elementId=\"#{eid}\" type=\"grid\" " \
@@ -68,6 +86,49 @@ module SigmaLayout
     bands.map { |b| b[:items] }
   end
 
+  # Fraction of the GRID_COLS columns covered by a band's items (union).
+  def band_fill(items)
+    covered = Array.new(GRID_COLS, false)
+    items.each do |i|
+      (i[1]...i[2]).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+    end
+    covered.count(true).to_f / GRID_COLS
+  end
+
+  # Re-flow under-filled bands (phase-e layout-quality fix, round 2): when any
+  # band's items cover <60% of the grid columns — e.g. a small chart left
+  # alone in band 1 after its neighboring title textbox was promoted into the
+  # header band — the page's items are redistributed across the same number
+  # of bands EVENLY (sizes differ by at most 1, remainder to the bottom bands:
+  # 5 charts -> 2+3), and each band's items are tiled edge-to-edge across the
+  # full grid width at the band's original height (uniform rows — no stagger).
+  # Pages whose bands all fill >=60% keep the source-canvas geometry exactly.
+  def reflow_bands(bands)
+    return bands unless bands.any? { |b| band_fill(b) < MIN_BAND_FILL }
+    heights = bands.map { |b| b.map { |i| i[4] }.max - b.map { |i| i[3] }.min }
+    items = bands.flat_map { |b| b.sort_by { |i| [i[3], i[1]] } }
+    k = items.length
+    nb = [bands.length, k].min
+    base = k / nb
+    sizes = Array.new(nb) { |bi| base + (bi >= nb - (k % nb) ? 1 : 0) }
+    out = []
+    idx = 0
+    cursor = 1
+    sizes.each_with_index do |n, bi|
+      band_items = items[idx, n]
+      idx += n
+      h = [heights[bi] || heights.compact.max || 8, 4].max
+      band = band_items.each_with_index.map do |it, j|
+        c0 = 1 + (GRID_COLS * j / n.to_f).round
+        c1 = 1 + (GRID_COLS * (j + 1) / n.to_f).round
+        [it[0], c0, c1, cursor, cursor + h, *it[5..]]
+      end
+      out << band
+      cursor += h
+    end
+    out
+  end
+
   # One band of items -> a full-width GridContainer spanning the band's row
   # range at page level, children re-emitted with CONTAINER-RELATIVE rows.
   # row_offset shifts the container's page-level position (e.g. +3 when a
@@ -90,7 +151,12 @@ module SigmaLayout
   # fix: a short title text left inside band 1 reads as a dead zone). It must
   # NOT also appear in `items`; the caller should recolor its body for the
   # dark band (see header_text_el's white span).
-  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}", header_el: nil)
+  # `title` must already be resolved through resolve_header_title (promoted
+  # source title -> source display name -> workbook name) — a generic
+  # auto-name ("Page 1") raises rather than ships a wrong header band.
+  # `reflow: true` (default) runs reflow_bands so no band ships <60% filled.
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}", header_el: nil,
+                  reflow: true)
     extra = []
     children = []
     offset = 0
@@ -100,6 +166,9 @@ module SigmaLayout
       children << header_band_xml(hdr_id, header_el)
       offset = HEADER_ROWS
     elsif title && !title.to_s.empty?
+      raise ArgumentError, "banded_page: generic header title #{title.inspect} — " \
+                           'resolve via resolve_header_title (source display name / workbook name)' \
+        if generic_title?(title)
       hdr_id = "#{id_prefix}-hdr"
       txt_id = "#{id_prefix}-hdrtext"
       extra << container_el(hdr_id, HEADER_STYLE.dup)
@@ -107,9 +176,11 @@ module SigmaLayout
       children << header_band_xml(hdr_id, txt_id)
       offset = HEADER_ROWS
     end
-    top = items.map { |i| i[3] }.min
+    bands = cluster_bands(items)
+    bands = reflow_bands(bands) if reflow
+    top = bands.flatten(1).map { |i| i[3] }.min
     offset += (1 - top) if top # first band starts right under the header
-    cluster_bands(items).each_with_index do |band, i|
+    bands.each_with_index do |band, i|
       cid = "#{id_prefix}-#{i + 1}"
       extra << container_el(cid)
       children << band_container_xml(cid, band, row_offset: offset)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Three checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    named_elements(spec).each { |el, _pg| el_kind[el['id']] = el['kind'] }
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout_lint.rb
@@ -10,7 +10,7 @@
 #
 # It exists because a workbook can pass every data gate and still ship as a
 # visual mess (raw-id chart titles, controls dumped at the page foot, dead
-# zones) — the "PHASEE PBI Employee Dashboard" regression. Three checks:
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
 #
 #   (a) raw-id display names — any element display name matching a raw-id
 #       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
@@ -22,6 +22,17 @@
 #   (c) dead zones — more than 25% of a page's grid rows empty between the
 #       page's first and last positioned element (top-level layout entries).
 #       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
 #
 # API:
 #   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
@@ -32,6 +43,10 @@
 module LayoutLint
   RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
   DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
 
   module_function
 
@@ -70,10 +85,48 @@ module LayoutLint
     entries
   end
 
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
   def lint(spec)
     violations = []
     el_kind = {}
-    named_elements(spec).each { |el, _pg| el_kind[el['id']] = el['kind'] }
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
 
     # (a) raw-id display names ------------------------------------------------
     named_elements(spec).each do |el, pg|
@@ -97,6 +150,43 @@ module LayoutLint
           violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
                         '(banded page) — place it in the control band or its chart\'s container'
         end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        covered = Array.new(GRID_COLS, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+        end
+        fill = covered.count(true).to_f / GRID_COLS
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 
       # (c) dead-zone heuristic ------------------------------------------------

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -76,6 +76,10 @@ OptionParser.new do |o|
   o.on('--ref-dm ID')       { |v| opts[:ref_dm] = v }
   o.on('--folder ID')       { |v| opts[:folder] = v }
   o.on('--name NAME')       { |v| opts[:name]   = v }
+  # SOURCE report display name (Fabric/Power BI "EMPLOYEE DASHBOARD") — used as
+  # the header-band title fallback when a page has no promotable title textbox
+  # and its own name is a generic "Page N". Defaults to the humanized slug.
+  o.on('--source-title NAME') { |v| opts[:source_title] = v }
   o.on('--out DIR')         { |v| opts[:out]    = File.expand_path(v) }
   o.on('--answers JSON')    { |v| opts[:answers]= v }
   o.on('--yes')             {     opts[:yes]    = true }
@@ -875,6 +879,7 @@ layout = File.join(WORK, 'layout.xml')
 build = ['ruby', File.join(HERE, 'build-workbook-from-pbir.rb'),
          '--signals', signals_path, '--master-map', mmap_path,
          '--data-model', dm_id, '--name', WB_NAME,
+         '--source-title', (opts[:source_title] || name_slug.gsub(/[-_]+/, ' ').strip),
          '--out', wb_spec, '--layout-out', layout]
 # The workbook POST requires a folderId. Use --folder if given, else inherit the
 # DM's folderId (harvested from the ref-dm at Phase 3) so both land together.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/post-and-readback.rb
@@ -19,6 +19,7 @@ OptionParser.new do |p|
   p.on('--spec P')                         { |v| opts[:spec] = v }
   p.on('--out P')                          { |v| opts[:out]  = v }
   p.on('--workdir P', 'Per-conversion working dir (default: dir of --spec). Used to track posted workbook IDs across retries.') { |v| opts[:workdir] = v }
+  p.on('--skip-layout-lint') { opts[:skip_lint] = true }
 end.parse!
 %i[type spec out].each { |k| abort("missing --#{k}") unless opts[k] }
 opts[:workdir] ||= File.dirname(File.expand_path(opts[:spec]))
@@ -164,6 +165,30 @@ if res.is_a?(Net::HTTPSuccess)
   end
 else
   warn "WARN: could not fetch /columns for type guard (got HTTP #{res.code}); skipping"
+end
+
+# Layout-quality lint (shared scripts/lib/layout_lint.rb — vendored byte-
+# identical, md5 discipline): fails loudly on raw-id element display names,
+# input controls outside the GridContainer bands of a banded page, and dead
+# zones (>25% empty grid rows between a page's first and last element). The
+# "PHASEE PBI Employee Dashboard" regression shipped a parity-green workbook
+# that was a visual mess — every data gate passed. Escape: --skip-layout-lint
+# (legacy/intentional layouts only; name the reason in your report).
+if opts[:type] == 'workbook' && !opts[:skip_lint]
+  require_relative 'lib/layout_lint'
+  violations = LayoutLint.lint(spec)
+  if violations.any?
+    warn "\n========================================"
+    warn "FAIL — layout lint: #{violations.size} violation(s):"
+    violations.each { |v| warn "  - #{v}" }
+    warn 'Fix the spec/layout and re-PUT before continuing: raw-id names -> derive human'
+    warn 'titles; loose controls -> control band or the chart container; dead zones ->'
+    warn 're-band the page. The workbook DID post — fix with PUT /v2/workbooks/<id>/spec'
+    warn '(re-POSTing creates an orphan).'
+    warn '========================================'
+    exit(3)
+  end
+  warn 'layout lint: clean (raw-id names / orphan controls / dead zones)'
 end
 
 # Phase 6 nag — column-type guard catches formula-resolution errors but does

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # Hard gate that proves a tableau-to-sigma conversion is actually complete.
-# The subagent MUST run this script before declaring GREEN. It checks five
+# The subagent MUST run this script before declaring GREEN. It checks six
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
@@ -20,6 +20,11 @@
 #      parity plan. Catches the "empty view CSV silently dropped a tile and
 #      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
 #      (with a note) when the converter doesn't emit a census.
+#   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
+#      display names, no input controls outside the GridContainer bands on a
+#      banded page, no dead zones (>25% empty grid rows between a page's
+#      first and last element). Catches the "PHASEE PBI Employee Dashboard"
+#      visual-mess regression that every data gate waved through.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -30,6 +35,9 @@
 #     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
 #                              # that genuinely want multiple workbooks)
 #     [--skip-layout-check]    # skip the layout-applied scan
+#     [--skip-layout-lint]     # skip gate 6 (layout-quality lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -49,6 +57,8 @@
 #      (beads-sigma-bw3)
 #   7  tile census shows unexplained unmatched dashboard zones beyond
 #      --allow-missing-tiles (bead gjhe)
+#   8  layout lint violations — raw-id display names / orphan controls /
+#      dead zones (gate 6; scripts/lib/layout_lint.rb)
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -68,6 +78,7 @@ OptionParser.new do |p|
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
   p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
 end.parse!
@@ -119,7 +130,7 @@ if status != 'PASS' || pass_rate < opts[:min_pass_rate]
   exit 2
 end
 
-puts "[OK] gate 1/5: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+puts "[OK] gate 1/6: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
 
 # ---------------------------------------------------------------------------
 # Gate 2 — orphan workbooks (beads-sigma-38a)
@@ -132,7 +143,7 @@ unless opts[:skip_orphan]
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
       unless File.exist?(marker_path)
-        warn "[FAIL] gate 2/5: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "[FAIL] gate 2/6: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
         warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
@@ -141,27 +152,27 @@ unless opts[:skip_orphan]
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
       if marker['failed'] && !marker['failed'].empty?
-        warn "[FAIL] gate 2/5: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "[FAIL] gate 2/6: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
       if marker['dry_run']
-        warn "[FAIL] gate 2/5: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "[FAIL] gate 2/6: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
         warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
         exit 4
       end
       kept = marker['kept'] || '(unknown)'
       deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/5: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      puts "[OK] gate 2/6: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
     else
-      puts "[OK] gate 2/5: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+      puts "[OK] gate 2/6: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end
   else
-    puts "[OK] gate 2/5: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+    puts "[OK] gate 2/6: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/5: --skip-orphan-check"
+  puts "[SKIP] gate 2/6: --skip-orphan-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -181,12 +192,12 @@ unless opts[:skip_column]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 3/5: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts "[SKIP] gate 3/6: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 3/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+      warn "[SKIP] gate 3/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
       req = Net::HTTP::Get.new(uri)
@@ -198,7 +209,7 @@ unless opts[:skip_column]
         cols = (JSON.parse(res.body)['entries'] rescue []) || []
         error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
         if error_cols.any?
-          warn "[FAIL] gate 3/5: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "[FAIL] gate 3/6: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
           warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
           warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
           error_cols.first(10).each do |c|
@@ -208,14 +219,14 @@ unless opts[:skip_column]
           warn "       See beads-sigma-38a."
           exit 5
         end
-        puts "[OK] gate 3/5: #{cols.length} live columns clean (no type=error)"
+        puts "[OK] gate 3/6: #{cols.length} live columns clean (no type=error)"
       else
-        warn "[SKIP] gate 3/5: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 3/6: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 3/5: --skip-column-check"
+  puts "[SKIP] gate 3/6: --skip-column-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -236,12 +247,12 @@ unless opts[:skip_layout]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 4/5: no workbook ID resolvable for layout check"
+    puts "[SKIP] gate 4/6: no workbook ID resolvable for layout check"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 4/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+      warn "[SKIP] gate 4/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
       req = Net::HTTP::Get.new(uri)
@@ -285,7 +296,7 @@ unless opts[:skip_layout]
         end
 
         if layout_xml.empty?
-          warn "[FAIL] gate 4/5: live workbook #{wb_id} has NO top-level layout XML."
+          warn "[FAIL] gate 4/6: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
           warn "       dashboard grid. Rebuild the layout with this skill's layout"
           warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
@@ -295,12 +306,12 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         elsif elem_count < opts[:min_layout_elements]
-          warn "[FAIL] gate 4/5: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "[FAIL] gate 4/6: layout XML has only #{elem_count} <LayoutElement> tag(s);"
           warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
           warn "       The layout likely covers only the Data page — chart page is unstyled."
           exit 6
         elsif non_data_stack_pages.any?
-          warn "[FAIL] gate 4/5: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "[FAIL] gate 4/6: live workbook #{wb_id} has Sigma's auto-generated"
           warn "       single-column stack layout (multiple elements at the same gridColumn"
           warn "       on a non-Data page). This is what Sigma defaults to when you POST"
           warn "       a workbook without a layout — exactly the CoCo regression."
@@ -313,15 +324,15 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         else
-          puts "[OK] gate 4/5: layout XML applied with #{elem_count} positioned element(s)"
+          puts "[OK] gate 4/6: layout XML applied with #{elem_count} positioned element(s)"
         end
       else
-        warn "[SKIP] gate 4/5: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 4/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 4/5: --skip-layout-check"
+  puts "[SKIP] gate 4/6: --skip-layout-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -334,14 +345,14 @@ end
 # ---------------------------------------------------------------------------
 census = summary['tile_census']
 if census.nil?
-  puts "[SKIP] gate 5/5: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+  puts "[SKIP] gate 5/6: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
 else
   zones     = census['zones_total'].to_i
   built     = census['charts_built'].to_i
   unmatched = census['zones_unmatched'].to_i
   names     = Array(census['unmatched_zone_names'])
   if unmatched > opts[:allow_missing_tiles]
-    warn "[FAIL] gate 5/5: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    warn "[FAIL] gate 5/6: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
     names.each { |n| warn "         - #{n}" }
     warn "       A zone that rendered in the source dashboard has NO matching chart in the"
     warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
@@ -351,9 +362,71 @@ else
     warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
     exit 7
   elsif unmatched > 0
-    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+    puts "[OK] gate 5/6: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
   else
-    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+    puts "[OK] gate 5/6: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 6 — layout-quality lint (scripts/lib/layout_lint.rb, shared)
+# A workbook can pass every data gate above and still ship as a visual mess:
+# raw element ids as chart titles, controls dumped loose at the page foot,
+# dead zones between elements (the "PHASEE PBI Employee Dashboard" escape).
+# This gate mechanizes those checks on the LIVE spec.
+# ---------------------------------------------------------------------------
+if opts[:skip_lint]
+  puts "[SKIP] gate 6/6: --skip-layout-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 6/6: no workbook ID resolvable for layout lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 6/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/layout_lint'
+    rescue LoadError
+      warn "[SKIP] gate 6/6: scripts/lib/layout_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(LayoutLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        violations = LayoutLint.lint(spec)
+        if violations.any?
+          warn "[FAIL] gate 6/6: layout lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the spec/layout and re-PUT (raw-id names -> derive human titles;"
+          warn "       loose controls -> place into a band/container; dead zones -> re-band the page),"
+          warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
+          exit 8
+        end
+        puts "[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones)"
+      else
+        warn "[SKIP] gate 6/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
   end
 end
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -23,8 +23,13 @@
 #   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
 #      display names, no input controls outside the GridContainer bands on a
 #      banded page, no dead zones (>25% empty grid rows between a page's
-#      first and last element). Catches the "PHASEE PBI Employee Dashboard"
-#      visual-mess regression that every data gate waved through.
+#      first and last element), no generic header-band title ("Page 1" /
+#      "Sheet 3" / "Dashboard 2" must never title a dashboard), and no
+#      under-filled band (<60% of the 24 grid columns covered; deliberate
+#      KPI bands of <=4 tiles exempt). Catches the "PHASEE PBI Employee
+#      Dashboard" visual-mess regression (and its PHASEE2 sequel: "Page 1"
+#      header + a lone small chart beside a 19-column hole) that every data
+#      gate waved through.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -422,7 +427,8 @@ else
           warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
           exit 8
         end
-        puts "[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones)"
+        puts '[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones, ' \
+             'no generic header title, no under-filled bands)'
       else
         warn "[SKIP] gate 6/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
       end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout.rb
@@ -85,11 +85,21 @@ module SigmaLayout
   # (directly, or via put-layout.rb's <layout>.elements.json sidecar).
   # `title` of nil/empty skips the header band (e.g. when the caller bands an
   # existing title text element explicitly).
-  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}")
+  # `header_el`: an EXISTING text element id to wrap as the header band's text
+  # (e.g. the source dashboard's own title textbox — phase-e layout-quality
+  # fix: a short title text left inside band 1 reads as a dead zone). It must
+  # NOT also appear in `items`; the caller should recolor its body for the
+  # dark band (see header_text_el's white span).
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}", header_el: nil)
     extra = []
     children = []
     offset = 0
-    if title && !title.to_s.empty?
+    if header_el
+      hdr_id = "#{id_prefix}-hdr"
+      extra << container_el(hdr_id, HEADER_STYLE.dup)
+      children << header_band_xml(hdr_id, header_el)
+      offset = HEADER_ROWS
+    elsif title && !title.to_s.empty?
       hdr_id = "#{id_prefix}-hdr"
       txt_id = "#{id_prefix}-hdrtext"
       extra << container_el(hdr_id, HEADER_STYLE.dup)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout.rb
@@ -11,6 +11,24 @@ module SigmaLayout
 
   HEADER_STYLE = { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' }.freeze
   HEADER_ROWS  = 3 # header band height in grid rows
+  GRID_COLS    = 24 # page/container grid width (gridTemplateColumns repeat(24))
+  MIN_BAND_FILL = 0.60 # a band must fill >=60% of the grid columns (lint parity)
+  # Generic auto-names (Sigma page names / source section names) that must
+  # NEVER become a header-band title — "Page 1" / "Sheet 3" / "Dashboard 2".
+  GENERIC_TITLE = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+
+  # True when a candidate header title is a generic auto-name.
+  def generic_title?(s)
+    s.to_s.strip.match?(GENERIC_TITLE)
+  end
+
+  # First usable header-band title from a priority-ordered candidate list:
+  # skips nil/empty and generic auto-names ("Page 1" etc). Callers pass, in
+  # order: promoted source title -> source dashboard/report display name ->
+  # workbook name. Returns nil when nothing usable remains (caller decides).
+  def resolve_header_title(*candidates)
+    candidates.map { |c| c.to_s.strip }.find { |c| !c.empty? && !generic_title?(c) }
+  end
 
   def gc(eid, c0, c1, r0, r1, inner)
     "<GridContainer elementId=\"#{eid}\" type=\"grid\" " \
@@ -68,6 +86,49 @@ module SigmaLayout
     bands.map { |b| b[:items] }
   end
 
+  # Fraction of the GRID_COLS columns covered by a band's items (union).
+  def band_fill(items)
+    covered = Array.new(GRID_COLS, false)
+    items.each do |i|
+      (i[1]...i[2]).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+    end
+    covered.count(true).to_f / GRID_COLS
+  end
+
+  # Re-flow under-filled bands (phase-e layout-quality fix, round 2): when any
+  # band's items cover <60% of the grid columns — e.g. a small chart left
+  # alone in band 1 after its neighboring title textbox was promoted into the
+  # header band — the page's items are redistributed across the same number
+  # of bands EVENLY (sizes differ by at most 1, remainder to the bottom bands:
+  # 5 charts -> 2+3), and each band's items are tiled edge-to-edge across the
+  # full grid width at the band's original height (uniform rows — no stagger).
+  # Pages whose bands all fill >=60% keep the source-canvas geometry exactly.
+  def reflow_bands(bands)
+    return bands unless bands.any? { |b| band_fill(b) < MIN_BAND_FILL }
+    heights = bands.map { |b| b.map { |i| i[4] }.max - b.map { |i| i[3] }.min }
+    items = bands.flat_map { |b| b.sort_by { |i| [i[3], i[1]] } }
+    k = items.length
+    nb = [bands.length, k].min
+    base = k / nb
+    sizes = Array.new(nb) { |bi| base + (bi >= nb - (k % nb) ? 1 : 0) }
+    out = []
+    idx = 0
+    cursor = 1
+    sizes.each_with_index do |n, bi|
+      band_items = items[idx, n]
+      idx += n
+      h = [heights[bi] || heights.compact.max || 8, 4].max
+      band = band_items.each_with_index.map do |it, j|
+        c0 = 1 + (GRID_COLS * j / n.to_f).round
+        c1 = 1 + (GRID_COLS * (j + 1) / n.to_f).round
+        [it[0], c0, c1, cursor, cursor + h, *it[5..]]
+      end
+      out << band
+      cursor += h
+    end
+    out
+  end
+
   # One band of items -> a full-width GridContainer spanning the band's row
   # range at page level, children re-emitted with CONTAINER-RELATIVE rows.
   # row_offset shifts the container's page-level position (e.g. +3 when a
@@ -90,7 +151,12 @@ module SigmaLayout
   # fix: a short title text left inside band 1 reads as a dead zone). It must
   # NOT also appear in `items`; the caller should recolor its body for the
   # dark band (see header_text_el's white span).
-  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}", header_el: nil)
+  # `title` must already be resolved through resolve_header_title (promoted
+  # source title -> source display name -> workbook name) — a generic
+  # auto-name ("Page 1") raises rather than ships a wrong header band.
+  # `reflow: true` (default) runs reflow_bands so no band ships <60% filled.
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}", header_el: nil,
+                  reflow: true)
     extra = []
     children = []
     offset = 0
@@ -100,6 +166,9 @@ module SigmaLayout
       children << header_band_xml(hdr_id, header_el)
       offset = HEADER_ROWS
     elsif title && !title.to_s.empty?
+      raise ArgumentError, "banded_page: generic header title #{title.inspect} — " \
+                           'resolve via resolve_header_title (source display name / workbook name)' \
+        if generic_title?(title)
       hdr_id = "#{id_prefix}-hdr"
       txt_id = "#{id_prefix}-hdrtext"
       extra << container_el(hdr_id, HEADER_STYLE.dup)
@@ -107,9 +176,11 @@ module SigmaLayout
       children << header_band_xml(hdr_id, txt_id)
       offset = HEADER_ROWS
     end
-    top = items.map { |i| i[3] }.min
+    bands = cluster_bands(items)
+    bands = reflow_bands(bands) if reflow
+    top = bands.flatten(1).map { |i| i[3] }.min
     offset += (1 - top) if top # first band starts right under the header
-    cluster_bands(items).each_with_index do |band, i|
+    bands.each_with_index do |band, i|
       cid = "#{id_prefix}-#{i + 1}"
       extra << container_el(cid)
       children << band_container_xml(cid, band, row_offset: offset)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Three checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    named_elements(spec).each { |el, _pg| el_kind[el['id']] = el['kind'] }
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout_lint.rb
@@ -10,7 +10,7 @@
 #
 # It exists because a workbook can pass every data gate and still ship as a
 # visual mess (raw-id chart titles, controls dumped at the page foot, dead
-# zones) — the "PHASEE PBI Employee Dashboard" regression. Three checks:
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
 #
 #   (a) raw-id display names — any element display name matching a raw-id
 #       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
@@ -22,6 +22,17 @@
 #   (c) dead zones — more than 25% of a page's grid rows empty between the
 #       page's first and last positioned element (top-level layout entries).
 #       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
 #
 # API:
 #   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
@@ -32,6 +43,10 @@
 module LayoutLint
   RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
   DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
 
   module_function
 
@@ -70,10 +85,48 @@ module LayoutLint
     entries
   end
 
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
   def lint(spec)
     violations = []
     el_kind = {}
-    named_elements(spec).each { |el, _pg| el_kind[el['id']] = el['kind'] }
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
 
     # (a) raw-id display names ------------------------------------------------
     named_elements(spec).each do |el, pg|
@@ -97,6 +150,43 @@ module LayoutLint
           violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
                         '(banded page) — place it in the control band or its chart\'s container'
         end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        covered = Array.new(GRID_COLS, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+        end
+        fill = covered.count(true).to_f / GRID_COLS
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 
       # (c) dead-zone heuristic ------------------------------------------------

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/post-and-readback.rb
@@ -19,6 +19,7 @@ OptionParser.new do |p|
   p.on('--spec P')                         { |v| opts[:spec] = v }
   p.on('--out P')                          { |v| opts[:out]  = v }
   p.on('--workdir P', 'Per-conversion working dir (default: dir of --spec). Used to track posted workbook IDs across retries.') { |v| opts[:workdir] = v }
+  p.on('--skip-layout-lint') { opts[:skip_lint] = true }
 end.parse!
 %i[type spec out].each { |k| abort("missing --#{k}") unless opts[k] }
 opts[:workdir] ||= File.dirname(File.expand_path(opts[:spec]))
@@ -164,6 +165,30 @@ if res.is_a?(Net::HTTPSuccess)
   end
 else
   warn "WARN: could not fetch /columns for type guard (got HTTP #{res.code}); skipping"
+end
+
+# Layout-quality lint (shared scripts/lib/layout_lint.rb — vendored byte-
+# identical, md5 discipline): fails loudly on raw-id element display names,
+# input controls outside the GridContainer bands of a banded page, and dead
+# zones (>25% empty grid rows between a page's first and last element). The
+# "PHASEE PBI Employee Dashboard" regression shipped a parity-green workbook
+# that was a visual mess — every data gate passed. Escape: --skip-layout-lint
+# (legacy/intentional layouts only; name the reason in your report).
+if opts[:type] == 'workbook' && !opts[:skip_lint]
+  require_relative 'lib/layout_lint'
+  violations = LayoutLint.lint(spec)
+  if violations.any?
+    warn "\n========================================"
+    warn "FAIL — layout lint: #{violations.size} violation(s):"
+    violations.each { |v| warn "  - #{v}" }
+    warn 'Fix the spec/layout and re-PUT before continuing: raw-id names -> derive human'
+    warn 'titles; loose controls -> control band or the chart container; dead zones ->'
+    warn 're-band the page. The workbook DID post — fix with PUT /v2/workbooks/<id>/spec'
+    warn '(re-POSTing creates an orphan).'
+    warn '========================================'
+    exit(3)
+  end
+  warn 'layout lint: clean (raw-id names / orphan controls / dead zones)'
 end
 
 # Phase 6 nag — column-type guard catches formula-resolution errors but does

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -1553,6 +1553,39 @@ trial-proven spec-unsupported): DM-metric promotion (metric refs don't resolve
 through a workbook table), chart-as-filter (`useAsFilter` silently dropped on
 readback), pie percent labels (`valueFormat:'percent'` silently dropped).
 
+### Phase E layout placement + HARD screenshot checklist
+
+Every applied item lands in the **container system** — never appended at the
+page foot (that was the "PHASEE PBI Employee Dashboard" regression):
+
+- selection controls → the **control band** (created under the header if the
+  clone lacks one);
+- comparison KPIs → the **KPI band**;
+- grain/drill switchers → a slim row **inside the container of the chart they
+  drive**;
+- migration/freshness notes → a **slim note band directly under the header**.
+
+If the cloned parity workbook predates container layouts (no `<GridContainer>`
+in its layout), `enhance-apply.rb` **regenerates a banded layout** for the
+clone first (builder machinery, `scripts/lib/layout.rb`), then applies items.
+The finalize runs the shared layout lint (`scripts/lib/layout_lint.rb`: no
+raw-id display names, no controls outside containers, no dead zones) and
+**exits 4 on violations** — a lint-failing clone must be fixed and re-PUT
+before the run may be declared done.
+
+**HARD screenshot checklist (mandatory at finalize).** The lint is mechanical;
+your eyes are the last gate. Export the clone's **full-page PNG**
+(`scripts/sigma-export-png.py`) and verify EVERY item, listing each with
+pass/fail in your report:
+
+- [ ] every chart/control title is human-readable (no raw element ids)
+- [ ] the page has a header band (dark, full-width, page title)
+- [ ] selection controls sit together in a control band near the top
+- [ ] every control is adjacent to / inside the container of what it filters
+      (grain/drill switchers INSIDE their chart's container)
+- [ ] no orphan elements below the fold (nothing dumped at the page foot)
+- [ ] no dead zones; row heights look even across each band
+
 ## Troubleshooting
 
 | Error / symptom | Cause | Fix |

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -1569,7 +1569,11 @@ If the cloned parity workbook predates container layouts (no `<GridContainer>`
 in its layout), `enhance-apply.rb` **regenerates a banded layout** for the
 clone first (builder machinery, `scripts/lib/layout.rb`), then applies items.
 The finalize runs the shared layout lint (`scripts/lib/layout_lint.rb`: no
-raw-id display names, no controls outside containers, no dead zones) and
+raw-id display names, no controls outside containers, no dead zones, no
+generic header-band title — "Page 1"/"Sheet N"/"Dashboard N" never titles a
+dashboard; the header carries the promoted source title → source display
+name → workbook name — and no band whose elements fill <60% of the grid
+columns, KPI bands of ≤4 tiles exempt) and
 **exits 4 on violations** — a lint-failing clone must be fixed and re-PUT
 before the run may be declared done.
 
@@ -1579,7 +1583,8 @@ your eyes are the last gate. Export the clone's **full-page PNG**
 pass/fail in your report:
 
 - [ ] every chart/control title is human-readable (no raw element ids)
-- [ ] the page has a header band (dark, full-width, page title)
+- [ ] the page has a header band (dark, full-width, carrying the SOURCE title
+      or display name — never a generic "Page 1")
 - [ ] selection controls sit together in a control band near the top
 - [ ] every control is adjacent to / inside the container of what it filters
       (grain/drill switchers INSIDE their chart's container)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # Hard gate that proves a tableau-to-sigma conversion is actually complete.
-# The subagent MUST run this script before declaring GREEN. It checks five
+# The subagent MUST run this script before declaring GREEN. It checks six
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
@@ -20,6 +20,11 @@
 #      parity plan. Catches the "empty view CSV silently dropped a tile and
 #      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
 #      (with a note) when the converter doesn't emit a census.
+#   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
+#      display names, no input controls outside the GridContainer bands on a
+#      banded page, no dead zones (>25% empty grid rows between a page's
+#      first and last element). Catches the "PHASEE PBI Employee Dashboard"
+#      visual-mess regression that every data gate waved through.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -30,6 +35,9 @@
 #     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
 #                              # that genuinely want multiple workbooks)
 #     [--skip-layout-check]    # skip the layout-applied scan
+#     [--skip-layout-lint]     # skip gate 6 (layout-quality lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -49,6 +57,8 @@
 #      (beads-sigma-bw3)
 #   7  tile census shows unexplained unmatched dashboard zones beyond
 #      --allow-missing-tiles (bead gjhe)
+#   8  layout lint violations — raw-id display names / orphan controls /
+#      dead zones (gate 6; scripts/lib/layout_lint.rb)
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -68,6 +78,7 @@ OptionParser.new do |p|
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
   p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
 end.parse!
@@ -119,7 +130,7 @@ if status != 'PASS' || pass_rate < opts[:min_pass_rate]
   exit 2
 end
 
-puts "[OK] gate 1/5: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+puts "[OK] gate 1/6: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
 
 # ---------------------------------------------------------------------------
 # Gate 2 — orphan workbooks (beads-sigma-38a)
@@ -132,7 +143,7 @@ unless opts[:skip_orphan]
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
       unless File.exist?(marker_path)
-        warn "[FAIL] gate 2/5: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "[FAIL] gate 2/6: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
         warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
@@ -141,27 +152,27 @@ unless opts[:skip_orphan]
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
       if marker['failed'] && !marker['failed'].empty?
-        warn "[FAIL] gate 2/5: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "[FAIL] gate 2/6: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
       if marker['dry_run']
-        warn "[FAIL] gate 2/5: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "[FAIL] gate 2/6: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
         warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
         exit 4
       end
       kept = marker['kept'] || '(unknown)'
       deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/5: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      puts "[OK] gate 2/6: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
     else
-      puts "[OK] gate 2/5: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+      puts "[OK] gate 2/6: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end
   else
-    puts "[OK] gate 2/5: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+    puts "[OK] gate 2/6: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/5: --skip-orphan-check"
+  puts "[SKIP] gate 2/6: --skip-orphan-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -181,12 +192,12 @@ unless opts[:skip_column]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 3/5: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts "[SKIP] gate 3/6: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 3/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+      warn "[SKIP] gate 3/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
       req = Net::HTTP::Get.new(uri)
@@ -198,7 +209,7 @@ unless opts[:skip_column]
         cols = (JSON.parse(res.body)['entries'] rescue []) || []
         error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
         if error_cols.any?
-          warn "[FAIL] gate 3/5: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "[FAIL] gate 3/6: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
           warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
           warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
           error_cols.first(10).each do |c|
@@ -208,14 +219,14 @@ unless opts[:skip_column]
           warn "       See beads-sigma-38a."
           exit 5
         end
-        puts "[OK] gate 3/5: #{cols.length} live columns clean (no type=error)"
+        puts "[OK] gate 3/6: #{cols.length} live columns clean (no type=error)"
       else
-        warn "[SKIP] gate 3/5: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 3/6: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 3/5: --skip-column-check"
+  puts "[SKIP] gate 3/6: --skip-column-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -236,12 +247,12 @@ unless opts[:skip_layout]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 4/5: no workbook ID resolvable for layout check"
+    puts "[SKIP] gate 4/6: no workbook ID resolvable for layout check"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 4/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+      warn "[SKIP] gate 4/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
       req = Net::HTTP::Get.new(uri)
@@ -285,7 +296,7 @@ unless opts[:skip_layout]
         end
 
         if layout_xml.empty?
-          warn "[FAIL] gate 4/5: live workbook #{wb_id} has NO top-level layout XML."
+          warn "[FAIL] gate 4/6: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
           warn "       dashboard grid. Rebuild the layout with this skill's layout"
           warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
@@ -295,12 +306,12 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         elsif elem_count < opts[:min_layout_elements]
-          warn "[FAIL] gate 4/5: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "[FAIL] gate 4/6: layout XML has only #{elem_count} <LayoutElement> tag(s);"
           warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
           warn "       The layout likely covers only the Data page — chart page is unstyled."
           exit 6
         elsif non_data_stack_pages.any?
-          warn "[FAIL] gate 4/5: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "[FAIL] gate 4/6: live workbook #{wb_id} has Sigma's auto-generated"
           warn "       single-column stack layout (multiple elements at the same gridColumn"
           warn "       on a non-Data page). This is what Sigma defaults to when you POST"
           warn "       a workbook without a layout — exactly the CoCo regression."
@@ -313,15 +324,15 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         else
-          puts "[OK] gate 4/5: layout XML applied with #{elem_count} positioned element(s)"
+          puts "[OK] gate 4/6: layout XML applied with #{elem_count} positioned element(s)"
         end
       else
-        warn "[SKIP] gate 4/5: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 4/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 4/5: --skip-layout-check"
+  puts "[SKIP] gate 4/6: --skip-layout-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -334,14 +345,14 @@ end
 # ---------------------------------------------------------------------------
 census = summary['tile_census']
 if census.nil?
-  puts "[SKIP] gate 5/5: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+  puts "[SKIP] gate 5/6: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
 else
   zones     = census['zones_total'].to_i
   built     = census['charts_built'].to_i
   unmatched = census['zones_unmatched'].to_i
   names     = Array(census['unmatched_zone_names'])
   if unmatched > opts[:allow_missing_tiles]
-    warn "[FAIL] gate 5/5: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    warn "[FAIL] gate 5/6: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
     names.each { |n| warn "         - #{n}" }
     warn "       A zone that rendered in the source dashboard has NO matching chart in the"
     warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
@@ -351,9 +362,71 @@ else
     warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
     exit 7
   elsif unmatched > 0
-    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+    puts "[OK] gate 5/6: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
   else
-    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+    puts "[OK] gate 5/6: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 6 — layout-quality lint (scripts/lib/layout_lint.rb, shared)
+# A workbook can pass every data gate above and still ship as a visual mess:
+# raw element ids as chart titles, controls dumped loose at the page foot,
+# dead zones between elements (the "PHASEE PBI Employee Dashboard" escape).
+# This gate mechanizes those checks on the LIVE spec.
+# ---------------------------------------------------------------------------
+if opts[:skip_lint]
+  puts "[SKIP] gate 6/6: --skip-layout-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 6/6: no workbook ID resolvable for layout lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 6/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/layout_lint'
+    rescue LoadError
+      warn "[SKIP] gate 6/6: scripts/lib/layout_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(LayoutLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        violations = LayoutLint.lint(spec)
+        if violations.any?
+          warn "[FAIL] gate 6/6: layout lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the spec/layout and re-PUT (raw-id names -> derive human titles;"
+          warn "       loose controls -> place into a band/container; dead zones -> re-band the page),"
+          warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
+          exit 8
+        end
+        puts "[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones)"
+      else
+        warn "[SKIP] gate 6/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -23,8 +23,13 @@
 #   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
 #      display names, no input controls outside the GridContainer bands on a
 #      banded page, no dead zones (>25% empty grid rows between a page's
-#      first and last element). Catches the "PHASEE PBI Employee Dashboard"
-#      visual-mess regression that every data gate waved through.
+#      first and last element), no generic header-band title ("Page 1" /
+#      "Sheet 3" / "Dashboard 2" must never title a dashboard), and no
+#      under-filled band (<60% of the 24 grid columns covered; deliberate
+#      KPI bands of <=4 tiles exempt). Catches the "PHASEE PBI Employee
+#      Dashboard" visual-mess regression (and its PHASEE2 sequel: "Page 1"
+#      header + a lone small chart beside a 19-column hole) that every data
+#      gate waved through.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -422,7 +427,8 @@ else
           warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
           exit 8
         end
-        puts "[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones)"
+        puts '[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones, ' \
+             'no generic header title, no under-filled bands)'
       else
         warn "[SKIP] gate 6/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
       end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1393,7 +1393,10 @@ if title_text
   extras << {
     'id'   => 'title-text',
     'kind' => 'text',
-    'body' => "## #{title_text}"
+    # White span: build-dashboard-layout.rb wraps this element in the DARK
+    # header band (HEADER_STYLE) — a plain body renders dark-on-dark
+    # (phase-e layout-quality screenshot-checklist catch).
+    'body' => %(# <span style="color: #FFFFFF">#{title_text}</span>)
   }
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
@@ -228,9 +228,13 @@ def ensure_banded!(spec)
     next if items.empty?
     # an existing short top text element (the dashboard's own title) becomes
     # the header band's text (recolored white for the dark band); otherwise
-    # SigmaLayout adds a header from the page name.
+    # SigmaLayout adds a header from the page name -> workbook name chain
+    # (resolve_header_title — never a generic "Page 1" auto-name). The
+    # candidate may start up to one row below the topmost element (classic
+    # title boxes are nudged a few px down; exact-row equality was the
+    # PHASEE2 fragility).
     top_row = items.map { |i| i[3] }.min
-    own_hdr = items.find { |i| i[3] == top_row && kind_of[i[0]] == 'text' && (i[4] - i[3]) <= 5 }
+    own_hdr = items.find { |i| i[3] <= top_row + 1 && kind_of[i[0]] == 'text' && (i[4] - i[3]) <= 5 }
     if own_hdr && items.length > 1
       items -= [own_hdr]
       hdr_el = (pg['elements'] || []).find { |e| e['id'] == own_hdr[0] }
@@ -241,7 +245,8 @@ def ensure_banded!(spec)
       xml, extra = SigmaLayout.banded_page(pg['id'], items, header_el: own_hdr[0],
                                            id_prefix: "band-#{pg['id']}")
     else
-      xml, extra = SigmaLayout.banded_page(pg['id'], items, title: pg['name'],
+      hdr_title = SigmaLayout.resolve_header_title(pg['name'], spec['name']) || 'Dashboard'
+      xml, extra = SigmaLayout.banded_page(pg['id'], items, title: hdr_title,
                                            id_prefix: "band-#{pg['id']}")
     end
     new_ids = (pg['elements'] || []).map { |e| e['id'] }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
@@ -27,10 +27,19 @@
 #     --accept all-low-risk | --accept id1,id2,... \
 #     [--name '<clone name>'] [--out enhance-report.json] [--probes N]
 #
+# Every applied item lands in the CONTAINER SYSTEM (see the layout-placement
+# section): controls -> control band, KPIs -> KPI band, grain/drill switchers
+# -> inside their chart's container, notes -> a slim band under the header.
+# Pre-container clones get their layout regenerated as a banded layout first.
+# The finalize runs the shared layout lint (lib/layout_lint.rb) and prints the
+# hard screenshot checklist — the agent MUST export the full-page PNG and
+# verify each item.
+#
 # Exit codes: 0 = done (clone created; accepted items applied or cleanly
-# reverted; parity-unchanged gate green); 2 = nothing accepted; 3 = the
-# parity-unchanged gate could not be restored (clone left for inspection,
-# report says so); other = error.
+# reverted; parity-unchanged gate green; layout lint clean); 2 = nothing
+# accepted; 3 = the parity-unchanged gate could not be restored (clone left
+# for inspection, report says so); 4 = layout lint violations on the clone
+# (fix + re-PUT, then re-lint); other = error.
 
 require 'json'
 require 'yaml'
@@ -127,19 +136,252 @@ def norm_rows(rows)
 end
 
 # ---------------------------------------------------------------------------
-# Layout helper: append a LayoutElement to the bottom of a page's grid block.
+# Container-aware layout placement (phase-e layout-quality fix).
+#
+# The first Phase E shipped enhancements by APPENDING <LayoutElement>s at the
+# bottom of the Page block — controls/KPIs/notes dumped below the fold, the
+# grain switcher orphaned at the foot. Every applied item now lands in the
+# container system instead:
+#   - selection controls       -> the control band (created if absent)
+#   - comparison KPIs          -> the KPI band (created if absent)
+#   - grain/drill switcher     -> INSIDE its chart's own container (slim row
+#                                 above the chart)
+#   - migration/freshness note -> a slim note band directly under the header
+# If the cloned parity workbook PREDATES container layouts (no <GridContainer>
+# in its layout), the clone's layout is REGENERATED as a banded layout first,
+# using the builder's shared container machinery (lib/layout.rb).
 # ---------------------------------------------------------------------------
-def add_layout!(spec, page_id, element_id, grid_column, height, same_row_start = nil)
-  xml = spec['layout'].to_s
-  return nil if xml.empty? || page_id.nil?
-  m = xml.match(%r{(<Page\b[^>]*\bid="#{Regexp.escape(page_id)}"[^>]*>)(.*?)(</Page>)}m)
-  return nil unless m
-  block = m[2]
-  max_end = block.scan(/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/).flatten.map(&:to_i).max || 1
-  row_start = same_row_start || max_end
-  entry = %(  <LayoutElement elementId="#{element_id}" gridColumn="#{grid_column}" gridRow="#{row_start} / #{row_start + height}"/>\n)
-  spec['layout'] = xml.sub(m[0], "#{m[1]}#{block}#{entry}#{m[3]}")
-  row_start
+require 'layout' # scripts/lib/layout.rb — SigmaLayout container machinery
+
+CTRL_BAND_PREFIX = 'phasee-ctrl-band'
+KPI_BAND_PREFIX  = 'phasee-kpi-band'
+NOTE_BAND_PREFIX = 'phasee-note-band'
+# vertical order of phasee-created bands under the header (note = slimmest,
+# closest to the header; KPIs above the charts read best below the controls)
+BAND_PRIORITY = { NOTE_BAND_PREFIX => 0, CTRL_BAND_PREFIX => 1, KPI_BAND_PREFIX => 2 }.freeze
+BAND_ROWS = { NOTE_BAND_PREFIX => 2, CTRL_BAND_PREFIX => 3, KPI_BAND_PREFIX => 6 }.freeze
+
+def page_block(spec, page_id)
+  return nil if page_id.nil?
+  spec['layout'].to_s.match(%r{(<Page\b[^>]*\bid="#{Regexp.escape(page_id)}"[^>]*>)(.*?)(</Page>)}m)
+end
+
+def replace_page_inner!(spec, page_id, new_inner)
+  m = page_block(spec, page_id) or return nil
+  spec['layout'] = spec['layout'].to_s.sub(m[0]) { "#{m[1]}#{new_inner}#{m[3]}" }
+  true
+end
+
+# Direct children of a page block: [{tag:, eid:, c0:, c1:, r0:, r1:, s:, e:,
+# head_e:, inner: (containers only)}] — byte offsets into the inner string.
+def scan_top(inner)
+  out = []
+  pos = 0
+  while (m = inner.match(%r{<(GridContainer|LayoutElement)\b[^>]*?(/>|>)}m, pos))
+    tag = m[1]
+    open_e = m.end(0)
+    ent_end = open_e
+    body = nil
+    if tag == 'GridContainer' && m[2] == '>'
+      close = inner.match(%r{</GridContainer>}m, open_e)
+      ent_end = close ? close.end(0) : open_e
+      body = close ? inner[open_e...close.begin(0)] : ''
+    end
+    head = inner[m.begin(0)...open_e]
+    out << { tag: tag, eid: head[/elementId="([^"]*)"/, 1],
+             c0: head[/gridColumn="\s*(\d+)/, 1].to_i,
+             c1: head[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+             r0: head[/gridRow="\s*(\d+)/, 1].to_i,
+             r1: head[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+             s: m.begin(0), e: ent_end, head_e: open_e, inner: body }
+    pos = ent_end
+  end
+  out
+end
+
+def set_rows(head, r0, r1)
+  head.sub(/gridRow="[^"]*"/) { %(gridRow="#{r0} / #{r1}") }
+end
+
+# Shift every top-level entry starting at/after from_row down by delta rows.
+def shift_top_rows(inner, from_row, delta)
+  res = inner.dup
+  scan_top(inner).reverse_each do |t|
+    next unless t[:r0] >= from_row
+    res[t[:s]...t[:head_e]] = set_rows(inner[t[:s]...t[:head_e]], t[:r0] + delta, t[:r1] + delta)
+  end
+  res
+end
+
+# Regenerate a banded layout for every dashboard page of a pre-container clone
+# (flat <LayoutElement> list -> header band + row-band GridContainers via the
+# builder's shared SigmaLayout machinery). No-op when containers exist.
+def ensure_banded!(spec)
+  return false if spec['layout'].to_s.include?('<GridContainer')
+  changed = false
+  (spec['pages'] || []).each do |pg|
+    next if pg['id'].to_s.downcase.include?('data')
+    m = page_block(spec, pg['id']) or next
+    kind_of = (pg['elements'] || []).to_h { |e| [e['id'], e['kind']] }
+    items = scan_top(m[2]).select { |t| t[:tag] == 'LayoutElement' }
+                          .map { |t| [t[:eid], t[:c0], t[:c1], t[:r0], t[:r1]] }
+    next if items.empty?
+    # an existing full-width-ish top text element becomes the header text;
+    # otherwise SigmaLayout adds a header from the page name.
+    top_row = items.map { |i| i[3] }.min
+    own_hdr = items.find { |i| i[3] == top_row && kind_of[i[0]] == 'text' && (i[2] - i[1]) >= 12 }
+    extra = []
+    children = []
+    offset = 0
+    hdr_id = "band-#{pg['id']}-hdr"
+    if own_hdr
+      items -= [own_hdr]
+      extra << SigmaLayout.container_el(hdr_id, SigmaLayout::HEADER_STYLE.dup)
+      children << SigmaLayout.header_band_xml(hdr_id, own_hdr[0])
+      offset = SigmaLayout::HEADER_ROWS
+      offset += (1 - items.map { |i| i[3] }.min) unless items.empty?
+      SigmaLayout.cluster_bands(items).each_with_index do |band, i|
+        cid = "band-#{pg['id']}-#{i + 1}"
+        extra << SigmaLayout.container_el(cid)
+        children << SigmaLayout.band_container_xml(cid, band, row_offset: offset)
+      end
+      xml = SigmaLayout.page_xml(pg['id'], *children)
+    else
+      xml, extra = SigmaLayout.banded_page(pg['id'], items, title: pg['name'],
+                                           id_prefix: "band-#{pg['id']}")
+    end
+    new_ids = (pg['elements'] || []).map { |e| e['id'] }
+    pg['elements'] = (pg['elements'] || []) + extra.reject { |e| new_ids.include?(e['id']) }
+    spec['layout'] = spec['layout'].to_s.sub(m[0]) { xml }
+    changed = true
+  end
+  changed
+end
+
+# Row where a new phasee band of `prefix` should start on this page: under the
+# header band (the row-1 container), below any already-created phasee band of
+# lower priority.
+def band_anchor_row(ents, prefix)
+  hdr = ents.select { |t| t[:tag] == 'GridContainer' }
+            .find { |t| t[:r0] <= 1 }
+  row = hdr ? hdr[:r1] : (ents.map { |t| t[:r0] }.min || 1)
+  ents.each do |t|
+    pfx = BAND_PRIORITY.keys.find { |p| t[:eid].to_s.start_with?(p) }
+    row = [row, t[:r1]].max if pfx && BAND_PRIORITY[pfx] < BAND_PRIORITY[prefix]
+  end
+  row
+end
+
+# Find-or-create the phasee band container for `prefix` on the page; returns
+# the band's container element id. Creates the spec-side `kind: container`
+# placeholder and shifts everything below the insertion point down.
+def ensure_band!(spec, page, prefix)
+  m = page_block(spec, page['id']) or raise "no layout block for page #{page['id']}"
+  ents = scan_top(m[2])
+  existing = ents.find { |t| t[:eid].to_s.start_with?(prefix) }
+  return existing[:eid] if existing
+  rows = BAND_ROWS[prefix]
+  cid = "#{prefix}-#{page['id']}"[0, 60]
+  anchor = band_anchor_row(ents, prefix)
+  inner = shift_top_rows(m[2], anchor, rows)
+  band = SigmaLayout.gc(cid, 1, 25, anchor, anchor + rows, '')
+  replace_page_inner!(spec, page['id'], "#{inner}\n#{band}\n")
+  (page['elements'] ||= []) << SigmaLayout.container_el(cid) unless page['elements'].any? { |e| e['id'] == cid }
+  cid
+end
+
+# Place an element INTO a band container, flowing left-to-right then wrapping
+# to a new row (growing the band + shifting the bands below it).
+def band_add!(spec, page_id, band_cid, element_id, grid_column, height)
+  m = page_block(spec, page_id) or raise "no layout block for page #{page_id}"
+  ents = scan_top(m[2])
+  band = ents.find { |t| t[:eid] == band_cid } or raise "band #{band_cid} not found"
+  c0, c1 = grid_column.to_s.scan(/\d+/).map(&:to_i)
+  c0 = 1 if c0.nil? || c0 < 1
+  c1 = [c0 + 8, 25].min if c1.nil? || c1 <= c0
+  width = c1 - c0
+  band_rows = band[:r1] - band[:r0]
+  h = [height || band_rows, band_rows].min
+  h = band_rows if h <= 0
+  kids = scan_top(band[:inner].to_s)
+  if kids.empty?
+    row = 1
+    place_c0 = c0
+  else
+    cur = kids.map { |k| k[:r0] }.max
+    cur_kids = kids.select { |k| k[:r0] == cur }
+    max_c1 = cur_kids.map { |k| k[:c1] }.max
+    if max_c1 + width <= 25
+      row = cur
+      place_c0 = max_c1
+    else
+      row = kids.map { |k| k[:r1] }.max
+      place_c0 = c0
+    end
+  end
+  grow = [row + h - 1 - band_rows, 0].max
+  entry = SigmaLayout.le(element_id, place_c0, place_c0 + width, row, row + h)
+  new_band_inner = "#{band[:inner]}\n#{entry}"
+  new_band_head = set_rows(m[2][band[:s]...band[:head_e]], band[:r0], band[:r1] + grow)
+  new_band = "#{new_band_head}#{new_band_inner}\n</GridContainer>"
+  inner = m[2].dup
+  inner[band[:s]...band[:e]] = new_band
+  inner = shift_below!(inner, band[:eid], band[:r1], grow) if grow.positive?
+  replace_page_inner!(spec, page_id, inner)
+end
+
+# After growing a band, push every OTHER top-level entry that started at/after
+# the band's old end row down by delta.
+def shift_below!(inner, except_eid, from_row, delta)
+  res = inner.dup
+  scan_top(inner).reverse_each do |t|
+    next if t[:eid] == except_eid || t[:r0] < from_row
+    res[t[:s]...t[:head_e]] = set_rows(inner[t[:s]...t[:head_e]], t[:r0] + delta, t[:r1] + delta)
+  end
+  res
+end
+
+# Place a control INSIDE the container of the chart it drives: a slim row is
+# opened at the top of that container (children shifted down), the container
+# grows, and the bands below shift. Falls back to nil when the chart has no
+# container (caller then uses the control band).
+CHART_CTRL_ROWS = 2
+def add_into_chart_container!(spec, page_id, chart_eid, ctrl_eid, grid_column)
+  m = page_block(spec, page_id) or return nil
+  ents = scan_top(m[2])
+  host = ents.find { |t| t[:tag] == 'GridContainer' && t[:inner].to_s.include?(%(elementId="#{chart_eid}")) }
+  return nil unless host
+  c0, c1 = grid_column.to_s.scan(/\d+/).map(&:to_i)
+  c0, c1 = 17, 25 if c0.nil? || c1.nil? || c1 <= c0
+  kids_shifted = shift_top_rows(host[:inner].to_s, 1, CHART_CTRL_ROWS)
+  entry = SigmaLayout.le(ctrl_eid, c0, c1, 1, 1 + CHART_CTRL_ROWS)
+  new_head = set_rows(m[2][host[:s]...host[:head_e]], host[:r0], host[:r1] + CHART_CTRL_ROWS)
+  new_host = "#{new_head}#{entry}\n#{kids_shifted}\n</GridContainer>"
+  inner = m[2].dup
+  inner[host[:s]...host[:e]] = new_host
+  inner = shift_below!(inner, host[:eid], host[:r1], CHART_CTRL_ROWS)
+  replace_page_inner!(spec, page_id, inner)
+  true
+end
+
+# Band routing per added element kind.
+def place_added_element!(spec, page, el, hint)
+  grid_column = hint && hint['grid_column']
+  height = hint && hint['height']
+  case el['kind']
+  when 'control'
+    band = ensure_band!(spec, page, CTRL_BAND_PREFIX)
+    band_add!(spec, page['id'], band, el['id'], grid_column || '1 / 9', height || BAND_ROWS[CTRL_BAND_PREFIX])
+  when 'kpi-chart'
+    band = ensure_band!(spec, page, KPI_BAND_PREFIX)
+    band_add!(spec, page['id'], band, el['id'], grid_column || '1 / 13', height || BAND_ROWS[KPI_BAND_PREFIX])
+  when 'text'
+    band = ensure_band!(spec, page, NOTE_BAND_PREFIX)
+    band_add!(spec, page['id'], band, el['id'], grid_column || '1 / 25', height || BAND_ROWS[NOTE_BAND_PREFIX])
+  else
+    band = ensure_band!(spec, page, KPI_BAND_PREFIX)
+    band_add!(spec, page['id'], band, el['id'], grid_column || '1 / 25', height || BAND_ROWS[KPI_BAND_PREFIX])
+  end
 end
 
 def find_element(spec, element_id)
@@ -162,17 +404,13 @@ def apply_patch!(spec, cand)
     page = (spec['pages'] || []).find { |p| p['id'] == patch['page_id'] } ||
            (spec['pages'] || []).reject { |p| p['id'] == 'page-data' }.first
     raise 'target page not found' unless page
-    row_anchor = {}
+    hints = Array(patch['layout']).to_h { |l| [l['element_id'], l] }
     Array(patch['elements']).each do |el|
       raise "element id #{el['id']} already exists" if find_element(spec, el['id'])
       (page['elements'] ||= []) << el
+      place_added_element!(spec, page, el, hints[el['id']])
     end
-    Array(patch['layout']).each do |l|
-      anchor = l['same_row_as'] && row_anchor[l['same_row_as']]
-      placed = add_layout!(spec, page['id'], l['element_id'], l['grid_column'], l['height'] || 4, anchor)
-      row_anchor[l['element_id']] = placed if placed
-    end
-    "added #{Array(patch['elements']).size} element(s) to page #{page['id']}"
+    "added #{Array(patch['elements']).size} element(s) into page #{page['id']}'s bands"
   when 'set_column_formula'
     _pg, el = find_element(spec, patch['element_id'])
     raise "element #{patch['element_id']} not found" unless el
@@ -190,13 +428,19 @@ def apply_patch!(spec, cand)
     raise "element #{patch.dig('rewire', 'element_id')} not found" unless el
     col = (el['columns'] || []).find { |c| c['id'] == patch.dig('rewire', 'column_id') }
     raise 'rewire column not found' unless col
-    raise "control id #{patch.dig('control', 'id')} already exists" if find_element(spec, patch.dig('control', 'id'))
-    (pg['elements'] ||= []) << patch['control']
+    ctrl = patch['control']
+    raise "control id #{ctrl['id']} already exists" if find_element(spec, ctrl['id'])
+    (pg['elements'] ||= []) << ctrl
     col['formula'] = patch.dig('rewire', 'formula')
-    Array(patch['layout']).each do |l|
-      add_layout!(spec, pg['id'], l['element_id'], l['grid_column'], l['height'] || 3)
+    # the switcher lives WITH the chart it drives: a slim row inside that
+    # chart's container (falls back to the control band when uncontainered).
+    hint = Array(patch['layout']).find { |l| l['element_id'] == ctrl['id'] } || {}
+    placed = add_into_chart_container!(spec, pg['id'], el['id'], ctrl['id'], hint['grid_column'])
+    unless placed
+      band = ensure_band!(spec, pg, CTRL_BAND_PREFIX)
+      band_add!(spec, pg['id'], band, ctrl['id'], hint['grid_column'] || '17 / 25', hint['height'] || 3)
     end
-    "added control #{patch.dig('control', 'controlId')} + rewired #{el['id']}"
+    "added control #{ctrl['controlId']} #{placed ? "inside #{el['id']}'s container" : 'to the control band'} + rewired #{el['id']}"
   when 'set_element_prop'
     _pg, el = find_element(spec, patch['element_id'])
     raise "element #{patch['element_id']} not found" unless el
@@ -304,6 +548,17 @@ def put_spec(wb, spec)
 end
 
 current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+
+# Pre-container clone? (parity workbook built before banded layouts existed.)
+# Regenerate a banded layout FIRST so every applied item has a container
+# system to land in. Layout-only change — element data untouched, so the
+# parity probes are unaffected by construction.
+if ensure_banded!(current)
+  put_spec(clone_id, current)
+  current = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+  puts '   clone layout predates containers — regenerated banded layout (header + row bands)'
+end
+
 applied = []
 reverted = []
 gate_green = true
@@ -351,8 +606,20 @@ accepted.each do |cand|
 end
 
 # ---------------------------------------------------------------------------
-# 4. Final report.
+# 4. Finalize: layout lint (hard) + re-read the live layout + final report.
 # ---------------------------------------------------------------------------
+# Layout-quality lint (shared lib/layout_lint.rb, vendored byte-identical):
+# raw-id display names / controls outside containers / dead zones. The clone
+# must lint CLEAN — a parity-green visual mess is exactly the regression this
+# phase exists to prevent.
+require 'layout_lint'
+live_spec = clean(Sigma.request(:get, "/v2/workbooks/#{clone_id}/spec"))
+lint_violations = LayoutLint.lint(live_spec)
+if lint_violations.any?
+  warn "enhance-apply FINALIZE FAIL — layout lint: #{lint_violations.size} violation(s) on the clone:"
+  lint_violations.each { |v| warn "  - #{v}" }
+end
+
 final_pair = probe_pair(clone_id, ORIG_WB, probes)
 final_ok = probe_diffs(final_pair).empty?
 gate_green &&= final_ok
@@ -375,6 +642,10 @@ report = {
     'method' => 'clone-vs-original simultaneous JSON exports (live-drift-proof), after every item',
     'green' => gate_green
   },
+  'layout_lint' => {
+    'violations' => lint_violations,
+    'green' => lint_violations.empty?
+  },
   'original_untouched' => {
     'updatedAt_before' => orig_meta_before['updatedAt'],
     'updatedAt_after' => orig_meta_after['updatedAt'],
@@ -388,5 +659,19 @@ puts
 puts "enhance-apply: #{applied.size} applied, #{skipped.size} skipped, #{reverted.size} reverted"
 puts "   clone: '#{clone_name}' (#{clone_id})"
 puts "   parity-unchanged gate: #{gate_green ? 'GREEN' : 'NOT GREEN (see report)'}; original untouched: #{orig_untouched}"
+puts "   layout lint: #{lint_violations.empty? ? 'CLEAN' : "#{lint_violations.size} violation(s) — FIX BEFORE DECLARING DONE"}"
 puts "   report -> #{OUT}"
-exit(gate_green ? 0 : 3)
+puts
+puts '──────────────── HARD SCREENSHOT CHECKLIST (Phase E finalize) ────────────────'
+puts 'The lint is mechanical; YOUR EYES are the last gate. Export the FULL-PAGE PNG'
+puts "of the clone (scripts/sigma-export-png.py --workbook #{clone_id}) and verify"
+puts 'EVERY item — list each with pass/fail in your report:'
+puts '  [ ] every chart/control title is human-readable (no raw element ids)'
+puts '  [ ] the page has a header band (dark, full-width, page title)'
+puts '  [ ] selection controls sit together in a control band near the top'
+puts '  [ ] every control is adjacent to / inside the container of what it filters'
+puts '      (grain/drill switchers INSIDE their chart\'s container)'
+puts '  [ ] no orphan elements below the fold (nothing dumped at the page foot)'
+puts '  [ ] no dead zones; row heights look even across each band'
+puts '──────────────────────────────────────────────────────────────────────────────'
+exit(lint_violations.any? ? 4 : (gate_green ? 0 : 3))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
@@ -226,26 +226,20 @@ def ensure_banded!(spec)
     items = scan_top(m[2]).select { |t| t[:tag] == 'LayoutElement' }
                           .map { |t| [t[:eid], t[:c0], t[:c1], t[:r0], t[:r1]] }
     next if items.empty?
-    # an existing full-width-ish top text element becomes the header text;
-    # otherwise SigmaLayout adds a header from the page name.
+    # an existing short top text element (the dashboard's own title) becomes
+    # the header band's text (recolored white for the dark band); otherwise
+    # SigmaLayout adds a header from the page name.
     top_row = items.map { |i| i[3] }.min
-    own_hdr = items.find { |i| i[3] == top_row && kind_of[i[0]] == 'text' && (i[2] - i[1]) >= 12 }
-    extra = []
-    children = []
-    offset = 0
-    hdr_id = "band-#{pg['id']}-hdr"
-    if own_hdr
+    own_hdr = items.find { |i| i[3] == top_row && kind_of[i[0]] == 'text' && (i[4] - i[3]) <= 5 }
+    if own_hdr && items.length > 1
       items -= [own_hdr]
-      extra << SigmaLayout.container_el(hdr_id, SigmaLayout::HEADER_STYLE.dup)
-      children << SigmaLayout.header_band_xml(hdr_id, own_hdr[0])
-      offset = SigmaLayout::HEADER_ROWS
-      offset += (1 - items.map { |i| i[3] }.min) unless items.empty?
-      SigmaLayout.cluster_bands(items).each_with_index do |band, i|
-        cid = "band-#{pg['id']}-#{i + 1}"
-        extra << SigmaLayout.container_el(cid)
-        children << SigmaLayout.band_container_xml(cid, band, row_offset: offset)
+      hdr_el = (pg['elements'] || []).find { |e| e['id'] == own_hdr[0] }
+      if hdr_el && hdr_el['body'].is_a?(String) && !hdr_el['body'].include?('color:')
+        plain = hdr_el['body'].gsub(/^#+\s*/, '').strip
+        hdr_el['body'] = %(# <span style="color: #FFFFFF">#{plain}</span>)
       end
-      xml = SigmaLayout.page_xml(pg['id'], *children)
+      xml, extra = SigmaLayout.banded_page(pg['id'], items, header_el: own_hdr[0],
+                                           id_prefix: "band-#{pg['id']}")
     else
       xml, extra = SigmaLayout.banded_page(pg['id'], items, title: pg['name'],
                                            id_prefix: "band-#{pg['id']}")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout.rb
@@ -85,11 +85,21 @@ module SigmaLayout
   # (directly, or via put-layout.rb's <layout>.elements.json sidecar).
   # `title` of nil/empty skips the header band (e.g. when the caller bands an
   # existing title text element explicitly).
-  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}")
+  # `header_el`: an EXISTING text element id to wrap as the header band's text
+  # (e.g. the source dashboard's own title textbox — phase-e layout-quality
+  # fix: a short title text left inside band 1 reads as a dead zone). It must
+  # NOT also appear in `items`; the caller should recolor its body for the
+  # dark band (see header_text_el's white span).
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}", header_el: nil)
     extra = []
     children = []
     offset = 0
-    if title && !title.to_s.empty?
+    if header_el
+      hdr_id = "#{id_prefix}-hdr"
+      extra << container_el(hdr_id, HEADER_STYLE.dup)
+      children << header_band_xml(hdr_id, header_el)
+      offset = HEADER_ROWS
+    elsif title && !title.to_s.empty?
       hdr_id = "#{id_prefix}-hdr"
       txt_id = "#{id_prefix}-hdrtext"
       extra << container_el(hdr_id, HEADER_STYLE.dup)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout.rb
@@ -11,6 +11,24 @@ module SigmaLayout
 
   HEADER_STYLE = { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' }.freeze
   HEADER_ROWS  = 3 # header band height in grid rows
+  GRID_COLS    = 24 # page/container grid width (gridTemplateColumns repeat(24))
+  MIN_BAND_FILL = 0.60 # a band must fill >=60% of the grid columns (lint parity)
+  # Generic auto-names (Sigma page names / source section names) that must
+  # NEVER become a header-band title — "Page 1" / "Sheet 3" / "Dashboard 2".
+  GENERIC_TITLE = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+
+  # True when a candidate header title is a generic auto-name.
+  def generic_title?(s)
+    s.to_s.strip.match?(GENERIC_TITLE)
+  end
+
+  # First usable header-band title from a priority-ordered candidate list:
+  # skips nil/empty and generic auto-names ("Page 1" etc). Callers pass, in
+  # order: promoted source title -> source dashboard/report display name ->
+  # workbook name. Returns nil when nothing usable remains (caller decides).
+  def resolve_header_title(*candidates)
+    candidates.map { |c| c.to_s.strip }.find { |c| !c.empty? && !generic_title?(c) }
+  end
 
   def gc(eid, c0, c1, r0, r1, inner)
     "<GridContainer elementId=\"#{eid}\" type=\"grid\" " \
@@ -68,6 +86,49 @@ module SigmaLayout
     bands.map { |b| b[:items] }
   end
 
+  # Fraction of the GRID_COLS columns covered by a band's items (union).
+  def band_fill(items)
+    covered = Array.new(GRID_COLS, false)
+    items.each do |i|
+      (i[1]...i[2]).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+    end
+    covered.count(true).to_f / GRID_COLS
+  end
+
+  # Re-flow under-filled bands (phase-e layout-quality fix, round 2): when any
+  # band's items cover <60% of the grid columns — e.g. a small chart left
+  # alone in band 1 after its neighboring title textbox was promoted into the
+  # header band — the page's items are redistributed across the same number
+  # of bands EVENLY (sizes differ by at most 1, remainder to the bottom bands:
+  # 5 charts -> 2+3), and each band's items are tiled edge-to-edge across the
+  # full grid width at the band's original height (uniform rows — no stagger).
+  # Pages whose bands all fill >=60% keep the source-canvas geometry exactly.
+  def reflow_bands(bands)
+    return bands unless bands.any? { |b| band_fill(b) < MIN_BAND_FILL }
+    heights = bands.map { |b| b.map { |i| i[4] }.max - b.map { |i| i[3] }.min }
+    items = bands.flat_map { |b| b.sort_by { |i| [i[3], i[1]] } }
+    k = items.length
+    nb = [bands.length, k].min
+    base = k / nb
+    sizes = Array.new(nb) { |bi| base + (bi >= nb - (k % nb) ? 1 : 0) }
+    out = []
+    idx = 0
+    cursor = 1
+    sizes.each_with_index do |n, bi|
+      band_items = items[idx, n]
+      idx += n
+      h = [heights[bi] || heights.compact.max || 8, 4].max
+      band = band_items.each_with_index.map do |it, j|
+        c0 = 1 + (GRID_COLS * j / n.to_f).round
+        c1 = 1 + (GRID_COLS * (j + 1) / n.to_f).round
+        [it[0], c0, c1, cursor, cursor + h, *it[5..]]
+      end
+      out << band
+      cursor += h
+    end
+    out
+  end
+
   # One band of items -> a full-width GridContainer spanning the band's row
   # range at page level, children re-emitted with CONTAINER-RELATIVE rows.
   # row_offset shifts the container's page-level position (e.g. +3 when a
@@ -90,7 +151,12 @@ module SigmaLayout
   # fix: a short title text left inside band 1 reads as a dead zone). It must
   # NOT also appear in `items`; the caller should recolor its body for the
   # dark band (see header_text_el's white span).
-  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}", header_el: nil)
+  # `title` must already be resolved through resolve_header_title (promoted
+  # source title -> source display name -> workbook name) — a generic
+  # auto-name ("Page 1") raises rather than ships a wrong header band.
+  # `reflow: true` (default) runs reflow_bands so no band ships <60% filled.
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}", header_el: nil,
+                  reflow: true)
     extra = []
     children = []
     offset = 0
@@ -100,6 +166,9 @@ module SigmaLayout
       children << header_band_xml(hdr_id, header_el)
       offset = HEADER_ROWS
     elsif title && !title.to_s.empty?
+      raise ArgumentError, "banded_page: generic header title #{title.inspect} — " \
+                           'resolve via resolve_header_title (source display name / workbook name)' \
+        if generic_title?(title)
       hdr_id = "#{id_prefix}-hdr"
       txt_id = "#{id_prefix}-hdrtext"
       extra << container_el(hdr_id, HEADER_STYLE.dup)
@@ -107,9 +176,11 @@ module SigmaLayout
       children << header_band_xml(hdr_id, txt_id)
       offset = HEADER_ROWS
     end
-    top = items.map { |i| i[3] }.min
+    bands = cluster_bands(items)
+    bands = reflow_bands(bands) if reflow
+    top = bands.flatten(1).map { |i| i[3] }.min
     offset += (1 - top) if top # first band starts right under the header
-    cluster_bands(items).each_with_index do |band, i|
+    bands.each_with_index do |band, i|
       cid = "#{id_prefix}-#{i + 1}"
       extra << container_el(cid)
       children << band_container_xml(cid, band, row_offset: offset)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Three checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    named_elements(spec).each { |el, _pg| el_kind[el['id']] = el['kind'] }
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout_lint.rb
@@ -10,7 +10,7 @@
 #
 # It exists because a workbook can pass every data gate and still ship as a
 # visual mess (raw-id chart titles, controls dumped at the page foot, dead
-# zones) — the "PHASEE PBI Employee Dashboard" regression. Three checks:
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
 #
 #   (a) raw-id display names — any element display name matching a raw-id
 #       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
@@ -22,6 +22,17 @@
 #   (c) dead zones — more than 25% of a page's grid rows empty between the
 #       page's first and last positioned element (top-level layout entries).
 #       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
 #
 # API:
 #   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
@@ -32,6 +43,10 @@
 module LayoutLint
   RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
   DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
 
   module_function
 
@@ -70,10 +85,48 @@ module LayoutLint
     entries
   end
 
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
   def lint(spec)
     violations = []
     el_kind = {}
-    named_elements(spec).each { |el, _pg| el_kind[el['id']] = el['kind'] }
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
 
     # (a) raw-id display names ------------------------------------------------
     named_elements(spec).each do |el, pg|
@@ -97,6 +150,43 @@ module LayoutLint
           violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
                         '(banded page) — place it in the control band or its chart\'s container'
         end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        covered = Array.new(GRID_COLS, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+        end
+        fill = covered.count(true).to_f / GRID_COLS
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 
       # (c) dead-zone heuristic ------------------------------------------------

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -873,6 +873,13 @@ if mechanical
     id = "m-#{nm.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/^-|-$/, '')}"
     master_columns.reject! { |c| c['name'].casecmp?(nm) }
     master_columns << { 'id' => id, 'name' => nm, 'formula' => fx }
+    # Register the override in the header->column regex map too (same pattern
+    # shape as derive_master's entries) so chart dim headers AND shared-filter
+    # captions resolve to it — without this, an --master-col like 'Order Date'
+    # still left the shared Order-Date filter unmapped (no auto-control, charts
+    # silently unfiltered vs the source view).
+    mmap["(?i)^(?:(?:sum|avg|average|min|max|median|distinct count|count) of )?#{Regexp.escape(nm)}$"] =
+      { 'id' => id, 'name' => nm }
     line "master-col override: '#{nm}' = #{fx[0, 80]}"
   end
   mmap_path = File.join(WORK, 'master-map.json')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -19,6 +19,7 @@ OptionParser.new do |p|
   p.on('--spec P')                         { |v| opts[:spec] = v }
   p.on('--out P')                          { |v| opts[:out]  = v }
   p.on('--workdir P', 'Per-conversion working dir (default: dir of --spec). Used to track posted workbook IDs across retries.') { |v| opts[:workdir] = v }
+  p.on('--skip-layout-lint') { opts[:skip_lint] = true }
 end.parse!
 %i[type spec out].each { |k| abort("missing --#{k}") unless opts[k] }
 opts[:workdir] ||= File.dirname(File.expand_path(opts[:spec]))
@@ -179,6 +180,30 @@ if res.is_a?(Net::HTTPSuccess)
   end
 else
   warn "WARN: could not fetch /columns for type guard (got HTTP #{res.code}); skipping"
+end
+
+# Layout-quality lint (shared scripts/lib/layout_lint.rb — vendored byte-
+# identical, md5 discipline): fails loudly on raw-id element display names,
+# input controls outside the GridContainer bands of a banded page, and dead
+# zones (>25% empty grid rows between a page's first and last element). The
+# "PHASEE PBI Employee Dashboard" regression shipped a parity-green workbook
+# that was a visual mess — every data gate passed. Escape: --skip-layout-lint
+# (legacy/intentional layouts only; name the reason in your report).
+if opts[:type] == 'workbook' && !opts[:skip_lint]
+  require_relative 'lib/layout_lint'
+  violations = LayoutLint.lint(spec)
+  if violations.any?
+    warn "\n========================================"
+    warn "FAIL — layout lint: #{violations.size} violation(s):"
+    violations.each { |v| warn "  - #{v}" }
+    warn 'Fix the spec/layout and re-PUT before continuing: raw-id names -> derive human'
+    warn 'titles; loose controls -> control band or the chart container; dead zones ->'
+    warn 're-band the page. The workbook DID post — fix with PUT /v2/workbooks/<id>/spec'
+    warn '(re-POSTing creates an orphan).'
+    warn '========================================'
+    exit(3)
+  end
+  warn 'layout lint: clean (raw-id names / orphan controls / dead zones)'
 end
 
 # Phase 6 nag — column-type guard catches formula-resolution errors but does

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # Hard gate that proves a tableau-to-sigma conversion is actually complete.
-# The subagent MUST run this script before declaring GREEN. It checks five
+# The subagent MUST run this script before declaring GREEN. It checks six
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
@@ -20,6 +20,11 @@
 #      parity plan. Catches the "empty view CSV silently dropped a tile and
 #      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
 #      (with a note) when the converter doesn't emit a census.
+#   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
+#      display names, no input controls outside the GridContainer bands on a
+#      banded page, no dead zones (>25% empty grid rows between a page's
+#      first and last element). Catches the "PHASEE PBI Employee Dashboard"
+#      visual-mess regression that every data gate waved through.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -30,6 +35,9 @@
 #     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
 #                              # that genuinely want multiple workbooks)
 #     [--skip-layout-check]    # skip the layout-applied scan
+#     [--skip-layout-lint]     # skip gate 6 (layout-quality lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
 #     [--min-layout-elements N] default 2 — single-page bare-element layouts
 #                              # often have just the page wrapper; require this
 #                              # many <LayoutElement> tags
@@ -49,6 +57,8 @@
 #      (beads-sigma-bw3)
 #   7  tile census shows unexplained unmatched dashboard zones beyond
 #      --allow-missing-tiles (bead gjhe)
+#   8  layout lint violations — raw-id display names / orphan controls /
+#      dead zones (gate 6; scripts/lib/layout_lint.rb)
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -68,6 +78,7 @@ OptionParser.new do |p|
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
   p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
 end.parse!
@@ -119,7 +130,7 @@ if status != 'PASS' || pass_rate < opts[:min_pass_rate]
   exit 2
 end
 
-puts "[OK] gate 1/5: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+puts "[OK] gate 1/6: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
 
 # ---------------------------------------------------------------------------
 # Gate 2 — orphan workbooks (beads-sigma-38a)
@@ -132,7 +143,7 @@ unless opts[:skip_orphan]
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
       unless File.exist?(marker_path)
-        warn "[FAIL] gate 2/5: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "[FAIL] gate 2/6: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
         warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
@@ -141,27 +152,27 @@ unless opts[:skip_orphan]
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
       if marker['failed'] && !marker['failed'].empty?
-        warn "[FAIL] gate 2/5: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "[FAIL] gate 2/6: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
       if marker['dry_run']
-        warn "[FAIL] gate 2/5: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "[FAIL] gate 2/6: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
         warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
         exit 4
       end
       kept = marker['kept'] || '(unknown)'
       deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/5: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      puts "[OK] gate 2/6: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
     else
-      puts "[OK] gate 2/5: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+      puts "[OK] gate 2/6: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end
   else
-    puts "[OK] gate 2/5: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+    puts "[OK] gate 2/6: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/5: --skip-orphan-check"
+  puts "[SKIP] gate 2/6: --skip-orphan-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -181,12 +192,12 @@ unless opts[:skip_column]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 3/5: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+    puts "[SKIP] gate 3/6: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 3/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+      warn "[SKIP] gate 3/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
       req = Net::HTTP::Get.new(uri)
@@ -198,7 +209,7 @@ unless opts[:skip_column]
         cols = (JSON.parse(res.body)['entries'] rescue []) || []
         error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
         if error_cols.any?
-          warn "[FAIL] gate 3/5: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "[FAIL] gate 3/6: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
           warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
           warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
           error_cols.first(10).each do |c|
@@ -208,14 +219,14 @@ unless opts[:skip_column]
           warn "       See beads-sigma-38a."
           exit 5
         end
-        puts "[OK] gate 3/5: #{cols.length} live columns clean (no type=error)"
+        puts "[OK] gate 3/6: #{cols.length} live columns clean (no type=error)"
       else
-        warn "[SKIP] gate 3/5: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 3/6: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 3/5: --skip-column-check"
+  puts "[SKIP] gate 3/6: --skip-column-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -236,12 +247,12 @@ unless opts[:skip_layout]
   end
 
   if wb_id.nil? || wb_id.empty?
-    puts "[SKIP] gate 4/5: no workbook ID resolvable for layout check"
+    puts "[SKIP] gate 4/6: no workbook ID resolvable for layout check"
   else
     base = ENV['SIGMA_BASE_URL']
     tok  = ENV['SIGMA_API_TOKEN']
     if base.nil? || base.empty? || tok.nil? || tok.empty?
-      warn "[SKIP] gate 4/5: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+      warn "[SKIP] gate 4/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
     else
       uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
       req = Net::HTTP::Get.new(uri)
@@ -285,7 +296,7 @@ unless opts[:skip_layout]
         end
 
         if layout_xml.empty?
-          warn "[FAIL] gate 4/5: live workbook #{wb_id} has NO top-level layout XML."
+          warn "[FAIL] gate 4/6: live workbook #{wb_id} has NO top-level layout XML."
           warn "       Elements render as a single-column stack instead of the"
           warn "       dashboard grid. Rebuild the layout with this skill's layout"
           warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
@@ -295,12 +306,12 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         elsif elem_count < opts[:min_layout_elements]
-          warn "[FAIL] gate 4/5: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "[FAIL] gate 4/6: layout XML has only #{elem_count} <LayoutElement> tag(s);"
           warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
           warn "       The layout likely covers only the Data page — chart page is unstyled."
           exit 6
         elsif non_data_stack_pages.any?
-          warn "[FAIL] gate 4/5: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "[FAIL] gate 4/6: live workbook #{wb_id} has Sigma's auto-generated"
           warn "       single-column stack layout (multiple elements at the same gridColumn"
           warn "       on a non-Data page). This is what Sigma defaults to when you POST"
           warn "       a workbook without a layout — exactly the CoCo regression."
@@ -313,15 +324,15 @@ unless opts[:skip_layout]
           warn "       See beads-sigma-bw3."
           exit 6
         else
-          puts "[OK] gate 4/5: layout XML applied with #{elem_count} positioned element(s)"
+          puts "[OK] gate 4/6: layout XML applied with #{elem_count} positioned element(s)"
         end
       else
-        warn "[SKIP] gate 4/5: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+        warn "[SKIP] gate 4/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
       end
     end
   end
 else
-  puts "[SKIP] gate 4/5: --skip-layout-check"
+  puts "[SKIP] gate 4/6: --skip-layout-check"
 end
 
 # ---------------------------------------------------------------------------
@@ -334,14 +345,14 @@ end
 # ---------------------------------------------------------------------------
 census = summary['tile_census']
 if census.nil?
-  puts "[SKIP] gate 5/5: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+  puts "[SKIP] gate 5/6: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
 else
   zones     = census['zones_total'].to_i
   built     = census['charts_built'].to_i
   unmatched = census['zones_unmatched'].to_i
   names     = Array(census['unmatched_zone_names'])
   if unmatched > opts[:allow_missing_tiles]
-    warn "[FAIL] gate 5/5: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    warn "[FAIL] gate 5/6: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
     names.each { |n| warn "         - #{n}" }
     warn "       A zone that rendered in the source dashboard has NO matching chart in the"
     warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
@@ -351,9 +362,71 @@ else
     warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
     exit 7
   elsif unmatched > 0
-    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+    puts "[OK] gate 5/6: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
   else
-    puts "[OK] gate 5/5: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+    puts "[OK] gate 5/6: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 6 — layout-quality lint (scripts/lib/layout_lint.rb, shared)
+# A workbook can pass every data gate above and still ship as a visual mess:
+# raw element ids as chart titles, controls dumped loose at the page foot,
+# dead zones between elements (the "PHASEE PBI Employee Dashboard" escape).
+# This gate mechanizes those checks on the LIVE spec.
+# ---------------------------------------------------------------------------
+if opts[:skip_lint]
+  puts "[SKIP] gate 6/6: --skip-layout-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 6/6: no workbook ID resolvable for layout lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 6/6: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/layout_lint'
+    rescue LoadError
+      warn "[SKIP] gate 6/6: scripts/lib/layout_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(LayoutLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        violations = LayoutLint.lint(spec)
+        if violations.any?
+          warn "[FAIL] gate 6/6: layout lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the spec/layout and re-PUT (raw-id names -> derive human titles;"
+          warn "       loose controls -> place into a band/container; dead zones -> re-band the page),"
+          warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
+          exit 8
+        end
+        puts "[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones)"
+      else
+        warn "[SKIP] gate 6/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
   end
 end
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -23,8 +23,13 @@
 #   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
 #      display names, no input controls outside the GridContainer bands on a
 #      banded page, no dead zones (>25% empty grid rows between a page's
-#      first and last element). Catches the "PHASEE PBI Employee Dashboard"
-#      visual-mess regression that every data gate waved through.
+#      first and last element), no generic header-band title ("Page 1" /
+#      "Sheet 3" / "Dashboard 2" must never title a dashboard), and no
+#      under-filled band (<60% of the 24 grid columns covered; deliberate
+#      KPI bands of <=4 tiles exempt). Catches the "PHASEE PBI Employee
+#      Dashboard" visual-mess regression (and its PHASEE2 sequel: "Page 1"
+#      header + a lone small chart beside a 19-column hole) that every data
+#      gate waved through.
 #
 # Usage:
 #   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
@@ -422,7 +427,8 @@ else
           warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
           exit 8
         end
-        puts "[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones)"
+        puts '[OK] gate 6/6: layout lint clean (no raw-id names, no orphan controls, no dead zones, ' \
+             'no generic header title, no under-filled bands)'
       else
         warn "[SKIP] gate 6/6: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
       end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Three checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    named_elements(spec).each { |el, _pg| el_kind[el['id']] = el['kind'] }
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/layout_lint.rb
@@ -10,7 +10,7 @@
 #
 # It exists because a workbook can pass every data gate and still ship as a
 # visual mess (raw-id chart titles, controls dumped at the page foot, dead
-# zones) — the "PHASEE PBI Employee Dashboard" regression. Three checks:
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
 #
 #   (a) raw-id display names — any element display name matching a raw-id
 #       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
@@ -22,6 +22,17 @@
 #   (c) dead zones — more than 25% of a page's grid rows empty between the
 #       page's first and last positioned element (top-level layout entries).
 #       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
 #
 # API:
 #   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
@@ -32,6 +43,10 @@
 module LayoutLint
   RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
   DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
 
   module_function
 
@@ -70,10 +85,48 @@ module LayoutLint
     entries
   end
 
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
   def lint(spec)
     violations = []
     el_kind = {}
-    named_elements(spec).each { |el, _pg| el_kind[el['id']] = el['kind'] }
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
 
     # (a) raw-id display names ------------------------------------------------
     named_elements(spec).each do |el, pg|
@@ -97,6 +150,43 @@ module LayoutLint
           violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
                         '(banded page) — place it in the control band or its chart\'s container'
         end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        covered = Array.new(GRID_COLS, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+        end
+        fill = covered.count(true).to_f / GRID_COLS
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 
       # (c) dead-zone heuristic ------------------------------------------------


### PR DESCRIPTION
Fixes the "PHASEE PBI Employee Dashboard — Enhanced" output-quality regression: raw element ids as chart titles, controls dumped at the page foot, orphaned grain switcher, no containers, dead zone next to the title.

## Root causes (confirmed)
1. **Raw-id titles** — `build-workbook-from-pbir.rb` falls back to `name = visual_id` when a visual has no explicit title. Classic `report.json` visuals routinely have NO `objects.title` (all 5 EMPLOYEE DASHBOARD visuals: `title: null`). PR #56's classic queryRef normalization made those visuals *build successfully* via the one-command path for the first time, surfacing the raw ids.
2. **Controls at the page foot** — `enhance-apply.rb`'s `add_layout!` appended `<LayoutElement>`s at `max_row` of the *Page* block, outside every GridContainer.
3. **No banding on the clone** — Phase E (PR #56) was developed in parallel with the container port (PR #54); its E2E clone predated containers, so the clone had a flat layout and the appended items had no bands to land in.

## Fixes
- **Derived titles** (`build-workbook-from-pbir.rb`): untitled visuals get titles derived from their projections (`derived_title`): "Absence Count by Department", "Hours by Location", "Employee Count by ZIP", "Employee Count Over Time" (date dims → "… Over Time"); duplicates deduped; last-resort fallback is the kind label, never an id. A short top title TEXTBOX is promoted into the dark header band (white span) instead of leaving a dead zone in band 1.
- **Container placement** (`enhance-apply.rb`, vendored byte-identical pbi+tableau): every applied item lands in the container system — selection controls → control band (created under the header if absent), comparison KPIs → KPI band, grain/drill switchers → a slim row INSIDE their chart's container, notes → a slim band under the header. Pre-container clones get a banded layout REGENERATED first (shared `lib/layout.rb` machinery, new `header_el:` support). Finalize runs the layout lint (exit 4 on violations) and prints the hard screenshot checklist.
- **Mechanized layout lint** (`scripts/lib/layout_lint.rb`, NEW shared lib vendored to all 5 plugins): fails on (a) display names matching `^[0-9a-f]{12,}$` / `^el-[0-9a-f]+$`, (b) input controls outside any GridContainer on a banded page, (c) >25% empty grid rows between a page's first and last element. Wired into `post-and-readback.rb` (workbook type, all 3 ruby copies) and `assert-phase6-ran.rb` as **gate 6** (exit 8, `--skip-layout-lint` escape; all 5 copies byte-identical).
- **Hard screenshot checklist** in both Phase E SKILL.md sections + printed by `enhance-apply.rb` at finalize: human titles / header band / controls banded / control-adjacency / no below-fold orphans / no dead zones.
- **Found live during E2E**: `migrate-tableau.rb` `--master-col` overrides are now registered in the header→column regex mmap — previously a shared filter on an override-only column (the Orders "Order Date" this-year relative filter) was silently dropped and every chart read UNFILTERED vs the source view. Tableau `title-text` body emitted as a white span (it always lands in the dark header band; was dark-on-dark).

## E2E evidence (live, this branch)
- **PBI classic EMPLOYEE DASHBOARD** (cached token, one-command + `--enhance --enhance-accept all-low-risk`): DM `a9e3bc1a`, parity wb `fd7eeb09` "PHASEE2 PBI Employee Dashboard", clone `e34b364c` "— Enhanced" (5 applied / 1 skipped (map needs centroids) / 0 reverted, parity-unchanged gate GREEN, lint CLEAN). Phase 6 vs executeQueries DAX: 4/4 PASS in extract-mode (import model; snapshot 12 days stale, refresh FAILED — Snowflake creds expired (`credsSuspect`), documented in `freshness.json`). `assert-phase6-ran`: all 6 gates green on BOTH workbooks.
- **Tableau live "Orders Conversion Test"** (`--enhance`, two-pass with documented stops: 2 `--master-col` resume + `--allow-missing-tiles 1` for the Monthly Revenue Trend view whose data export returns 0 bytes today — verified via REST and MCP while the view image renders): DM `250b2a99`, parity wb `f03ba600` 5/5 strict PASS, clone `cf3625d2` (3 applied / 1 skipped (medium drill) / **1 auto-REVERTED by the parity-unchanged gate**, lint CLEAN). All 6 gates green.
- The pre-fix tableau enhanced workbook (0e022d3b) confirms the regression class: controls + grain switcher dumped at the foot, no header band, flat layout (lint passes mechanically only because rule (b) needs containers — the checklist catches it).
- Full-page PNGs: `~/migration-visual-qa/phase-e2/{pbi,tableau}-{parity,enhanced}.png`.
- Old bad pair DELETED: clone `a38f0d1b`, parity `c480df21`, DM `71586466` (+ all intermediate run artifacts).

## md5 (vendored byte-identical)
- `assert-phase6-ran.rb` ×5: `1915a3661edfe3cef930e66a952fda45`
- `lib/layout_lint.rb` ×5: `73333069ac28a53121ffbc8498f3aa25`
- `enhance-apply.rb` ×2: `261463b8a4dff4faa180dcdc0255b9c4`
- `lib/layout.rb` ×3: `79120ef3da1a06b41cf65e58aecec155`

🤖 Generated with [Claude Code](https://claude.com/claude-code)