### PR TITLE
Add microstrategy-to-sigma plugin (converter + assessment)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace-manifest.json",
   "name": "sigma-migration-skills",
-  "description": "Skills for migrating BI tools (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight, Looker, Cognos) to Sigma — converters + assessments, validated end-to-end with warehouse parity.",
+  "description": "Skills for migrating BI tools (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight, Looker, Cognos, MicroStrategy) to Sigma — converters + assessments, validated end-to-end with warehouse parity.",
   "version": "1.0.0",
   "owner": { "name": "Thomas Wells" },
   "metadata": { "pluginRoot": "./plugins" },
@@ -54,6 +54,13 @@
       "description": "IBM Cognos Analytics → Sigma — Data Module JSON → Sigma data model, report-spec XML → Sigma workbook (crosstab→pivot, RAVE2 charts, maps), Cognos expression DSL translation, with parity verification. Bundles cognos-to-sigma + cognos-assessment.",
       "category": "migration",
       "keywords": ["cognos", "ibm-cognos", "data-module", "report-studio", "migration", "bi"]
+    },
+    {
+      "name": "microstrategy-to-sigma",
+      "source": "./microstrategy-to-sigma",
+      "description": "MicroStrategy (Strategy One) → Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Bundles microstrategy-to-sigma + microstrategy-assessment.",
+      "category": "migration",
+      "keywords": ["microstrategy", "strategy-one", "dossier", "migration", "bi"]
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — sigma-migration-skills
 
 Migration skills for moving BI tools (**Tableau, Power BI, Qlik, ThoughtSpot,
-QuickSight, Looker, Cognos**) to
+QuickSight, Looker, Cognos, MicroStrategy**) to
 **Sigma**: per-tool *converters* (source → Sigma data model + workbook, with
 warehouse parity verification) and read-only *assessments* (tenant inventory →
 migration-readiness readout + shortlist).
@@ -37,6 +37,8 @@ reading the relevant `SKILL.md` and executing its scripts.
 | Scope/assess a Looker instance | `looker-assessment` | `plugins/looker-to-sigma/skills/looker-assessment/` |
 | Convert an IBM Cognos data module + report → Sigma | `cognos-to-sigma` | `plugins/cognos-to-sigma/skills/cognos-to-sigma/` |
 | Scope/assess a Cognos Analytics instance | `cognos-assessment` | `plugins/cognos-to-sigma/skills/cognos-assessment/` |
+| Convert a MicroStrategy dossier + semantic model → Sigma | `microstrategy-to-sigma` | `plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/` |
+| Scope/assess a MicroStrategy (Strategy One) instance | `microstrategy-assessment` | `plugins/microstrategy-to-sigma/skills/microstrategy-assessment/` |
 | Land a Tableau published-datasource/extract in Snowflake or Databricks | `tableau-vds-to-cdw` | `plugins/tableau-to-sigma/skills/tableau-vds-to-cdw/` |
 
 Assessments are read-only (never write to the source or post to Sigma); run one

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ shared `~/.sigma-migration/env` under any agent.
 /plugin install quicksight-to-sigma@sigma-migration-skills
 /plugin install cognos-to-sigma@sigma-migration-skills
 /plugin install looker-to-sigma@sigma-migration-skills
+/plugin install microstrategy-to-sigma@sigma-migration-skills
 ```
 
 **Other agents (Cursor, Cortex Code, …)** — clone the repo and point your agent at the
@@ -48,6 +49,7 @@ and the skill drives discovery → translation → build → parity.
 | [`quicksight-to-sigma`](plugins/quicksight-to-sigma/) | Amazon QuickSight | `quicksight-to-sigma`, `quicksight-assessment` |
 | [`cognos-to-sigma`](plugins/cognos-to-sigma/) | IBM Cognos Analytics | `cognos-to-sigma`, `cognos-assessment` |
 | [`looker-to-sigma`](plugins/looker-to-sigma/) | Looker | `looker-to-sigma`, `looker-assessment` |
+| [`microstrategy-to-sigma`](plugins/microstrategy-to-sigma/) | MicroStrategy (Strategy One) | `microstrategy-to-sigma`, `microstrategy-assessment` |
 
 In Claude Code, installed skills are namespaced — e.g. `/powerbi-to-sigma:powerbi-assessment`.
 

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "microstrategy-to-sigma",
+  "displayName": "MicroStrategy → Sigma",
+  "version": "0.1.0",
+  "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
+  "author": { "name": "Thomas Wells" },
+  "license": "MIT",
+  "keywords": ["microstrategy", "strategy-one", "dossier", "sigma", "migration", "bi", "converter", "assessment"],
+  "skills": "./skills/"
+}

--- a/plugins/microstrategy-to-sigma/.gitignore
+++ b/plugins/microstrategy-to-sigma/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.DS_Store
+.mstr_env
+.token
+exports/
+samples/
+*.log

--- a/plugins/microstrategy-to-sigma/README.md
+++ b/plugins/microstrategy-to-sigma/README.md
@@ -1,0 +1,88 @@
+# microstrategy-to-sigma
+
+Claude Code plugin for migrating **MicroStrategy (Strategy One)** to
+**Sigma**, in the same format and phase structure as the
+[sigma-migration-skills](https://github.com/twells89/sigma-migration-skills)
+converters (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight, Cognos,
+Metabase). Built standalone so it can graduate into that marketplace's
+`plugins/`.
+
+## Status: live-validated (classic-schema grid path)
+
+Validated end-to-end on a live Strategy One trial against Snowflake:
+dossier + classic semantic model (star schema with heterogeneous key columns,
+facts, metrics incl. `Count<Distinct=True>` and a compound margin) →
+Sigma data model + workbook with **exact parity — 19/19 + 30/30 + 3/3 rows**
+(money/counts exact, ratios rel 1e-6), including one report whose
+Analytical-Engine row-collapse quirk is reproduced deterministically
+(`resolve_ae_winners.py`).
+
+**Roadmap** (deliberately not in the validated path — see
+`skills/microstrategy-to-sigma/refs/design-notes.md`):
+chart-visualization emission (the dossier viz-type lookup is
+extraction-validated; only `grid` builds are parity-proven) and filters /
+selectors / page-by / prompts.
+
+Strategy One's newer **"Data Model" object** (Mosaic, `/api/model/dataModels`)
+IS covered: extraction + authoring + parity-validated live querying
+(`connect_live`, exact 19/19 vs the classic fixture) — see
+`skills/microstrategy-to-sigma/refs/datamodels.md` and
+`scripts/{build,extract}_datamodel.py`. Its `securityFilters` (RLS) remain
+the future RLS-port surface.
+
+## What's in the box
+
+| Skill | What it does |
+|---|---|
+| [`skills/microstrategy-to-sigma`](skills/microstrategy-to-sigma/SKILL.md) | The converter: REST discovery → `extract.py` (dossier + semantic model → `bundle.json`) → `convert.py` (→ Sigma DM + workbook specs) → POST + readback gate → `verify_parity.py` (hard parity gate). Plus `resolve_ae_winners.py` for the Analytical-Engine row-collapse trap. |
+| [`skills/microstrategy-assessment`](skills/microstrategy-assessment/SKILL.md) | Read-only estate inventory + readout: project/report/dossier counts, viz-type histogram (walking panel stacks recursively), datasource types, per-dossier complexity flags + migrate-first/moderate/needs-review tags scored against the converter's actual viz coverage. |
+
+The hard-won knowledge lives in `skills/microstrategy-to-sigma/refs/`:
+`mstr-rest-api.md` (every verified REST gotcha — changeset locks, lowercase
+response headers, session-bound dossier flows, the datasource trio),
+`ae-row-collapse.md`, `viz-type-mapping.md`, `design-notes.md`.
+
+## Quick start
+
+```bash
+# MicroStrategy creds (session auth — no API-key concept exists)
+export MSTR_BASE_URL="https://<host>/MicroStrategyLibrary"
+export MSTR_USERNAME="..." MSTR_PASSWORD="..."   # or ~/.sigma-migration/env
+
+# Assess the estate (read-only)
+python3 skills/microstrategy-assessment/scripts/assess.py --out /tmp/mstr-assessment
+
+# Migrate (see skills/microstrategy-to-sigma/SKILL.md for the full phase walkthrough)
+python3 skills/microstrategy-to-sigma/scripts/extract.py <dossierId> bundle.json
+python3 skills/microstrategy-to-sigma/scripts/convert.py --bundle bundle.json \
+  --connection-id <SIGMA_CONN> --database <DB> --folder-id <FOLDER>
+# ... POST DM spec -> readback ids -> re-emit workbook -> POST -> verify_parity.py
+```
+
+Or install as a Claude Code plugin and just ask: *"migrate my MicroStrategy
+dossier to Sigma"* / *"assess my MicroStrategy estate."*
+
+`fixtures/` contains the real validated artifacts: `bundle.json` (the
+converter contract, extracted live), `expected_parity.json` (the MSTR ground
+truth), `dossier_definition.json`, plus the fixture builders
+(`build_schema.py`, `BUILD_SPEC.md`) for rehearsing the loop on a fresh trial.
+
+## Design contract
+
+Core principle (shared with every sibling converter): **flag, never fake.**
+Anything without a clean Sigma analog (unmapped viz types, panel-stack
+content) is surfaced as a loud warning with a readable table fallback — never
+silently wrong numbers. Parity is a hard gate: a migration is green only when
+`verify_parity.py` passes against numbers taken from MicroStrategy itself.
+
+## Graduating into sigma-migration-skills
+
+This repo is already in the marketplace plugin layout
+(`.claude-plugin/plugin.json` + `skills/<name>/SKILL.md|scripts|refs|fixtures`).
+To graduate: drop the repo content into
+`sigma-migration-skills/plugins/microstrategy-to-sigma/` — no path changes
+needed (all script cross-references are relative).
+
+## License
+
+MIT

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/PRIVACY.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/PRIVACY.md
@@ -1,0 +1,45 @@
+# MicroStrategy Assessment — privacy disclosure
+
+Share this with the customer's privacy / security reviewer before running the
+skill against a live MicroStrategy environment.
+
+## What this skill does
+
+It logs in (`POST /api/auth/login` — the only POST, it creates a session) and
+then issues **read-only `GET` requests** to the MicroStrategy REST API to
+count reports/documents, fetch dossier definitions, and list datasources. It
+then scores everything locally and renders a markdown readout. It **never**
+modifies, executes, or deletes anything in MicroStrategy, **never runs a
+report or warehouse query**, and never touches Sigma.
+
+## What crosses the LLM (Anthropic) API
+
+Like every Claude Code skill, the content it reads is sent through the
+Anthropic API to Claude so the assessment can be produced:
+
+| Crosses the API | Stays in MicroStrategy / local only |
+|---|---|
+| Aggregate counts (report / document / dossier / datasource counts) | Warehouse rows — never queried |
+| Object names and ids (projects, reports, dossiers, datasources) | Database credentials (the endpoints used never return them) |
+| Dossier definitions: chapter/page names, visualization types, panel-stack structure, dataset attribute/metric names | Report *results* / metric values (no report is executed) |
+| Datasource database types (e.g. `snow_flake`) | Connection strings / logins |
+
+## Where outputs go
+
+A local directory (`/tmp/mstr-assessment-<env>/` by default):
+`inventory.json` + `readout.md`. Nothing is uploaded anywhere; sharing the
+readout is a deliberate user action.
+
+## Auth handling
+
+`MSTR_USERNAME` / `MSTR_PASSWORD` are read from environment variables (or
+`~/.sigma-migration/env`) and used only for the login call. The session token
+lives in process memory; credentials are not stored and not written to any
+output file.
+
+## How to run it more privately
+
+- Use a **low-privilege account** — MicroStrategy's own object security bounds
+  what the walk can see.
+- Cap the per-dossier fetches with `--max-dossiers`.
+- Scope to one project with `--project`.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: microstrategy-assessment
+description: >-
+  Take inventory of a MicroStrategy (Strategy One) environment and produce a
+  migration-readiness readout — project/report/dossier counts, a
+  visualization-type histogram (walking panel stacks recursively), datasource
+  types, per-dossier complexity flags, and migrate-first / moderate /
+  needs-review tags scored against the microstrategy-to-sigma converter's
+  actual coverage. Use when a user wants to scope a MicroStrategy→Sigma
+  migration, audit dossier sprawl, or pick which dossiers to convert first.
+  Read-only, all-free pre-scoping.
+user-invocable: true
+---
+
+# MicroStrategy Assessment
+
+Surveys a MicroStrategy (Strategy One) environment via its REST API and
+produces a JSON inventory + markdown readout. The differentiator versus a
+generic BI audit is **converter-coverage classification**: every dossier's
+visualizations are scored against the *same* viz-type lookup the
+`microstrategy-to-sigma` converter actually applies
+(`../microstrategy-to-sigma/refs/viz-type-mapping.md`), so the readout
+reflects what the tool will really do.
+
+> **Read-only.** Only `GET`s against the MicroStrategy API (login `POST` aside,
+> which creates a session, nothing else). It never modifies, executes, or
+> deletes anything in MicroStrategy, never runs a warehouse query, and never
+> touches Sigma. See `PRIVACY.md` for the full disclosure — surface it to the
+> customer before running.
+
+> **All free.** Inventory, scoring, readout — all part of the open migration
+> tooling; no paid tier. For a deeper engagement (security-filter audit, live
+> parity testing), point the customer at a Sigma SE.
+
+---
+
+## Phase 0 — Connect
+
+```bash
+export MSTR_BASE_URL="https://<host>/MicroStrategyLibrary"   # Library root
+export MSTR_USERNAME="..." MSTR_PASSWORD="..."
+# optional: export MSTR_PROJECT_ID="..."   (default: first project)
+python3 ../microstrategy-to-sigma/scripts/mstr.py            # login probe
+```
+
+Credentials can also live in `~/.sigma-migration/env` (agent-neutral pattern).
+Auth is session-based — no API key exists. REST gotchas (TLS strictness on
+trial certs, headers) are documented in
+`../microstrategy-to-sigma/refs/mstr-rest-api.md`; `mstr.py` handles them.
+
+## Phase 1 — Inventory + readout
+
+```bash
+python3 scripts/assess.py --out /tmp/mstr-assessment-<env> [--project <id>] [--max-dossiers 100]
+```
+
+What it does:
+
+- **Counts** reports (quick-search type 3) and documents (type 55) in the
+  project; lists instance datasources with database types.
+- **Classifies documents vs dossiers** by probing
+  `GET /api/v2/dossiers/{id}/definition` (non-dossier documents error — that
+  *is* the probe).
+- **Walks every dossier correctly**: each page's `visualizations` AND
+  `panelStacks[].panels[]` **recursively** (panels nest further panel stacks)
+  plus free-form `fields` (images/text) and `selectors` — the places naive
+  walks silently miss content.
+- **Histograms `visualizationType`** and classifies each against the
+  converter's `VIZ_MAPPED` lookup (mapped vs flagged-table fallback).
+- **Tags each dossier**: `needs-review` (panel stacks or unmapped viz types),
+  `moderate` (selectors / free-form fields / chart mix), `migrate-first`
+  (grid/kpi-only, no panel stacks).
+
+Outputs `<out>/inventory.json` (machine-readable, feeds the converter's
+Phase 0) and `<out>/readout.md` (counts, viz histogram with converter status,
+per-dossier table with flags + tags).
+
+## Phase 2 — Hand off (optional)
+
+Hand the migrate-first shortlist to the **`microstrategy-to-sigma`** converter
+skill — `inventory.json`'s dossier ids go straight into
+`extract.py <dossierId>`. Do not auto-convert; surface the shortlist and let
+the user choose.
+
+## Limitations (honest)
+
+- **Usage telemetry**: not collected — Strategy One exposes usage through
+  Platform Analytics (a separate warehouse-backed project), not the plain
+  REST surface this skill uses. Value ranking therefore isn't usage-weighted;
+  ask the admin for Platform Analytics access if usage matters.
+- **Security filters**: the classic REST extract doesn't surface them;
+  ask the customer explicitly (see the converter SKILL's security note).
+- Documents that aren't dossiers are counted but not analyzed (their format is
+  the legacy Report Services document, out of converter scope).

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/assess.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/assess.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+assess.py — read-only MicroStrategy (Strategy One) estate inventory.
+
+GET-only against the MicroStrategy REST API. Produces:
+  <out>/inventory.json   — machine-readable estate inventory
+  <out>/readout.md       — human-readable migration-readiness readout
+
+Surveyed per project:
+  - report + document/dossier counts (quick-search API)
+  - per-dossier structure: chapters / pages / visualizations, walking
+    panelStacks[].panels[] RECURSIVELY (panels nest further panelStacks)
+    and counting free-form `fields` (images / text boxes)
+  - visualization-type histogram, classified against the converter's
+    viz-type lookup (see ../microstrategy-to-sigma/refs/viz-type-mapping.md)
+  - instance datasource inventory (database types)
+  - per-dossier complexity flags + migrate-first / moderate / needs-review tag
+
+Usage:
+  python3 assess.py [--project <id>] [--out /tmp/mstr-assessment] [--max-dossiers 100]
+
+Credentials: MSTR_BASE_URL / MSTR_USERNAME / MSTR_PASSWORD env vars (or
+~/.sigma-migration/env) — see ../../microstrategy-to-sigma/scripts/mstr.py.
+"""
+import argparse
+import collections
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                '..', '..', 'microstrategy-to-sigma', 'scripts'))
+import mstr  # noqa: E402
+
+# Sigma-analog lookup, mirroring the converter (flagged-table fallback).
+# Keep in sync with refs/viz-type-mapping.md in the converter skill.
+# Types with a real Sigma mapping (see ../microstrategy-to-sigma/refs/
+# viz-type-mapping.md, demo-sweep-validated). Others = flagged-table fallback;
+# custom/marketplace vizzes (HC*/D3*/Vitara*/EChart*/Arria*…) are never mapped.
+VIZ_MAPPED = {
+    'grid', 'compound_grid', 'kpi', 'multi_metric_kpi', 'comparison_kpi',
+    'bar_chart', 'line_chart', 'combo_chart', 'area_chart',
+    'pie_chart', 'ring_chart', 'bubble_chart',
+    'geospatial_service', 'google_map', 'esri_map',
+}
+# MicroStrategy object types (quick-search `type` param)
+TYPE_REPORT = 3
+TYPE_DOCUMENT = 55  # documents AND dossiers
+
+
+def search(s, obj_type, limit=500):
+    """Quick-search for objects of a type in the session's project."""
+    out, offset = [], 0
+    while True:
+        r = s.get(f'/searches/results?type={obj_type}'
+                  f'&offset={offset}&limit={limit}')
+        items = r.get('result', [])
+        out.extend(items)
+        offset += len(items)
+        if offset >= r.get('totalItems', 0) or not items:
+            return out
+
+
+def walk_container(node, hist, flags):
+    """Recursively walk a page/panel: visualizations + panelStacks[].panels[]
+    (+ free-form `fields` — images / text boxes)."""
+    for v in node.get('visualizations') or []:
+        hist[v.get('visualizationType', 'unknown')] += 1
+    for _f in node.get('fields') or []:
+        flags['free_form_fields'] += 1
+    if node.get('selectors'):
+        flags['selectors'] += len(node['selectors'])
+    for ps in node.get('panelStacks') or []:
+        flags['panel_stacks'] += 1
+        for p in ps.get('panels') or []:
+            walk_container(p, hist, flags)
+
+
+def assess_dossier(s, doc):
+    """Fetch /v2/dossiers/{id}/definition; None if not a dossier."""
+    try:
+        d = s.get(f"/v2/dossiers/{doc['id']}/definition")
+    except RuntimeError:
+        return None
+    hist = collections.Counter()
+    flags = collections.Counter()
+    n_pages = 0
+    for ch in d.get('chapters') or []:
+        for pg in ch.get('pages') or []:
+            n_pages += 1
+            walk_container(pg, hist, flags)
+    unmapped = sorted(t for t in hist if t not in VIZ_MAPPED)
+    if flags['panel_stacks'] or unmapped:
+        tag = 'needs-review'
+    elif flags['free_form_fields'] or flags['selectors'] or len(hist) > 2:
+        tag = 'moderate'
+    else:
+        tag = 'migrate-first'
+    return {
+        'id': doc['id'],
+        'name': d.get('name', doc.get('name')),
+        'chapters': len(d.get('chapters') or []),
+        'pages': n_pages,
+        'datasets': len(d.get('datasets') or []),
+        'visualizations': sum(hist.values()),
+        'viz_types': dict(hist),
+        'unmapped_viz_types': unmapped,
+        'flags': dict(flags),
+        'tag': tag,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--project', default=None,
+                    help='project id (default: MSTR_PROJECT_ID, else first project)')
+    ap.add_argument('--out', default='/tmp/mstr-assessment')
+    ap.add_argument('--max-dossiers', type=int, default=100,
+                    help='cap on per-dossier definition fetches')
+    args = ap.parse_args()
+
+    s = mstr.Session(project_id=args.project)
+    projects = s.get('/projects')
+    if not s.project_id:
+        s.project_id = projects[0]['id']
+    project = next((p for p in projects if p['id'] == s.project_id), None)
+
+    # instance-level datasources (db types)
+    try:
+        ds = s.get('/datasources').get('datasources', [])
+    except RuntimeError:
+        ds = []
+    ds_types = collections.Counter(
+        (d.get('database') or {}).get('type', 'unknown') for d in ds)
+
+    reports = search(s, TYPE_REPORT)
+    documents = search(s, TYPE_DOCUMENT)
+
+    dossiers, plain_documents = [], []
+    viz_hist = collections.Counter()
+    for doc in documents[: args.max_dossiers]:
+        a = assess_dossier(s, doc)
+        if a is None:
+            plain_documents.append({'id': doc['id'], 'name': doc.get('name')})
+        else:
+            dossiers.append(a)
+            viz_hist.update(a['viz_types'])
+
+    inventory = {
+        'project': {'id': s.project_id,
+                    'name': project['name'] if project else None},
+        'projects_available': [{'id': p['id'], 'name': p['name']}
+                               for p in projects],
+        'counts': {
+            'reports': len(reports),
+            'documents': len(documents),
+            'dossiers': len(dossiers),
+            'plain_documents': len(plain_documents),
+            'datasources': len(ds),
+        },
+        'datasource_types': dict(ds_types),
+        'viz_type_histogram': dict(viz_hist),
+        'unmapped_viz_types': sorted(t for t in viz_hist if t not in VIZ_MAPPED),
+        'dossiers': dossiers,
+        'plain_documents': plain_documents,
+        'reports': [{'id': r['id'], 'name': r.get('name')} for r in reports],
+    }
+
+    os.makedirs(args.out, exist_ok=True)
+    inv_path = os.path.join(args.out, 'inventory.json')
+    json.dump(inventory, open(inv_path, 'w'), indent=1)
+
+    # ---- readout
+    L = ['# MicroStrategy estate — migration readout', '',
+         f"Project: **{inventory['project']['name']}** (`{s.project_id}`)", '',
+         '## Counts', '',
+         f"- Reports: {len(reports)}",
+         f"- Documents: {len(documents)} ({len(dossiers)} dossiers, "
+         f"{len(plain_documents)} non-dossier documents)",
+         f"- Datasources: {len(ds)} "
+         f"({', '.join(f'{k}: {v}' for k, v in ds_types.items()) or 'n/a'})",
+         '', '## Visualization types (all dossiers, incl. panel stacks)', '',
+         '| Type | Count | Converter |', '|---|---|---|']
+    for t, n in viz_hist.most_common():
+        L.append(f"| {t} | {n} | "
+                 f"{'mapped' if t in VIZ_MAPPED else 'FLAGGED (table fallback)'} |")
+    L += ['', '## Dossiers', '',
+          '| Dossier | Chapters | Pages | Vizzes | Flags | Tag |', '|---|---|---|---|---|---|']
+    for d in sorted(dossiers, key=lambda x: x['tag']):
+        fl = ', '.join(f'{k}={v}' for k, v in d['flags'].items()) or '—'
+        if d['unmapped_viz_types']:
+            fl += f"; unmapped: {', '.join(d['unmapped_viz_types'])}"
+        L.append(f"| {d['name']} | {d['chapters']} | {d['pages']} | "
+                 f"{d['visualizations']} | {fl} | **{d['tag']}** |")
+    L += ['', '_Tags: migrate-first = grid/kpi-only, no panel stacks; '
+          'moderate = selectors / free-form fields / chart mix; '
+          'needs-review = panel stacks or unmapped viz types._', '']
+    md_path = os.path.join(args.out, 'readout.md')
+    open(md_path, 'w').write('\n'.join(L))
+
+    print(f"project: {inventory['project']['name']}")
+    print(f"reports={len(reports)} documents={len(documents)} "
+          f"dossiers={len(dossiers)} datasources={len(ds)}")
+    print(f"viz histogram: {dict(viz_hist)}")
+    print(f"wrote {inv_path} and {md_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/QUICKSTART.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/QUICKSTART.md
@@ -1,0 +1,108 @@
+author: Sigma Computing
+summary: Migrating from MicroStrategy made easy — convert Strategy One semantic models and dossiers to Sigma with Claude Code
+id: developers_migrating_from_microstrategy_made_easy
+categories: Developers, Migration, AI
+environments: Web
+status: Draft
+feedback link: https://github.com/twells89/microstrategy-to-sigma/issues
+
+# Migrating from MicroStrategy to Sigma made easy
+
+## Introduction & why it matters
+Duration: 2
+
+Rebuilding MicroStrategy content by hand means re-deriving every attribute's
+key mapping, re-typing every metric formula, and hoping the numbers still tie
+out — across a semantic layer (attributes, facts, metrics), reports, and
+dossiers.
+
+This quickstart automates the path with **your coding agent** (Claude Code,
+Cursor, Cortex Code, …) + the MicroStrategy→Sigma skills: discover content
+over the MicroStrategy REST API, extract the dossier *and* the semantic model
+behind it, build a Sigma data model and matching workbook, and **verify data
+parity** against the same warehouse.
+
+positive
+: **Validation status:** live-validated end-to-end on a Strategy One cloud
+trial against Snowflake — exact parity on every row of every report in the
+fixture (money/counts exact, ratios 1e-6), for both the classic project
+schema **and** the newer Mosaic "Data Model" objects.
+
+negative
+: Dossier **visualization authoring** has no public REST surface, so the
+parity-proven build path is grids; chart viz types are extracted and mapped
+by lookup, and anything unmapped is **flagged as a table, never faked**.
+
+## Who this is for
+Duration: 1
+
+- Sigma SEs and technical CSMs
+- Migration partners
+- MicroStrategy admins evaluating a move to Sigma
+
+## Prerequisites
+Duration: 2
+
+- **A coding agent that runs skills** — Claude Code (CLI or desktop), Cursor, etc.
+- **MicroStrategy REST access** — any Library deployment exposes it at
+  `…/MicroStrategyLibrary/api` (cloud trials included; no API key concept —
+  standard login works): `MSTR_BASE_URL`, `MSTR_USERNAME`, `MSTR_PASSWORD`.
+- **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`,
+  or `~/.sigma-migration/env`).
+- **The same warehouse on both sides** — Sigma's connection must reach the
+  database MicroStrategy queries. In-memory cubes migrate as their
+  *underlying* warehouse tables.
+
+## Assess the estate (optional, ~minutes)
+Duration: 5
+
+```bash
+export MSTR_BASE_URL="https://<env>/MicroStrategyLibrary" \
+       MSTR_USERNAME="…" MSTR_PASSWORD="…"
+python3 skills/microstrategy-assessment/scripts/assess.py --out /tmp/mstr-assessment
+open /tmp/mstr-assessment/readout.md
+```
+
+The readout inventories projects, reports, documents, and dossiers, walks
+panel stacks for a visualization-type histogram, and tags each dossier
+migrate-first / moderate / needs-review against the converter's actual
+coverage.
+
+## Migrate a dossier
+Duration: 15
+
+Ask your agent:
+
+> Migrate my MicroStrategy dossier "Orders Performance Overview" to Sigma.
+
+The `microstrategy-to-sigma` skill walks the phases: discover → `extract.py`
+(dossier + every attribute/fact/metric/table it touches → `bundle.json`;
+join keys are recovered from attributes whose ID form maps to both the fact
+and a lookup table) → `convert.py` (→ Sigma data model + workbook specs,
+metrics translated incl. `Count<Distinct=True>` and compound ratios) →
+POST + readback gate (hard-fails on any error-typed column) →
+`verify_parity.py` (hard gate: every row compared to numbers re-executed
+from MicroStrategy itself — expected values are never invented).
+
+negative
+: If a report groups by an attribute with a **non-unique key**, MicroStrategy's
+Analytical Engine silently collapses groups to arbitrary representative rows.
+The skill detects this and reproduces it deterministically
+(`resolve_ae_winners.py`) instead of shipping a near-miss.
+
+## Strategy One Data Models (Mosaic)
+Duration: 3
+
+If the customer models in the newer **Data Model** objects instead of the
+classic schema, the same flow applies: `extract_datamodel.py` pulls tables,
+attributes, factMetrics, metrics, and relationships (`refs/datamodels.md`
+documents the dataServer-pipeline binding and the
+`POST /v2/cubes/{id}/instances` parity-query path).
+
+## Verify & wrap up
+Duration: 3
+
+- Parity gate: `verify_parity.py` green — all rows, exact (ratios 1e-6).
+- Readback gate: no `type: "error"` columns in the DM or workbook spec.
+- Anything flagged (unmapped viz types, prompts, selectors) is listed in the
+  conversion notes for human follow-up — loud and explicit, never silent.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: microstrategy-to-sigma
+description: >-
+  Migrate MicroStrategy (Strategy One) content to Sigma. Use when the user has
+  MicroStrategy dossiers, reports, or a classic schema (attributes / facts /
+  metrics) and wants to recreate them in Sigma. Extracts the dossier + full
+  semantic model over the MSTR REST API into a bundle, converts it to a Sigma
+  data model + workbook, reproduces Analytical-Engine row-collapse quirks
+  deterministically, and verifies row-level parity. Live-validated with exact
+  parity on the classic-schema grid path.
+user-invocable: true
+---
+
+# MicroStrategy → Sigma migration
+
+Extract a MicroStrategy **dossier + its full semantic model** into one
+`bundle.json`, convert it to a Sigma **data model** (table sources + joins +
+metrics) and a matching **workbook**, then **verify row-level parity** against
+the numbers MicroStrategy itself reports. Translate what maps cleanly; **flag
+what doesn't** (unmapped viz types → flagged tables) instead of emitting wrong
+logic.
+
+> **Validated**: exact parity (19/19 + 30/30 + 3/3 rows) on a live Strategy One
+> trial against Snowflake — classic-schema path, grid reports, incl. a
+> `Count<Distinct=True>` metric, a compound margin metric, and an
+> Analytical-Engine row-collapse report. Chart-viz emission and the newer
+> "Data Model" object are roadmap (`refs/design-notes.md`).
+
+> Read `refs/` before relying on shapes: `mstr-rest-api.md` (every verified
+> REST gotcha — changesets, locks, lowercase response headers, session-bound
+> dossier flows), `ae-row-collapse.md` (the one MSTR behavior no clean SQL
+> reproduces, and the pinning workflow), `viz-type-mapping.md` (dossier viz →
+> Sigma element lookup), `design-notes.md` (architecture + modeling gotchas +
+> roadmap). For canonical Sigma spec shapes, defer to the companion
+> `sigma-data-models` / `sigma-workbooks` skills.
+
+---
+
+## Prerequisites
+
+- **MicroStrategy REST access** — `MSTR_BASE_URL` (the Library root, e.g.
+  `https://<host>/MicroStrategyLibrary`), `MSTR_USERNAME`, `MSTR_PASSWORD`
+  (+ optional `MSTR_PROJECT_ID`), exported or in `~/.sigma-migration/env`.
+  Auth is session-based (`POST /api/auth/login`, loginMode 1) — there is no
+  API-key concept; `scripts/mstr.py` handles it.
+- **Sigma API token** — `eval "$(scripts/get-token.sh)"` (uses
+  `SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`, same neutral-cred pattern as the
+  sibling skills).
+- **The same warehouse on both sides.** Sigma reads the warehouse live; parity
+  only means something when the Sigma connection reaches the database
+  MicroStrategy queries.
+- **Python 3** (stdlib only; `resolve_ae_winners.py` and parity readback also
+  want `PyYAML` for Sigma's YAML spec responses).
+
+## Phase 0 — Discover
+
+Run the sibling **`microstrategy-assessment`** skill for an estate-wide
+inventory (reports/dossiers, viz histogram, complexity tags) — its
+`inventory.json` lists dossier ids. Or quick-check connectivity and pick a
+dossier by hand:
+
+```bash
+python3 scripts/mstr.py                          # login probe + project list
+# dossiers: see assessment, or GET /api/searches/results?type=55 via mstr.py
+```
+
+## Phase 1 — Extract the bundle
+
+```bash
+python3 scripts/extract.py <dossierId> bundle.json
+```
+
+Walks dossier definition → dataset reports (`showExpressionAs=tokens`) →
+referenced attributes / metrics (compound bases included via a second pass) /
+facts / logical tables / hierarchy relationships. The bundle is the converter
+contract — `fixtures/bundle.json` is a real, validated example.
+
+## Phase 2 — Convert → Sigma specs
+
+```bash
+python3 scripts/convert.py --bundle bundle.json \
+  --connection-id <SIGMA_CONNECTION_ID> --database <DB> --folder-id <FOLDER_ID> \
+  [--inode-map inodes.json]        # physical table name -> inode tail, optional
+```
+
+Emits `sigma_dm_spec.json` (one table element per logical table, derived
+left-outer joins, a consumable join element, token-parsed metrics with derived
+display formats) + `sigma_workbook_spec.json` (one page per dossier chapter,
+grouped tables mirroring each report template) + `parity_keys.json`. The
+workbook spec carries `{{DATA_MODEL_ID}}` / element-id placeholders until
+Phase 4 re-runs with real ids.
+
+Conversion patterns to know (details in `refs/`): grids group by the
+attribute's KEY form and label with `Max([DESC])`; dim-keyed groupings get an
+`exclude [null]` filter to mirror MSTR's inner joins; metrics referencing
+metrics are inlined in workbook context, `[Name]`-referenced in DM context.
+
+## Phase 2.5 — AE row-collapse resolution (only when flagged)
+
+If any report has an attribute whose DESC form differs from its key (the
+converter's grouping output makes this visible — and `resolve_ae_winners.py`
+detects it itself), MicroStrategy's Analytical Engine collapses non-unique key
+groups to one representative row that **cannot be derived from the model**:
+
+```bash
+eval "$(scripts/get-token.sh)"
+python3 scripts/resolve_ae_winners.py --connection-id <id> --database <DB> \
+  --folder-id <folderId> --out ae_winners.json
+python3 scripts/convert.py ... --ae-winners ae_winners.json
+```
+
+It re-executes the affected reports in MSTR, computes the clean warehouse
+groups via a throwaway Sigma probe workbook, pins each winner empirically, and
+the converter emits a deterministic SQL element reproducing the grid. Read
+`refs/ae-row-collapse.md` — this is the single biggest parity trap.
+
+## Phase 3 — POST the data model + read back ids (hard gate)
+
+```bash
+eval "$(scripts/get-token.sh)"
+curl -s -X POST "$SIGMA_BASE_URL/v2/dataModels/spec" \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Content-Type: application/json" \
+  -d @sigma_dm_spec.json            # -> dataModelId
+curl -s "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" > dm_readback.yaml
+```
+
+The readback is **YAML**, with **reassigned element ids** — capture them as
+`dm_element_ids.json` (`{"<element name>": "<server id>"}`). **Gate:** scan the
+readback for any column with `type: error` (a spec can POST 200 yet carry
+formulas that don't resolve at query time). Do not proceed on errors —
+`mcp__sigma-data-model__diagnose_sigma_save_error` and the
+`sigma-data-models` skill are the debugging path.
+
+## Phase 4 — Re-emit the workbook with real ids, POST it
+
+```bash
+python3 scripts/convert.py ... --data-model-id <dataModelId> \
+  --dm-element-ids dm_element_ids.json [--ae-winners ae_winners.json]
+curl -s -X POST "$SIGMA_BASE_URL/v2/workbooks/spec" \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Content-Type: application/json" \
+  -d @sigma_workbook_spec.json      # -> workbookId
+```
+
+Read the workbook spec back the same way and confirm no `type: error` columns.
+(Workbook DELETE, if you need to retry, is `DELETE /v2/files/<id>` — not
+`/v2/workbooks/<id>`.)
+
+## Phase 5 — Verify parity (hard gate — the real proof)
+
+Expected values come **from MicroStrategy, never invented**: execute each
+report via `POST /api/v2/reports/{id}/instances?limit=N` and write
+`expected_parity.json` (`{"<report name>": [{"keys": [...], "values": {...}}]}`
+— `fixtures/expected_parity.json` is the shape). Then:
+
+```bash
+python3 scripts/verify_parity.py --workbook-id <workbookId> \
+  --expected expected_parity.json --report parity_report.md
+```
+
+Exports every workbook element to CSV via the Sigma export API and compares
+row-by-row (money/counts exact; ratio metrics rel 1e-6). **GREEN only when
+every report PASSes** — never on a 200 POST alone. Mind freshness: Sigma reads
+the live warehouse; if rows landed since the MSTR numbers were captured,
+re-capture before calling a delta a failure.
+
+---
+
+## What converts, what's flagged (never faked)
+
+**Converted (live-validated):** classic schema → DM (logical tables → table
+elements; attribute key forms on fact+lookup → left-outer joins; heterogeneous
+key columns; facts + token-parsed metrics incl. `Count<Distinct=True>` →
+`CountDistinct` and compound metrics; semantic display formats) · dossier
+chapters → workbook pages with grouped tables (KEY-form grouping + `Max(DESC)`
+labels + null-exclude filters) · AE row-collapse reports → deterministic
+pinned-winner SQL elements.
+
+**Flagged / roadmap:** unmapped viz types → flagged table fallback
+(`refs/viz-type-mapping.md`); chart emission (kpi/bar/line/combo) extraction-
+validated but build roadmap; filters/selectors/page-by/prompts; the newer
+REST-authorable "Data Model" object incl. `securityFilters` (the future RLS
+port surface — until then, **ask the customer about security filters
+explicitly**; never assume an estate has none just because the classic extract
+doesn't carry them).
+
+## Gotchas baked into the scripts (don't re-learn these)
+
+- Changeset lock dangling + `DELETE /api/model/schema/lock`; reports do NOT
+  use changesets; lowercase `x-mstr-ms-instance` response header; PUT
+  relationships REPLACES the parent list — `refs/mstr-rest-api.md`.
+- Attribute-count metrics (`Count(Customer)`) → cartesian governance aborts —
+  count a fact/key column instead; compound denominators need `ZeroToNull()`
+  or Snowflake kills the report — `refs/design-notes.md`.
+- Python 3.13+ rejects some MSTR cloud CA certs (`VERIFY_X509_STRICT`) —
+  `mstr.py` handles it.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/BUILD_SPEC.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/BUILD_SPEC.md
@@ -1,0 +1,65 @@
+# "Orders Analytics Workbench" — dossier build spec (Library UI)
+
+Goal: one big dossier exercising every visualization type the Library gallery
+offers, all on live Snowflake data, as the migration-converter fixture.
+REST cannot author visualizations, so this is ~30 min of drag-and-drop.
+
+**Dataset:** every page uses the report **`Orders Wide Dataset`**
+(Public Objects → Reports). When creating the dossier: ⊕ New Dashboard →
+Add Data → Existing Dataset → Orders Wide Dataset.
+It has 15 attributes (Region, State, Store, Store Type, Category, Subcategory,
+Brand, Customer Segment, Loyalty Tier, Year, Month, Day, Order Channel,
+Ship Method, Order Status) and 12 metrics (Total Net Revenue, Total Gross
+Profit, Profit Margin Pct, Units Sold, Order Count, Avg Unit Price, Total
+Discount, Total Shipping, Units Returned, Customer Count, Avg Order Value,
+Return Rate).
+
+Name the dossier **Orders Analytics Workbench**, save into Public Objects → Reports.
+
+If a viz type below isn't in your gallery, skip it and note which.
+
+## Page 1 — Revenue Overview
+| # | Viz type | Slots |
+|---|----------|-------|
+| 1 | KPI | Metric: Total Net Revenue |
+| 2 | Multi-Metric KPI | Metrics: Total Net Revenue, Order Count, Units Sold, Avg Order Value |
+| 3 | Bar (vertical clustered) | Vertical: Total Net Revenue · Horizontal: Region · Color By: Category |
+| 4 | Bar (stacked) | Vertical: Total Net Revenue · Horizontal: Order Channel · Color By: Category (Stacked) |
+| 5 | Line | Vertical: Total Net Revenue · Horizontal: Month (sorted by ID) · Break By: Year |
+| 6 | Area | Vertical: Units Sold · Horizontal: Month |
+
+## Page 2 — Product & Mix
+| # | Viz type | Slots |
+|---|----------|-------|
+| 7 | Pie | Angle: Total Net Revenue · Slice: Category |
+| 8 | Ring/Donut | Angle: Order Count · Slice: Loyalty Tier |
+| 9 | Heat Map | Grouping: Category, Subcategory · Size By: Total Net Revenue · Color By: Profit Margin Pct |
+| 10 | Combo | Vertical L: Total Net Revenue (bar) · Vertical R: Profit Margin Pct (line) · Horizontal: Month |
+| 11 | Grid | Rows: Brand · Metrics: all 12 — then add a **threshold** (e.g. Profit Margin Pct < 0.5 red) |
+
+## Page 3 — Statistical
+| # | Viz type | Slots |
+|---|----------|-------|
+| 12 | Scatter | X: Avg Unit Price · Y: Units Sold · Group/point: Product? not in dataset — use Subcategory · Color: Category |
+| 13 | Bubble | X: Total Net Revenue · Y: Profit Margin Pct · Size: Units Sold · Group: Store · Color: Region |
+| 14 | Histogram | Metric: Avg Order Value · binning default (per Store) |
+| 15 | Box Plot | Y: Total Net Revenue · Group: Region · point = Store |
+| 16 | Waterfall | Vertical: Total Net Revenue · Horizontal: Category |
+
+## Page 4 — Geo, Flow & Text
+| # | Viz type | Slots |
+|---|----------|-------|
+| 17 | Map (Geospatial / ESRI) | Geo attribute: State (set Geo Role → State when prompted) · Color: Total Net Revenue |
+| 18 | Sankey (if present) | From: Region · To: Order Channel · Weight: Units Sold |
+| 19 | Network (if present) | From: Category · To: Brand · Weight: Order Count |
+| 20 | Funnel (if present) | Stage: Order Status · Metric: Order Count |
+| 21 | Word Cloud (if present) | Word: Brand · Size: Total Net Revenue |
+| 22 | Text box + Image | any title text + any image (free-form `fields` coverage) |
+
+## Dossier-level features (converter coverage beyond viz types)
+- **Chapter filter:** add Year as a filter (All / 2026).
+- **Selector/panel:** put vizzes 7–8 in a Panel Stack with a panel selector.
+- **Attribute selector** targeting viz 3 (e.g. element selector on Region).
+- Rename chapters: "Overview", "Product", "Statistical", "Geo & Flow".
+
+When done, tell Claude — extraction + Sigma migration take it from there.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/build_schema.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/build_schema.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Build the orders-star fixture schema in a MicroStrategy project.
+
+This is the FIXTURE BUILDER (not part of a customer migration): it recreates
+the schema objects behind fixtures/bundle.json in a fresh Strategy One
+project so the converter's validated end-to-end loop can be rehearsed on a
+trial env. Logical tables must exist first (create via the modeling UI or
+POST /api/model/tables) and two small sidecar files describe them:
+
+  table_ids.json  — {"ORDER_FACT": "<logical table objectId>", ...}
+  folder_ids.json — {"attributes": "<folderId>", "facts": ..., "metrics": ...}
+
+Creates attributes, hierarchy relationships, facts, and metrics; reloads the
+schema at the end. Progress is checkpointed to object_ids.json. Idempotence
+beyond that checkpoint: not attempted — run against a clean project.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                '..', 'scripts'))
+import mstr
+
+s = mstr.Session()
+T = json.load(open('table_ids.json'))
+F = json.load(open('folder_ids.json'))
+state_path = 'object_ids.json'
+try:
+    state = json.load(open(state_path))
+except FileNotFoundError:
+    state = {'attributes': {}, 'facts': {}, 'metrics': {}}
+
+
+def tbl(name):
+    return {'objectId': T[name], 'subType': 'logical_table', 'name': name}
+
+
+def save():
+    json.dump(state, open(state_path, 'w'), indent=1)
+
+
+def form(category, display, column, tables, name=None):
+    f = {'category': category, 'displayFormat': display,
+         'expressions': [{'expression': {'tokens': [{'value': column}]},
+                          'tables': [tbl(t) for t in tables]}]}
+    if name:
+        f['name'] = name
+    return f
+
+
+# (name, lookup table, forms, report/browse display form)
+ATTRIBUTES = [
+    ('Customer', 'CUSTOMER_DIM',
+     [form('ID', 'number', 'CUSTOMER_KEY', ['CUSTOMER_DIM', 'ORDER_FACT']),
+      form('DESC', 'text', 'CUSTOMER_ID', ['CUSTOMER_DIM'])], 'DESC'),
+    ('Customer Segment', 'CUSTOMER_DIM',
+     [form('ID', 'text', 'CUSTOMER_SEGMENT', ['CUSTOMER_DIM'])], 'ID'),
+    ('Region', 'STORE_DIM',
+     [form('ID', 'text', 'REGION', ['STORE_DIM'])], 'ID'),
+    ('Store', 'STORE_DIM',
+     [{'category': 'ID', 'displayFormat': 'number',
+       'expressions': [
+           {'expression': {'tokens': [{'value': 'STORE_KEY'}]},
+            'tables': [tbl('STORE_DIM')]},
+           {'expression': {'tokens': [{'value': 'ORDER_STORE_KEY'}]},
+            'tables': [tbl('ORDER_FACT')]},
+       ]},
+      form('DESC', 'text', 'STORE_NAME', ['STORE_DIM'])], 'DESC'),
+    ('Category', 'PRODUCT_DIM',
+     [form('ID', 'text', 'CATEGORY', ['PRODUCT_DIM'])], 'ID'),
+    ('Product', 'PRODUCT_DIM',
+     [form('ID', 'number', 'PRODUCT_KEY', ['PRODUCT_DIM', 'ORDER_FACT']),
+      form('DESC', 'text', 'PRODUCT_NAME', ['PRODUCT_DIM'])], 'DESC'),
+    ('Year', 'DATE_DIM',
+     [form('ID', 'number', 'YEAR', ['DATE_DIM'])], 'ID'),
+    ('Month', 'DATE_DIM',
+     [form('ID', 'number', 'MONTH_NUMBER', ['DATE_DIM']),
+      form('DESC', 'text', 'MONTH_NAME', ['DATE_DIM'])], 'DESC'),
+    ('Day', 'DATE_DIM',
+     [{'category': 'ID', 'displayFormat': 'number',
+       'expressions': [
+           {'expression': {'tokens': [{'value': 'DATE_KEY'}]},
+            'tables': [tbl('DATE_DIM')]},
+           {'expression': {'tokens': [{'value': 'ORDER_DATE_KEY'}]},
+            'tables': [tbl('ORDER_FACT')]},
+       ]},
+      form('DESC', 'date', 'FULL_DATE', ['DATE_DIM'])], 'DESC'),
+    ('Order Channel', 'ORDER_FACT',
+     [form('ID', 'text', 'ORDER_CHANNEL', ['ORDER_FACT'])], 'ID'),
+    ('Order Status', 'ORDER_FACT',
+     [form('ID', 'text', 'ORDER_STATUS', ['ORDER_FACT'])], 'ID'),
+]
+
+# child -> (parent, relationship table)
+RELATIONSHIPS = {
+    'Customer': ('Customer Segment', 'CUSTOMER_DIM'),
+    'Store': ('Region', 'STORE_DIM'),
+    'Product': ('Category', 'PRODUCT_DIM'),
+    'Month': ('Year', 'DATE_DIM'),
+    'Day': ('Month', 'DATE_DIM'),
+}
+
+FACTS = [
+    ('Net Revenue', 'NET_REVENUE'),
+    ('Gross Profit', 'GROSS_PROFIT'),
+    ('Quantity', 'QUANTITY_ORDERED'),
+    ('Discount', 'DISCOUNT_AMOUNT'),
+    ('Order Id Fact', 'ORDER_ID'),
+]
+
+METRICS = [
+    ('Total Net Revenue', 'Sum([Net Revenue]) {~}'),
+    ('Total Gross Profit', 'Sum([Gross Profit]) {~}'),
+    ('Units Sold', 'Sum([Quantity]) {~}'),
+    ('Order Count', 'Count<Distinct=True>([Order Id Fact]) {~}'),
+    ('Profit Margin Pct', '([Total Gross Profit] / [Total Net Revenue])'),
+]
+
+
+def create_attributes(cs):
+    for name, lookup, forms, disp in ATTRIBUTES:
+        if name in state['attributes']:
+            continue
+        body = {
+            'information': {'name': name, 'subType': 'attribute',
+                            'destinationFolderId': F['attributes']},
+            'forms': forms,
+            'attributeLookupTable': tbl(lookup),
+            'keyForm': {'name': 'ID'},
+            'displays': {'reportDisplays': [{'name': disp}],
+                         'browseDisplays': [{'name': disp}]},
+        }
+        r = s.cs_post('/model/attributes', body, cs)
+        state['attributes'][name] = r['information']['objectId']
+        print('attribute', name, '->', state['attributes'][name])
+        save()
+
+
+def create_relationships(cs):
+    for child, (parent, table) in RELATIONSHIPS.items():
+        child_id = state['attributes'][child]
+        body = {'relationships': [{
+            'parent': {'objectId': state['attributes'][parent],
+                       'subType': 'attribute', 'name': parent},
+            'child': {'objectId': child_id,
+                      'subType': 'attribute', 'name': child},
+            'relationshipTable': tbl(table),
+            'relationshipType': 'one_to_many',
+        }]}
+        s.put(f'/model/systemHierarchy/attributes/{child_id}/relationships',
+              body, headers={'X-MSTR-MS-Changeset': cs})
+        print('relationship', parent, '>', child)
+
+
+def create_facts(cs):
+    for name, column in FACTS:
+        if name in state['facts']:
+            continue
+        body = {
+            'information': {'name': name, 'subType': 'fact',
+                            'destinationFolderId': F['facts']},
+            'expressions': [{'expression': {'tokens': [{'value': column}]},
+                             'tables': [tbl('ORDER_FACT')]}],
+        }
+        r = s.cs_post('/model/facts', body, cs)
+        state['facts'][name] = r['information']['objectId']
+        print('fact', name, '->', state['facts'][name])
+        save()
+
+
+def create_metrics(cs):
+    for name, formula in METRICS:
+        if name in state['metrics']:
+            continue
+        body = {
+            'information': {'name': name, 'subType': 'metric',
+                            'destinationFolderId': F['metrics']},
+            'expression': {'tokens': [{'value': formula}]},
+        }
+        r = s.cs_post('/model/metrics', body, cs)
+        state['metrics'][name] = r['information']['objectId']
+        print('metric', name, '->', state['metrics'][name])
+        save()
+
+
+if __name__ == '__main__':
+    s.schema_edit(create_attributes)
+    s.schema_edit(create_relationships)
+    s.schema_edit(create_facts)
+    s.schema_edit(create_metrics)
+    s.post('/model/schema/reload')
+    print('schema reloaded')

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/bundle.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/bundle.json
@@ -1,0 +1,4323 @@
+{
+ "dossier": {
+  "id": "77EFB43F5B441BA7B6EEECAB4D92A7EF",
+  "name": "Orders Performance Overview",
+  "datasets": [
+   {
+    "name": "Revenue by Region and Category",
+    "id": "5C8ABD78BC4EA7F4AF876E97091E6BA5",
+    "availableObjects": [
+     {
+      "id": "6140BFA7309B406AA76A90454BC7BB53",
+      "name": "Region",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     },
+     {
+      "id": "13AF74581AA84A46B8FD2D1BBA073150",
+      "name": "Category",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     },
+     {
+      "id": "413D98E4993B4D6ABB2DC440F7B31971",
+      "name": "Total Net Revenue",
+      "type": "metric"
+     },
+     {
+      "id": "653830C2CB684809B7030FBBEA498C8C",
+      "name": "Total Gross Profit",
+      "type": "metric"
+     },
+     {
+      "id": "5393F49A94A443E79E38CB3855B0272F",
+      "name": "Profit Margin Pct",
+      "type": "metric"
+     }
+    ],
+    "rows": [
+     {
+      "id": "6140BFA7309B406AA76A90454BC7BB53",
+      "name": "Region",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     },
+     {
+      "id": "13AF74581AA84A46B8FD2D1BBA073150",
+      "name": "Category",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     }
+    ],
+    "columns": [
+     {
+      "id": "00000000000000000000000000000000",
+      "name": "Metrics",
+      "type": "templateMetrics",
+      "elements": [
+       {
+        "name": "Total Net Revenue",
+        "id": "413D98E4993B4D6ABB2DC440F7B31971",
+        "type": "metric",
+        "dataType": "reserved"
+       },
+       {
+        "name": "Total Gross Profit",
+        "id": "653830C2CB684809B7030FBBEA498C8C",
+        "type": "metric",
+        "dataType": "reserved"
+       },
+       {
+        "name": "Profit Margin Pct",
+        "id": "5393F49A94A443E79E38CB3855B0272F",
+        "type": "metric",
+        "dataType": "reserved"
+       }
+      ]
+     }
+    ],
+    "pageBy": []
+   },
+   {
+    "name": "Monthly Revenue Trend",
+    "id": "864205BFBA4B4E6E863C3FB42FB0A406",
+    "availableObjects": [
+     {
+      "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+      "name": "Year",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "decimal",
+        "baseFormCategory": "ID",
+        "baseFormType": "number"
+       }
+      ]
+     },
+     {
+      "id": "C3292DAD4FAF404F88590CB19C3930F9",
+      "name": "Month",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "name": "DESC",
+        "dataType": "varChar",
+        "baseFormCategory": "DESC",
+        "baseFormType": "text"
+       }
+      ]
+     },
+     {
+      "id": "413D98E4993B4D6ABB2DC440F7B31971",
+      "name": "Total Net Revenue",
+      "type": "metric"
+     },
+     {
+      "id": "145746BAC65E4BF39E83149A843A3DF7",
+      "name": "Order Count",
+      "type": "metric"
+     }
+    ],
+    "rows": [
+     {
+      "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+      "name": "Year",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "decimal",
+        "baseFormCategory": "ID",
+        "baseFormType": "number"
+       }
+      ]
+     },
+     {
+      "id": "C3292DAD4FAF404F88590CB19C3930F9",
+      "name": "Month",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "name": "DESC",
+        "dataType": "varChar",
+        "baseFormCategory": "DESC",
+        "baseFormType": "text"
+       }
+      ]
+     }
+    ],
+    "columns": [
+     {
+      "id": "00000000000000000000000000000000",
+      "name": "Metrics",
+      "type": "templateMetrics",
+      "elements": [
+       {
+        "name": "Total Net Revenue",
+        "id": "413D98E4993B4D6ABB2DC440F7B31971",
+        "type": "metric",
+        "dataType": "reserved"
+       },
+       {
+        "name": "Order Count",
+        "id": "145746BAC65E4BF39E83149A843A3DF7",
+        "type": "metric",
+        "dataType": "reserved"
+       }
+      ]
+     }
+    ],
+    "pageBy": []
+   },
+   {
+    "name": "Channel Performance",
+    "id": "69759BAD734F3EB9308219B61D916432",
+    "availableObjects": [
+     {
+      "id": "E951AA8437BF46BB860E98F0DB349617",
+      "name": "Order Channel",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     },
+     {
+      "id": "413D98E4993B4D6ABB2DC440F7B31971",
+      "name": "Total Net Revenue",
+      "type": "metric"
+     },
+     {
+      "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+      "name": "Units Sold",
+      "type": "metric"
+     },
+     {
+      "id": "145746BAC65E4BF39E83149A843A3DF7",
+      "name": "Order Count",
+      "type": "metric"
+     }
+    ],
+    "rows": [
+     {
+      "id": "E951AA8437BF46BB860E98F0DB349617",
+      "name": "Order Channel",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     }
+    ],
+    "columns": [
+     {
+      "id": "00000000000000000000000000000000",
+      "name": "Metrics",
+      "type": "templateMetrics",
+      "elements": [
+       {
+        "name": "Total Net Revenue",
+        "id": "413D98E4993B4D6ABB2DC440F7B31971",
+        "type": "metric",
+        "dataType": "reserved"
+       },
+       {
+        "name": "Units Sold",
+        "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+        "type": "metric",
+        "dataType": "reserved"
+       },
+       {
+        "name": "Order Count",
+        "id": "145746BAC65E4BF39E83149A843A3DF7",
+        "type": "metric",
+        "dataType": "reserved"
+       }
+      ]
+     }
+    ],
+    "pageBy": []
+   }
+  ],
+  "currentChapter": "K123",
+  "chapters": [
+   {
+    "key": "K65",
+    "name": "Revenue by Region and Category",
+    "pages": [
+     {
+      "key": "K85",
+      "name": "Page 1",
+      "visualizations": [
+       {
+        "key": "K86",
+        "name": "Visualization 1",
+        "visualizationType": "grid"
+       }
+      ]
+     }
+    ],
+    "filters": []
+   },
+   {
+    "key": "K69",
+    "name": "Monthly Revenue Trend",
+    "pages": [
+     {
+      "key": "K120",
+      "name": "Page 1",
+      "visualizations": [
+       {
+        "key": "K121",
+        "name": "Visualization 1",
+        "visualizationType": "grid"
+       }
+      ]
+     }
+    ],
+    "filters": []
+   },
+   {
+    "key": "K123",
+    "name": "Channel Performance",
+    "pages": [
+     {
+      "key": "K158",
+      "name": "Page 1",
+      "visualizations": [
+       {
+        "key": "K159",
+        "name": "Visualization 1",
+        "visualizationType": "grid"
+       }
+      ]
+     }
+    ],
+    "filters": []
+   }
+  ]
+ },
+ "reports": {
+  "5C8ABD78BC4EA7F4AF876E97091E6BA5": {
+   "information": {
+    "dateCreated": "2026-06-11T01:51:17.284Z",
+    "dateModified": "2026-06-11T01:51:17.284Z",
+    "versionId": "A81A552B3B4FAB584A8293ABBBEE2798",
+    "acg": 255,
+    "objectId": "5C8ABD78BC4EA7F4AF876E97091E6BA5",
+    "subType": "report_grid",
+    "name": "Revenue by Region and Category"
+   },
+   "sourceType": "normal",
+   "dataSource": {
+    "dataTemplate": {
+     "units": [
+      {
+       "id": "6140BFA7309B406AA76A90454BC7BB53",
+       "name": "Region",
+       "type": "attribute",
+       "nonAggregatable": false
+      },
+      {
+       "id": "13AF74581AA84A46B8FD2D1BBA073150",
+       "name": "Category",
+       "type": "attribute",
+       "nonAggregatable": false
+      },
+      {
+       "type": "metrics",
+       "elements": [
+        {
+         "id": "413D98E4993B4D6ABB2DC440F7B31971",
+         "name": "Total Net Revenue",
+         "subType": "metric"
+        },
+        {
+         "id": "653830C2CB684809B7030FBBEA498C8C",
+         "name": "Total Gross Profit",
+         "subType": "metric"
+        },
+        {
+         "id": "5393F49A94A443E79E38CB3855B0272F",
+         "name": "Profit Margin Pct",
+         "subType": "metric"
+        }
+       ]
+      }
+     ]
+    },
+    "filter": {}
+   },
+   "grid": {
+    "viewTemplate": {
+     "rows": {
+      "units": [
+       {
+        "id": "6140BFA7309B406AA76A90454BC7BB53",
+        "name": "Region",
+        "type": "attribute"
+       },
+       {
+        "id": "13AF74581AA84A46B8FD2D1BBA073150",
+        "name": "Category",
+        "type": "attribute"
+       }
+      ],
+      "sorts": []
+     },
+     "columns": {
+      "units": [
+       {
+        "type": "metrics",
+        "elements": [
+         {
+          "id": "413D98E4993B4D6ABB2DC440F7B31971",
+          "name": "Total Net Revenue",
+          "subType": "metric"
+         },
+         {
+          "id": "653830C2CB684809B7030FBBEA498C8C",
+          "name": "Total Gross Profit",
+          "subType": "metric"
+         },
+         {
+          "id": "5393F49A94A443E79E38CB3855B0272F",
+          "name": "Profit Margin Pct",
+          "subType": "metric"
+         }
+        ]
+       }
+      ],
+      "sorts": []
+     },
+     "pageBy": {
+      "units": [],
+      "sorts": []
+     }
+    },
+    "viewFilter": {}
+   }
+  },
+  "864205BFBA4B4E6E863C3FB42FB0A406": {
+   "information": {
+    "dateCreated": "2026-06-11T01:51:17.779Z",
+    "dateModified": "2026-06-11T01:51:17.779Z",
+    "versionId": "43BB95B68A4CCA7DBDBC93B9B2F6DA34",
+    "acg": 255,
+    "objectId": "864205BFBA4B4E6E863C3FB42FB0A406",
+    "subType": "report_grid",
+    "name": "Monthly Revenue Trend"
+   },
+   "sourceType": "normal",
+   "dataSource": {
+    "dataTemplate": {
+     "units": [
+      {
+       "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+       "name": "Year",
+       "type": "attribute",
+       "nonAggregatable": false
+      },
+      {
+       "id": "C3292DAD4FAF404F88590CB19C3930F9",
+       "name": "Month",
+       "type": "attribute",
+       "nonAggregatable": false
+      },
+      {
+       "type": "metrics",
+       "elements": [
+        {
+         "id": "413D98E4993B4D6ABB2DC440F7B31971",
+         "name": "Total Net Revenue",
+         "subType": "metric"
+        },
+        {
+         "id": "145746BAC65E4BF39E83149A843A3DF7",
+         "name": "Order Count",
+         "subType": "metric"
+        }
+       ]
+      }
+     ]
+    },
+    "filter": {}
+   },
+   "grid": {
+    "viewTemplate": {
+     "rows": {
+      "units": [
+       {
+        "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+        "name": "Year",
+        "type": "attribute"
+       },
+       {
+        "id": "C3292DAD4FAF404F88590CB19C3930F9",
+        "name": "Month",
+        "type": "attribute"
+       }
+      ],
+      "sorts": []
+     },
+     "columns": {
+      "units": [
+       {
+        "type": "metrics",
+        "elements": [
+         {
+          "id": "413D98E4993B4D6ABB2DC440F7B31971",
+          "name": "Total Net Revenue",
+          "subType": "metric"
+         },
+         {
+          "id": "145746BAC65E4BF39E83149A843A3DF7",
+          "name": "Order Count",
+          "subType": "metric"
+         }
+        ]
+       }
+      ],
+      "sorts": []
+     },
+     "pageBy": {
+      "units": [],
+      "sorts": []
+     }
+    },
+    "viewFilter": {}
+   }
+  },
+  "69759BAD734F3EB9308219B61D916432": {
+   "information": {
+    "dateCreated": "2026-06-11T01:51:18.212Z",
+    "dateModified": "2026-06-11T01:51:18.212Z",
+    "versionId": "A44A49EA35425984036D79927BEFA145",
+    "acg": 255,
+    "objectId": "69759BAD734F3EB9308219B61D916432",
+    "subType": "report_grid",
+    "name": "Channel Performance"
+   },
+   "sourceType": "normal",
+   "dataSource": {
+    "dataTemplate": {
+     "units": [
+      {
+       "id": "E951AA8437BF46BB860E98F0DB349617",
+       "name": "Order Channel",
+       "type": "attribute",
+       "nonAggregatable": false
+      },
+      {
+       "type": "metrics",
+       "elements": [
+        {
+         "id": "413D98E4993B4D6ABB2DC440F7B31971",
+         "name": "Total Net Revenue",
+         "subType": "metric"
+        },
+        {
+         "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+         "name": "Units Sold",
+         "subType": "metric"
+        },
+        {
+         "id": "145746BAC65E4BF39E83149A843A3DF7",
+         "name": "Order Count",
+         "subType": "metric"
+        }
+       ]
+      }
+     ]
+    },
+    "filter": {}
+   },
+   "grid": {
+    "viewTemplate": {
+     "rows": {
+      "units": [
+       {
+        "id": "E951AA8437BF46BB860E98F0DB349617",
+        "name": "Order Channel",
+        "type": "attribute"
+       }
+      ],
+      "sorts": []
+     },
+     "columns": {
+      "units": [
+       {
+        "type": "metrics",
+        "elements": [
+         {
+          "id": "413D98E4993B4D6ABB2DC440F7B31971",
+          "name": "Total Net Revenue",
+          "subType": "metric"
+         },
+         {
+          "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+          "name": "Units Sold",
+          "subType": "metric"
+         },
+         {
+          "id": "145746BAC65E4BF39E83149A843A3DF7",
+          "name": "Order Count",
+          "subType": "metric"
+         }
+        ]
+       }
+      ],
+      "sorts": []
+     },
+     "pageBy": {
+      "units": [],
+      "sorts": []
+     }
+    },
+    "viewFilter": {}
+   }
+  }
+ },
+ "attributes": {
+  "13AF74581AA84A46B8FD2D1BBA073150": {
+   "information": {
+    "dateCreated": "2026-06-11T01:39:45.089Z",
+    "dateModified": "2026-06-11T01:40:35.091Z",
+    "versionId": "2F7B0587EB4A72B49B0EAAAC1FC4B0C4",
+    "acg": 255,
+    "objectId": "13AF74581AA84A46B8FD2D1BBA073150",
+    "subType": "attribute",
+    "name": "Category"
+   },
+   "forms": [
+    {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "",
+     "category": "ID",
+     "type": "system",
+     "displayFormat": "text",
+     "dataType": {
+      "type": "fixed_length_string",
+      "precision": 50,
+      "scale": -2147483648
+     },
+     "expressions": [
+      {
+       "expressionId": "B8BB213EB9B3474BA0A064C69F846AE9",
+       "expression": {
+        "text": "CATEGORY",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "CATEGORY",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "EE2E24FFDF58489193BB93F5FEB66D5B",
+           "subType": "column",
+           "name": "CATEGORY"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+         "subType": "logical_table",
+         "name": "PRODUCT_DIM"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "CATEGORY",
+     "lookupTable": {
+      "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+      "subType": "logical_table",
+      "name": "PRODUCT_DIM"
+     }
+    }
+   ],
+   "attributeLookupTable": {
+    "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+    "subType": "logical_table",
+    "name": "PRODUCT_DIM"
+   },
+   "keyForm": {
+    "id": "45C11FA478E745FEA08D781CEA190FE5"
+   },
+   "displays": {
+    "reportDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ],
+    "browseDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ]
+   },
+   "sorts": {},
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "13AF74581AA84A46B8FD2D1BBA073150",
+      "subType": "attribute",
+      "name": "Category"
+     },
+     "child": {
+      "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+      "subType": "attribute",
+      "name": "Product"
+     },
+     "relationshipTable": {
+      "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+      "subType": "logical_table",
+      "name": "PRODUCT_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ],
+   "nonAggregatable": false,
+   "applySecurityFiltersToElementBrowsing": true,
+   "enableElementCaching": true,
+   "elementDisplayOption": "all_elements"
+  },
+  "6140BFA7309B406AA76A90454BC7BB53": {
+   "information": {
+    "dateCreated": "2026-06-11T01:39:45.089Z",
+    "dateModified": "2026-06-11T01:40:35.091Z",
+    "versionId": "2F7B0587EB4A72B49B0EAAAC1FC4B0C4",
+    "acg": 255,
+    "objectId": "6140BFA7309B406AA76A90454BC7BB53",
+    "subType": "attribute",
+    "name": "Region"
+   },
+   "forms": [
+    {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "",
+     "category": "ID",
+     "type": "system",
+     "displayFormat": "text",
+     "dataType": {
+      "type": "fixed_length_string",
+      "precision": 20,
+      "scale": -2147483648
+     },
+     "expressions": [
+      {
+       "expressionId": "02676EBADA84448B9F8C161CA904811C",
+       "expression": {
+        "text": "REGION",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "REGION",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "31FC4505562A431BBBB15D0B79514023",
+           "subType": "column",
+           "name": "REGION"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+         "subType": "logical_table",
+         "name": "STORE_DIM"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "REGION",
+     "lookupTable": {
+      "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+      "subType": "logical_table",
+      "name": "STORE_DIM"
+     }
+    }
+   ],
+   "attributeLookupTable": {
+    "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+    "subType": "logical_table",
+    "name": "STORE_DIM"
+   },
+   "keyForm": {
+    "id": "45C11FA478E745FEA08D781CEA190FE5"
+   },
+   "displays": {
+    "reportDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ],
+    "browseDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ]
+   },
+   "sorts": {},
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "6140BFA7309B406AA76A90454BC7BB53",
+      "subType": "attribute",
+      "name": "Region"
+     },
+     "child": {
+      "objectId": "9177026370BB44A3A0CD521FE5166500",
+      "subType": "attribute",
+      "name": "Store"
+     },
+     "relationshipTable": {
+      "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+      "subType": "logical_table",
+      "name": "STORE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ],
+   "nonAggregatable": false,
+   "applySecurityFiltersToElementBrowsing": true,
+   "enableElementCaching": true,
+   "elementDisplayOption": "all_elements"
+  },
+  "C025482DAE4C4BFDA72E8297D981ABAC": {
+   "information": {
+    "dateCreated": "2026-06-11T01:39:45.089Z",
+    "dateModified": "2026-06-11T01:40:35.091Z",
+    "versionId": "2F7B0587EB4A72B49B0EAAAC1FC4B0C4",
+    "acg": 255,
+    "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+    "subType": "attribute",
+    "name": "Year"
+   },
+   "forms": [
+    {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "",
+     "category": "ID",
+     "type": "system",
+     "displayFormat": "number",
+     "dataType": {
+      "type": "decimal",
+      "precision": 4,
+      "scale": 0
+     },
+     "expressions": [
+      {
+       "expressionId": "D06E7BCA19D543F589D084E7C90B89E9",
+       "expression": {
+        "text": "YEAR",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "YEAR",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "A443425EB7684086B49B5182EDA0D825",
+           "subType": "column",
+           "name": "YEAR"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+         "subType": "logical_table",
+         "name": "DATE_DIM"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "YEAR",
+     "lookupTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     }
+    }
+   ],
+   "attributeLookupTable": {
+    "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+    "subType": "logical_table",
+    "name": "DATE_DIM"
+   },
+   "keyForm": {
+    "id": "45C11FA478E745FEA08D781CEA190FE5"
+   },
+   "displays": {
+    "reportDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ],
+    "browseDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ]
+   },
+   "sorts": {},
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+      "subType": "attribute",
+      "name": "Year"
+     },
+     "child": {
+      "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "relationshipTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ],
+   "nonAggregatable": false,
+   "applySecurityFiltersToElementBrowsing": true,
+   "enableElementCaching": true,
+   "elementDisplayOption": "all_elements"
+  },
+  "C3292DAD4FAF404F88590CB19C3930F9": {
+   "information": {
+    "dateCreated": "2026-06-11T01:39:45.089Z",
+    "dateModified": "2026-06-11T01:40:35.091Z",
+    "versionId": "2F7B0587EB4A72B49B0EAAAC1FC4B0C4",
+    "acg": 255,
+    "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+    "subType": "attribute",
+    "name": "Month"
+   },
+   "forms": [
+    {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "",
+     "category": "ID",
+     "type": "system",
+     "displayFormat": "number",
+     "dataType": {
+      "type": "decimal",
+      "precision": 2,
+      "scale": 0
+     },
+     "expressions": [
+      {
+       "expressionId": "526242A750714963BE42EB4E80918214",
+       "expression": {
+        "text": "MONTH_NUMBER",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "MONTH_NUMBER",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "421F8160638F4F9AA7FC434C0EBF14EC",
+           "subType": "column",
+           "name": "MONTH_NUMBER"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+         "subType": "logical_table",
+         "name": "DATE_DIM"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "MONTH_NUMBER",
+     "lookupTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     }
+    },
+    {
+     "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+     "name": "",
+     "category": "DESC",
+     "type": "system",
+     "displayFormat": "text",
+     "dataType": {
+      "type": "fixed_length_string",
+      "precision": 10,
+      "scale": -2147483648
+     },
+     "expressions": [
+      {
+       "expressionId": "E56418E7E00A4115BB562695AE70921E",
+       "expression": {
+        "text": "MONTH_NAME",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "MONTH_NAME",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "4C6BF4B48BF94197B76731366E39ED7A",
+           "subType": "column",
+           "name": "MONTH_NAME"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+         "subType": "logical_table",
+         "name": "DATE_DIM"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "MONTH_NAME",
+     "lookupTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     }
+    }
+   ],
+   "attributeLookupTable": {
+    "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+    "subType": "logical_table",
+    "name": "DATE_DIM"
+   },
+   "keyForm": {
+    "id": "45C11FA478E745FEA08D781CEA190FE5"
+   },
+   "displays": {
+    "reportDisplays": [
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C"
+     }
+    ],
+    "browseDisplays": [
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C"
+     }
+    ]
+   },
+   "sorts": {},
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+      "subType": "attribute",
+      "name": "Year"
+     },
+     "child": {
+      "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "relationshipTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    },
+    {
+     "parent": {
+      "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "child": {
+      "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+      "subType": "attribute",
+      "name": "Day"
+     },
+     "relationshipTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ],
+   "nonAggregatable": false,
+   "applySecurityFiltersToElementBrowsing": true,
+   "enableElementCaching": true,
+   "elementDisplayOption": "all_elements"
+  },
+  "E951AA8437BF46BB860E98F0DB349617": {
+   "information": {
+    "dateCreated": "2026-06-11T01:39:45.089Z",
+    "dateModified": "2026-06-11T01:39:45.089Z",
+    "versionId": "B6C6654A01446E6F7D4C42BDD134E645",
+    "acg": 255,
+    "objectId": "E951AA8437BF46BB860E98F0DB349617",
+    "subType": "attribute",
+    "name": "Order Channel"
+   },
+   "forms": [
+    {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "",
+     "category": "ID",
+     "type": "system",
+     "displayFormat": "text",
+     "dataType": {
+      "type": "fixed_length_string",
+      "precision": 20,
+      "scale": -2147483648
+     },
+     "expressions": [
+      {
+       "expressionId": "30FCC73845F54BD0AAA4D55C723C8432",
+       "expression": {
+        "text": "ORDER_CHANNEL",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "ORDER_CHANNEL",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "6D2F6387F5624C3FA6D4F9CC5320D324",
+           "subType": "column",
+           "name": "ORDER_CHANNEL"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "D9FC61279B1B493896B8D146734F3706",
+         "subType": "logical_table",
+         "name": "ORDER_FACT"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "ORDER_CHANNEL",
+     "lookupTable": {
+      "objectId": "D9FC61279B1B493896B8D146734F3706",
+      "subType": "logical_table",
+      "name": "ORDER_FACT"
+     }
+    }
+   ],
+   "attributeLookupTable": {
+    "objectId": "D9FC61279B1B493896B8D146734F3706",
+    "subType": "logical_table",
+    "name": "ORDER_FACT"
+   },
+   "keyForm": {
+    "id": "45C11FA478E745FEA08D781CEA190FE5"
+   },
+   "displays": {
+    "reportDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ],
+    "browseDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ]
+   },
+   "sorts": {},
+   "relationships": [],
+   "nonAggregatable": false,
+   "applySecurityFiltersToElementBrowsing": true,
+   "enableElementCaching": true,
+   "elementDisplayOption": "all_elements"
+  }
+ },
+ "metrics": {
+  "145746BAC65E4BF39E83149A843A3DF7": {
+   "information": {
+    "dateCreated": "2026-06-11T01:41:18.866Z",
+    "dateModified": "2026-06-11T01:41:18.866Z",
+    "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+    "acg": 255,
+    "objectId": "145746BAC65E4BF39E83149A843A3DF7",
+    "subType": "metric",
+    "name": "Order Count"
+   },
+   "expression": {
+    "text": "Count({Order Id Fact})",
+    "tokens": [
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Count",
+      "type": "function",
+      "target": {
+       "dateCreated": "2025-05-29T19:58:08.059Z",
+       "dateModified": "2025-05-29T19:58:08.059Z",
+       "versionId": "CD5315C011DF671600088AA0669A0C20",
+       "acg": 255,
+       "objectId": "8107C31CDD9911D3B98100C04F2233EA",
+       "subType": "function",
+       "name": "Count",
+       "description": "Returns the number of values the ValueList. This is a group-value function."
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "<",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Distinct",
+      "type": "identifier"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "=",
+      "type": "function"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "True",
+      "type": "boolean"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ",",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "UseLookupForAttributes",
+      "type": "identifier"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "=",
+      "type": "function"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "False",
+      "type": "boolean"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ">",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "(",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "[Order Id Fact]",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:40:36.959Z",
+       "dateModified": "2026-06-11T01:40:36.959Z",
+       "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+       "acg": 255,
+       "objectId": "313BB989028B430A9E8734AEB7432BF3",
+       "subType": "fact",
+       "name": "Order Id Fact"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ")",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "{",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "~",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "}",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "",
+      "type": "end_of_text"
+     }
+    ]
+   },
+   "dimty": {
+    "dimtyUnits": [
+     {
+      "dimtyUnitType": "report_base_level",
+      "aggregation": "normal",
+      "filtering": "none",
+      "groupBy": true
+     }
+    ],
+    "excludeAttribute": false,
+    "allowAddingUnit": true
+   },
+   "conditionality": {
+    "embedMethod": "report_into_metric_filter",
+    "removeElements": true
+   },
+   "metricSubtotals": [],
+   "aggregateFromBase": false,
+   "formulaJoinType": "default",
+   "smartTotal": "decomposable_false",
+   "dataType": {
+    "type": "reserved",
+    "precision": 0,
+    "scale": 0
+   },
+   "format": {
+    "header": [],
+    "values": []
+   },
+   "subtotalFromBase": false,
+   "metricFormatType": "reserved",
+   "thresholds": []
+  },
+  "3BF64C66D95D41888EE5EEDEFAFB7C69": {
+   "information": {
+    "dateCreated": "2026-06-11T01:41:18.866Z",
+    "dateModified": "2026-06-11T01:41:18.866Z",
+    "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+    "acg": 255,
+    "objectId": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+    "subType": "metric",
+    "name": "Units Sold"
+   },
+   "expression": {
+    "text": "Sum(Quantity)",
+    "tokens": [
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Sum",
+      "type": "function",
+      "target": {
+       "dateCreated": "2025-05-29T19:58:08.059Z",
+       "dateModified": "2025-05-29T19:58:08.059Z",
+       "versionId": "CD5315C011DF671600088AA0669A0C20",
+       "acg": 255,
+       "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+       "subType": "function",
+       "name": "Sum",
+       "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "<",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "UseLookupForAttributes",
+      "type": "identifier"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "=",
+      "type": "function"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "False",
+      "type": "boolean"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ">",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "(",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Quantity",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:40:36.959Z",
+       "dateModified": "2026-06-11T01:40:36.959Z",
+       "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+       "acg": 255,
+       "objectId": "5BC47E4C35454EA5BD24C54AF3430577",
+       "subType": "fact",
+       "name": "Quantity"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ")",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "{",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "~",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "}",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "",
+      "type": "end_of_text"
+     }
+    ]
+   },
+   "dimty": {
+    "dimtyUnits": [
+     {
+      "dimtyUnitType": "report_base_level",
+      "aggregation": "normal",
+      "filtering": "none",
+      "groupBy": true
+     }
+    ],
+    "excludeAttribute": false,
+    "allowAddingUnit": true
+   },
+   "conditionality": {
+    "embedMethod": "report_into_metric_filter",
+    "removeElements": true
+   },
+   "metricSubtotals": [],
+   "aggregateFromBase": false,
+   "formulaJoinType": "default",
+   "smartTotal": "decomposable_false",
+   "dataType": {
+    "type": "reserved",
+    "precision": 0,
+    "scale": 0
+   },
+   "format": {
+    "header": [],
+    "values": []
+   },
+   "subtotalFromBase": false,
+   "metricFormatType": "reserved",
+   "thresholds": []
+  },
+  "413D98E4993B4D6ABB2DC440F7B31971": {
+   "information": {
+    "dateCreated": "2026-06-11T01:41:18.866Z",
+    "dateModified": "2026-06-11T01:41:18.866Z",
+    "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+    "acg": 255,
+    "objectId": "413D98E4993B4D6ABB2DC440F7B31971",
+    "subType": "metric",
+    "name": "Total Net Revenue"
+   },
+   "expression": {
+    "text": "Sum({Net Revenue})",
+    "tokens": [
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Sum",
+      "type": "function",
+      "target": {
+       "dateCreated": "2025-05-29T19:58:08.059Z",
+       "dateModified": "2025-05-29T19:58:08.059Z",
+       "versionId": "CD5315C011DF671600088AA0669A0C20",
+       "acg": 255,
+       "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+       "subType": "function",
+       "name": "Sum",
+       "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "<",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "UseLookupForAttributes",
+      "type": "identifier"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "=",
+      "type": "function"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "False",
+      "type": "boolean"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ">",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "(",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "[Net Revenue]",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:40:36.959Z",
+       "dateModified": "2026-06-11T01:40:36.959Z",
+       "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+       "acg": 255,
+       "objectId": "DDBF580D0AD14785A742CCC40EE2EE5C",
+       "subType": "fact",
+       "name": "Net Revenue"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ")",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "{",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "~",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "}",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "",
+      "type": "end_of_text"
+     }
+    ]
+   },
+   "dimty": {
+    "dimtyUnits": [
+     {
+      "dimtyUnitType": "report_base_level",
+      "aggregation": "normal",
+      "filtering": "none",
+      "groupBy": true
+     }
+    ],
+    "excludeAttribute": false,
+    "allowAddingUnit": true
+   },
+   "conditionality": {
+    "embedMethod": "report_into_metric_filter",
+    "removeElements": true
+   },
+   "metricSubtotals": [],
+   "aggregateFromBase": false,
+   "formulaJoinType": "default",
+   "smartTotal": "decomposable_false",
+   "dataType": {
+    "type": "reserved",
+    "precision": 0,
+    "scale": 0
+   },
+   "format": {
+    "header": [],
+    "values": []
+   },
+   "subtotalFromBase": false,
+   "metricFormatType": "reserved",
+   "thresholds": []
+  },
+  "5393F49A94A443E79E38CB3855B0272F": {
+   "information": {
+    "dateCreated": "2026-06-11T01:41:19.395Z",
+    "dateModified": "2026-06-11T01:41:19.395Z",
+    "versionId": "1CEBD6B78A4C252713DAA3ACB624BBB3",
+    "acg": 255,
+    "objectId": "5393F49A94A443E79E38CB3855B0272F",
+    "subType": "metric",
+    "name": "Profit Margin Pct"
+   },
+   "expression": {
+    "text": "{Total Gross Profit} / {Total Net Revenue}",
+    "tokens": [
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "[Total Gross Profit]",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:41:18.866Z",
+       "dateModified": "2026-06-11T01:41:18.866Z",
+       "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+       "acg": 255,
+       "objectId": "653830C2CB684809B7030FBBEA498C8C",
+       "subType": "metric",
+       "name": "Total Gross Profit"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "/",
+      "type": "character",
+      "target": {
+       "dateCreated": "2025-05-29T19:58:08.059Z",
+       "dateModified": "2025-05-29T19:58:08.059Z",
+       "versionId": "CD5315C011DF671600088AA0669A0C20",
+       "acg": 255,
+       "objectId": "8107C313DD9911D3B98100C04F2233EA",
+       "subType": "function",
+       "name": "/",
+       "description": "Returns the quotient when one value is divided by another."
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "[Total Net Revenue]",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:41:18.866Z",
+       "dateModified": "2026-06-11T01:41:18.866Z",
+       "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+       "acg": 255,
+       "objectId": "413D98E4993B4D6ABB2DC440F7B31971",
+       "subType": "metric",
+       "name": "Total Net Revenue"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "",
+      "type": "end_of_text"
+     }
+    ]
+   },
+   "metricSubtotals": [],
+   "aggregateFromBase": false,
+   "formulaJoinType": "default",
+   "smartTotal": "decomposable_false",
+   "dataType": {
+    "type": "reserved",
+    "precision": 0,
+    "scale": 0
+   },
+   "format": {
+    "header": [],
+    "values": []
+   },
+   "subtotalFromBase": false,
+   "metricFormatType": "reserved",
+   "thresholds": []
+  },
+  "653830C2CB684809B7030FBBEA498C8C": {
+   "information": {
+    "dateCreated": "2026-06-11T01:41:18.866Z",
+    "dateModified": "2026-06-11T01:41:18.866Z",
+    "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+    "acg": 255,
+    "objectId": "653830C2CB684809B7030FBBEA498C8C",
+    "subType": "metric",
+    "name": "Total Gross Profit"
+   },
+   "expression": {
+    "text": "Sum({Gross Profit})",
+    "tokens": [
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Sum",
+      "type": "function",
+      "target": {
+       "dateCreated": "2025-05-29T19:58:08.059Z",
+       "dateModified": "2025-05-29T19:58:08.059Z",
+       "versionId": "CD5315C011DF671600088AA0669A0C20",
+       "acg": 255,
+       "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+       "subType": "function",
+       "name": "Sum",
+       "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "<",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "UseLookupForAttributes",
+      "type": "identifier"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "=",
+      "type": "function"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "False",
+      "type": "boolean"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ">",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "(",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "[Gross Profit]",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:40:36.959Z",
+       "dateModified": "2026-06-11T01:40:36.959Z",
+       "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+       "acg": 255,
+       "objectId": "AE6CEAC55D054ABDAA3526C8931BD21B",
+       "subType": "fact",
+       "name": "Gross Profit"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ")",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "{",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "~",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "}",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "",
+      "type": "end_of_text"
+     }
+    ]
+   },
+   "dimty": {
+    "dimtyUnits": [
+     {
+      "dimtyUnitType": "report_base_level",
+      "aggregation": "normal",
+      "filtering": "none",
+      "groupBy": true
+     }
+    ],
+    "excludeAttribute": false,
+    "allowAddingUnit": true
+   },
+   "conditionality": {
+    "embedMethod": "report_into_metric_filter",
+    "removeElements": true
+   },
+   "metricSubtotals": [],
+   "aggregateFromBase": false,
+   "formulaJoinType": "default",
+   "smartTotal": "decomposable_false",
+   "dataType": {
+    "type": "reserved",
+    "precision": 0,
+    "scale": 0
+   },
+   "format": {
+    "header": [],
+    "values": []
+   },
+   "subtotalFromBase": false,
+   "metricFormatType": "reserved",
+   "thresholds": []
+  }
+ },
+ "facts": {
+  "313BB989028B430A9E8734AEB7432BF3": {
+   "information": {
+    "dateCreated": "2026-06-11T01:40:36.959Z",
+    "dateModified": "2026-06-11T01:40:36.959Z",
+    "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+    "acg": 255,
+    "objectId": "313BB989028B430A9E8734AEB7432BF3",
+    "subType": "fact",
+    "name": "Order Id Fact"
+   },
+   "dataType": {
+    "type": "fixed_length_string",
+    "precision": 20,
+    "scale": -2147483648
+   },
+   "expressions": [
+    {
+     "expressionId": "81AA6DD90EDC46B5BF314F1830DDA14E",
+     "expression": {
+      "text": "ORDER_ID",
+      "tokens": [
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "ORDER_ID",
+        "type": "column_reference",
+        "target": {
+         "dateCreated": "2026-06-11T01:34:19.851Z",
+         "dateModified": "2026-06-11T01:34:19.851Z",
+         "versionId": "D84CD810B84204E035ADD5BF872EC621",
+         "acg": 255,
+         "objectId": "B183B71282A94A5ABC04FEC48ABDE592",
+         "subType": "column",
+         "name": "ORDER_ID"
+        }
+       },
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "",
+        "type": "end_of_text"
+       }
+      ]
+     },
+     "tables": [
+      {
+       "objectId": "D9FC61279B1B493896B8D146734F3706",
+       "subType": "logical_table",
+       "name": "ORDER_FACT"
+      }
+     ],
+     "autoMapping": true
+    }
+   ],
+   "extensions": [],
+   "entryLevel": [
+    {
+     "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+     "subType": "attribute",
+     "name": "Customer"
+    },
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    {
+     "objectId": "E951AA8437BF46BB860E98F0DB349617",
+     "subType": "attribute",
+     "name": "Order Channel"
+    },
+    {
+     "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+     "subType": "attribute",
+     "name": "Order Status"
+    },
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "alias": "ORDER_ID"
+  },
+  "5BC47E4C35454EA5BD24C54AF3430577": {
+   "information": {
+    "dateCreated": "2026-06-11T01:40:36.959Z",
+    "dateModified": "2026-06-11T01:40:36.959Z",
+    "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+    "acg": 255,
+    "objectId": "5BC47E4C35454EA5BD24C54AF3430577",
+    "subType": "fact",
+    "name": "Quantity"
+   },
+   "dataType": {
+    "type": "decimal",
+    "precision": 6,
+    "scale": 0
+   },
+   "expressions": [
+    {
+     "expressionId": "2057D1110EA14C20822C052771D8D47B",
+     "expression": {
+      "text": "QUANTITY_ORDERED",
+      "tokens": [
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "QUANTITY_ORDERED",
+        "type": "column_reference",
+        "target": {
+         "dateCreated": "2026-06-11T01:34:19.851Z",
+         "dateModified": "2026-06-11T01:34:19.851Z",
+         "versionId": "D84CD810B84204E035ADD5BF872EC621",
+         "acg": 255,
+         "objectId": "3FBBDD38F0174D8096AF8840C4740821",
+         "subType": "column",
+         "name": "QUANTITY_ORDERED"
+        }
+       },
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "",
+        "type": "end_of_text"
+       }
+      ]
+     },
+     "tables": [
+      {
+       "objectId": "D9FC61279B1B493896B8D146734F3706",
+       "subType": "logical_table",
+       "name": "ORDER_FACT"
+      }
+     ],
+     "autoMapping": true
+    }
+   ],
+   "extensions": [],
+   "entryLevel": [
+    {
+     "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+     "subType": "attribute",
+     "name": "Customer"
+    },
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    {
+     "objectId": "E951AA8437BF46BB860E98F0DB349617",
+     "subType": "attribute",
+     "name": "Order Channel"
+    },
+    {
+     "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+     "subType": "attribute",
+     "name": "Order Status"
+    },
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "alias": "QUANTITY_ORDERED"
+  },
+  "AE6CEAC55D054ABDAA3526C8931BD21B": {
+   "information": {
+    "dateCreated": "2026-06-11T01:40:36.959Z",
+    "dateModified": "2026-06-11T01:40:36.959Z",
+    "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+    "acg": 255,
+    "objectId": "AE6CEAC55D054ABDAA3526C8931BD21B",
+    "subType": "fact",
+    "name": "Gross Profit"
+   },
+   "dataType": {
+    "type": "decimal",
+    "precision": 12,
+    "scale": 2
+   },
+   "expressions": [
+    {
+     "expressionId": "1C48419202864E2092EB33D7AB7C7184",
+     "expression": {
+      "text": "GROSS_PROFIT",
+      "tokens": [
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "GROSS_PROFIT",
+        "type": "column_reference",
+        "target": {
+         "dateCreated": "2026-06-11T01:34:19.851Z",
+         "dateModified": "2026-06-11T01:34:19.851Z",
+         "versionId": "D84CD810B84204E035ADD5BF872EC621",
+         "acg": 255,
+         "objectId": "962C692A0DC748F2802B6479DC93756A",
+         "subType": "column",
+         "name": "GROSS_PROFIT"
+        }
+       },
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "",
+        "type": "end_of_text"
+       }
+      ]
+     },
+     "tables": [
+      {
+       "objectId": "D9FC61279B1B493896B8D146734F3706",
+       "subType": "logical_table",
+       "name": "ORDER_FACT"
+      }
+     ],
+     "autoMapping": true
+    }
+   ],
+   "extensions": [],
+   "entryLevel": [
+    {
+     "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+     "subType": "attribute",
+     "name": "Customer"
+    },
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    {
+     "objectId": "E951AA8437BF46BB860E98F0DB349617",
+     "subType": "attribute",
+     "name": "Order Channel"
+    },
+    {
+     "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+     "subType": "attribute",
+     "name": "Order Status"
+    },
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "alias": "GROSS_PROFIT"
+  },
+  "DDBF580D0AD14785A742CCC40EE2EE5C": {
+   "information": {
+    "dateCreated": "2026-06-11T01:40:36.959Z",
+    "dateModified": "2026-06-11T01:40:36.959Z",
+    "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+    "acg": 255,
+    "objectId": "DDBF580D0AD14785A742CCC40EE2EE5C",
+    "subType": "fact",
+    "name": "Net Revenue"
+   },
+   "dataType": {
+    "type": "decimal",
+    "precision": 12,
+    "scale": 2
+   },
+   "expressions": [
+    {
+     "expressionId": "31463B9045A24EF0B627A186801BDB85",
+     "expression": {
+      "text": "NET_REVENUE",
+      "tokens": [
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "NET_REVENUE",
+        "type": "column_reference",
+        "target": {
+         "dateCreated": "2026-06-11T01:34:19.851Z",
+         "dateModified": "2026-06-11T01:34:19.851Z",
+         "versionId": "D84CD810B84204E035ADD5BF872EC621",
+         "acg": 255,
+         "objectId": "03E5DD935D8C4BB48FA2335D47921180",
+         "subType": "column",
+         "name": "NET_REVENUE"
+        }
+       },
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "",
+        "type": "end_of_text"
+       }
+      ]
+     },
+     "tables": [
+      {
+       "objectId": "D9FC61279B1B493896B8D146734F3706",
+       "subType": "logical_table",
+       "name": "ORDER_FACT"
+      }
+     ],
+     "autoMapping": true
+    }
+   ],
+   "extensions": [],
+   "entryLevel": [
+    {
+     "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+     "subType": "attribute",
+     "name": "Customer"
+    },
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    {
+     "objectId": "E951AA8437BF46BB860E98F0DB349617",
+     "subType": "attribute",
+     "name": "Order Channel"
+    },
+    {
+     "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+     "subType": "attribute",
+     "name": "Order Status"
+    },
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "alias": "NET_REVENUE"
+  }
+ },
+ "tables": {
+  "47E46839DEBB4EEF9B10CCA524E0C794": {
+   "information": {
+    "dateCreated": "2026-06-11T01:34:19.851Z",
+    "dateModified": "2026-06-11T01:39:45.089Z",
+    "versionId": "B6C6654A01446E6F7D4C42BDD134E645",
+    "acg": 255,
+    "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+    "subType": "logical_table",
+    "name": "PRODUCT_DIM"
+   },
+   "physicalTable": {
+    "information": {
+     "dateCreated": "2026-06-11T01:34:19.851Z",
+     "dateModified": "2026-06-11T01:34:19.851Z",
+     "versionId": "D84CD810B84204E035ADD5BF872EC621",
+     "acg": 255,
+     "objectId": "D940EBAC1FB74D9689BED56A11642F05",
+     "subType": "physical_table",
+     "name": "PRODUCT_DIM"
+    },
+    "tableName": "PRODUCT_DIM",
+    "columns": [
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "1BBA29679ABE48E7B554D8FD947DB2BE",
+       "subType": "column",
+       "name": "BRAND"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 50,
+       "scale": -2147483648
+      },
+      "columnName": "BRAND"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "EE2E24FFDF58489193BB93F5FEB66D5B",
+       "subType": "column",
+       "name": "CATEGORY"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 50,
+       "scale": -2147483648
+      },
+      "columnName": "CATEGORY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "E23718322CBE48F3980C90549F47691C",
+       "subType": "column",
+       "name": "DISCONTINUE_DATE"
+      },
+      "dataType": {
+       "type": "date",
+       "precision": 0,
+       "scale": -2147483648
+      },
+      "columnName": "DISCONTINUE_DATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "9E4A20F1F6D84F259409F1A8617667EE",
+       "subType": "column",
+       "name": "IS_ACTIVE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_ACTIVE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "45C00E20CE4244F0A33DCDD0EE27FAE6",
+       "subType": "column",
+       "name": "IS_PRIVATE_LABEL"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_PRIVATE_LABEL"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "51038229B06B400F98B2470A75A0B4D8",
+       "subType": "column",
+       "name": "IS_SEASONAL"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_SEASONAL"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "F28C6CD1025E4B068CEC24D7C43F4B1D",
+       "subType": "column",
+       "name": "LAUNCH_DATE"
+      },
+      "dataType": {
+       "type": "date",
+       "precision": 0,
+       "scale": -2147483648
+      },
+      "columnName": "LAUNCH_DATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "022FD6B1B053432E998F5BD387583EEF",
+       "subType": "column",
+       "name": "PRODUCT_ID"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "PRODUCT_ID"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "42FC35A6FBF248458F96D54C8404E071",
+       "subType": "column",
+       "name": "PRODUCT_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "PRODUCT_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "748EC2993D1D4C5D87CAD5421722B576",
+       "subType": "column",
+       "name": "PRODUCT_NAME"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 150,
+       "scale": -2147483648
+      },
+      "columnName": "PRODUCT_NAME"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "661455C3624F4CE3B614D1627D7D6E9F",
+       "subType": "column",
+       "name": "Product_Key/Name"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 16777216,
+       "scale": -2147483648
+      },
+      "columnName": "Product_Key/Name"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "4F17FDCB18764647AFAFFD24D6217CAE",
+       "subType": "column",
+       "name": "SUBCATEGORY"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 50,
+       "scale": -2147483648
+      },
+      "columnName": "SUBCATEGORY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D30824A0D0D54A4DB3B5300BAFB2D859",
+       "subType": "column",
+       "name": "UNIT_COST"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "UNIT_COST"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "4A933FCF738D45B89787EF4E8D70053B",
+       "subType": "column",
+       "name": "UNIT_PRICE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "UNIT_PRICE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "FC32EF80F2A04FE8B061D05F52F09630",
+       "subType": "column",
+       "name": "WEIGHT_LBS"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 2
+      },
+      "columnName": "WEIGHT_LBS"
+     }
+    ],
+    "namespace": "TJ",
+    "tablePrefix": "TJ.",
+    "type": "normal"
+   },
+   "logicalSize": 15,
+   "isLogicalSizeLocked": false,
+   "isTrueKey": true,
+   "isPartOfPartition": false,
+   "tableKey": [
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    }
+   ],
+   "attributes": [
+    {
+     "information": {
+      "objectId": "13AF74581AA84A46B8FD2D1BBA073150",
+      "subType": "attribute",
+      "name": "Category"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+        "subType": "logical_table",
+        "name": "PRODUCT_DIM"
+       },
+       "expression": {
+        "text": "CATEGORY"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+      "subType": "attribute",
+      "name": "Product"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+        "subType": "logical_table",
+        "name": "PRODUCT_DIM"
+       },
+       "expression": {
+        "text": "PRODUCT_KEY"
+       }
+      },
+      {
+       "formCategory": {
+        "objectId": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "subType": "attribute_form_system",
+        "name": "DESC"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": false,
+       "lookupTable": {
+        "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+        "subType": "logical_table",
+        "name": "PRODUCT_DIM"
+       },
+       "expression": {
+        "text": "PRODUCT_NAME"
+       }
+      }
+     ]
+    }
+   ],
+   "primaryDataSource": {
+    "objectId": "B2ABAAB6EA4FE181C3BF43B09D0930FC",
+    "subType": "db_role",
+    "name": "Snowflake CSA"
+   },
+   "secondaryDataSources": []
+  },
+  "64D5C75E86F84FC78F39C8413018DF3D": {
+   "information": {
+    "dateCreated": "2026-06-11T01:34:19.851Z",
+    "dateModified": "2026-06-11T01:39:45.089Z",
+    "versionId": "B6C6654A01446E6F7D4C42BDD134E645",
+    "acg": 255,
+    "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+    "subType": "logical_table",
+    "name": "DATE_DIM"
+   },
+   "physicalTable": {
+    "information": {
+     "dateCreated": "2026-06-11T01:34:19.851Z",
+     "dateModified": "2026-06-11T01:34:19.851Z",
+     "versionId": "D84CD810B84204E035ADD5BF872EC621",
+     "acg": 255,
+     "objectId": "9609286525994536AE82F4CAD0BB05EC",
+     "subType": "physical_table",
+     "name": "DATE_DIM"
+    },
+    "tableName": "DATE_DIM",
+    "columns": [
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "CF20E78112994A5D96B2D39B628240E9",
+       "subType": "column",
+       "name": "DATE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "DATE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "C635418469C84543A173102128C48A02",
+       "subType": "column",
+       "name": "DAY_OF_MONTH"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 2,
+       "scale": 0
+      },
+      "columnName": "DAY_OF_MONTH"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "E314B08C2F51449081C21E13C044E490",
+       "subType": "column",
+       "name": "DAY_OF_WEEK"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 10,
+       "scale": -2147483648
+      },
+      "columnName": "DAY_OF_WEEK"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "2390FE17710B4F7EB162540D2AF60934",
+       "subType": "column",
+       "name": "FISCAL_PERIOD"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 10,
+       "scale": -2147483648
+      },
+      "columnName": "FISCAL_PERIOD"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "6C552A18D8114E0E89E934EDE6EE0534",
+       "subType": "column",
+       "name": "FULL_DATE"
+      },
+      "dataType": {
+       "type": "date",
+       "precision": 0,
+       "scale": -2147483648
+      },
+      "columnName": "FULL_DATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "B4DBBBD4F03845E3843E121237CA1E22",
+       "subType": "column",
+       "name": "IS_HOLIDAY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_HOLIDAY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "04FBCA2E65074CF2855F2C636EF51055",
+       "subType": "column",
+       "name": "IS_WEEKEND"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_WEEKEND"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "4C6BF4B48BF94197B76731366E39ED7A",
+       "subType": "column",
+       "name": "MONTH_NAME"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 10,
+       "scale": -2147483648
+      },
+      "columnName": "MONTH_NAME"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "421F8160638F4F9AA7FC434C0EBF14EC",
+       "subType": "column",
+       "name": "MONTH_NUMBER"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 2,
+       "scale": 0
+      },
+      "columnName": "MONTH_NUMBER"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "A48AC88A9B4C4D599059820954BE4043",
+       "subType": "column",
+       "name": "QUARTER"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "QUARTER"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "15842FC875714225ADD1D284FA31167B",
+       "subType": "column",
+       "name": "WEEK_OF_YEAR"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 2,
+       "scale": 0
+      },
+      "columnName": "WEEK_OF_YEAR"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "A443425EB7684086B49B5182EDA0D825",
+       "subType": "column",
+       "name": "YEAR"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 4,
+       "scale": 0
+      },
+      "columnName": "YEAR"
+     }
+    ],
+    "namespace": "TJ",
+    "tablePrefix": "TJ.",
+    "type": "normal"
+   },
+   "logicalSize": 20,
+   "isLogicalSizeLocked": false,
+   "isTrueKey": true,
+   "isPartOfPartition": false,
+   "tableKey": [
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    }
+   ],
+   "attributes": [
+    {
+     "information": {
+      "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+      "subType": "attribute",
+      "name": "Year"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "YEAR"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "MONTH_NUMBER"
+       }
+      },
+      {
+       "formCategory": {
+        "objectId": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "subType": "attribute_form_system",
+        "name": "DESC"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": false,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "MONTH_NAME"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+      "subType": "attribute",
+      "name": "Day"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "DATE_KEY"
+       }
+      },
+      {
+       "formCategory": {
+        "objectId": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "subType": "attribute_form_system",
+        "name": "DESC"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": false,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "FULL_DATE"
+       }
+      }
+     ]
+    }
+   ],
+   "primaryDataSource": {
+    "objectId": "B2ABAAB6EA4FE181C3BF43B09D0930FC",
+    "subType": "db_role",
+    "name": "Snowflake CSA"
+   },
+   "secondaryDataSources": []
+  },
+  "98D96DCF86D1494DA8F62DDB5A6A8482": {
+   "information": {
+    "dateCreated": "2026-06-11T01:34:19.851Z",
+    "dateModified": "2026-06-11T01:39:45.089Z",
+    "versionId": "B6C6654A01446E6F7D4C42BDD134E645",
+    "acg": 255,
+    "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+    "subType": "logical_table",
+    "name": "STORE_DIM"
+   },
+   "physicalTable": {
+    "information": {
+     "dateCreated": "2026-06-11T01:34:19.851Z",
+     "dateModified": "2026-06-11T01:34:19.851Z",
+     "versionId": "D84CD810B84204E035ADD5BF872EC621",
+     "acg": 255,
+     "objectId": "47AE6C5128A64F0FB312D9B5EAC84F22",
+     "subType": "physical_table",
+     "name": "STORE_DIM"
+    },
+    "tableName": "STORE_DIM",
+    "columns": [
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "C77D2175AF254A5C85709C45ECFA62ED",
+       "subType": "column",
+       "name": "ANNUAL_LEASE_COST"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 12,
+       "scale": 2
+      },
+      "columnName": "ANNUAL_LEASE_COST"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "9CE28E0180B7443CADBFBD7DB37E7FE5",
+       "subType": "column",
+       "name": "CITY"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 50,
+       "scale": -2147483648
+      },
+      "columnName": "CITY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "69188ED23ABC41E1B32ECE2B6AD80FDF",
+       "subType": "column",
+       "name": "CLOSE_DATE"
+      },
+      "dataType": {
+       "type": "date",
+       "precision": 0,
+       "scale": -2147483648
+      },
+      "columnName": "CLOSE_DATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "FAF47F66F94349CF945911773FB44325",
+       "subType": "column",
+       "name": "DISTRICT"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 30,
+       "scale": -2147483648
+      },
+      "columnName": "DISTRICT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "120FA2DC07804DB586A155E9BF814939",
+       "subType": "column",
+       "name": "HAS_CAFE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "HAS_CAFE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D3EC8A6674484BC489483131D185A607",
+       "subType": "column",
+       "name": "HAS_CURBSIDE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "HAS_CURBSIDE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "9E4A20F1F6D84F259409F1A8617667EE",
+       "subType": "column",
+       "name": "IS_ACTIVE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_ACTIVE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "6E8637DEC6534B30A0CB423BC49E782D",
+       "subType": "column",
+       "name": "MANAGER_NAME"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 100,
+       "scale": -2147483648
+      },
+      "columnName": "MANAGER_NAME"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D7D8D64FDC3E4DFFB3532169E1D58E83",
+       "subType": "column",
+       "name": "OPEN_DATE"
+      },
+      "dataType": {
+       "type": "date",
+       "precision": 0,
+       "scale": -2147483648
+      },
+      "columnName": "OPEN_DATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "31FC4505562A431BBBB15D0B79514023",
+       "subType": "column",
+       "name": "REGION"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "REGION"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "90A0AE1E5DFC4774B00335784C9A9DBF",
+       "subType": "column",
+       "name": "SQUARE_FOOTAGE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "SQUARE_FOOTAGE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "5F24D32D23DB420397496C9B7880AF63",
+       "subType": "column",
+       "name": "STATE"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 2,
+       "scale": -2147483648
+      },
+      "columnName": "STATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "BCD37EA759D64B8DB1E069B9F3E315CB",
+       "subType": "column",
+       "name": "STORE_ID"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 10,
+       "scale": -2147483648
+      },
+      "columnName": "STORE_ID"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "552771515DA84D10833176D8DBA883C9",
+       "subType": "column",
+       "name": "STORE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "STORE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "3395C2D0B6B3423F99B5B7E0937FEEC3",
+       "subType": "column",
+       "name": "STORE_NAME"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 100,
+       "scale": -2147483648
+      },
+      "columnName": "STORE_NAME"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "A52225949EEB49C8BB9754730EC747ED",
+       "subType": "column",
+       "name": "STORE_PHONE"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "STORE_PHONE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "BE4FD6C00FB24D13B9A6625D345C1B0C",
+       "subType": "column",
+       "name": "STORE_TYPE"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "STORE_TYPE"
+     }
+    ],
+    "namespace": "TJ",
+    "tablePrefix": "TJ.",
+    "type": "normal"
+   },
+   "logicalSize": 15,
+   "isLogicalSizeLocked": false,
+   "isTrueKey": true,
+   "isPartOfPartition": false,
+   "tableKey": [
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "attributes": [
+    {
+     "information": {
+      "objectId": "6140BFA7309B406AA76A90454BC7BB53",
+      "subType": "attribute",
+      "name": "Region"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+        "subType": "logical_table",
+        "name": "STORE_DIM"
+       },
+       "expression": {
+        "text": "REGION"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "9177026370BB44A3A0CD521FE5166500",
+      "subType": "attribute",
+      "name": "Store"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+        "subType": "logical_table",
+        "name": "STORE_DIM"
+       },
+       "expression": {
+        "text": "STORE_KEY"
+       }
+      },
+      {
+       "formCategory": {
+        "objectId": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "subType": "attribute_form_system",
+        "name": "DESC"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": false,
+       "lookupTable": {
+        "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+        "subType": "logical_table",
+        "name": "STORE_DIM"
+       },
+       "expression": {
+        "text": "STORE_NAME"
+       }
+      }
+     ]
+    }
+   ],
+   "primaryDataSource": {
+    "objectId": "B2ABAAB6EA4FE181C3BF43B09D0930FC",
+    "subType": "db_role",
+    "name": "Snowflake CSA"
+   },
+   "secondaryDataSources": []
+  },
+  "D9FC61279B1B493896B8D146734F3706": {
+   "information": {
+    "dateCreated": "2026-06-11T01:34:19.851Z",
+    "dateModified": "2026-06-11T01:40:36.959Z",
+    "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+    "acg": 255,
+    "objectId": "D9FC61279B1B493896B8D146734F3706",
+    "subType": "logical_table",
+    "name": "ORDER_FACT"
+   },
+   "physicalTable": {
+    "information": {
+     "dateCreated": "2026-06-11T01:34:19.851Z",
+     "dateModified": "2026-06-11T01:34:19.851Z",
+     "versionId": "D84CD810B84204E035ADD5BF872EC621",
+     "acg": 255,
+     "objectId": "1474B0C677424416B11BD2A5B0CC2547",
+     "subType": "physical_table",
+     "name": "ORDER_FACT"
+    },
+    "tableName": "ORDER_FACT",
+    "columns": [
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "4C7A7D12875E4F4098327715B0F21EB8",
+       "subType": "column",
+       "name": "CUSTOMER_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 0
+      },
+      "columnName": "CUSTOMER_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "EA1E5EA3AA2244B2A4E54C81B9E42A8C",
+       "subType": "column",
+       "name": "DAYS_TO_SHIP"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 4,
+       "scale": 0
+      },
+      "columnName": "DAYS_TO_SHIP"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "3F3F02DC39264F29A1AFF03069A641FB",
+       "subType": "column",
+       "name": "DISCOUNT_AMOUNT"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "DISCOUNT_AMOUNT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "962C692A0DC748F2802B6479DC93756A",
+       "subType": "column",
+       "name": "GROSS_PROFIT"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 12,
+       "scale": 2
+      },
+      "columnName": "GROSS_PROFIT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "CB1AB2B339DE4B28B0E6E2D6390BFFBE",
+       "subType": "column",
+       "name": "GROSS_REVENUE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 12,
+       "scale": 2
+      },
+      "columnName": "GROSS_REVENUE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "972BA50D709B4357A138F6B1983FF24D",
+       "subType": "column",
+       "name": "IS_CANCELLED"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_CANCELLED"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "AEB35B531C53417182CE74A3B2C6AD13",
+       "subType": "column",
+       "name": "IS_FIRST_ORDER"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_FIRST_ORDER"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "0180EFD155CA477AB0645696DC17CCEB",
+       "subType": "column",
+       "name": "IS_RETURNED"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_RETURNED"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "A7978E37459449D1831DBE5631DDA7D1",
+       "subType": "column",
+       "name": "NET_PROFIT"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 12,
+       "scale": 2
+      },
+      "columnName": "NET_PROFIT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "03E5DD935D8C4BB48FA2335D47921180",
+       "subType": "column",
+       "name": "NET_REVENUE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 12,
+       "scale": 2
+      },
+      "columnName": "NET_REVENUE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "6D2F6387F5624C3FA6D4F9CC5320D324",
+       "subType": "column",
+       "name": "ORDER_CHANNEL"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "ORDER_CHANNEL"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D8385C86002E4CC99F15963514C2D021",
+       "subType": "column",
+       "name": "ORDER_DATE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "ORDER_DATE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "B183B71282A94A5ABC04FEC48ABDE592",
+       "subType": "column",
+       "name": "ORDER_ID"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "ORDER_ID"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "B6FCDA0DFC2341148D2AFA04D29CB9EE",
+       "subType": "column",
+       "name": "ORDER_LINE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 4,
+       "scale": 0
+      },
+      "columnName": "ORDER_LINE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "43B8E563195C41AAB52E269715A0D911",
+       "subType": "column",
+       "name": "ORDER_STATUS"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "ORDER_STATUS"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "FC60FB86414944DD92C531722810969D",
+       "subType": "column",
+       "name": "ORDER_STORE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "ORDER_STORE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "42FC35A6FBF248458F96D54C8404E071",
+       "subType": "column",
+       "name": "PRODUCT_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "PRODUCT_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "2FB5F360FFF14AA6A11F75444AFD0C97",
+       "subType": "column",
+       "name": "PROMO_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "PROMO_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "3FBBDD38F0174D8096AF8840C4740821",
+       "subType": "column",
+       "name": "QUANTITY_ORDERED"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "QUANTITY_ORDERED"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D9B0143462C14E9BAC286E197CE424B6",
+       "subType": "column",
+       "name": "QUANTITY_RETURNED"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "QUANTITY_RETURNED"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "11F75D9969E4401EA6C48D9C9C0174D9",
+       "subType": "column",
+       "name": "RETURN_DATE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "RETURN_DATE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "B5EDD927FCF94037A4E42288CC779839",
+       "subType": "column",
+       "name": "SHIPPING_AMOUNT"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "SHIPPING_AMOUNT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "37635702709D4774B648E7B29628CAB0",
+       "subType": "column",
+       "name": "SHIP_DATE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "SHIP_DATE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "3B4F476C0326472BB7E0342CB3C995BE",
+       "subType": "column",
+       "name": "SHIP_METHOD"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "SHIP_METHOD"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "DA75D433DD894A43A448F822083BBCDA",
+       "subType": "column",
+       "name": "SHIP_STORE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "SHIP_STORE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "DEF4C308852A4F8BA0C257AC41B13CC7",
+       "subType": "column",
+       "name": "TAX_AMOUNT"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "TAX_AMOUNT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D30824A0D0D54A4DB3B5300BAFB2D859",
+       "subType": "column",
+       "name": "UNIT_COST"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "UNIT_COST"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "4A933FCF738D45B89787EF4E8D70053B",
+       "subType": "column",
+       "name": "UNIT_PRICE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "UNIT_PRICE"
+     }
+    ],
+    "namespace": "TJ",
+    "tablePrefix": "TJ.",
+    "type": "normal"
+   },
+   "logicalSize": 60,
+   "isLogicalSizeLocked": false,
+   "isTrueKey": true,
+   "isPartOfPartition": false,
+   "tableKey": [
+    {
+     "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+     "subType": "attribute",
+     "name": "Customer"
+    },
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    {
+     "objectId": "E951AA8437BF46BB860E98F0DB349617",
+     "subType": "attribute",
+     "name": "Order Channel"
+    },
+    {
+     "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+     "subType": "attribute",
+     "name": "Order Status"
+    },
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "attributes": [
+    {
+     "information": {
+      "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+      "subType": "attribute",
+      "name": "Customer"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "CE414C694E64481AB6640AE63BBB2B50",
+        "subType": "logical_table",
+        "name": "CUSTOMER_DIM"
+       },
+       "expression": {
+        "text": "CUSTOMER_KEY"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "9177026370BB44A3A0CD521FE5166500",
+      "subType": "attribute",
+      "name": "Store"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+        "subType": "logical_table",
+        "name": "STORE_DIM"
+       },
+       "expression": {
+        "text": "ORDER_STORE_KEY"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+      "subType": "attribute",
+      "name": "Product"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+        "subType": "logical_table",
+        "name": "PRODUCT_DIM"
+       },
+       "expression": {
+        "text": "PRODUCT_KEY"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+      "subType": "attribute",
+      "name": "Day"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "ORDER_DATE_KEY"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "E951AA8437BF46BB860E98F0DB349617",
+      "subType": "attribute",
+      "name": "Order Channel"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "D9FC61279B1B493896B8D146734F3706",
+        "subType": "logical_table",
+        "name": "ORDER_FACT"
+       },
+       "expression": {
+        "text": "ORDER_CHANNEL"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+      "subType": "attribute",
+      "name": "Order Status"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "D9FC61279B1B493896B8D146734F3706",
+        "subType": "logical_table",
+        "name": "ORDER_FACT"
+       },
+       "expression": {
+        "text": "ORDER_STATUS"
+       }
+      }
+     ]
+    }
+   ],
+   "facts": [
+    {
+     "information": {
+      "objectId": "DDBF580D0AD14785A742CCC40EE2EE5C",
+      "subType": "fact",
+      "name": "Net Revenue"
+     },
+     "expression": {
+      "text": "NET_REVENUE"
+     }
+    },
+    {
+     "information": {
+      "objectId": "AE6CEAC55D054ABDAA3526C8931BD21B",
+      "subType": "fact",
+      "name": "Gross Profit"
+     },
+     "expression": {
+      "text": "GROSS_PROFIT"
+     }
+    },
+    {
+     "information": {
+      "objectId": "5BC47E4C35454EA5BD24C54AF3430577",
+      "subType": "fact",
+      "name": "Quantity"
+     },
+     "expression": {
+      "text": "QUANTITY_ORDERED"
+     }
+    },
+    {
+     "information": {
+      "objectId": "B5F33B1C52D74E95B98EB05A08DBFB59",
+      "subType": "fact",
+      "name": "Discount"
+     },
+     "expression": {
+      "text": "DISCOUNT_AMOUNT"
+     }
+    },
+    {
+     "information": {
+      "objectId": "313BB989028B430A9E8734AEB7432BF3",
+      "subType": "fact",
+      "name": "Order Id Fact"
+     },
+     "expression": {
+      "text": "ORDER_ID"
+     }
+    }
+   ],
+   "primaryDataSource": {
+    "objectId": "B2ABAAB6EA4FE181C3BF43B09D0930FC",
+    "subType": "db_role",
+    "name": "Snowflake CSA"
+   },
+   "secondaryDataSources": []
+  }
+ },
+ "relationships": {
+  "13AF74581AA84A46B8FD2D1BBA073150": [
+   {
+    "parent": {
+     "objectId": "13AF74581AA84A46B8FD2D1BBA073150",
+     "subType": "attribute",
+     "name": "Category"
+    },
+    "child": {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    "relationshipTable": {
+     "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+     "subType": "logical_table",
+     "name": "PRODUCT_DIM"
+    },
+    "relationshipType": "one_to_many"
+   }
+  ],
+  "6140BFA7309B406AA76A90454BC7BB53": [
+   {
+    "parent": {
+     "objectId": "6140BFA7309B406AA76A90454BC7BB53",
+     "subType": "attribute",
+     "name": "Region"
+    },
+    "child": {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    },
+    "relationshipTable": {
+     "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+     "subType": "logical_table",
+     "name": "STORE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   }
+  ],
+  "C025482DAE4C4BFDA72E8297D981ABAC": [
+   {
+    "parent": {
+     "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+     "subType": "attribute",
+     "name": "Year"
+    },
+    "child": {
+     "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+     "subType": "attribute",
+     "name": "Month"
+    },
+    "relationshipTable": {
+     "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   }
+  ],
+  "C3292DAD4FAF404F88590CB19C3930F9": [
+   {
+    "parent": {
+     "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+     "subType": "attribute",
+     "name": "Year"
+    },
+    "child": {
+     "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+     "subType": "attribute",
+     "name": "Month"
+    },
+    "relationshipTable": {
+     "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   },
+   {
+    "parent": {
+     "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+     "subType": "attribute",
+     "name": "Month"
+    },
+    "child": {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    "relationshipTable": {
+     "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   }
+  ]
+ }
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/datamodel_definition.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/datamodel_definition.json
@@ -1,0 +1,3349 @@
+{
+ "dataModelId": "45D9150F17634F7AB43B00D5FC381951",
+ "dataModel": {
+  "information": {
+   "dateCreated": "2026-06-11T02:54:52.497Z",
+   "dateModified": "2026-06-11T02:55:03.048Z",
+   "versionId": "717D54A62B49024DA91D46B13AD2159E",
+   "acg": 255,
+   "objectId": "45D9150F17634F7AB43B00D5FC381951",
+   "subType": "report_emma_cube",
+   "name": "Orders Data Model"
+  },
+  "dataServeMode": "connect_live",
+  "schemaFolderId": "80808BA0E03949BD988ABBF0C116BE5E",
+  "enableWrangleRecommendations": true,
+  "enableAutoHierarchyRelationships": true,
+  "sampling": {
+   "type": "first",
+   "rowCount": 1000
+  },
+  "autoJoin": true
+ },
+ "tables": {
+  "offset": 0,
+  "limit": -1,
+  "total": 4,
+  "tables": [
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+     "subType": "logical_table",
+     "name": "ORDER_FACT"
+    }
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "7751DF0514D64104A56548A014AB7253",
+     "subType": "logical_table",
+     "name": "PRODUCT_DIM"
+    }
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+     "subType": "logical_table",
+     "name": "STORE_DIM"
+    }
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    }
+   }
+  ]
+ },
+ "attributes": {
+  "offset": 0,
+  "limit": -1,
+  "total": 8,
+  "attributes": [
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+     "subType": "attribute",
+     "name": "Region",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 20,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "5CC8555A72484D539B52E16C481AD204",
+        "expression": {
+         "text": "REGION",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "REGION",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "75E5C96E03B244E8AD595A688E471C8E",
+            "subType": "column",
+            "name": "REGION"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+          "subType": "logical_table",
+          "name": "STORE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "REGION",
+      "lookupTable": {
+       "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+       "subType": "logical_table",
+       "name": "STORE_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+     "subType": "logical_table",
+     "name": "STORE_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+       "subType": "attribute",
+       "name": "Region"
+      },
+      "child": {
+       "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+       "subType": "attribute",
+       "name": "Store"
+      },
+      "relationshipTable": {
+       "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+       "subType": "logical_table",
+       "name": "STORE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+     "subType": "attribute",
+     "name": "Category",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 50,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "5D079ED5FF744B478A940C7C9C5A47B8",
+        "expression": {
+         "text": "CATEGORY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "CATEGORY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "25AD0BE937304BDC962A1E2E12415B3D",
+            "subType": "column",
+            "name": "CATEGORY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "7751DF0514D64104A56548A014AB7253",
+          "subType": "logical_table",
+          "name": "PRODUCT_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "CATEGORY",
+      "lookupTable": {
+       "objectId": "7751DF0514D64104A56548A014AB7253",
+       "subType": "logical_table",
+       "name": "PRODUCT_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "7751DF0514D64104A56548A014AB7253",
+     "subType": "logical_table",
+     "name": "PRODUCT_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+       "subType": "attribute",
+       "name": "Category"
+      },
+      "child": {
+       "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+       "subType": "attribute",
+       "name": "Product"
+      },
+      "relationshipTable": {
+       "objectId": "7751DF0514D64104A56548A014AB7253",
+       "subType": "logical_table",
+       "name": "PRODUCT_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+     "subType": "attribute",
+     "name": "Year",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "number",
+      "dataType": {
+       "type": "int64",
+       "precision": 8,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "A0B18927EB7E4D30AF3AA080026A8F62",
+        "expression": {
+         "text": "YEAR",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "YEAR",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "D838C0CDF1A6417994AAFF651D5BF688",
+            "subType": "column",
+            "name": "YEAR"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+          "subType": "logical_table",
+          "name": "DATE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "YEAR",
+      "lookupTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+       "subType": "attribute",
+       "name": "Year"
+      },
+      "child": {
+       "objectId": "FCC42217F759485DB03D155EAA9B727A",
+       "subType": "attribute",
+       "name": "Month"
+      },
+      "relationshipTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "FCC42217F759485DB03D155EAA9B727A",
+     "subType": "attribute",
+     "name": "Month",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "number",
+      "dataType": {
+       "type": "int64",
+       "precision": 8,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "EAE34347A0A24E54A7703DE3E7C06C24",
+        "expression": {
+         "text": "MONTH_NUMBER",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "MONTH_NUMBER",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "DE981C8BAE544FC3AFEA415D5E646A73",
+            "subType": "column",
+            "name": "MONTH_NUMBER"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+          "subType": "logical_table",
+          "name": "DATE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "MONTH_NUMBER",
+      "lookupTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      }
+     },
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+      "name": "DESC",
+      "category": "DESC",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 10,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "37D3B7BAA52A4B7DA22E0883EDBCE87D",
+        "expression": {
+         "text": "MONTH_NAME",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "MONTH_NAME",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "98D8A1F502F642839F380293EA18DD26",
+            "subType": "column",
+            "name": "MONTH_NAME"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+          "subType": "logical_table",
+          "name": "DATE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "MONTH_NAME",
+      "lookupTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+       "subType": "attribute",
+       "name": "Year"
+      },
+      "child": {
+       "objectId": "FCC42217F759485DB03D155EAA9B727A",
+       "subType": "attribute",
+       "name": "Month"
+      },
+      "relationshipTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     },
+     {
+      "parent": {
+       "objectId": "FCC42217F759485DB03D155EAA9B727A",
+       "subType": "attribute",
+       "name": "Month"
+      },
+      "child": {
+       "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+       "subType": "attribute",
+       "name": "Day"
+      },
+      "relationshipTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+     "subType": "attribute",
+     "name": "Store",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "number",
+      "dataType": {
+       "type": "int64",
+       "precision": 8,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "DED11BCA95284F3C8A4533DF64FD02B5",
+        "expression": {
+         "text": "ORDER_STORE_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "ORDER_STORE_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "1152FF8B98504D309747B883CE29D278",
+            "subType": "column",
+            "name": "ORDER_STORE_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+          "subType": "logical_table",
+          "name": "ORDER_FACT"
+         }
+        ]
+       },
+       {
+        "expressionId": "F6ADB88910D6438EBD338BAA386CEB30",
+        "expression": {
+         "text": "STORE_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "STORE_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "021BF7D49D1A41AE966A9739AA180D2D",
+            "subType": "column",
+            "name": "STORE_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+          "subType": "logical_table",
+          "name": "STORE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "STORE_KEY",
+      "lookupTable": {
+       "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+       "subType": "logical_table",
+       "name": "STORE_DIM"
+      }
+     },
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+      "name": "DESC",
+      "category": "DESC",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 100,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "4D13DE00C17941E888E41E99B6AAE5A8",
+        "expression": {
+         "text": "STORE_NAME",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "STORE_NAME",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "0C4BEEEB53DE4634A2BE0C79C0EB959C",
+            "subType": "column",
+            "name": "STORE_NAME"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+          "subType": "logical_table",
+          "name": "STORE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "STORE_NAME",
+      "lookupTable": {
+       "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+       "subType": "logical_table",
+       "name": "STORE_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+     "subType": "logical_table",
+     "name": "STORE_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+       "subType": "attribute",
+       "name": "Region"
+      },
+      "child": {
+       "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+       "subType": "attribute",
+       "name": "Store"
+      },
+      "relationshipTable": {
+       "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+       "subType": "logical_table",
+       "name": "STORE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+     "subType": "attribute",
+     "name": "Product",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "number",
+      "dataType": {
+       "type": "int64",
+       "precision": 8,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "E7456CDD660A442EA37899DF7138A2B8",
+        "expression": {
+         "text": "PRODUCT_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "PRODUCT_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "2C1EB4DE89F34373887F82F33961A1BE",
+            "subType": "column",
+            "name": "PRODUCT_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+          "subType": "logical_table",
+          "name": "ORDER_FACT"
+         }
+        ]
+       },
+       {
+        "expressionId": "9B4C7878CD594259B0C0E195F88543AB",
+        "expression": {
+         "text": "PRODUCT_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "PRODUCT_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "92AEFD8F75654F539739676266BE9F61",
+            "subType": "column",
+            "name": "PRODUCT_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "7751DF0514D64104A56548A014AB7253",
+          "subType": "logical_table",
+          "name": "PRODUCT_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "PRODUCT_KEY",
+      "lookupTable": {
+       "objectId": "7751DF0514D64104A56548A014AB7253",
+       "subType": "logical_table",
+       "name": "PRODUCT_DIM"
+      }
+     },
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+      "name": "DESC",
+      "category": "DESC",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 150,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "86E10C0549FD409D9135AD213F684D3B",
+        "expression": {
+         "text": "PRODUCT_NAME",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "PRODUCT_NAME",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "80441289FD404F2C88A020BF04060D54",
+            "subType": "column",
+            "name": "PRODUCT_NAME"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "7751DF0514D64104A56548A014AB7253",
+          "subType": "logical_table",
+          "name": "PRODUCT_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "PRODUCT_NAME",
+      "lookupTable": {
+       "objectId": "7751DF0514D64104A56548A014AB7253",
+       "subType": "logical_table",
+       "name": "PRODUCT_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "7751DF0514D64104A56548A014AB7253",
+     "subType": "logical_table",
+     "name": "PRODUCT_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+       "subType": "attribute",
+       "name": "Category"
+      },
+      "child": {
+       "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+       "subType": "attribute",
+       "name": "Product"
+      },
+      "relationshipTable": {
+       "objectId": "7751DF0514D64104A56548A014AB7253",
+       "subType": "logical_table",
+       "name": "PRODUCT_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+     "subType": "attribute",
+     "name": "Day",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "number",
+      "dataType": {
+       "type": "int64",
+       "precision": 8,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "63A512BCB4AC42ABA978EDB9902F1B2A",
+        "expression": {
+         "text": "ORDER_DATE_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "ORDER_DATE_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "871C62FBF0E04F968482C728084A50EB",
+            "subType": "column",
+            "name": "ORDER_DATE_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+          "subType": "logical_table",
+          "name": "ORDER_FACT"
+         }
+        ]
+       },
+       {
+        "expressionId": "B575DE5DF22342E988499C33DF2DB557",
+        "expression": {
+         "text": "DATE_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "DATE_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "B02BE2D4448640B79BF3169E849A4C9B",
+            "subType": "column",
+            "name": "DATE_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+          "subType": "logical_table",
+          "name": "DATE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "DATE_KEY",
+      "lookupTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      }
+     },
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+      "name": "DESC",
+      "category": "DESC",
+      "type": "system",
+      "displayFormat": "date",
+      "dataType": {
+       "type": "date",
+       "precision": 10,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "77464646F08D4C0FAC58A14B5E3F29E6",
+        "expression": {
+         "text": "FULL_DATE",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "FULL_DATE",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "501C00D4EE9D4017A90AF74478A3635D",
+            "subType": "column",
+            "name": "FULL_DATE"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+          "subType": "logical_table",
+          "name": "DATE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "FULL_DATE",
+      "lookupTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "FCC42217F759485DB03D155EAA9B727A",
+       "subType": "attribute",
+       "name": "Month"
+      },
+      "child": {
+       "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+       "subType": "attribute",
+       "name": "Day"
+      },
+      "relationshipTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "A0B193BE721E4C10B161B49A5086F97F",
+     "subType": "attribute",
+     "name": "Order Channel",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 20,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "2CB3D80EA5424A729428BF66C5ACFEA2",
+        "expression": {
+         "text": "ORDER_CHANNEL",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "ORDER_CHANNEL",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "83D463BBD45E410B9873652078955B41",
+            "subType": "column",
+            "name": "ORDER_CHANNEL"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+          "subType": "logical_table",
+          "name": "ORDER_FACT"
+         }
+        ]
+       }
+      ],
+      "alias": "ORDER_CHANNEL",
+      "lookupTable": {
+       "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+       "subType": "logical_table",
+       "name": "ORDER_FACT"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+     "subType": "logical_table",
+     "name": "ORDER_FACT"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   }
+  ]
+ },
+ "factMetrics": {
+  "offset": 0,
+  "limit": -1,
+  "total": 4,
+  "factMetrics": [
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "C3331A42A2054CC19665490F06554DDD",
+     "subType": "fact_metric",
+     "name": "NET_REVENUE",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "fact": {
+     "dataType": {
+      "type": "double",
+      "precision": 8,
+      "scale": 2
+     },
+     "expressions": [
+      {
+       "expressionId": "127B6FD1A37C4EDD9A22E8468947FA03",
+       "expression": {
+        "text": "NET_REVENUE",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "NET_REVENUE",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T02:54:52.497Z",
+           "dateModified": "2026-06-11T02:54:52.497Z",
+           "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+           "acg": 255,
+           "objectId": "2358BF7FA6BD44998507B95725612D64",
+           "subType": "column",
+           "name": "NET_REVENUE"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+         "subType": "logical_table",
+         "name": "ORDER_FACT"
+        }
+       ]
+      }
+     ],
+     "extensions": [],
+     "entryLevel": []
+    },
+    "function": "sum",
+    "functionProperties": [
+     {
+      "name": "UseLookupForAttributes",
+      "value": {
+       "type": "boolean",
+       "value": "false"
+      }
+     }
+    ],
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "apply",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      },
+      "implementation": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     }
+    ],
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "metricFormatType": "reserved"
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "4C2FA40DDACF483E909724459CECD0AC",
+     "subType": "fact_metric",
+     "name": "GROSS_PROFIT",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "fact": {
+     "dataType": {
+      "type": "double",
+      "precision": 8,
+      "scale": 2
+     },
+     "expressions": [
+      {
+       "expressionId": "68A5D6212D3B4CA3AE112F146E198733",
+       "expression": {
+        "text": "GROSS_PROFIT",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "GROSS_PROFIT",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T02:54:52.497Z",
+           "dateModified": "2026-06-11T02:54:52.497Z",
+           "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+           "acg": 255,
+           "objectId": "E411AA7426BC4FC69F13110FDB307362",
+           "subType": "column",
+           "name": "GROSS_PROFIT"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+         "subType": "logical_table",
+         "name": "ORDER_FACT"
+        }
+       ]
+      }
+     ],
+     "extensions": [],
+     "entryLevel": []
+    },
+    "function": "sum",
+    "functionProperties": [
+     {
+      "name": "UseLookupForAttributes",
+      "value": {
+       "type": "boolean",
+       "value": "false"
+      }
+     }
+    ],
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "apply",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      },
+      "implementation": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     }
+    ],
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "metricFormatType": "reserved"
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "2B54F0E3EE4F4E35A382B39C8433CAB6",
+     "subType": "fact_metric",
+     "name": "QUANTITY_ORDERED",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "fact": {
+     "dataType": {
+      "type": "int64",
+      "precision": 8,
+      "scale": 0
+     },
+     "expressions": [
+      {
+       "expressionId": "C2F94E4728154683B5DAAA206340CCB2",
+       "expression": {
+        "text": "QUANTITY_ORDERED",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "QUANTITY_ORDERED",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T02:54:52.497Z",
+           "dateModified": "2026-06-11T02:54:52.497Z",
+           "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+           "acg": 255,
+           "objectId": "691CED4C7ADE41258636AF79121CAA92",
+           "subType": "column",
+           "name": "QUANTITY_ORDERED"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+         "subType": "logical_table",
+         "name": "ORDER_FACT"
+        }
+       ]
+      }
+     ],
+     "extensions": [],
+     "entryLevel": []
+    },
+    "function": "sum",
+    "functionProperties": [
+     {
+      "name": "UseLookupForAttributes",
+      "value": {
+       "type": "boolean",
+       "value": "false"
+      }
+     }
+    ],
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "apply",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      },
+      "implementation": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     }
+    ],
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "metricFormatType": "reserved"
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "6CD8AF360D1B40259910F69C0122F3E5",
+     "subType": "fact_metric",
+     "name": "ORDER_ID",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "fact": {
+     "dataType": {
+      "type": "utf8_char",
+      "precision": 20,
+      "scale": 0
+     },
+     "expressions": [
+      {
+       "expressionId": "41139E0B57434355A14C1B555F0C8B83",
+       "expression": {
+        "text": "ORDER_ID",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "ORDER_ID",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T02:54:52.497Z",
+           "dateModified": "2026-06-11T02:54:52.497Z",
+           "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+           "acg": 255,
+           "objectId": "217118E54335470FAF5BDB78FF07955A",
+           "subType": "column",
+           "name": "ORDER_ID"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+         "subType": "logical_table",
+         "name": "ORDER_FACT"
+        }
+       ]
+      }
+     ],
+     "extensions": [],
+     "entryLevel": []
+    },
+    "function": "count",
+    "functionProperties": [
+     {
+      "name": "UseLookupForAttributes",
+      "value": {
+       "type": "boolean",
+       "value": "false"
+      }
+     },
+     {
+      "name": "Distinct",
+      "value": {
+       "type": "boolean",
+       "value": "true"
+      }
+     }
+    ],
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "apply",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      },
+      "implementation": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     }
+    ],
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "metricFormatType": "reserved"
+   }
+  ]
+ },
+ "metrics": {
+  "offset": 0,
+  "limit": -1,
+  "total": 3,
+  "metrics": [
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:55:03.048Z",
+     "dateModified": "2026-06-11T02:55:03.048Z",
+     "versionId": "717D54A62B49024DA91D46B13AD2159E",
+     "acg": 255,
+     "objectId": "11D0F479626041DAB61CFA7C349AE9DE",
+     "subType": "metric",
+     "name": "Total Net Revenue",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "expression": {
+     "text": "Sum(NET_REVENUE)",
+     "tokens": [
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "Sum",
+       "type": "function",
+       "target": {
+        "dateCreated": "2025-05-29T19:58:08.059Z",
+        "dateModified": "2025-05-29T19:58:08.059Z",
+        "versionId": "CD5315C011DF671600088AA0669A0C20",
+        "acg": 255,
+        "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+        "subType": "function",
+        "name": "Sum",
+        "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "<",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "UseLookupForAttributes",
+       "type": "identifier"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "=",
+       "type": "function"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "False",
+       "type": "boolean"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ">",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "(",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "NET_REVENUE",
+       "type": "object_reference",
+       "target": {
+        "dateCreated": "2026-06-11T02:54:52.497Z",
+        "dateModified": "2026-06-11T02:54:52.497Z",
+        "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+        "acg": 255,
+        "objectId": "C3331A42A2054CC19665490F06554DDD",
+        "subType": "fact_metric",
+        "name": "NET_REVENUE"
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ")",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "{",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "~",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "}",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "",
+       "type": "end_of_text"
+      }
+     ]
+    },
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "none",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "conditionality": {
+     "embedMethod": "report_into_metric_filter",
+     "removeElements": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      }
+     }
+    ],
+    "aggregateFromBase": true,
+    "formulaJoinType": "default",
+    "smartTotal": "decomposable_false",
+    "dataType": {
+     "type": "reserved",
+     "precision": 0,
+     "scale": 0
+    },
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "subtotalFromBase": false,
+    "metricFormatType": "reserved",
+    "thresholds": [],
+    "embeddedObjects": [
+     {
+      "id": "7DB65280B549A50D078991BECBDF82ED",
+      "subType": "agg_metric",
+      "expression": {
+       "text": "Sum(NET_REVENUE)",
+       "tokens": [
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "Sum",
+         "type": "function",
+         "target": {
+          "dateCreated": "2025-05-29T19:58:08.059Z",
+          "dateModified": "2025-05-29T19:58:08.059Z",
+          "versionId": "CD5315C011DF671600088AA0669A0C20",
+          "acg": 255,
+          "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+          "subType": "function",
+          "name": "Sum",
+          "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "<",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "UseLookupForAttributes",
+         "type": "identifier"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "=",
+         "type": "function"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "False",
+         "type": "boolean"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ">",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "(",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "NET_REVENUE",
+         "type": "object_reference",
+         "target": {
+          "dateCreated": "2026-06-11T02:54:52.497Z",
+          "dateModified": "2026-06-11T02:54:52.497Z",
+          "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+          "acg": 255,
+          "objectId": "C3331A42A2054CC19665490F06554DDD",
+          "subType": "fact_metric",
+          "name": "NET_REVENUE"
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ")",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "",
+         "type": "end_of_text"
+        }
+       ]
+      }
+     }
+    ],
+    "pushDownBehavior": "automatic"
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:55:03.048Z",
+     "dateModified": "2026-06-11T02:55:03.048Z",
+     "versionId": "717D54A62B49024DA91D46B13AD2159E",
+     "acg": 255,
+     "objectId": "003ECB8FC2CB4336B8BD403570B0AA00",
+     "subType": "metric",
+     "name": "Total Gross Profit",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "expression": {
+     "text": "Sum(GROSS_PROFIT)",
+     "tokens": [
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "Sum",
+       "type": "function",
+       "target": {
+        "dateCreated": "2025-05-29T19:58:08.059Z",
+        "dateModified": "2025-05-29T19:58:08.059Z",
+        "versionId": "CD5315C011DF671600088AA0669A0C20",
+        "acg": 255,
+        "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+        "subType": "function",
+        "name": "Sum",
+        "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "<",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "UseLookupForAttributes",
+       "type": "identifier"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "=",
+       "type": "function"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "False",
+       "type": "boolean"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ">",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "(",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "GROSS_PROFIT",
+       "type": "object_reference",
+       "target": {
+        "dateCreated": "2026-06-11T02:54:52.497Z",
+        "dateModified": "2026-06-11T02:54:52.497Z",
+        "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+        "acg": 255,
+        "objectId": "4C2FA40DDACF483E909724459CECD0AC",
+        "subType": "fact_metric",
+        "name": "GROSS_PROFIT"
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ")",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "{",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "~",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "}",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "",
+       "type": "end_of_text"
+      }
+     ]
+    },
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "none",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "conditionality": {
+     "embedMethod": "report_into_metric_filter",
+     "removeElements": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      }
+     }
+    ],
+    "aggregateFromBase": true,
+    "formulaJoinType": "default",
+    "smartTotal": "decomposable_false",
+    "dataType": {
+     "type": "reserved",
+     "precision": 0,
+     "scale": 0
+    },
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "subtotalFromBase": false,
+    "metricFormatType": "reserved",
+    "thresholds": [],
+    "embeddedObjects": [
+     {
+      "id": "C50B6BA202403656344063913F5C67D8",
+      "subType": "agg_metric",
+      "expression": {
+       "text": "Sum(GROSS_PROFIT)",
+       "tokens": [
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "Sum",
+         "type": "function",
+         "target": {
+          "dateCreated": "2025-05-29T19:58:08.059Z",
+          "dateModified": "2025-05-29T19:58:08.059Z",
+          "versionId": "CD5315C011DF671600088AA0669A0C20",
+          "acg": 255,
+          "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+          "subType": "function",
+          "name": "Sum",
+          "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "<",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "UseLookupForAttributes",
+         "type": "identifier"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "=",
+         "type": "function"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "False",
+         "type": "boolean"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ">",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "(",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "GROSS_PROFIT",
+         "type": "object_reference",
+         "target": {
+          "dateCreated": "2026-06-11T02:54:52.497Z",
+          "dateModified": "2026-06-11T02:54:52.497Z",
+          "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+          "acg": 255,
+          "objectId": "4C2FA40DDACF483E909724459CECD0AC",
+          "subType": "fact_metric",
+          "name": "GROSS_PROFIT"
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ")",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "",
+         "type": "end_of_text"
+        }
+       ]
+      }
+     }
+    ],
+    "pushDownBehavior": "automatic"
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:55:03.048Z",
+     "dateModified": "2026-06-11T02:55:03.048Z",
+     "versionId": "717D54A62B49024DA91D46B13AD2159E",
+     "acg": 255,
+     "objectId": "9F428B57068E4DA5BD4D0E45B0FF75E5",
+     "subType": "metric",
+     "name": "Order Count",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "expression": {
+     "text": "Count(ORDER_ID)",
+     "tokens": [
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "Count",
+       "type": "function",
+       "target": {
+        "dateCreated": "2025-05-29T19:58:08.059Z",
+        "dateModified": "2025-05-29T19:58:08.059Z",
+        "versionId": "CD5315C011DF671600088AA0669A0C20",
+        "acg": 255,
+        "objectId": "8107C31CDD9911D3B98100C04F2233EA",
+        "subType": "function",
+        "name": "Count",
+        "description": "Returns the number of values the ValueList. This is a group-value function."
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "<",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "Distinct",
+       "type": "identifier"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "=",
+       "type": "function"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "True",
+       "type": "boolean"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ",",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "UseLookupForAttributes",
+       "type": "identifier"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "=",
+       "type": "function"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "False",
+       "type": "boolean"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ">",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "(",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "ORDER_ID",
+       "type": "object_reference",
+       "target": {
+        "dateCreated": "2026-06-11T02:54:52.497Z",
+        "dateModified": "2026-06-11T02:54:52.497Z",
+        "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+        "acg": 255,
+        "objectId": "6CD8AF360D1B40259910F69C0122F3E5",
+        "subType": "fact_metric",
+        "name": "ORDER_ID"
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ")",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "{",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "~",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "}",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "",
+       "type": "end_of_text"
+      }
+     ]
+    },
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "none",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "conditionality": {
+     "embedMethod": "report_into_metric_filter",
+     "removeElements": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      }
+     }
+    ],
+    "aggregateFromBase": true,
+    "formulaJoinType": "default",
+    "smartTotal": "decomposable_false",
+    "dataType": {
+     "type": "reserved",
+     "precision": 0,
+     "scale": 0
+    },
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "subtotalFromBase": true,
+    "metricFormatType": "reserved",
+    "thresholds": [],
+    "embeddedObjects": [
+     {
+      "id": "FB08BE7FED4883046261C2A95D2BE8BB",
+      "subType": "agg_metric",
+      "expression": {
+       "text": "Count(ORDER_ID)",
+       "tokens": [
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "Count",
+         "type": "function",
+         "target": {
+          "dateCreated": "2025-05-29T19:58:08.059Z",
+          "dateModified": "2025-05-29T19:58:08.059Z",
+          "versionId": "CD5315C011DF671600088AA0669A0C20",
+          "acg": 255,
+          "objectId": "8107C31CDD9911D3B98100C04F2233EA",
+          "subType": "function",
+          "name": "Count",
+          "description": "Returns the number of values the ValueList. This is a group-value function."
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "<",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "Distinct",
+         "type": "identifier"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "=",
+         "type": "function"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "True",
+         "type": "boolean"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ",",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "UseLookupForAttributes",
+         "type": "identifier"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "=",
+         "type": "function"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "False",
+         "type": "boolean"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ">",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "(",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "ORDER_ID",
+         "type": "object_reference",
+         "target": {
+          "dateCreated": "2026-06-11T02:54:52.497Z",
+          "dateModified": "2026-06-11T02:54:52.497Z",
+          "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+          "acg": 255,
+          "objectId": "6CD8AF360D1B40259910F69C0122F3E5",
+          "subType": "fact_metric",
+          "name": "ORDER_ID"
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ")",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "",
+         "type": "end_of_text"
+        }
+       ]
+      }
+     }
+    ],
+    "pushDownBehavior": "automatic"
+   }
+  ]
+ },
+ "links": {
+  "offset": 0,
+  "limit": -1,
+  "total": 0,
+  "links": []
+ },
+ "hierarchy": {
+  "relationships": [
+   {
+    "parent": {
+     "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+     "subType": "attribute",
+     "name": "Year"
+    },
+    "child": {
+     "objectId": "FCC42217F759485DB03D155EAA9B727A",
+     "subType": "attribute",
+     "name": "Month"
+    },
+    "relationshipTable": {
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   },
+   {
+    "parent": {
+     "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+     "subType": "attribute",
+     "name": "Region"
+    },
+    "child": {
+     "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+     "subType": "attribute",
+     "name": "Store"
+    },
+    "relationshipTable": {
+     "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+     "subType": "logical_table",
+     "name": "STORE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   },
+   {
+    "parent": {
+     "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+     "subType": "attribute",
+     "name": "Category"
+    },
+    "child": {
+     "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    "relationshipTable": {
+     "objectId": "7751DF0514D64104A56548A014AB7253",
+     "subType": "logical_table",
+     "name": "PRODUCT_DIM"
+    },
+    "relationshipType": "one_to_many"
+   },
+   {
+    "parent": {
+     "objectId": "FCC42217F759485DB03D155EAA9B727A",
+     "subType": "attribute",
+     "name": "Month"
+    },
+    "child": {
+     "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    "relationshipTable": {
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   }
+  ],
+  "isolatedAttributes": [
+   {
+    "objectId": "A0B193BE721E4C10B161B49A5086F97F",
+    "subType": "attribute",
+    "name": "Order Channel"
+   }
+  ]
+ },
+ "attributeRelationships": {
+  "Region": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+      "subType": "attribute",
+      "name": "Region"
+     },
+     "child": {
+      "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+      "subType": "attribute",
+      "name": "Store"
+     },
+     "relationshipTable": {
+      "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+      "subType": "logical_table",
+      "name": "STORE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Category": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+      "subType": "attribute",
+      "name": "Category"
+     },
+     "child": {
+      "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+      "subType": "attribute",
+      "name": "Product"
+     },
+     "relationshipTable": {
+      "objectId": "7751DF0514D64104A56548A014AB7253",
+      "subType": "logical_table",
+      "name": "PRODUCT_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Year": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+      "subType": "attribute",
+      "name": "Year"
+     },
+     "child": {
+      "objectId": "FCC42217F759485DB03D155EAA9B727A",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "relationshipTable": {
+      "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Month": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+      "subType": "attribute",
+      "name": "Year"
+     },
+     "child": {
+      "objectId": "FCC42217F759485DB03D155EAA9B727A",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "relationshipTable": {
+      "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    },
+    {
+     "parent": {
+      "objectId": "FCC42217F759485DB03D155EAA9B727A",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "child": {
+      "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+      "subType": "attribute",
+      "name": "Day"
+     },
+     "relationshipTable": {
+      "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Store": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+      "subType": "attribute",
+      "name": "Region"
+     },
+     "child": {
+      "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+      "subType": "attribute",
+      "name": "Store"
+     },
+     "relationshipTable": {
+      "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+      "subType": "logical_table",
+      "name": "STORE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Product": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+      "subType": "attribute",
+      "name": "Category"
+     },
+     "child": {
+      "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+      "subType": "attribute",
+      "name": "Product"
+     },
+     "relationshipTable": {
+      "objectId": "7751DF0514D64104A56548A014AB7253",
+      "subType": "logical_table",
+      "name": "PRODUCT_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Day": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "FCC42217F759485DB03D155EAA9B727A",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "child": {
+      "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+      "subType": "attribute",
+      "name": "Day"
+     },
+     "relationshipTable": {
+      "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Order Channel": {
+   "relationships": []
+  }
+ }
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/dossier_definition.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/dossier_definition.json
@@ -1,0 +1,345 @@
+{
+ "id": "77EFB43F5B441BA7B6EEECAB4D92A7EF",
+ "name": "Orders Performance Overview",
+ "datasets": [
+  {
+   "name": "Revenue by Region and Category",
+   "id": "5C8ABD78BC4EA7F4AF876E97091E6BA5",
+   "availableObjects": [
+    {
+     "id": "6140BFA7309B406AA76A90454BC7BB53",
+     "name": "Region",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    },
+    {
+     "id": "13AF74581AA84A46B8FD2D1BBA073150",
+     "name": "Category",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    },
+    {
+     "id": "413D98E4993B4D6ABB2DC440F7B31971",
+     "name": "Total Net Revenue",
+     "type": "metric"
+    },
+    {
+     "id": "653830C2CB684809B7030FBBEA498C8C",
+     "name": "Total Gross Profit",
+     "type": "metric"
+    },
+    {
+     "id": "5393F49A94A443E79E38CB3855B0272F",
+     "name": "Profit Margin Pct",
+     "type": "metric"
+    }
+   ],
+   "rows": [
+    {
+     "id": "6140BFA7309B406AA76A90454BC7BB53",
+     "name": "Region",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    },
+    {
+     "id": "13AF74581AA84A46B8FD2D1BBA073150",
+     "name": "Category",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    }
+   ],
+   "columns": [
+    {
+     "id": "00000000000000000000000000000000",
+     "name": "Metrics",
+     "type": "templateMetrics",
+     "elements": [
+      {
+       "name": "Total Net Revenue",
+       "id": "413D98E4993B4D6ABB2DC440F7B31971",
+       "type": "metric",
+       "dataType": "reserved"
+      },
+      {
+       "name": "Total Gross Profit",
+       "id": "653830C2CB684809B7030FBBEA498C8C",
+       "type": "metric",
+       "dataType": "reserved"
+      },
+      {
+       "name": "Profit Margin Pct",
+       "id": "5393F49A94A443E79E38CB3855B0272F",
+       "type": "metric",
+       "dataType": "reserved"
+      }
+     ]
+    }
+   ],
+   "pageBy": []
+  },
+  {
+   "name": "Monthly Revenue Trend",
+   "id": "864205BFBA4B4E6E863C3FB42FB0A406",
+   "availableObjects": [
+    {
+     "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+     "name": "Year",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "decimal",
+       "baseFormCategory": "ID",
+       "baseFormType": "number"
+      }
+     ]
+    },
+    {
+     "id": "C3292DAD4FAF404F88590CB19C3930F9",
+     "name": "Month",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC",
+       "dataType": "varChar",
+       "baseFormCategory": "DESC",
+       "baseFormType": "text"
+      }
+     ]
+    },
+    {
+     "id": "413D98E4993B4D6ABB2DC440F7B31971",
+     "name": "Total Net Revenue",
+     "type": "metric"
+    },
+    {
+     "id": "145746BAC65E4BF39E83149A843A3DF7",
+     "name": "Order Count",
+     "type": "metric"
+    }
+   ],
+   "rows": [
+    {
+     "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+     "name": "Year",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "decimal",
+       "baseFormCategory": "ID",
+       "baseFormType": "number"
+      }
+     ]
+    },
+    {
+     "id": "C3292DAD4FAF404F88590CB19C3930F9",
+     "name": "Month",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC",
+       "dataType": "varChar",
+       "baseFormCategory": "DESC",
+       "baseFormType": "text"
+      }
+     ]
+    }
+   ],
+   "columns": [
+    {
+     "id": "00000000000000000000000000000000",
+     "name": "Metrics",
+     "type": "templateMetrics",
+     "elements": [
+      {
+       "name": "Total Net Revenue",
+       "id": "413D98E4993B4D6ABB2DC440F7B31971",
+       "type": "metric",
+       "dataType": "reserved"
+      },
+      {
+       "name": "Order Count",
+       "id": "145746BAC65E4BF39E83149A843A3DF7",
+       "type": "metric",
+       "dataType": "reserved"
+      }
+     ]
+    }
+   ],
+   "pageBy": []
+  },
+  {
+   "name": "Channel Performance",
+   "id": "69759BAD734F3EB9308219B61D916432",
+   "availableObjects": [
+    {
+     "id": "E951AA8437BF46BB860E98F0DB349617",
+     "name": "Order Channel",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    },
+    {
+     "id": "413D98E4993B4D6ABB2DC440F7B31971",
+     "name": "Total Net Revenue",
+     "type": "metric"
+    },
+    {
+     "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+     "name": "Units Sold",
+     "type": "metric"
+    },
+    {
+     "id": "145746BAC65E4BF39E83149A843A3DF7",
+     "name": "Order Count",
+     "type": "metric"
+    }
+   ],
+   "rows": [
+    {
+     "id": "E951AA8437BF46BB860E98F0DB349617",
+     "name": "Order Channel",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    }
+   ],
+   "columns": [
+    {
+     "id": "00000000000000000000000000000000",
+     "name": "Metrics",
+     "type": "templateMetrics",
+     "elements": [
+      {
+       "name": "Total Net Revenue",
+       "id": "413D98E4993B4D6ABB2DC440F7B31971",
+       "type": "metric",
+       "dataType": "reserved"
+      },
+      {
+       "name": "Units Sold",
+       "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+       "type": "metric",
+       "dataType": "reserved"
+      },
+      {
+       "name": "Order Count",
+       "id": "145746BAC65E4BF39E83149A843A3DF7",
+       "type": "metric",
+       "dataType": "reserved"
+      }
+     ]
+    }
+   ],
+   "pageBy": []
+  }
+ ],
+ "currentChapter": "K123",
+ "chapters": [
+  {
+   "key": "K65",
+   "name": "Revenue by Region and Category",
+   "pages": [
+    {
+     "key": "K85",
+     "name": "Page 1",
+     "visualizations": [
+      {
+       "key": "K86",
+       "name": "Visualization 1",
+       "visualizationType": "grid"
+      }
+     ]
+    }
+   ],
+   "filters": []
+  },
+  {
+   "key": "K69",
+   "name": "Monthly Revenue Trend",
+   "pages": [
+    {
+     "key": "K120",
+     "name": "Page 1",
+     "visualizations": [
+      {
+       "key": "K121",
+       "name": "Visualization 1",
+       "visualizationType": "grid"
+      }
+     ]
+    }
+   ],
+   "filters": []
+  },
+  {
+   "key": "K123",
+   "name": "Channel Performance",
+   "pages": [
+    {
+     "key": "K158",
+     "name": "Page 1",
+     "visualizations": [
+      {
+       "key": "K159",
+       "name": "Visualization 1",
+       "visualizationType": "grid"
+      }
+     ]
+    }
+   ],
+   "filters": []
+  }
+ ]
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/expected_parity.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/expected_parity.json
@@ -1,0 +1,547 @@
+{
+ "Revenue by Region and Category": [
+  {
+   "keys": [
+    "Midwest",
+    "Apparel"
+   ],
+   "values": {
+    "Total Net Revenue": 1338.56,
+    "Total Gross Profit": 904.0,
+    "Profit Margin Pct": 0.67535262
+   }
+  },
+  {
+   "keys": [
+    "Midwest",
+    "Beauty"
+   ],
+   "values": {
+    "Total Net Revenue": 961.05,
+    "Total Gross Profit": 728.0,
+    "Profit Margin Pct": 0.75750481
+   }
+  },
+  {
+   "keys": [
+    "Midwest",
+    "Electronics"
+   ],
+   "values": {
+    "Total Net Revenue": 434.91,
+    "Total Gross Profit": 287.91,
+    "Profit Margin Pct": 0.66199903
+   }
+  },
+  {
+   "keys": [
+    "Midwest",
+    "Home"
+   ],
+   "values": {
+    "Total Net Revenue": 351.8,
+    "Total Gross Profit": 240.95,
+    "Profit Margin Pct": 0.6849062
+   }
+  },
+  {
+   "keys": [
+    "Midwest",
+    "Sports"
+   ],
+   "values": {
+    "Total Net Revenue": 382.41,
+    "Total Gross Profit": 291.41,
+    "Profit Margin Pct": 0.76203551
+   }
+  },
+  {
+   "keys": [
+    "Northeast",
+    "Apparel"
+   ],
+   "values": {
+    "Total Net Revenue": 882.81,
+    "Total Gross Profit": 539.0,
+    "Profit Margin Pct": 0.6105504
+   }
+  },
+  {
+   "keys": [
+    "Northeast",
+    "Beauty"
+   ],
+   "values": {
+    "Total Net Revenue": 216.48,
+    "Total Gross Profit": 168.0,
+    "Profit Margin Pct": 0.77605322
+   }
+  },
+  {
+   "keys": [
+    "Northeast",
+    "Electronics"
+   ],
+   "values": {
+    "Total Net Revenue": 2711.3,
+    "Total Gross Profit": 1737.72,
+    "Profit Margin Pct": 0.64091764
+   }
+  },
+  {
+   "keys": [
+    "Northeast",
+    "Home"
+   ],
+   "values": {
+    "Total Net Revenue": 864.82,
+    "Total Gross Profit": 583.87,
+    "Profit Margin Pct": 0.67513471
+   }
+  },
+  {
+   "keys": [
+    "Northeast",
+    "Sports"
+   ],
+   "values": {
+    "Total Net Revenue": 706.31,
+    "Total Gross Profit": 486.91,
+    "Profit Margin Pct": 0.68937152
+   }
+  },
+  {
+   "keys": [
+    "South",
+    "Apparel"
+   ],
+   "values": {
+    "Total Net Revenue": 3012.85,
+    "Total Gross Profit": 1968.0,
+    "Profit Margin Pct": 0.65320212
+   }
+  },
+  {
+   "keys": [
+    "South",
+    "Beauty"
+   ],
+   "values": {
+    "Total Net Revenue": 928.88,
+    "Total Gross Profit": 728.0,
+    "Profit Margin Pct": 0.78373956
+   }
+  },
+  {
+   "keys": [
+    "South",
+    "Electronics"
+   ],
+   "values": {
+    "Total Net Revenue": 4450.83,
+    "Total Gross Profit": 2753.72,
+    "Profit Margin Pct": 0.61869809
+   }
+  },
+  {
+   "keys": [
+    "South",
+    "Home"
+   ],
+   "values": {
+    "Total Net Revenue": 3045.65,
+    "Total Gross Profit": 2164.96,
+    "Profit Margin Pct": 0.71083677
+   }
+  },
+  {
+   "keys": [
+    "South",
+    "Sports"
+   ],
+   "values": {
+    "Total Net Revenue": 2239.54,
+    "Total Gross Profit": 1614.69,
+    "Profit Margin Pct": 0.72099181
+   }
+  },
+  {
+   "keys": [
+    "West",
+    "Apparel"
+   ],
+   "values": {
+    "Total Net Revenue": 2696.87,
+    "Total Gross Profit": 1711.0,
+    "Profit Margin Pct": 0.63443918
+   }
+  },
+  {
+   "keys": [
+    "West",
+    "Electronics"
+   ],
+   "values": {
+    "Total Net Revenue": 2771.95,
+    "Total Gross Profit": 1739.81,
+    "Profit Margin Pct": 0.62764841
+   }
+  },
+  {
+   "keys": [
+    "West",
+    "Home"
+   ],
+   "values": {
+    "Total Net Revenue": 2799.81,
+    "Total Gross Profit": 1914.74,
+    "Profit Margin Pct": 0.68388212
+   }
+  },
+  {
+   "keys": [
+    "West",
+    "Sports"
+   ],
+   "values": {
+    "Total Net Revenue": 1167.35,
+    "Total Gross Profit": 842.0,
+    "Profit Margin Pct": 0.72129181
+   }
+  }
+ ],
+ "Monthly Revenue Trend": [
+  {
+   "keys": [
+    "2024",
+    "January"
+   ],
+   "values": {
+    "Total Net Revenue": 2947.38,
+    "Order Count": 19
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "Feb"
+   ],
+   "values": {
+    "Total Net Revenue": 3309.41,
+    "Order Count": 13
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "March"
+   ],
+   "values": {
+    "Total Net Revenue": 3255.74,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "Apr"
+   ],
+   "values": {
+    "Total Net Revenue": 3243.79,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "May"
+   ],
+   "values": {
+    "Total Net Revenue": 16176.6,
+    "Order Count": 133
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "June"
+   ],
+   "values": {
+    "Total Net Revenue": 3345.98,
+    "Order Count": 22
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "July"
+   ],
+   "values": {
+    "Total Net Revenue": 3068.53,
+    "Order Count": 17
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "August"
+   ],
+   "values": {
+    "Total Net Revenue": 3043.97,
+    "Order Count": 15
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "September"
+   ],
+   "values": {
+    "Total Net Revenue": 2982.02,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "October"
+   ],
+   "values": {
+    "Total Net Revenue": 2000.41,
+    "Order Count": 14
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "November"
+   ],
+   "values": {
+    "Total Net Revenue": 5020.6,
+    "Order Count": 22
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "December"
+   ],
+   "values": {
+    "Total Net Revenue": 2685.91,
+    "Order Count": 20
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "January"
+   ],
+   "values": {
+    "Total Net Revenue": 2947.38,
+    "Order Count": 19
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "Feb"
+   ],
+   "values": {
+    "Total Net Revenue": 3309.41,
+    "Order Count": 13
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "March"
+   ],
+   "values": {
+    "Total Net Revenue": 3255.74,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "Apr"
+   ],
+   "values": {
+    "Total Net Revenue": 3243.79,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "May"
+   ],
+   "values": {
+    "Total Net Revenue": 16176.6,
+    "Order Count": 133
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "June"
+   ],
+   "values": {
+    "Total Net Revenue": 3345.98,
+    "Order Count": 22
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "July"
+   ],
+   "values": {
+    "Total Net Revenue": 3068.53,
+    "Order Count": 17
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "August"
+   ],
+   "values": {
+    "Total Net Revenue": 3043.97,
+    "Order Count": 15
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "September"
+   ],
+   "values": {
+    "Total Net Revenue": 2982.02,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "October"
+   ],
+   "values": {
+    "Total Net Revenue": 2000.41,
+    "Order Count": 14
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "November"
+   ],
+   "values": {
+    "Total Net Revenue": 5020.6,
+    "Order Count": 22
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "December"
+   ],
+   "values": {
+    "Total Net Revenue": 2685.91,
+    "Order Count": 20
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "January"
+   ],
+   "values": {
+    "Total Net Revenue": 2947.38,
+    "Order Count": 19
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "Feb"
+   ],
+   "values": {
+    "Total Net Revenue": 3309.41,
+    "Order Count": 13
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "March"
+   ],
+   "values": {
+    "Total Net Revenue": 3255.74,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "Apr"
+   ],
+   "values": {
+    "Total Net Revenue": 3243.79,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "May"
+   ],
+   "values": {
+    "Total Net Revenue": 16176.6,
+    "Order Count": 133
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "June"
+   ],
+   "values": {
+    "Total Net Revenue": 3345.98,
+    "Order Count": 22
+   }
+  }
+ ],
+ "Channel Performance": [
+  {
+   "keys": [
+    "App"
+   ],
+   "values": {
+    "Total Net Revenue": 16507.39,
+    "Units Sold": 228,
+    "Order Count": 93
+   }
+  },
+  {
+   "keys": [
+    "In-Store"
+   ],
+   "values": {
+    "Total Net Revenue": 31964.18,
+    "Units Sold": 411,
+    "Order Count": 173
+   }
+  },
+  {
+   "keys": [
+    "Online"
+   ],
+   "values": {
+    "Total Net Revenue": 62316.78,
+    "Units Sold": 842,
+    "Order Count": 387
+   }
+  }
+ ]
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/ae-row-collapse.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/ae-row-collapse.md
@@ -1,0 +1,48 @@
+# Analytical-Engine row collapse — why `resolve_ae_winners.py` exists
+
+## The behavior
+
+When an attribute's **key (ID) form is non-unique in its lookup table**,
+MicroStrategy's Analytical Engine does something no clean SQL GROUP BY
+reproduces: it collapses the per-(parent, key) result to **one
+arbitrary-but-stable representative row per key element** and cross-tabs that
+row's label + metric values across the parent attribute.
+
+Fixture example: `Month.key = MONTH_NUMBER` while `DATE_DIM` carries multiple
+`MONTH_NAME` spellings and repeats month numbers across years. The grid shows
+one `MONTH_NAME` spelling per month number — which one is a **hash artifact of
+the engine**. It cannot be derived from the model bundle, only observed.
+
+A report is **affected** when one of its attribute units has a DESC form
+distinct from its grouping key (`convert.py` → `attribute_unit_cols`). Reports
+without such attributes produce clean grids — no resolution needed.
+
+## The resolution workflow (`scripts/resolve_ae_winners.py`)
+
+1. **Re-execute** each affected report via
+   `POST /api/v2/reports/{id}/instances?limit=N` — the MSTR grid is ground
+   truth for which representative won.
+2. Compute the **clean** per-(parents, key) aggregates from the warehouse —
+   the same SQL MicroStrategy generated (`Bundle.build_clean_group_sql`) — via
+   a temporary Sigma workbook with a `sql` element (deleted afterward).
+3. **Match** each key's MSTR-reported label + metric values to the unique
+   clean row. Ambiguity is a hard error, never a guess.
+4. Emit `ae_winners.json`
+   (`{report: {quirkKeyCol, quirkDescCol, parentKeyCols, winners[]}}`) for
+   `convert.py --ae-winners`.
+
+`convert.py` then emits a **SQL element** per affected report
+(`Bundle.build_ae_sql`): a CTE of the clean groups self-joined so every
+parent-key row takes the pinned winner row's label + metric values — exactly
+reproducing the AE grid, deterministic and parity-verifiable.
+
+## Related converter patterns (clean reports)
+
+- **Grouping by key, labeling by DESC**: MSTR grids group by the attribute's
+  KEY form and render the DESC form; when they differ, the converter emits the
+  key as the grouping column and `Max([DESC])` as the rendered label.
+- **Inner-join semantics**: MicroStrategy inner-joins lookup tables, so fact
+  rows with no matching dim row never appear in its grid. The converted Sigma
+  DM join is left-outer (other consumers need all fact rows) — so the
+  converter adds a per-element `exclude [null]` list filter on each dim-keyed
+  grouping column to mirror MSTR.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/datamodels.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/datamodels.md
@@ -1,0 +1,53 @@
+# Strategy One "Data Models" (Mosaic) — extraction + authoring, live-validated
+
+Strategy One has a newer semantic-layer object alongside the classic project
+schema: the **Data Model** (subType `report_emma_cube`, "Mosaic model").
+Customers on current versions may model in these instead of classic
+attributes/facts. Both paths are handled; this doc covers the Data Model side.
+Everything below was validated live (build + query, exact parity vs the
+classic-schema fixture: same 19/19 Region×Category cells).
+
+## Why it matters for migration
+- Maps almost 1:1 to a Sigma data model: tables + key-joined star +
+  metrics, with `dataServeMode: connect_live` (live warehouse SQL — same
+  execution model as Sigma) or `in_memory` (cube — migrate as the underlying
+  tables, not the cache).
+- Has `securityFilters` (RLS) with member assignment — extractable via
+  `GET /api/dataModels/{id}/securityFilters` (+ `/members`).
+
+## Extraction (converter input)
+`extract_datamodel.py <dataModelId>` → `datamodel_definition.json`:
+dataModel info + tables (with token expressions) + attributes + factMetrics +
+metrics + hierarchy + per-attribute relationships + links. See
+`fixtures/datamodel_definition.json` for the shape.
+- Joins are NOT in `/links` — in-model star joins are classic-style
+  **shared multi-table key attributes** (e.g. Store ID = `STORE_KEY`@dim +
+  `ORDER_STORE_KEY`@fact). Derive Sigma joins exactly like the classic path.
+- `/links` is **cross-data-model linking only** ("target objects must come
+  from different Mosaic models"); also the only GET that requires an
+  `X-MSTR-MS-Changeset` header.
+- Query for parity: `POST /api/v2/cubes/{dmId}/instances` — synchronous,
+  data inline in the response. Do NOT poll `.../instances/{iid}/status`
+  (500s for connect_live instances).
+
+## Authoring (fixture building) — flow that works
+`build_datamodel.py` (phased: core|metrics|query|all; state in
+`datamodel_ids.json`):
+1. dataServer pipeline first, NO changeset: `POST /api/dataServer/workspaces`
+   → `.../pipelines` → `.../pipelines/{pid}/tables` with
+   `importSource:{type:"single_table", dataSourceId, namespace, tableName}`
+   (the data server introspects warehouse columns itself). Workspaces are
+   session-bound — never reuse across logins (401 "trusted communication").
+2. ONE `schemaEdit=false` changeset: create DM (+ `destinationFolderId` —
+   enforced at COMMIT, not POST) → add tables with
+   `physicalTable:{pipeline:"<stringified pipeline JSON>"}` (classic logical
+   tables are rejected: "not from pipeline") → attributes → relationships →
+   factMetrics → commit. An EMPTY DM cannot commit; DM + tables share the
+   changeset. Inline `attributes`/`factMetrics` in the table POST are
+   silently ignored — use the dedicated endpoints. `isKeyForm` on a form is
+   rejected; key is the attribute-level `keyForm:{name:'ID'}`.
+3. Second changeset for metrics (one-token formula text, e.g.
+   `Sum([NET_REVENUE]) {~}`; distinct count via `function:"count"` +
+   `functionProperties:[{name:"Distinct", value:{type:"boolean", value:"true"}}]`).
+4. No `/model/schema/reload` needed; connect_live DMs have NO publish
+   workflow (`POST /api/dataModels/{id}/publish` → 400 — skip it).

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/design-notes.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/design-notes.md
@@ -1,0 +1,65 @@
+# Design notes — MicroStrategy → Sigma converter
+
+## Architecture (one-way data flow)
+
+```
+MSTR REST ──extract.py──> bundle.json ──convert.py──> sigma_dm_spec.json
+                                              │            sigma_workbook_spec.json
+              resolve_ae_winners.py ──────────┘  (ae_winners.json, when needed)
+```
+
+- **`bundle.json` is the contract.** `extract.py` walks a dossier definition →
+  its dataset reports (templates, `showExpressionAs=tokens`) → the schema
+  objects they reference (attributes incl. forms/expressions/lookup tables,
+  facts, metrics incl. compound bases via a second pass, logical tables,
+  hierarchy relationships). The converter never talks to MicroStrategy.
+- **Everything in the output is derived from the bundle** — sources (one DM
+  table element per logical table), the fact table (the logical table carrying
+  fact expressions), joins (attribute key forms mapped to BOTH the fact table
+  and a lookup table become left-outer join legs), a consumable join element
+  with de-duplicated columns (each join's own key column is skipped on the
+  lookup side — a cross-element passthrough of a join key compiles to type
+  `error` in Sigma), metrics (token-parsed; `Count<Distinct=True>` →
+  `CountDistinct`), and one workbook page per dossier chapter.
+- Display formats: MSTR bundle format blocks come back empty, so formats are
+  derived from semantics (count/quantity → integer, pct/margin/ratio →
+  percent, money-named facts → currency).
+
+## Validated scope (live trial, exact parity)
+
+- Classic-schema path: star schema (fact + dims, incl. heterogeneous key
+  columns like `ORDER_STORE_KEY = STORE_KEY`), 3 grid reports in a dossier →
+  Sigma DM + workbook, **19/19 + 30/30 + 3/3 rows exact** (money/counts exact,
+  ratios rel 1e-6). Includes a `Count<Distinct=True>` metric, a compound
+  margin metric, and one AE-collapse report (see `ae-row-collapse.md`).
+
+## Modeling gotchas that bite conversions (verified)
+
+- **Attribute-count metrics cause cartesian-join governance aborts.** A metric
+  like `Count(Customer)` (counting an *attribute*) makes the SQL engine join
+  the attribute's lookup table without a constraining fact path — on a real
+  warehouse the resulting cross join trips MicroStrategy's governance limits
+  and kills the report. Count a **fact column** instead (e.g. a
+  `CUSTOMER_KEY` fact on the fact table) — same number, sane SQL. The same
+  applies on the Sigma side: count the key column of the join element.
+- **Compound-metric denominators need `ZeroToNull()`.** A ratio like
+  `[Profit] / [Revenue]` dies with a Snowflake division-by-zero error on any
+  zero-denominator group. In MSTR wrap the denominator
+  (`ZeroToNull([Total Net Revenue])`); the converter's Sigma output should
+  use the equivalent null-guard if the source metric did.
+
+## Roadmap (deliberately not in the validated path)
+
+1. **Chart visualization emission** — the viz-type lookup
+   (`viz-type-mapping.md`) is extraction-validated; emitting non-table Sigma
+   elements (kpi/bar/line/combo + layout) is the long tail. Author the
+   `fixtures/BUILD_SPEC.md` dossier on a trial to drive it.
+2. **The newer "Data Model" object** (`/api/model/dataModels`) — fully
+   REST-authorable (incl. `securityFilters`, publish, `connect_live`), unlike
+   the classic schema. Two implications: (a) a richer, cleaner extraction
+   source for customers who've adopted it; (b) `securityFilters` is the
+   surface for an RLS detect→ask→port flow (same principles as the sibling
+   converters: never silently dropped, never silently ported).
+3. **Filters, selectors targeting vizzes, page-by, prompts** — extracted
+   structurally (the assessment counts selectors/panel stacks) but not yet
+   converted.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/mstr-rest-api.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/mstr-rest-api.md
@@ -1,0 +1,115 @@
+# MicroStrategy (Strategy One) REST API — verified behaviors & gotchas
+
+Everything below was verified live on a Strategy One 2026 cloud trial during the
+validated end-to-end migration. `scripts/mstr.py` bakes the session/changeset
+mechanics in; this doc is the why.
+
+## Auth & plumbing
+
+- **Login**: `POST /api/auth/login` `{username, password, loginMode: 1}` →
+  session token in the `X-MSTR-AuthToken` **response header** + cookies. Send
+  both on every call, plus `X-MSTR-ProjectID` for project-scoped endpoints.
+  There is **no API-key concept** — sessions only.
+- **OpenAPI**: the full spec is served by the instance itself at
+  `GET /api/openapi.json` (~6 MB). The hosted docs URL serves a stub — trust
+  the instance.
+- **Response headers matter**: several flows return required handles only as
+  response headers (see report saving below). `mstr.py` exposes them as
+  `session.last_headers`, **lowercased** (e.g. `x-mstr-ms-instance`).
+- **Python 3.13+ TLS**: some MicroStrategy cloud CA certs lack the key-usage
+  extension; Python 3.13+ rejects them under `VERIFY_X509_STRICT` (on by
+  default — curl accepts the same cert). `mstr.py` clears only that flag and
+  keeps verification on.
+
+## Datasources
+
+- `GET /api/dbmss` can be **404** on current builds — use `GET /api/gateways`;
+  a gateway id **works as the dbms id** in `POST /api/datasources`
+  (e.g. Snowflake gateway, `dbType: snow_flake`).
+- Creating a warehouse datasource is a **trio**:
+  1. `POST /api/datasources/logins` (username/password)
+  2. `POST /api/datasources/connections` (connectionString + `database.type` +
+     login id) — test first via `POST /api/datasources/connections/test`
+     (accepts an inline login)
+  3. `POST /api/datasources` (dbms + connection id)
+  then attach to a project:
+  `PATCH /api/projects/{id}/datasources`
+  `{"operationList":[{"op":"add","path":"/id","value":"<dsId>"}]}`.
+- On cloud trials, **JDBC connection strings work where ODBC driver names all
+  fail** (`IM002`), e.g.
+  `JDBC;DRIVER=net.snowflake.client.jdbc.SnowflakeDriver;URL={jdbc:snowflake://<account>.snowflakecomputing.com/?...};`
+
+## Changesets (schema edits)
+
+- Creating/editing **tables, attributes, facts, metrics** requires a changeset:
+  `POST /api/model/changesets?schemaEdit=true` → use the returned id as the
+  `X-MSTR-MS-Changeset` header on each modeling call → commit. `mstr.py`'s
+  `schema_edit(fn)` wraps create/commit/abort.
+- **A failed call inside a changeset dangles the schema lock** ("Schema
+  editing is in use by another user") unless you `DELETE` the changeset.
+  If a lock is already stuck: `DELETE /api/model/schema/lock`.
+- Objects created in an **uncommitted** changeset are **not name-resolvable by
+  later calls in the same changeset** — compound metrics that reference newly
+  created base metrics need a **second changeset** after committing the first.
+- Attribute/fact form-expression `tables` entries **require**
+  `subType: "logical_table"`.
+- Metric formulas accept **one token carrying the whole formula text**
+  (`Sum([Net Revenue]) {~}`, `Count<Distinct=True>([Order Id Fact]) {~}`) —
+  the server tokenizes it.
+- After schema changes, reload with a **required body**:
+  `POST /api/model/schema/reload`
+  `{"updateTypes":["table_key","entry_level","logical_size","clear_element_cache"]}`.
+
+## Hierarchy relationships
+
+- `PUT /api/model/systemHierarchy/attributes/{id}/relationships` requires an
+  explicit `child` ref **alongside** `parent`, else a 500 NPE
+  (`getJointChild`).
+- **The PUT REPLACES the attribute's entire parent list.** Writing one new
+  relationship silently drops existing ones — GET the current relationships
+  and merge before every write.
+
+## Reports (the dossier datasets)
+
+- **Reports do NOT use changesets** — the header is rejected.
+- `POST /api/model/reports` only **stages in-memory** (the response's
+  `versionId` is all zeros and the object is NOT in metadata yet). Persist via
+  `POST /api/model/reports/{id}/instances/save` with the `X-MSTR-MS-Instance`
+  header taken from the **creation response header** (lowercase
+  `x-mstr-ms-instance` via `session.last_headers`).
+- The save body needs `dataSource.dataTemplate.units` mirroring
+  `grid.viewTemplate`.
+- **Execution**: `POST /api/v2/reports/{id}/instances?limit=N` returns data
+  directly; the `sqlView` endpoint on an instance exposes the generated
+  warehouse SQL + the Analytical Engine steps (essential for parity debugging
+  — see `ae-row-collapse.md`).
+
+## Dossiers
+
+- **Extraction**: `GET /api/v2/dossiers/{id}/definition` returns
+  `{datasets, chapters[].pages[]}`. Walk each page's `visualizations` **and**
+  `panelStacks[].panels[]` **recursively** — panels nest further `panelStacks`
+  — plus free-form `fields` (images / text boxes), or you silently miss
+  content. Non-dossier documents 404/error on this endpoint (useful as a
+  dossier-vs-document probe).
+- **Per-viz definition is shallow**: a visualization exposes ONLY
+  `visualizationType` + `definition.grid` (`rows` / `columns` / `metrics` /
+  `crossTab` / `metricsPosition`). There is no slot/encoding detail beyond the
+  grid — the converter maps `visualizationType` → Sigma chart kind via lookup
+  with a flagged-table fallback (see `viz-type-mapping.md`).
+- **Authoring is REST-hostile**: `POST /api/dossiers/instances`
+  `{objects:[{id, type:3}]}` wraps reports into an in-memory dossier (returns
+  `mid`); save via `POST /api/documents/{id}/instances/{mid}/saveAs` — but the
+  flow is **session-bound** (create + saveAs must share one auth session). The
+  public manipulations API supports ONLY `setFilter` / `setCurrentPanel`; viz
+  types can't be set via REST (UI only). Chart-rich fixtures must be authored
+  in the Library UI (see `../fixtures/BUILD_SPEC.md`).
+
+## Roadmap: the newer "Data Model" object
+
+Strategy One also ships a **newer Data Model object**
+(`/api/model/dataModels`) that is **fully REST-authorable** — including
+`securityFilters`, publish, and `connect_live`. The validated converter targets
+the classic schema path (attributes/facts/metrics + reports + dossiers); the
+Data Model object is not yet exercised and is the natural next extraction
+source (and the RLS port surface). Tracked as roadmap in `design-notes.md`.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/viz-type-mapping.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/viz-type-mapping.md
@@ -1,0 +1,66 @@
+# Dossier visualization types → Sigma element kinds
+
+What the dossier API exposes per visualization is **shallow**: only
+`visualizationType` + `definition.grid` (`rows` / `columns` / `metrics` /
+`crossTab` / `metricsPosition`). There are no slot/encoding details beyond
+which attributes and metrics sit on which grid axis. The converter therefore
+maps `visualizationType` → a Sigma element kind via this lookup, feeds the
+grid axes into the closest Sigma slots, and falls back to a **flagged table**
+(data preserved, loud warning) for anything unmapped — never silently wrong.
+
+**Status legend** — *extraction validated*: the type was pulled from real
+demo-content dossiers and its `definition.grid` parsed as documented.
+*Build*: whether the Sigma-element emission is part of the validated path
+(the live-validated fixture used grid reports; chart emission is roadmap).
+
+Counts below are from a 365-dossier / ~7,400-viz sweep of MicroStrategy's
+public demo environment (Tutorial, MobileDashboards, Embedded Analytics,
+AI Auto projects, 2026-06) — the extractor walker parsed **all** of them,
+so every listed type is extraction-validated. Counts double as gap priority.
+
+| MSTR `visualizationType` | n | Sigma element kind | Build |
+|---|---|---|---|
+| `grid` | 1893 | `table` (pivot when `crossTab: true`) | **validated (parity-verified)** |
+| `kpi` | 1633 | `kpi-chart` | roadmap (top priority by volume) |
+| `bar_chart` | 810 | `bar` | roadmap |
+| `geospatial_service` | 331 | `region-map` / `point-map` (by geo attribute granularity — cognos `tiledmap` precedent) | roadmap |
+| `line_chart` | 252 | `line` | roadmap |
+| `bubble_chart` | 221 | `scatter` (size slot) | roadmap |
+| `heat_map` | 188 | flagged `table` (size+color tile grid has no Sigma analog) | fallback |
+| `combo_chart` | 182 | `combo` | roadmap |
+| `area_chart` | 170 | `area` | roadmap |
+| `multi_metric_kpi` | 168 | one `kpi-chart` per metric | roadmap |
+| `compound_grid` | 155 | `table` | roadmap |
+| `microcharts` | 113 | `table` + flagged sparkline columns | fallback |
+| `ring_chart` | 111 | `pie` (donut variant) | roadmap |
+| `google_map` | 104 | `region-map` / `point-map` | roadmap |
+| `pie_chart` | 90 | `pie` | roadmap |
+| `comparison_kpi` | 67 | `kpi-chart` (comparison value flagged) | roadmap |
+| `sankey` | 42 | flagged `table` | fallback |
+| `gauge` | 33 | `kpi-chart` (gauge bands flagged) | fallback |
+| `histogram` | 27 | `bar` (pre-binned) or flagged | fallback |
+| `network` | 25 | flagged `table` | fallback |
+| `waterfall` | 23 | flagged `table` | fallback |
+| `esri_map` | 21 | `region-map` / `point-map` | roadmap |
+| `box_plot` | 16 | `box` if available, else flagged | fallback |
+| `key_driver`, `time_series`, `auto_narratives`, `sequences_sunburst`, `forecast_line_chart`, `PageBy`, `ImageOverlay` | ≤12 ea | flagged `table` | fallback |
+| **custom/marketplace vizzes** — any `HC*` (Highcharts), `D3*`, `Vitara*`, `EChart*`, `Arria*`, `Google*`, `CardWidget`, `RadarChart`, `SimpleKPIChart`, … | ~230 total | flagged `table` — third-party viz plugins, unconvertible by definition | fallback |
+| *anything else* | — | flagged `table` fallback | fallback |
+
+Custom-viz names are not a closed set (they're marketplace plugins) — treat
+any type not in this table as custom and flag it.
+
+**Structural-feature frequencies** from the same sweep (extractor handles all
+of these; converter coverage noted): selectors 51% of dossiers, chapter
+filters 49%, multi-dataset 42%, free-form `fields` — text 65% / image 54% /
+shape 33% / **html 11%** — and nested panelStacks 23%. Free-form text →
+Sigma `text` elements; images/shapes/html are flagged; selectors/filters →
+Sigma controls (roadmap); multi-dataset chapters → one Sigma element per
+dataset-backed viz (each viz names its dataset).
+
+`fixtures/BUILD_SPEC.md` is the drag-and-drop spec for an "every viz type"
+fixture dossier (REST cannot author visualizations — Library UI only); use it
+to extend the validated set.
+
+Keep `VIZ_MAPPED` in `../../microstrategy-assessment/scripts/assess.py` in
+sync with this table — the assessment classifies estates against it.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/build_datamodel.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/build_datamodel.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Build + validate a Strategy One Data Model ("Orders Data Model") via REST.
+
+Flow (all learned by probing; see final report):
+  Phase A  dataServer workspace -> per-table pipelines (this is the ONLY way to
+           bind a data-model table to a datasource; classic physical tables are
+           rejected with "not from pipeline").
+  Phase B  one changeset: create DM (connect_live) + 4 tables + attributes
+           (+ hierarchy relationships) + factMetrics, then commit.  An EMPTY
+           data model cannot be committed, so DM + tables share a changeset.
+  Phase C  second changeset: /metrics (token text resolves committed names).
+  Phase D  publish (instances -> publish -> poll publishStatus).
+  Phase E  query validation via /api/v2/cubes/{id}/instances (revenue by region).
+
+State in datamodel_ids.json; re-running skips completed phases.
+NOTE: /links is cross-data-model only — in-model joins come from shared
+multi-table key attributes (Store/Product/Day below).
+"""
+import json
+import sys
+import time
+
+import mstr, os
+
+DS = os.environ['MSTR_DATASOURCE_ID']  # Snowflake datasource (GET /api/datasources)
+TABLES = ['ORDER_FACT', 'PRODUCT_DIM', 'STORE_DIM', 'DATE_DIM']
+STATE_PATH = 'datamodel_ids.json'
+
+s = mstr.Session()
+try:
+    state = json.load(open(STATE_PATH))
+except FileNotFoundError:
+    state = {'tables': {}, 'attributes': {}, 'factMetrics': {}, 'metrics': {}}
+
+
+def save():
+    json.dump(state, open(STATE_PATH, 'w'), indent=1)
+
+
+# ---------- Phase A: pipelines ----------
+def make_pipelines():
+    wid = s.post('/dataServer/workspaces', {})['id']
+    pipelines = {}
+    for t in TABLES:
+        p = s.post(f'/dataServer/workspaces/{wid}/pipelines', {})
+        pid = p['id']
+        s.post(f'/dataServer/workspaces/{wid}/pipelines/{pid}/tables',
+               {'type': 'source', 'name': t,
+                'importSource': {'type': 'single_table', 'dataSourceId': DS,
+                                 'namespace': 'TJ', 'tableName': t}})
+        pipelines[t] = s.get(f'/dataServer/workspaces/{wid}/pipelines/{pid}')
+        print('pipeline', t, 'ok')
+    return pipelines
+
+
+# ---------- Phase B: DM + tables + attributes + factMetrics ----------
+def tref(name):
+    return {'objectId': state['tables'][name], 'subType': 'logical_table',
+            'name': name}
+
+
+def aref(name):
+    return {'objectId': state['attributes'][name], 'subType': 'attribute',
+            'name': name}
+
+
+def form(name, fmt, exprs, lookup, category=None):
+    """exprs: list of (column, table)."""
+    f = {'name': name, 'displayFormat': fmt, 'lookupTable': tref(lookup),
+         'expressions': [{'expression': {'tokens': [{'value': col}]},
+                          'tables': [tref(t)]} for col, t in exprs]}
+    if category:
+        f['category'] = category
+    return f
+
+
+def build_core(cs):
+    pipelines = make_pipelines()
+    # destinationFolderId is REQUIRED at commit time ("The destination folder
+    # is not provided"), even though POST succeeds without it.
+    reports_folder = json.load(open('folder_ids.json'))['reports']
+    r = s.cs_post('/model/dataModels',
+                  {'information': {'name': 'Orders Data Model',
+                                   'destinationFolderId': reports_folder},
+                   'dataServeMode': 'connect_live'}, cs)
+    state['dataModelId'] = r['information']['objectId']
+    state['schemaFolderId'] = r.get('schemaFolderId')
+    dm = state['dataModelId']
+    print('dataModel:', dm)
+
+    for t in TABLES:
+        rt = s.cs_post(f'/model/dataModels/{dm}/tables',
+                       {'information': {'name': t},
+                        'physicalTable': {'pipeline': json.dumps(pipelines[t])}},
+                       cs)
+        state['tables'][t] = rt['information']['objectId']
+        print('table', t, '->', state['tables'][t])
+
+    # (name, lookup, forms, display form, parent-or-None)
+    attrs = [
+        ('Region', 'STORE_DIM',
+         [form('ID', 'text', [('REGION', 'STORE_DIM')], 'STORE_DIM', 'ID')],
+         'ID', None),
+        ('Category', 'PRODUCT_DIM',
+         [form('ID', 'text', [('CATEGORY', 'PRODUCT_DIM')], 'PRODUCT_DIM', 'ID')],
+         'ID', None),
+        ('Year', 'DATE_DIM',
+         [form('ID', 'number', [('YEAR', 'DATE_DIM')], 'DATE_DIM', 'ID')],
+         'ID', None),
+        ('Month', 'DATE_DIM',
+         [form('ID', 'number', [('MONTH_NUMBER', 'DATE_DIM')], 'DATE_DIM', 'ID'),
+          form('DESC', 'text', [('MONTH_NAME', 'DATE_DIM')], 'DATE_DIM', 'DESC')],
+         'DESC', 'Year'),
+        # multi-table key attributes below carry the star joins
+        ('Store', 'STORE_DIM',
+         [form('ID', 'number', [('STORE_KEY', 'STORE_DIM'),
+                                ('ORDER_STORE_KEY', 'ORDER_FACT')],
+               'STORE_DIM', 'ID'),
+          form('DESC', 'text', [('STORE_NAME', 'STORE_DIM')], 'STORE_DIM', 'DESC')],
+         'DESC', 'Region'),
+        ('Product', 'PRODUCT_DIM',
+         [form('ID', 'number', [('PRODUCT_KEY', 'PRODUCT_DIM'),
+                                ('PRODUCT_KEY', 'ORDER_FACT')],
+               'PRODUCT_DIM', 'ID'),
+          form('DESC', 'text', [('PRODUCT_NAME', 'PRODUCT_DIM')], 'PRODUCT_DIM',
+               'DESC')],
+         'DESC', 'Category'),
+        ('Day', 'DATE_DIM',
+         [form('ID', 'number', [('DATE_KEY', 'DATE_DIM'),
+                                ('ORDER_DATE_KEY', 'ORDER_FACT')],
+               'DATE_DIM', 'ID'),
+          form('DESC', 'date', [('FULL_DATE', 'DATE_DIM')], 'DATE_DIM', 'DESC')],
+         'DESC', 'Month'),
+        ('Order Channel', 'ORDER_FACT',
+         [form('ID', 'text', [('ORDER_CHANNEL', 'ORDER_FACT')], 'ORDER_FACT',
+               'ID')],
+         'ID', None),
+    ]
+    rels = []
+    for name, lookup, forms, disp, parent in attrs:
+        body = {'information': {'name': name}, 'forms': forms,
+                'attributeLookupTable': tref(lookup),
+                'keyForm': {'name': forms[0]['name']},
+                'displays': {'reportDisplays': [{'name': disp}],
+                             'browseDisplays': [{'name': disp}]}}
+        ra = s.cs_post(f'/model/dataModels/{dm}/attributes', body, cs)
+        state['attributes'][name] = ra['information']['objectId']
+        print('attribute', name, '->', state['attributes'][name])
+        if parent:
+            rels.append((name, parent, lookup))
+
+    for child, parent, table in rels:
+        body = {'relationships': [{'parent': aref(parent), 'child': aref(child),
+                                   'relationshipTable': tref(table),
+                                   'relationshipType': 'one_to_many'}]}
+        s.put(f'/model/dataModels/{dm}/attributes/'
+              f'{state["attributes"][child]}/relationships',
+              body, headers={'X-MSTR-MS-Changeset': cs})
+        print('relationship', parent, '>', child)
+
+    fms = [
+        ('NET_REVENUE', 'NET_REVENUE', 'sum',
+         {'type': 'double', 'precision': 8, 'scale': 2}, None),
+        ('GROSS_PROFIT', 'GROSS_PROFIT', 'sum',
+         {'type': 'double', 'precision': 8, 'scale': 2}, None),
+        ('QUANTITY_ORDERED', 'QUANTITY_ORDERED', 'sum',
+         {'type': 'int64', 'precision': 8, 'scale': 0}, None),
+        ('ORDER_ID', 'ORDER_ID', 'count',
+         {'type': 'utf8_char', 'precision': 20, 'scale': 0},
+         [{'name': 'Distinct', 'value': {'type': 'boolean', 'value': 'true'}}]),
+    ]
+    for name, col, fn, dt, props in fms:
+        body = {'information': {'name': name},
+                'fact': {'dataType': dt,
+                         'expressions': [{'expression': {'tokens': [{'value': col}]},
+                                          'tables': [tref('ORDER_FACT')]}]},
+                'function': fn}
+        if props:
+            body['functionProperties'] = props
+        try:
+            rf = s.cs_post(f'/model/dataModels/{dm}/factMetrics', body, cs)
+        except RuntimeError as e:
+            if props:
+                print('factMetric', name, 'with Distinct failed:', str(e)[:200])
+                body.pop('functionProperties')
+                rf = s.cs_post(f'/model/dataModels/{dm}/factMetrics', body, cs)
+            else:
+                raise
+        state['factMetrics'][name] = rf['information']['objectId']
+        print('factMetric', name, '->', state['factMetrics'][name])
+
+
+# ---------- Phase C: metrics ----------
+def build_metrics(cs):
+    dm = state['dataModelId']
+    metrics = [
+        ('Total Net Revenue', ['Sum([NET_REVENUE]) {~}',
+                               '[NET_REVENUE]']),
+        ('Total Gross Profit', ['Sum([GROSS_PROFIT]) {~}',
+                                '[GROSS_PROFIT]']),
+        ('Order Count', ['Count<Distinct=True>([ORDER_ID]) {~}',
+                         '[ORDER_ID]']),
+    ]
+    for name, variants in metrics:
+        if name in state['metrics']:
+            continue
+        last = None
+        for v in variants:
+            body = {'information': {'name': name},
+                    'expression': {'tokens': [{'value': v}]}}
+            try:
+                rm = s.cs_post(f'/model/dataModels/{dm}/metrics', body, cs)
+                state['metrics'][name] = rm['information']['objectId']
+                print('metric', name, '->', state['metrics'][name],
+                      'formula:', v)
+                last = None
+                break
+            except RuntimeError as e:
+                last = e
+                print('metric', name, 'variant failed:', v, '|', str(e)[:200])
+        if last:
+            raise last
+
+
+# ---------- Phase D: publish ----------
+def publish():
+    dm = state['dataModelId']
+    s.post(f'/dataModels/{dm}/instances')
+    inst = (s.last_headers.get('x-mstr-ms-instance')
+            or s.last_headers.get('x-mstr-datamodelinstanceid'))
+    print('instance:', inst, {k: v for k, v in s.last_headers.items()
+                              if 'mstr' in k})
+    body = {'tables': [{'id': tid, 'refreshPolicy': 'replace'}
+                       for tid in state['tables'].values()]}
+    try:
+        s.post(f'/dataModels/{dm}/publish', body,
+               headers={'X-MSTR-DataModelInstanceId': inst})
+    except RuntimeError as e:
+        if 'no publish workflow' in str(e):
+            # connect_live data models are live — nothing to publish
+            print('publish skipped:', str(e)[:120])
+            state['published'] = 'skipped (connect_live has no publish workflow)'
+            return
+    for _ in range(60):
+        st = s.get(f'/dataModels/{dm}/publishStatus')
+        print('publishStatus:', json.dumps(st)[:200])
+        if st.get('status') == 1:   # DssXmlStatusResult = ready
+            break
+        time.sleep(2)
+    state['published'] = True
+
+
+# ---------- Phase E: query validation ----------
+def query():
+    dm = state['dataModelId']
+    body = {'requestedObjects': {
+        'attributes': [{'id': state['attributes']['Region']}],
+        'metrics': [{'id': state['metrics']['Total Net Revenue']},
+                    {'id': state['metrics']['Order Count']}]}}
+    out = s.post(f'/v2/cubes/{dm}/instances', body)
+    # connect_live executes synchronously: status==1 with data inline.
+    # (GET /v2/cubes/{id}/instances/{iid}/status 500s "Catastrophic failure"
+    # for these instances — do not poll.)
+    iid = out['instanceId']
+    for _ in range(30):
+        if out.get('status') == 1 and 'data' in out:
+            break
+        time.sleep(1)
+        out = s.get(f'/v2/cubes/{dm}/instances/{iid}')
+    json.dump(out, open('query_validation.json', 'w'), indent=1)
+    rows = out['data']['headers']['rows']
+    attr_el = out['definition']['grid']['rows'][0]['elements']
+    vals = out['data']['metricValues']['raw']
+    print('\nRevenue by Region (live Snowflake via data model):')
+    for i, hr in enumerate(rows):
+        region = attr_el[hr[0]]['formValues'][0]
+        print(f'  {region:10s}  net_rev={vals[i][0]:>10}  orders={vals[i][1]}')
+    return out
+
+
+if __name__ == '__main__':
+    step = sys.argv[1] if len(sys.argv) > 1 else 'all'
+    if 'dataModelId' not in state and step in ('all', 'core'):
+        cs = s.changeset(schema_edit=False)
+        try:
+            build_core(cs)
+        except Exception:
+            s.abort(cs)
+            state.pop('dataModelId', None)
+            state['tables'].clear(); state['attributes'].clear()
+            state['factMetrics'].clear()
+            raise
+        s.commit(cs)
+        save()
+        print('core committed')
+    if step in ('all', 'metrics') and len(state['metrics']) < 3:
+        cs = s.changeset(schema_edit=False)
+        try:
+            build_metrics(cs)
+        except Exception:
+            s.abort(cs)
+            raise
+        s.commit(cs)
+        save()
+        print('metrics committed')
+    if step in ('all', 'publish') and not state.get('published'):
+        publish()
+        save()
+    if step in ('all', 'query'):
+        query()

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/convert.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/convert.py
@@ -1,0 +1,755 @@
+#!/usr/bin/env python3
+"""
+convert.py — MicroStrategy bundle.json -> Sigma data-model spec + workbook spec.
+
+Everything is derived programmatically from the bundle:
+  - Sources: every logical table in bundle["tables"], path [<database>, <namespace>, <tableName>].
+  - Base/fact table: the logical table that carries fact expressions.
+  - Joins: attributes whose ID (key) form has expressions mapped to BOTH the fact
+    table and a different lookup table that is present in the bundle. The fact-side
+    expression and the lookup-side expression become the left/right join keys.
+  - Metrics: parsed from bundle["metrics"] expression tokens (function + fact /
+    metric object references + Distinct=True parameter -> CountDistinct).
+  - Workbook pages: one page per dossier chapter; each chapter's dataset report's
+    dataTemplate units give the grouping attributes + metric columns.
+
+Usage:
+  python3 convert.py --connection-id <uuid> --database CSA --folder-id <uuid> \
+      [--inode-map inodes.json] [--bundle bundle.json] \
+      [--dm-name "..."] [--wb-name "..."] \
+      [--data-model-id <uuid>] [--orders-element-id <id>]
+
+Outputs sigma_dm_spec.json and sigma_workbook_spec.json. The workbook spec uses
+placeholders {{DATA_MODEL_ID}} / {{ORDERS_ELEMENT_ID}} unless the corresponding
+args are given.
+"""
+import argparse
+import json
+import re
+
+
+def friendly(col: str) -> str:
+    """Sigma friendly-name normalization for ALL_CAPS_UNDERSCORE warehouse names."""
+    return " ".join(p.capitalize() for p in col.split("_"))
+
+
+def slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")
+
+
+# ---------------------------------------------------------------- bundle model
+class Bundle:
+    def __init__(self, raw):
+        self.raw = raw
+        self.tables = raw["tables"]          # logical table id -> def
+        self.attributes = raw["attributes"]  # attribute id -> def
+        self.metrics = raw["metrics"]        # metric id -> def
+        self.facts = raw["facts"]            # fact id -> def
+        self.reports = raw["reports"]
+        self.dossier = raw["dossier"]
+
+        # logical table id -> (name, schema/namespace, physical table name)
+        self.table_info = {}
+        for tid, t in self.tables.items():
+            pt = t["physicalTable"]
+            self.table_info[tid] = {
+                "name": t["information"]["name"],
+                "tableName": pt["tableName"],
+                "namespace": pt.get("namespace"),
+            }
+
+        # fact table = the logical table that carries fact expressions
+        fact_tids = set()
+        for f in self.facts.values():
+            for de in f["expressions"]:
+                for tb in de.get("tables", []):
+                    fact_tids.add(tb["objectId"])
+        if len(fact_tids) != 1:
+            raise SystemExit(f"expected exactly 1 fact table, found {fact_tids}")
+        self.fact_tid = next(iter(fact_tids))
+
+        # per logical table: attribute id -> list of forms
+        #   form := {category, expr(column), isKeyForm}
+        self.table_attr_forms = {}   # tid -> {attr_id: [form,...]}
+        for tid, t in self.tables.items():
+            am = {}
+            for a in t.get("attributes", []):
+                aid = a["information"]["objectId"]
+                forms = []
+                for f in a.get("forms", []):
+                    forms.append({
+                        "category": f["formCategory"]["name"],
+                        "expr": f["expression"]["text"],
+                        "isKeyForm": f.get("isKeyForm", False),
+                        "lookupTable": f["lookupTable"]["objectId"],
+                    })
+                am[aid] = forms
+            self.table_attr_forms[tid] = am
+
+        # fact id -> physical column on the fact table
+        self.fact_col = {}
+        for fid, f in self.facts.items():
+            for de in f["expressions"]:
+                for tb in de.get("tables", []):
+                    if tb["objectId"] == self.fact_tid:
+                        self.fact_col[fid] = de["expression"]["text"]
+        # name -> fact id (metric text sometimes references facts by bare name)
+        self.fact_by_name = {f["information"]["name"]: fid
+                             for fid, f in self.facts.items()}
+        self.metric_by_name = {m["information"]["name"]: mid
+                               for mid, m in self.metrics.items()}
+
+    # ---- joins: attribute key form mapped to BOTH fact table and lookup table
+    def derive_joins(self):
+        joins = []
+        fact_forms = self.table_attr_forms[self.fact_tid]
+        for aid, forms in fact_forms.items():
+            key_fact = next((f for f in forms if f["isKeyForm"]), None)
+            if not key_fact:
+                continue
+            lookup_tid = key_fact["lookupTable"]
+            if lookup_tid == self.fact_tid or lookup_tid not in self.tables:
+                continue  # degenerate (fact-resident attr) or table not extracted
+            lookup_forms = self.table_attr_forms.get(lookup_tid, {}).get(aid, [])
+            key_lookup = next((f for f in lookup_forms if f["isKeyForm"]), None)
+            if not key_lookup:
+                continue
+            joins.append({
+                "attribute": aid,
+                "lookup_tid": lookup_tid,
+                "fact_col": key_fact["expr"],
+                "lookup_col": key_lookup["expr"],
+            })
+        return joins
+
+    # ---- columns each table contributes (any expression mapped to it)
+    def table_columns(self, tid):
+        cols = []
+        seen = set()
+        for aid, forms in self.table_attr_forms.get(tid, {}).items():
+            for f in forms:
+                c = f["expr"]
+                if f["lookupTable"] == tid and c not in seen:
+                    seen.add(c)
+                    cols.append(c)
+        if tid == self.fact_tid:
+            for fid, c in self.fact_col.items():
+                if c not in seen:
+                    seen.add(c)
+                    cols.append(c)
+            # join keys on the fact side
+            for j in self.derive_joins():
+                if j["fact_col"] not in seen:
+                    seen.add(j["fact_col"])
+                    cols.append(j["fact_col"])
+        return cols
+
+    # ---- metric expression -> Sigma formula
+    def metric_formula(self, mid, ref, expand_metrics=False):
+        """ref(column_friendly) -> bracketed reference string.
+        expand_metrics: inline referenced metrics (workbook context) instead of
+        emitting [Metric Name] (data-model context)."""
+        m = self.metrics[mid]
+        toks = m["expression"]["tokens"]
+        out = []
+        i = 0
+        while i < len(toks):
+            t = toks[i]
+            v, ty = t.get("value"), t.get("type")
+            if ty == "function" and v not in ("=",):
+                fname = v
+                # peek a <...> parameter block for Distinct=True
+                j = i + 1
+                distinct = False
+                if j < len(toks) and toks[j].get("value") == "<":
+                    while j < len(toks) and toks[j].get("value") != ">":
+                        if (toks[j].get("value") == "Distinct"
+                                and j + 2 < len(toks)
+                                and toks[j + 2].get("value") == "True"):
+                            distinct = True
+                        j += 1
+                    i = j  # skip past the parameter block
+                if fname == "Count" and distinct:
+                    fname = "CountDistinct"
+                out.append(fname)
+            elif ty == "object_reference":
+                tgt = t.get("target", {})
+                sub = tgt.get("subType")
+                oid = tgt.get("objectId")
+                if sub == "fact":
+                    out.append(ref(friendly(self.fact_col[oid])))
+                elif sub == "metric":
+                    if expand_metrics:
+                        out.append("(" + self.metric_formula(
+                            oid, ref, expand_metrics=True) + ")")
+                    else:
+                        out.append(f"[{self.metrics[oid]['information']['name']}]")
+                else:
+                    raise SystemExit(f"unhandled object_reference {sub} in metric "
+                                     f"{m['information']['name']}")
+            elif ty == "character":
+                if v in ("<", ">"):
+                    pass  # parameter block delimiters already handled
+                elif v in ("(", ")", ",", "+", "-", "*", "/"):
+                    out.append(v)
+            elif ty == "identifier" or ty == "boolean":
+                pass  # parameter names/values inside <...>
+            i += 1
+        # join with spaces around operators, none around parens
+        f = ""
+        for tok in out:
+            if tok in ("+", "-", "*", "/"):
+                f += f" {tok} "
+            elif tok == ",":
+                f += ", "
+            else:
+                f += tok
+        return f
+
+    # ---- metric expression -> warehouse SQL (for AE-emulation sql elements)
+    def metric_sql(self, mid, fact_alias="ORDER_FACT"):
+        m = self.metrics[mid]
+        toks = m["expression"]["tokens"]
+        FN = {"Sum": "SUM", "Count": "COUNT", "Avg": "AVG", "Max": "MAX",
+              "Min": "MIN"}
+        out = []
+        distinct_pending = False
+        i = 0
+        while i < len(toks):
+            t = toks[i]
+            v, ty = t.get("value"), t.get("type")
+            if ty == "function" and v not in ("=",):
+                fname, distinct = v, False
+                j = i + 1
+                if j < len(toks) and toks[j].get("value") == "<":
+                    while j < len(toks) and toks[j].get("value") != ">":
+                        if (toks[j].get("value") == "Distinct"
+                                and j + 2 < len(toks)
+                                and toks[j + 2].get("value") == "True"):
+                            distinct = True
+                        j += 1
+                    i = j
+                out.append(FN.get(fname, fname.upper()))
+                distinct_pending = distinct
+            elif ty == "object_reference":
+                tgt = t.get("target", {})
+                if tgt.get("subType") == "fact":
+                    out.append(f"{fact_alias}.{self.fact_col[tgt['objectId']]}")
+                elif tgt.get("subType") == "metric":
+                    out.append("(" + self.metric_sql(tgt["objectId"],
+                                                     fact_alias) + ")")
+            elif ty == "character":
+                if v == "(":
+                    out.append("(DISTINCT " if distinct_pending else "(")
+                    distinct_pending = False
+                elif v in (")", ",", "+", "-", "*", "/"):
+                    out.append(v)
+        # NB: '<'/'>' parameter blocks skipped above
+            i += 1
+        sql = ""
+        for tok in out:
+            if tok in ("+", "-", "*", "/"):
+                sql += f" {tok} "
+            elif tok == ",":
+                sql += ", "
+            else:
+                sql += tok
+        return sql
+
+    # ---- clean per-(attribute keys) aggregation SQL for a report
+    def report_attr_units(self, report):
+        units = report["dataSource"]["dataTemplate"]["units"]
+        return ([u for u in units if u.get("type") == "attribute"],
+                [el for u in units if u.get("type") == "metrics"
+                 for el in u["elements"]])
+
+    def clean_group_aliases(self, report):
+        attr_units, metric_units = self.report_attr_units(report)
+        aliases = []
+        for u in attr_units:
+            key_col, desc_col = self.attribute_unit_cols(u["id"])
+            aliases.append(friendly(key_col))
+            if desc_col:
+                aliases.append(friendly(desc_col))
+        aliases += [el["name"] for el in metric_units]
+        return aliases
+
+    def build_clean_group_sql(self, database, report):
+        """SELECT <attr keys>, MAX(<desc>) per desc form, <metric aggs>
+        FROM fact JOIN needed dims GROUP BY keys — the same statement
+        MicroStrategy generates for the report."""
+        attr_units, metric_units = self.report_attr_units(report)
+        fact = self.table_info[self.fact_tid]
+        fq = lambda tid: ".".join([database,
+                                   self.table_info[tid]["namespace"],
+                                   self.table_info[tid]["tableName"]])
+        joins_by_tid = {j["lookup_tid"]: j for j in self.derive_joins()}
+
+        select, group_pos, needed_tids = [], [], []
+        pos = 0
+        for u in attr_units:
+            key_col, desc_col = self.attribute_unit_cols(u["id"])
+            a = self.attributes[u["id"]]
+            lookup_tid = a["attributeLookupTable"]["objectId"]
+            alias = self.table_info[lookup_tid]["tableName"]
+            if lookup_tid != self.fact_tid and lookup_tid not in needed_tids:
+                needed_tids.append(lookup_tid)
+            pos += 1
+            select.append(f'{alias}.{key_col} AS "{friendly(key_col)}"')
+            group_pos.append(str(pos))
+            if desc_col:
+                pos += 1
+                select.append(f'MAX({alias}.{desc_col}) AS "{friendly(desc_col)}"')
+        for el in metric_units:
+            select.append(f'{self.metric_sql(el["id"], fact["tableName"])} '
+                          f'AS "{el["name"]}"')
+
+        from_sql = f'{fq(self.fact_tid)} {fact["tableName"]}'
+        for tid in needed_tids:
+            j = joins_by_tid[tid]
+            dim = self.table_info[tid]["tableName"]
+            from_sql += (f'\n  JOIN {fq(tid)} {dim} ON '
+                         f'{fact["tableName"]}.{j["fact_col"]} = '
+                         f'{dim}.{j["lookup_col"]}')
+        return ("SELECT " + ",\n       ".join(select)
+                + f"\nFROM {from_sql}\nGROUP BY " + ", ".join(group_pos))
+
+    def build_ae_sql(self, database, report, ae_cfg):
+        """AE-emulation: clean groups, then every parent-key row takes the
+        pinned representative row's label + metric values for its quirk key."""
+        attr_units, metric_units = self.report_attr_units(report)
+        qkey_f = friendly(ae_cfg["quirkKeyCol"])
+        qdesc_f = friendly(ae_cfg["quirkDescCol"])
+        parent_f = [friendly(c) for c in ae_cfg["parentKeyCols"]]
+
+        def lit(v):
+            s = str(v)
+            try:
+                float(s)
+                return s
+            except ValueError:
+                return "'" + s.replace("'", "''") + "'"
+
+        conds = []
+        for w in ae_cfg["winners"]:
+            parts = [f'w."{qkey_f}" = {lit(w[qkey_f])}']
+            parts += [f'w."{p}" = {lit(w[p])}' for p in parent_f]
+            conds.append("(" + " AND ".join(parts) + ")")
+
+        out_cols = [f'f."{p}" AS "{p}"' for p in parent_f]
+        out_cols.append(f'w."{qkey_f}" AS "{qkey_f}"')
+        out_cols.append(f'w."{qdesc_f}" AS "{qdesc_f}"')
+        out_cols += [f'w."{el["name"]}" AS "{el["name"]}"'
+                     for el in metric_units]
+        return (
+            "WITH F AS (\n" + self.build_clean_group_sql(database, report)
+            + "\n)\nSELECT " + ",\n       ".join(out_cols)
+            + f'\nFROM F f\nJOIN F w ON w."{qkey_f}" = f."{qkey_f}"\n  AND ('
+            + "\n    OR ".join(conds) + ")")
+
+    # ---- display format for a metric (MSTR bundle format blocks are empty,
+    # so derive from semantics: count/quantity -> integer, ratio/pct -> percent,
+    # money facts -> currency)
+    def metric_display_format(self, mid):
+        m = self.metrics[mid]
+        name = m["information"]["name"]
+        if re.search(r"pct|percent|margin|ratio|rate", name, re.I):
+            return {"kind": "number", "formatString": ",.2%"}
+        toks = m["expression"]["tokens"]
+        funcs = [t["value"] for t in toks if t.get("type") == "function"
+                 and t.get("value") not in ("=",)]
+        fact_cols = [self.fact_col[t["target"]["objectId"]] for t in toks
+                     if t.get("type") == "object_reference"
+                     and t.get("target", {}).get("subType") == "fact"]
+        if any(f.startswith("Count") for f in funcs):
+            return {"kind": "number", "formatString": ",.0f"}
+        if any(re.search(r"REVENUE|PROFIT|COST|AMOUNT|PRICE", c) for c in fact_cols):
+            return {"kind": "number", "formatString": "$,.2f"}
+        if any(re.search(r"QUANTITY|UNITS|COUNT", c) for c in fact_cols):
+            return {"kind": "number", "formatString": ",.0f"}
+        return None
+
+    # ---- attribute key + display columns for a report unit
+    def attribute_unit_cols(self, aid):
+        """Returns (key_col, desc_col_or_None) physical column names.
+
+        MicroStrategy grids group by the attribute's KEY (ID) form and render
+        the DESC form. When the DESC form differs from the key, the rendered
+        label per element resolves to the max DESC value over the joined fact
+        rows — so the converter emits the key as the grouping column and the
+        DESC as a Max() calculation."""
+        a = self.attributes[aid]
+        forms = a["forms"]
+        key = next((f for f in forms if f.get("category") == "ID"), forms[0])
+        desc = next((f for f in forms if f.get("category") == "DESC"), None)
+        key_col = key["expressions"][0]["expression"]["text"]
+        desc_col = desc["expressions"][0]["expression"]["text"] if desc else None
+        return key_col, desc_col
+
+
+# ------------------------------------------------------------------- emitters
+def ae_element_name(report_name):
+    return f"{report_name} (MSTR AE)"
+
+
+def build_dm_spec(b: Bundle, args, inode_map, ae_winners=None):
+    conn = args.connection_id
+    elements = []
+    el_id = {}    # tid -> element id
+    el_name = {}  # tid -> element name (= logical table name)
+
+    def col_id(tid, col):
+        tail = inode_map.get(b.table_info[tid]["tableName"])
+        if tail:
+            return f"inode-{tail}/{col}"
+        return f"{slug(b.table_info[tid]['name'])}-{slug(col)}"
+
+    for tid, info in b.table_info.items():
+        eid = f"el-{slug(info['name'])}"
+        el_id[tid], el_name[tid] = eid, info["name"]
+        cols = b.table_columns(tid)
+        elements.append({
+            "id": eid,
+            "kind": "table",
+            "name": info["name"],
+            "source": {
+                "kind": "warehouse-table",
+                "connectionId": conn,
+                "path": [args.database, info["namespace"], info["tableName"]],
+            },
+            "columns": [
+                {
+                    "id": col_id(tid, c),
+                    "name": friendly(c),
+                    "formula": f"[{info['tableName']}/{friendly(c)}]",
+                }
+                for c in cols
+            ],
+        })
+
+    # ---- join element (the consumable "Orders" view)
+    joins = b.derive_joins()
+    join_legs = [
+        {
+            "left": {"kind": "table", "elementId": el_id[b.fact_tid]},
+            "right": {"kind": "table", "elementId": el_id[j["lookup_tid"]]},
+            "columns": [{
+                "left": f"[{friendly(j['fact_col'])}]",
+                "right": f"[{friendly(j['lookup_col'])}]",
+            }],
+            "joinType": "left-outer",
+        }
+        for j in joins
+    ]
+
+    join_cols = []
+    seen_names = set()
+
+    def add_join_col(src_tid, col):
+        name = friendly(col)
+        if name in seen_names:
+            return
+        seen_names.add(name)
+        join_cols.append({
+            "id": f"ord-{slug(col)}",
+            "name": name,
+            "formula": f"[{el_name[src_tid]}/{name}]",
+        })
+
+    join_key_lookup_cols = {(j["lookup_tid"], j["lookup_col"]) for j in joins}
+    # fact columns first (skip nothing on the fact side)
+    for c in b.table_columns(b.fact_tid):
+        add_join_col(b.fact_tid, c)
+    # dim columns, skipping each join's own key column on the lookup side
+    for j in joins:
+        for c in b.table_columns(j["lookup_tid"]):
+            if (j["lookup_tid"], c) in join_key_lookup_cols:
+                continue
+            add_join_col(j["lookup_tid"], c)
+
+    # ---- metrics on the join element
+    def dm_ref(col_friendly):
+        return f"[{col_friendly}]"
+
+    metrics = []
+    for mid, m in b.metrics.items():
+        md = {
+            "id": f"m-{slug(m['information']['name'])}",
+            "name": m["information"]["name"],
+            "formula": b.metric_formula(mid, dm_ref, expand_metrics=False),
+        }
+        fmt = b.metric_display_format(mid)
+        if fmt:
+            md["format"] = fmt
+        metrics.append(md)
+
+    elements.append({
+        "id": "el-orders",
+        "kind": "table",
+        "name": args.join_element_name,
+        "source": {
+            "kind": "join",
+            "joins": join_legs,
+            "primarySource": {"kind": "table", "elementId": el_id[b.fact_tid]},
+        },
+        "columns": join_cols,
+        "metrics": metrics,
+    })
+
+    # ---- AE-emulation sql elements (MicroStrategy non-unique-key collapse)
+    report_by_name = {r["information"]["name"]: r for r in b.reports.values()}
+    for rname, cfg in (ae_winners or {}).items():
+        report = report_by_name[rname]
+        attr_units, metric_units = b.report_attr_units(report)
+        aliases = ([friendly(c) for c in cfg["parentKeyCols"]]
+                   + [friendly(cfg["quirkKeyCol"]), friendly(cfg["quirkDescCol"])]
+                   + [el["name"] for el in metric_units])
+        elements.append({
+            "id": f"el-ae-{slug(rname)}",
+            "kind": "table",
+            "name": ae_element_name(rname),
+            "source": {
+                "kind": "sql",
+                "connectionId": args.connection_id,
+                "statement": b.build_ae_sql(args.database, report, cfg),
+            },
+            "columns": [
+                {"id": f"ae-{slug(rname)}-{slug(a)}", "name": a,
+                 "formula": f"[Custom SQL/{a}]"}
+                for a in aliases
+            ],
+        })
+
+    return {
+        "name": args.dm_name,
+        "folderId": args.folder_id,
+        "schemaVersion": 1,
+        "pages": [{"id": "page-1", "name": "Model", "elements": elements}],
+    }
+
+
+def build_ae_page(b: Bundle, args, ch_name, report, cfg, dm_id, el_ref,
+                  report_keys):
+    """Page backed by the AE-emulation sql element. Groups by parent keys +
+    quirk key; label and metric values are already representative-resolved
+    in the element's SQL, so metric columns aggregate the (single) row with
+    Sum() and the label with Max()."""
+    rname = report["information"]["name"]
+    el_name = ae_element_name(rname)
+    _attr_units, metric_units = b.report_attr_units(report)
+    qkey_f = friendly(cfg["quirkKeyCol"])
+    qdesc_f = friendly(cfg["quirkDescCol"])
+    parent_f = [friendly(c) for c in cfg["parentKeyCols"]]
+
+    columns, group_ids, calc_ids = [], [], []
+    for p in parent_f:
+        cid = f"c-{slug(ch_name)}-{slug(p)}"
+        columns.append({"id": cid, "name": p, "formula": f"[{el_name}/{p}]"})
+        group_ids.append(cid)
+    kid = f"c-{slug(ch_name)}-{slug(qkey_f)}"
+    columns.append({"id": kid, "name": qkey_f,
+                    "formula": f"[{el_name}/{qkey_f}]"})
+    group_ids.append(kid)
+    did = f"c-{slug(ch_name)}-{slug(qdesc_f)}"
+    columns.append({"id": did, "name": qdesc_f,
+                    "formula": f"Max([{el_name}/{qdesc_f}])"})
+    calc_ids.append(did)
+    for el in metric_units:
+        mname = el["name"]
+        cid = f"c-{slug(ch_name)}-{slug(mname)}"
+        col = {"id": cid, "name": mname,
+               "formula": f"Sum([{el_name}/{mname}])"}
+        fmt = b.metric_display_format(el["id"])
+        if fmt:
+            col["format"] = fmt
+        columns.append(col)
+        calc_ids.append(cid)
+
+    report_keys[rname] = parent_f + [qdesc_f]
+    return {
+        "id": f"pg-{slug(ch_name)}",
+        "name": ch_name,
+        "elements": [{
+            "id": f"tbl-{slug(ch_name)}",
+            "kind": "table",
+            "name": rname,
+            "source": {"kind": "data-model", "dataModelId": dm_id,
+                       "elementId": el_ref(el_name)},
+            "columns": columns,
+            "groupings": [{
+                "id": f"g-{slug(ch_name)}",
+                "groupBy": group_ids,
+                "calculations": calc_ids,
+            }],
+        }],
+    }
+
+
+def build_workbook_spec(b: Bundle, args, ae_winners=None, dm_element_ids=None):
+    dm_id = args.data_model_id or "{{DATA_MODEL_ID}}"
+    dm_element_ids = dm_element_ids or {}
+    join_name = args.join_element_name
+
+    def el_ref(name):
+        if name == join_name and args.orders_element_id:
+            return args.orders_element_id
+        return dm_element_ids.get(name, "{{ELEMENT_" + slug(name) + "}}")
+
+    def wb_ref(col_friendly):
+        return f"[{join_name}/{col_friendly}]"
+
+    pages = []
+    report_keys = {}  # report name -> ordered display column names of its keys
+    # chapter -> dataset/report mapping comes from the dossier datasets by name
+    report_by_name = {r["information"]["name"]: (rid, r)
+                      for rid, r in b.reports.items()}
+    for ch in b.dossier["chapters"]:
+        ch_name = ch["name"]
+        rid, report = report_by_name[ch_name]
+        rname = report["information"]["name"]
+        units = report["dataSource"]["dataTemplate"]["units"]
+
+        if ae_winners and rname in ae_winners:
+            pages.append(build_ae_page(b, args, ch_name, report,
+                                       ae_winners[rname], dm_id, el_ref,
+                                       report_keys))
+            continue
+
+        columns, group_ids, calc_ids, key_names = [], [], [], []
+        filters = []
+        for u in units:
+            if u.get("type") == "attribute":
+                key_col, desc_col = b.attribute_unit_cols(u["id"])
+                cid = f"c-{slug(ch_name)}-{slug(key_col)}"
+                columns.append({
+                    "id": cid,
+                    "name": friendly(key_col),
+                    "formula": wb_ref(friendly(key_col)),
+                })
+                group_ids.append(cid)
+                # MicroStrategy inner-joins the lookup table, so fact rows
+                # with no matching dim row never appear in its grid. The DM
+                # join is left-outer (other reports need all fact rows), so
+                # drop the null group keys per-element to mirror MSTR.
+                a = b.attributes[u["id"]]
+                if a["attributeLookupTable"]["objectId"] != b.fact_tid:
+                    filters.append({
+                        "id": f"f-{slug(ch_name)}-{slug(key_col)}",
+                        "columnId": cid,
+                        "kind": "list",
+                        "mode": "exclude",
+                        "values": [None],
+                    })
+                if desc_col:
+                    # DESC label rendered per key element = Max over fact rows
+                    did = f"c-{slug(ch_name)}-{slug(desc_col)}"
+                    columns.append({
+                        "id": did,
+                        "name": friendly(desc_col),
+                        "formula": f"Max({wb_ref(friendly(desc_col))})",
+                    })
+                    calc_ids.append(did)
+                    key_names.append(friendly(desc_col))
+                else:
+                    key_names.append(friendly(key_col))
+            elif u.get("type") == "metrics":
+                for el in u["elements"]:
+                    mid = el["id"]
+                    mname = b.metrics[mid]["information"]["name"]
+                    cid = f"c-{slug(ch_name)}-{slug(mname)}"
+                    col = {
+                        "id": cid,
+                        "name": mname,
+                        "formula": b.metric_formula(mid, wb_ref,
+                                                    expand_metrics=True),
+                    }
+                    fmt = b.metric_display_format(mid)
+                    if fmt:
+                        col["format"] = fmt
+                    columns.append(col)
+                    calc_ids.append(cid)
+
+        report_keys[report["information"]["name"]] = key_names
+        element = {
+            "id": f"tbl-{slug(ch_name)}",
+            "kind": "table",
+            "name": report["information"]["name"],
+            "source": {
+                "kind": "data-model",
+                "dataModelId": dm_id,
+                "elementId": el_ref(join_name),
+            },
+            "columns": columns,
+            "groupings": [{
+                "id": f"g-{slug(ch_name)}",
+                "groupBy": group_ids,
+                "calculations": calc_ids,
+            }],
+        }
+        if filters:
+            element["filters"] = filters
+        pages.append({
+            "id": f"pg-{slug(ch_name)}",
+            "name": ch_name,
+            "elements": [element],
+        })
+
+    return {
+        "name": args.wb_name,
+        "folderId": args.folder_id,
+        "schemaVersion": 1,
+        "pages": pages,
+    }, report_keys
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bundle", default="bundle.json")
+    ap.add_argument("--connection-id", required=True)
+    ap.add_argument("--database", required=True,
+                    help="warehouse database the Sigma connection reads")
+    ap.add_argument("--folder-id", required=True)
+    ap.add_argument("--inode-map", default=None,
+                    help="JSON file: physical table name -> inode tail")
+    ap.add_argument("--dm-name", default=None,
+                    help="default: '<dossier name> (MSTR Model)'")
+    ap.add_argument("--wb-name", default=None,
+                    help="default: '<dossier name> (MSTR)'")
+    ap.add_argument("--join-element-name", default="Orders")
+    ap.add_argument("--data-model-id", default=None)
+    ap.add_argument("--orders-element-id", default=None)
+    ap.add_argument("--dm-element-ids", default=None,
+                    help="JSON file: DM element name -> server element id")
+    ap.add_argument("--ae-winners", default=None,
+                    help="ae_winners.json from resolve_ae_winners.py")
+    ap.add_argument("--out-dm", default="sigma_dm_spec.json")
+    ap.add_argument("--out-wb", default="sigma_workbook_spec.json")
+    args = ap.parse_args()
+
+    b = Bundle(json.load(open(args.bundle)))
+    dossier_name = b.dossier.get("name", "MicroStrategy")
+    args.dm_name = args.dm_name or f"{dossier_name} (MSTR Model)"
+    args.wb_name = args.wb_name or f"{dossier_name} (MSTR)"
+    inode_map = json.load(open(args.inode_map)) if args.inode_map else {}
+    ae_winners = json.load(open(args.ae_winners)) if args.ae_winners else None
+    dm_element_ids = (json.load(open(args.dm_element_ids))
+                      if args.dm_element_ids else None)
+
+    dm = build_dm_spec(b, args, inode_map, ae_winners)
+    wb, report_keys = build_workbook_spec(b, args, ae_winners, dm_element_ids)
+    json.dump(dm, open(args.out_dm, "w"), indent=1)
+    json.dump(wb, open(args.out_wb, "w"), indent=1)
+    json.dump(report_keys, open("parity_keys.json", "w"), indent=1)
+
+    print(f"fact table: {b.table_info[b.fact_tid]['name']}")
+    for j in b.derive_joins():
+        print(f"join: {b.table_info[b.fact_tid]['tableName']}.{j['fact_col']} = "
+              f"{b.table_info[j['lookup_tid']]['tableName']}.{j['lookup_col']}")
+    for el in dm["pages"][0]["elements"]:
+        for m in el.get("metrics", []):
+            print(f"metric: {m['name']} = {m['formula']}")
+    print(f"wrote {args.out_dm}, {args.out_wb}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/extract.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/extract.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Extract a MicroStrategy dossier + its full semantic model into one JSON bundle.
+
+Usage: python3 extract.py <dossierId> [out.json]
+
+The bundle is the converter input: dossier definition (chapters/pages/vizzes),
+each dataset report's template, and the schema objects they reference —
+attributes (forms, expressions, lookup tables), facts, metrics (formula text),
+and logical tables (physical table + namespace + datasource).
+"""
+import json
+import sys
+import mstr
+
+
+def extract(s, dossier_id):
+    bundle = {'dossier': s.get(f'/v2/dossiers/{dossier_id}/definition')}
+
+    # datasets -> report definitions (template + data source)
+    reports = {}
+    for ds in bundle['dossier'].get('datasets', []):
+        rid = ds['id']
+        reports[rid] = s.get(
+            f'/model/reports/{rid}?showExpressionAs=tokens')
+    bundle['reports'] = reports
+
+    # collect referenced attribute/metric ids from report templates
+    attr_ids, metric_ids = set(), set()
+    for r in reports.values():
+        units = (r.get('dataSource', {}).get('dataTemplate', {})
+                 .get('units', []))
+        for u in units:
+            if u.get('type') == 'attribute':
+                attr_ids.add(u['id'])
+            elif u.get('type') == 'metrics':
+                for e in u.get('elements', []):
+                    metric_ids.add(e['id'])
+
+    bundle['attributes'] = {}
+    table_ids = set()
+    for aid in sorted(attr_ids):
+        a = s.get(f'/model/attributes/{aid}?showExpressionAs=tokens')
+        bundle['attributes'][aid] = a
+        for f in a.get('forms', []):
+            for ex in f.get('expressions', []):
+                for t in ex.get('tables', []):
+                    table_ids.add(t['objectId'])
+
+    bundle['metrics'] = {}
+    fact_ids = set()
+    for mid in sorted(metric_ids):
+        m = s.get(f'/model/metrics/{mid}?showExpressionAs=tokens')
+        bundle['metrics'][mid] = m
+        for tok in m.get('expression', {}).get('tokens', []):
+            tgt = tok.get('target')
+            if tgt and tgt.get('subType') == 'fact':
+                fact_ids.add(tgt['objectId'])
+            if tgt and tgt.get('subType') == 'metric':
+                metric_ids.add(tgt['objectId'])  # compound metric base
+
+    # second pass for compound-metric bases discovered above
+    for mid in sorted(metric_ids):
+        if mid not in bundle['metrics']:
+            m = s.get(f'/model/metrics/{mid}?showExpressionAs=tokens')
+            bundle['metrics'][mid] = m
+            for tok in m.get('expression', {}).get('tokens', []):
+                tgt = tok.get('target')
+                if tgt and tgt.get('subType') == 'fact':
+                    fact_ids.add(tgt['objectId'])
+
+    bundle['facts'] = {}
+    for fid in sorted(fact_ids):
+        f = s.get(f'/model/facts/{fid}?showExpressionAs=tokens')
+        bundle['facts'][fid] = f
+        for ex in f.get('expressions', []):
+            for t in ex.get('tables', []):
+                table_ids.add(t['objectId'])
+
+    bundle['tables'] = {}
+    for tid in sorted(table_ids):
+        bundle['tables'][tid] = s.get(f'/model/tables/{tid}')
+
+    # attribute relationships (hierarchy) for join/topology hints
+    bundle['relationships'] = {}
+    for aid in sorted(attr_ids):
+        try:
+            rel = s.get(f'/model/systemHierarchy/attributes/{aid}/relationships')
+            if rel.get('relationships'):
+                bundle['relationships'][aid] = rel['relationships']
+        except Exception:
+            pass
+
+    return bundle
+
+
+if __name__ == '__main__':
+    dossier_id = sys.argv[1]
+    out = sys.argv[2] if len(sys.argv) > 2 else 'bundle.json'
+    s = mstr.Session()
+    b = extract(s, dossier_id)
+    json.dump(b, open(out, 'w'), indent=1)
+    print(f'wrote {out}: {len(b["reports"])} reports, '
+          f'{len(b["attributes"])} attributes, {len(b["metrics"])} metrics, '
+          f'{len(b["facts"])} facts, {len(b["tables"])} tables')

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/extract_datamodel.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/extract_datamodel.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Extract the complete 'Orders Data Model' definition -> datamodel_definition.json.
+
+Reads every dataModels sub-resource (model + tables + attributes + factMetrics
++ metrics + links + hierarchy) with token+tree expression forms where the API
+supports showExpressionAs. GETs work without a changeset (read from metadata).
+Output is the converter input for MicroStrategy DataModel -> Sigma.
+"""
+import json
+
+import mstr
+
+s = mstr.Session()
+state = json.load(open('datamodel_ids.json'))
+dm = state['dataModelId']
+
+
+def get(path, **kw):
+    try:
+        return s.get(path, **kw)
+    except RuntimeError as e:
+        return {'_error': str(e)[:500]}
+
+
+out = {
+    'dataModelId': dm,
+    'dataModel': get(f'/model/dataModels/{dm}'),
+    'tables': get(f'/model/dataModels/{dm}/tables'
+                  '?showExpressionAs=tokens&showDerivedColumns=true'
+                  '&showDerivedForms=true'),
+    'attributes': get(f'/model/dataModels/{dm}/attributes'
+                      '?showExpressionAs=tokens&showDerivedForms=true'),
+    'factMetrics': get(f'/model/dataModels/{dm}/factMetrics'
+                       '?showExpressionAs=tokens'),
+    'metrics': get(f'/model/dataModels/{dm}/metrics'
+                   '?showExpressionAs=tokens&showFilterTokens=true'),
+    'links': None,  # filled below — GET /links requires a changeset header
+    'hierarchy': get(f'/model/dataModels/{dm}/hierarchy'),
+    'attributeRelationships': {},
+}
+for name, aid in state['attributes'].items():
+    out['attributeRelationships'][name] = get(
+        f'/model/dataModels/{dm}/attributes/{aid}/relationships')
+
+# GET /links is changeset-scoped (unlike every other GET here); use a
+# throwaway non-schema changeset and abort it immediately.
+cs = s.changeset(schema_edit=False)
+try:
+    out['links'] = get(f'/model/dataModels/{dm}/links',
+                       headers={'X-MSTR-MS-Changeset': cs})
+finally:
+    s.abort(cs)
+
+json.dump(out, open('datamodel_definition.json', 'w'), indent=1)
+print('wrote datamodel_definition.json')
+for k, v in out.items():
+    if isinstance(v, dict):
+        err = v.get('_error')
+        n = v.get('total', '')
+        print(f'  {k}: {"ERR " + err if err else ("total=" + str(n) if n != "" else "ok")}')

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get-token.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get-token.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Exchange Sigma client credentials for a bearer token.
+# Usage:  eval "$(scripts/get-token.sh)"
+# Sets SIGMA_API_TOKEN in the calling shell.
+
+set -euo pipefail
+
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  "$SIGMA_BASE_URL/v2/auth/token") || {
+    echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null \
+  || echo "$RESPONSE" | ruby -r json -e "print JSON.parse(STDIN.read)['access_token']")
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Token exchange failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+echo "export SIGMA_API_TOKEN=${TOKEN}"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/mstr.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/mstr.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Minimal MicroStrategy (Strategy One) REST client. Zero dependencies.
+
+Usage: import mstr; s = mstr.Session(); s.get('/projects') ...
+
+Credentials (in priority order):
+  1. Environment: MSTR_BASE_URL, MSTR_USERNAME, MSTR_PASSWORD
+     (+ optional MSTR_PROJECT_ID, MSTR_LOGIN_MODE — default 1 = standard)
+  2. The agent-neutral cred file ~/.sigma-migration/env (lines of
+     `export KEY="value"`), same pattern as the sibling sigma-migration-skills.
+
+MSTR_BASE_URL is the Library root, e.g. https://<host>/MicroStrategyLibrary
+(the client appends /api). Auth = POST /api/auth/login -> X-MSTR-AuthToken
+header + session cookies; there is no API-key concept.
+"""
+import json
+import os
+import ssl
+import urllib.error
+import urllib.request
+
+# Some MicroStrategy cloud-trial CA certs lack the key-usage extension;
+# Python 3.13+ rejects them under VERIFY_X509_STRICT (on by default).
+# curl accepts them — relax only the strictness flag, keep verification on.
+_SSL_CTX = ssl.create_default_context()
+_SSL_CTX.verify_flags &= ~ssl.VERIFY_X509_STRICT
+
+CRED_FILE = os.path.expanduser('~/.sigma-migration/env')
+
+
+def _load_env():
+    env = {}
+    if os.path.exists(CRED_FILE):
+        for line in open(CRED_FILE):
+            line = line.strip()
+            if line.startswith('export '):
+                k, _, v = line[7:].partition('=')
+                env[k] = v.strip('"').strip("'")
+    env.update({k: v for k, v in os.environ.items() if k.startswith('MSTR_')})
+    missing = [k for k in ('MSTR_BASE_URL', 'MSTR_USERNAME', 'MSTR_PASSWORD')
+               if not env.get(k)]
+    if missing:
+        raise SystemExit(
+            f'missing {", ".join(missing)} — export them or add them to '
+            f'{CRED_FILE} (export KEY="value" lines)')
+    return env
+
+
+class Session:
+    def __init__(self, project_id=None):
+        e = _load_env()
+        self.base = e['MSTR_BASE_URL'].rstrip('/') + '/api'
+        self.project_id = project_id or e.get('MSTR_PROJECT_ID')
+        self.cookies = {}
+        self.token = None
+        self.last_headers = {}
+        self._login(e['MSTR_USERNAME'], e['MSTR_PASSWORD'],
+                    int(e.get('MSTR_LOGIN_MODE', '1')))
+
+    def _req(self, method, path, body=None, headers=None, raw=False):
+        url = self.base + path
+        h = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+        if self.token:
+            h['X-MSTR-AuthToken'] = self.token
+        if self.project_id:
+            h['X-MSTR-ProjectID'] = self.project_id
+        if self.cookies:
+            h['Cookie'] = '; '.join(f'{k}={v}' for k, v in self.cookies.items())
+        if headers:
+            h.update(headers)
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, headers=h, method=method)
+        try:
+            resp = urllib.request.urlopen(req, context=_SSL_CTX)
+        except urllib.error.HTTPError as err:
+            detail = err.read().decode()[:2000]
+            raise RuntimeError(f'{method} {path} -> {err.code}: {detail}') from None
+        # Response headers, lowercased — instance-save flows need
+        # x-mstr-ms-instance from a *creation response* header.
+        self.last_headers = {k.lower(): v for k, v in resp.headers.items()}
+        for sc in resp.headers.get_all('Set-Cookie') or []:
+            kv = sc.split(';', 1)[0]
+            k, _, v = kv.partition('=')
+            self.cookies[k] = v
+        tok = resp.headers.get('X-MSTR-AuthToken')
+        if tok:
+            self.token = tok
+        text = resp.read().decode()
+        if raw:
+            return text
+        return json.loads(text) if text else None
+
+    def _login(self, user, pw, login_mode=1):
+        self._req('POST', '/auth/login',
+                  {'username': user, 'password': pw, 'loginMode': login_mode})
+
+    def get(self, path, **kw):
+        return self._req('GET', path, **kw)
+
+    def post(self, path, body=None, **kw):
+        return self._req('POST', path, body, **kw)
+
+    def put(self, path, body=None, **kw):
+        return self._req('PUT', path, body, **kw)
+
+    def patch(self, path, body=None, **kw):
+        return self._req('PATCH', path, body, **kw)
+
+    def delete(self, path, **kw):
+        return self._req('DELETE', path, **kw)
+
+    # -- changeset helpers (schema edits require one; reports do NOT) --
+    def changeset(self, schema_edit=True):
+        r = self.post(f'/model/changesets?schemaEdit={"true" if schema_edit else "false"}')
+        return r['id']
+
+    def commit(self, cs_id):
+        r = self.post(f'/model/changesets/{cs_id}/commit',
+                      headers={'X-MSTR-MS-Changeset': cs_id})
+        self.delete(f'/model/changesets/{cs_id}',
+                    headers={'X-MSTR-MS-Changeset': cs_id})
+        return r
+
+    def cs_post(self, path, body, cs_id):
+        return self.post(path, body, headers={'X-MSTR-MS-Changeset': cs_id})
+
+    def abort(self, cs_id):
+        """Delete a changeset (releases its schema lock)."""
+        try:
+            self.delete(f'/model/changesets/{cs_id}',
+                        headers={'X-MSTR-MS-Changeset': cs_id})
+        except Exception:
+            pass
+
+    def schema_edit(self, fn):
+        """Run fn(cs_id) inside a schema changeset; commit on success,
+        abort on failure so the schema lock is never left dangling.
+        (A failed call inside an undeleted changeset leaves 'Schema editing
+        is in use by another user' — clear via DELETE /api/model/schema/lock.)"""
+        cs = self.changeset()
+        try:
+            result = fn(cs)
+        except Exception:
+            self.abort(cs)
+            raise
+        self.commit(cs)
+        return result
+
+
+if __name__ == '__main__':
+    s = Session()
+    print('token ok; projects:', [p['name'] for p in s.get('/projects')])

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/resolve_ae_winners.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/resolve_ae_winners.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+resolve_ae_winners.py — pin MicroStrategy Analytical-Engine representative rows.
+
+Why: when an attribute's key form is non-unique in its lookup table (here:
+Month.key = MONTH_NUMBER while DATE_DIM carries multiple MONTH_NAME spellings
+and repeats month numbers across years), MicroStrategy's Analytical Engine
+collapses the per-(parent, key) SQL result to ONE arbitrary-but-stable
+representative row per key and cross-tabs it across the parent attribute.
+The representative is a hash artifact of the engine — it cannot be derived
+from the model bundle. This script pins it empirically:
+
+  1. Re-execute each affected report via the MicroStrategy REST API.
+  2. Compute the clean per-(parents, key) aggregates from the warehouse
+     (same SQL MicroStrategy generated) via a temporary Sigma workbook.
+  3. Match each key's MSTR-reported label+values to the unique clean row.
+  4. Emit ae_winners.json for convert.py.
+
+A report is affected when one of its attribute units has a DESC form
+(label column distinct from the grouping key). Reports without such
+attributes are skipped (their grids are clean).
+
+Usage: python3 resolve_ae_winners.py --connection-id <uuid> --database CSA \
+          [--bundle bundle.json] [--folder-id <uuid>] [--out ae_winners.json]
+"""
+import argparse
+import csv
+import io
+import json
+import time
+
+import mstr
+from convert import Bundle, friendly
+from verify_parity import api, export_element
+
+
+def run_mstr_grid(s, report_id):
+    """Execute a report, return list of (keys_tuple, values_list)."""
+    inst = s.post(f"/v2/reports/{report_id}/instances?limit=500", {})
+    d, data = inst["definition"], inst["data"]
+    rowsets = d["grid"]["rows"]
+    attr_elems = []
+    for unit in rowsets:
+        attr_elems.append([
+            e.get("formValues", [None])[0] if e.get("formValues") else e.get("name")
+            for e in unit["elements"]])
+    out = []
+    for i, h in enumerate(data["headers"]["rows"]):
+        keys = tuple(attr_elems[j][idx] for j, idx in enumerate(h))
+        out.append((keys, data["metricValues"]["raw"][i]))
+    return out
+
+
+def clean_groups_via_sigma(b, args, report, quirk_aid, parent_aids):
+    """Run the clean per-(parents, key) aggregation on the warehouse through a
+    temporary Sigma workbook (sql element) and return the rows."""
+    sql = b.build_clean_group_sql(args.database, report)
+    spec = {
+        "name": "zz-ae-resolver-probe",
+        "folderId": args.folder_id,
+        "schemaVersion": 1,
+        "pages": [{"id": "p1", "name": "P", "elements": [{
+            "id": "t1", "kind": "table", "name": "Probe",
+            "source": {"kind": "sql", "connectionId": args.connection_id,
+                       "statement": sql},
+            "columns": [
+                {"id": f"c{i}", "name": alias,
+                 "formula": f"[Custom SQL/{alias}]"}
+                for i, alias in enumerate(b.clean_group_aliases(report))
+            ],
+        }]}],
+    }
+    st, out = api("POST", "/v2/workbooks/spec", spec)
+    if st >= 300:
+        raise SystemExit(f"probe workbook POST failed {st}: {out[:500]}")
+    wb_id = json.loads(out)["workbookId"]
+    try:
+        # element id may be remapped — read back
+        import yaml
+        st, out = api("GET", f"/v2/workbooks/{wb_id}/spec")
+        eid = yaml.safe_load(out)["pages"][0]["elements"][0]["id"]
+        csv_text = export_element(wb_id, eid)
+    finally:
+        api("DELETE", f"/v2/files/{wb_id}")
+    return list(csv.DictReader(io.StringIO(csv_text)))
+
+
+def close(a, b_, tol=1e-6):
+    try:
+        fa, fb = float(a), float(b_)
+    except (TypeError, ValueError):
+        return str(a) == str(b_)
+    return abs(fa - fb) <= tol * max(abs(fb), 1.0)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bundle", default="bundle.json")
+    ap.add_argument("--connection-id", required=True)
+    ap.add_argument("--database", default="CSA")
+    ap.add_argument("--folder-id", required=True)
+    ap.add_argument("--out", default="ae_winners.json")
+    args = ap.parse_args()
+
+    b = Bundle(json.load(open(args.bundle)))
+    s = mstr.Session()
+    result = {}
+
+    for rid, report in b.reports.items():
+        rname = report["information"]["name"]
+        units = report["dataSource"]["dataTemplate"]["units"]
+        attr_units = [u for u in units if u.get("type") == "attribute"]
+        quirk = None
+        for u in attr_units:
+            key_col, desc_col = b.attribute_unit_cols(u["id"])
+            if desc_col:
+                quirk = (u["id"], key_col, desc_col)
+        if not quirk:
+            continue  # clean report — no DESC-form attribute
+        quirk_aid, qkey, qdesc = quirk
+        parent_units = [u for u in attr_units if u["id"] != quirk_aid]
+        parent_cols = [b.attribute_unit_cols(u["id"])[0] for u in parent_units]
+
+        print(f"resolving AE representatives for {rname!r} "
+              f"(quirk attr key={qkey} desc={qdesc})")
+        grid = run_mstr_grid(s, rid)
+        clean = clean_groups_via_sigma(b, args, report,
+                                       quirk_aid, [u["id"] for u in parent_units])
+
+        qkey_f, qdesc_f = friendly(qkey), friendly(qdesc)
+        parent_f = [friendly(c) for c in parent_cols]
+        metric_names = [el["name"] for u in units if u.get("type") == "metrics"
+                        for el in u["elements"]]
+
+        # MSTR grid: label + values per quirk element (identical across parents)
+        per_label = {}
+        for keys, vals in grid:
+            label = keys[-1]  # quirk attr is rendered by its DESC form
+            per_label.setdefault(label, vals)
+
+        winners = []
+        for label, vals in per_label.items():
+            cands = [r for r in clean
+                     if r[qdesc_f] == label
+                     and all(close(r[m], v) for m, v in zip(metric_names, vals))]
+            keys_seen = {tuple(r[p] for p in parent_f) +
+                         (r[qkey_f],) for r in cands}
+            if len(keys_seen) != 1:
+                raise SystemExit(
+                    f"{rname}: could not uniquely match label {label!r} "
+                    f"{vals} -> {len(keys_seen)} candidates")
+            r = cands[0]
+            w = {qkey_f: r[qkey_f]}
+            for p in parent_f:
+                w[p] = r[p]
+            winners.append(w)
+            print(f"  {label!r:14} -> {w}")
+
+        result[rname] = {
+            "quirkKeyCol": qkey, "quirkDescCol": qdesc,
+            "parentKeyCols": parent_cols,
+            "winners": winners,
+        }
+
+    json.dump(result, open(args.out, "w"), indent=1)
+    print(f"wrote {args.out} ({len(result)} report(s))")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify_parity.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify_parity.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+verify_parity.py — export each workbook table element from Sigma via the REST
+export API and compare against expected_parity.json (MicroStrategy ground truth).
+
+Money / counts: exact. Profit Margin Pct: relative tolerance 1e-6.
+
+Usage: python3 verify_parity.py --workbook-id <id> [--report parity_report.md]
+Requires SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/get-token.sh)").
+"""
+import argparse
+import csv
+import io
+import json
+import os
+import sys
+import time
+import urllib.request
+
+BASE = os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com")
+TOKEN = os.environ.get("SIGMA_API_TOKEN") or sys.exit(
+    'SIGMA_API_TOKEN not set — run: eval "$(scripts/get-token.sh)"')
+
+# report name -> (element name, key column names, tolerance map)
+TOLERANT = {"Profit Margin Pct": 1e-6}
+
+
+def api(method, path, body=None, raw=False):
+    req = urllib.request.Request(BASE + path, method=method)
+    req.add_header("Authorization", "Bearer " + TOKEN)
+    if not path.endswith("/spec") or body is not None:
+        req.add_header("Accept", "application/json")
+    data = None
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+        data = json.dumps(body).encode()
+    try:
+        with urllib.request.urlopen(req, data) as r:
+            payload = r.read()
+            return r.status, payload if raw else payload.decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+
+
+def export_element(workbook_id, element_id):
+    st, out = api("POST", f"/v2/workbooks/{workbook_id}/export", {
+        "elementId": element_id,
+        "format": {"type": "csv"},
+    })
+    if st >= 300:
+        raise SystemExit(f"export start failed {st}: {out[:500]}")
+    query_id = json.loads(out)["queryId"]
+    for _ in range(60):
+        st, out = api("GET", f"/v2/query/{query_id}/download", raw=True)
+        if st == 200:
+            return out.decode("utf-8-sig")
+        time.sleep(2)
+    raise SystemExit(f"export {query_id} never became ready")
+
+
+def parse_number(s):
+    s = s.strip()
+    pct = s.endswith("%")
+    s = s.replace(",", "").replace("$", "").replace("%", "")
+    if s in ("", "null", "None"):
+        return None
+    v = float(s)
+    return v / 100.0 if pct else v
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook-id", required=True)
+    ap.add_argument("--expected", default="expected_parity.json")
+    ap.add_argument("--keys", default="parity_keys.json",
+                    help="optional report-name -> ordered key column names")
+    ap.add_argument("--report", default="parity_report.md")
+    ap.add_argument("--save-csv-dir", default="exports")
+    args = ap.parse_args()
+
+    expected = json.load(open(args.expected))
+    key_cols_by_report = {}
+    if os.path.exists(args.keys):
+        key_cols_by_report = json.load(open(args.keys))
+
+    # map report name -> element id from the workbook spec readback
+    st, out = api("GET", f"/v2/workbooks/{args.workbook_id}/spec")
+    if st >= 300:
+        raise SystemExit(f"spec GET failed {st}: {out[:300]}")
+    try:
+        spec = json.loads(out)
+    except json.JSONDecodeError:
+        import yaml
+        spec = yaml.safe_load(out)
+    el_by_name = {}
+    for pg in spec["pages"]:
+        for el in pg["elements"]:
+            el_by_name[el["name"]] = el["id"]
+
+    os.makedirs(args.save_csv_dir, exist_ok=True)
+    lines = ["# MicroStrategy -> Sigma Parity Report", "",
+             f"Workbook: `{args.workbook_id}`", ""]
+    all_green = True
+    summary = []
+
+    for report_name, rows in expected.items():
+        eid = el_by_name.get(report_name)
+        if not eid:
+            raise SystemExit(f"no workbook element named {report_name!r}; "
+                             f"have {list(el_by_name)}")
+        csv_text = export_element(args.workbook_id, eid)
+        open(os.path.join(args.save_csv_dir,
+                          report_name.replace(" ", "_") + ".csv"), "w").write(csv_text)
+
+        rdr = csv.DictReader(io.StringIO(csv_text))
+        n_keys = len(rows[0]["keys"])
+        key_cols = key_cols_by_report.get(report_name) or rdr.fieldnames[:n_keys]
+        missing_keys = [k for k in key_cols if k not in rdr.fieldnames]
+        if missing_keys:
+            raise SystemExit(f"{report_name}: key columns {missing_keys} not in "
+                             f"export ({rdr.fieldnames})")
+        metric_names = list(rows[0]["values"].keys())
+
+        # Sigma rows keyed by the tuple of key-column values (as strings)
+        sigma = {}
+        for r in rdr:
+            key = tuple(str(r[k]).strip() for k in key_cols)
+            # normalize numeric-looking keys like "2024.0" or 2024 -> "2024"
+            key = tuple(k[:-2] if k.endswith(".0") else k for k in key)
+            sigma[key] = r
+
+        matched, mismatches = 0, []
+        for row in rows:
+            key = tuple(str(k) for k in row["keys"])
+            srow = sigma.get(key)
+            if srow is None:
+                mismatches.append(f"MISSING row {key}")
+                continue
+            ok = True
+            for m, exp in row["values"].items():
+                col = next((c for c in rdr.fieldnames if c == m), None)
+                if col is None:
+                    mismatches.append(f"{key}: metric column {m!r} not in export "
+                                      f"({rdr.fieldnames})")
+                    ok = False
+                    continue
+                got = parse_number(srow[col])
+                if got is None:
+                    mismatches.append(f"{key}: {m} is null (expected {exp})")
+                    ok = False
+                    continue
+                tol = TOLERANT.get(m)
+                if tol is not None:
+                    if abs(got - exp) > tol * max(abs(exp), 1e-12):
+                        mismatches.append(f"{key}: {m} got {got!r} expected {exp!r} "
+                                          f"(rel diff {abs(got-exp)/abs(exp):.2e})")
+                        ok = False
+                else:
+                    if abs(got - exp) > 1e-9:
+                        mismatches.append(f"{key}: {m} got {got!r} expected {exp!r}")
+                        ok = False
+            if ok:
+                matched += 1
+
+        extra = len(sigma) - len(rows)
+        status = "PASS" if (matched == len(rows) and not mismatches) else "FAIL"
+        if status == "FAIL":
+            all_green = False
+        summary.append((report_name, matched, len(rows), extra, status))
+        lines.append(f"## {report_name} — {status}")
+        lines.append("")
+        lines.append(f"- Rows matched: **{matched} / {len(rows)}**")
+        lines.append(f"- Sigma rows: {len(sigma)}"
+                     + (f" ({extra:+d} vs expected)" if extra else ""))
+        lines.append(f"- Metrics compared: {', '.join(metric_names)}")
+        if mismatches:
+            lines.append("- Mismatches:")
+            for mm in mismatches[:50]:
+                lines.append(f"  - {mm}")
+        lines.append("")
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Report | Matched / Total | Status |")
+    lines.append("|---|---|---|")
+    for name, m, t, _x, st_ in summary:
+        lines.append(f"| {name} | {m} / {t} | {st_} |")
+    lines.append("")
+    lines.append("Tolerances: money and counts exact; Profit Margin Pct relative 1e-6.")
+
+    open(args.report, "w").write("\n".join(lines) + "\n")
+    for name, m, t, _x, st_ in summary:
+        print(f"{st_}: {name} {m}/{t}")
+    print(f"report -> {args.report}")
+    sys.exit(0 if all_green else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Graduates the standalone [twells89/microstrategy-to-sigma](https://github.com/twells89/microstrategy-to-sigma) repo (at `a11598e`) into the marketplace as the 8th vendor plugin.

## What's included
- **`microstrategy-to-sigma`** (converter): MicroStrategy (Strategy One) dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification.
- **`microstrategy-assessment`**: read-only estate inventory + migration-readiness readout, with an empirical viz-type mapping built from a ~7.4k-viz public-demo sweep (69 viz types → gap priorities, custom-viz policy, structural-feature frequencies).

## Validation
Live-validated with **exact parity** on both the classic-schema grid path and Mosaic Data Models (2026-06-11).

## Registration
- `marketplace.json`: new plugin entry + MicroStrategy added to the marketplace description
- `README.md`: install line + plugin table row
- `AGENTS.md`: vendor list + task-routing rows for both skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)