### PR TITLE
thoughtspot-to-sigma: fleet-run hardening — table/pivot parity planning, row-grain dedupe, chasm-trap guard, export saturation backoff

### DIFF
--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
@@ -119,19 +119,27 @@ def resolve_folder():
 
 
 # ── Sigma CSV export (ACTUAL side of parity + the warehouse freshness probe) ──
-def export_csv(wb_id, element_id, timeout=240):
-    res = json.loads(migrate.sigma("POST", f"/v2/workbooks/{wb_id}/export",
-                                   {"elementId": element_id, "format": {"type": "csv"}}))
-    qid = res["queryId"]
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            body = migrate.sigma("GET", f"/v2/query/{qid}/download")
-            if body and body.strip():
-                return body
-        except RuntimeError:
-            pass
-        time.sleep(2)
+def export_csv(wb_id, element_id, timeout=240, retries=1):
+    """One slow export usually means warehouse/org saturation, not a broken
+    element — pause once and retry before failing the whole run (never hammer:
+    a single retry, with a cool-down, then a hard error)."""
+    for attempt in range(retries + 1):
+        res = json.loads(migrate.sigma("POST", f"/v2/workbooks/{wb_id}/export",
+                                       {"elementId": element_id, "format": {"type": "csv"}}))
+        qid = res["queryId"]
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                body = migrate.sigma("GET", f"/v2/query/{qid}/download")
+                if body and body.strip():
+                    return body
+            except RuntimeError:
+                pass
+            time.sleep(2)
+        if attempt < retries:
+            print(f"   WARN: CSV export of {element_id} timed out after {timeout}s — "
+                  f"cooling down 60s, then retrying once (saturation guard)")
+            time.sleep(60)
     raise RuntimeError(f"CSV export of element {element_id} timed out")
 
 
@@ -157,14 +165,17 @@ TS_AGG = {"SUM": lambda vs: sum(vs),
           "COUNT_DISTINCT": lambda vs: len(set(vs))}
 
 
-def viz_specs_with_aggs(lb_tml_path):
-    """Parse a Liveboard TML → {viz name: {spec, aggs}}. The per-measure agg comes
-    from the TML's own table_columns[].headline_aggregation (default SUM) — the
-    SOURCE definition, not the built Sigma formula, so a builder bug diverges."""
-    lb = yaml.safe_load(open(lb_tml_path).read())["liveboard"]
+def viz_specs_with_aggs(lb_tml_path, resolver=None):
+    """Parse a Liveboard TML → ({viz name: {spec, aggs}}, liveboard_guid). The
+    per-measure agg comes from the TML's own table_columns[].headline_aggregation
+    (default SUM) — the SOURCE definition, not the built Sigma formula, so a
+    builder bug diverges."""
+    doc = yaml.safe_load(open(lb_tml_path).read())
+    lb_guid = doc.get("guid")
+    lb = doc["liveboard"]
     out = {}
     for v in lb["visualizations"]:
-        spec = ts_common.parse_ts_viz(v)
+        spec = ts_common.parse_ts_viz(v, resolver)
         if not spec:
             continue
         aggs = {}
@@ -173,7 +184,7 @@ def viz_specs_with_aggs(lb_tml_path):
             if tc.get("headline_aggregation"):
                 aggs[base] = tc["headline_aggregation"].upper()
         out[spec["name"]] = {"spec": spec, "aggs": aggs}
-    return out
+    return out, lb_guid
 
 
 def expected_offline(spec, aggs, resolver, headers, rows):
@@ -208,9 +219,13 @@ def expected_offline(spec, aggs, resolver, headers, rows):
 
 def expected_live(spec, model_id):
     """Ground truth from ThoughtSpot itself: run the viz's search tokens through
-    searchdata against the model."""
+    searchdata against the model. Only the x dim is queried (a color/series dim
+    would change the grain — parity compares per-x totals); `top N` tokens ride
+    along so top-N tiles compare the same row set."""
     import ts_lib
-    q = " ".join(f"[{c}]" for c in spec["dims"] + spec["measures"])
+    q = " ".join(f"[{c}]" for c in spec["dims"][:1] + spec["measures"])
+    if spec.get("topn"):
+        q += f" top {spec['topn']}"
     for f in spec.get("filters", []):
         q += f" [{f['col']}] {'=' if f['mode'] == 'include' else '!='} " + \
              " ".join(f"'{v}'" for v in f["values"])
@@ -221,9 +236,46 @@ def expected_live(spec, model_id):
         return [[None, numify(drows[0][0])]] if drows else None
     didx = names.index(spec["dims"][0]) if spec["dims"][0] in names else 0
     meas = spec["measures"][0]
-    vidx = next((names.index(n) for n in (f"Total {meas}", meas) if n in names),
+    vidx = next((names.index(n) for n in (f"Total {meas}", f"Average {meas}", meas) if n in names),
                 len(names) - 1)
     return [[r[didx], numify(r[vidx])] for r in drows]
+
+
+def expected_from_lbdata(lb_guid, spec, _cache={}):
+    """Ground truth for tiles whose dim/measure is an ANSWER-level formula —
+    searchdata can't express those, but metadata/liveboard/data returns the
+    tile's own rows as ThoughtSpot renders them."""
+    import ts_lib
+    if lb_guid not in _cache:
+        _cache[lb_guid] = ts_lib._req("metadata/liveboard/data", {
+            "metadata_identifier": lb_guid, "data_format": "COMPACT", "record_size": 1000})
+    tiles = (_cache[lb_guid] or {}).get("contents", [])
+    t = next((t for t in tiles if (t.get("visualization_name") or "") == spec["name"]), None)
+    if not t:
+        return None
+    names = [c["name"] if isinstance(c, dict) else c for c in (t.get("column_names") or [])]
+    rows = t.get("data_rows") or []
+    if not spec["dims"]:
+        return [[None, numify(rows[0][0])]] if rows else None
+    def col_idx(cands):
+        return next((names.index(c) for c in cands if c in names), None)
+    didx = col_idx([spec["dims"][0]])
+    meas = spec["measures"][0]
+    vidx = col_idx([f"Total {meas}", f"Average {meas}", meas])
+    if didx is None or vidx is None:
+        return None
+    groups, order = {}, []
+    for r in rows:
+        d = r[didx]
+        d = None if (d is None or str(d).strip() == "") else d
+        val = numify(r[vidx])
+        if d in groups and isinstance(groups[d], float) and isinstance(val, float):
+            groups[d] += val
+        else:
+            if d not in groups:
+                order.append(d)
+            groups[d] = val
+    return [[d, groups[d]] for d in order]
 
 
 def scan_modified(obj):
@@ -460,12 +512,38 @@ def main():
         if rc != 0:
             sys.exit(f"FATAL: parity pass 1 failed for {wb}")
         plan = json.load(open(os.path.join(pdir, "parity-plan.json")))
-        vmap = viz_specs_with_aggs(r["lb_tml"]) if r.get("lb_tml") else {}
+        vmap, lb_guid = viz_specs_with_aggs(r["lb_tml"], resolver) if r.get("lb_tml") else ({}, None)
         expected, actuals = {}, {}
         for c in plan["charts"]:
             cname = c["chart"]
             # ACTUAL — the built Sigma chart, via CSV export
             headers, rows = parse_csv(export_csv(wb, c["sigma_element_id"]))
+            if c.get("kind") == "pivot-table" and rows and "Total" in rows[0]:
+                # Pivot CSV is a matrix: line 1 = measure/col-dim banner (lands in
+                # `headers`), rows[0] = the real header (row dim, col-dim values,
+                # 'Total'), then one row per row-dim value and a trailing grand-
+                # total row. Parity compares row-dim totals — the 'Total' column.
+                hdr2 = rows[0]
+                tidx = hdr2.index("Total")
+                actuals[cname] = [
+                    [(r[0] if str(r[0]).strip() != "" else None), numify(r[tidx])]
+                    for r in rows[1:] if str(r[0]).strip() != "Total"]
+                v = vmap.get(cname)
+                if not v:
+                    print(f"   WARN: no source viz named {cname!r} in the Liveboard TML — chart will DIVERGE")
+                    continue
+                exp = None
+                if model_id and not offline:
+                    try:
+                        exp = expected_live(v["spec"], model_id)
+                    except Exception as ex:
+                        print(f"   WARN: TS expected fetch failed for {cname!r} ({ex}); falling back to warehouse re-aggregation")
+                if exp is None:
+                    mh, mr = masters[wb]
+                    exp = expected_offline(v["spec"], v["aggs"], resolver, mh, mr)
+                if exp is not None:
+                    expected[cname] = exp
+                continue
             idx = {h: i for i, h in enumerate(headers)}
             want = c["sigma_columns"]
             if len(want) == 1:                      # KPI
@@ -473,18 +551,49 @@ def main():
                 actuals[cname] = [[None, numify(rows[0][vi])]] if rows else []
             else:
                 di, vi = idx.get(want[0], 0), idx.get(want[1], 1 if len(headers) > 1 else 0)
-                actuals[cname] = [[row[di], numify(row[vi])] for row in rows]
+                # Normalize the null bucket ('' from Sigma CSV vs None from
+                # searchdata) and group-sum duplicate dims (a chart with a
+                # color/series dim exports one CSV row per (x, series) pair —
+                # parity compares per-x totals on both sides).
+                pairs = [[row[di] if str(row[di]).strip() != "" else None, numify(row[vi])]
+                         for row in rows]
+                if c.get("kind") == "table":
+                    # Grouped-table CSV exports drop to UNDERLYING-row grain when
+                    # the element carries a non-grouped passthrough column (e.g. a
+                    # filter column) — each of a group's n rows repeats the
+                    # group-level calculation, so group-summing squares counts
+                    # (n rows x value n = n^2). The calculation is already at
+                    # group level: dedupe exact (dim, value) repeats first.
+                    seen, deduped = set(), []
+                    for d, val in pairs:
+                        if (d, val) not in seen:
+                            seen.add((d, val))
+                            deduped.append([d, val])
+                    pairs = deduped
+                grouped, order = {}, []
+                for d, val in pairs:
+                    if d in grouped and isinstance(grouped[d], float) and isinstance(val, float):
+                        grouped[d] += val
+                    else:
+                        if d not in grouped:
+                            order.append(d)
+                        grouped[d] = val
+                actuals[cname] = [[d, round(grouped[d], 6) if isinstance(grouped[d], float) else grouped[d]]
+                                  for d in order]
             # EXPECTED — searchdata ground truth (live) or source-TML re-aggregation (offline)
             v = vmap.get(cname)
             if not v:
                 print(f"   WARN: no source viz named {cname!r} in the Liveboard TML — chart will DIVERGE")
                 continue
             exp = None
+            sp = v["spec"]
+            afn = set(sp.get("af_names") or [])
+            use_lb = bool(afn & set(sp.get("dims", [])[:1])) or bool(afn & set(sp.get("measures", [])[:1]))
             if model_id and not offline:
                 try:
-                    exp = expected_live(v["spec"], model_id)
+                    exp = expected_from_lbdata(lb_guid, sp) if (use_lb and lb_guid) else expected_live(sp, model_id)
                 except Exception as ex:
-                    print(f"   WARN: searchdata failed for {cname!r} ({ex}); falling back to warehouse re-aggregation")
+                    print(f"   WARN: TS expected fetch failed for {cname!r} ({ex}); falling back to warehouse re-aggregation")
             if exp is None:
                 mh, mr = masters[wb]
                 exp = expected_offline(v["spec"], v["aggs"], resolver, mh, mr)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -118,6 +118,19 @@ def find_denorm(dm):
         denorm = max(els, key=lambda e: len(e.get("columns", [])))
     return denorm["id"], denorm["name"]
 
+def find_table_elements(dm):
+    """Map the DM's raw warehouse-table elements: {TABLE_NAME: {id, name}}.
+    Used to source dimension-grain measures at their owning table's grain
+    (chasm-trap guard) instead of the fanned-out denorm view."""
+    dmspec = yaml.safe_load(sigma("GET", f"/v2/dataModels/{dm}/spec"))
+    out = {}
+    for el in dmspec["pages"][0]["elements"]:
+        src = el.get("source") or {}
+        if src.get("kind") == "warehouse-table" and src.get("path"):
+            out[src["path"][-1]] = {"id": el["id"], "name": el.get("name") or src["path"][-1]}
+    return out
+
+
 def build_dm(conv, name, folder):
     """POST the converted Sigma data model. Returns (dmId, denormElemId, denormName)."""
     spec = conv["model"]; spec["name"] = name
@@ -157,7 +170,7 @@ def lb_tiles(lb, viz_specs, elements):
 def migrate_liveboard(lb_doc, dm, denorm_id, denorm_name, resolver, prefix, fallback_name, folder, wd):
     lb = yaml.safe_load(lb_doc)["liveboard"]
     display = lb.get("name") or fallback_name          # never name a workbook after a UUID
-    viz_specs = [(v.get("id"), ps) for v in lb["visualizations"] if (ps := ts_common.parse_ts_viz(v))]
+    viz_specs = [(v.get("id"), ps) for v in lb["visualizations"] if (ps := ts_common.parse_ts_viz(v, resolver))]
     specs = [ps for _, ps in viz_specs]
     master = ts_common.master_element(specs, resolver, dm, denorm_id, denorm_name)
     elements = [ts_common.sigma_element(s, resolver) for s in specs]
@@ -222,7 +235,7 @@ def migrate_answer(ans_id, dm, denorm_id, denorm_name, resolver, prefix, folder,
         raise RuntimeError("export failed: " + err)
     ans = yaml.safe_load(edoc)["answer"]
     display = ans.get("name") or ("Answer " + ans_id[:8])
-    spec_v = ts_common.parse_ts_viz({"answer": ans})
+    spec_v = ts_common.parse_ts_viz({"answer": ans}, resolver)
     master = ts_common.master_element([spec_v], resolver, dm, denorm_id, denorm_name)
     spec = {"name": f"{prefix}{display} (from ThoughtSpot)", "folderId": folder, "schemaVersion": 1,
             "pages": [{"id": "p-data", "name": "Data", "elements": [master]},
@@ -285,6 +298,15 @@ def main():
     else:
         conv = convert_model(model_tml, wd, a.converted)
         dm, denorm_id, denorm_name = build_dm(conv, f"{prefix}{model_name} (from ThoughtSpot)", folder)
+
+    # chasm-trap guard inputs: the DM's raw table elements, for dimension-grain
+    # measures that must NOT be aggregated over the fanned-out denorm view
+    resolver["__dm_id__"] = dm
+    try:
+        resolver["__dim_elements__"] = find_table_elements(dm)
+    except Exception as ex:
+        print(f"  WARN: could not map DM table elements ({ex}) — dim-grain measures will use the denorm view")
+        resolver["__dim_elements__"] = {}
 
     # pick Liveboards: offline TML files, or join the export lane
     targets = []                                       # (lb_doc, fallback_name)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/phase6-parity-thoughtspot.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/phase6-parity-thoughtspot.rb
@@ -36,8 +36,12 @@
 #   Runs verify-parity.rb, prints the pass/fail summary, writes
 #   parity-final.txt + parity-final.json (the hard-gate sentinel).
 #
-# Plain `table` elements aren't auto-planned (no single dim/measure axis) —
-# query-verify those manually and note it in the migration report.
+# Plain `table` elements ARE auto-planned (first groupBy dim + first grouping
+# calculation — parity compares per-dim totals of the first measure), as are
+# `pivot-table` elements (rowsBy[0] dim + values[0] measure; their CSV export
+# is a matrix whose per-row `Total` column carries the row-dim totals — the
+# Python caller handles that shape). The DM master element (id m-ofv) is the
+# denorm feed, not a tile, and stays excluded.
 
 require 'json'
 require 'optparse'
@@ -81,6 +85,16 @@ def chart_columns(el)
     did = el.dig('color', 'id') || el.dig('color', 'columnId')
     vid = el.dig('value', 'id') || el.dig('value', 'columnId')
     by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
+  when 'table'
+    g = Array(el['groupings']).first || {}
+    did = Array(g['groupBy']).first  || cols.map { |c| c['id'] }.find { |i| i.to_s.start_with?('d-') }
+    vid = Array(g['calculations']).first || cols.map { |c| c['id'] }.find { |i| i.to_s.start_with?('m-') }
+    by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
+  when 'pivot-table'
+    did = (Array(el['rowsBy']).first || {})['id']
+    vid = Array(el['values']).first
+    vid = vid['id'] if vid.is_a?(Hash)
+    by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
   else # bar-chart, line-chart, combo-chart, scatter-chart, ...
     did = el.dig('xAxis', 'columnId')
     vid = Array(el.dig('yAxis', 'columnIds')).first
@@ -102,9 +116,18 @@ if !opts[:finalize]
   File.write(File.join(opts[:dir], 'wb-readback.json'), JSON.pretty_generate(spec))
 
   charts = []
+  flagged = []
   Array(spec['pages']).each do |page|
     Array(page['elements']).each do |el|
-      next unless el['kind'].to_s.end_with?('-chart')
+      plannable = el['kind'].to_s.end_with?('-chart') ||
+                  (%w[table pivot-table].include?(el['kind'].to_s) && el['id'].to_s != 'm-ofv')
+      next unless plannable
+      if el['name'].to_s.include?('[FLAGGED')
+        # flag-not-drop tile (window formula, bead 5d9k): present in the workbook,
+        # excluded from value parity, surfaced in the summary as flagged.
+        flagged << { 'chart' => el['name'], 'sigma_element_id' => el['id'], 'kind' => el['kind'] }
+        next
+      end
       pairs = chart_columns(el)
       next unless pairs
       charts << { 'chart' => el['name'], 'sigma_element_id' => el['id'],
@@ -116,7 +139,7 @@ if !opts[:finalize]
   end
   abort('no plannable chart elements found in the workbook spec') if charts.empty?
 
-  File.write(plan_path, JSON.pretty_generate({ 'charts' => charts }))
+  File.write(plan_path, JSON.pretty_generate({ 'charts' => charts, 'flagged' => flagged }))
 
   puts ''
   puts '=' * 70
@@ -186,6 +209,7 @@ File.write(File.join(opts[:dir], 'parity-final.txt'), out)
 total  = plan['charts'].size
 passed = out.scan(/^PASS\s+\[[^\]]+\]\s+(.+)$/).flatten.map(&:strip)
 failed = out.scan(/^DIVERGE\s+\[[^\]]+\]\s+(.+)$/).flatten.map(&:strip)
+flagged = Array(plan['flagged'])
 summary = {
   'workbook_id'  => plan.dig('charts', 0, 'workbook_id'),
   'ran_at'       => Time.now.utc.iso8601,
@@ -194,6 +218,8 @@ summary = {
   'charts_total' => total,
   'charts_pass'  => passed.size,
   'charts_fail'  => failed.size,
+  'charts_flagged' => flagged.size,
+  'flagged_names'  => flagged.map { |f| f['chart'] },
   'pass_names'   => passed,
   'fail_names'   => failed,
   'status'       => (status.success? && total > 0 && passed.size == total) ? 'PASS' : 'FAIL'

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
@@ -67,6 +67,8 @@ def build_resolver(model_root):
         ctype = (c.get("type") or props.get("column_type") or "").upper()
         iso = (props.get("currency_type") or {}).get("iso_code")
         fmt = ts_format_to_sigma(props.get("format_pattern"), iso)
+        is_formula = False
+        table = field = None
         if "::" in cid:                       # physical column
             table, phys = cid.split("::", 1)
             field = sigma_display_name(phys)
@@ -75,10 +77,15 @@ def build_resolver(model_root):
         elif c.get("formula_id"):             # formula column (lives on the fact element)
             name = c.get("name", c["formula_id"])
             ofv = name
+            is_formula = True
         else:
             continue
         friendly = re.sub(r'\s+', ' ', name.replace("(", "").replace(")", "")).strip()
-        resolver[name] = {"measure": ctype == "MEASURE", "ofv": ofv, "friendly": friendly, "fmt": fmt}
+        resolver[name] = {"measure": ctype == "MEASURE", "ofv": ofv, "friendly": friendly, "fmt": fmt,
+                          "agg": (str(props.get("aggregation") or "").upper() or None),
+                          "is_formula": is_formula, "table": table, "field": field}
+    resolver["__model_formulas__"] = model_formula_map(model_root)
+    resolver["__fact__"] = fact
     return resolver
 
 # ── ThoughtSpot side: a viz spec -> a Liveboard visualization dict (fixtures) ─
@@ -104,7 +111,7 @@ def ts_viz(idx, spec):
 def _strip_total(c):
     return c[len("Total "):] if c.startswith("Total ") else c
 
-def parse_ts_viz(v):
+def parse_ts_viz(v, resolver=None):
     a = v.get("answer")
     if not a:
         return None
@@ -116,13 +123,72 @@ def parse_ts_viz(v):
     if ordered:
         known = set(cols)
         cols = [c for c in ordered if c in known] + [c for c in cols if c not in set(ordered)]
-    measures = [_strip_total(c) for c in cols if c.startswith("Total ")]
-    dims = [c for c in cols if not c.startswith("Total ")]
-    ctype = (a.get("chart") or {}).get("type", "TABLE")
+    af = {f["name"]: f.get("expr", "") for f in (a.get("formulas") or []) if f.get("name")}
+    mf = (resolver or {}).get("__model_formulas__") or {}
+    dims, measures, mtypes, row_formulas, flagged = [], [], {}, {}, []
+
+    def add_formula_col(name, expr):
+        cls = formula_class(expr)
+        if cls == "row":
+            dims.append(name)
+            row_formulas[name] = expr
+        else:
+            measures.append(name)
+            mtypes[name] = {"kind": cls, "expr": expr}
+            if cls == "window":
+                flagged.append({"name": name, "fn": window_fn_name(expr)})
+
+    for c in cols:
+        if c in af:                                   # answer-level formula
+            add_formula_col(c, af[c])
+            continue
+        hit = False
+        for prefix, agg in (("Total ", "SUM"), ("Average ", "AVERAGE"),
+                            ("Min ", "MIN"), ("Max ", "MAX")):
+            if c.startswith(prefix):
+                base = c[len(prefix):]
+                ent = (resolver or {}).get(base) or {}
+                info = {"kind": "plain", "agg": agg}
+                if ent.get("is_formula"):
+                    mexpr = mf.get(base, "")
+                    if formula_class(mexpr) == "row":   # e.g. "Total Avg Order Value"
+                        info["needs_row_calc"] = True
+                    else:
+                        info = {"kind": "aggregate", "expr": mexpr}
+                measures.append(base)
+                mtypes[base] = info
+                hit = True
+                break
+        if hit:
+            continue
+        ent = (resolver or {}).get(c)
+        if ent and ent.get("is_formula"):             # bare model formula (e.g. Order Count)
+            add_formula_col(c, mf.get(c, ""))
+            continue
+        if ent and ent.get("measure"):                # bare model measure (uses model agg)
+            measures.append(c)
+            mtypes[c] = {"kind": "plain", "agg": ent.get("agg") or "SUM"}
+            continue
+        dims.append(c)
+
+    chart_node = a.get("chart") or {}
+    ctype = chart_node.get("type", "TABLE")
     if a.get("display_mode") == "TABLE_MODE":
         ctype = "TABLE"
+    # Axis configs: honor the chart's own x ordering and color/series dim.
+    ax = (chart_node.get("axis_configs") or [{}])[0] or {}
+    xs = [d for d in (ax.get("x") or []) if d in dims]
+    if xs:
+        dims = xs + [d for d in dims if d not in xs]
+    color = next((d for d in (ax.get("color") or []) if d in dims), None)
+    if color:
+        dims = [d for d in dims if d != color] + [color]    # color dim LAST
+    m = re.search(r"\btop\s+(\d+)\b", a.get("search_query", "") or "", re.I)
     return {"name": a.get("name", "Viz"), "chart": ctype, "dims": dims, "measures": measures,
-            "filters": parse_filters(a.get("search_query", "")), "sorts": parse_sorts(a)}
+            "filters": parse_filters(a.get("search_query", "")), "sorts": parse_sorts(a),
+            "mtypes": mtypes, "row_formulas": row_formulas, "flagged": flagged,
+            "color_dim": color, "topn": int(m.group(1)) if m else None,
+            "af_names": sorted(af.keys())}
 
 def parse_sorts(a):
     """Carry the answer's sorts: (1) `sort by [Col] descending` tokens in the
@@ -199,8 +265,20 @@ def _resolve(resolver, base):
 
 def sigma_element(spec, resolver, master="OFV"):
     """Build the element, then apply any ThoughtSpot search-query filters as
-    Sigma element list-filters (adds the filter column if not already present)."""
+    Sigma element list-filters (adds the filter column if not already present).
+    Also: TS `top N` search tokens become a Sigma top-n element filter, and
+    window-formula tiles get a loud [FLAGGED: …] title (flag-not-drop, bead 5d9k)."""
     el = _element_core(spec, resolver, master)
+    if spec.get("topn") and el.get("kind") != "kpi-chart" and spec.get("measures"):
+        mname = spec["measures"][0]
+        mcol = next((c for c in el["columns"] if c.get("name") in (mname, "Total " + mname)), None)
+        if mcol:
+            el.setdefault("filters", []).append({"id": nid(), "columnId": mcol["id"],
+                "kind": "top-n", "rankingFunction": "rank", "mode": "top-n",
+                "rowCount": spec["topn"]})
+    if spec.get("flagged"):
+        fns = ", ".join(sorted({f["fn"] for f in spec["flagged"]}))
+        el["name"] = f"{el['name']} [FLAGGED: {fns} not converted]"
     # Show value labels on bar/pie/donut (Sigma defaults them OFF). Lines stay clean.
     if el.get("kind") in ("bar-chart", "pie-chart", "donut-chart"):
         el["dataLabel"] = {"labels": "shown"}
@@ -246,10 +324,43 @@ def _apply_sorts(el, spec):
 def _element_core(spec, resolver, master="OFV"):
     name, chart, dims, meas = spec["name"], spec["chart"], spec["dims"], spec["measures"]
     src = {"elementId": "m-ofv", "kind": "table"}
-    mref = lambda b: f"Sum([{master}/{_resolve(resolver, b)['friendly']}])"
+    mtypes = spec.get("mtypes") or {}
     dref = lambda b: f"[{master}/{_resolve(resolver, b)['friendly']}]"
+
+    def mref(b):
+        mt = mtypes.get(b)
+        if mt and mt.get("kind") == "aggregate":      # answer/model aggregate formula
+            return ts_expr_to_sigma(mt["expr"], lambda n: dref(n))
+        if mt and mt.get("kind") == "window":         # FLAGGED: inner raw aggregate fallback
+            inner = window_inner_ref(mt.get("expr")) or b
+            return f"Sum([{master}/{_resolve(resolver, inner)['friendly']}])"
+        agg = TS_AGG_TO_SIGMA.get((mt or {}).get("agg") or "SUM", "Sum")
+        return f"{agg}([{master}/{_resolve(resolver, b)['friendly']}])"
+
+    color_dim = spec.get("color_dim")
+    if color_dim and chart not in ("PIE", "DONUT", "PIVOT_TABLE", "PIVOT", "TABLE", "ADVANCED_COLUMN"):
+        dims = [d for d in dims if d != color_dim]    # x-dims only; color added below
     if chart == "KPI" or (not dims and meas):
         c = nid("c") + "-v"
+        ent = resolver.get(meas[0]) or {}
+        dim_els = resolver.get("__dim_elements__") or {}
+        tbl = ent.get("table")
+        mt0 = mtypes.get(meas[0]) or {}
+        plain = mt0.get("kind") in (None, "plain") and not mt0.get("needs_row_calc")
+        if (plain and not spec.get("filters") and tbl
+                and tbl != resolver.get("__fact__") and tbl in dim_els):
+            # Dimension-grain measure (e.g. CUSTOMER_DIM.LIFETIME_REVENUE): the
+            # denorm view fans each dim row across its fact rows, so aggregating
+            # over OFV over-counts (chasm trap). ThoughtSpot aggregates at the
+            # OWNING table's grain — source the DM's raw dim-table element.
+            de = dim_els[tbl]
+            agg = TS_AGG_TO_SIGMA.get(mt0.get("agg") or ent.get("agg") or "SUM", "Sum")
+            return {"id": nid(), "kind": "kpi-chart", "name": name,
+                    "source": {"dataModelId": resolver.get("__dm_id__"),
+                               "elementId": de["id"], "kind": "data-model"},
+                    "columns": [{"id": c, "formula": f"{agg}([{de['name']}/{ent['field']}])",
+                                 "name": meas[0], "format": _fmt(ent)}],
+                    "value": {"columnId": c}}
         return {"id": nid(), "kind": "kpi-chart", "name": name, "source": src,
                 "columns": [{"id": c, "formula": mref(meas[0]), "name": meas[0],
                              "format": _fmt(_resolve(resolver, meas[0]))}], "value": {"columnId": c}}
@@ -271,11 +382,13 @@ def _element_core(spec, resolver, master="OFV"):
         return {"id": nid(), "kind": "pivot-table", "name": name, "source": src, "columns": cols,
                 "rowsBy": [{"id": rid}], "columnsBy": [{"id": cidd}], "values": mids}
     if chart in ("TABLE", "ADVANCED_COLUMN"):
-        did = nid("d"); cols = [{"id": did, "formula": dref(dims[0]), "name": dims[0]}]; mids = []
+        dids, cols, mids = [], [], []
+        for d in dims:
+            did = nid("d"); cols.append({"id": did, "formula": dref(d), "name": d}); dids.append(did)
         for m in meas:
             mid = nid("m"); cols.append({"id": mid, "formula": mref(m), "name": m, "format": _fmt(_resolve(resolver, m))}); mids.append(mid)
         return {"id": nid(), "kind": "table", "name": name, "source": src, "columns": cols,
-                "groupings": [{"id": nid(), "groupBy": [did], "calculations": mids}]}
+                "groupings": [{"id": nid(), "groupBy": dids, "calculations": mids}]}
     # Scatter / bubble — plot two measures (x vs y) with an optional category color.
     # Falls through to the default axis chart when there aren't two measures.
     if chart in ("SCATTER", "BUBBLE") and len(meas) >= 2:
@@ -307,19 +420,186 @@ def _element_core(spec, resolver, master="OFV"):
     x = nid("x"); cols = [{"id": x, "formula": dref(dims[0]), "name": dims[0]}]; ymids = []
     for m in meas:
         y = nid("y"); cols.append({"id": y, "formula": mref(m), "name": m, "format": _fmt(_resolve(resolver, m))}); ymids.append(y)
-    return {"id": nid(), "kind": KIND.get(chart, "bar-chart"), "name": name, "source": src,
-            "columns": cols, "xAxis": {"columnId": x}, "yAxis": {"columnIds": ymids}}
+    el = {"id": nid(), "kind": KIND.get(chart, "bar-chart"), "name": name, "source": src,
+          "columns": cols, "xAxis": {"columnId": x}, "yAxis": {"columnIds": ymids}}
+    if color_dim:
+        cc = nid("c"); cols.append({"id": cc, "formula": dref(color_dim), "name": color_dim})
+        el["color"] = {"by": "category", "column": cc}
+    return el
 
 def master_element(specs, resolver, dm_id, denorm_elem, denorm_name="Order Fact View"):
-    seen, cols, i = {}, [], 0
-    for s in specs:
-        for base in s.get("dims", []) + s["measures"] + [f["col"] for f in s.get("filters", [])]:
-            e = _resolve(resolver, base)
-            if e["friendly"] in seen:
-                continue
+    """Master table fed by the DM denorm view. Plain columns pass through; the
+    DM's row-level formula columns are NOT on the denorm view, so any row-level
+    formula (model or answer) is re-materialized here as a calc column over its
+    underlying master columns (recursively); aggregate/window formulas get their
+    underlying raw columns surfaced (the aggregate lives on the viz element)."""
+    mf = (resolver or {}).get("__model_formulas__") or {}
+    seen, cols = {}, []
+
+    def add_base(base):
+        e = _resolve(resolver, base)
+        if e["friendly"] not in seen:
             seen[e["friendly"]] = 1
-            cols.append({"id": "ofv-%d" % i, "name": e["friendly"], "formula": f"[{denorm_name}/{e['ofv']}]"})
-            i += 1
+            cols.append({"id": "ofv-%d" % len(cols), "name": e["friendly"],
+                         "formula": f"[{denorm_name}/{e['ofv']}]"})
+        return e["friendly"]
+
+    def materialize(name, expr):
+        fr = _resolve(resolver, name)["friendly"]
+        if fr in seen:
+            return fr
+        seen[fr] = 1                       # reserve before recursing into deps
+        formula = ts_expr_to_sigma(expr, lambda n: "[%s]" % ensure(n))
+        cols.append({"id": "ofv-%d" % len(cols), "name": fr, "formula": formula or "null"})
+        return fr
+
+    def ensure(name):
+        ent = (resolver or {}).get(name)
+        if ent and ent.get("is_formula") and formula_class(mf.get(name, "")) == "row":
+            return materialize(name, mf.get(name, ""))
+        return add_base(name)
+
+    for s in specs:
+        mtypes, rfs = s.get("mtypes") or {}, s.get("row_formulas") or {}
+        for base in s.get("dims", []) + s["measures"] + [f["col"] for f in s.get("filters", [])]:
+            mt = mtypes.get(base)
+            if base in rfs:                                  # row-level formula dim
+                materialize(base, rfs[base])
+            elif mt and mt.get("kind") == "window":          # flagged: surface the raw measure
+                inner = window_inner_ref(mt.get("expr"))
+                ensure(inner) if inner else None
+            elif mt and mt.get("kind") == "aggregate":       # element-level agg formula deps
+                for rn in expr_refs(mt.get("expr") or ""):
+                    ensure(rn)
+            elif mt and mt.get("needs_row_calc"):            # e.g. "Total Avg Order Value"
+                materialize(base, mf.get(base, ""))
+            else:
+                ensure(base)
     return {"id": "m-ofv", "name": "OFV", "kind": "table",
             "source": {"dataModelId": dm_id, "elementId": denorm_elem, "kind": "data-model"},
             "columns": cols}
+# ── Answer/model formula support (fleet run 2026-06-11, bead d0qu) ───────────
+# ThoughtSpot formulas appear at two levels: model TML `formulas:` (worksheet
+# formulas — e.g. Order Count = count([ORDER_FACT::ORDER_ID])) and answer-level
+# `answer.formulas` on a Liveboard viz (e.g. Return Rate = safe_divide(...)).
+# Classification:
+#   row        → materialized as a master-element calc column (if/then buckets)
+#   aggregate  → translated to a Sigma aggregate formula on the viz element
+#   window     → NOT converted (bead 5d9k): the tile is built from the inner
+#                raw aggregate and its element name carries a [FLAGGED: …]
+#                marker; parity records it as flagged, never silently dropped.
+_WINDOW_RE = re.compile(
+    r'\b(cumulative_sum|running_total|moving_average|moving_sum|moving_min|moving_max|'
+    r'rank|dense_rank|cumulative_average|cumulative_max|cumulative_min|group_aggregate)\s*\(', re.I)
+_AGG_FN_RE = re.compile(
+    r'\b(sum|count_distinct|unique_count|count_not_null|count|average|avg|max|min|median|'
+    r'std_deviation|stddev|variance|sum_if|count_if|average_if|max_if|min_if|unique_count_if)\s*\(', re.I)
+_UNIQUE_COUNT_RE = re.compile(r'\bunique\s+count\s*\(', re.I)
+
+TS_AGG_TO_SIGMA = {"SUM": "Sum", "AVERAGE": "Avg", "AVG": "Avg", "MIN": "Min", "MAX": "Max",
+                   "COUNT": "Count", "COUNT_DISTINCT": "CountDistinct", "MEDIAN": "Median",
+                   "STD_DEVIATION": "StdDev", "VARIANCE": "Variance"}
+
+def formula_class(expr):
+    if not expr:
+        return "row"
+    if _WINDOW_RE.search(expr):
+        return "window"
+    if _AGG_FN_RE.search(expr) or _UNIQUE_COUNT_RE.search(expr):
+        return "aggregate"
+    return "row"
+
+def window_fn_name(expr):
+    m = _WINDOW_RE.search(expr or "")
+    return m.group(1).lower() if m else "window"
+
+def window_inner_ref(expr):
+    """First bracketed ref inside a window call — the raw measure to fall back to."""
+    m = re.search(r'\(\s*\[([^\]]+)\]', expr or "")
+    return m.group(1) if m else None
+
+def expr_refs(expr):
+    """All column refs in a TS expr, normalized to worksheet display names."""
+    out = []
+    for ref in re.findall(r'\[([^\]]+)\]', expr or ""):
+        if "::" in ref:
+            ref = sigma_display_name(ref.split("::", 1)[1].strip())
+        out.append(ref)
+    return out
+
+def _balanced_two_args(s, start):
+    """Given s[start:] = '( a , b )…' return (a, b, end_index) honoring nesting."""
+    depth, args, cur, i = 0, [], "", start
+    while i < len(s):
+        ch = s[i]
+        if ch == "(":
+            depth += 1
+            if depth > 1:
+                cur += ch
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                args.append(cur.strip())
+                return args[0] if args else "", args[1] if len(args) > 1 else "", i + 1
+            cur += ch
+        elif ch == "," and depth == 1:
+            args.append(cur.strip()); cur = ""
+        else:
+            cur += ch
+        i += 1
+    return None, None, len(s)
+
+def _rewrite_safe_divide(s):
+    out = s
+    while True:
+        m = re.search(r'\bsafe_divide\s*\(', out, re.I)
+        if not m:
+            return out
+        a, b, end = _balanced_two_args(out, m.end() - 1)
+        if a is None:
+            return out
+        repl = f"If(IsNull({b}) or {b} = 0, null, {a} / {b})"
+        out = out[:m.start()] + repl + out[end:]
+
+def _convert_if_chain(s):
+    """`if ( c ) then a else b` (chained else-if) → nested If(...). Conditions in
+    the fleet/model TMLs are simple comparisons; nested-paren conditions are out
+    of scope (gap-scout catches them)."""
+    m = re.match(r'\s*if\s*\((.*?)\)\s*then\s*(.*?)\s*else\s*(.*)$', s, re.S | re.I)
+    if not m:
+        return s
+    cond, then, els = m.group(1).strip(), m.group(2).strip(), m.group(3).strip()
+    return f"If({cond}, {then}, {_convert_if_chain(els)})"
+
+def ts_expr_to_sigma(expr, ref):
+    """Translate a ThoughtSpot formula expr to a Sigma formula. `ref(name)` maps a
+    worksheet column display name to the Sigma reference to emit. Returns None
+    for window formulas (flag-not-drop, bead 5d9k)."""
+    if formula_class(expr) == "window":
+        return None
+    s = expr.strip()
+    s = re.sub(r'\[([^\]:]+)::([^\]]+)\]', lambda m: f"[{sigma_display_name(m.group(2).strip())}]", s)
+    s = _convert_if_chain(s)
+    # `<ref> in { "a" , "b" }` → In(<ref>, "a", "b")
+    s = re.sub(r'(\[[^\]]+\])\s+in\s*\{([^}]+)\}',
+               lambda m: f"In({m.group(1)}, {', '.join(v.strip() for v in m.group(2).split(','))})",
+               s, flags=re.I)
+    s = _UNIQUE_COUNT_RE.sub("CountDistinct(", s)
+    for ts_fn, sig_fn in [("count_distinct", "CountDistinct"), ("unique_count", "CountDistinct"),
+                          ("count_not_null", "CountDistinct"), ("std_deviation", "StdDev"),
+                          ("average", "Avg"), ("avg", "Avg"), ("variance", "Variance"),
+                          ("median", "Median"), ("sum", "Sum"), ("count", "Count"),
+                          ("max", "Max"), ("min", "Min")]:
+        s = re.sub(r'\b' + ts_fn + r'\s*\(', sig_fn + "(", s, flags=re.I)
+    s = _rewrite_safe_divide(s)
+    # Map every remaining bracketed ref through the resolver
+    s = re.sub(r'\[([^\]/]+)\]', lambda m: ref(m.group(1)), s)
+    return re.sub(r'\s+', ' ', s).strip()
+
+def model_formula_map(model_root):
+    """{formula display name: expr} from the model/worksheet TML."""
+    out = {}
+    for f in model_root.get("formulas", []) or []:
+        if f.get("name") and f.get("expr"):
+            out[f["name"]] = f["expr"]
+    return out

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-parity.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-parity.rb
@@ -73,10 +73,14 @@ end
 
 def round_row(row)
   # Convert all numerics to Float-rounded so Integer 11 and Float 11.0 compare equal in the set,
-  # and canonicalize date-like dim strings so equivalent monthly buckets match.
+  # canonicalize date-like dim strings so equivalent monthly buckets match, and
+  # coerce purely-numeric STRINGS to floats (Sigma CSV exports Quarter/Year as
+  # "2024" while ThoughtSpot searchdata returns 2024.0 — same bucket).
   row.map do |v|
     if v.is_a?(Numeric)
       v.to_f.round(2)
+    elsif v.is_a?(String) && v.strip.match?(/\A-?\d+(\.\d+)?\z/)
+      v.strip.to_f.round(2)
     else
       canonicalize_dim(v)
     end


### PR DESCRIPTION
Working fixes from the 2026-06-11 18-board fleet parity run (18/18 green, 93/93 tiles, bead d0qu):

- Parity planner now plans plain `table` and `pivot-table` tiles (previously skipped by design → 7 silently-thin PASSes caught by sentinel audit); pivot CSV matrix parsing
- Table-actuals dedupe: grouped tables with passthrough filter columns export at row grain, squaring counts (n→n²)
- **Chasm-trap guard**: dim-grain measures (e.g. CUSTOMER_DIM.LIFETIME_REVENUE) over-counted ~23× via denorm fan-out — dim-pure KPIs now source the raw dim element (C2 KPI 6,667,350.50 → 285,466.25, ties TS + warehouse exactly)
- export_csv saturation guard (60s-cooldown single retry)

Evidence: ~/thoughtspot-migration/FLEET-RUN-RESULTS.md, median 0.56 min/board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)