### PR TITLE
Fast discovery: cognos batch-window resume + looker token cache / 4-wide parity

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/QUICKSTART.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/QUICKSTART.md
@@ -106,9 +106,13 @@ Duration: 10
 In Claude Code, point the `cognos-to-sigma` skill at a Data Module + report. The skill
 runs these phases (`scripts/*`):
 
-1. **Discover** (`cognos-discover.sh`) — list a folder, then pull the **Data Module JSON**
-   (`GET /bi/v1/metadata/modules/{id}`) and **report-spec XML**
-   (`GET /bi/v1/objects/{id}?fields=specification`).
+1. **Discover** (`cognos-batch-fetch.sh` / `cognos-discover.sh`) — pull the **Data Module
+   JSON** (`GET /bi/v1/metadata/modules/{id}`) and **report-spec XML**
+   (`GET /bi/v1/objects/{id}?fields=specification`). For anything beyond a couple of
+   objects use `cognos-batch-fetch.sh batch`: it fetches the whole estate in one
+   hot-session window (4-wide, resumable disk cache keyed id+modificationTime) — a
+   dead session resumes instead of restarting, and single-artifact runs (`one`) are
+   served from the same cache.
 2. **Convert the Data Module** (`cli.ts <module.json>`) — query subjects → warehouse-table
    elements, items → columns/metrics, calculations → Sigma formulas (`total..for`→`SumOver`,
    `if/then/else`→`If`, date/string fns), relationships → DM relationships.
@@ -157,6 +161,8 @@ Duration: 3
   (`regionType` defaults to `country`, flagged to confirm).
 - **Workbook POST responses are YAML**, not JSON — parse the `workbookId` accordingly.
 - **Sessions:** CAoC `HTTP 441` = re-login + re-copy the full cookie; prefer a CA API key.
+  Batch everything you need into one hot-session window (`cognos-batch-fetch.sh batch`)
+  — it resumes from its disk cache after a 441 instead of restarting.
 
 ## The techniques worth carrying forward
 Duration: 1

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -85,13 +85,35 @@ checkpoint, never silently ported or dropped).
 
 ## Phase 0 — Discover (CA REST)
 
+**Work in batch windows.** CAoC sessions die in MINUTES — never walk an estate one
+object per agent turn (each re-auth costs the human a browser round-trip). The moment
+you have a hot session, pull EVERYTHING you might need in one burst with
+`cognos-batch-fetch.sh`, then work offline from its disk cache:
+
 ```bash
 export COGNOS_BASE="https://<host>/bi/v1"
 export COGNOS_COOKIE="<cookie string>"   export COGNOS_XSRF="<x-xsrf-token>"
-scripts/cognos-discover.sh list   <folderId>          # list a folder's items
-scripts/cognos-discover.sh module <moduleId> > m.json # Data Module JSON
-scripts/cognos-discover.sh report <reportId> > r.xml  # report-spec XML
+
+# THE BATCH WINDOW — walk the tree + fetch ALL module/report specs, 4-wide
+# (hard cap — Akamai WAF; modest bursts only), into a resumable disk cache
+# (default ~/.cognos/batch-cache, override with --out / $COGNOS_CACHE_DIR):
+scripts/cognos-batch-fetch.sh batch [--root <folderId>]
+# Session died mid-run? It exits 4 with "SESSION DIED — N of M specs fetched";
+# re-auth (re-copy a HOT cookie) and re-run the SAME command — it RESUMES from
+# the manifest + cache (already-fetched specs, keyed id+modificationTime, are
+# never re-fetched). Exit 0 = the whole estate is cached.
+
+# Single-artifact runs go through the SAME cache — unchanged modificationTime
+# = cache HIT, ONE metadata request, no spec re-fetch:
+scripts/cognos-batch-fetch.sh one module <moduleId> > m.json
+scripts/cognos-batch-fetch.sh one report <reportId> > r.xml
 ```
+
+`cognos-discover.sh` (`list`/`module`/`report`) remains for ad-hoc pokes at a live
+session, but prefer the batch + cache path for anything beyond a couple of objects.
+And keep pushing for the **durable path**: a CA **API key / service credential**
+(where the tenant allows it) removes the session-death problem entirely — batch
+windows are the workaround for session-replay auth, not a substitute for asking.
 
 - Samples folder, modules, and reports are discovered by walking `GET /objects/{id}/items`.
 - **Data Module spec**: `GET /bi/v1/metadata/modules/{id}` (NOT `/modules/{id}`, which is empty).

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/cognos-batch-fetch.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/cognos-batch-fetch.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# cognos-batch-fetch.sh — fetch the WHOLE Cognos estate in one hot-session
+# window, and serve single-artifact runs from the same disk cache.
+#
+# WHY: CAoC sessions die in minutes (HTTP 441 — IBMid SSO re-auth + Akamai WAF).
+# Walking an estate with one request per agent turn burns a human re-auth cycle
+# every few objects. This script instead pulls ALL module + report specs as fast
+# as the session allows (parallel curl, capped at 4 — modest bursts only, the
+# Akamai WAF throttles aggressive clients), and every fetch lands in a disk
+# cache keyed by object id + modificationTime. When the session dies mid-walk
+# the run STOPS CLEANLY and a re-run RESUMES — nothing already fetched is
+# re-fetched.
+#
+# Auth (same shape as cognos-discover.sh / get-cognos-session.sh):
+#   export COGNOS_BASE="https://<host>/bi/v1"      # /bi/v1, NOT /api/v1
+#   export COGNOS_COOKIE="<full Cookie header>"    # incl. Akamai _abck/bm_sz/…
+#   export COGNOS_XSRF="<X-XSRF-Token value>"
+#
+# Usage:
+#   cognos-batch-fetch.sh batch [--root <folderId>] [--out <dir>]
+#                               [--parallel N] [--rewalk] [--max-depth N] [--page N]
+#       Walk the folder tree under --root (default .public_folders), then fetch
+#       every module's Data-Module JSON and every report's spec XML, N-wide
+#       (default and HARD CAP = 4). Resumable: re-run the same command after a
+#       441 and it continues from the manifest + cache.
+#
+#   cognos-batch-fetch.sh one {module|report} <objectId> [--out <dir>]
+#       Single-artifact fetch through the SAME cache: one cheap metadata GET
+#       checks modificationTime; unchanged → the cached spec is printed with NO
+#       spec re-fetch (1 request instead of a full pull). Changed/missing →
+#       fetch, cache, print.
+#
+# Cache layout (default --out: $COGNOS_CACHE_DIR or ~/.cognos/batch-cache):
+#   <out>/manifest.json      the walked tree (artifacts + modificationTime)
+#   <out>/cache-index.json   id → {modificationTime, file, fetchedAt}
+#   <out>/specs/<id>.module.json | <id>.report.xml
+#
+# Exit codes: 0 = complete; 4 = SESSION DIED mid-run (resume by re-running);
+#             2 = usage / env error.
+set -euo pipefail
+
+CMD="${1:-}"; shift || true
+ROOT=".public_folders"
+OUT="${COGNOS_CACHE_DIR:-$HOME/.cognos/batch-cache}"
+PAR=4
+PAGE=100
+MAXDEPTH=12
+REWALK=0
+ONE_TYPE=""
+ONE_ID=""
+
+case "$CMD" in
+  batch) ;;
+  one)
+    ONE_TYPE="${1:-}"; ONE_ID="${2:-}"; shift 2 || true
+    case "$ONE_TYPE" in module|report|reportview) ;; *)
+      echo "usage: cognos-batch-fetch.sh one {module|report} <objectId> [--out <dir>]" >&2; exit 2 ;;
+    esac ;;
+  *)
+    echo "usage: cognos-batch-fetch.sh batch [--root <id>] [--out <dir>] [--parallel N] [--rewalk]" >&2
+    echo "       cognos-batch-fetch.sh one {module|report} <objectId> [--out <dir>]" >&2
+    exit 2 ;;
+esac
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root)      ROOT="$2"; shift 2 ;;
+    --out)       OUT="$2"; shift 2 ;;
+    --parallel)  PAR="$2"; shift 2 ;;
+    --page)      PAGE="$2"; shift 2 ;;
+    --max-depth) MAXDEPTH="$2"; shift 2 ;;
+    --rewalk)    REWALK=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+: "${COGNOS_BASE:?set COGNOS_BASE (e.g. https://host/bi/v1)}"
+: "${COGNOS_COOKIE:?set COGNOS_COOKIE}"
+: "${COGNOS_XSRF:?set COGNOS_XSRF}"
+
+if [ "$PAR" -gt 4 ]; then
+  echo "WARN: --parallel $PAR clamped to 4 (Akamai WAF — modest bursts only)" >&2
+  PAR=4
+fi
+
+mkdir -p "$OUT/specs"
+export COGNOS_BASE COGNOS_COOKIE COGNOS_XSRF OUT ROOT PAGE MAXDEPTH PAR REWALK CMD ONE_TYPE ONE_ID
+
+python3 - <<'PY'
+import datetime
+import json
+import os
+import subprocess
+import sys
+import threading
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor
+
+BASE     = os.environ["COGNOS_BASE"]
+COOKIE   = os.environ["COGNOS_COOKIE"]
+XSRF     = os.environ["COGNOS_XSRF"]
+OUT      = os.environ["OUT"]
+ROOT     = os.environ["ROOT"]
+PAGE     = int(os.environ["PAGE"])
+MAXDEPTH = int(os.environ["MAXDEPTH"])
+PAR      = int(os.environ["PAR"])
+REWALK   = os.environ["REWALK"] == "1"
+CMD      = os.environ["CMD"]
+ONE_TYPE = os.environ["ONE_TYPE"]
+ONE_ID   = os.environ["ONE_ID"]
+
+MANIFEST = os.path.join(OUT, "manifest.json")
+INDEX    = os.path.join(OUT, "cache-index.json")
+SPECS    = os.path.join(OUT, "specs")
+
+LEAF   = {"module", "report", "reportview"}
+FOLDER = {"folder", "package", "myfolders", "namespacefolder"}
+DEAD   = {401, 403, 441}  # session death / WAF rejection — stop + resume later
+
+session_dead = threading.Event()
+index_lock = threading.Lock()
+
+
+def get(path):
+    """GET <path> (leading slash) via curl. Returns (status, text)."""
+    p = subprocess.run(
+        ["curl", "-s", "-w", "\n%{http_code}", BASE + path,
+         "-H", "Accept: application/json",
+         "-H", "X-XSRF-TOKEN: " + XSRF,
+         "-H", "X-Requested-With: XMLHttpRequest",
+         "-b", COOKIE],
+        capture_output=True, text=True)
+    body = p.stdout
+    nl = body.rfind("\n")
+    code, text = (body[nl + 1:].strip(), body[:nl]) if nl >= 0 else ("", body)
+    try:
+        status = int(code)
+    except ValueError:
+        status = 0
+    if status in DEAD or status == 0:
+        session_dead.set()
+    return status, text
+
+
+def load_json(path, default):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return default
+
+
+def save_json(path, obj):
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(obj, f, indent=2)
+    os.replace(tmp, path)
+
+
+def safe_name(aid):
+    return urllib.parse.quote(str(aid), safe="")
+
+
+def cache_fresh(index, art):
+    """True when the cached spec for art is present AND modificationTime matches."""
+    ent = index.get(art["id"])
+    if not ent:
+        return False
+    if (art.get("modificationTime") or "") != (ent.get("modificationTime") or ""):
+        return False
+    f = os.path.join(SPECS, ent.get("file") or "")
+    return bool(ent.get("file")) and os.path.exists(f) and os.path.getsize(f) > 0
+
+
+def fetch_spec(art):
+    """Fetch one module/report spec. Returns (id, filename|None, err|None)."""
+    aid, atype = art["id"], art["type"]
+    if session_dead.is_set():
+        return aid, None, "skipped (session dead)"
+    if atype == "module":
+        status, text = get(f"/metadata/modules/{urllib.parse.quote(str(aid))}")
+        if session_dead.is_set() or status >= 400 or not text.strip():
+            return aid, None, f"HTTP {status}"
+        fname = f"{safe_name(aid)}.module.json"
+        payload = text
+    else:  # report / reportview
+        status, text = get(f"/objects/{urllib.parse.quote(str(aid))}?fields=specification")
+        if session_dead.is_set() or status >= 400:
+            return aid, None, f"HTTP {status}"
+        try:
+            o = (json.loads(text).get("data") or [{}])[0]
+            payload = o.get("specification") or ""
+        except Exception:
+            payload = ""
+        if not payload.strip():
+            return aid, None, "empty specification"
+        fname = f"{safe_name(aid)}.report.xml"
+    with open(os.path.join(SPECS, fname), "w") as f:
+        f.write(payload)
+    return aid, fname, None
+
+
+def record(index, art, fname):
+    with index_lock:
+        index[art["id"]] = {
+            "type": art["type"],
+            "name": art.get("name"),
+            "modificationTime": art.get("modificationTime"),
+            "file": fname,
+            "fetchedAt": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        save_json(INDEX, index)
+
+
+# ── one — single artifact through the same cache ─────────────────────────────
+if CMD == "one":
+    index = load_json(INDEX, {})
+    status, text = get(f"/objects/{urllib.parse.quote(ONE_ID)}"
+                       "?fields=defaultName,type,modificationTime")
+    if status >= 400 or status == 0:
+        ent = index.get(ONE_ID) or {}
+        cached = os.path.join(SPECS, ent.get("file") or "")
+        hint = (f" A cached copy (modificationTime {ent.get('modificationTime')}) exists at"
+                f" {cached} — use it only if staleness is acceptable.") if ent.get("file") else ""
+        sys.exit(f"SESSION DIED (HTTP {status}) on the metadata check — re-auth "
+                 f"(re-copy COGNOS_COOKIE/COGNOS_XSRF) and re-run.{hint}")
+    try:
+        meta = (json.loads(text).get("data") or [{}])[0]
+    except Exception:
+        meta = {}
+    art = {"id": ONE_ID, "type": ONE_TYPE if ONE_TYPE != "reportview" else "report",
+           "name": meta.get("defaultName"),
+           "modificationTime": meta.get("modificationTime")}
+    if cache_fresh(index, art):
+        ent = index[ONE_ID]
+        print(f"cache HIT: {ONE_ID} unchanged (modificationTime "
+              f"{ent['modificationTime']}) — serving {ent['file']}, no re-fetch", file=sys.stderr)
+        with open(os.path.join(SPECS, ent["file"])) as f:
+            sys.stdout.write(f.read())
+        sys.exit(0)
+    aid, fname, err = fetch_spec(art)
+    if err:
+        if session_dead.is_set():
+            sys.exit(f"SESSION DIED ({err}) fetching {ONE_ID} — re-auth and re-run.")
+        sys.exit(f"fetch failed for {ONE_ID}: {err}")
+    record(index, art, fname)
+    print(f"cache MISS: fetched {ONE_ID} -> {fname}", file=sys.stderr)
+    with open(os.path.join(SPECS, fname)) as f:
+        sys.stdout.write(f.read())
+    sys.exit(0)
+
+# ── batch — walk (or reuse manifest), then fetch PAR-wide ────────────────────
+manifest = None if REWALK else load_json(MANIFEST, None)
+if manifest and manifest.get("root") == ROOT:
+    arts = manifest["artifacts"]
+    print(f"reusing manifest ({len(arts)} artifacts, walked {manifest.get('walkedAt')}) "
+          f"— pass --rewalk to re-list the tree", file=sys.stderr)
+else:
+    print(f"walking tree under '{ROOT}' …", file=sys.stderr)
+    arts, seen = [], set()
+
+    def items_of(folder_id):
+        skip = 0
+        while not session_dead.is_set():
+            q = (f"/objects/{urllib.parse.quote(str(folder_id))}/items"
+                 f"?fields=defaultName,type,id,modificationTime&top={PAGE}&skip={skip}")
+            status, text = get(q)
+            if status >= 400 or status == 0:
+                return
+            try:
+                d = json.loads(text)
+            except Exception:
+                return
+            batch = d.get("data") or d.get("content") or d.get("items") or []
+            if not batch:
+                return
+            yield from batch
+            if len(batch) < PAGE:
+                return
+            skip += PAGE
+
+    def walk(folder_id, path, depth):
+        if depth > MAXDEPTH or session_dead.is_set():
+            return
+        for it in items_of(folder_id):
+            aid = it.get("id")
+            if not aid or aid in seen:
+                continue
+            seen.add(aid)
+            atype = (it.get("type") or "").lower()
+            name = it.get("defaultName") or it.get("name") or aid
+            if atype in FOLDER:
+                walk(aid, f"{path}/{name}", depth + 1)
+            elif atype in LEAF:
+                arts.append({"id": aid,
+                             "type": "report" if atype == "reportview" else atype,
+                             "name": name, "path": f"{path}/{name}",
+                             "modificationTime": it.get("modificationTime")})
+
+    walk(ROOT, "", 0)
+    if session_dead.is_set():
+        sys.exit("SESSION DIED during the tree walk — nothing cached yet from this walk. "
+                 "Re-auth (re-copy COGNOS_COOKIE/COGNOS_XSRF from a hot browser session) "
+                 "and re-run the SAME command.")
+    save_json(MANIFEST, {"root": ROOT, "base": BASE,
+                         "walkedAt": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                         "artifacts": arts})
+    print(f"manifest: {len(arts)} fetchable artifacts "
+          f"({sum(1 for a in arts if a['type'] == 'module')} modules, "
+          f"{sum(1 for a in arts if a['type'] == 'report')} reports) -> {MANIFEST}",
+          file=sys.stderr)
+
+index = load_json(INDEX, {})
+todo = [a for a in arts if not cache_fresh(index, a)]
+done_before = len(arts) - len(todo)
+if done_before:
+    print(f"cache: {done_before}/{len(arts)} already fetched (id+modificationTime match) "
+          f"— skipping those", file=sys.stderr)
+if not todo:
+    print(f"COMPLETE: all {len(arts)} specs cached in {SPECS}", file=sys.stderr)
+    sys.exit(0)
+
+print(f"fetching {len(todo)} spec(s) {PAR}-wide …", file=sys.stderr)
+fetched, errors = 0, []
+with ThreadPoolExecutor(max_workers=PAR) as ex:
+    for art, (aid, fname, err) in zip(todo, ex.map(fetch_spec, todo)):
+        if fname:
+            record(index, art, fname)
+            fetched += 1
+        elif not session_dead.is_set() and err:
+            errors.append((aid, art.get("name"), err))
+
+total_cached = done_before + fetched
+if session_dead.is_set():
+    print(f"\nSESSION DIED — {total_cached} of {len(arts)} specs fetched "
+          f"({fetched} this run). Everything fetched so far is cached in {SPECS}.\n"
+          f"Re-auth (re-copy COGNOS_COOKIE/COGNOS_XSRF from a hot browser session) and\n"
+          f"re-run the SAME command to RESUME — cached specs are NOT re-fetched.",
+          file=sys.stderr)
+    sys.exit(4)
+for aid, name, err in errors:
+    print(f"WARN: {aid} ({name}): {err} — not cached", file=sys.stderr)
+print(f"COMPLETE: {total_cached} of {len(arts)} specs cached in {SPECS}"
+      + (f" ({len(errors)} non-fatal error(s) above)" if errors else ""), file=sys.stderr)
+PY

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/cognos-discover.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/cognos-discover.sh
@@ -12,6 +12,11 @@
 # Grab COGNOS_COOKIE + COGNOS_XSRF from the browser: DevTools → Network → any
 # `coreBundle.js`-initiated `bi/v1/...` request → Copy as cURL (the -b cookie and
 # the X-XSRF-Token header). Session is short-lived; re-grab when it 401s.
+#
+# MORE THAN A COUPLE OF OBJECTS? Use cognos-batch-fetch.sh instead — it pulls
+# the WHOLE estate in one hot-session window (4-wide, resumable disk cache) and
+# its `one` mode serves single module/report fetches from that cache when the
+# modificationTime is unchanged (1 request instead of a re-fetch).
 set -euo pipefail
 : "${COGNOS_BASE:?set COGNOS_BASE}"; : "${COGNOS_COOKIE:?set COGNOS_COOKIE}"; : "${COGNOS_XSRF:?set COGNOS_XSRF}"
 cmd="${1:-}"; id="${2:-}"

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/looker_api.py
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/looker_api.py
@@ -11,11 +11,23 @@ Usage:
 import json
 import os
 import sys
+import threading
 import urllib.parse
 import urllib.request
 from configparser import ConfigParser
 
 INI = os.path.expanduser("~/.looker/looker.ini")
+
+# In-process token cache (same pattern as fetch_looker_dashboard.get._cache):
+# login ONCE per process instead of once per call() — Looker bearers live ~1h,
+# so for a multi-call run (parity fetches, estate walks) this removes a full
+# network round-trip per call. call() retries once with a fresh login on 401.
+# DEV-WORKSPACE CAVEAT: caching keeps ONE session across calls, which is what
+# dev-workspace flows REQUIRE (`PATCH /session {workspace_id: dev}` only sticks
+# within a session) — but a forced re-login (the 401 retry, or login(force=True))
+# starts a NEW session that resets the workspace to production; re-PATCH after.
+_token_lock = threading.Lock()
+_token_cache = {}  # base_url -> access_token
 
 
 def _cfg():
@@ -38,16 +50,25 @@ def _ctx(verify):
     return ctx
 
 
-def login():
+def login(force=False):
+    """Return (base, token, verify), reusing the per-process cached token.
+
+    force=True mints a fresh token (NEW Looker session — see the dev-workspace
+    caveat above). Thread-safe: parallel callers share one login.
+    """
     base, cid, csec, verify = _cfg()
-    data = urllib.parse.urlencode({"client_id": cid, "client_secret": csec}).encode()
-    req = urllib.request.Request(base + "/login", data=data, method="POST")
-    with urllib.request.urlopen(req, context=_ctx(verify), timeout=30) as r:
-        tok = json.load(r)["access_token"]
+    with _token_lock:
+        if not force and base in _token_cache:
+            return base, _token_cache[base], verify
+        data = urllib.parse.urlencode({"client_id": cid, "client_secret": csec}).encode()
+        req = urllib.request.Request(base + "/login", data=data, method="POST")
+        with urllib.request.urlopen(req, context=_ctx(verify), timeout=30) as r:
+            tok = json.load(r)["access_token"]
+        _token_cache[base] = tok
     return base, tok, verify
 
 
-def call(method, path, body=None):
+def call(method, path, body=None, _retry=True):
     base, tok, verify = login()
     if not path.startswith("/"):
         path = "/" + path
@@ -65,6 +86,10 @@ def call(method, path, body=None):
     except urllib.error.HTTPError as e:
         raw = e.read().decode()
         code = e.code
+    if code == 401 and _retry:
+        # cached token expired (~1h TTL) — re-login once and retry.
+        login(force=True)
+        return call(method, path, body, _retry=False)
     try:
         parsed = json.loads(raw)
     except Exception:

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -80,7 +80,10 @@ python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
   SOURCE-LookML-derived re-aggregation of the master's warehouse rows (offline —
   measure semantics from the `.view.lkml` `type:`, independent of the builder's
   formulas). Then `phase6-parity-looker.rb --finalize` + `assert-phase6-ran.rb`
-  run automatically.
+  run automatically. Both per-chart fetch sides run in a **bounded 4-wide thread
+  pool** (measured 24.3s → 5.8s on the 5-chart fixture); set
+  `LOOKER_PARITY_WORKERS=1` to serialize on a loaded warehouse (max is clamped
+  to 4 — warehouse-friendly bursts only).
 - Exit codes: `0` GREEN · `3` MCP convert request emitted · `10` RLS decision
   needed · `2` built but a gate FAILED. `--dry-run` = no Sigma POSTs.
 
@@ -95,7 +98,7 @@ python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
 | `scripts/verify-parity.rb` | **Phase 4:** the comparator (strict set-compare with date-bucket canonicalization; `--extract-mode` tolerance variant). Vendored from the shared converter copy. |
 | `scripts/assert-phase6-ran.rb` | **HARD GATE** (vendored **byte-identical** from quicksight-to-sigma — keep the md5 in lockstep): parity ran + PASS, no orphan workbooks, no `type=error` columns, layout applied. `ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <wb>` must **exit 0** before declaring GREEN. |
 | `scripts/get-token.sh` | Exchange `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` → `SIGMA_API_TOKEN` (~1h TTL). `eval "$(scripts/get-token.sh)"` |
-| `scripts/looker_api.py` | Minimal Looker REST API 4.0 client (no SDK). Reads `~/.looker/looker.ini`, logs in via `client_credentials`, exposes `L.call(method, path, body)`. CLI: `python3 looker_api.py whoami` / `get <path>` / `raw GET /lookml_models`. |
+| `scripts/looker_api.py` | Minimal Looker REST API 4.0 client (no SDK). Reads `~/.looker/looker.ini`, logs in via `client_credentials`, exposes `L.call(method, path, body)`. **Caches the bearer per process** (thread-safe; one login instead of one per call — ~150ms/call saved, measured 2.4x on a 10-call run) and retries once with a fresh login on 401. CLI: `python3 looker_api.py whoami` / `get <path>` / `raw GET /lookml_models`. |
 | `scripts/fetch_looker_dashboard.py` | **Phase 1 (live):** `GET /dashboards/{id}` → the normalized contract (`refs/dashboard-contract.md`). Works for UDD AND LookML dashboards. Self-contained (reads `~/.looker/looker.ini`). `tileType` is read from `query.vis_config.type` (NOT `element.type`, which is always `"vis"`); `listen` from `result_maker.filterables`; layout from the **active** layout's components. |
 | `scripts/parse_lookml_dashboard.py` | **Phase 1 (offline):** parse a `.dashboard.lookml` (YAML) → the SAME contract. Dev/test only; cannot see UDD dashboards. Requires PyYAML. |
 | `scripts/detect_rls.py` | **Phase 1 (RLS scan):** dependency-free regex scan of a LookML dir/file (and/or model JSON) for row-level-security constructs (`access_filter`, `sql_always_where`, `access_grant`, `user_attribute`). Prints a structured summary + recommended Sigma mapping per finding (or `--json`). **Prints nothing / exits 0 when there's no RLS** (zero-overhead). `python3 detect_rls.py <lookml_dir> [--json]` |
@@ -205,6 +208,11 @@ For a specific explore's field graph:
 ```bash
 python3 scripts/fetch_looker_dashboard.py <dashboard_id> /tmp/<name>/<dash>.contract.json
 ```
+
+> **Discovery speed: already sub-second.** A dashboard pull is one login (cached
+> per process) + one `GET /dashboards/{id}` — there is no estate walk to optimize.
+> For many-call sessions (parity, inventory) `looker_api.py`'s per-process token
+> cache removes the per-call login round-trip (~150ms each).
 
 This hits `GET /dashboards/{id}` and normalizes into `refs/dashboard-contract.md`. It works
 for UDD **and** LookML dashboards (the API returns both identically). Key extraction details
@@ -707,4 +715,4 @@ declaring Phase 4 green.
 | Looker LookML deploy fails "Invalid lookml syntax" | Compact `{ a: yes; b: yes; }` params | Use multi-line blocks; only `;;` terminates a `sql` |
 | LookML model 404s on query right after deploy | Model not registered | `POST /lookml_models {name, project_name, allowed_db_connection_names}` |
 | `PUT /projects/{id}` 404 when setting git remote | Wrong verb | Use `PATCH /projects/{id}` |
-| Looker dev-workspace mutation has no effect | Each `looker_api.py` call logs in fresh (new session) | For multi-step dev flows use ONE persistent session (`PATCH /session {workspace_id: dev}` then reuse the bearer) |
+| Looker dev-workspace mutation has no effect | The calls ran in separate processes/sessions (the bearer cache is per-process; a 401 re-login also starts a NEW session that resets the workspace to production) | Do the whole dev flow in ONE process — `looker_api.py`'s cached token keeps one session, so `PATCH /session {workspace_id: dev}` sticks for subsequent `call()`s; re-PATCH after any forced re-login |

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/looker_api.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/looker_api.py
@@ -11,11 +11,23 @@ Usage:
 import json
 import os
 import sys
+import threading
 import urllib.parse
 import urllib.request
 from configparser import ConfigParser
 
 INI = os.path.expanduser("~/.looker/looker.ini")
+
+# In-process token cache (same pattern as fetch_looker_dashboard.get._cache):
+# login ONCE per process instead of once per call() — Looker bearers live ~1h,
+# so for a multi-call run (parity fetches, estate walks) this removes a full
+# network round-trip per call. call() retries once with a fresh login on 401.
+# DEV-WORKSPACE CAVEAT: caching keeps ONE session across calls, which is what
+# dev-workspace flows REQUIRE (`PATCH /session {workspace_id: dev}` only sticks
+# within a session) — but a forced re-login (the 401 retry, or login(force=True))
+# starts a NEW session that resets the workspace to production; re-PATCH after.
+_token_lock = threading.Lock()
+_token_cache = {}  # base_url -> access_token
 
 
 def _cfg():
@@ -38,16 +50,25 @@ def _ctx(verify):
     return ctx
 
 
-def login():
+def login(force=False):
+    """Return (base, token, verify), reusing the per-process cached token.
+
+    force=True mints a fresh token (NEW Looker session — see the dev-workspace
+    caveat above). Thread-safe: parallel callers share one login.
+    """
     base, cid, csec, verify = _cfg()
-    data = urllib.parse.urlencode({"client_id": cid, "client_secret": csec}).encode()
-    req = urllib.request.Request(base + "/login", data=data, method="POST")
-    with urllib.request.urlopen(req, context=_ctx(verify), timeout=30) as r:
-        tok = json.load(r)["access_token"]
+    with _token_lock:
+        if not force and base in _token_cache:
+            return base, _token_cache[base], verify
+        data = urllib.parse.urlencode({"client_id": cid, "client_secret": csec}).encode()
+        req = urllib.request.Request(base + "/login", data=data, method="POST")
+        with urllib.request.urlopen(req, context=_ctx(verify), timeout=30) as r:
+            tok = json.load(r)["access_token"]
+        _token_cache[base] = tok
     return base, tok, verify
 
 
-def call(method, path, body=None):
+def call(method, path, body=None, _retry=True):
     base, tok, verify = login()
     if not path.startswith("/"):
         path = "/" + path
@@ -65,6 +86,10 @@ def call(method, path, body=None):
     except urllib.error.HTTPError as e:
         raw = e.read().decode()
         code = e.code
+    if code == 401 and _retry:
+        # cached token expired (~1h TTL) — re-login once and retry.
+        login(force=True)
+        return call(method, path, body, _retry=False)
     try:
         parsed = json.loads(raw)
     except Exception:

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -73,6 +73,7 @@ but a parity/hard gate FAILED; other = error.
 """
 import argparse, csv, glob, io, json, os, re, statistics, subprocess, sys, time
 import urllib.request, urllib.error
+from concurrent.futures import ThreadPoolExecutor
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from build_workbook import build_field_index, disp, leaf
 
@@ -679,18 +680,25 @@ console.error('stats:', JSON.stringify(res.stats));
     by_name = {e.get("name"): e for e in dash["elements"]}
     ev = SourceEval(measures, view_pk, explore, mh)
     expected, actuals = {}, {}
-    for c in plan["charts"]:
+
+    # Both fetch sides are per-chart and independent — fan them out N-wide
+    # (default 4; LOOKER_PARITY_WORKERS overrides, e.g. =1 on a loaded
+    # warehouse). The Sigma CSV exports and the Looker inline queries are each
+    # network-bound; 4 concurrent queries is a modest, warehouse-friendly burst.
+    # looker_api's token cache is thread-safe (one shared login).
+    def parity_fetch(c):
         cname = c["chart"]
+        msgs = []
         headers, rows = parse_csv(export_csv(wb, c["sigma_element_id"]))
         cidx = {h: i for i, h in enumerate(headers)}
         want = c["sigma_columns"]
         if len(want) == 1:                      # KPI
             vi = cidx.get(want[0], 0)
-            actuals[cname] = [[None, numify(rows[0][vi])]] if rows else []
+            act = [[None, numify(rows[0][vi])]] if rows else []
         else:
             di = cidx.get(want[0], 0)
             vi = cidx.get(want[1], 1 if len(headers) > 1 else 0)
-            actuals[cname] = [[row[di], numify(row[vi])] for row in rows]
+            act = [[row[di], numify(row[vi])] for row in rows]
         el = by_name.get(cname)
         want_label = None
         if not el and " · " in cname:
@@ -698,19 +706,32 @@ console.error('stats:', JSON.stringify(res.stats));
             base_name, want_label = cname.rsplit(" · ", 1)
             el = by_name.get(base_name)
         if not el:
-            print(f"   WARN: no source tile named {cname!r} in the contract — chart will DIVERGE")
-            continue
+            msgs.append(f"   WARN: no source tile named {cname!r} in the contract — chart will DIVERGE")
+            return cname, act, None, msgs
         exp = None
         if not offline:
             try:
                 exp = expected_live(el, measures, want_label)
             except Exception as ex:
-                print(f"   WARN: Looker inline query failed for {cname!r} ({ex}); "
-                      "falling back to warehouse re-aggregation")
+                msgs.append(f"   WARN: Looker inline query failed for {cname!r} ({ex}); "
+                            "falling back to warehouse re-aggregation")
         if exp is None:
             exp = expected_offline(el, ev, mr)
+        return cname, act, exp, msgs
+
+    workers = max(1, min(4, int(os.environ.get("LOOKER_PARITY_WORKERS", "4") or 4),
+                         len(plan["charts"])))
+    t_par = time.time()
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        results = list(pool.map(parity_fetch, plan["charts"]))
+    for cname, act, exp, msgs in results:
+        for m in msgs:
+            print(m)
+        actuals[cname] = act
         if exp is not None:
             expected[cname] = exp
+    print(f"   fetched expected+actual for {len(plan['charts'])} chart(s) "
+          f"{workers}-wide in {time.time() - t_par:.1f}s")
     json.dump(expected, open(os.path.join(wd, "parity-expected.json"), "w"), indent=2)
     json.dump(actuals, open(os.path.join(wd, "parity-actuals.json"), "w"), indent=2)
     rc, _ = run(["ruby", os.path.join(HERE, "phase6-parity-looker.rb"),

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/phase6-parity-looker.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/phase6-parity-looker.rb
@@ -21,8 +21,9 @@
 #     - a reminder to fetch EXPECTED rows from Looker (inline query) or the
 #       warehouse with the same dimension + aggregation
 #
-#   The agent (or scripts/migrate-looker.py, which scripts this whole flow)
-#   then writes two JSON files keyed by chart name, each
+#   The agent (or scripts/migrate-looker.py, which scripts this whole flow —
+#   fetching BOTH sides per chart in a bounded 4-wide thread pool, see
+#   LOOKER_PARITY_WORKERS) then writes two JSON files keyed by chart name, each
 #   { "<chart name>": [[dim, val], ...], ... } :
 #     <workdir>/parity-expected.json   (Looker / warehouse ground truth)
 #     <workdir>/parity-actuals.json    (Sigma element rows)


### PR DESCRIPTION
Priorities 5 and 6 of the approved discovery-speed plan (cognos = reliability, looker = small wins). Scope-disciplined: only `plugins/cognos-to-sigma/` and `plugins/looker-to-sigma/` touched.

## Cognos — batch-window discovery (reliability, not speed)

CAoC sessions die in minutes (HTTP 441 + Akamai WAF), so estate walks burned a human re-auth cycle every few objects.

- **NEW `scripts/cognos-batch-fetch.sh`** — `batch` walks the folder tree and pulls ALL module + report specs in one hot-session window, parallel curl **hard-capped at 4** (Akamai WAF; modest bursts only). Every fetch lands in a disk cache keyed **object id + modificationTime** (`~/.cognos/batch-cache` default). Session death stops cleanly — `SESSION DIED — N of M specs fetched … re-run the SAME command to RESUME` (exit 4) — and a re-run resumes from the manifest + cache.
- **`one {module|report} <id>`** serves single-artifact runs from the same cache: one cheap metadata GET; unchanged modificationTime = cache HIT, no spec re-fetch.
- SKILL.md Phase 0 documents the batch-window workflow and keeps pushing the **durable CA API-key path**; QUICKSTART + `cognos-discover.sh` point at it.

**Resume proof (local mock CA server, per-cookie request budget → 441 after 6 requests):**

| step | result |
|---|---|
| run 1 (cookie A) | walked 8 artifacts, fetched **3/8**, hit 441 → exit 4 with resume message |
| run 2 (cookie B = "re-auth") | reused manifest, skipped 3 cached, fetched remaining 5 in **exactly 5 requests** → COMPLETE 8/8, exit 0 |
| mock `maxConcurrent` | **4** (cap respected) |
| `one report rep3` | cache HIT, **1 request**, spec served from disk |
| server-side modificationTime bump | cache MISS → re-fetch → subsequent HIT at new mtime |
| dead session on `one` | loud failure naming the cached copy + its mtime |

## Looker — discovery already sub-second (now says so in SKILL.md); two wins

1. **`looker_api.py` token caching** — per-process bearer cache (same pattern as `fetch_looker_dashboard.get._cache`), thread-safe, one forced re-login retry on 401; dev-workspace single-session caveat documented in-code (cache actually *helps* dev flows — one session persists). Assessment skill's vendored copy kept byte-identical.

   Live hakkoda1, 10× `GET /user`: **267ms/call → 113ms/call (2.36x, ~154ms saved/call)**.

2. **Phase-6 parity fetch 4-wide** in `migrate-looker.py` — Sigma CSV export + Looker `expected_live` inline query per chart now run in a bounded `ThreadPoolExecutor` (default 4, `LOOKER_PARITY_WORKERS` override, clamped ≤4 — warehouse-load aware).

**E2E (offline fixture one-command migration, both runs PARITY GREEN 5/5 + hard gate PASS, posted objects deleted after):**

| run | parity fetch | whole command |
|---|---|---|
| `LOOKER_PARITY_WORKERS=1` (old serial) | 24.3s | 45.3s |
| default 4-wide | **5.8s (4.2x)** | **22.4s** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)