### PR TITLE
Fast discovery for qlik + thoughtspot (customer scale)

### DIFF
--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -89,6 +89,32 @@ Assemble into the converter's input JSON (`refs/example-converter-input.json`):
 `{appName, tables:[{name, noOfRows, fields:[{name}]}], masterMeasures:[{title,qDef}], masterDimensions:[]}`.
 **Use the post-rename Qlik field names** so relationships come out clean.
 
+### Discovery speed & safety (customer scale — 20-40+ apps)
+Discovery is **fully parallel and strictly read-only** (re-engineered 2026-06-11):
+- All engine/REST fetches share one pool (`--pool`, default 8) bounded by a
+  single global semaphore — the per-object `properties` loop was the serial
+  bottleneck (46 × ~1.2s). Measured on the 46-object fixture app:
+  **57.3s serial → 12.5s full / 8.4s with `--defer-snapshot`** (≈4.6×). Per-app
+  cost scales with pool width, not object count — a 40-app estate's discovery
+  drops from ~38 min to ~6 min of source-side wall clock.
+- **Zero app writes**: master items are enumerated via read-only
+  `qlik app measure/dimension ls` + per-item `properties`. The old temp
+  MeasureList/DimensionList object briefly SAVED the app — bumping
+  `modifiedDate` on every discovery (verified live: old run bumps it, three
+  new-mode runs leave it untouched). Discovery never reloads, never writes.
+- **Engine-snapshot lane**: the KPI/max-date/bucket evals (`snapshot.json`) are
+  consumed only at the Phase-6 freshness banner, and in-memory totals can't
+  change without a reload — so `migrate-qlik.rb` runs discovery with
+  `--defer-snapshot` and computes the snapshot via `--snapshot-only` as a
+  background lane under Phases 2-5.
+- **Throttle handling (never silent)**: Qlik Cloud throttles new engine
+  sessions after rapid bursts ("could not connect to engine"). Transient
+  errors retry with exponential backoff; anything still missing after a pooled
+  + serial second pass **aborts discovery (exit 4)** rather than silently
+  building a workbook with missing sheets/charts. `timings.json` (and
+  `timings-snapshot.json`) record per-stage wall-clock + retry counts on every
+  run.
+
 ### Phase 1.5 — SOURCE-FRESHNESS PREFLIGHT (never skip)
 Before ANY side-by-side, compare the app's `lastReloadTime` + in-memory snapshot
 against the live warehouse. Qlik shows a **reload-time snapshot**; Sigma queries the
@@ -209,10 +235,10 @@ the likely cause. (First run matched to the cent; staleness-explained deltas don
 ## Scripts
 | Script | Phase | Purpose |
 |---|---|---|
-| `scripts/qlik-discover.py` | 1 | Extract data model (load script), master measures/dimensions (Engine MeasureList/DimensionList), and sheets/charts from any app → `converter-input.json`. **Validated.** |
+| `scripts/qlik-discover.py` | 1 | Extract data model (load script), master measures/dimensions (read-only `measure/dimension ls` + properties), and sheets/charts from any app → `converter-input.json`. Pooled (`--pool 8`), strictly read-only, `--defer-snapshot`/`--snapshot-only` lanes, `timings.json` evidence. **Validated (57.3s → 12.5s on the 46-object fixture app).** |
 | `scripts/qlik-dm-signature.py` | 2.5 | Converter-input JSON → DM-reuse signature (`{warehouse_tables, referenced_columns, measures}`) for `find-or-pick-dm.rb`. **Validated live.** |
 | `scripts/vendor/find-or-pick-dm.rb` | 2.5 | Scan existing Sigma DMs and recommend reuse (score = 0.7·column + 0.2·table + 0.1·metric overlap; `--auto-pick` with tie-window safety). Shared vendor-neutral copy (canonical: tableau-to-sigma). Non-destructive. |
-| `scripts/migrate-qlik.rb` | ALL | **The one command** — chains every phase below for any app/sheet; OPEN-QUESTIONS checkpoint, freshness preflight, bucket parity; `--from-discovery` + `--dry-run` = offline smoke. **Validated live 2026-06-10 (1m59s, zero hand-edits).** |
+| `scripts/migrate-qlik.rb` | ALL | **The one command** — chains every phase below for any app/sheet; OPEN-QUESTIONS checkpoint, freshness preflight, bucket parity; `--from-discovery` + `--dry-run` = offline smoke. Discovery runs as a background lane with Sigma-side prep (token, folder, DM-spec prefetch for Phase 2.5) interleaved in the foreground; the engine snapshot runs as its own lane under Phases 2-5; `PHASE TIMINGS` printed at exit. **Validated live 2026-06-11 (68s wall, zero hand-edits, GREEN incl. layout lint).** |
 | `scripts/reconcile-columns.py` | 3 | Auto-derive the Qlik-field → real-warehouse-column map from the load script's `AS` aliases + `FROM` tables (so the DM points at real columns). **Validated.** |
 | `scripts/gen-denorm-sql.py` | 3 | Turn reconcile.json into the denormalized SQL element (`real AS qlik` + inferred fact↔dim joins) — feeds `build-sigma-dm.py`. Display names match Sigma's own derivation rule. **Validated.** |
 | `scripts/batch-migrate.py` | 3–6 | Migrate many apps in one pass (one Sigma workbook each, reusing a SHARED DM) — for tenant-scale demos. For distinct apps, run `migrate-qlik.rb` per app. **Validated on 5 apps.** |
@@ -225,11 +251,13 @@ the likely cause. (First run matched to the cent; staleness-explained deltas don
 | `refs/example-converter-input.json` | 1–2 | The exact convert_qlik_to_sigma input from the first migration. |
 | `fixtures/retail-orders/` | — | Complete offline discovery+converter input set (sanitized demo app) — see `fixtures/README.md` for the offline smoke path. |
 
-`qlik-discover.py --app <id>` enumerates master items via a temporary
-`MeasureList`/`DimensionList` object (create → layout → remove; briefly saves the
-app and cleans up) — qlik-cli's `object ls` does NOT list master items. Everything
-else (incl. `qlik app eval` for the freshness snapshot) is read-only; the app is
-never reloaded.
+`qlik-discover.py --app <id>` enumerates master items via the read-only
+`qlik app measure ls` / `qlik app dimension ls` + per-item `properties`
+(qlik-cli's `object ls` does NOT list master items; the old temp
+MeasureList/DimensionList object create→rm briefly SAVED the app, bumping its
+`modifiedDate` on every discovery — eliminated 2026-06-11). Everything
+(incl. `qlik app eval` for the freshness snapshot) is read-only; the app is
+never reloaded and never written.
 
 ## Open work
 - ✅ Set Analysis (simple) → `Sum(If(...))` — auto-translated in the converter + validated live (2026-06-05). Host dim-flag measures on the denorm element.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -9,7 +9,17 @@
 # This script does NOT re-implement any phase — it chains the per-phase scripts
 # (each independently usable + artifact-driven):
 #   qlik-discover.py            (Phase 1 — model, charts, sheet CELL GRIDS, app
-#                                freshness meta + Qlik-engine KPI snapshot)
+#                                freshness meta + Qlik-engine KPI snapshot.
+#                                Runs as a BACKGROUND lane with --defer-snapshot
+#                                while the pure-Sigma-side prep — token mint,
+#                                folder resolve, DM list+spec prefetch — runs
+#                                concurrently in the foreground; the engine
+#                                snapshot then runs as its OWN background lane
+#                                under Phases 2-4 and is consumed only at the
+#                                Phase-6 freshness banner. In-memory app totals
+#                                cannot change without a reload, so the deferral
+#                                is exact. Measured: 54.8s serial discovery →
+#                                ~12s lane + ~4s snapshot hidden under the build.)
 #   convertQlikToSigma()        (Phase 2 — the sigma-data-model-mcp converter, via node shim)
 #   reconcile-columns.py + gen-denorm-sql.py + build-sigma-dm.py
 #                               (Phase 3 — star repointed via reconcile + denorm
@@ -47,8 +57,62 @@ require 'fileutils'
 require 'open3'
 require 'time'
 
+$stdout.sync = true # lane/foreground progress lines interleave correctly
+
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('vendor/lib', HERE)
+
+# Phase-timing summary — printed at every terminal exit so the discovery
+# interleave speedup stays visible in every run (regressions show up in the
+# first slow report instead of an investigation).
+START_T = Time.now
+PHASE_T = {}
+$t_mark = Time.now
+def mark(key)
+  now = Time.now
+  PHASE_T[key] = (PHASE_T[key] || 0.0) + (now - $t_mark)
+  $t_mark = now
+end
+
+def phase_summary
+  return if PHASE_T.empty?
+  puts
+  puts "PHASE TIMINGS  #{PHASE_T.map { |k, v| "#{k}=#{v.round(1)}s" }.join('  ')}  " \
+       "total=#{(Time.now - START_T).round(1)}s"
+end
+
+# Background lanes (discovery / engine snapshot). Artifacts are written
+# atomically by qlik-discover.py, so polling for them is safe.
+def spawn_lane(cmd, log)
+  File.write(log, '')
+  { started: Time.now, log: log, status: nil,
+    pid: Process.spawn(*cmd, %i[out err] => [log, 'a']) }
+end
+
+def lane_done?(lane)
+  return true if lane.nil? || lane[:status]
+  if (st = Process.wait2(lane[:pid], Process::WNOHANG))
+    lane[:status] = st[1]
+    lane[:ended] = Time.now
+    true
+  else
+    false
+  end
+end
+
+def join_lane(lane, label, timeout: 600)
+  t0 = Time.now
+  until lane_done?(lane)
+    abort "FATAL: #{label} lane timed out (#{timeout}s)" if Time.now - t0 > timeout
+    sleep 0.1
+  end
+  lane
+end
+
+def print_lane_log(lane)
+  return unless lane && File.exist?(lane[:log])
+  File.read(lane[:log]).each_line { |l| puts "   │ #{l.rstrip}" }
+end
 
 opts = { context: 'sigma-migration', database: 'CSA', schema: 'TJ' }
 OptionParser.new do |o|
@@ -107,10 +171,19 @@ end
 TOTAL = 6
 
 # ---------------------------------------------------------------------------
-# Phase 1 — Discover (qlik-cli: load script, master items, charts, sheet grids,
-#                     app freshness meta + Qlik-engine KPI snapshot)
+# Phase 1 — Discover (qlik-cli), INTERLEAVED. qlik-discover.py (its own pooled
+# fetcher, --defer-snapshot) runs as a BACKGROUND lane while the pure-Sigma-
+# side prep (token mint, folder resolve, DM list+spec prefetch for the
+# Phase-2.5 reuse scan — all READ-ONLY, no Sigma objects created) runs
+# concurrently in the foreground. The lanes JOIN before anything consumes
+# discovery output. The Qlik-engine snapshot then runs as its OWN lane under
+# Phases 2-4 (in-memory totals can't change without a reload) and is consumed
+# at the Phase-6 freshness banner.
 # ---------------------------------------------------------------------------
 hdr(1, TOTAL, 'Discover')
+$t_mark = Time.now
+snap_lane = nil
+prep = {}
 if opts[:from]
   %w[script.qvs measures.json charts.json converter-input.json].each do |f|
     abort "FATAL: --from-discovery dir missing #{f}" unless File.exist?(File.join(opts[:from], f))
@@ -120,9 +193,87 @@ if opts[:from]
   end
   puts "   reusing discovery artifacts from #{opts[:from]}"
 else
-  run!(['python3', File.join(HERE, 'qlik-discover.py'),
-        '--app', opts[:app], '--context', opts[:context], '--out', WORK])
+  disc_lane = spawn_lane(['python3', File.join(HERE, 'qlik-discover.py'),
+                          '--app', opts[:app], '--context', opts[:context],
+                          '--out', WORK, '--defer-snapshot'],
+                         File.join(WORK, 'phase1-discover.log'))
+  puts "   Qlik discovery: BACKGROUND lane (pid #{disc_lane[:pid]}, log phase1-discover.log;"
+  puts "   engine snapshot deferred to its own lane). Sigma-side prep runs concurrently."
+
+  if opts[:dry_run]
+    puts '   Sigma-side prep skipped (--dry-run)'
+  else
+    begin
+      require 'sigma_rest'
+      Sigma.auth_token # mint once — exported via ENV to every child script
+      puts '   ✓ Sigma token ready'
+      # Folder resolve (read-only; same preference order as build-sigma-dm.py's
+      # pick_folder: editable TEST/MIGRATION folder, else first editable).
+      folders = (Sigma.request(:get, '/v2/files?typeFilters=folder&limit=200')['entries'] rescue []) || []
+      editable = folders.select do |f|
+        f['type'] == 'folder' && (%w[edit contribute].include?(f['permission']) || f['permission'].nil?)
+      end
+      pick = editable.find { |f| f['name'].to_s.upcase =~ /TEST|MIGRATION/ } || editable.first
+      if pick
+        prep[:folder_id], prep[:folder_name] = pick['id'], pick['name']
+        puts "   ✓ folder resolved: '#{pick['name']}' (#{pick['id']})" \
+             "#{opts[:folder] ? ' — overridden by --folder' : ''}"
+      end
+      # DM list + spec prefetch — warms the Phase-2.5 reuse scan so it costs ~0
+      # at scan time (mirrors find-or-pick-dm.rb's own list/sort/limit logic).
+      all_dms, page = [], nil
+      loop do
+        qs = 'limit=100' + (page ? "&page=#{page}" : '')
+        data = (Sigma.request(:get, "/v2/dataModels?#{qs}") rescue {})
+        rows = data['entries'] || data['dataModels'] || []
+        break if rows.empty?
+        all_dms.concat(rows)
+        break if all_dms.size >= 500
+        page = data['nextPage']
+        break if page.nil? || page.to_s.empty?
+      end
+      top = all_dms.sort_by { |dm| [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s] }
+                   .first(25)
+      specs, smu, sq = {}, Mutex.new, Queue.new
+      top.each { |dm| sq << dm }
+      Array.new(5) do
+        Thread.new do
+          loop do
+            dm = (sq.pop(true) rescue nil) or break
+            dm_id = dm['dataModelId'] || dm['id']
+            next unless dm_id
+            # spec endpoint may answer YAML — store the RAW body; the scan
+            # (find-or-pick-dm.rb --specs-cache) parses JSON-else-YAML itself.
+            raw = (Sigma.request(:get, "/v2/dataModels/#{dm_id}/spec", accept: '*/*') rescue nil)
+            smu.synchronize { specs[dm_id] = raw } if raw && !raw.to_s.empty?
+          end
+        end
+      end.each(&:join)
+      File.write(File.join(WORK, 'dm-specs-cache.json'),
+                 JSON.generate('fetched_at' => Time.now.utc.iso8601,
+                               'dms' => all_dms, 'specs' => specs))
+      puts "   ✓ prefetched #{specs.size}/#{all_dms.size} DM spec(s) → dm-specs-cache.json (feeds Phase 2.5)"
+    rescue StandardError => e
+      puts "   Sigma-side prep degraded (#{e.class}: #{e.message[0, 120]}) — later phases fall back to inline resolution"
+    end
+  end
+  mark('phase1-prep(fg)')
+
+  join_lane(disc_lane, 'discovery')
+  print_lane_log(disc_lane)
+  abort "FATAL: qlik discovery failed (exit #{disc_lane[:status].exitstatus}) — see lane log above" \
+    unless disc_lane[:status].success?
+  PHASE_T['phase1-discovery(bg)'] = (disc_lane[:ended] - disc_lane[:started])
+
+  # Engine-snapshot lane: runs under Phases 2-4, joined at Phase 6. Read-only.
+  snap_lane = spawn_lane(['python3', File.join(HERE, 'qlik-discover.py'),
+                          '--app', opts[:app], '--context', opts[:context],
+                          '--out', WORK, '--snapshot-only'],
+                         File.join(WORK, 'phase1-snapshot.log'))
+  puts "   engine-snapshot lane started (pid #{snap_lane[:pid]}) — runs under Phases 2-4," \
+       ' consumed at the Phase-6 freshness banner'
 end
+mark('phase1')
 
 conv_input = JSON.parse(File.read(File.join(WORK, 'converter-input.json')))
 charts     = JSON.parse(File.read(File.join(WORK, 'charts.json')))
@@ -152,6 +303,8 @@ if (lr = app_meta['lastReloadTime'])
   if (snapshot['kpis'] || []).any?
     puts "      Qlik in-memory snapshot: " +
          snapshot['kpis'].map { |k| "#{k['title']}=#{k['value']}" }.join(' · ')
+  elsif snap_lane
+    puts '      Qlik in-memory KPI snapshot: evaluating in a background lane — consumed at Phase 6.'
   end
   if stale_days >= 1
     puts "      → The Qlik snapshot is ~#{stale_days.ceil} day(s) old. Sigma queries the LIVE warehouse"
@@ -191,6 +344,41 @@ cstats = conv['stats'] || {}
 puts "   #{cstats['elements']} element(s), #{cstats['columns']} column(s), " \
      "#{cstats['metrics']} metric(s), #{cstats['relationships']} relationship(s); " \
      "#{conv_warnings.size} converter warning(s)"
+mark('phase2-convert')
+
+# ---------------------------------------------------------------------------
+# Phase 2.5 — DM-reuse scan (non-destructive; candidates PRINTED, default =
+# BUILD NEW). Consumes the dm-specs-cache.json prefetched concurrently with
+# discovery, so the scan itself costs ~0 network. Reuse stays an explicit
+# human decision — see SKILL.md Phase 2.5.
+# ---------------------------------------------------------------------------
+hdr('2.5', TOTAL, 'DM-reuse scan')
+if opts[:dry_run]
+  puts '   skipped (--dry-run: no Sigma access)'
+else
+  begin
+    sig_path = File.join(WORK, 'dm-signature.json')
+    run!(['python3', File.join(HERE, 'qlik-dm-signature.py'),
+          '--model', File.join(WORK, 'converter-input.json'),
+          '--database', opts[:database], '--schema', opts[:schema], '--out', sig_path])
+    match_path = File.join(WORK, 'dm-match.json')
+    fp_cmd = ['ruby', File.join(HERE, 'vendor', 'find-or-pick-dm.rb'),
+              '--workbook-signature', sig_path, '--out', match_path]
+    cache_path = File.join(WORK, 'dm-specs-cache.json')
+    fp_cmd += ['--specs-cache', cache_path] if File.exist?(cache_path)
+    _, _fp_st = Open3.capture2e(*fp_cmd) # exit 1 = no candidate ≥ min-score (normal)
+    cands = ((JSON.parse(File.read(match_path))['candidates'] rescue nil) || []).first(3)
+    if cands.any?
+      puts '   top candidate(s) — default is BUILD NEW; to reuse, follow SKILL.md Phase 2.5:'
+      cands.each { |c| puts "     score #{format('%.2f', c['score'] || 0)}  #{c['dm_id']}  '#{c['dm_name']}'" }
+    else
+      puts '   no existing DM covers this app — building new'
+    end
+  rescue StandardError => e
+    puts "   DM-reuse scan unavailable (#{e.message[0, 100]}) — building new"
+  end
+end
+mark('phase2.5-dm-scan')
 
 # ---------------------------------------------------------------------------
 # DECISIONS CHECKPOINT — surface the genuine Qlik human questions ONLY
@@ -247,9 +435,10 @@ end
 
 # (e) folder not supplied
 unless opts[:folder] || opts[:dry_run]
+  resolved = prep[:folder_id] ? "'#{prep[:folder_name]}' (#{prep[:folder_id]}) — pre-resolved during discovery" \
+                              : 'the first editable folder (prefers a TEST/MIGRATION folder)'
   questions << { 'id' => 'folder', 'severity' => 'required',
-                 'detail' => 'No Sigma --folder supplied; DM + workbook will land in the first editable folder ' \
-                             '(prefers a TEST/MIGRATION folder).',
+                 'detail' => "No Sigma --folder supplied; DM + workbook will land in #{resolved}.",
                  'options' => ['supply --folder <id>', 'proceed into auto-resolved folder'],
                  'default' => 'proceed into auto-resolved folder' }
 end
@@ -274,6 +463,12 @@ if questions.any? && !opts[:yes] && answers.nil?
   puts '======================================================='
   puts
   puts "#{questions.size} decision(s) need a human. No Sigma objects were created."
+  if snap_lane && !lane_done?(snap_lane)
+    puts '   (waiting for the background engine-snapshot lane so the discovery dir is complete'
+    puts "    — re-run with --from-discovery #{WORK} to skip re-discovery)"
+    join_lane(snap_lane, 'snapshot', timeout: 300)
+  end
+  phase_summary
   exit 10
 end
 
@@ -289,6 +484,8 @@ if questions.any?
     chosen = (answers && answers[q['id']]) || q['default']
     if chosen.to_s.start_with?('abort')
       puts "   '#{q['id']}' answered abort — stopping before any Sigma object is created."
+      join_lane(snap_lane, 'snapshot', timeout: 300) if snap_lane
+      phase_summary
       exit 10
     end
   end
@@ -313,7 +510,11 @@ dm_cmd = ['python3', File.join(HERE, 'build-sigma-dm.py'),
           '--denorm', denorm_out, '--measures', File.join(WORK, 'measures.json'),
           '--name', "#{base_name} (Qlik→Sigma)",
           '--out', File.join(WORK, 'dm-result.json'), '--spec-out', File.join(WORK, 'dm-spec.json')]
-dm_cmd += ['--folder', opts[:folder]] if opts[:folder]
+# --folder: explicit flag wins; else the folder pre-resolved concurrently with
+# discovery (identical preference order), saving build-sigma-dm.py the lookup.
+if (fid = opts[:folder] || prep[:folder_id])
+  dm_cmd += ['--folder', fid]
+end
 dm_cmd << '--dry-run' if opts[:dry_run]
 run!(dm_cmd)
 dm_res = JSON.parse(File.read(File.join(WORK, 'dm-result.json')))
@@ -321,6 +522,7 @@ DM_ID = dm_res['dataModelId']
 puts "   dataModelId = #{DM_ID || '(dry-run)'}  denorm element #{dm_res['denormElementId']}  " \
      "#{dm_res['starElements']} star element(s), #{dm_res['metricsKept']} metric(s)" \
      "#{dm_res['metricsDropped'].to_a.any? ? "; dropped: #{dm_res['metricsDropped'].join(', ')}" : ''}"
+mark('phase3-dm')
 
 # ---------------------------------------------------------------------------
 # Phase 4 — Build workbook (one Sigma page per Qlik sheet, from charts.json)
@@ -334,7 +536,7 @@ wb_cmd = ['python3', File.join(HERE, 'build-sigma-workbook.py'),
           '--out', File.join(WORK, 'wb-result.json'), '--spec-out', File.join(WORK, 'wb-spec.json'),
           '--layout-out', File.join(WORK, 'layout.xml'),
           '--element-map', File.join(WORK, 'element-map.json')]
-wb_cmd += ['--folder', (opts[:folder] || dm_res['folderId'])] if opts[:folder] || dm_res['folderId']
+wb_cmd += ['--folder', (opts[:folder] || dm_res['folderId'] || prep[:folder_id])] if opts[:folder] || dm_res['folderId'] || prep[:folder_id]
 wb_cmd << '--dry-run' if opts[:dry_run]
 run!(wb_cmd)
 wb_res = JSON.parse(File.read(File.join(WORK, 'wb-result.json')))
@@ -342,6 +544,7 @@ WB_ID = wb_res['workbookId']
 emap  = JSON.parse(File.read(File.join(WORK, 'element-map.json')))
 puts "   workbookId = #{WB_ID || '(dry-run)'}  (#{wb_res['pages']} page(s), #{wb_res['elements']} element(s), " \
      "#{wb_res['kpis']} KPI(s))"
+mark('phase4-wb')
 
 # ---------------------------------------------------------------------------
 # Phase 5 — Layout (the Qlik sheet cell grids, mapped onto Sigma's 24-col grid)
@@ -354,11 +557,28 @@ else
         '--workbook', WB_ID, '--layout', File.join(WORK, 'layout.xml')])
   puts "   layout applied (#{sheets.size} Qlik sheet grid(s) → 24-col Sigma grid, row-scale ≥2)"
 end
+mark('phase5-layout')
 
 # ---------------------------------------------------------------------------
 # Phase 6 — Parity (freshness banner FIRST, then columns + values + buckets)
 # ---------------------------------------------------------------------------
 hdr(6, TOTAL, 'Parity')
+# Join the engine-snapshot lane (started at Phase 1, ran under Phases 2-5).
+# The freshness banner + bucket parity below consume it; in-memory totals
+# can't have changed (no reload happens anywhere in this pipeline).
+if snap_lane
+  join_lane(snap_lane, 'snapshot', timeout: 300)
+  PHASE_T['snapshot-lane(bg)'] = (snap_lane[:ended] - snap_lane[:started])
+  if snap_lane[:status].success?
+    snapshot = (JSON.parse(File.read(File.join(WORK, 'snapshot.json'))) rescue {})
+    puts "   engine-snapshot lane joined (#{(snap_lane[:ended] - snap_lane[:started]).round(1)}s, " \
+         "ran under Phases 2-5): #{(snapshot['kpis'] || []).size} KPI(s), " \
+         "#{(snapshot['buckets'] || []).size} bucket count(s)"
+  else
+    print_lane_log(snap_lane)
+    puts '   snapshot lane FAILED — falling back to live engine evals below'
+  end
+end
 if opts[:dry_run]
   puts '   DRY RUN: skipping live parity. Artifacts:'
   %w[dm-spec.json wb-spec.json layout.xml element-map.json].each { |f| puts "     #{File.join(WORK, f)}" }
@@ -366,6 +586,7 @@ if opts[:dry_run]
   puts '================ RESULT (dry run) ================'
   puts "specs       : #{WORK}"
   puts '=================================================='
+  phase_summary
   exit 0
 end
 
@@ -450,12 +671,17 @@ end
 puts
 puts '   ── BUCKET COUNTS (per chart, Sigma rows vs Qlik engine) ──'
 bucket_warns = 0
+# Bucket counts were precomputed by the snapshot lane (same expr strings —
+# see qlik-discover.py bucket_expr); live eval is only the fallback.
+snapshot_buckets = (snapshot['buckets'] || []).to_h { |b| [b['expr'], b['value']] }
 emap.reject { |e| e['kind'] == 'kpi-chart' }.each do |e|
   dims = e['qlik']['dims']
   next if dims.empty?
   expr = dims.size == 1 ? "Count(distinct [#{dims[0]}])" :
            "Count(distinct #{dims.map { |d| "[#{d}]" }.join("&'|'&")})"
-  qcount = opts[:app] ? numish(qlik_eval(opts[:app], opts[:context], expr))&.to_i : nil
+  qraw = snapshot_buckets[expr]
+  qraw = qlik_eval(opts[:app], opts[:context], expr) if qraw.nil? && opts[:app]
+  qcount = numish(qraw)&.to_i
   scount = csv_for[e['elementId']] ? csv_rows(csv_for[e['elementId']]).size : nil
   status = if qcount && scount && qcount == scount
              'MATCH'
@@ -470,6 +696,7 @@ end
 
 divergent = kpi_results.count('DIVERGENT')
 parity_ok = err_cols.empty? && entries.size.positive? && divergent.zero?
+mark('phase6-parity')
 
 # ---------------------------------------------------------------------------
 # Summary
@@ -484,4 +711,5 @@ puts "PARITY      : #{parity_ok ? 'GREEN' : 'RED'} — #{entries.size} cols reso
 puts "freshness   : Qlik last reload #{app_meta['lastReloadTime'] || '?'} (#{stale_days} days ago)" if stale_days
 puts "warnings    : #{conv_warnings.size} converter, #{(wb_res['warnings'] || []).size} workbook-build" if conv_warnings.any? || (wb_res['warnings'] || []).any?
 puts '======================================='
+phase_summary
 exit(parity_ok ? 0 : 3)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
@@ -7,7 +7,9 @@ sheet/chart inventory, the per-sheet CELL GRID (layout), the app's freshness
 metadata, and a Qlik-engine snapshot of the app's KPI totals — everything the
 downstream build steps need, with no hand-edits.
 
-    python3 qlik-discover.py --app <appId> [--context <ctx>] [--out discovery] [--skip-eval]
+    python3 qlik-discover.py --app <appId> [--context <ctx>] [--out discovery]
+                             [--pool 8] [--skip-eval]
+                             [--defer-snapshot | --snapshot-only]
 
 Outputs in --out/:
   script.qvs            raw load script (the data-model source of truth)
@@ -21,20 +23,96 @@ Outputs in --out/:
   app-meta.json         REST item record: name, lastReloadTime, hasSectionAccess,
                         isDirectQueryMode — feeds the source-freshness preflight
   snapshot.json         Qlik-engine eval of every sheet KPI expression + Max() of
-                        date-ish fact fields — the app's IN-MEMORY totals, used to
-                        report staleness vs the live warehouse before any parity
+                        date-ish fact fields + per-chart distinct-bucket counts —
+                        the app's IN-MEMORY totals, used to report staleness vs
+                        the live warehouse before any parity
   converter-input.json  ready for convert_qlik_to_sigma (tables + masterMeasures + masterDimensions)
+  timings.json          ALWAYS written — per-stage wall-clock + retry counts, the
+                        evidence trail for any future "discovery is slow" report
+                        (--snapshot-only writes timings-snapshot.json instead)
+
+PERFORMANCE (measured on app ec9a73e3, 46 objects, 2026-06-11): the serial
+version took ~55-64s; almost all of it was the per-object `properties` loop
+(46 × ~1.2s engine round-trips) plus the serial KPI/max-date evals. Everything
+network-bound now runs through ONE shared thread pool (--pool, default 8 —
+measured 4.7× on the properties batch; each qlik-cli call opens its own
+engine session so calls are independent). Customer apps at 40+ objects scale
+linearly in pool width, not object count.
+
+Snapshot deferral: the engine snapshot (KPI evals + max-date + bucket counts)
+is only CONSUMED at the orchestrator's Phase-6 freshness banner, and the app's
+in-memory totals cannot change without a reload — so `--defer-snapshot` skips
+it here and `--snapshot-only` computes JUST it (reading charts.json etc. from
+--out) as a background lane concurrent with Phases 2-4. snapshot.json is
+written atomically so a polling orchestrator never observes a half-written file.
 
 Requires qlik-cli on PATH and an active context (`qlik context use <ctx>`).
-Master items are enumerated via a temporary MeasureList/DimensionList object
-(create → layout → remove); this briefly saves the app and cleans up after.
-All other access is read-only; the app is NEVER reloaded.
+Discovery is STRICTLY READ-ONLY: master items are enumerated via
+`qlik app measure ls` / `qlik app dimension ls` + per-item `properties`
+(the old temp MeasureList/DimensionList object create→rm briefly SAVED the
+app — bumping its modifiedDate on every discovery; eliminated 2026-06-11).
+The app is NEVER reloaded and NEVER written.
+
+Transient engine failures ("session closed", "could not connect to engine",
+websocket drops, 429s) are retried with exponential backoff — expected
+occasionally at 8-wide concurrency, and Qlik Cloud throttles NEW engine
+sessions after rapid bursts (observed live 2026-06-11: back-to-back pool-8
+runs → "could not connect to engine" on 3/46 objects). Any per-object fetch
+still empty after the pooled pass is retried SERIALLY after a cooldown, and
+discovery ABORTS (exit 4) if anything is still missing — an incomplete
+charts.json must never silently become an incomplete Sigma workbook.
 """
-import json, os, re, subprocess, sys, argparse, tempfile, secrets, string
+import json, os, re, subprocess, sys, argparse, threading, time
+from concurrent.futures import ThreadPoolExecutor
+
+T0 = time.time()
+STAGES = {}          # stage name -> seconds (timings.json evidence trail)
+RETRIES = {"n": 0}
+_LOCK = threading.Lock()
+# Global cap on CONCURRENT qlik-cli engine sessions (set from --pool in main).
+# Several pmaps run at once (master measures + dimensions + top-level fetches),
+# so without one shared gate the burst is pools ADDED together (~19 sessions) —
+# which is what trips Qlik Cloud's new-session throttle. One semaphore makes
+# --pool the true total, whatever shape the fan-out has.
+_SEM = threading.Semaphore(8)
+
+TRANSIENT_RX = re.compile(
+    r"session closed|socket: close|websocket|connection reset|broken pipe"
+    r"|unexpected EOF|timed? ?out|temporarily unavailable"
+    r"|could not connect to engine|too many (requests|sessions)|429|rate limit", re.I)
+
+
+class stage:
+    """Record a stage's wall-clock into STAGES (concurrent stages overlap)."""
+    def __init__(self, name): self.name = name
+    def __enter__(self): self.t0 = time.time(); return self
+    def __exit__(self, *_):
+        with _LOCK:
+            STAGES[self.name] = round(STAGES.get(self.name, 0.0) + time.time() - self.t0, 3)
+
+
+def qlik_run(args, attempts=4):
+    """Run qlik-cli with retry + exponential backoff on transient engine
+    errors. Safe to retry: discovery is read-only. Backoff is exponential
+    (1s/2s/4s) because Qlik Cloud throttles new engine sessions after rapid
+    bursts — a fixed 0.5s retry just re-hits the throttle."""
+    out = None
+    for attempt in range(attempts):
+        with _SEM:
+            out = subprocess.run(["qlik", *args], capture_output=True, text=True)
+        if out.returncode == 0:
+            return out
+        if attempt < attempts - 1 and TRANSIENT_RX.search((out.stderr or "") + (out.stdout or "")):
+            with _LOCK:
+                RETRIES["n"] += 1
+            time.sleep(min(8.0, 2.0 ** attempt))
+            continue
+        return out
+    return out
+
 
 def qlik(*args, parse_json=True):
-    cmd = ["qlik", *args]
-    out = subprocess.run(cmd, capture_output=True, text=True)
+    out = qlik_run(list(args))
     if out.returncode != 0 and parse_json:
         sys.stderr.write(f"WARN {' '.join(args)} -> {out.stderr[:160]}\n")
     if not parse_json:
@@ -44,38 +122,77 @@ def qlik(*args, parse_json=True):
     except json.JSONDecodeError:
         return None
 
-def tmpid():
-    return "disc-" + "".join(secrets.choice(string.ascii_lowercase) for _ in range(8))
 
-def enumerate_master(app, ctx_args, kind):
-    """kind: 'measure' or 'dimension'. Returns list of {title, expr}."""
-    oid = tmpid()
-    if kind == "measure":
-        props = {"qInfo": {"qId": oid, "qType": "MeasureList"},
-                 "qMeasureListDef": {"qType": "measure",
-                     "qData": {"title": "/qMetaDef/title", "expr": "/qMeasure/qDef"}}}
-        layout_key, expr_field = "qMeasureList", "expr"
-    else:
-        props = {"qInfo": {"qId": oid, "qType": "DimensionList"},
-                 "qDimensionListDef": {"qType": "dimension",
-                     "qData": {"title": "/qMetaDef/title", "expr": "/qDim/qFieldDefs"}}}
-        layout_key, expr_field = "qDimensionList", "expr"
-    f = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
-    json.dump(props, f); f.close()
-    subprocess.run(["qlik", "app", "object", "set", f.name, "-a", app, *ctx_args],
-                   capture_output=True, text=True)
-    lay = qlik("app", "object", "layout", oid, "-a", app, *ctx_args)
-    subprocess.run(["qlik", "app", "object", "rm", oid, "-a", app, *ctx_args],
-                   capture_output=True, text=True)
-    os.unlink(f.name)
-    items = ((lay or {}).get(layout_key) or {}).get("qItems", [])
-    res = []
-    for it in items:
-        d = it.get("qData", {})
-        e = d.get(expr_field)
-        if isinstance(e, list): e = e[0] if e else ""
-        res.append({"title": d.get("title") or it.get("qInfo", {}).get("qId"), "expr": e or ""})
+def awrite(path, obj):
+    """Atomic JSON write — orchestrators poll for these files from a
+    concurrent lane and must never observe a half-written artifact."""
+    tmp = f"{path}.tmp.{os.getpid()}"
+    with open(tmp, "w") as f:
+        json.dump(obj, f, indent=2)
+    os.replace(tmp, path)
+
+
+def pmap(fn, items, pool):
+    """Parallel map preserving order. Submitted from the main thread only —
+    no nested submit-and-wait, so no executor deadlock."""
+    if not items:
+        return []
+    with ThreadPoolExecutor(max_workers=max(1, pool)) as ex:
+        return list(ex.map(fn, items))
+
+
+def pmap_complete(fetch, items, pool, key, what):
+    """pmap `fetch` (which returns a truthy dict or None) over items, then
+    retry any empty result SERIALLY after a cooldown — Qlik Cloud throttles
+    new engine sessions after rapid bursts, and the pooled pass can lose a few
+    items even with per-call retries (observed live: 3/46 object `properties`
+    failed with 'could not connect to engine'). ABORTS (exit 4) if anything is
+    still missing: a silently incomplete discovery (missing sheets/charts)
+    must never become a silently incomplete Sigma workbook."""
+    res = pmap(fetch, items, pool)
+    missing = [i for i, r in enumerate(res) if not r]
+    if missing:
+        sys.stderr.write(f"WARN {what}: {len(missing)}/{len(items)} pooled fetch(es) empty — "
+                         f"serial retry after 5s cooldown (engine session throttle)\n")
+        time.sleep(5)
+        for i in missing:
+            res[i] = fetch(items[i])
+    still = [str(key(items[i])) for i, r in enumerate(res) if not r]
+    if still:
+        sys.stderr.write(f"FATAL {what}: no properties for {len(still)} item(s) after pooled + "
+                         f"serial retries: {', '.join(still[:8])}\n"
+                         f"       The engine is refusing new sessions (throttle/capacity). "
+                         f"Re-run, or use a smaller --pool (e.g. 4).\n")
+        sys.exit(4)
     return res
+
+
+# ---- master items: READ-ONLY enumeration (measure/dimension ls + properties) ----
+def enumerate_master(app, ctx_args, kind, pool):
+    """kind: 'measure' or 'dimension'. Returns list of {title, expr}.
+    `qlik app {measure,dimension} ls` is read-only (verified: returns
+    [{qId,title}]); the expression comes from per-item `properties`
+    (qMeasure.qDef / qDim.qFieldDefs), fetched in parallel."""
+    items = qlik("app", kind, "ls", "-a", app, "--json", *ctx_args) or []
+
+    prop_list = pmap_complete(
+        lambda it: qlik("app", kind, "properties", it.get("qId"), "-a", app, *ctx_args),
+        items, pool, key=lambda it: it.get("qId"), what=f"master-{kind} properties")
+
+    def shape(it, props):
+        oid = it.get("qId")
+        if kind == "measure":
+            body = props.get("qMeasure") or {}
+            expr, label = body.get("qDef"), body.get("qLabel")
+        else:
+            body = props.get("qDim") or {}
+            defs = body.get("qFieldDefs") or []
+            expr, label = (defs[0] if defs else ""), body.get("title")
+        title = (props.get("qMetaDef") or {}).get("title") or it.get("title") or label or oid
+        return {"title": title, "expr": expr or ""}
+
+    return [shape(it, props) for it, props in zip(items, prop_list)]
+
 
 # ---- load-script → tables/fields (best-effort) ----
 def parse_script(qvs):
@@ -98,43 +215,180 @@ def parse_script(qvs):
             tables.append({"name": name, "noOfRows": 0, "fields": [{"name": f} for f in fields]})
     return tables
 
+
 def qlik_eval(app, ctx_args, expr):
     """Evaluate one expression via the engine (read-only). Returns the raw value string or None."""
-    out = subprocess.run(["qlik", "app", "eval", expr, "-a", app, *ctx_args],
-                         capture_output=True, text=True)
+    out = qlik_run(["app", "eval", expr, "-a", app, *ctx_args])
     lines = [l for l in out.stdout.splitlines() if l.strip()]
     return lines[1].strip() if out.returncode == 0 and len(lines) >= 2 else None
+
+
+def bucket_expr(dims):
+    """The distinct-bucket-count expression Phase 6 compares per chart —
+    MUST stay in sync with migrate-qlik.rb's bucket parity (same string)."""
+    if len(dims) == 1:
+        return f"Count(distinct [{dims[0]}])"
+    return "Count(distinct " + "&'|'&".join(f"[{d}]" for d in dims) + ")"
+
+
+def compute_snapshot(app, ctx, charts, tables, app_meta, pool, skip_eval):
+    """The Qlik-engine snapshot (source-freshness preflight input): every
+    on-sheet KPI expression, Max() of date-ish fact fields, and per-chart
+    distinct-bucket counts — all evaluated against the app's IN-MEMORY data
+    (cannot change without a reload, hence safely deferrable). All evals run
+    through the shared pool."""
+    snapshot = {"lastReloadTime": app_meta.get("lastReloadTime"),
+                "kpis": [], "maxDates": [], "buckets": []}
+    if skip_eval:
+        return snapshot
+
+    kpi_jobs, seen = [], set()
+    for c in charts:
+        if not (c["sheet"] and c["measures"] and not c["dimensions"]):
+            continue
+        expr = c["measures"][0]
+        if not expr or expr in seen:
+            continue
+        seen.add(expr)
+        kpi_jobs.append((expr, c["title"] or (c["measureLabels"] or [None])[0]))
+
+    date_jobs = []
+    if tables:
+        fact = max(tables, key=lambda t: sum(1 for f in t["fields"] if f["name"].upper().endswith("_KEY")))
+        date_jobs = [f["name"] for f in fact["fields"] if "DATE" in f["name"].upper()][:2]
+
+    # per-chart bucket counts (deduped by expr): Phase 6's bucket parity used to
+    # eval these serially against the engine at the end of the run — precompute
+    # them here so the deferred-snapshot lane absorbs that cost too.
+    bucket_jobs, bseen = [], set()
+    for c in charts:
+        dims = [(d[0] if isinstance(d, list) else d) for d in (c.get("dimensions") or [])]
+        dims = [d for d in dims if d]
+        if not (c.get("sheet") and dims and c.get("measures")):
+            continue
+        expr = bucket_expr(dims)
+        if expr in bseen:
+            continue
+        bseen.add(expr)
+        bucket_jobs.append(expr)
+
+    jobs = [("kpi", e, t) for e, t in kpi_jobs] + \
+           [("maxDate", f"Max({f})", f) for f in date_jobs] + \
+           [("bucket", e, None) for e in bucket_jobs]
+    vals = pmap(lambda j: qlik_eval(app, ctx, j[1]), jobs, pool)
+    for (kind, expr, label), val in zip(jobs, vals):
+        if kind == "kpi":
+            snapshot["kpis"].append({"expr": expr, "title": label, "value": val})
+        elif kind == "maxDate":
+            snapshot["maxDates"].append({"field": label, "value": val})
+        else:
+            snapshot["buckets"].append({"expr": expr, "value": val})
+    return snapshot
+
+
+def write_timings(out_dir, mode, pool, n_objects=None):
+    name = "timings-snapshot.json" if mode == "snapshot-only" else "timings.json"
+    awrite(os.path.join(out_dir, name),
+           {"mode": mode, "pool": pool, "total_seconds": round(time.time() - T0, 3),
+            "objects": n_objects, "retries": RETRIES["n"],
+            "stages": dict(sorted(STAGES.items()))})
+
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--app", required=True)
     ap.add_argument("--context")
     ap.add_argument("--out", default="discovery")
+    ap.add_argument("--pool", type=int, default=8,
+                    help="shared fetch/eval pool width (default 8 — measured 4.7x on the "
+                         "per-object properties batch; 'session closed' retries cover the "
+                         "occasional dropped engine session)")
     ap.add_argument("--skip-eval", action="store_true",
-                    help="skip the Qlik-engine snapshot evals (snapshot.json)")
+                    help="skip the Qlik-engine snapshot evals (snapshot.json gets empty lists)")
+    ap.add_argument("--defer-snapshot", action="store_true",
+                    help="write everything EXCEPT snapshot.json — run --snapshot-only later "
+                         "(or concurrently) to produce it; in-memory totals can't change "
+                         "without a reload, so deferral is exact")
+    ap.add_argument("--snapshot-only", action="store_true",
+                    help="compute ONLY snapshot.json from an existing --out dir "
+                         "(charts.json / converter-input.json / app-meta.json)")
     a = ap.parse_args()
+    global _SEM
+    _SEM = threading.Semaphore(max(1, a.pool))  # ONE cap across every pmap
     ctx = ["--context", a.context] if a.context else []
     os.makedirs(a.out, exist_ok=True)
 
-    # 1) load script
-    script = qlik("app", "script", "get", "-a", a.app, *ctx, parse_json=False)
+    # ---- snapshot-only lane: read prior artifacts, eval, write atomically ----
+    if a.snapshot_only:
+        with stage("snapshot"):
+            charts = json.load(open(os.path.join(a.out, "charts.json")))
+            conv = json.load(open(os.path.join(a.out, "converter-input.json")))
+            app_meta = json.load(open(os.path.join(a.out, "app-meta.json"))) \
+                if os.path.exists(os.path.join(a.out, "app-meta.json")) else {}
+            snapshot = compute_snapshot(a.app, ctx, charts, conv.get("tables") or [],
+                                        app_meta, a.pool, a.skip_eval)
+            awrite(os.path.join(a.out, "snapshot.json"), snapshot)
+        write_timings(a.out, "snapshot-only", a.pool)
+        print(f"snapshot: {len(snapshot['kpis'])} KPI(s), {len(snapshot['maxDates'])} max-date(s), "
+              f"{len(snapshot['buckets'])} bucket count(s) in {time.time() - T0:.1f}s "
+              f"(pool={a.pool}, retries={RETRIES['n']}) -> {a.out}/snapshot.json")
+        return
+
+    # ---- full discovery: ONE shared pool covers every engine/REST fetch ----
+    # Independent top-level fetches (script, REST item record, master-item ls,
+    # object ls) start together; the per-object/per-item properties batches are
+    # then mapped over the same pool width.
+    results = {}
+    def _script():
+        with stage("script"):
+            results["script"] = qlik("app", "script", "get", "-a", a.app, *ctx, parse_json=False)
+
+    def _items():
+        with stage("app-meta"):
+            items = qlik("item", "ls", "--resourceType", "app", "--limit", "200", *ctx) or []
+            rec = next((i for i in items if i.get("resourceId") == a.app), {})
+            results["app_meta"] = rec.get("resourceAttributes") or {}
+
+    def _measures():
+        with stage("master-measures"):
+            results["measures"] = enumerate_master(a.app, ctx, "measure", a.pool)
+
+    def _dimensions():
+        with stage("master-dimensions"):
+            results["dimensions"] = enumerate_master(a.app, ctx, "dimension", a.pool)
+
+    def _objects():
+        with stage("object-ls"):
+            results["objs"] = qlik("app", "object", "ls", "-a", a.app, "--json", *ctx) or []
+
+    with stage("parallel-fetch"):
+        with ThreadPoolExecutor(max_workers=5) as top:
+            futs = [top.submit(f) for f in (_script, _items, _measures, _dimensions, _objects)]
+            for f in futs:
+                f.result()
+
+        # per-object properties — the dominant cost (46 × ~1.2s serial on the
+        # fixture app); pool-8 measured 4.7×. Each qlik-cli call is its own
+        # engine session, so width is bounded by tenant session limits, not
+        # correctness; transient 'session closed' is retried in qlik_run.
+        objs = results["objs"]
+        with stage("object-properties"):
+            prop_list = pmap_complete(
+                lambda o: qlik("app", "object", "properties", o.get("qId"), "-a", a.app, *ctx),
+                objs, a.pool, key=lambda o: o.get("qId"), what="object properties")
+        all_props = {o.get("qId"): p for o, p in zip(objs, prop_list)}
+
+    script = results["script"] or ""
     open(os.path.join(a.out, "script.qvs"), "w").write(script)
     tables = parse_script(script)
+    measures, dims_raw = results["measures"], results["dimensions"]
+    awrite(os.path.join(a.out, "measures.json"), measures)
+    awrite(os.path.join(a.out, "dimensions.json"), dims_raw)
+    app_meta = results["app_meta"]
+    awrite(os.path.join(a.out, "app-meta.json"), app_meta)
 
-    # 2) master measures + dimensions
-    measures = enumerate_master(a.app, ctx, "measure")
-    dims_raw = enumerate_master(a.app, ctx, "dimension")
-    json.dump(measures, open(os.path.join(a.out, "measures.json"), "w"), indent=2)
-    json.dump(dims_raw, open(os.path.join(a.out, "dimensions.json"), "w"), indent=2)
-
-    # 3) sheets + chart objects (+ the per-sheet CELL GRID for layout)
-    objs = qlik("app", "object", "ls", "-a", a.app, "--json", *ctx) or []
-    charts, sheets, obj_sheet = [], [], {}
-    all_props = {}
-    for o in objs:
-        oid = o.get("qId")
-        all_props[oid] = qlik("app", "object", "properties", oid, "-a", a.app, *ctx) or {}
     # sheets first, so each chart can be annotated with its sheet
+    charts, sheets, obj_sheet = [], [], {}
     for o in objs:
         oid, qtype = o.get("qId"), o.get("qType")
         if qtype != "sheet": continue
@@ -150,7 +404,7 @@ def main():
                        "columns": props.get("columns", 24), "rows": props.get("rows", 12),
                        "cells": cells})
     sheets.sort(key=lambda s: (s["rank"] is None, s["rank"]))
-    json.dump(sheets, open(os.path.join(a.out, "layout.json"), "w"), indent=2)
+    awrite(os.path.join(a.out, "layout.json"), sheets)
 
     for o in objs:
         oid, qtype = o.get("qId"), o.get("qType")
@@ -180,51 +434,44 @@ def main():
             "measureFmts": [ (mm.get("qDef", {}).get("qNumFormat") or {}).get("qFmt") for mm in qmeas ],
             "sort": sort,
         })
-    json.dump(charts, open(os.path.join(a.out, "charts.json"), "w"), indent=2)
+    awrite(os.path.join(a.out, "charts.json"), charts)
 
-    # 4) app metadata (freshness + security + mode) via the REST item record
-    items = qlik("item", "ls", "--resourceType", "app", "--limit", "200", *ctx) or []
-    rec = next((i for i in items if i.get("resourceId") == a.app), {})
-    app_meta = rec.get("resourceAttributes") or {}
-    json.dump(app_meta, open(os.path.join(a.out, "app-meta.json"), "w"), indent=2)
-
-    # 5) Qlik-engine snapshot (source-freshness preflight input): evaluate every
-    #    on-sheet KPI expression + Max() of date-ish fact fields IN THE APP's
-    #    in-memory data. Comparing these against the live warehouse tells the user
-    #    up front whether Qlik is stale ("Sigma will show more data").
-    snapshot = {"lastReloadTime": app_meta.get("lastReloadTime"), "kpis": [], "maxDates": []}
-    if not a.skip_eval:
-        seen = set()
-        kpi_like = [c for c in charts if c["sheet"] and c["measures"] and not c["dimensions"]]
-        for c in kpi_like:
-            expr = c["measures"][0]
-            if not expr or expr in seen: continue
-            seen.add(expr)
-            val = qlik_eval(a.app, ctx, expr)
-            snapshot["kpis"].append({"expr": expr, "title": c["title"] or c["measureLabels"][0], "value": val})
-        # date-ish fields on the (heuristic) fact table = the table with the most *_KEY fields
-        if tables:
-            fact = max(tables, key=lambda t: sum(1 for f in t["fields"] if f["name"].upper().endswith("_KEY")))
-            datey = [f["name"] for f in fact["fields"] if "DATE" in f["name"].upper()][:2]
-            for fld in datey:
-                val = qlik_eval(a.app, ctx, f"Max({fld})")
-                snapshot["maxDates"].append({"field": fld, "value": val})
-    json.dump(snapshot, open(os.path.join(a.out, "snapshot.json"), "w"), indent=2)
-
-    # 6) converter input (feed the Qlik MODEL field names; simple dims are skipped by converter)
+    # converter input (feed the Qlik MODEL field names; simple dims are skipped by converter)
     CALC = re.compile(r'^=|\b(If|Sum|Count|Avg|Concat|Year|Month|Day|Left|Right|Upper|Lower|Trim)\s*\(', re.I)
     master_dims = [{"title": d["title"], "fieldDef": d["expr"]} for d in dims_raw if CALC.search(d["expr"] or "")]
     conv = {"appName": app_meta.get("name") or a.app, "tables": tables,
             "masterMeasures": [{"title": m["title"], "qDef": m["expr"]} for m in measures],
             "masterDimensions": master_dims}
-    json.dump(conv, open(os.path.join(a.out, "converter-input.json"), "w"), indent=2)
+    awrite(os.path.join(a.out, "converter-input.json"), conv)
+
+    # engine snapshot — inline unless deferred (a --snapshot-only lane picks it up)
+    snapshot = None
+    if a.defer_snapshot:
+        # ensure no STALE snapshot.json survives from a prior run — the
+        # orchestrator polls for this file as the lane-completion signal.
+        try:
+            os.unlink(os.path.join(a.out, "snapshot.json"))
+        except FileNotFoundError:
+            pass
+    else:
+        with stage("snapshot"):
+            snapshot = compute_snapshot(a.app, ctx, charts, tables, app_meta, a.pool, a.skip_eval)
+        awrite(os.path.join(a.out, "snapshot.json"), snapshot)
+
+    mode = "defer-snapshot" if a.defer_snapshot else "full"
+    write_timings(a.out, mode, a.pool, n_objects=len(objs))
 
     on_sheet = sum(1 for c in charts if c["sheet"])
     print(f"tables={len(tables)} measures={len(measures)} dimensions={len(dims_raw)} "
           f"(calc={len(master_dims)}) charts={len(charts)} (on-sheet={on_sheet}) sheets={len(sheets)} -> {a.out}/")
-    if snapshot["kpis"]:
+    if snapshot and snapshot["kpis"]:
         print("snapshot:", "; ".join(f"{k['title']}={k['value']}" for k in snapshot["kpis"][:6]))
+    elif a.defer_snapshot:
+        print("snapshot: DEFERRED (run --snapshot-only as a concurrent lane; "
+              "consumed at the Phase-6 freshness banner)")
     print(f"lastReloadTime={app_meta.get('lastReloadTime', '?')}")
+    print(f"timing: {time.time() - T0:.1f}s wall (pool={a.pool}, retries={RETRIES['n']}; "
+          f"per-stage breakdown in timings.json)")
     print("Next: scripts/migrate-qlik.rb runs the whole pipeline from this directory in one command.")
 
 if __name__ == "__main__":

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/find-or-pick-dm.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/find-or-pick-dm.rb
@@ -54,6 +54,10 @@ OptionParser.new do |p|
        'Auto-recommend without UX prompt when top score >= --auto-pick-threshold AND no other candidate within --auto-pick-tie-window of it. Sets `auto_picked: true` on the result so the caller can WARN about inherited columns.') { |_| opts[:auto_pick] = true }
   p.on('--auto-pick-threshold F', Float, 'Min score for auto-pick (default 0.55).')                  { |v| opts[:auto_pick_threshold] = v }
   p.on('--auto-pick-tie-window F', Float, 'Gap from top score within which other candidates count as a tie that disables auto-pick (default 0.05).') { |v| opts[:auto_pick_tie_window] = v }
+  p.on('--specs-cache P',
+       'JSON cache {"dms":[…list entries…],"specs":{dmId:spec}} prefetched by an orchestrator ' \
+       '(e.g. migrate-qlik.rb prefetches it CONCURRENTLY with source discovery). When supplied, ' \
+       'the DM list + spec fetches are served from the cache (missing specs still fetched live).') { |v| opts[:specs_cache] = v }
 end.parse!
 %i[sig out].each { |k| abort "missing --#{k}" unless opts[k] }
 
@@ -105,21 +109,31 @@ end
 # fetch all DMs (cheap — one list call per 100), sort by updatedAt desc
 # (recent DMs are usually more relevant), then take the first --limit for
 # parallel spec-fetch + scoring. Stable tiebreaker by name. beads-sigma-3kw.
+cache = nil
+if opts[:specs_cache] && File.exist?(opts[:specs_cache])
+  cache = (JSON.parse(File.read(opts[:specs_cache])) rescue nil)
+  warn "specs-cache: #{opts[:specs_cache]} (#{(cache['dms'] || []).size} DMs, #{(cache['specs'] || {}).size} specs)" if cache
+end
+
 all_dms = []
-page = nil
-hard_cap = 500
-loop do
-  qs = "limit=100"
-  qs += "&page=#{page}" if page
-  r = http_get("/v2/dataModels?#{qs}")
-  break unless r.code.to_i == 200
-  data = JSON.parse(r.body)
-  rows = data['entries'] || data['dataModels'] || []
-  break if rows.empty?
-  all_dms.concat(rows)
-  break if all_dms.size >= hard_cap
-  page = data['nextPage']
-  break if page.nil? || page.empty?
+if cache
+  all_dms = cache['dms'] || []
+else
+  page = nil
+  hard_cap = 500
+  loop do
+    qs = "limit=100"
+    qs += "&page=#{page}" if page
+    r = http_get("/v2/dataModels?#{qs}")
+    break unless r.code.to_i == 200
+    data = JSON.parse(r.body)
+    rows = data['entries'] || data['dataModels'] || []
+    break if rows.empty?
+    all_dms.concat(rows)
+    break if all_dms.size >= hard_cap
+    page = data['nextPage']
+    break if page.nil? || page.empty?
+  end
 end
 
 # Deterministic ranking: updatedAt desc, then name asc.
@@ -152,7 +166,23 @@ dm_failures = []
 require 'thread'
 mu = Mutex.new
 queue = Queue.new
-all_dms.take(opts[:limit]).each { |dm| queue << dm }
+# Serve specs from the orchestrator's prefetch cache when present; only DMs
+# missing from the cache go to the network. Cached entries may be raw strings
+# (the spec endpoint can answer YAML) — parse JSON-else-YAML, same as below.
+if cache
+  (cache['specs'] || {}).each do |dm_id, spec|
+    if spec.is_a?(String)
+      spec = begin
+        JSON.parse(spec)
+      rescue JSON::ParserError
+        (YAML.safe_load(spec, permitted_classes: [Date, Time]) rescue nil)
+      end
+    end
+    dm_specs[dm_id] = spec if spec
+  end
+end
+all_dms.take(opts[:limit]).reject { |dm| dm_specs.key?(dm['dataModelId'] || dm['id']) }
+       .each { |dm| queue << dm }
 threads = 5.times.map do
   Thread.new do
     until queue.empty?

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -65,6 +65,33 @@ python3 scripts/migrate.py --model <TS_MODEL_ID> [--liveboard <ID> ...] \
 ```
 `migrate.py` runs the whole pipeline with **no hardcoded ids or paths** and
 migrates every Liveboard that reads the model (or just the `--liveboard` ones).
+
+### Discovery speed (customer scale — 20-40+ liveboard estates)
+Liveboard selection used to **export every Liveboard TML in the org** serially
+and grep for the model name — O(org-size), measured 19.2s on a 33-liveboard
+trial org and linear from there (a 200-liveboard org ≈ 2 min per model).
+Re-engineered 2026-06-11:
+- **Dependency API first**: `ts_lib.dependents(model_id)` asks `metadata/search`
+  (`include_dependent_objects`) which liveboards READ the model — verified live
+  (13 candidates of 33 org liveboards) — so only candidates are exported.
+- **Parallel + disk-cached TML export**: `ts_lib.export_tml_many()` exports
+  candidates on a ThreadPool(4) with a disk cache keyed
+  `(metadata_id, modified-epoch-ms)` (`$TS_TML_CACHE`, default
+  `~/.sigma-migration/ts-tml-cache`; hits/misses logged). Measured:
+  **19.2s → 1.7s cold / 0.2s warm**, and re-runs after the MCP-converter
+  exit-3 resume are all cache hits.
+- **Concurrent lane**: the selection + export runs as a lane UNDER convert +
+  DM POST in `migrate.py` (joined before workbook builds), so on warm paths it
+  costs ~0 wall-clock.
+- **One keep-alive session per thread** (`http.client`): no per-request TLS
+  handshake. (The TS Cloud edge WAF rejects UA-less requests with an HTML 403
+  — `ts_lib` always sends a User-Agent.)
+- **Fallback (patch point)**: when `dependents()` returns `None` (older TS
+  builds without `dependent_objects` in `metadata/search`), `migrate.py`
+  falls back to export-all-then-grep — still parallel + cached, but
+  O(org-size), and it SAYS so. If a customer estate hits this, extend
+  `ts_lib.dependents()` for their TS version (the patch point is marked in
+  `collect_liveboards`, `scripts/migrate.py`).
 All artifacts (manifest, TML, parity files) land in `--workdir`
 (default `$TS_WORKDIR` or `./ts-migration`, created if missing). `--name` is a
 prefix applied to BOTH the data model and every workbook; workbooks and pages

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
@@ -49,6 +49,51 @@ def _gc(cid, r0, r1, inner):
             f'gridRow="{r0} / {r1}" gridTemplateColumns="repeat(24, 1fr)" '
             f'gridTemplateRows="auto">\n{inner}\n</GridContainer>')
 
+GRID_COLS = 24
+MIN_BAND_FILL = 0.60     # must mirror lib/layout_lint.rb MIN_BAND_FILL
+
+
+def _band_fill(items):
+    covered = [False] * GRID_COLS
+    for it in items:
+        for c in range(it[1], it[2]):
+            if 1 <= c <= GRID_COLS:
+                covered[c - 1] = True
+    return sum(covered) / GRID_COLS
+
+
+def _reflow_bands(bands):
+    """Python port of lib/layout.rb reflow_bands (tableau/pbi/quicksight
+    plugins, phase-e layout quality): when any band's items cover <60% of the
+    grid columns — e.g. a half-width trailing Liveboard tile — redistribute
+    the page's items across the same number of bands evenly and tile each band
+    edge-to-edge at its original height. Pages whose bands all fill >=60% keep
+    the source-tile geometry exactly. Keeps the layout-lint gate
+    (lib/layout_lint.rb, 'band under-filled') GREEN by construction."""
+    if not any(_band_fill(b["items"]) < MIN_BAND_FILL for b in bands):
+        return bands
+    heights = [b["r1"] - b["r0"] for b in bands]
+    items = [it for b in bands for it in sorted(b["items"], key=lambda i: (i[3], i[1]))]
+    k = len(items)
+    nb = min(len(bands), k)
+    base, rem = divmod(k, nb)
+    sizes = [base + (1 if bi >= nb - rem else 0) for bi in range(nb)]
+    out, idx, cursor = [], 0, 1
+    fallback_h = max([h for h in heights if h] or [8])
+    for bi, n in enumerate(sizes):
+        band_items = items[idx:idx + n]
+        idx += n
+        h = max(heights[bi] if bi < len(heights) and heights[bi] else fallback_h, 4)
+        new_items = [[it[0],
+                      1 + int(GRID_COLS * j / n + 0.5),
+                      1 + int(GRID_COLS * (j + 1) / n + 0.5),
+                      cursor, cursor + h]
+                     for j, it in enumerate(band_items)]
+        out.append({"r0": cursor, "r1": cursor + h, "items": new_items})
+        cursor += h
+    return out
+
+
 def banded_page(page_id, items, title):
     """items: [eid, c0, c1, r0, r1] page-absolute. Header band + one container
     per row band (children relative; relative TS proportions preserved inside).
@@ -58,7 +103,6 @@ def banded_page(page_id, items, title):
     extra.append({"id": "band-hdrtext", "kind": "text",
                   "body": f'# <span style="color: #FFFFFF">{title}</span>'})
     children.append(_gc("band-hdr", 1, 1 + HEADER_ROWS, _le("band-hdrtext", 1, 25, 1, 1 + HEADER_ROWS)))
-    offset = HEADER_ROWS + (1 - min(i[3] for i in items) if items else 0)
     bands = []
     for it in sorted(items, key=lambda i: (i[3], i[1])):
         if bands and it[3] < bands[-1]["r1"]:
@@ -66,6 +110,8 @@ def banded_page(page_id, items, title):
             bands[-1]["r1"] = max(bands[-1]["r1"], it[4])
         else:
             bands.append({"r0": it[3], "r1": it[4], "items": [it]})
+    bands = _reflow_bands(bands)
+    offset = HEADER_ROWS + (1 - min(b["r0"] for b in bands)) if bands else HEADER_ROWS
     for n, b in enumerate(bands, 1):
         cid = f"band-{n}"
         extra.append({"id": cid, "kind": "container"})

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -34,7 +34,7 @@ Env:
   TS_DB, TS_SCHEMA                          warehouse db/schema for the model's tables
   TS_WORKDIR                                default for --workdir (else ./ts-migration)
 """
-import argparse, json, os, re, ssl, subprocess, sys, urllib.request, urllib.error
+import argparse, json, os, re, ssl, subprocess, sys, time, urllib.request, urllib.error
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import yaml, ts_common, apply_layouts
 yaml.SafeLoader.add_constructor("tag:yaml.org,2002:value", lambda l, n: l.construct_scalar(n))
@@ -169,6 +169,51 @@ def migrate_liveboard(lb_doc, dm, denorm_id, denorm_name, resolver, prefix, fall
     apply_layouts.apply(wb, tiles=tiles)
     return wb, display, len(specs), tiles
 
+def collect_liveboards(a, model_name):
+    """Liveboard candidate selection + TML export — runs as a LANE concurrent
+    with convert + DM POST (main joins it before workbook builds). Estate-scale
+    behavior (an org with 40+ liveboards must not cost 40+ serial exports):
+
+      1. explicit --liveboard ids       → cached parallel export of exactly those
+      2. dependency API                 → ts_lib.dependents(model): the server
+         names the liveboards that READ this model; only those are exported
+         (parallel, disk-cached). VERIFIED LIVE 2026-06-11.
+      3. fallback (PATCH POINT)         → when dependents() returns None (older
+         TS builds with no dependent_objects in metadata/search), fall back to
+         export-ALL-then-grep — still parallel + cached, but O(org-size). If
+         you hit this on a customer estate, verify their TS version's
+         dependency endpoint and extend ts_lib.dependents() accordingly.
+
+    Returns [(edoc, fallback_name)]."""
+    import ts_lib
+    log = lambda m: print("  " + m.lstrip())
+    if a.liveboard:
+        heads = {h["id"]: h for h in ts_lib.search_headers("LIVEBOARD")}
+        items = [heads.get(i) or {"id": i, "name": i, "modified": None} for i in a.liveboard]
+    else:
+        deps = ts_lib.dependents(a.model)
+        org = ts_lib.search_headers("LIVEBOARD")
+        if deps is None:
+            # ── PATCH POINT: dependency API unusable on this TS build ──
+            log(f"dependency API unavailable — falling back to export-all-then-grep "
+                f"({len(org)} liveboard(s) in org; parallel + cached)")
+            out = []
+            for it, edoc, err in ts_lib.export_tml_many(org, log=log):
+                if not err and edoc and model_name in edoc:
+                    out.append((edoc, it.get("name") or it["id"]))
+            return out
+        log(f"dependency API: {len(deps)} liveboard(s) read this model "
+            f"(org has {len(org)} — exporting candidates only)")
+        items = deps
+    out = []
+    for it, edoc, err in ts_lib.export_tml_many(items, log=log):
+        if err:
+            log(f"✗ liveboard {it['id']}: export failed: {err}")
+            continue
+        out.append((edoc, it.get("name") or it["id"]))
+    return out
+
+
 def migrate_answer(ans_id, dm, denorm_id, denorm_name, resolver, prefix, folder, wd):
     """A standalone Answer is a single viz — build a one-element workbook."""
     import ts_lib
@@ -220,6 +265,19 @@ def main():
     print(f"Model '{model_name}': {len(resolver)} resolvable columns  ·  workdir {wd}")
 
     folder = need_env("SIGMA_FOLDER_ID")[0]
+
+    # ── Liveboard selection + TML export LANE: starts BEFORE convert + DM POST
+    #    and runs concurrent with them (pure TS-side reads vs pure Sigma-side
+    #    writes — no shared state). Joined right before the workbook builds.
+    #    On the MCP-fallback exit(3) path the lane still completes before the
+    #    process exits (non-daemon thread), so its exports land in the TML
+    #    disk cache and the --converted resume run gets all cache hits.
+    lb_lane = None
+    if not (offline or a.liveboard_tml):
+        from concurrent.futures import ThreadPoolExecutor
+        t_lane = time.time()
+        lb_lane = ThreadPoolExecutor(max_workers=1).submit(collect_liveboards, a, model_name)
+
     if a.reuse_dm:
         dm = a.reuse_dm
         denorm_id, denorm_name = find_denorm(dm)
@@ -228,27 +286,14 @@ def main():
         conv = convert_model(model_tml, wd, a.converted)
         dm, denorm_id, denorm_name = build_dm(conv, f"{prefix}{model_name} (from ThoughtSpot)", folder)
 
-    # pick Liveboards: offline TML files, explicit ids, or every Liveboard that references the model
+    # pick Liveboards: offline TML files, or join the export lane
     targets = []                                       # (lb_doc, fallback_name)
     if a.liveboard_tml:
         targets = [(open(p).read(), os.path.basename(p)) for p in a.liveboard_tml]
-    elif offline:
-        pass                                           # offline with no liveboard TML → DM only
-    else:
-        import ts_lib
-        if a.liveboard:
-            for lb_id in a.liveboard:
-                edoc, e = ts_lib.export_tml(lb_id, "LIVEBOARD")
-                if e:
-                    print(f"  ✗ liveboard {lb_id}: export failed: {e}"); continue
-                targets.append((edoc, lb_id))
-        else:
-            for lb in ts_lib.search("LIVEBOARD"):
-                edoc, e = ts_lib.export_tml(lb["metadata_id"], "LIVEBOARD")
-                if e:
-                    continue
-                if model_name in edoc:
-                    targets.append((edoc, lb["metadata_name"]))
+    elif lb_lane:
+        targets = lb_lane.result()
+        print(f"  Liveboard TML lane: {len(targets)} ready in {time.time() - t_lane:.1f}s "
+              f"(ran concurrent with convert + DM POST)")
     print(f"Migrating {len(targets)} Liveboard(s)…")
 
     # persist each Liveboard TML so downstream phases (parity expected-side,

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_lib.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_lib.py
@@ -6,28 +6,65 @@ password, get a token by visiting `${TS_HOST}/api/rest/2.0/auth/session/token`
 in the browser tab where you're logged in, or via Develop > REST Playground.
 For a service identity, enable Trusted Auth (Develop > Customizations >
 Security Settings) and POST username+secret_key to auth/token/full.
+
+SCALE NOTES (2026-06-11, for 20-40+ liveboard estates):
+  - One persistent keep-alive HTTPS connection PER THREAD (http.client) instead
+    of a fresh TLS handshake per request — TS Cloud handshakes cost ~0.3-0.5s
+    each, which dominates header-only calls.
+  - dependents(model_id): server-side dependency lookup (metadata/search with
+    include_dependent_objects) — returns ONLY the liveboards/answers that read
+    the model, so callers export N candidate TMLs instead of every liveboard
+    in the org. VERIFIED LIVE against team2.thoughtspot.cloud (13 candidates
+    of 33 org liveboards for the Retail Analytics worksheet).
+  - export_tml_many(): ThreadPool(4) parallel TML export with a DISK CACHE
+    keyed (metadata_id, modified-epoch-ms) — re-runs and multi-liveboard
+    migrations skip unchanged exports entirely (hit/miss logged).
 """
-import json, os, ssl, urllib.request, urllib.error
+import http.client, json, os, ssl, threading, urllib.parse
 
 HOST = os.environ.get("TS_HOST", "").rstrip("/")
 TOKEN = os.environ.get("TS_TOKEN", "")
 # Trials often sit behind corp TLS interception whose CA Python won't verify
 # (curl uses the system store and works). Use an unverified context.
 _SSL = ssl._create_unverified_context()
+_TL = threading.local()      # one persistent keep-alive connection per thread
+
+
+def _conn():
+    c = getattr(_TL, "conn", None)
+    if c is None:
+        netloc = urllib.parse.urlparse(HOST).netloc
+        c = http.client.HTTPSConnection(netloc, context=_SSL, timeout=120)
+        _TL.conn = c
+    return c
 
 
 def _req(path, body=None, method="POST"):
-    url = f"{HOST}/api/rest/2.0/{path}"
-    data = json.dumps(body).encode() if body is not None else None
-    r = urllib.request.Request(url, data=data, method=method,
-        headers={"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json",
-                 "Accept": "application/json"})
-    try:
-        raw = urllib.request.urlopen(r, context=_SSL).read().decode()
-    except urllib.error.HTTPError as e:
-        raise RuntimeError(f"TS {method} {path} -> {e.code}: {e.read().decode()[:400]}")
-    # TML export embeds raw control chars in the JSON string values
-    return json.loads(raw, strict=False) if raw.strip() else None
+    payload = json.dumps(body) if body is not None else None
+    headers = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json",
+               "Accept": "application/json",
+               # http.client sends NO default User-Agent and the TS Cloud edge
+               # (WAF) answers UA-less requests with an HTML 403 — keep one.
+               "User-Agent": "thoughtspot-to-sigma/1.0"}
+    last = None
+    for attempt in (0, 1):                  # one transparent retry on a dropped keep-alive
+        c = _conn()
+        try:
+            c.request(method, f"/api/rest/2.0/{path}", body=payload, headers=headers)
+            r = c.getresponse()
+            raw = r.read().decode()
+        except (http.client.HTTPException, OSError) as e:
+            try:
+                c.close()
+            finally:
+                _TL.conn = None
+            last = e
+            continue
+        if r.status >= 400:
+            raise RuntimeError(f"TS {method} {path} -> {r.status}: {raw[:400]}")
+        # TML export embeds raw control chars in the JSON string values
+        return json.loads(raw, strict=False) if raw.strip() else None
+    raise RuntimeError(f"TS {method} {path} -> connection failed twice: {last}")
 
 
 def whoami():
@@ -39,6 +76,51 @@ def search(mtype, record_size=200):
     return _req("metadata/search", {"metadata": [{"type": mtype}], "record_size": record_size})
 
 
+def search_headers(mtype, record_size=200):
+    """HEADERS-ONLY listing — id/name/modified per object, NO TML export.
+    The O(1)-per-object call estate-scale code paths list with; only confirmed
+    candidates get the expensive tml/export."""
+    out = []
+    for x in search(mtype, record_size):
+        h = x.get("metadata_header") or {}
+        out.append({"id": x.get("metadata_id"), "name": x.get("metadata_name"),
+                    "modified": h.get("modified")})  # epoch-ms; cache key component
+    return out
+
+
+def dependents(model_id, types=("PINBOARD_ANSWER_BOOK",), record_size=200):
+    """Server-side dependency lookup: the liveboards (PINBOARD_ANSWER_BOOK) /
+    answers (QUESTION_ANSWER_BOOK) that READ a model — so callers never export
+    the whole org's TML to find them. Returns [{id, name, modified}] (deduped)
+    or None when the API yields nothing usable (caller falls back to the
+    export-all-then-grep path and says so).
+    VERIFIED LIVE 2026-06-11 (team2.thoughtspot.cloud, REST v2 metadata/search
+    + include_dependent_objects on the LOGICAL_TABLE identifier)."""
+    try:
+        d = _req("metadata/search",
+                 {"metadata": [{"identifier": model_id, "type": "LOGICAL_TABLE"}],
+                  "include_dependent_objects": True,
+                  "dependent_objects_record_size": record_size})
+    except Exception:
+        return None
+    if not d:
+        return None
+    dep = d[0].get("dependent_objects")
+    if dep is None:                      # older TS builds: field absent/null
+        return None
+    seen, out = set(), []
+    for _table_guid, by_type in dep.items():
+        for t, items in (by_type or {}).items():
+            if t not in types:
+                continue
+            for it in items or []:
+                if it.get("id") and it["id"] not in seen:
+                    seen.add(it["id"])
+                    out.append({"id": it["id"], "name": it.get("name"),
+                                "modified": it.get("modified")})
+    return out
+
+
 def export_tml(identifier, mtype="LIVEBOARD"):
     """Export one object's TML (YAML string). Returns (edoc, error_or_None)."""
     d = _req("metadata/tml/export", {"metadata": [{"identifier": identifier, "type": mtype}],
@@ -48,6 +130,48 @@ def export_tml(identifier, mtype="LIVEBOARD"):
     if st.get("status_code") == "ERROR":
         return None, st.get("error_message", "")[:120]
     return it.get("edoc"), None
+
+
+def _cache_dir():
+    d = os.environ.get("TS_TML_CACHE") or os.path.expanduser("~/.sigma-migration/ts-tml-cache")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def export_tml_many(items, mtype="LIVEBOARD", pool=4, use_cache=True, log=print):
+    """Parallel TML export with a disk cache.
+
+    items: [{id, name, modified}] (search_headers()/dependents() shape).
+    Cache key = (metadata_id, modified epoch-ms) — a re-export can only differ
+    if the object was modified, so an id+modified hit is exact, and a stale
+    entry is unreachable (its key includes the old stamp). Returns
+    [(item, edoc_or_None, err_or_None)] in input order; logs hits/misses."""
+    from concurrent.futures import ThreadPoolExecutor
+    cdir = _cache_dir() if use_cache else None
+    hit_ids = []                                  # list.append is thread-safe
+
+    def one(it):
+        cpath = None
+        if cdir and it.get("id") and it.get("modified"):
+            cpath = os.path.join(cdir, f"{it['id']}.{it['modified']}.tml")
+            if os.path.exists(cpath):
+                hit_ids.append(it["id"])
+                return it, open(cpath).read(), None
+        edoc, err = export_tml(it["id"], mtype)
+        if edoc and cpath:
+            tmp = f"{cpath}.tmp.{os.getpid()}.{threading.get_ident()}"
+            with open(tmp, "w") as f:
+                f.write(edoc)
+            os.replace(tmp, cpath)
+        return it, edoc, err
+
+    if not items:
+        return []
+    with ThreadPoolExecutor(max_workers=max(1, pool)) as ex:
+        res = list(ex.map(one, items))
+    if cdir:
+        log(f"  TML cache: {len(hit_ids)} hit(s), {len(items) - len(hit_ids)} miss(es) ({cdir})")
+    return res
 
 
 def import_tml(tml_str, policy="ALL_OR_NONE", create_new=True):


### PR DESCRIPTION
Implements the approved discovery-speed plan for the qlik and thoughtspot plugins, designed for customer-scale estates (20-40+ apps/liveboards). Completes the fast-discovery series (#58-#60).

## Qlik — 57.3s → 12.5s full / 8.4s orchestrated lane (46-object live app)

| measurement (app ec9a73e3, 46 objects, live) | old | new |
|---|---|---|
| discovery, full (incl. engine snapshot) | 57.3s | 12.5s |
| discovery as orchestrator lane (`--defer-snapshot`) | — | 8.4s |
| snapshot lane (`--snapshot-only`, hidden under Phases 2-5) | inline | 4.8-11.9s (0 wall-clock cost) |
| app writes per discovery | **1 (modifiedDate bumped)** | **0 (proven)** |

- **P1/P2/P4**: one shared thread pool (`--pool 8`, global semaphore so concurrent pmaps can't stack into a ~19-session burst) covers the per-object `properties` loop, master-item enumeration, and all snapshot evals. Master items now enumerated via read-only `measure/dimension ls` + `properties` — the temp MeasureList/DimensionList object (discovery's only app write) is gone. modifiedDate proven identical across five new-mode runs incl. two full E2Es; one old-mode run bumps it.
- **P3**: engine snapshot deferred to its own background lane (consumed only at the Phase-6 freshness banner; in-memory totals can't change without a reload, so deferral is exact). Bucket-count parity exprs precomputed in the same lane.
- **P5**: `migrate-qlik.rb` interleaves Sigma-side prep (token, folder resolve, DM list+spec prefetch) under discovery, mirroring `migrate-tableau.rb`; `find-or-pick-dm.rb --specs-cache` consumes the prefetch. `PHASE TIMINGS` at every exit + `timings.json` per stage.
- **Throttle hardening (found during live E2E):** Qlik Cloud throttles new engine sessions after rapid bursts — "could not connect to engine" was NOT matched by the transient-retry regex and discovery silently lost 3/46 objects (built a 21-chart workbook from a 35-chart app). Now: widened regex, exponential backoff, pooled-then-serial second pass, and a hard abort (exit 4) if anything is still missing. Slow or loud, never silent.

**40-estate extrapolation:** source-side discovery wall-clock drops from ~38 min (40 × 57s) to ~6 min (40 × 8.4s lane), with the remaining snapshot cost hidden under each build — and zero modifiedDate churn across the customer's tenant.

## ThoughtSpot — O(org-size) → O(candidates): 19.2s → 1.7s cold / 0.2s warm (33-liveboard live org)

| measurement (live, team2 trial) | old | new |
|---|---|---|
| liveboard selection for one model | 19.2s (33 serial TML exports + grep) | 1.7s cold / 0.2s warm (13 candidate exports) |
| wall-clock cost inside the pipeline | serial, after DM POST | ~0 (lane concurrent with convert + DM POST) |

- **Dependency API verified live**: `metadata/search` + `include_dependent_objects` on the model returns exactly the liveboards that read it (13/33). Used first; fallback to export-all-then-grep (still parallel + cached) with the patch point clearly marked for older TS builds.
- **P2**: headers-only listing + ThreadPool(4) exports for candidates only. **P3**: TML disk cache keyed `(metadata_id, modified)` with hit/miss logging (`$TS_TML_CACHE`). **P4**: selection+export lane runs under convert + DM POST; exit-3 MCP-resume re-runs are all cache hits. **P5**: one persistent keep-alive HTTPS connection per thread (plus a User-Agent — the TS Cloud WAF 403s UA-less http.client requests).
- `apply_layouts.py` gained a Python port of the shared `reflow_bands` (lib/layout.rb) so TML tile geometry with under-filled trailing bands passes the new layout-lint gate by construction.

**At 40+ scale:** selection cost is now bounded by the model's own liveboard count, not the org's; a 200-liveboard org costs the same as a 20-liveboard one for a 5-liveboard model.

## E2E evidence (all live)
- **Qlik one-command** (`migrate-qlik.rb`, app ec9a73e3): exit 0, PARITY GREEN — 142/142 columns resolve, 0 divergent KPIs (14 stale-explained, freshness-banner led), 68s total. Layout lint (shared lib): **0 violations**. Kept pair: DM `e118a361` + WB `9f0b7634` ("QDISC2 Qlik …"); intermediates deleted.
- **ThoughtSpot one-command** (`migrate-thoughtspot.py`, model d09e27fd): exit 0, PARITY GREEN — all 6 hard gates PASS **including gate 6 layout lint**, parity 6/6 strict. Kept pair: DM `a0e7817d` + WB `59e2130c` ("QDISC2 TS …"); the pre-reflow lint-failing pair deleted.
- Offline smokes green: qlik `--from-discovery fixtures/retail-orders --dry-run` and TS fixtures `--dry-run`.
- Discovery artifact parity old-vs-new: byte-identical except `dimensions.json` now carries real field defs (old list-object enumeration returned empty exprs — strict fidelity improvement; converter input unchanged) and `snapshot.json` gains the precomputed `buckets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)