### PR TITLE
Cleanup wave A: PBI validator mirror, one-command friction, looker RLS scoping + live VISQA4 DM repair (2ybh/eqom/8nq5/xskt)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -29,10 +29,17 @@ of emitting wrong logic.
 ```bash
 node scripts/migrate-cognos.mjs \
   --module <module.json> --report <report.xml> \
-  --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID> \
+  --connection <SIGMA_CONNECTION_ID> \
+  [--folder <SIGMA_FOLDER_ID>] \
   [--database CSA --schema TJ] [--name '<prefix>'] \
   [--reuse-dm [ID]] [--expected expected.json] [--yes]
 ```
+
+`--folder` is optional: when omitted, the DM + workbook land in **your My
+Documents** (resolved automatically via `GET /v2/whoami`). To target a shared
+folder, look its id up first — `GET /v2/files?typeFilters=folder&limit=500`
+(match on `name`/`path`) — and pass `--folder <id>`. Converter deps install
+themselves on first run (`npm install` in `converter/`; needs Node ≥ 18 + npm).
 
 Chains every phase below in one process: module convert → DM-reuse scan
 (candidates printed; default BUILD NEW, `--reuse-dm` opts in) → DM
@@ -45,6 +52,10 @@ Parity is two-pass when `--expected` isn't supplied up front: pass 1 auto-export
 every element to CSV via the Sigma REST export API → `<workdir>/sigma-actuals.json`
 (keys `"<Element>/<Column>" = sum`, `"<Element>/rows" = count`), prints the
 `assert-parity --plan` mcp-v2 query list, then exits 10 with resume instructions.
+When two elements share a display name (a report can render the same query twice,
+e.g. two "Sheet 1 — qMain" tables), their parity keys are disambiguated with an
+elementId suffix — `"<Element> [<elementId>]/<Column>"` — so BOTH verify; copy
+the exact keys from `sigma-actuals.json` into `expected.json`.
 Build `expected.json` from the **Cognos** report's numbers (same keys, subset ok)
 and resume:
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
@@ -35,7 +35,10 @@
 // Usage:
 //   node scripts/migrate-cognos.mjs \
 //     --module <module.json> --report <report.xml> \
-//     --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID> \
+//     --connection <SIGMA_CONNECTION_ID> \
+//     [--folder <SIGMA_FOLDER_ID>]     # default: YOUR My Documents, resolved
+//                                      # via whoami (list candidates with
+//                                      # GET /v2/files?typeFilters=folder)
 //     [--database CSA] [--schema TJ] [--name '<prefix for DM/workbook names>'] \
 //     [--out DIR] [--expected expected.json] [--tol 0.01] \
 //     [--reuse-dm [dataModelId]]   # opt IN to DM reuse (default: build new;
@@ -75,7 +78,8 @@ if (!opt.resume) {
   if (!opt.module) die('missing --module <module.json>');
   if (!opt.report) die('missing --report <report.xml>');
   if (!opt.connection) die('missing --connection');
-  if (!opt.folder && !opt['dry-run']) die('missing --folder (post-and-readback requires one)');
+  // --folder is optional (bead eqom): when unset, the caller's My Documents is
+  // resolved via whoami right before the first POST (see resolveFolder).
 }
 const slug = basename((opt.module || opt.out || 'cognos')).replace(/\.[^.]+$/, '').replace(/[^A-Za-z0-9_-]/g, '-');
 const WORK = resolve(opt.out || join(homedir(), 'cognos-migration', slug));
@@ -127,6 +131,25 @@ async function api(method, path, body) {
   return { status: res.status, ok: res.ok, text, json };
 }
 
+// --folder default (bead eqom; prior art: migrate-tableau.rb's folderId
+// default). POST /v2/dataModels/spec and the workbook post both REQUIRE a
+// folderId — when none is supplied, resolve the caller's My Documents via
+// whoami and use it (never emit a folderless POST, never guess a folder).
+async function resolveFolder() {
+  const who = await api('GET', '/v2/whoami');
+  const uid = who.json?.userId;
+  if (!uid) die(`could not resolve My Documents: whoami → HTTP ${who.status} — pass --folder <id>`);
+  const mine = await api('GET', `/v2/members/${uid}/files`);
+  let entry = (mine.json?.entries || []).find((e) => e.path === 'My Documents');
+  if (!entry?.parentId) {
+    const all = await api('GET', '/v2/files?typeFilters=folder&limit=500');
+    entry = (all.json?.entries || []).find((e) => e.path === 'My Documents' && e.ownerId === uid);
+  }
+  if (!entry?.parentId) die('could not resolve the caller\'s My Documents folder id — pass --folder <id> (find one via GET /v2/files?typeFilters=folder)');
+  line(`no --folder supplied — using your My Documents (${entry.parentId})`);
+  return entry.parentId;
+}
+
 // Tiny CSV parser (quoted fields, no embedded newlines-in-quotes edge beyond basic).
 function parseCsv(text) {
   const rows = [];
@@ -173,8 +196,18 @@ async function runParity(state) {
   // Auto-actuals: export every data-bearing workbook element to CSV via REST
   // and aggregate to "<Element>/<Column>"=sum + "<Element>/rows"=count.
   const els = (state.wbElements || []).filter((e) => !['control', 'text'].includes(String(e.kind)));
+  // Duplicate display names (a Cognos report can render the same query twice —
+  // e.g. two "Sheet 1 — qMain" tables) would collide on a name-only parity key
+  // and only ONE would verify. Disambiguate dupes with an elementId suffix
+  // (bead eqom); unique names keep the plain key so existing expected.json
+  // files stay valid.
+  const nameCounts = {};
+  for (const e of els) nameCounts[e.name] = (nameCounts[e.name] || 0) + 1;
+  const keyOf = (e) => (nameCounts[e.name] > 1 ? `${e.name} [${e.id}]` : e.name);
+  const dupes = Object.entries(nameCounts).filter(([, n]) => n > 1);
   line('');
   line(`exporting ${els.length} element(s) for Sigma actuals…`);
+  if (dupes.length) line(`duplicate element name(s) ${dupes.map(([n]) => `'${n}'`).join(', ')} — parity keys get an elementId suffix: "<Name> [<elementId>]"`);
   const actuals = {};
   for (const e of els) {
     const post = await api('POST', `/v2/workbooks/${state.workbookId}/export`,
@@ -192,14 +225,15 @@ async function runParity(state) {
     const rows = parseCsv(body);
     const headers = rows[0] || [];
     const data = rows.slice(1);
-    actuals[`${e.name}/rows`] = data.length;
+    const key = keyOf(e);
+    actuals[`${key}/rows`] = data.length;
     headers.forEach((h, ci) => {
       const vals = data.map((r) => numish(r[ci])).filter((v) => v != null);
       if (vals.length === data.length && data.length > 0) {
-        actuals[`${e.name}/${h}`] = Number(vals.reduce((a, b) => a + b, 0).toFixed(6));
+        actuals[`${key}/${h}`] = Number(vals.reduce((a, b) => a + b, 0).toFixed(6));
       }
     });
-    line(`'${e.name}': ${data.length} row(s), ${headers.length} col(s)`);
+    line(`'${key}': ${data.length} row(s), ${headers.length} col(s)`);
   }
   const actualsPath = join(WORK, 'sigma-actuals.json');
   writeFileSync(actualsPath, JSON.stringify(actuals, null, 2));
@@ -258,9 +292,18 @@ if (opt.resume) {
 // Phase 1 — Convert the Data Module → Sigma DM spec (converter/cli.ts).
 // ---------------------------------------------------------------------------
 hdr(1, 'Convert data module');
-if (!existsSync(join(CONV, 'node_modules'))) {
+// One-time converter-deps preflight (bead eqom): node_modules existing is NOT
+// enough — the converter shells `node --import tsx/esm`, so require the tsx
+// binary specifically and fail with a clear, actionable error (not a cryptic
+// ERR_MODULE_NOT_FOUND three phases in).
+if (!existsSync(join(CONV, 'node_modules', '.bin', 'tsx'))) {
   line('converter deps missing — running npm install (once)…');
-  run('npm', ['install', '--silent'], { cwd: CONV });
+  const inst = run('npm', ['install', '--silent'], { cwd: CONV, allowFail: true });
+  if (inst.status !== 0 || !existsSync(join(CONV, 'node_modules', '.bin', 'tsx'))) {
+    die(`converter dependencies could not be installed automatically.\n` +
+        `  Run manually:  cd ${CONV} && npm install\n` +
+        `  (requires Node >= 18 and npm on PATH; the converter runs via tsx)`);
+  }
 }
 const modulePath = resolve(opt.module);
 const reportPath = resolve(opt.report);
@@ -381,6 +424,7 @@ if (opt['dry-run']) {
 }
 
 sigmaLogin();
+if (!opt.folder) opt.folder = await resolveFolder();
 const state = { workdir: WORK, moduleFile: modulePath, reportFile: reportPath,
   securityRules: securityDetected.length || 0 };
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
@@ -5,6 +5,10 @@ End-to-end: a Looker LookML model + its dashboards (UDD or LookML-defined) → a
 
 ## 0. ONE COMMAND (preferred)
 ```bash
+# env: SIGMA_CONNECTION_ID (full warehouse-connection UUID, NOT a short prefix)
+# is required unless --reuse-dm — persist it via setup.rb (~/.sigma-migration/env,
+# auto-sourced) or export it here:
+export SIGMA_CONNECTION_ID=<full-connection-uuid>
 # offline (fixtures work end-to-end):
 python3 scripts/migrate-looker.py --lookml-dir fixtures/skilltest-orders \
     --dashboard fixtures/skilltest-orders/skilltest_orders.dashboard.lookml \

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -55,6 +55,11 @@ Gates are never bypassed: the command exits non-zero if parity or
 `assert-phase6-ran.rb` fails.
 
 ```bash
+# env: SIGMA_CONNECTION_ID = the FULL warehouse-connection UUID (NOT a short
+# prefix) — required unless --reuse-dm. Persist it once via the tableau plugin's
+# `ruby scripts/setup.rb` (writes ~/.sigma-migration/env, which this command
+# auto-sources) or export it for the run:
+export SIGMA_CONNECTION_ID=<full-connection-uuid>
 # offline (.dashboard.lookml + view files; the fixture pair works end-to-end):
 python3 scripts/migrate-looker.py --lookml-dir fixtures/skilltest-orders \
     --dashboard fixtures/skilltest-orders/skilltest_orders.dashboard.lookml \

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/detect_rls.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/detect_rls.py
@@ -28,6 +28,15 @@ Usage:
     # also accepts a model JSON (e.g. from `looker_api.py raw GET
     # /lookml_models/<model>/explores/<explore>`) — its access_filters /
     # sql_always_where show up the same way.
+
+Scoping (bead 8nq5): a project dir can hold MANY models; RLS on a model the
+converted dashboard never touches must not hard-stop the migration. Pass
+    --scope-models m1,m2  and/or  --scope-explores e1,e2
+to partition findings: a finding positively attributable to ANOTHER model
+(source file `<other>.model.lkml`) or ANOTHER explore is demoted to
+informational. Un-attributable findings (e.g. Liquid user_attribute refs in a
+shared view file) stay IN scope — the safe default. With either flag, --json
+emits {"findings": [...], "informational": [...]} instead of a bare list.
 """
 import argparse
 import json
@@ -192,24 +201,63 @@ def render(findings):
     return "\n".join(lines)
 
 
+_MODEL_FILE = re.compile(r"^(.+)\.model\.(?:lkml|lookml)$")
+
+
+def split_scope(findings, models, explores):
+    """Partition findings into (in_scope, informational). A finding is demoted
+    ONLY when positively attributable to a model/explore outside the scope;
+    anything ambiguous stays in scope (never silently drop real RLS)."""
+    in_scope, info = [], []
+    for f in findings:
+        out = False
+        m = _MODEL_FILE.match(os.path.basename(str(f.get("source") or "")))
+        if models and m and m.group(1) not in models:
+            out = True
+        ex = f.get("explore")
+        if explores and ex and ex not in explores:
+            out = True
+        (info if out else in_scope).append(f)
+    return in_scope, info
+
+
 def main():
     ap = argparse.ArgumentParser(description="Scan LookML for RLS constructs (silent if none).")
     ap.add_argument("paths", nargs="+", help="LookML dir(s)/file(s) and/or model JSON")
     ap.add_argument("--json", action="store_true", help="emit findings as JSON")
+    ap.add_argument("--scope-models", help="comma-separated model name(s) the dashboard uses — "
+                    "findings on OTHER models become informational (bead 8nq5)")
+    ap.add_argument("--scope-explores", help="comma-separated explore name(s) the dashboard uses — "
+                    "findings on OTHER explores become informational")
     a = ap.parse_args()
 
     findings = scan(a.paths)
+    scoped = bool(a.scope_models or a.scope_explores)
+    informational = []
+    if scoped:
+        models = {m.strip() for m in (a.scope_models or "").split(",") if m.strip()}
+        explores = {e.strip() for e in (a.scope_explores or "").split(",") if e.strip()}
+        findings, informational = split_scope(findings, models, explores)
 
     # Zero-overhead happy path: nothing found → print nothing, exit clean.
-    if not findings:
+    if not findings and not informational:
         if a.json:
-            print("[]")
+            print(json.dumps({"findings": [], "informational": []}) if scoped else "[]")
         return 0
 
     if a.json:
-        print(json.dumps(findings, indent=2))
-    else:
+        print(json.dumps({"findings": findings, "informational": informational}, indent=2)
+              if scoped else json.dumps(findings, indent=2))
+        return 0
+    if findings:
         print(render(findings))
+    if informational:
+        print(f"\nINFORMATIONAL — {len(informational)} RLS finding(s) on model(s)/explore(s) "
+              "this dashboard does NOT use (no decision needed for THIS migration; "
+              "they matter when those models are migrated):")
+        for it in informational:
+            bits = [f"{k}={it[k]}" for k in ("explore", "field", "user_attribute", "name") if it.get(k)]
+            print(f"  - [{it['construct']}] {it['source']}: " + ("  ".join(bits) or "(matched)"))
     return 0
 
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -80,8 +80,43 @@ from build_workbook import build_field_index, disp, leaf
 HERE = os.path.dirname(os.path.abspath(__file__))
 T0 = time.time()
 MCP_TOOL = "mcp__sigma-data-model__convert_lookml_to_sigma"
+# ~/sigma-data-model-mcp FIRST: the Desktop copy is routinely a stale clone
+# (version-skew footgun, bead 8nq5) — prefer the canonical checkout and warn
+# loudly (warn_converter_skew) when whichever one resolves is behind origin/main.
 CONVERTER_HOMES = [os.path.expanduser(p) for p in
-                   ("~/Desktop/sigma-data-model-mcp", "~/sigma-data-model-mcp")]
+                   ("~/sigma-data-model-mcp", "~/Desktop/sigma-data-model-mcp")]
+
+
+def warn_converter_skew(resolved_path):
+    """Version-skew footgun (bead 8nq5): the resolved converter checkout may be
+    behind origin/main (e.g. a stale ~/Desktop clone). Compare HEAD vs
+    origin/main and warn LOUDLY — never silently convert with old rules."""
+    repo = resolved_path
+    while repo and repo != os.path.dirname(repo) and not os.path.isdir(os.path.join(repo, ".git")):
+        repo = os.path.dirname(repo)
+    if not repo or not os.path.isdir(os.path.join(repo, ".git")):
+        return
+    def _git(*args, timeout=None):
+        try:
+            p = subprocess.run(["git", "-C", repo, *args], capture_output=True,
+                               text=True, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            return None
+        return p.stdout.strip() if p.returncode == 0 else None
+    # A stale clone's LOCAL origin/main ref is stale too — refresh it (bounded;
+    # offline/slow networks fall back to the local ref, never block the run).
+    _git("fetch", "--quiet", "origin", "main", timeout=8)
+    head = _git("rev-parse", "HEAD")
+    main = _git("rev-parse", "origin/main")
+    if head and main and head != main:
+        print(f"\n   ════════ ⚠ CONVERTER VERSION SKEW ════════")
+        print(f"   converter checkout : {repo}")
+        print(f"   git HEAD           : {head[:12]}  ≠  origin/main {main[:12]}")
+        print(f"   This checkout does NOT match origin/main — converter fixes may be")
+        print(f"   missing (or unmerged local edits may be in play). Run:")
+        print(f"     git -C {repo} fetch && git -C {repo} log --oneline HEAD..origin/main")
+        print(f"   or set CONVERTER_SRC/CONVERTER_PATH at the checkout you intend to use.")
+        print("   " + "═" * 42)
 
 
 def hdr(n, total, title):
@@ -126,21 +161,52 @@ def sigma(method, path, body=None):
         raise RuntimeError(f"Sigma {method} {path} -> {e.code}: {e.read().decode()[:300]}")
 
 
+def my_documents_id():
+    """Caller's My Documents folder id via whoami (prior art:
+    migrate-tableau.rb's folderId default)."""
+    uid = json.loads(sigma("GET", "/v2/whoami"))["userId"]
+    entries = (json.loads(sigma("GET", f"/v2/members/{uid}/files")) or {}).get("entries") or []
+    entry = next((e for e in entries if e.get("path") == "My Documents"), None)
+    if entry and entry.get("parentId"):
+        return entry["parentId"]
+    entries = (json.loads(sigma("GET", "/v2/files?typeFilters=folder&limit=500")) or {}).get("entries") or []
+    entry = next((e for e in entries
+                  if e.get("path") == "My Documents" and e.get("ownerId") == uid), None)
+    return entry.get("parentId") if entry else None
+
+
 def resolve_folder(arg):
+    """--folder / SIGMA_FOLDER_ID, else an EXACT 'Looker Migrations' folder,
+    else create one under My Documents, else My Documents itself. The old
+    substring heuristic (LOOKER/MIGRATION/TEST) is gone — it happily dropped
+    Looker output into 'ThoughtSpot Migrations' (bead eqom)."""
     if arg:
         return arg
     if os.environ.get("SIGMA_FOLDER_ID"):
         return os.environ["SIGMA_FOLDER_ID"]
-    files = json.loads(sigma("GET", "/v2/files?typeFilters=folder&limit=200"))
+    files = json.loads(sigma("GET", "/v2/files?typeFilters=folder&limit=500"))
     entries = files.get("entries") or []
     pick = next((f for f in entries
-                 if any(k in (f.get("name") or "").upper()
-                        for k in ("LOOKER", "MIGRATION", "TEST"))),
-                entries[0] if entries else None)
-    if not pick:
-        sys.exit("FATAL: no writable folder found — pass --folder")
-    print(f"   no --folder supplied — using folder '{pick.get('name')}' ({pick['id']})")
-    return pick["id"]
+                 if (f.get("name") or "").strip().lower() == "looker migrations"), None)
+    if pick:
+        print(f"   no --folder supplied — using existing folder '{pick.get('name')}' ({pick['id']})")
+        return pick["id"]
+    mydocs = my_documents_id()
+    try:
+        body = {"name": "Looker Migrations", "type": "folder"}
+        if mydocs:
+            body["parentId"] = mydocs
+        created = json.loads(sigma("POST", "/v2/files", body))
+        fid = created.get("id") or created.get("fileId")
+        if fid:
+            print(f"   no --folder supplied — created folder 'Looker Migrations' ({fid})")
+            return fid
+    except Exception as ex:
+        print(f"   could not create 'Looker Migrations' folder ({str(ex)[:120]})")
+    if mydocs:
+        print(f"   no --folder supplied — using My Documents ({mydocs})")
+        return mydocs
+    sys.exit("FATAL: no writable folder found — pass --folder")
 
 
 def surface_converter_warnings(wd, warns):
@@ -406,17 +472,36 @@ def main():
           f"explore '{explore}' · {len(view_files)} view file(s), {len(measures)} measure(s) · workdir {wd}")
 
     # ── Phase 2 — RLS gate (zero overhead when clean; LOUD when not) ─────────
+    # Scoped to the model(s)/explore(s) THIS dashboard uses (bead 8nq5): RLS on
+    # other models in the same project dir is an informational note, not a stop.
     hdr(2, TOTAL, "RLS gate (detect_rls.py)")
-    p = subprocess.run(["python3", os.path.join(HERE, "detect_rls.py"), lookml_dir, "--json"],
-                       capture_output=True, text=True)
-    findings = []
+    dash_models = sorted({el.get("model") for el in dash["elements"] if el.get("model")})
+    dash_explores = sorted({e for e in explores if e} | ({explore} if explore else set()))
+    scope_args = []
+    if dash_models:
+        scope_args += ["--scope-models", ",".join(dash_models)]
+    if dash_explores:
+        scope_args += ["--scope-explores", ",".join(dash_explores)]
+    p = subprocess.run(["python3", os.path.join(HERE, "detect_rls.py"), lookml_dir,
+                        "--json"] + scope_args, capture_output=True, text=True)
+    findings, info_findings = [], []
     try:
         parsed = json.loads(p.stdout) if p.stdout.strip() else []
         findings = parsed.get("findings", parsed) if isinstance(parsed, dict) else parsed
+        info_findings = parsed.get("informational", []) if isinstance(parsed, dict) else []
     except ValueError:
         findings = []
+    if info_findings:
+        print(f"   ℹ {len(info_findings)} RLS finding(s) on OTHER model(s)/explore(s) in this "
+              f"project (dashboard uses {', '.join(dash_models or dash_explores)}) — "
+              "informational only, no gate:")
+        for f in info_findings[:5]:
+            print(f"     - [{f.get('construct')}] {f.get('source')}"
+                  + (f" explore={f.get('explore')}" if f.get("explore") else ""))
+        json.dump(info_findings, open(os.path.join(wd, "rls-out-of-scope.json"), "w"), indent=2)
     if not findings:
-        print("   no RLS constructs found — proceeding (zero-overhead happy path)")
+        print("   no RLS constructs found on this dashboard's model(s) — proceeding "
+              "(zero-overhead happy path)")
     else:
         print(f"   ⚠ {len(findings)} RLS finding(s):")
         for f in findings[:10]:
@@ -456,6 +541,9 @@ def main():
         build = os.environ.get("CONVERTER_PATH") or next(
             (os.path.join(h, "build", "lookml.js") for h in CONVERTER_HOMES
              if os.path.exists(os.path.join(h, "build", "lookml.js"))), None)
+        if src or build:
+            print(f"   converter: {src or build}")
+            warn_converter_skew(src or build)
         if src:
             repo = os.path.dirname(os.path.dirname(src))
             run(["node", "--import", "tsx/esm", os.path.join(HERE, "convert_dm.mjs"),

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
@@ -248,7 +248,15 @@ if opts[:type] == 'workbook'
     end
     next if masters.empty?
 
-    others = els.reject { |e| masters.include?(e) }
+    # HIDDEN helper tables that source a master (visibleAsSource:false, e.g.
+    # the scatter grouped-source tables — bead z1d0/ry0n) are data-page
+    # citizens, not content: exempt them from the mixing rule.
+    master_ids = masters.map { |m| m['id'] }
+    helpers = els.select do |e|
+      e['kind'] == 'table' && e['visibleAsSource'] == false &&
+        e.dig('source', 'kind') == 'table' && master_ids.include?(e.dig('source', 'elementId'))
+    end
+    others = els.reject { |e| masters.include?(e) || helpers.include?(e) }
     unless others.empty?
       master_names = masters.map { |m| m['name'] || m['id'] }.join(', ')
       kind_counts = Hash.new(0)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -37,6 +37,8 @@ ruby scripts/migrate-quicksight.rb \
 
 Exit 0 = parity + hard gate green; exit 10 = a gate (converter MCP / parity collection / OPEN QUESTIONS) printed its exact resume command; exit 3 = parity fail. Each phase prints a visible header — it is not a black box. The per-script phases below remain the reference for running any stage by hand.
 
+`--folder` accepts a folder **id or exact name** (name is looked up via `/v2/files`; ambiguous names abort with candidates). Re-running the same command with the same `--out` after a mid-run crash is **idempotent**: a DM/workbook already posted by that workdir is detected (dm-readback.json / wb-id.txt), verified live, and reused — never duplicated. Use a fresh `--out` for a fresh build.
+
 ## Phase 1 — Auth
 
 **QuickSight (AWS CLI).**
@@ -173,6 +175,12 @@ ruby scripts/assert-phase6-ran.rb --workdir /tmp/<name> --workbook-id <WORKBOOK_
 **POST success ≠ working.** You MUST query-verify the built elements:
 - `sigma-mcp-v2 query` each element → confirm real rows (not blank / not all `error`).
 - True parity: compare each Sigma aggregation against the same aggregation computed from the QuickSight side (or the warehouse). `assert-phase6-ran.rb` is a hard gate — a subagent must run it and it must pass before reporting success.
+- **mcp-v2 warehouse-side (EXPECTED) queries can NOT use the raw warehouse FQN**
+  (`SELECT … FROM DB.SCHEMA.TABLE` fails): with `type=connection` the table must
+  be addressed as `"connection"."<inodeId>"`, where `<inodeId>` is the table's
+  inode from `GET /v2/connections/{connectionId}/lookup?path=…` (or a prior DM
+  spec's `source.path`). The Sigma-ACTUAL side (`type=workbook` →
+  `"workbook"."<elementId>"`) follows the same quoting pattern.
 
 ## Gotchas (carry these forward)
 - **Enterprise edition is mandatory** for the `describe-*-definition` APIs. Standard rejects them outright — there's no fallback extraction.

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
@@ -21,9 +21,16 @@
 # Usage (live):
 #   ruby scripts/migrate-quicksight.rb \
 #     --analysis-id <ID> --account-id <ACCT> --region <REGION> --profile <PROFILE> \
-#     --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID> \
+#     --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID-or-name> \
 #     [--database DB --schema SCH] [--name "My Dashboard"] \
 #     [--out DIR] [--answers '<json>'] [--yes]
+#   --folder accepts a folder id OR an exact folder NAME (looked up via
+#   /v2/files; ambiguous names abort with the candidate ids).
+#
+# IDEMPOTENT RESUME: re-running with the same --out after a mid-run crash
+# NEVER duplicates the DM or workbook — ids already posted by this workdir
+# (dm-readback.json / wb-id.txt) are verified live and reused. Use a fresh
+# --out (or delete the workdir) to force a fresh build.
 #
 # Usage (offline fixtures — no AWS needed):
 #   ruby scripts/migrate-quicksight.rb --from-fixtures fixtures/ \
@@ -325,6 +332,19 @@ end
 # attach to it (--reuse-dm <id>), but never silently reuses.
 # ---------------------------------------------------------------------------
 require 'sigma_rest' # also loads ~/.sigma-migration/env for the child scripts
+
+# --folder accepts a NAME or an id (bead eqom): anything that isn't a UUID is
+# looked up by exact (case-insensitive) folder name via /v2/files.
+if opts[:folder] && opts[:folder] !~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+  want = opts[:folder].strip.downcase
+  entries = (Sigma.request(:get, '/v2/files?typeFilters=folder&limit=500')['entries'] rescue []) || []
+  hits = entries.select { |e| (e['name'] || '').strip.downcase == want }
+  abort "FATAL: --folder #{opts[:folder].inspect} matched no folder by name — list them via GET /v2/files?typeFilters=folder, or pass an id" if hits.empty?
+  abort "FATAL: --folder #{opts[:folder].inspect} is ambiguous (#{hits.size} folders named that): #{hits.map { |h| h['id'] }.join(', ')} — pass an id" if hits.size > 1
+  puts "   --folder resolved by name: '#{hits[0]['name']}' → #{hits[0]['id']}"
+  opts[:folder] = hits[0]['id']
+end
+
 hdr('2.5', TOTAL, 'DM reuse check')
 if opts[:reuse_dm]
   puts "   --reuse-dm #{opts[:reuse_dm]} — attaching to the existing DM (Phase 3 skipped)"
@@ -358,7 +378,24 @@ end
 hdr(3, TOTAL, 'Build data model')
 dm_spec = File.join(WORK, 'dm-spec.json')
 dm_readback = File.join(WORK, 'dm-readback.json')
-if opts[:reuse_dm]
+# Idempotent resume BEFORE the parity state (bead eqom): a mid-run crash after
+# the DM POST must not create a duplicate DM on re-run. dm-readback.json is
+# written only by a successful post — when this workdir already has one,
+# verify the DM still exists and REUSE it.
+prior_dm = File.exist?(dm_readback) ? (JSON.parse(File.read(dm_readback))['dataModelId'] rescue nil) : nil
+if prior_dm && !opts[:reuse_dm]
+  if (Sigma.request(:get, "/v2/dataModels/#{prior_dm}") rescue nil)
+    dm_id = prior_dm
+    puts "   idempotent resume: dataModelId #{dm_id} was already posted by a prior run of"
+    puts "   this workdir — REUSING it (no duplicate DM). Use a fresh --out for a fresh build."
+  else
+    puts "   prior dataModelId #{prior_dm} in #{dm_readback} no longer exists — rebuilding"
+    prior_dm = nil
+  end
+end
+if dm_id
+  # reused above — nothing to post
+elsif opts[:reuse_dm]
   # Read the existing DM's spec back and synthesize the dm-readback artifact the
   # workbook builder consumes (element names/ids). The spec endpoint answers in
   # YAML even when asked for JSON — parse both.
@@ -398,6 +435,23 @@ end
 # ---------------------------------------------------------------------------
 hdr(4, TOTAL, 'Build workbook')
 wb_spec = File.join(WORK, 'wb-spec.json')
+wb_readback = File.join(WORK, 'wb-readback.json')
+# Idempotent resume (bead eqom): a workbook already posted by this workdir is
+# reused — never duplicated. wb-id.txt is the primary record; wb-readback.json
+# still holds workbookId when the crash hit before wb-id.txt was written.
+prior_wb = File.exist?(wb_id_path) ? File.read(wb_id_path).strip : nil
+prior_wb = (JSON.parse(File.read(wb_readback))['workbookId'] rescue nil) if (prior_wb.nil? || prior_wb.empty?) && File.exist?(wb_readback)
+if prior_wb && !prior_wb.empty?
+  if (Sigma.request(:get, "/v2/workbooks/#{prior_wb}") rescue nil)
+    wb_id = prior_wb
+    File.write(wb_id_path, wb_id)
+    puts "   idempotent resume: workbook #{wb_id} was already posted by a prior run of"
+    puts "   this workdir — REUSING it (no duplicate workbook). Use a fresh --out for a fresh build."
+  else
+    puts "   prior workbookId #{prior_wb} no longer exists — rebuilding"
+  end
+end
+unless wb_id
 build = ['ruby', File.join(HERE, 'build-workbook-from-quicksight.rb'),
          '--analysis', File.join(WORK, 'analysis.json'),
          '--dm-readback', dm_readback, '--out', wb_spec]
@@ -411,7 +465,6 @@ if opts[:name]
   j['name'] = opts[:name]
   File.write(wb_spec, JSON.pretty_generate(j))
 end
-wb_readback = File.join(WORK, 'wb-readback.json')
 run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
       '--spec', wb_spec, '--out', wb_readback, '--workdir', WORK])
 wb_id = JSON.parse(File.read(wb_readback))['workbookId']
@@ -419,6 +472,7 @@ wb_id = JSON.parse(File.read(wb_readback))['workbookId']
 # key), so persist the id separately — the parity-finalize resume needs it.
 File.write(wb_id_path, wb_id)
 puts "   workbookId = #{wb_id}"
+end # unless wb_id (idempotent resume)
 
 # ---------------------------------------------------------------------------
 # Phase 5 — Layout (build-quicksight-layout.rb infers the QS grid width — the

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/put-layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/put-layout.rb
@@ -14,12 +14,15 @@
 #   ruby put-layout.rb --workbook <wbId> --layout <layout.xml> \
 #     [--elements <elements.json>]
 
-require 'net/http'
-require 'uri'
 require 'json'
 require 'yaml'
 require 'date'
 require 'optparse'
+# sigma_rest self-exchanges SIGMA_CLIENT_ID/SECRET (auto-loading
+# ~/.sigma-migration/env) exactly like the phase 1-4 scripts — SIGMA_API_TOKEN
+# is optional, not a hard requirement (bead eqom).
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
 
 opts = {}
 OptionParser.new do |p|
@@ -29,24 +32,14 @@ OptionParser.new do |p|
 end.parse!
 %i[wb layout].each { |k| abort("missing --#{k}") unless opts[k] }
 
-BASE = ENV.fetch('SIGMA_BASE_URL')
-TOK  = ENV.fetch('SIGMA_API_TOKEN')
-
 def http(method, path, body = nil)
-  uri = URI("#{BASE}#{path}")
-  req = case method
-        when :get then Net::HTTP::Get.new(uri)
-        when :put then r = Net::HTTP::Put.new(uri); r.body = body; r['Content-Type'] = 'application/json'; r
-        end
-  req['Authorization'] = "Bearer #{TOK}"
-  req['Accept']        = 'application/json'
-  Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
+  Sigma.request(method, path, body: body, binary: true)
 end
 
 xml = File.read(opts[:layout])
 abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
 
-spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec").body)
+spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec"))
 spec['pages'].each { |p| p.delete('layout') }
 spec['layout'] = xml
 
@@ -73,7 +66,12 @@ if File.exist?(elements_path)
 end
 %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
 
-resp = http(:put, "/v2/workbooks/#{opts[:wb]}/spec", JSON.pretty_generate(spec))
-parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+begin
+  resp_body = http(:put, "/v2/workbooks/#{opts[:wb]}/spec", JSON.pretty_generate(spec))
+rescue Sigma::Error => e
+  puts "ERROR: #{e.message}"
+  exit 1
+end
+parsed = YAML.safe_load(resp_body, permitted_classes: [Date, Time])
 puts parsed['workbookId'] ? "PUT ok: workbookId=#{parsed['workbookId']}" : "ERROR: #{parsed.inspect}"
 exit(parsed['workbookId'] ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb
@@ -47,19 +47,28 @@ print "Client Secret: "
 sec = $stdin.noecho(&:gets).chomp
 puts
 
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
 settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
 settings["env"] ||= {}
 settings["env"]["SIGMA_BASE_URL"]      = base
 settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
-upsert_neutral_env(
+pairs = {
   "SIGMA_BASE_URL"      => base,
   "SIGMA_CLIENT_ID"     => cid,
   "SIGMA_CLIENT_SECRET" => sec,
-)
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
 
 puts
 puts "Credentials saved to:"


### PR DESCRIPTION
Closes out 4 small cleanup items, each E2E-tested before this PR. Items 1–3 are repo changes; item 4 (xskt) is a live-artifact repair documented here (no repo change).

## 1. 2ybh — PBI validator mirror
`powerbi-to-sigma/scripts/validate-spec.rb` now carries tableau's one-hunk exemption: hidden helper tables (`visibleAsSource:false`, `source.kind=table`) that source a data-page master are data-page citizens — the PBI builder's own ry0n scatter grouped-source emission no longer self-rejects.

**Test (offline):** synthetic scatter fixture through `build-workbook-from-pbir.rb` → new validator passes (`--- 0 errors`), origin/main validator rejects the same spec (`page "Data" mixes master table(s) [EMP] with 1 table`); an injected bar-chart on the Data page still fails (`2 errors`, exit 1).

## 2. eqom — one-command friction
- **(a)** `setup.rb` optionally captures `SIGMA_CONNECTION_ID` → `~/.claude/settings.json` + `~/.sigma-migration/env`; looker SKILL.md/QUICKSTART one-command sections now document it (qlik/cognos/QS/tableau/TS already pass it explicitly in theirs).
- **(b)** looker `resolve_folder`: exact `"Looker Migrations"` match → else create it under My Documents (whoami, migrate-tableau.rb prior art) → else My Documents. The substring heuristic that matched **"ThoughtSpot Migrations"** is removed.
- **(c)** cognos `migrate-cognos.mjs`: `--folder` optional (defaults to caller's My Documents via whoami; folder-lookup hint in SKILL.md); converter preflight checks for the `tsx` binary and errors actionably if `npm install` can't produce it; **duplicate element names get elementId-suffixed parity keys** (`"<Name> [<elementId>]/<Column>"`).
- **(d)** QS: `put-layout.rb` self-exchanges `SIGMA_CLIENT_ID/SECRET` via `lib/sigma_rest` like phases 1–4; `migrate-quicksight.rb` is **idempotent before the parity state** (posted ids in `dm-readback.json`/`wb-id.txt` are verified live and reused — mid-run crash never duplicates DM/workbook); `--folder` accepts an exact name or id; SKILL.md parity section documents the mcp-v2 `"connection"."<inodeId>"` FQN requirement.

## 3. 8nq5 — looker RLS gate scoping + converter footgun
- `detect_rls.py --scope-models/--scope-explores`: findings positively attributable to a model/explore the converted dashboard does NOT use are demoted to informational (`{findings, informational}` JSON); un-attributable findings stay in scope (safe default). `migrate-looker.py` passes the dashboard's models/explores, prints out-of-scope findings as a note (`rls-out-of-scope.json`) and exits 10 only on in-scope findings.
- `CONVERTER_HOMES` prefers `~/sigma-data-model-mcp` over `~/Desktop/...`; `warn_converter_skew` (bounded `git fetch` + HEAD vs origin/main) warns loudly on version skew.

## 4. xskt — stale broken VISQA4 trial DM (live repair, no repo change)
DM `09c8be53-5f84-4ec4-a1eb-66794622e849` ("VISQA4 Tableau ORDER_FACT…", sourced by workbook `3e23b761` "VISQA4 Tableau Orders Overview — ENHANCED (trial)") carried the pre-FATSCALE date-join mis-keying: relationship `ulmbC5iebC` (Order Fact → Date Dim) was keyed on **Return Date Key** (`_pxxNwB3ft`) instead of **Order Date Key** (`ik8r-MpGxO`).

**Before:** master `Full Date` **248/249 NULL (99.6%)**.
**Fix:** single-key relationship re-key via DM spec PUT (FATSCALE relationship-surgery pattern). Readback confirms the re-key persisted and **no element/column ids churned** (no remap needed).
**After:** master `Full Date` **0/249 NULL (0.0%)**; spot-check `Full Date == Order Date Key` on all 249 rows (0 mismatches). Affected views unchanged and correct: Monthly Revenue Trend 6 buckets (Jan 2026 = 1959.35), Net Revenue YTD 34922.55, YoY 0.93545786 — identical pre/post because the trial's Phase-E columns derive from Order Date Key arithmetic; the DM's `Full Date (DATE_DIM)` passthrough now also resolves. Nothing else about the artifact changed.

## E2E evidence (org tj-wells-1989, creds `~/.sigma-migration/env`, all "CLEANA …" test objects deleted after green)
- **looker** one-command, fixtures + synthetic other-model RLS (`finance.model.lkml` access_filter + sql_always_where): scoped to informational, **no exit 10**; skew warning fired on the resolved checkout; `Looker Migrations` folder created (then reused on a second resolve — no duplicate); **parity 5/5 strict, hard gate PASS, exit 0** (31.7s).
- **cognos** one-command, go-sales fixtures (synthetic CSA.TJ tables verified present): npm preflight auto-installed converter deps; My Documents default resolved via whoami; duplicate `Sheet 1 — qMain` parity keys disambiguated — **PARITY GREEN 17/17** incl. both duplicates (`[6EZ0TKT9l3]` 1 row / `[Bvy0bOIl0M]` 2 rows, Swap Measure 2000.5 each, expected derived independently from the source DB).
- **quicksight** one-command, fixtures: `--folder "QuickSight Migrations"` resolved by name; deliberate `kill -9` right after the DM POST → re-run reused DM `4f517b61` (no duplicate; org scan showed exactly one "CLEANA QS DM"), third run reused the workbook too; `put-layout.rb` ran standalone with `SIGMA_API_TOKEN` unset (origin/main version KeyErrors, new version `PUT ok`); **parity 5/5 strict + assert-phase6-ran hard gate PASS, exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)