### PR TITLE
qlik-to-sigma: fleet-run hardening — master-item resolution, set-analysis translate hardening, pivot/region-map builders, 429 backoff

### DIFF
--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-dm.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-dm.py
@@ -30,7 +30,7 @@ metricsKept, metricsDropped, columnsDropped}. With --dry-run nothing is POSTed
 
 Env (live mode): SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/vendor/get-token.sh)").
 """
-import json, os, re, sys, argparse, urllib.request
+import json, os, re, sys, time, argparse, urllib.request
 
 # Sigma's display-name rule (verified live 2026-06-10): lowercase particles
 # unless first word — DAYS_TO_SHIP -> "Days to Ship".
@@ -47,11 +47,20 @@ def api(method, path, body=None):
     req = urllib.request.Request(BASE + path, data=data, method=method,
         headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json",
                  "Accept": "application/json"})
-    try:
-        with urllib.request.urlopen(req) as r:
-            raw = r.read().decode()
-    except urllib.error.HTTPError as e:
-        print("HTTP", e.code, "on", method, path, "->", e.read().decode()[:800], file=sys.stderr); raise
+    raw = None
+    for attempt in range(6):
+        try:
+            with urllib.request.urlopen(req) as r:
+                raw = r.read().decode()
+            break
+        except urllib.error.HTTPError as e:
+            detail = e.read().decode()
+            if e.code == 429 and attempt < 5:  # Cloudflare 1015 rate limit: transient, retryable
+                wait = min(120, 30 * (2 ** attempt))
+                print(f"HTTP 429 on {method} {path} -- backing off {wait}s (attempt {attempt+1}/6)", file=sys.stderr)
+                time.sleep(wait)
+                continue
+            print("HTTP", e.code, "on", method, path, "->", detail[:800], file=sys.stderr); raise
     try:
         return json.loads(raw or "{}")
     except json.JSONDecodeError:
@@ -141,7 +150,12 @@ def main():
         if m.get("name") in seen_metric: continue
         seen_metric.add(m.get("name"))
         refs = [r.split("/")[-1] for r in re.findall(r"\[([^\]]+)\]", m.get("formula", ""))]
-        if refs and all(r.lower() in denorm_disp for r in refs):
+        # Qlik-only residue the converter could not translate ($(var) expansion,
+        # inter-record/ranking/Aggr functions) POST-blocks the WHOLE spec with a
+        # 400 -- drop + report instead of emitting an invalid formula
+        body = re.sub(r"\[[^\]]*\]", "", m.get("formula", ""))
+        qlik_only = re.search(r"\$\(|\b(?:Rank|HRank|Aggr|Above|Below|Peek|Previous|RowNo|FirstSortedValue)\s*\(", body, re.I)
+        if refs and not qlik_only and all(r.lower() in denorm_disp for r in refs):
             if src_expr.get(m.get("name")):
                 m.setdefault("description", f"Qlik: {src_expr[m['name']]}")
             kept.append(m)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -42,7 +42,7 @@ With --dry-run nothing is POSTed.
 
 Env (live mode): SIGMA_BASE_URL + SIGMA_API_TOKEN.
 """
-import json, os, re, sys, argparse, urllib.request
+import json, os, re, sys, time, argparse, urllib.request
 
 MASTER_ID, MASTER = "m-master", "Master"
 KEEP_UNMATCHED = os.environ.get("QLIK_KEEP_UNMATCHED", "") == "1"
@@ -51,7 +51,8 @@ KPI_MIN_ROWS = 5       # Sigma kpi-chart clips its title below ~5 grid rows
 TEMPORAL = re.compile(r"DATE|MONTH|YEAR|QUARTER|WEEK|DAY", re.I)
 NATIVE = {"barchart": "bar-chart", "linechart": "line-chart", "piechart": "pie-chart",
           "combochart": "combo-chart", "scatterplot": "scatter-chart",
-          "table": "table", "kpi": "kpi-chart", "pivot-table": "pivot-table"}
+          "table": "table", "kpi": "kpi-chart", "pivot-table": "pivot-table",
+          "map": "region-map"}
 
 _ids = {}
 def nid(prefix):
@@ -63,10 +64,17 @@ def api_post(path, body):
     req = urllib.request.Request(BASE + path, data=json.dumps(body).encode(), method="POST",
         headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json",
                  "Accept": "application/json"})
-    try:
-        return urllib.request.urlopen(req).read().decode()
-    except urllib.error.HTTPError as e:
-        print("HTTP", e.code, e.read().decode()[:800], file=sys.stderr); raise
+    for attempt in range(6):
+        try:
+            return urllib.request.urlopen(req).read().decode()
+        except urllib.error.HTTPError as e:
+            detail = e.read().decode()
+            if e.code == 429 and attempt < 5:  # Cloudflare 1015 rate limit: transient, retryable
+                wait = min(120, 30 * (2 ** attempt))
+                print(f"HTTP 429 on POST {path} -- backing off {wait}s (attempt {attempt+1}/6)", file=sys.stderr)
+                time.sleep(wait)
+                continue
+            print("HTTP", e.code, detail[:800], file=sys.stderr); raise
 
 def sigma_fmt(qfmt, name=""):
     """Qlik qNumFormat.qFmt -> Sigma formatString. Falls back to a name heuristic."""
@@ -106,14 +114,24 @@ def translate_measure(expr, resolve):
         if d is None: unresolved.append(f)
         return f"[{MASTER}/{d}]"
     def set_analysis(m):
-        agg, cf, val, xf = m.group(1).capitalize(), m.group(2), m.group(3).strip(), m.group(4)
-        val = val.strip("'\"")
-        lit = val if re.fullmatch(r"-?\d+(\.\d+)?", val) else f'"{val}"'
-        inner = f"If({ref(cf)} = {lit}, {ref(xf)})"
+        agg, cf, op, vals_raw, xf = (m.group(1).capitalize(), m.group(2),
+                                     m.group(3), m.group(4), m.group(5))
+        conds = []
+        for val in (v.strip() for v in vals_raw.split(",")):
+            val = val.strip("'\"")
+            if not val or re.search(r"[*?<>=$()]", val):
+                # search mask / $(var) / operator inside the set: no clean
+                # row-wise equivalent -- flag instead of emitting wrong semantics
+                unresolved.append(vals_raw); return m.group(0)
+            lit = val if re.fullmatch(r"-?\d+(\.\d+)?", val) else f'"{val}"'
+            conds.append(f"{ref(cf)} {'<>' if op == '-=' else '='} {lit}")
+        cond = (" and " if op == "-=" else " or ").join(conds)
+        if len(conds) > 1: cond = f"({cond})"
+        inner = f"If({cond}, {ref(xf)})"
         return f"CountDistinct({inner})" if agg == "Count" and m.group(0).upper().find("DISTINCT") >= 0 \
             else f"{agg}({inner})"
-    # 1) simple Set Analysis  Agg({<F={v}>} [DISTINCT] X)
-    e = re.sub(r"\b(Sum|Avg|Min|Max|Count)\s*\(\s*\{\s*<\s*([A-Za-z0-9_]+)\s*=\s*\{([^}]*)\}\s*>\s*\}\s*(?:DISTINCT\s+)?([A-Za-z0-9_]+)\s*\)",
+    # 1) simple Set Analysis  Agg({<F={v,...}>} [DISTINCT] X)  (also F-={...} exclusion)
+    e = re.sub(r"\b(Sum|Avg|Min|Max|Count)\s*\(\s*\{\s*<\s*([A-Za-z0-9_]+)\s*(-?=)\s*\{([^}]*)\}\s*>\s*\}\s*(?:DISTINCT\s+)?([A-Za-z0-9_]+)\s*\)",
                set_analysis, e, flags=re.I)
     # 2) Count(DISTINCT X)
     e = re.sub(r"\bCount\s*\(\s*DISTINCT\s+([A-Za-z0-9_]+)\s*\)",
@@ -123,7 +141,7 @@ def translate_measure(expr, resolve):
                lambda m: f"{m.group(1).capitalize()}({ref(m.group(2))})", e, flags=re.I)
     if unresolved: return None
     # anything left that looks like a bare Qlik field/function = untranslated
-    leftovers = re.sub(r"\[[^\]]*\]|CountDistinct|Sum|Avg|Min|Max|Count|If", "", e)
+    leftovers = re.sub(r'"[^"]*"|\[[^\]]*\]|\b(?:CountDistinct|Sum|Avg|Min|Max|Count|If|and|or)\b', "", e)
     if re.search(r"[A-Za-z_]{2,}", leftovers): return None
     return e
 
@@ -225,6 +243,25 @@ def build_element(c, resolve, warnings):
         # Aggregating table needs explicit groupings or it renders 1 row/source row
         el["groupings"] = [{"id": nid("g"), "groupBy": dim_ids, "calculations": mids}]
         if sort: el["groupings"][0]["sort"] = [{"columnId": sort[0], "direction": sort[1]}]
+        return el
+    if kind == "region-map":
+        # Qlik map layer dim -> Sigma region-map; only emit when the region
+        # grain is recognizable (else flag, never guess a wrong regionType)
+        dname = (dims_raw[0] or "").upper()
+        rtype = "us-state" if "STATE" in dname else ("country" if "COUNTRY" in dname else None)
+        if rtype is None:
+            warnings.append(f"skip '{title}' (map): region grain '{dims_raw[0]}' not recognized (us-state/country)")
+            return None
+        el["region"] = {"id": dim_ids[0], "regionType": rtype}
+        el["color"] = {"by": "scale", "column": mids[0]}
+        return el
+    if kind == "pivot-table":
+        # cross-tab: first dim -> rowsBy, remaining dims -> columnsBy,
+        # measures -> values (bare column-id strings; rowsBy/columnsBy = {id})
+        el["values"] = mids
+        el["rowsBy"] = [{"id": dim_ids[0]}]
+        if len(dim_ids) > 1:
+            el["columnsBy"] = [{"id": d} for d in dim_ids[1:]]
         return el
     if kind == "pie-chart":
         el["value"] = {"id": mids[0]}; el["color"] = {"id": dim_ids[0]}
@@ -346,6 +383,34 @@ def main():
     a = ap.parse_args()
 
     charts = {c["id"]: c for c in json.load(open(a.charts))}
+
+    # Resolve master-item LIBRARY IDS (md-*/mm-*) on chart hypercubes: charts
+    # that use a master dimension/measure carry only its qLibraryId; substitute
+    # the master item's expr (and default the label to its title) so the chart
+    # builds instead of skipping with "not on the denorm element".
+    workdir = os.path.dirname(os.path.abspath(a.charts))
+    def _master(fname):
+        fp = os.path.join(workdir, fname)
+        items = json.load(open(fp)) if os.path.exists(fp) else []
+        return {it["id"]: it for it in items if isinstance(it, dict) and it.get("id")}
+    mdims, mmeas = _master("dimensions.json"), _master("measures.json")
+    for c in charts.values():
+        dims = c.get("dimensions") or []
+        dlabels = c.get("dimLabels") or [None] * len(dims)
+        for i, d in enumerate(dims):
+            hit = mdims.get(d[0] if isinstance(d, list) else d)
+            if hit:
+                dims[i] = [hit["expr"]]
+                if i < len(dlabels) and not dlabels[i]: dlabels[i] = hit["title"]
+        if dims: c["dimLabels"] = dlabels
+        meas = c.get("measures") or []
+        mlabels = c.get("measureLabels") or [None] * len(meas)
+        for i, mx in enumerate(meas):
+            hit = mmeas.get(mx) if isinstance(mx, str) else None
+            if hit:
+                meas[i] = hit["expr"]
+                if i < len(mlabels) and not mlabels[i]: mlabels[i] = hit["title"]
+        if meas: c["measureLabels"] = mlabels
     sheets = json.load(open(a.layout)) if a.layout and os.path.exists(a.layout) else []
     denorm = json.load(open(a.denorm))["element"]
     denorm_cols = [(c["name"], (re.search(r"\[Custom SQL/(.+)\]", c["formula"]) or [None, c["name"]])[1])

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-denorm-sql.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-denorm-sql.py
@@ -36,7 +36,9 @@ def main():
     ap.add_argument("--out", default="denorm-element.json")
     a = ap.parse_args()
     tables = json.load(open(a.reconcile))
-    def wh(t): return f'{a.database}.{a.schema}.{re.sub(r"\.csv$","",t["sourceTable"],flags=re.I)}'
+    def wh(t):
+        s = re.sub(r"\.csv$", "", t["sourceTable"], flags=re.I)
+        return s if "." in s else f'{a.database}.{a.schema}.{s}'
     keyfields = lambda t: [f["qlikField"] for f in t["fields"] if f["qlikField"].upper().endswith("_KEY")]
     # fact = name has FACT, else most *_KEY fields
     fact = next((t for t in tables if "FACT" in t["qlikTable"].upper()), None) \

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -636,7 +636,12 @@ emap.select { |e| e['kind'] == 'kpi-chart' }.each do |e|
   srow = csv_rows(csv_for[e['elementId']]).first
   sval = srow && srow.split(',').first
   qn, sn = numish(qval), numish(sval)
-  status = if qn && sn && ((qn - sn).abs <= [qn.abs, sn.abs].max * 1e-6 + 1e-9)
+  # the CSV export prints a format-rounded value (e.g. percent KPIs at 5
+  # decimals): a Qlik value that rounds to EXACTLY the printed Sigma value is a
+  # MATCH, not a divergence -- compare at the precision the export carries
+  printed_dp = sval.to_s[/\A-?\d+\.(\d+)\z/, 1]&.length
+  rounded_match = qn && sn && printed_dp && (qn.round(printed_dp) - sn).abs <= 1e-9
+  status = if qn && sn && ((qn - sn).abs <= [qn.abs, sn.abs].max * 1e-6 + 1e-9 || rounded_match)
              'MATCH'
            elsif qn && sn && stale_days && stale_days >= 1
              'STALE-EXPLAINED'

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
@@ -189,20 +189,40 @@ def enumerate_master(app, ctx_args, kind, pool):
             defs = body.get("qFieldDefs") or []
             expr, label = (defs[0] if defs else ""), body.get("title")
         title = (props.get("qMetaDef") or {}).get("title") or it.get("title") or label or oid
-        return {"title": title, "expr": expr or ""}
+        # keep the library id: charts reference master items by qLibraryId
+        # (md-*/mm-*) and the workbook builder must resolve id -> expr/title
+        return {"id": oid, "title": title, "expr": expr or ""}
 
     return [shape(it, props) for it, props in zip(items, prop_list)]
 
 
 # ---- load-script → tables/fields (best-effort) ----
+def split_fields(s):
+    """Split a LOAD field list on top-level commas only (paren-depth aware), so
+    function-built fields like `Dual(MONTH_NAME, MONTH_NUMBER) AS MONTH` stay
+    one token instead of shedding a bogus duplicate column."""
+    parts, depth, cur = [], 0, []
+    for ch in s:
+        if ch in "([":
+            depth += 1
+        elif ch in ")]":
+            depth = max(0, depth - 1)
+        if ch == "," and depth == 0:
+            parts.append("".join(cur)); cur = []
+        else:
+            cur.append(ch)
+    if cur:
+        parts.append("".join(cur))
+    return parts
+
 def parse_script(qvs):
     tables = []
     # Match  Label:\n LOAD <fields> (FROM|RESIDENT|SQL|AUTOGENERATE|INLINE)
-    for m in re.finditer(r'(\w+)\s*:\s*\n\s*LOAD\b(.*?)(?:\bFROM\b|\bRESIDENT\b|\bSQL\b|\bAUTOGENERATE\b|\bINLINE\b)',
+    for m in re.finditer(r'(\w+)\s*:\s*\n\s*LOAD\b(.*?)(?:\bFROM\b|\bRESIDENT\b|\bSQL\b|\bSELECT\b|\bAUTOGENERATE\b|\bINLINE\b)',
                          qvs, re.IGNORECASE | re.DOTALL):
         name, body = m.group(1), m.group(2)
         fields = []
-        for tok in body.split(","):
+        for tok in split_fields(body):
             tok = tok.strip().strip(";").strip()
             if not tok: continue
             mm = re.search(r'\bAS\s+"?([A-Za-z0-9_]+)"?\s*$', tok, re.IGNORECASE)  # alias wins
@@ -422,6 +442,15 @@ def main():
             "measures":   [ (mm.get("qSortBy") or {}) for mm in hc.get("qMeasures", []) ],
         }
         qdims, qmeas = hc.get("qDimensions", []), hc.get("qMeasures", [])
+        if not qdims and not qmeas:
+            # map objects carry their hypercube on a layer (gaLayers[].qHyperCubeDef),
+            # not the top-level object -- surface the first layer that has one
+            for layer in (props.get("gaLayers") or []):
+                lhc = layer.get("qHyperCubeDef") or {}
+                if lhc.get("qDimensions") or lhc.get("qMeasures"):
+                    hc = lhc
+                    qdims, qmeas = lhc.get("qDimensions", []), lhc.get("qMeasures", [])
+                    break
         charts.append({
             "id": oid, "vizType": qtype,
             "title": (props.get("qMetaDef") or {}).get("title") or (props.get("title")),

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/reconcile-columns.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/reconcile-columns.py
@@ -19,24 +19,45 @@ Handles: `SQL SELECT ... FROM db.schema.TABLE;` (real migration) and
 import re, json, argparse, sys
 
 BLOCK = re.compile(
-    r'(\w+)\s*:\s*\n\s*LOAD\b(.*?);\s*(?:\n|$)', re.IGNORECASE | re.DOTALL)
+    r'(\w+)\s*:\s*\n\s*LOAD\b(.*?;)\s*((?:SQL\s+)?SELECT\b.*?;)?\s*(?:\n|$)',
+    re.IGNORECASE | re.DOTALL)
 SOURCE = re.compile(
-    r'\bSQL\s+SELECT\b.*?\bFROM\s+([A-Za-z0-9_."]+(?:\.[A-Za-z0-9_."]+)*)'  # SQL FROM db.schema.table
+    r'\b(?:SQL\s+)?SELECT\b.*?\bFROM\s+([A-Za-z0-9_."]+(?:\.[A-Za-z0-9_."]+)*)'  # [SQL] SELECT ... FROM db.schema.table
     r'|\bFROM\s+\[lib://[^/]+/([^\]]+)\]'                                    # lib CSV
     r'|\bRESIDENT\s+(\w+)|\b(INLINE|AUTOGENERATE)\b',
     re.IGNORECASE | re.DOTALL)
 
+def split_fields(s):
+    """Split a LOAD field list on top-level commas only (paren-depth aware), so
+    function-built fields like `Dual(MONTH_NAME, MONTH_NUMBER) AS MONTH` stay
+    one token instead of shedding a bogus duplicate column."""
+    parts, depth, cur = [], 0, []
+    for ch in s:
+        if ch in "([":
+            depth += 1
+        elif ch in ")]":
+            depth = max(0, depth - 1)
+        if ch == "," and depth == 0:
+            parts.append("".join(cur)); cur = []
+        else:
+            cur.append(ch)
+    if cur:
+        parts.append("".join(cur))
+    return parts
+
 def parse(qvs):
     out = []
     for m in BLOCK.finditer(qvs):
-        name, body = m.group(1), m.group(2)
-        # split source clause off the field list
-        src_m = SOURCE.search(body)
-        field_part = body[:src_m.start()] if src_m else body
+        name, body, trailing = m.group(1), m.group(2), (m.group(3) or "")
+        # split source clause off the field list (the SELECT may trail the LOAD as
+        # a separate preceding-load statement, with or without the SQL keyword)
+        full = body + ("\n" + trailing if trailing else "")
+        src_m = SOURCE.search(full)
+        field_part = body[:src_m.start()] if src_m and src_m.start() < len(body) else body
         sql_from, lib_file, resident, special = (src_m.groups() if src_m else (None, None, None, None))
         source = (sql_from or "").strip('"') or (lib_file or "") or (f"RESIDENT {resident}" if resident else "") or (special or "?")
         fields = []
-        for tok in field_part.split(","):
+        for tok in split_fields(field_part):
             tok = tok.strip().strip(";").strip()
             if not tok or tok.upper() == "LOAD": continue
             tok = re.sub(r'^LOAD\b', '', tok, flags=re.IGNORECASE).strip()
@@ -44,6 +65,11 @@ def parse(qvs):
             if am:
                 real = am.group(1).strip().strip('"'); qlik = am.group(2)
                 # real may be an expression; flag if not a plain column
+                dual = re.match(r'^Dual\s*\(\s*"?([A-Za-z0-9_]+)"?\s*,\s*"?([A-Za-z0-9_]+)"?\s*\)$', real, re.IGNORECASE)
+                if dual:  # Dual(text, num): the dual's IDENTITY is the numeric arg
+                    # (Qlik collapses buckets by number; text is display-only and
+                    # may be dirty, e.g. mixed Apr/April) -> map to the numeric column
+                    real = dual.group(2)
                 renamed = real.upper() != qlik.upper()
                 fields.append({"qlikField": qlik, "realColumn": real, "renamed": renamed,
                                "isExpression": not re.match(r'^[A-Za-z0-9_]+$', real)})

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
@@ -119,6 +119,12 @@ module Sigma
         refresh_token!
         next
       end
+      if res.code.to_i == 429 && attempts < 6 # Cloudflare 1015 rate limit: transient, retryable
+        wait = [30 * (2**(attempts - 1)), 120].min
+        warn "HTTP 429 #{method.upcase} #{path} -- backing off #{wait}s (attempt #{attempts}/6)"
+        sleep wait
+        next
+      end
       unless res.is_a?(Net::HTTPSuccess)
         raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
       end


### PR DESCRIPTION
Working fixes accumulated across the 2026-06-11 8-app fleet parity run (8/8 green, bead jh96):

- master-item library-id resolution (root cause of every "md-* not on denorm" skip)
- translate_measure hardening: multi-value or-chains, `-=` exclusion sets, search-mask/`$()` guard, string-literal leftover check
- Dual()→numeric arg (fixes 23-vs-12 month split from dirty Apr/April data)
- DM metric Qlik-residue guard; pivot-table builder branch; gaLayers→region-map; printed-precision KPI compare; 429 backoff + paren-depth split + bare-SELECT + denorm qualification (from run 1)

Fixture regression byte-identical after each change. Evidence: ~/qlik-fleet-build/FLEET-RUN-RESULTS.md (8/8 PASS, median 4.9 min/app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)