### PR TITLE
Workstream B: qlik + powerbi builders emit controls targeted per the source's intended scope

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -64,6 +64,15 @@ OptionParser.new do |p|
   # its own name is a generic auto-name ("Page 1"). See resolve_header_title.
   p.on('--source-title NAME') { |v| opts[:source_title] = v }
   p.on('--folder-id ID')     { |v| opts[:folder] = v }
+  # Control-targeting wave (workstream B): the TMSL model (model.bim / .tmsl)
+  # supplies the relationships a PBI slicer's filter flows through, so each
+  # control can be wired to EVERY master whose table the slicer reaches —
+  # not just the master the sliced column lives on. Optional: without it,
+  # slicers wire same-table masters only (a WARN says the scope was reduced).
+  p.on('--model PATH')       { |v| opts[:model] = v }
+  # Where the intended-scope contract lands (consumed by workstream A's lint).
+  # Default: control-scope.json next to --out.
+  p.on('--control-scope-out PATH') { |v| opts[:scope_out] = v }
 end.parse!
 %i[sig mmap out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
 
@@ -71,6 +80,98 @@ signals = JSON.parse(File.read(opts[:sig]))
 mmap    = JSON.parse(File.read(opts[:mmap]))
 fields  = mmap['fields'] || {}
 masters = mmap['masters'] || {}
+
+# ---------------------------------------------------------------------------
+# Slicer relationship scope (control-targeting wave, workstream B).
+# A PBI slicer filters its page ACROSS related tables: the filter flows from
+# the sliced table along model relationships (one side -> many side; both ways
+# when crossFilteringBehavior is bothDirections; inactive rels don't flow).
+# ---------------------------------------------------------------------------
+_tmsl = opts[:model] && File.exist?(opts[:model]) ? (JSON.parse(File.read(opts[:model])) rescue nil) : nil
+_tmodel = _tmsl && (_tmsl['model'] || _tmsl)
+MODEL_RELATIONSHIPS = _tmodel ? (_tmodel['relationships'] || []) : []
+MODEL_TABLES_FULL = _tmodel ? (_tmodel['tables'] || []) : []
+MODEL_TABLES = MODEL_TABLES_FULL.map { |t| t['name'].to_s }
+warn '[build-workbook] NOTE: no --model TMSL given — slicer controls wire same-table masters only ' \
+     '(relationship-scoped targets need the model).' if _tmodel.nil?
+
+# Tables reachable by a filter applied on `entity` (always includes entity).
+def reachable_entities(entity)
+  adj = Hash.new { |h, k| h[k] = [] }
+  MODEL_RELATIONSHIPS.each do |r|
+    next if r['isActive'] == false                       # inactive: no filter flow
+    from = r['fromTable'].to_s                           # many side
+    to   = r['toTable'].to_s                             # one side
+    adj[to] << from                                      # one filters many (PBI default)
+    adj[from] << to if r['crossFilteringBehavior'].to_s =~ /both/i
+  end
+  seen = [entity]
+  queue = [entity]
+  until queue.empty?
+    adj[queue.shift].each do |t|
+      next if seen.include?(t)
+      seen << t
+      queue << t
+    end
+  end
+  seen
+end
+
+# entity -> masters that can resolve at least one of its fields (primary + alts).
+# Derived/restructured elements (Dense Rank …, time-intel, Custom SQL calc
+# tables) surface as PSEUDO entities here — names that are not TMSL tables.
+def entity_master_coverage(fields)
+  cov = Hash.new { |h, k| h[k] = [] }
+  fields.each do |k, v|
+    ent = k.to_s.split('.').first
+    ([v['master']] + Array(v['alts']).map { |a| a['master'] }).compact.each do |m|
+      cov[ent] << m unless cov[ent].include?(m)
+    end
+  end
+  cov
+end
+
+# Find the column on a master matching the sliced leaf. Exact (case/​separator-
+# insensitive) name match wins; else a disambiguated "Leaf (ENTITY)" view column
+# — preferring the sliced entity's own. Returns the column hash or nil. NEVER
+# falls back to an arbitrary column (that was the silent wrong-column bug).
+def match_master_column(mrec, leaf, prefer_entity = nil)
+  norm = ->(s) { s.to_s.downcase.gsub(/[^a-z0-9]/, '') }
+  cols = mrec['columns'] || []
+  nl = norm.call(leaf)
+  exact = cols.find { |c| norm.call(c['name']) == nl }
+  return exact if exact
+  cands = cols.select do |c|
+    m = c['name'].to_s.match(/\A(.+?)\s+\(([^)]+)\)\s*\z/)
+    m && norm.call(m[1]) == nl
+  end
+  preferred = prefer_entity && cands.find do |c|
+    c['name'].to_s =~ /\(\s*#{Regexp.escape(prefer_entity)}\s*\)\s*\z/i
+  end
+  preferred || cands.first
+end
+
+# Intended-scope contract accumulators -> control-scope.json (the sidecar
+# workstream A's control lint consumes — schema in lib/control_lint.rb header
+# CONTRACT + refs/control-parity.md). `$control_scope` gets one entry per
+# EMITTED control ({controlId, sourceName, scope:[element ids], excluded:[...]});
+# `$control_unbound` records slicers that produced NO control element (an
+# unresolvable column is dropped LOUDLY, never wired to a wrong column and
+# never shipped dead) so the sidecar carries the full source-signal story.
+$control_scope = []
+$control_unbound = []
+$used_control_ids = Hash.new(0)
+
+# TMSL column type for ENTITY.LEAF — date-typed slicers must become date-range
+# controls: a `list` control bound to a datetime column posts fine but Sigma
+# SILENTLY STRIPS its filter targets (known estate-repair gotcha).
+def tmsl_date_column?(ent, leaf)
+  return false if MODEL_TABLES.empty?
+  tmodel_tables = MODEL_TABLES_FULL
+  t = tmodel_tables.find { |tb| tb['name'].to_s == ent.to_s }
+  c = t && (t['columns'] || []).find { |col| col['name'].to_s.casecmp(leaf.to_s).zero? }
+  !!(c && c['dataType'].to_s =~ /date/i)
+end
 
 SIGMA_KIND = {
   'kpi' => 'kpi-chart', 'bar' => 'bar-chart', 'line' => 'line-chart',
@@ -229,6 +330,16 @@ def apply_fmt(col, queryref, fields, vfmts)
   col
 end
 
+# A field spec is a MEASURE unless it is a bare stored-column reference. The
+# old `agg`/`formula`-emptiness test misclassified auto-derived master-map
+# metrics (always agg:nil with the full expression in `ref`, e.g.
+# "Median([m/Annual Salary])") as dimensions — tables then built UNGROUPED
+# (1 row per source row) and scatters skipped their grouped source (ry0n).
+def measure_ref?(fs)
+  return true unless fs['agg'].to_s.empty? && fs['formula'].to_s.empty?
+  !(fs['ref'].to_s =~ /\A\[[^\]]+\]\z/)
+end
+
 def measure_formula(fs)
   # bead qb2i: an explicit `formula` wins — lets the master-map emit a verbatim
   # Sigma expression (e.g. a window calc "Lag(Sum([X/v]), 1)" / "Rank(Sum([X/v]),
@@ -381,28 +492,102 @@ def build_element(rec, fields, masters, extra_data = [])
 
   case kind
   when 'control'
-    # bead 14w(a)/6z5: a PBI slicer -> a Sigma `list` control bound to the sliced
-    # column on its master element. Valid shape (controls.md): controlType:list +
-    # controlId + mode + selectionMode + values[] + source{kind:source,...} +
-    # filters[]. The control defines NO columns of its own — it references the
-    # master's existing column id, so it both populates from and filters that col.
+    # bead 14w(a)/6z5 + control-targeting wave (workstream B): a PBI slicer -> a
+    # Sigma `list` control bound to the sliced column on its master element.
+    # Valid shape (controls.md): controlType:list + controlId + mode +
+    # selectionMode + values[] + source{kind:source,...} + filters[]. The control
+    # defines NO columns of its own — it references master columns by id.
+    #
+    # TARGETING: a PBI slicer filters its whole page ACROSS related tables, so
+    # the control's filters[] gets one entry per master the slicer's filter
+    # reaches: the sliced table's own master(s) always, plus every master
+    # covering a table reachable via model relationships (one->many flow;
+    # bothDirections adds the reverse), plus derived/restructured elements
+    # (pseudo entities) that carry the sliced column. A slicer column that
+    # cannot be resolved to a real master column SKIPS the control with a LOUD
+    # warning — never silently wires the wrong column (the old `|| mcols.first`).
     qr = (b['Values'] || b['Category'] || b['Fields'] || []).first
-    colname = qr_leaf(qr, 'Filter')
-    mcols = (master && masters[master] ? (masters[master]['columns'] || []) : [])
-    mcol = mcols.find { |c| c['name'] == colname } || mcols.first
-    tgt = mcol ? mcol['id'] : nil
-    el['kind'] = 'control'
-    el['controlId'] = colname.gsub(/[^A-Za-z0-9]/, '') + 'Filter'
-    el['name'] = colname
-    el['controlType'] = 'list'
-    el['mode'] = 'include'
-    el['selectionMode'] = 'multiple'
-    el['values'] = []
-    el.delete('source')
-    if master_id && tgt
-      el['source']  = { 'kind' => 'source', 'source' => { 'kind' => 'table', 'elementId' => master_id }, 'columnId' => tgt }
-      el['filters'] = [{ 'source' => { 'kind' => 'table', 'elementId' => master_id }, 'columnId' => tgt }]
+    leaf = qr_leaf(qr, 'Filter')
+    ent  = qr.to_s.split('.').first
+    fs = qr && field_spec(qr, fields)
+    pmaster = fs && fs['master']
+    pm = pmaster && masters[pmaster]
+    pcol = pm && match_master_column(pm, leaf, ent)
+    if pm.nil? || pcol.nil?
+      warn "[build-workbook] ERROR slicer '#{name}' (#{vid}): column '#{qr}' does not resolve to a " \
+           "column on any master (resolved master=#{pmaster.inspect}) — control SKIPPED. " \
+           'Fix the master-map (or add the column to the master) and re-run; a control must ' \
+           'never be silently wired to the wrong column.'
+      $control_unbound << { 'sourceName' => "slicer #{name} (#{vid}) column #{qr}",
+                            'status' => 'unbound',
+                            'reason' => "column '#{qr}' resolves to no master column " \
+                                        "(master=#{pmaster.inspect}); dropped loudly rather than " \
+                                        'wired to a wrong column or shipped dead' }
+      return nil
     end
+    reach = MODEL_RELATIONSHIPS.any? || MODEL_TABLES.any? ? reachable_entities(ent) : [ent]
+    cov = entity_master_coverage(fields)
+    filters, wired, unwired = [], [], []
+    masters.each do |mname, mrec|
+      ents = cov.select { |_e, ms| ms.include?(mname) }.keys
+      real = MODEL_TABLES.any? ? (ents & MODEL_TABLES) : ents
+      pseudo = MODEL_TABLES.any? && real.empty?      # derived/restructured element
+      in_scope = (real & reach).any? || mname == pmaster
+      col = match_master_column(mrec, leaf, ent)
+      # pseudo elements: only when they actually carry the sliced column —
+      # column-name evidence is the best provenance we have for restructured
+      # (Dense Rank / time-intel / calc-table SQL) elements.
+      in_scope ||= pseudo && !col.nil?
+      next unless in_scope
+      if col.nil?
+        unwired << mname
+        next
+      end
+      filters << { 'source' => { 'kind' => 'table', 'elementId' => mrec['id'] }, 'columnId' => col['id'] }
+      wired << mname
+    end
+    unless unwired.empty?
+      warn "[build-workbook] WARN slicer '#{name}': master(s) #{unwired.join(', ')} are in the " \
+           "slicer's relationship scope but carry no column matching '#{leaf}' — NOT wired. " \
+           'Charts on those masters will not respond to this control; add the related column ' \
+           'to the master (cross-element ref) to wire it.'
+    end
+    ctl_id = (title_leaf(qr) || leaf).gsub(/[^A-Za-z0-9]/, '') + 'Filter'
+    n = ($used_control_ids[ctl_id] += 1)
+    ctl_id = "#{ctl_id}#{n}" if n > 1     # two slicers on one column: unique ids
+    el['kind'] = 'control'
+    el['controlId'] = ctl_id
+    el['name'] = name
+    if tmsl_date_column?(ent, leaf)
+      # date-typed slicer -> date-range control. A `list` control bound to a
+      # datetime column gets its filter targets SILENTLY STRIPPED by Sigma
+      # (estate-repair gotcha) — the control posts, then filters nothing.
+      # date-range needs no `source` (columns come from `filters`) but DOES
+      # require a flat `mode` — without it the POST 400s with the misleading
+      # "Invalid kind: control" (live-verified 2026-06-12).
+      el['controlType'] = 'date-range'
+      el['mode'] = 'between'
+      el['includeNulls'] = 'when-no-value-is-selected'
+    else
+      el['controlType'] = 'list'
+      el['mode'] = 'include'
+      el['selectionMode'] = 'multiple'
+      el['values'] = []
+      el['source'] = { 'kind' => 'source', 'source' => { 'kind' => 'table', 'elementId' => pm['id'] }, 'columnId' => pcol['id'] }
+    end
+    el['filters'] = filters
+    $control_scope << { 'controlId' => ctl_id,
+                        'sourceName' => "slicer #{name} (#{vid}) column #{qr}",
+                        'status' => 'wired',
+                        'reachableTables' => reach,
+                        'wiredMasters' => wired,
+                        'unwiredMasters' => unwired,
+                        # internal (stripped before write): resolved to the
+                        # scope allowlist + excluded[] at page assembly.
+                        '_visual_id' => vid,
+                        '_leaf' => leaf,
+                        '_wired_ids' => filters.map { |f| f.dig('source', 'elementId') },
+                        'scope' => [], 'excluded' => [] }
   when 'kpi-chart'
     # A single-value PBI card -> kpi-chart. A multiRowCard (multiple Values) ->
     # ONE kpi-chart tile per measure (bead x81l: a kpi-chart renders only
@@ -533,7 +718,7 @@ def build_element(rec, fields, masters, extra_data = [])
     detail = (b['Category'] || b['Details'] || b['Series'] || b['Legend'] || []).first
     sizeqr = (b['Size'] || []).first
     xfs = field_spec(xqr, fields, master); yfs = field_spec(yqr, fields, master)
-    is_meas = ->(fs) { !(fs['agg'].to_s.empty? && fs['formula'].to_s.empty?) }
+    is_meas = ->(fs) { measure_ref?(fs) }
     if is_meas.call(xfs) && detail && master_id
       # bead ry0n: Sigma's scatter xAxis is a GROUPING axis — binding an AGGREGATE
       # to it makes the aggregate evaluate per-row (Count -> 1) and every point
@@ -635,7 +820,7 @@ def build_element(rec, fields, masters, extra_data = [])
     (b['Values'] || []).each_with_index do |qr, i|
       fs = field_spec(qr, fields, master)
       cid = "#{eid}-c#{i}"
-      is_dim = fs['agg'].to_s.empty? && fs['formula'].to_s.empty?
+      is_dim = !measure_ref?(fs)
       col = { 'id' => cid, 'formula' => is_dim ? fs['ref'] : measure_formula(fs),
               'name' => qr_leaf(qr) }
       apply_fmt(col, qr, fields, vfmts) unless is_dim
@@ -706,14 +891,99 @@ end
 # and are appended to the Data page below.
 extra_data_elements = []
 content_pages = signals['pages'].map do |pg|
-  # build_element may return one element or an array (multiRowCard -> N KPIs).
+  # build_element may return one element or an array (multiRowCard -> N KPIs),
+  # or nil (unresolvable slicer -> control skipped loudly, never wired wrong).
+  vis_elements = {}   # visual_id -> [built element ids] (feeds intended-scope)
   els = pg['visuals'].flat_map do |v|
     r = build_element(v, fields, masters, extra_data_elements)
-    r.is_a?(Array) ? r : [r]   # NB: not Array(r) — that explodes a Hash into pairs
+    list = r.is_a?(Array) ? r : [r] # NB: not Array(r) — that explodes a Hash into pairs
+    list = list.compact
+    vis_elements[v['visual_id']] = list.map { |e| e['id'] }
+    list
+  end
+  # Intended-scope contract (workstream B): for each control on this page,
+  # `scope` (the lint's allowlist — EVERY listed element is hard-asserted to
+  # be in the control's reach) = every chart element built from a same-page
+  # visual whose bound tables the slicer's filter reaches in the SOURCE (PBI:
+  # slicer scope is its page, flowing across relationships) AND whose Sigma
+  # element chains to a master this control actually wired. The remainder —
+  # source-reachable but UN-wireable (cross-grain: the master carries no
+  # column matching the sliced leaf and no relationship-resolvable column
+  # exists) — lands in `excluded` with a reason, NOT in scope, so gate 7
+  # neither asserts the impossible nor lets it pass silently.
+  # Visual-interaction "edit interactions" overrides (page.json
+  # visualInteractions, type none/nofilter) also exclude that target visual —
+  # best-effort: master-level wiring cannot exempt one visual that SHARES a
+  # master with an intended one, so warn when that happens.
+  offs = (pg['interactions'] || []).select { |ia| ia['type'].to_s =~ /no.?filter|none/i }
+  # element id -> the master element id it (transitively) sources, walking
+  # restructured intermediates (e.g. a scatter's grouped source element).
+  src_of = (els + extra_data_elements).each_with_object({}) do |e, h|
+    h[e['id']] = e.dig('source', 'elementId') || e.dig('source', 'source', 'elementId')
+  end
+  eff_master = lambda do |eid|
+    cur = src_of[eid]
+    cur = src_of[cur] while cur && src_of.key?(cur)
+    cur
+  end
+  $control_scope.select { |sc| vis_elements.key?(sc['_visual_id']) }.each do |sc|
+    reach = sc['reachableTables'] || []
+    wired_ids = sc['_wired_ids'] || []
+    pg['visuals'].each do |v|
+      next if v['visual_id'] == sc['_visual_id']
+      next if %w[control text].include?(SIGMA_KIND[v['sigma_kind']] || v['sigma_kind'])
+      ents = (v['bindings'] || {}).values.flatten.compact.map { |q| q.to_s.split('.').first }.uniq
+      next unless ents.any? { |e| reach.include?(e) } || reach.empty?
+      if offs.any? { |ia| ia['source'] == sc['_visual_id'] && ia['target'] == v['visual_id'] }
+        warn "[build-workbook] NOTE control '#{sc['controlId']}': source report turns OFF its " \
+             "interaction with visual '#{v['title'] || v['visual_id']}' — excluded from intended " \
+             'scope. Master-level wiring cannot exempt it if it shares a master with an ' \
+             'intended chart; verify in Sigma.'
+        (vis_elements[v['visual_id']] || []).each do |eid|
+          sc['excluded'] << { 'element' => eid,
+                              'reason' => 'source report visual-interaction set to none for this ' \
+                                          'target — intentionally not filtered in PBI' }
+        end
+        next
+      end
+      (vis_elements[v['visual_id']] || []).each do |eid|
+        if wired_ids.include?(eff_master.call(eid))
+          sc['scope'] << eid
+        else
+          sc['excluded'] << { 'element' => eid,
+                              'reason' => "cross-grain: its master carries no column matching " \
+                                          "'#{sc['_leaf']}' and no relationship path resolves one " \
+                                          '— unreachable without a model change ' \
+                                          "(masters not wired: #{(sc['unwiredMasters'] || []).join(', ')})" }
+        end
+      end
+    end
+    sc['scope'].uniq!
   end
   { 'id' => "page-#{pg['page_id']}", 'name' => pg['page_title'], 'elements' => els }
 end
 data_elements += extra_data_elements
+
+# control-scope.json — the intended-scope contract sidecar (schema: the
+# CONTRACT block in scripts/lib/control_lint.rb + refs/control-parity.md).
+# `sourceFilterSignals` counts the source report's slicer visuals — >0 with
+# zero spec controls FAILS gate 7 (the "interactive source, static migration"
+# class). Each emitted control carries `scope` (allowlist of element ids the
+# lint hard-asserts reachable) + `excluded` (cross-grain / interaction-off,
+# with reasons); slicers that produced no control land in `unbound`.
+scope_path = opts[:scope_out] || File.join(File.dirname(File.expand_path(opts[:out])), 'control-scope.json')
+source_signals = signals['pages'].sum do |pg|
+  (pg['visuals'] || []).count { |v| (SIGMA_KIND[v['sigma_kind']] || v['sigma_kind']) == 'control' }
+end
+scope_controls = $control_scope.map { |sc| sc.reject { |k, _| k.start_with?('_') } }
+File.write(scope_path, JSON.pretty_generate(
+             { 'version' => 1, 'source' => 'powerbi',
+               'sourceFilterSignals' => source_signals,
+               'controls' => scope_controls,
+               'unbound' => $control_unbound }
+           ))
+warn "[build-workbook] wrote control scope -> #{scope_path} (#{scope_controls.size} control(s), " \
+     "#{source_signals} source signal(s), #{$control_unbound.size} unbound)"
 
 # Derived titles can collide (two untitled visuals over the same projections) —
 # suffix duplicates so every element keeps a distinct human-readable name.
@@ -787,8 +1057,14 @@ pages_xml = signals['pages'].map do |pg|
     end
   end
   page_id = "page-#{pg['page_id']}"
-  next nil if items.empty?
   page_spec = content_pages.find { |p| p['id'] == page_id }
+  # A skipped visual (e.g. an unresolvable slicer) has no spec element — a
+  # layout entry for a non-existent element id breaks the layout write.
+  if page_spec
+    built_ids = page_spec['elements'].map { |e| e['id'] }
+    items = items.select { |i| built_ids.include?(i[0]) }
+  end
+  next nil if items.empty?
   # phase-e layout-quality fix: a short title TEXTBOX at the top of the source
   # canvas becomes the header band's text (white-on-dark), MOVED out of band 1
   # (never left behind as a dead zone). The candidate may start up to one grid

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
@@ -269,12 +269,23 @@ def extract(pbir_dir):
                 rec["text"] = _textbox_body(visual)
             visuals.append(rec)
         visuals.sort(key=lambda r: (r["y"], r["x"]))
+        # Visual-interaction overrides (slicer "edit interactions"): page.json
+        # carries them as visualInteractions[{source, target, type}] ONLY when an
+        # author edited them (absent = PBI defaults: slicers filter the page).
+        # Normalized here so the workbook builder can honor a "NoFilter" edit
+        # when wiring control targets (control-targeting wave, workstream B).
+        interactions = []
+        for ia in (page.get("visualInteractions") or []):
+            if isinstance(ia, dict) and ia.get("source") and ia.get("target"):
+                interactions.append({"source": ia["source"], "target": ia["target"],
+                                     "type": str(ia.get("type", "")).lower()})
         out_pages.append({
             "page_id": page.get("name", pname),
             "page_title": page.get("displayName", pname),
             "page_w": page.get("width", 1280),
             "page_h": page.get("height", 720),
             "visuals": visuals,
+            "interactions": interactions,
         })
     return {"source": "pbir", "pbir_dir": pbir_dir, "pages": out_pages}
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
@@ -216,14 +216,35 @@ def extract(report):
             }
             if rec["sigma_kind"] == "text":
                 rec["text"] = _textbox_body(sv)
-            visuals.append(rec)
-        visuals.sort(key=lambda r: (r["y"], r["x"]))
+            visuals.append((cfg.get("name"), rec))
+        visuals.sort(key=lambda nr: (nr[1]["y"], nr[1]["x"]))
+        # Visual-interaction overrides ("edit interactions"): the classic
+        # section config (JSON string) carries visualInteractions[{source,
+        # target, type}] ONLY when an author edited them; source/target are
+        # config names — remapped here onto the synthesized visual_ids the
+        # builder keys on (control-targeting wave, workstream B). Numeric
+        # types: 3 = none/no-filter (the exemption the builder honors);
+        # 1/2 = filter/highlight (both still filter-like — kept verbatim).
+        name_to_id = {n: r["visual_id"] for n, r in visuals if n}
+        interactions = []
+        try:
+            scfg = json.loads(s.get("config") or "{}")
+        except (TypeError, ValueError):
+            scfg = {}
+        for ia in (scfg.get("visualInteractions") or []):
+            src, tgt = name_to_id.get(ia.get("source")), name_to_id.get(ia.get("target"))
+            if not (src and tgt):
+                continue
+            t = ia.get("type")
+            interactions.append({"source": src, "target": tgt,
+                                 "type": "none" if t in (3, "3", "none", "noFilter") else str(t).lower()})
         out_pages.append({
             "page_id": s.get("name"),
             "page_title": s.get("displayName", s.get("name")),
             "page_w": s.get("width", 1280),
             "page_h": s.get("height", 720),
-            "visuals": visuals,
+            "visuals": [r for _n, r in visuals],
+            "interactions": interactions,
         })
     return {"source": "report.json-classic", "pages": out_pages}
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -557,17 +557,38 @@ inner_path = lambda do |formula|
 end
 
 # Build one master per converter element. master id is "master-<elementId-tail>".
+# The POSTED dm-spec is the column display-name AUTHORITY: convert-model.rb's
+# pre-fixup names bare columns from their formula (e.g. [Custom SQL/ANNUAL_SALARY]
+# -> "Annual Salary"), and workbook refs resolve by that DISPLAY name. Deriving
+# the name from the converter formula leaf alone left raw ALIASES on SQL-element
+# masters ([Dense Rank DEPARTMENT/ANNUAL_SALARY] -> "Dependency not found").
+spec_elements = begin
+  (JSON.parse(File.read(dm_spec))['pages'] || []).flat_map { |p| p['elements'] || [] }
+rescue StandardError
+  []
+end
 masters = {}
 field_map = {}
-conv_elements.each do |cel|
+conv_elements.each_with_index do |cel, cel_idx|
   cname = cel['name']
   # match the posted DM element: by NAME first (PUT keeps names; ids may change),
-  # then by ID. A Custom SQL element is NAMELESS in the spec (rule 3) and Sigma
-  # auto-names it "Custom SQL" on readback — recover that name by id-match so the
-  # master keys + column prefixes resolve (Bug E: nameless SQL element).
+  # then by ID, then POSITIONALLY (POST /spec preserves element order). A Custom
+  # SQL element is NAMELESS in the spec (rule 3) and the readback can ALSO carry
+  # name:null — the old `|| dm_elements.first` fallback then bound it to the
+  # FIRST element (usually the fact table), OVERWRITING that master with the SQL
+  # element's columns (live failure: EMPLOYEES master got SalaryBands' "Band
+  # Floor" -> "Dependency not found: 'employees/band floor'"). Positional match
+  # keeps the nameless element its OWN master (Bug E: nameless SQL element).
   dmel = (cname && dm_elements.find { |e| e['name'] == cname }) ||
-         dm_elements.find { |e| e['id'] == cel['id'] } || dm_elements.first
+         dm_elements.find { |e| e['id'] == cel['id'] } ||
+         dm_elements[cel_idx] || dm_elements.first
   cname ||= (dmel && dmel['name']) || 'Custom SQL'
+  # POSTED-spec column display names for this element (matched the same way the
+  # dm element was), keyed by formula — overrides the formula-leaf derivation.
+  spec_el = (cel['name'] && spec_elements.find { |e| e['name'] == cel['name'] }) ||
+            spec_elements[cel_idx]
+  spec_name_for = (spec_el && spec_el['columns'] || [])
+                  .each_with_object({}) { |c, h| h[c['formula'].to_s] = c['name'] if c['name'] }
   mkey = cname
   mid  = "master-#{Digest::SHA1.hexdigest(cname)[0, 8]}"
   # Bug A: key the master-column id on the FULL cross-element path (not the leaf)
@@ -596,7 +617,10 @@ conv_elements.each do |cel|
     full = c['formula'].to_s.gsub(/^\[|\]$/, '')         # e.g. ORDER_FACT/CUSTOMER_DIM/Customer Key
     next nil if full.empty? || seen_paths[full]
     seen_paths[full] = true
-    dn   = sigma_view_disp.call(c['formula'])            # "Customer Key (CUSTOMER_DIM)"
+    # the POSTED spec's display name wins (it's what workbook refs resolve by);
+    # fall back to Sigma's own derivation from the formula path.
+    dn   = spec_name_for[c['formula'].to_s] ||
+           sigma_view_disp.call(c['formula'])            # "Customer Key (CUSTOMER_DIM)"
     { 'id' => "mc-#{Digest::SHA1.hexdigest("#{cname}/#{full}")[0, 10]}", 'name' => dn,
       'formula' => "[#{cname}/#{dn}]", '_leaf' => disp.call(c['formula']) }
   end.compact
@@ -640,6 +664,11 @@ conv_elements.each do |cel|
   end
   (cel['metrics'] || []).each do |m|
     rewritten = resolve_metric.call(m['formula'].to_s, 0)
+    # Converter gap (live 2026-06-12): DAX SEARCH/FIND translate with their
+    # start argument, but Sigma's Find() takes only (text, search) — a third
+    # arg compiles the column to type "error" (verified: dropping it fixes).
+    # Strip a trailing integer start arg until the converter is fixed.
+    rewritten = rewritten.gsub(/\bFind\((\[[^\]]+\]|"[^"]*")\s*,\s*(\[[^\]]+\]|"[^"]*")\s*,\s*\d+\s*\)/, 'Find(\1, \2)')
     field_map["#{cname}.#{m['name']}"] = { 'master' => mkey, 'ref' => rewritten, 'agg' => nil,
                                            'format' => (m.dig('format', 'formatString')) }
   end
@@ -704,17 +733,32 @@ conv_elements.each do |vcel|
   # masters whose columns the View subsumes: the fact + every dim reachable via
   # a "(DIM)" suffix in the View's columns.
   subsumed = [fact] + vcols.map { |c| c['name'][/\(([^)]*)\)\s*$/, 1] }.compact.uniq
+  # Register the View resolution as an ALT, not the primary (grain fix, found
+  # live during the control-targeting wave): making the View the PRIMARY routed
+  # EVERY field of the subsumed tables onto the join element, so a SINGLE-table
+  # visual (e.g. Median Salary over EMPLOYEES) silently evaluated at the JOIN
+  # grain — one row per fact/absence record, not per employee — and diverged
+  # (live: Sigma median 73,500 vs PBI 73,000). As an alt, visual_master still
+  # majority-picks the View for CROSS-table visuals (the View is the only
+  # master covering all their fields) while same-table visuals tie-break to the
+  # field's own master and keep their source grain.
   field_map.each do |qr, fs|
     next unless subsumed.include?(fs['master'])
+    next if fs['master'] == vname
     old_mid = masters[fs['master']] ? masters[fs['master']]['id'] : nil
     ref_str = fs['ref'].to_s
     is_plain_col = ref_str =~ /\A\[[^\]]+\]\z/ # exactly one bracketed ref, no agg
+    add_alt = lambda do |ref|
+      alts = (fs['alts'] ||= [])
+      alts << { 'master' => vname, 'ref' => ref, 'agg' => fs['agg'] } unless
+        alts.any? { |a| a['master'] == vname }
+    end
     if is_plain_col
       # plain dimension/column ref: match its leaf to a View column.
       leaf = qr.split('.', 2).last.to_s.sub(/\s+\([^)]*\)\s*$/, '')
       vcol = leaf_to_view[leaf] || leaf_to_view[qr.split('.', 2).last.to_s]
       next unless vcol
-      field_map[qr] = fs.merge('master' => vname, 'ref' => "[#{vmid}/#{vcol}]")
+      add_alt.call("[#{vmid}/#{vcol}]")
     elsif old_mid
       # measure/aggregation formula: every referenced fact column must exist on the
       # View (it does — the View carries all fact columns). Swap the old master id
@@ -724,8 +768,8 @@ conv_elements.each do |vcel|
         mapped = leaf_to_view[inner] || leaf_to_view[inner.sub(/\s+\([^)]*\)\s*$/, '')] || inner
         "[#{vmid}/#{mapped}]"
       end
-      # only re-route if we actually rewrote a ref onto the View master.
-      field_map[qr] = fs.merge('master' => vname, 'ref' => remapped) if remapped.include?(vmid)
+      # only register if we actually rewrote a ref onto the View master.
+      add_alt.call(remapped) if remapped.include?(vmid)
     end
   end
 end
@@ -909,6 +953,11 @@ build = ['ruby', File.join(HERE, 'build-workbook-from-pbir.rb'),
          '--signals', signals_path, '--master-map', mmap_path,
          '--data-model', dm_id, '--name', WB_NAME,
          '--source-title', (opts[:source_title] || name_slug.gsub(/[-_]+/, ' ').strip),
+         # control-targeting wave (workstream B): the TMSL relationships drive
+         # slicer-control target scope; control-scope.json (intended-scope
+         # contract for the control lint) lands in WORK.
+         '--model', opts[:tmsl],
+         '--control-scope-out', File.join(WORK, 'control-scope.json'),
          '--out', wb_spec, '--layout-out', layout]
 # The workbook POST requires a folderId. Use --folder if given, else inherit the
 # DM's folderId (harvested from the ref-dm at Phase 3) so both land together.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -211,6 +211,19 @@ The Qlik cell grid maps 1:1 onto the 24-col Sigma grid. Element shapes + the
 `source.dataModelId` requirement in `refs/sigma-build-gotchas.md`.
 POST `/v2/workbooks/spec`, then `scripts/vendor/put-layout.rb` applies the layout XML.
 
+**Filterpanes/listboxes → controls (NOT skipped).** Each filterpane child
+listbox (discovered via `qChildList` + per-listbox layout) and standalone
+listbox becomes a Sigma **list control** — or a **date-range control** when the
+field is date-typed (`$date`/`$timestamp` qTags; a list control bound to a
+datetime column gets its filter targets SILENTLY STRIPPED by Sigma). Scope is
+GLOBAL, matching Qlik's associative model: one filter target on the master
+table propagates to every chart on every page. A second listbox on the same
+field dedupes to the one global control; alternate-state listboxes are flagged
+MANUAL. The builder emits the **`control-scope.json` sidecar** (contract:
+`scripts/lib/control_lint.rb` header + `refs/control-parity.md`) with
+`sourceFilterSignals`, per-control `mustReach` over every chart on every page
+(static proof of global reach), and `unbound` entries with reasons.
+
 ## Phase 5 — Parity (hard gate)
 Three checks, led by the **freshness banner** (Phase 1.5 — read it before any
 side-by-side):
@@ -222,8 +235,16 @@ side-by-side):
    dim-value-without-facts surfaces **even when every shared cell matches**.
    (Known shape: Qlik shows dimension values with zero fact rows — e.g. a store with
    no orders — that a fact-grain LEFT JOIN can never emit; that's data shape, not a bug.)
-GREEN = all columns resolve + no DIVERGENT KPI. Bucket mismatches WARN loudly with
-the likely cause. (First run matched to the cent; staleness-explained deltas don't block.)
+4. **Control lint (gate 7)** — `scripts/lib/control_lint.rb` (shared, vendored
+   byte-identical) runs against the LIVE spec readback + the builder's
+   `control-scope.json` sidecar: no dead controls, no ghost targets, full reach
+   (incl. the Qlik `mustReach` global-scope assertions), and source-signal
+   coverage (filterpanes/listboxes in the app but zero controls = RED).
+   Optional runtime proof: `ruby scripts/probe-controls.rb --workbook-id <wb>`
+   (flip test via export `parameters`; MCP can NOT set a control value).
+GREEN = all columns resolve + no DIVERGENT KPI + control lint clean. Bucket
+mismatches WARN loudly with the likely cause. (First run matched to the cent;
+staleness-explained deltas don't block.)
 
 > **Querying for parity:** `metric('<id>', t)` against a data-model element can return
 > "Missing Metric" — aggregate the element's raw columns directly instead
@@ -248,6 +269,9 @@ the likely cause. (First run matched to the cent; staleness-explained deltas don
 | `scripts/qlik-screenshot.py` | 1/6 | Export PNGs of a sheet's charts (or specific viz ids) via the Qlik reporting API, for before/after capture. **Validated** (per-viz PNG; whole-sheet is PDF only). |
 | `scripts/build-sigma-dm.py` | 3 | Author + POST the Sigma data model FROM THE PIPELINE ARTIFACTS (converter-out + reconcile + denorm): repointed star + relationships + denorm SQL element + metrics. `--dry-run` for offline. **Proven (generalized 2026-06-10).** |
 | `scripts/build-sigma-workbook.py` | 4 | Author + POST the workbook FROM DISCOVERY (charts.json + layout.json): one page per Qlik sheet, cell-grid layout, sorts, formats, null-suppression filters. `--dry-run` for offline. **Proven (generalized 2026-06-10).** |
+| `scripts/lib/control_lint.rb` | 5 | **Shared control-wiring lint (gate 7)** — dead controls / ghost targets / reach / `control-scope.json` coverage; vendored byte-identical across plugins; run automatically by `migrate-qlik.rb` Phase 6e. |
+| `scripts/probe-controls.rb` | 5 | **Shared flip test** — runtime proof a control filters: export an in-closure element with/without `parameters:{controlId: value}`; cross-page exports prove Qlik's global scope. |
+| `refs/control-parity.md` | 5 | The control-parity contract: lint + sidecar schema + the MCP/export-API answer (export `parameters` is the only way to set a control value). |
 | `refs/example-converter-input.json` | 1–2 | The exact convert_qlik_to_sigma input from the first migration. |
 | `fixtures/retail-orders/` | — | Complete offline discovery+converter input set (sanitized demo app) — see `fixtures/README.md` for the offline smoke path. |
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/fixtures/README.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/fixtures/README.md
@@ -29,5 +29,24 @@ ruby scripts/migrate-qlik.rb \
 
 Expected: all 6 phases run; `/tmp/qlik-smoke/` gains `dm-spec.json` (7 elements:
 6 repointed star tables + denorm SQL element with 13 metrics), `wb-spec.json`
-(6 pages, 35 elements, 15 KPIs), `layout.xml` (6 `<Page>` grids), and
-`element-map.json`; exit code 0. Nothing is POSTed.
+(6 pages, 62 elements, 15 KPIs, 3 controls), `layout.xml` (6 `<Page>` grids),
+`element-map.json`, and `control-scope.json` (the gate-7 sidecar); exit code 0.
+Nothing is POSTed.
+
+### Filter-object fixtures (control-targeting wave)
+
+`charts.json`/`layout.json` carry synthetic filter objects exercising every
+control path in `build-sigma-workbook.py`:
+
+| object | case | expected outcome |
+|---|---|---|
+| `fp-1` (children `lb-1`,`lb-2`) | filterpane | one control per child listbox |
+| `lb-1` CUSTOMER_REGION | plain field | `list` control, wired to the master |
+| `lb-2` CATEGORY, state `AltA` | alternate state | NOT emitted; `unbound` status `manual` |
+| `lb-3` NO_SUCH_FIELD | unresolvable | NOT emitted (loud WARN); `unbound` |
+| `lb-4` CATEGORY | standalone listbox | `list` control |
+| `lb-5` CUSTOMER_REGION (2nd sheet) | duplicate field | deduped (`unbound` status `duplicate`) |
+| `lb-6` FULL_DATE, qTags `$date` | date-typed field | **`date-range` control** (a `list` on a datetime column gets its targets silently stripped) |
+
+`control-scope.json` must report `sourceFilterSignals: 5` and pass
+`ruby scripts/lib/control_lint.rb /tmp/qlik-smoke/wb-spec.json /tmp/qlik-smoke/control-scope.json`.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/fixtures/retail-orders/charts.json
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/fixtures/retail-orders/charts.json
@@ -1377,5 +1377,135 @@
         }
       ]
     }
+  },
+  {
+    "id": "fp-1",
+    "vizType": "filterpane",
+    "title": "Filters",
+    "sheet": "yGLwX",
+    "dimensions": [],
+    "dimLabels": [],
+    "dimNullSuppression": [],
+    "measures": [],
+    "measureLabels": [],
+    "measureFmts": [],
+    "sort": {},
+    "children": [
+      "lb-1",
+      "lb-2"
+    ]
+  },
+  {
+    "id": "lb-1",
+    "vizType": "listbox",
+    "title": "Region",
+    "sheet": null,
+    "dimensions": [],
+    "dimLabels": [],
+    "dimNullSuppression": [],
+    "measures": [],
+    "measureLabels": [],
+    "measureFmts": [],
+    "sort": {},
+    "listbox": {
+      "field": "CUSTOMER_REGION",
+      "label": "Customer Region",
+      "state": null
+    }
+  },
+  {
+    "id": "lb-2",
+    "vizType": "listbox",
+    "title": "AltState",
+    "sheet": null,
+    "dimensions": [],
+    "dimLabels": [],
+    "dimNullSuppression": [],
+    "measures": [],
+    "measureLabels": [],
+    "measureFmts": [],
+    "sort": {},
+    "listbox": {
+      "field": "CATEGORY",
+      "label": "Category",
+      "state": "AltA"
+    }
+  },
+  {
+    "id": "lb-3",
+    "vizType": "listbox",
+    "title": "Ship Mode",
+    "sheet": "yGLwX",
+    "dimensions": [],
+    "dimLabels": [],
+    "dimNullSuppression": [],
+    "measures": [],
+    "measureLabels": [],
+    "measureFmts": [],
+    "sort": {},
+    "listbox": {
+      "field": "NO_SUCH_FIELD",
+      "label": "Bogus",
+      "state": null
+    }
+  },
+  {
+    "id": "lb-4",
+    "vizType": "listbox",
+    "title": "Category",
+    "sheet": "yGLwX",
+    "dimensions": [],
+    "dimLabels": [],
+    "dimNullSuppression": [],
+    "measures": [],
+    "measureLabels": [],
+    "measureFmts": [],
+    "sort": {},
+    "listbox": {
+      "field": "CATEGORY",
+      "label": "Category",
+      "state": null
+    }
+  },
+  {
+    "id": "lb-5",
+    "vizType": "listbox",
+    "title": "Customer Region (dup)",
+    "sheet": "sh-product",
+    "dimensions": [],
+    "dimLabels": [],
+    "dimNullSuppression": [],
+    "measures": [],
+    "measureLabels": [],
+    "measureFmts": [],
+    "sort": {},
+    "listbox": {
+      "field": "CUSTOMER_REGION",
+      "label": "Customer Region",
+      "state": null
+    }
+  },
+  {
+    "id": "lb-6",
+    "vizType": "listbox",
+    "title": "Order Date",
+    "sheet": "yGLwX",
+    "dimensions": [],
+    "dimLabels": [],
+    "dimNullSuppression": [],
+    "measures": [],
+    "measureLabels": [],
+    "measureFmts": [],
+    "sort": {},
+    "listbox": {
+      "field": "FULL_DATE",
+      "label": "Order Date",
+      "state": null,
+      "tags": [
+        "$date",
+        "$numeric"
+      ],
+      "numFmt": "YYYY-MM-DD"
+    }
   }
 ]

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/fixtures/retail-orders/layout.json
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/fixtures/retail-orders/layout.json
@@ -61,6 +61,38 @@
         "row": 12,
         "colspan": 12,
         "rowspan": 9
+      },
+      {
+        "objectId": "fp-1",
+        "type": "filterpane",
+        "col": 0,
+        "row": 10,
+        "colspan": 4,
+        "rowspan": 6
+      },
+      {
+        "objectId": "lb-3",
+        "type": "listbox",
+        "col": 4,
+        "row": 10,
+        "colspan": 4,
+        "rowspan": 3
+      },
+      {
+        "objectId": "lb-4",
+        "type": "listbox",
+        "col": 8,
+        "row": 10,
+        "colspan": 4,
+        "rowspan": 3
+      },
+      {
+        "objectId": "lb-6",
+        "type": "listbox",
+        "col": 20,
+        "row": 0,
+        "colspan": 4,
+        "rowspan": 2
       }
     ]
   },
@@ -126,6 +158,14 @@
         "row": 12,
         "colspan": 12,
         "rowspan": 9
+      },
+      {
+        "objectId": "lb-5",
+        "type": "listbox",
+        "col": 0,
+        "row": 0,
+        "colspan": 4,
+        "rowspan": 3
       }
     ]
   },

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/control-parity.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/control-parity.md
@@ -1,0 +1,87 @@
+# Control parity — lint, flip test, and the MCP/export answer
+
+SHARED ref, vendored byte-identical into every covered plugin's `refs/`
+(md5 discipline). Companion to `scripts/lib/control_lint.rb` (gate 7 /
+post-and-readback control lint) and `scripts/probe-controls.rb` (flip test).
+
+## Why this exists
+
+A migrated workbook can pass data parity, the column-type guard, and the
+layout lint and still ship **broken interactivity**. The 2026-06 estate audit
+of tj-wells-1989 found 86 controls across 36 kept workbooks: 8 DEAD (no
+filter target, no formula reference — pure furniture), 18 PARTIAL (same-page
+charts outside the control's reach; 8 of them bugs), and the Qlik class
+(source dashboards full of listboxes migrated with zero controls). None of
+the existing gates noticed, because every existing gate evaluates elements in
+their default state.
+
+## The three layers
+
+1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
+   dead controls, ghost filter targets, source-closure reach vs same-page
+   queryable elements, and source-signal coverage via the
+   `control-scope.json` sidecar. Runs automatically in
+   `post-and-readback.rb --type workbook` (exit 4) and as
+   `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
+2. **control-scope.json contract** — emitted by the builder next to the
+   workbook spec. Carries (a) `sourceFilterSignals`: how many filter-like
+   signals the SOURCE artifact had (Tableau quick filters + actions, PBI
+   slicers, Qlik listboxes, QuickSight/Cognos parameters+prompts, Looker
+   dashboard filters, TS Liveboard filters) — `>0` with zero spec controls
+   FAILS the lint; (b) per-control intent: `scope: "page"` (default — the
+   control must reach every same-page queryable element) or
+   `scope: ["Element name or id", ...]` (the **single-chart-switcher
+   allowlist** for intentional narrow controls like grain/geo-level toggles)
+   plus optional `mustReach` hard assertions. Full schema in the
+   `control_lint.rb` header CONTRACT block. The in-spec `controlScope` key on
+   a control element means the same thing but does NOT survive Sigma
+   readback — the sidecar is the durable form.
+3. **Flip test** (`scripts/probe-controls.rb`) — OPTIONAL Phase-6 runtime
+   evidence, not the mandatory inner loop. Exports one in-closure element CSV
+   with and without `parameters:{<controlId>: <first non-default value>}` —
+   they must differ; with `--check-out-of-closure`, an out-of-closure element
+   must NOT differ. Use it after hand-wiring controls, after estate repairs,
+   or when the lint's static reach needs runtime confirmation.
+
+## The MCP question — definitive answer (verified 2026-06-12, tj-wells-1989)
+
+Tested by setting a saved default (`values: ["West"]`) on a live workbook's
+Region list control (PHASEE, `64e78398`), then querying/exporting the same
+in-closure bar chart every way available:
+
+| Path | Control defaults applied? | Can set a control value? |
+|---|---|---|
+| `mcp__sigma-mcp-v2__query` (type=workbook) | **YES** — returned only the West row | **NO** — schema is `{type, workbookId, sql}` only; no parameter mechanism exists in the MCP query path |
+| REST export, no `parameters` | **YES** — only the West row | n/a |
+| REST `POST /v2/workbooks/{id}/export` with `"parameters": {"<controlId>": "<value>"}` | starts from defaults | **YES** — and the parameter **REPLACES** the saved default (parameters `{"ctl-region":"South"}` over a West default returned only South — no intersection) |
+
+Consequences:
+
+- MCP is fine for **default-state parity** (Phase 6 uses exactly that), and
+  default-state MCP rows DO move if you change a control's saved default.
+- MCP can NOT exercise a non-default control value — flip testing MUST go
+  through the export API's `parameters` map. That is why probe-controls.rb is
+  built on export.
+- A parameter value that matches no data row returns an EMPTY (header-only)
+  CSV, not an error — pick flip values from the column's actual domain
+  (probe-controls.rb auto-picks from the control's value-source column).
+
+## Repair recipes (what the lint tells you to do)
+
+- **dead control, column exists on a master** → add
+  `filters: [{source: {kind: "table", elementId: "<master>"}, columnId: "<col>"}]`
+  (and point the control's own `source` at the same column for its value
+  list).
+- **dead control, column does NOT exist anywhere** → REMOVE the control.
+  Honest beats decorative; do not fake-wire to an unrelated column.
+- **partial reach, multi-master page** → add one filter target per master the
+  control should govern (the column must exist on each); elements sourcing
+  from those masters inherit via the closure.
+- **partial reach, chart bypasses the master** (sources the DM directly) →
+  either re-source the chart from the master or add a filter target on the
+  chart element itself with that element's own columnId.
+- **intentional narrow control** (grain switcher driving one chart by
+  formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
+
+After any repair: flip-test the workbook
+(`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -145,6 +145,101 @@ def translate_measure(expr, resolve):
     if re.search(r"[A-Za-z_]{2,}", leftovers): return None
     return e
 
+def date_field(info, raw):
+    """Date-typed Qlik field? Engine layout tags ($date/$timestamp) are
+    authoritative; the qNumFormat date pattern and the raw warehouse column
+    name are fallbacks. Matters because a Sigma `list` control whose filter
+    target is a datetime column posts fine but Sigma SILENTLY STRIPS the
+    target (estate-repair gotcha) — date fields need date-range controls."""
+    tags = [str(t).lower() for t in (info.get("tags") or [])]
+    if "$date" in tags or "$timestamp" in tags: return True
+    if "$text" in tags: return False              # tagged, and tagged non-date
+    fmt = (info.get("numFmt") or "").upper()
+    if re.search(r"[DMY]{2,}[-./ ]", fmt): return True
+    return bool(re.search(r"(^|_)(DATE|DT|TIMESTAMP)(_|$)", str(raw or "").upper()))
+
+def build_control(lb, resolve, mcol_id, raw_of, warnings, scope, unbound, seen_fields):
+    """One Qlik listbox (standalone or filterpane child) -> one Sigma control
+    (control-targeting wave, workstream B). Qlik's associative model is GLOBAL:
+    any field selection filters every chart on every sheet. Every chart in this
+    workbook sources the single master table, so ONE filter entry on the master
+    propagates to all of them across all pages (the proven shape:
+    filters:[{source:{kind:table, elementId}, columnId}]) — exactly the Qlik
+    semantics; the sidecar asserts it via mustReach over every queryable
+    element on every page (filled after page assembly). Date-typed fields
+    become date-range controls (list-on-datetime targets get silently
+    stripped). Alternate-state listboxes have no Sigma equivalent: recorded in
+    the sidecar's `unbound` as MANUAL, never silently dropped. Returns the
+    element or None."""
+    info = lb.get("listbox") or {}
+    field = info.get("field")
+    state = info.get("state")
+    label = info.get("label") or lb.get("title") or field
+    sig = f"{lb['vizType']} {lb['id']} field {field!r}"
+    if not field:
+        warnings.append(f"control '{lb['id']}': listbox has no field — skipped")
+        unbound.append({"sourceName": sig, "status": "unbound", "reason": "listbox has no field"})
+        return None
+    if state and state != "$":
+        warnings.append(f"control '{label}' (field {field}): ALTERNATE STATE '{state}' — "
+                        "Sigma has no alternate-state equivalent; flagged MANUAL (not emitted)")
+        unbound.append({"sourceName": sig, "status": "manual",
+                        "reason": f"alternate state '{state}' has no Sigma equivalent — port by hand "
+                                  "(e.g. duplicated charts + a dedicated control) if the analysis needs it"})
+        return None
+    if field in seen_fields:
+        # the same field filters globally — a second listbox on it (another
+        # sheet's filterpane) is the SAME control; Sigma controlIds are unique.
+        unbound.append({"sourceName": sig, "status": "duplicate",
+                        "reason": f"same field as control '{seen_fields[field]}' — one global Sigma "
+                                  "control already covers every sheet (Qlik associative semantics)"})
+        return None
+    dn = resolve(field)
+    if dn is None or dn not in mcol_id:
+        warnings.append(f"control '{label}': field '{field}' not on the denorm element — "
+                        "skipped (resolve the field and wire manually)")
+        unbound.append({"sourceName": sig, "status": "unbound",
+                        "reason": f"field '{field}' does not resolve to a denorm-element column; "
+                                  "dropped loudly rather than wired to a wrong column or shipped dead"})
+        return None
+    cid = mcol_id[dn]
+    ctl_id = re.sub(r"[^A-Za-z0-9]", "", str(dn).title()) + "Filter"
+    seen_fields[field] = ctl_id
+    el = {"id": "el-" + re.sub(r"[^a-z0-9]", "", str(lb["id"]).lower()),
+          "kind": "control", "controlId": ctl_id, "name": label or dn,
+          "filters": [{"source": {"kind": "table", "elementId": MASTER_ID}, "columnId": cid}]}
+    if date_field(info, raw_of.get(dn)):
+        # date-range needs no `source` (the column comes from the filter
+        # binding) but DOES require a flat `mode` — without it the POST fails
+        # with the misleading "Invalid kind: control" (live-verified 2026-06-12;
+        # the widget shape is picked by mode, see sigma-workbooks controls.md).
+        el.update({"controlType": "date-range", "mode": "between",
+                   "includeNulls": "when-no-value-is-selected"})
+    else:
+        el.update({"controlType": "list", "mode": "include", "selectionMode": "multiple",
+                   "values": [],
+                   "source": {"kind": "source",
+                              "source": {"kind": "table", "elementId": MASTER_ID}, "columnId": cid}})
+    # CONTRACT entry (lib/control_lint.rb header): scope "page" covers the
+    # same-page reach check; mustReach (every queryable element id on every
+    # page, filled after assembly) makes the lint statically assert Qlik's
+    # GLOBAL associative reach.
+    scope.append({"controlId": ctl_id, "sourceName": sig, "status": "wired",
+                  "controlType": el["controlType"], "scope": "page", "mustReach": [],
+                  "wired": [{"elementId": MASTER_ID, "columnId": cid}]})
+    return el
+
+def control_subcell(cell, i, n):
+    """Split a filterpane's sheet cell among its N child listbox controls —
+    vertically when the pane is taller than wide, else horizontally."""
+    if n <= 1:
+        return cell
+    if cell.get("rowspan", 1) >= cell.get("colspan", 1):
+        h = cell["rowspan"] / n
+        return {**cell, "row": cell["row"] + i * h, "rowspan": h}
+    w = cell["colspan"] / n
+    return {**cell, "col": cell["col"] + i * w, "colspan": w}
+
 def qlik_sort(c, dim_ids, meas_ids):
     """Explicit Qlik sort -> (columnId, direction) or None."""
     s = c.get("sort") or {}
@@ -339,25 +434,35 @@ def grid_layout(page_id, sheet, placed):
     for cell, el in placed:
         c0 = round(cell["col"] * 24 / qcols) + 1
         c1 = round((cell["col"] + cell["colspan"]) * 24 / qcols) + 1
-        r0 = cell["row"] * ROW_SCALE + 1
-        r1 = (cell["row"] + cell["rowspan"]) * ROW_SCALE + 1
+        # control_subcell splits a filterpane cell fractionally — round to grid
+        r0 = int(round(cell["row"] * ROW_SCALE)) + 1
+        r1 = int(round((cell["row"] + cell["rowspan"]) * ROW_SCALE)) + 1
         if el["kind"] == "kpi-chart" and (r1 - r0) < KPI_MIN_ROWS:
             r1 = r0 + KPI_MIN_ROWS
+        if el["kind"] == "control" and (r1 - r0) < 2:
+            r1 = r0 + 2
         items.append([el["id"], c0, c1, r0, r1])
     return banded_page(page_id, items, sheet.get("title"))
 
 def auto_layout(page_id, elems, title=None):
-    """Fallback when no layout.json: header band, KPI strip band, then chart
-    rows 2-wide — each a container. Returns (page_xml, extra_spec_elements)."""
+    """Fallback when no layout.json: header band, controls band, KPI strip band,
+    then chart rows 2-wide — each a container. Returns (page_xml, extra_spec_elements)."""
+    ctls = [e for e in elems if e["kind"] == "control"]
     kpis = [e for e in elems if e["kind"] == "kpi-chart"]
-    charts = [e for e in elems if e["kind"] != "kpi-chart"]
+    charts = [e for e in elems if e["kind"] not in ("kpi-chart", "control")]
     items, row = [], 1
+    if ctls:
+        w = 24 // len(ctls)
+        for i, e in enumerate(ctls):
+            c0 = 1 + i * w; c1 = c0 + w if i < len(ctls) - 1 else 25
+            items.append([e["id"], c0, c1, row, row + 3])
+        row += 3
     if kpis:
         w = 24 // len(kpis)
         for i, e in enumerate(kpis):
             c0 = 1 + i * w; c1 = c0 + w if i < len(kpis) - 1 else 25
-            items.append([e["id"], c0, c1, 1, 6])
-        row = 6
+            items.append([e["id"], c0, c1, row, row + 5])
+        row += 5
     for i in range(0, len(charts), 2):
         pair = charts[i:i + 2]
         for j, e in enumerate(pair):
@@ -380,6 +485,9 @@ def main():
     ap.add_argument("--spec-out", default="wb-spec.json")
     ap.add_argument("--layout-out", default="layout.xml")
     ap.add_argument("--element-map", default="element-map.json")
+    ap.add_argument("--control-scope-out", default=None,
+                    help="intended-scope contract for the control lint "
+                         "(default: control-scope.json next to --spec-out)")
     a = ap.parse_args()
 
     charts = {c["id"]: c for c in json.load(open(a.charts))}
@@ -429,6 +537,31 @@ def main():
 
     CHARTY = {"kpi", "auto-chart", "barchart", "linechart", "piechart", "combochart",
               "scatterplot", "table", "pivot-table"}
+    # master column id / raw warehouse column per display name — control
+    # source/filter targets + date-typed detection fallback
+    mcol_id = {dn: f"o{i}" for i, (dn, _raw) in enumerate(denorm_cols)}
+    raw_of = {dn: raw for dn, raw in denorm_cols}
+    scope, unbound, seen_fields, n_controls, n_signals = [], [], {}, 0, 0
+
+    def controls_for(c):
+        """Filterpane -> one control per child listbox; bare listbox -> one."""
+        if c["vizType"] == "filterpane":
+            lbs = [charts.get(ch) for ch in (c.get("children") or [])]
+            lbs = [lb for lb in lbs if lb]
+            if not lbs:
+                warnings.append(f"filterpane '{c.get('title') or c['id']}': no child listboxes "
+                                "discovered — no controls emitted")
+                unbound.append({"sourceName": f"filterpane {c['id']}", "status": "unbound",
+                                "reason": "no child listboxes discovered"})
+            for lb in lbs:  # a pane-level alternate state applies to its children
+                if c.get("state") and not (lb.get("listbox") or {}).get("state"):
+                    lb.setdefault("listbox", {})["state"] = c["state"]
+        else:
+            lbs = [c]
+        return [el for el in (build_control(lb, resolve, mcol_id, raw_of, warnings,
+                                            scope, unbound, seen_fields)
+                              for lb in lbs) if el]
+
     if sheets:
         for si, sheet in enumerate(sheets):
             pid = f"pg-{si + 1}"
@@ -436,6 +569,14 @@ def main():
             for cell in sorted(sheet["cells"], key=lambda c: (c["row"], c["col"])):
                 c = charts.get(cell["objectId"])
                 if c is None: continue
+                if c["vizType"] in ("filterpane", "listbox"):
+                    n_signals += 1
+                    ctls = controls_for(c)
+                    for i, ctl in enumerate(ctls):
+                        elems.append(ctl)
+                        placed.append((control_subcell(cell, i, len(ctls)), ctl))
+                    n_controls += len(ctls)
+                    continue
                 if c["vizType"] not in CHARTY and not (c.get("measures") or c.get("dimensions")):
                     warnings.append(f"skip '{cell['objectId']}' ({c['vizType']}): not a chart"); continue
                 el = build_element(c, resolve, warnings)
@@ -452,9 +593,19 @@ def main():
             pages.append({"id": pid, "name": sheet["title"], "elements": elems + extra})
             layout_pages.append(xml)
     else:
-        # no sheet layout discovered — build every dim+measure chart, auto-layout
+        # no sheet layout discovered — build every dim+measure chart, auto-layout;
+        # filterpanes/listboxes still become controls (top band). Children of a
+        # filterpane are skipped standalone (the pane emits them).
         pid, elems = "pg-1", []
+        child_ids = {ch for c in charts.values() if c["vizType"] == "filterpane"
+                     for ch in (c.get("children") or [])}
         for c in charts.values():
+            if c["vizType"] == "filterpane" or (c["vizType"] == "listbox" and c["id"] not in child_ids):
+                n_signals += 1
+                ctls = controls_for(c)
+                elems.extend(ctls)
+                n_controls += len(ctls)
+                continue
             if not (c.get("measures")): continue
             el = build_element(c, resolve, warnings)
             if el is None: continue
@@ -474,10 +625,33 @@ def main():
     json.dump(spec, open(a.spec_out, "w"), indent=2)
     open(a.layout_out, "w").write('<?xml version="1.0" encoding="utf-8"?>\n' + "\n".join(layout_pages))
     json.dump(emap, open(a.element_map, "w"), indent=2)
+    # control-scope.json — the intended-scope contract sidecar (schema: the
+    # CONTRACT block in scripts/lib/control_lint.rb + refs/control-parity.md).
+    # Qlik selections are GLOBAL (associative model), so every wired control
+    # gets mustReach = every queryable element on EVERY content page — the
+    # lint then statically asserts the global reach, not just same-page.
+    # sourceFilterSignals counts the source app's filter objects (filterpanes
+    # + standalone listboxes; pane children are part of their pane's signal) —
+    # >0 with zero spec controls FAILS gate 7 (the silently-dropped class this
+    # change exists to kill).
+    QUERYABLE = {"table", "pivot-table", "bar-chart", "line-chart", "pie-chart",
+                 "donut-chart", "area-chart", "scatter-chart", "combo-chart",
+                 "kpi-chart", "region-map", "point-map"}
+    must = [e["id"] for p in pages if p["id"] != "page-data"
+            for e in p["elements"] if e.get("kind") in QUERYABLE]
+    for sc in scope:
+        if sc.get("status") == "wired":
+            sc["mustReach"] = must
+    scope_path = a.control_scope_out or os.path.join(
+        os.path.dirname(os.path.abspath(a.spec_out)), "control-scope.json")
+    json.dump({"version": 1, "source": "qlik", "sourceFilterSignals": n_signals,
+               "controls": scope, "unbound": unbound},
+              open(scope_path, "w"), indent=2)
 
     n_elem = sum(len(p["elements"]) for p in pages) - 1
     result = {"workbookId": None, "pages": len(pages), "elements": n_elem,
               "kpis": sum(1 for e in emap if e["kind"] == "kpi-chart"),
+              "controls": n_controls, "controlScope": scope_path,
               "warnings": warnings, "layoutFile": a.layout_out, "elementMap": a.element_map}
     if a.dry_run:
         print(f"DRY RUN: spec -> {a.spec_out} ({len(pages)} pages, {n_elem} elements)", file=sys.stderr)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/control_lint.rb
@@ -1,0 +1,304 @@
+# frozen_string_literal: true
+#
+# control_lint.rb — mechanized control-wiring lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as layout_lint.rb / sigma_rest.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the layout lint
+#   - assert-phase6-ran.rb gate 7 (with a --skip-control-lint escape)
+#   - scripts/probe-controls.rb (reuses the reach computation to pick its
+#     in-closure / out-of-closure probe elements)
+#
+# It exists because a workbook can pass parity + layout gates and still ship
+# controls that DO NOTHING (the "Orders Overview (from Looker)" estate escape:
+# three list controls bound to no element at all) or controls that silently
+# skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
+# escape, and the Qlik class: source full of listboxes, spec with zero
+# controls). Three checks:
+#
+#   (a) dead control — every kind:control element must have >=1 `filters`
+#       target resolving to a REAL element id in the spec, OR be referenced
+#       as [controlId] in at least one non-control element (formula / spec
+#       reference). A control with neither is furniture: a user changes it
+#       and nothing on the page reacts.
+#   (b) reach — source-closure walk from the control's targets (filter
+#       targets + formula-referencing elements, expanded downstream through
+#       source.elementId chains). Any same-page QUERYABLE element outside
+#       the closure flags PARTIAL with the element names. Intentional
+#       single-chart switchers (grain / geo-level segmented controls) are
+#       allow-listed via the controlScope annotation (CONTRACT below).
+#   (c) source-scope coverage — when a control-scope sidecar is provided
+#       (emitted by the builder from the SOURCE BI artifact's filter
+#       signals), FAIL if the source had filter signals but the spec has
+#       zero controls, if an annotated control is missing from the spec,
+#       or if an annotated mustReach element is not in that control's
+#       closure.
+#
+# CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
+# to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
+# up from the workdir automatically, or take --control-scope PATH):
+#
+#   {
+#     "version": 1,
+#     "source": "qlik",               // provenance tag, free-form
+#     "sourceFilterSignals": 3,       // count of filter-like signals detected
+#                                     //   in the source artifact (listboxes,
+#                                     //   quick filters, actions, slicers,
+#                                     //   prompts, dashboard filters...).
+#                                     //   >0 with zero spec controls = FAIL.
+#     "controls": [
+#       {
+#         "controlId": "ctl-region",           // spec controlId (required)
+#         "sourceName": "Region quick filter", // optional, for messages
+#         "scope": "page",                     // "page" (default): the reach
+#                                              //   check applies to every
+#                                              //   same-page queryable element
+#                                              // OR an array of element ids /
+#                                              //   display names the control
+#                                              //   is INTENDED to affect — the
+#                                              //   single-chart-switcher
+#                                              //   allowlist (grain controls)
+#         "mustReach": ["Monthly Revenue Trend"] // optional hard assertions:
+#                                              //   each must be in the closure
+#       }
+#     ]
+#   }
+#
+# In-spec alternative (pre-POST local specs only): a control element may carry
+#   "controlScope": ["Element Name", ...]   // or "page"
+# with the same meaning as scope. NOTE: Sigma strips unknown keys on readback,
+# so the SIDECAR is the durable form — builders should emit both when the
+# allowlist must survive a live re-lint of the posted workbook.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on tj-wells-1989):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query) evaluates a workbook
+# element WITH the workbook's saved control DEFAULTS applied and exposes NO
+# parameter mechanism to override them. The REST export API
+# (POST /v2/workbooks/{id}/export with `"parameters": {"<controlId>": "<value>"}`)
+# IS the only programmatic way to exercise a non-default control value — which
+# is why probe-controls.rb (the flip test) is built on export, not MCP.
+#
+# API:
+#   report     = ControlLint.controls_report(spec)   # per-control reach rows
+#   violations = ControlLint.lint(spec, scope: nil)  # scope = parsed sidecar
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/control_lint.rb <spec.json|spec.yaml> [control-scope.json]
+require 'json'
+require 'set'
+
+module ControlLint
+  QUERYABLE = %w[
+    table pivot-table input-table bar-chart line-chart pie-chart donut-chart
+    area-chart scatter-chart combo-chart kpi-chart box-chart funnel-chart
+    gauge-chart waterfall-chart sankey-chart region-map point-map viz chart
+    treemap-chart heatmap-chart word-cloud
+  ].to_set.freeze
+
+  module_function
+
+  # { element_id => {el:, page:, kind:, name:, srcel:} } for every element.
+  def elements(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        eid = el['id'] || el['elementId']
+        next unless eid
+        out[eid] = { el: el, page: pg['name'] || pg['id'],
+                     kind: (el['kind'] || el['type']).to_s,
+                     name: el['name'], srcel: source_element_id(el) }
+      end
+    end
+    out
+  end
+
+  # Unwraps {kind:"source", source:{elementId}} and direct {elementId} forms.
+  def source_element_id(el)
+    src = el['source']
+    return nil unless src.is_a?(Hash)
+    src = src['source'] if src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src.is_a?(Hash) ? src['elementId'] : nil
+  end
+
+  def control?(info)
+    info[:kind].include?('control')
+  end
+
+  # Transitive closure of elements sourcing (directly or via chains) from any
+  # element in `roots`. Returns roots + downstream ids.
+  def closure(elems, roots)
+    reach = roots.to_set
+    loop do
+      grew = false
+      elems.each do |eid, info|
+        next if reach.include?(eid)
+        next unless info[:srcel] && reach.include?(info[:srcel])
+        reach << eid
+        grew = true
+      end
+      break unless grew
+    end
+    reach
+  end
+
+  # Non-control elements whose serialized spec references [controlId] —
+  # catches formula refs (If([GeoLevel]="State",...)) and any other spec-level
+  # binding that names the control.
+  def formula_refs(elems, cid)
+    return [] if cid.nil? || cid.to_s.empty?
+    pat = /\[#{Regexp.escape(cid)}\]/
+    elems.select { |_eid, info| !control?(info) && JSON.generate(info[:el]).match?(pat) }
+         .keys
+  end
+
+  # Per-control reach report. Each row:
+  #   { control_element_id:, control_id:, name:, page:, control_type:,
+  #     filter_targets: [ids], ghost_targets: [ids], formula_refs: [ids],
+  #     reach: Set[ids], page_queryable: [ids], uncovered: [ids] }
+  def controls_report(spec)
+    elems = elements(spec)
+    rows = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      cid = el['controlId']
+      tgt_ids = (el['filters'] || []).map { |t| t.is_a?(Hash) ? t.dig('source', 'elementId') : nil }.compact
+      live    = tgt_ids.select { |t| elems.key?(t) }
+      frefs   = formula_refs(elems, cid)
+      roots   = (live + frefs).uniq
+      reach   = roots.empty? ? Set.new : closure(elems, roots)
+      page_q  = elems.select do |qid, i|
+        qid != eid && i[:page] == info[:page] && QUERYABLE.include?(i[:kind])
+      end.keys
+      rows << { control_element_id: eid, control_id: cid, name: info[:name],
+                page: info[:page], control_type: el['controlType'],
+                filter_targets: live, ghost_targets: tgt_ids - live,
+                formula_refs: frefs, reach: reach, page_queryable: page_q,
+                uncovered: page_q.reject { |q| reach.include?(q) } }
+    end
+    rows
+  end
+
+  # Resolve a sidecar element reference (id or display name) to element ids.
+  def resolve_ref(elems, ref)
+    return [ref] if elems.key?(ref)
+    elems.select { |_eid, i| i[:name] == ref }.keys
+  end
+
+  def label(elems, eid)
+    n = elems[eid] && elems[eid][:name]
+    n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
+  end
+
+  def lint(spec, scope: nil)
+    violations = []
+    elems = elements(spec)
+    rows  = controls_report(spec)
+
+    scope_by_cid = {}
+    if scope.is_a?(Hash)
+      Array(scope['controls']).each do |c|
+        scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
+      end
+      # (c) the Qlik class: source had filter signals, spec built zero controls.
+      signals = scope['sourceFilterSignals'].to_i
+      if signals.positive? && rows.empty?
+        violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
+                      '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
+                      'elements — the source dashboard is interactive and the migration shipped a ' \
+                      'static one; build the controls (or set sourceFilterSignals to 0 with a ' \
+                      'reason if the signals are genuinely non-portable)'
+      end
+    end
+
+    rows.each do |r|
+      ann = scope_by_cid.delete(r[:control_id]) || {}
+      ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
+      ctl_label = "control #{label(elems, r[:control_element_id])}#{r[:control_id] ? " [#{r[:control_id]}]" : ''} on page #{r[:page].inspect}"
+
+      r[:ghost_targets].each do |g|
+        violations << "ghost target: #{ctl_label} lists filter target #{g.inspect} which does not " \
+                      'resolve to any element in the spec — fix or drop the target'
+      end
+
+      # (a) dead control --------------------------------------------------------
+      if r[:reach].empty?
+        violations << "dead control: #{ctl_label} has no resolving `filters` target and no " \
+                      '[controlId] reference in any non-control element — a user changes it and ' \
+                      'nothing reacts; wire it (filters: [{source:{elementId}, columnId}]) or, if ' \
+                      'the bound column genuinely does not exist on any element, REMOVE the ' \
+                      'control (honest) instead of shipping furniture'
+        next
+      end
+
+      # (c) mustReach assertions -------------------------------------------------
+      Array(ann['mustReach']).each do |ref|
+        ids = resolve_ref(elems, ref)
+        if ids.empty?
+          violations << "scope mustReach: #{ctl_label} — annotated element #{ref.inspect} does not " \
+                        'exist in the spec'
+        elsif ids.none? { |i| r[:reach].include?(i) }
+          violations << "scope mustReach: #{ctl_label} does NOT reach annotated element " \
+                        "#{ref.inspect} — wire a filter target (or formula ref) so it does"
+        end
+      end
+
+      # (b) reach / PARTIAL --------------------------------------------------------
+      if ann_scope.is_a?(Array)
+        # Explicit allowlist (single-chart switcher): every listed element must
+        # be reached; same-page elements OUTSIDE the list are intentionally
+        # unaffected and not flagged.
+        ann_scope.each do |ref|
+          ids = resolve_ref(elems, ref)
+          if ids.empty?
+            violations << "controlScope: #{ctl_label} — scoped element #{ref.inspect} does not exist " \
+                          'in the spec'
+          elsif ids.none? { |i| r[:reach].include?(i) }
+            violations << "controlScope: #{ctl_label} does NOT reach its scoped element #{ref.inspect}"
+          end
+        end
+      elsif r[:uncovered].any?
+        names = r[:uncovered].map { |u| label(elems, u) }
+        violations << "partial control: #{ctl_label} affects #{r[:page_queryable].length - r[:uncovered].length} " \
+                      "of #{r[:page_queryable].length} same-page queryable element(s); NOT affected: " \
+                      "#{names.join(', ')} — wire those elements (add filter targets on their " \
+                      'sources, matching the source dashboard\'s filter scope) or declare the ' \
+                      'narrow scope intentional via controlScope (sidecar control-scope.json ' \
+                      'scope:[...] — see header CONTRACT)'
+      end
+    end
+
+    # (c) annotated controls that never made it into the spec ------------------
+    scope_by_cid.each do |cid, c|
+      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                    'has no control with that controlId — the source filter was not migrated'
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  abort 'usage: ruby control_lint.rb <workbook-spec.json|yaml> [control-scope.json]' unless ARGV[0] && File.exist?(ARGV[0])
+  body = File.read(ARGV[0])
+  spec =
+    begin
+      JSON.parse(body)
+    rescue JSON::ParserError
+      require 'yaml'
+      require 'date'
+      YAML.safe_load(body, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+  scope = ARGV[1] && File.exist?(ARGV[1]) ? JSON.parse(File.read(ARGV[1])) : nil
+  v = ControlLint.lint(spec, scope: scope)
+  if v.empty?
+    n = ControlLint.controls_report(spec).length
+    puts "control lint: clean (#{n} control(s) checked)"
+  else
+    warn "control lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
@@ -1,0 +1,130 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Sigma creds aren't in ENV yet, load
+# them from the neutral cred file written by setup.rb. Existing env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env) do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN'] || refresh_token!
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      @token_mutex.synchronize { @token_override = tok }
+      # Surface the refreshed token to child processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -420,9 +420,13 @@ if app_meta['isDirectQueryMode'] == true
 end
 
 # (d) charts with no native Sigma element kind (auto-chart is resolved by shape).
-NATIVE = %w[barchart auto-chart kpi linechart table piechart combochart scatterplot pivot-table].freeze
-SKIP_KINDS = %w[sheet singlepublic appprops LoadModel measure dimension masterobject sheetlist
-                filterpane listbox].freeze
+# filterpane/listbox are NOT skipped (control-targeting wave, workstream B):
+# build-sigma-workbook.py turns them into Sigma list controls wired to the
+# master (global scope, matching Qlik's associative model); alternate-state
+# panes are flagged manual in its warnings + control-scope.json.
+NATIVE = %w[barchart auto-chart kpi linechart table piechart combochart scatterplot pivot-table
+            filterpane listbox].freeze
+SKIP_KINDS = %w[sheet singlepublic appprops LoadModel measure dimension masterobject sheetlist].freeze
 real_charts.each do |c|
   vt = c['vizType']
   next if NATIVE.include?(vt) || SKIP_KINDS.include?(vt)
@@ -543,7 +547,8 @@ wb_res = JSON.parse(File.read(File.join(WORK, 'wb-result.json')))
 WB_ID = wb_res['workbookId']
 emap  = JSON.parse(File.read(File.join(WORK, 'element-map.json')))
 puts "   workbookId = #{WB_ID || '(dry-run)'}  (#{wb_res['pages']} page(s), #{wb_res['elements']} element(s), " \
-     "#{wb_res['kpis']} KPI(s))"
+     "#{wb_res['kpis']} KPI(s), #{wb_res['controls'] || 0} control(s))"
+puts "   control scope contract -> #{wb_res['controlScope']}" if (wb_res['controls'] || 0) > 0
 mark('phase4-wb')
 
 # ---------------------------------------------------------------------------
@@ -701,6 +706,33 @@ end
 
 divergent = kpi_results.count('DIVERGENT')
 parity_ok = err_cols.empty? && entries.size.positive? && divergent.zero?
+
+# 6e — control-wiring lint, gate 7 (scripts/lib/control_lint.rb, shared —
+# vendored byte-identical across the migration plugins). Lints the LIVE spec
+# readback against the control-scope.json sidecar the workbook builder
+# emitted: dead controls, ghost targets, partial same-page reach, mustReach
+# (Qlik global-scope assertions over every chart on every page), and the
+# source-signal coverage check (filterpanes/listboxes in the app but zero
+# controls in the spec = the silently-dropped class this gate exists to
+# kill). RED here blocks GREEN exactly like a parity failure.
+puts
+puts '   ── CONTROL LINT (gate 7: every filterpane/listbox a WORKING control) ──'
+$LOAD_PATH.unshift File.expand_path('lib', HERE)
+require 'control_lint'
+live = Sigma.request(:get, "/v2/workbooks/#{WB_ID}/spec") rescue {}
+live_spec = live.is_a?(Hash) ? (live['spec'] || live) : {}
+ctl_scope = (JSON.parse(File.read(File.join(WORK, 'control-scope.json'))) rescue nil)
+ctl_violations = ControlLint.lint(live_spec, scope: ctl_scope)
+ctl_rows = ControlLint.controls_report(live_spec)
+if ctl_violations.empty?
+  puts "     [OK] control lint clean — #{ctl_rows.size} control(s), " \
+       "#{(ctl_scope || {})['sourceFilterSignals'].to_i} source filter signal(s), " \
+       "#{((ctl_scope || {})['unbound'] || []).size} unbound (reasons in control-scope.json)"
+else
+  puts "     [FAIL] #{ctl_violations.size} control-lint violation(s):"
+  ctl_violations.each { |v| puts "       - #{v}" }
+end
+control_ok = ctl_violations.empty?
 mark('phase6-parity')
 
 # ---------------------------------------------------------------------------
@@ -713,8 +745,10 @@ puts "workbookId  : #{WB_ID}"
 puts "PARITY      : #{parity_ok ? 'GREEN' : 'RED'} — #{entries.size} cols resolve (#{err_cols.size} error), " \
      "KPIs: #{kpi_results.count('MATCH')} match / #{kpi_results.count('STALE-EXPLAINED')} stale-explained / #{divergent} divergent, " \
      "#{bucket_warns} bucket warning(s)"
+puts "CONTROLS    : #{control_ok ? 'GREEN' : 'RED'} — gate 7 control lint, #{ctl_rows.size} control(s) checked" \
+     "#{ctl_violations.any? ? ", #{ctl_violations.size} violation(s)" : ''}"
 puts "freshness   : Qlik last reload #{app_meta['lastReloadTime'] || '?'} (#{stale_days} days ago)" if stale_days
 puts "warnings    : #{conv_warnings.size} converter, #{(wb_res['warnings'] || []).size} workbook-build" if conv_warnings.any? || (wb_res['warnings'] || []).any?
 puts '======================================='
 phase_summary
-exit(parity_ok ? 0 : 3)
+exit(parity_ok && control_ok ? 0 : 3)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/probe-controls.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/probe-controls.rb
@@ -1,0 +1,236 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# probe-controls.rb — live flip test proving a workbook's controls actually
+# filter what they claim to. OPTIONAL Phase 6 step (not the mandatory inner
+# loop): run it after the control lint (gate 7) passes when you want runtime
+# evidence, after repairing control wiring on a live workbook, or whenever a
+# control's reach was wired by hand.
+#
+# SHARED script, vendored byte-identical into every covered plugin's scripts/
+# (md5 discipline — same as scripts/lib/control_lint.rb, which it reuses).
+#
+# What it does, per control:
+#   1. computes the control's reach (filter targets + [controlId] formula
+#      references, expanded through source.elementId chains —
+#      ControlLint.controls_report)
+#   2. exports one IN-closure queryable element as CSV twice via
+#      POST /v2/workbooks/{id}/export — once with no `parameters` (the saved
+#      control defaults) and once with parameters:{<controlId>: <flip value>}.
+#      The two CSVs MUST differ, or the control is wired but inert -> FAIL.
+#   3. with --check-out-of-closure: also exports one same-page queryable
+#      element OUTSIDE the closure with and without the parameter — those
+#      MUST be identical (the flip must not leak) -> FAIL if they differ
+#      (the closure walk missed an edge; fix control_lint, not the workbook).
+#
+# Flip-value selection ("first non-default value"):
+#   --value <controlId>=<value> beats everything (repeatable).
+#   Otherwise: the control's value-source column (source.columnId, falling
+#   back to the first filter target's columnId) is resolved to its display
+#   label via GET /v2/workbooks/{id}/columns, that element is exported once,
+#   and the first distinct value of that column NOT in the control's saved
+#   defaults (`values`) is used. switch controls flip true<->false. Controls
+#   whose value cannot be auto-picked (date ranges, numeric sliders, missing
+#   labels) are SKIPped with a NOTE — pass --value for those.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on tj-wells-1989):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query / claude.ai Sigma MCP)
+# evaluates workbook elements WITH the saved control defaults applied and
+# exposes NO parameter mechanism to set a control value. The REST export API
+# (POST /v2/workbooks/{id}/export with "parameters": {"<controlId>": "<val>"})
+# is the ONLY programmatic way to exercise a non-default control value —
+# which is why this probe is built on export, not MCP. (MCP is still fine for
+# default-state parity checks — Phase 6 uses it for exactly that.)
+#
+# Usage:
+#   ruby scripts/probe-controls.rb --workbook-id <id> \
+#     [--control <controlId>]        # probe just one control (repeatable)
+#     [--value <controlId>=<value>]  # explicit flip value (repeatable)
+#     [--check-out-of-closure]       # also assert the flip does NOT leak
+#     [--out DIR]                    # CSV evidence dir (default /tmp/probe-controls-<id>)
+#     [--timeout SECS]               # export poll timeout per CSV (default 90)
+#
+# Exit codes: 0 = every probed control flips correctly (skips allowed);
+#             1 = at least one FAIL; 2 = no control could be probed at all.
+require 'json'
+require 'csv'
+require 'optparse'
+require 'net/http'
+require 'uri'
+require 'fileutils'
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+require 'control_lint'
+
+opts = { values: {}, controls: [], timeout: 90 }
+OptionParser.new do |p|
+  p.on('--workbook-id ID')        { |v| opts[:wb] = v }
+  p.on('--control CID')           { |v| opts[:controls] << v }
+  p.on('--value SPEC', '<controlId>=<value>') do |v|
+    cid, val = v.split('=', 2)
+    abort "bad --value #{v.inspect} (want <controlId>=<value>)" unless cid && val
+    opts[:values][cid] = val
+  end
+  p.on('--check-out-of-closure')  { opts[:check_out] = true }
+  p.on('--out DIR')               { |v| opts[:out] = v }
+  p.on('--timeout SECS', Integer) { |v| opts[:timeout] = v }
+end.parse!
+abort('--workbook-id required') unless opts[:wb]
+WB = opts[:wb]
+OUT = opts[:out] || "/tmp/probe-controls-#{WB}"
+FileUtils.mkdir_p(OUT)
+
+# --- Sigma plumbing ---------------------------------------------------------
+
+def fetch_spec(wb)
+  body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'application/json')
+  return body if body.is_a?(Hash)
+  require 'yaml'
+  require 'date'
+  YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {}
+end
+
+# Export an element as CSV (optionally with control parameters), poll the
+# query download until ready, return the CSV text. Raises on timeout/error.
+def export_csv(wb, element_id, params, timeout)
+  body = { 'elementId' => element_id, 'format' => { 'type' => 'csv' } }
+  body['parameters'] = params if params && !params.empty?
+  res = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+  qid = res.is_a?(Hash) && res['queryId']
+  raise "export request failed: #{res.inspect}" unless qid
+  deadline = Time.now + timeout
+  loop do
+    uri = URI("#{Sigma.base_url}/v2/query/#{qid}/download")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    r = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 60) { |h| h.request(req) }
+    return r.body if r.code.to_i == 200
+    raise "export download failed: HTTP #{r.code} #{r.body.to_s[0, 300]}" if r.code.to_i >= 400 && r.code.to_i != 404
+    raise "export timed out after #{timeout}s (queryId=#{qid})" if Time.now > deadline
+    sleep 2
+  end
+end
+
+# Row-order-insensitive CSV signature (filters change row SETS; ordering noise
+# must not mask or fake a flip).
+def csv_sig(text)
+  text.to_s.lines.map(&:chomp).sort
+end
+
+# --- reach + element metadata ------------------------------------------------
+
+spec  = fetch_spec(WB)
+elems = ControlLint.elements(spec)
+rows  = ControlLint.controls_report(spec)
+rows.select! { |r| opts[:controls].include?(r[:control_id]) } if opts[:controls].any?
+abort "no controls found in workbook #{WB}#{opts[:controls].any? ? " matching #{opts[:controls].inspect}" : ''}" if rows.empty?
+
+cols = Sigma.request(:get, "/v2/workbooks/#{WB}/columns")
+col_label = {} # [elementId, columnId] -> display label
+(cols && cols['entries'] || []).each do |c|
+  col_label[[c['elementId'], c['columnId']]] = c['label'] if c['elementId'] && c['columnId']
+end
+
+baseline_cache = {}
+get_baseline = lambda do |eid|
+  baseline_cache[eid] ||= export_csv(WB, eid, nil, opts[:timeout])
+end
+
+# Pick the flip value for a control (returns [value, note] — value nil = skip).
+pick_value = lambda do |r|
+  el = elems[r[:control_element_id]][:el]
+  cid = r[:control_id]
+  return [opts[:values][cid], 'explicit --value'] if opts[:values].key?(cid)
+  defaults = Array(el['values']).map(&:to_s)
+  case el['controlType'].to_s
+  when 'switch'
+    return [(defaults.first.to_s.downcase == 'true' ? 'false' : 'true'), 'switch flip']
+  when 'list', 'segmented', 'text'
+    src = el['source']
+    src = src['source'].merge('columnId' => src['columnId']) if src.is_a?(Hash) && src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src = (el['filters'] || []).map { |f| f.is_a?(Hash) ? (f['source'] || {}).merge('columnId' => f['columnId']) : nil }.compact.first if !src.is_a?(Hash) || !src['columnId']
+    return [nil, 'no value-source column resolvable — pass --value'] unless src.is_a?(Hash) && src['elementId'] && src['columnId']
+    label = col_label[[src['elementId'], src['columnId']]]
+    return [nil, "no /columns label for #{src['elementId']}/#{src['columnId']} — pass --value"] unless label
+    csv = CSV.parse(get_baseline.call(src['elementId']), headers: true)
+    return [nil, "column #{label.inspect} not in export of #{src['elementId']} — pass --value"] unless csv.headers.include?(label)
+    distinct = csv.map { |row| row[label] }.compact.map(&:to_s).reject(&:empty?).uniq
+    val = distinct.find { |v| !defaults.include?(v) }
+    val ? [val, "auto-picked from #{label.inspect}"] : [nil, 'no non-default value found — pass --value']
+  else
+    [nil, "controlType=#{el['controlType'].inspect} has no auto flip value — pass --value"]
+  end
+end
+
+# --- probe loop ----------------------------------------------------------------
+
+failures = 0
+probed = 0
+results = []
+rows.each do |r|
+  cid = r[:control_id]
+  ctl = "#{r[:name].inspect} [#{cid}]"
+  if r[:reach].empty?
+    results << { control: cid, result: 'FAIL', note: 'dead control — empty reach (run the control lint)' }
+    failures += 1
+    next
+  end
+
+  in_el = (r[:reach] & r[:page_queryable]).first ||
+          r[:reach].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+  if in_el.nil?
+    results << { control: cid, result: 'SKIP', note: 'no queryable element in closure' }
+    next
+  end
+
+  val, note = pick_value.call(r)
+  if val.nil?
+    results << { control: cid, result: 'SKIP', note: note }
+    next
+  end
+
+  probed += 1
+  base = get_baseline.call(in_el)
+  flip = export_csv(WB, in_el, { cid => val }, opts[:timeout])
+  File.write(File.join(OUT, "#{cid}--#{in_el}--base.csv"), base)
+  File.write(File.join(OUT, "#{cid}--#{in_el}--flip.csv"), flip)
+  changed = csv_sig(base) != csv_sig(flip)
+  if changed
+    results << { control: cid, result: 'PASS', element: in_el, value: val,
+                 note: "#{note}; in-closure export differs (#{base.lines.count - 1} -> #{flip.lines.count - 1} rows)" }
+  else
+    failures += 1
+    results << { control: cid, result: 'FAIL', element: in_el, value: val,
+                 note: "#{note}; in-closure export IDENTICAL with #{cid}=#{val.inspect} — control is wired but inert" }
+  end
+
+  next unless opts[:check_out]
+  out_el = r[:uncovered].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+  if out_el.nil?
+    results << { control: cid, result: 'OK', note: 'out-of-closure: none on page (full reach) — nothing to check' }
+  else
+    obase = get_baseline.call(out_el)
+    oflip = export_csv(WB, out_el, { cid => val }, opts[:timeout])
+    File.write(File.join(OUT, "#{cid}--#{out_el}--out-base.csv"), obase)
+    File.write(File.join(OUT, "#{cid}--#{out_el}--out-flip.csv"), oflip)
+    if csv_sig(obase) == csv_sig(oflip)
+      results << { control: cid, result: 'OK', element: out_el, note: 'out-of-closure export unchanged (no leak)' }
+    else
+      failures += 1
+      results << { control: cid, result: 'FAIL', element: out_el,
+                   note: 'out-of-closure export CHANGED — the closure walk missed an edge (fix control_lint, not the workbook)' }
+    end
+  end
+end
+
+puts format('%-22s %-6s %-34s %s', 'CONTROL', 'RESULT', 'ELEMENT', 'NOTE')
+results.each do |x|
+  puts format('%-22s %-6s %-34s %s', x[:control], x[:result], x[:element] || '-', [x[:value] && "flip=#{x[:value].inspect}", x[:note]].compact.join('; '))
+end
+File.write(File.join(OUT, 'probe-results.json'), JSON.pretty_generate(results))
+puts "evidence: #{OUT}/ (CSVs + probe-results.json)"
+
+exit 1 if failures.positive?
+exit 2 if probed.zero?
+exit 0

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
@@ -426,6 +426,39 @@ def main():
     sheets.sort(key=lambda s: (s["rank"] is None, s["rank"]))
     awrite(os.path.join(a.out, "layout.json"), sheets)
 
+    # Filterpane children (control-targeting wave, workstream B): a filterpane's
+    # listboxes are CHILD objects — not in its properties. `qlik app object
+    # layout` evaluates the object's layout incl. qChildList.qItems. Fetched
+    # through the same pool (filterpanes are few).
+    fp_ids = [o.get("qId") for o in objs if o.get("qType") == "filterpane"]
+    def _fp_children(fid):
+        lay = qlik("app", "object", "layout", fid, "-a", a.app, *ctx) or {}
+        items = ((lay.get("qChildList") or {}).get("qItems")) or []
+        return [it.get("qInfo", {}).get("qId") for it in items if it.get("qInfo", {}).get("qId")]
+    with stage("filterpane-children"):
+        fp_children = dict(zip(fp_ids, pmap(_fp_children, fp_ids, a.pool)))
+
+    # Listbox field metadata from the EVALUATED layout (qListObject.qDimensionInfo):
+    # qTags carries the field's type tags ($date/$timestamp) — the workbook builder
+    # needs them to emit a date-range control instead of a list (a list control's
+    # filter targets on a datetime column get SILENTLY STRIPPED by Sigma). Also the
+    # only source of field/title for pane children that `app object ls` omits.
+    known_ids = {o.get("qId") for o in objs}
+    lb_ids = [o.get("qId") for o in objs if o.get("qType") == "listbox"]
+    lb_ids += [c for kids in fp_children.values() for c in kids if c not in known_ids]
+    def _lb_meta(lid):
+        lay = qlik("app", "object", "layout", lid, "-a", a.app, *ctx) or {}
+        lo = lay.get("qListObject") or {}
+        di = lo.get("qDimensionInfo") or {}
+        return {"field": (di.get("qGroupFieldDefs") or [None])[0],
+                "label": di.get("qFallbackTitle"),
+                "title": (lay.get("title") or di.get("qFallbackTitle")),
+                "state": lo.get("qStateName") or lay.get("qStateName"),
+                "tags": di.get("qTags") or [],
+                "numFmt": (di.get("qNumFormat") or {}).get("qFmt")}
+    with stage("listbox-meta"):
+        lb_meta = dict(zip(lb_ids, pmap(_lb_meta, lb_ids, a.pool)))
+
     for o in objs:
         oid, qtype = o.get("qId"), o.get("qType")
         if qtype == "sheet": continue
@@ -451,7 +484,7 @@ def main():
                     hc = lhc
                     qdims, qmeas = lhc.get("qDimensions", []), lhc.get("qMeasures", [])
                     break
-        charts.append({
+        rec = {
             "id": oid, "vizType": qtype,
             "title": (props.get("qMetaDef") or {}).get("title") or (props.get("title")),
             "sheet": obj_sheet.get(oid),
@@ -462,7 +495,47 @@ def main():
             "measureLabels": [ mm.get("qDef", {}).get("qLabel") for mm in qmeas ],
             "measureFmts": [ (mm.get("qDef", {}).get("qNumFormat") or {}).get("qFmt") for mm in qmeas ],
             "sort": sort,
-        })
+        }
+        # Filter objects (control-targeting wave): a listbox's field lives on
+        # qListObjectDef (NOT the hypercube), and an alternate-state object
+        # carries qStateName — the workbook builder turns these into Sigma list
+        # controls (default state) or flags them manual (alternate state).
+        if qtype == "listbox":
+            lod = props.get("qListObjectDef") or {}
+            ldef = lod.get("qDef") or {}
+            meta = lb_meta.get(oid) or {}
+            rec["listbox"] = {
+                "field": (ldef.get("qFieldDefs") or [None])[0] or lod.get("qLibraryId")
+                         or meta.get("field"),
+                "label": (ldef.get("qFieldLabels") or [None])[0] or rec["title"]
+                         or meta.get("label"),
+                "state": lod.get("qStateName") or props.get("qStateName") or meta.get("state"),
+                "tags": meta.get("tags") or [],
+                "numFmt": meta.get("numFmt"),
+            }
+        elif qtype == "filterpane":
+            rec["children"] = fp_children.get(oid, [])
+            rec["state"] = props.get("qStateName")
+        charts.append(rec)
+    # Pane children that `app object ls` did NOT list as standalone objects:
+    # synthesize their listbox records from the evaluated layouts so the
+    # workbook builder still emits one control per pane field.
+    for fid, kids in fp_children.items():
+        for kid in kids:
+            if kid in known_ids:
+                continue
+            meta = lb_meta.get(kid) or {}
+            charts.append({"id": kid, "vizType": "listbox",
+                           "title": meta.get("title"),
+                           "sheet": obj_sheet.get(fid),
+                           "dimensions": [], "dimLabels": [], "dimNullSuppression": [],
+                           "measures": [], "measureLabels": [], "measureFmts": [],
+                           "sort": {},
+                           "listbox": {"field": meta.get("field"),
+                                       "label": meta.get("label"),
+                                       "state": meta.get("state"),
+                                       "tags": meta.get("tags") or [],
+                                       "numFmt": meta.get("numFmt")}})
     awrite(os.path.join(a.out, "charts.json"), charts)
 
     # converter input (feed the Qlik MODEL field names; simple dims are skipped by converter)


### PR DESCRIPTION
Workstream B of the control-targeting wave. Both builders now EMIT the `control-scope.json` contract sidecar (schema: `lib/control_lint.rb` header CONTRACT + `refs/control-parity.md`, merged in #73) and both live E2Es pass gate 7.

## Qlik — filterpanes were silently dropped (the lint's "Qlik class")

- `migrate-qlik.rb`: `filterpane`/`listbox` moved out of `SKIP_KINDS`.
- `qlik-discover.py`: fetches filterpane `qChildList` children + each listbox's **evaluated layout** (`qListObject.qDimensionInfo`: field, label, alternate state, `qTags`, `qNumFormat`); children that `app object ls` omits are synthesized onto their pane's sheet.
- `build-sigma-workbook.py`: every pane child / standalone listbox → a Sigma **list control**, or a **date-range control** when the field is date-typed (`$date`/`$timestamp` tags → fallback to qNumFormat / raw column name). Two live-verified gotchas baked in:
  - a `list` control whose filter target is a datetime column posts fine but Sigma **silently strips the target** (estate-repair finding) — hence date-range;
  - a date-range control **requires flat `mode` (e.g. `between`)** — without it POST 400s with the misleading `Invalid kind: "control"`.
- **Scope = GLOBAL** (Qlik associative model): one filter target on the master table propagates to every chart on every page. Duplicate-field listboxes on other sheets dedupe to the one global control (`unbound: duplicate`); alternate-state listboxes are flagged MANUAL (`unbound: manual`), never silently dropped; unresolvable fields are dropped loudly (`unbound`), never wired wrong.
- `migrate-qlik.rb` **Phase 6e = gate 7**: shared `ControlLint.lint` over the **live spec readback** + sidecar; `CONTROLS: RED` blocks GREEN exactly like parity. Vendored byte-identical (md5 discipline): `scripts/lib/control_lint.rb`, `scripts/lib/sigma_rest.rb`, `scripts/probe-controls.rb`, `refs/control-parity.md`.
- Fixtures: `fixtures/retail-orders` now carries filter objects covering every path (pane children, date-typed, alternate-state, unresolvable, duplicate) — the offline smoke regression-tests controls + the lint (`sourceFilterSignals: 5`, 3 controls incl. one date-range, lint clean).

### Qlik sidecar sample (live run)
```json
{ "version": 1, "source": "qlik", "sourceFilterSignals": 3,
  "controls": [
    { "controlId": "CustomerRegionFilter", "sourceName": "listbox lb-region field 'CUSTOMER_REGION'",
      "status": "wired", "controlType": "list", "scope": "page",
      "mustReach": ["el-krev", "el-kord", "… every queryable element on every page (35)"],
      "wired": [{ "elementId": "m-master", "columnId": "o30" }] },
    { "controlId": "FullDateFilter", "controlType": "date-range", "scope": "page", "mustReach": ["…35"] }
  ],
  "unbound": [
    { "sourceName": "listbox lb-region2 field 'CUSTOMER_REGION'", "status": "duplicate",
      "reason": "same field as control 'CustomerRegionFilter' — one global Sigma control already covers every sheet (Qlik associative semantics)" } ] }
```

### Qlik E2E (KEPT: DM `e1629cc9-31e7-413b-a27c-635c763ee80e`, workbook `9820da34-0ecf-43ea-89d3-bf35164f8d3b`)
One command, 58.8s: `PARITY: GREEN` (142/142 cols, 0 divergent) + `CONTROLS: GREEN — gate 7 control lint, 3 control(s) checked` (3 source signals, 1 dedup). probe-controls: both list controls PASS (flip="South" / "Electronics"). **Global scope proven verbatim** (controls live on page 1, exports via `parameters:` on OTHER pages):

```
pg-3 Net Revenue by Segment      | CustomerRegionFilter=South
  BEFORE: Consumer,58366.72 / Corporate,26017.27 / Home Office,23752.92
  AFTER : Consumer,16729.94 / Home Office,7546.75 / Corporate,7532.45
pg-4 Net Revenue by Store Region | CustomerRegionFilter=South   (changed)
pg-5 Net Revenue by Promo Type   | CategoryFilter=Electronics   (5 rows -> 4, all values changed)
pg-1 Revenue & Profit by Month   | FullDateFilter=min:2025-09-01,max:2025-09-30
  BEFORE: 12 monthly rows   AFTER: 1 row ("9,2982.02,1837.02")  ← date-range control works
```

⚠ E2E caveat: the original `ec9a73e3` app's **engine doc is wedged tenant-side** ("session closed before receiving OnConnected" for hours; REST fine; every other app opens; even a fresh copy of it opens instantly) AND it contains **zero filter objects**. The E2E therefore ran against an exact tenant **copy** (`76b4225e`, named "Retail Orders", kept) enriched with a real filterpane (2 children), a standalone date listbox, and a duplicate-field listbox on a second sheet — the original app was never written.

## Power BI — multi-master misses + silent wrong-column fallback

- `build-workbook-from-pbir.rb`:
  - **(i)** `|| mcols.first` fallback removed. Unresolvable slicer column = loud `ERROR` + control dropped (no element emitted), recorded in the sidecar `unbound` with reason. Column matching is exact-or-`Leaf (ENTITY)` only — never an arbitrary column.
  - **(ii)** slicer targets are **relationship-scoped**: one `filters[]` entry per master whose table the slicer's filter reaches in the TMSL (`--model`, wired automatically by `migrate-powerbi.rb`): same-table always; related tables via one→many flow (+`bothDirections`, inactive rels skipped); restructured/pseudo elements (Dense Rank / time-intel / calc-table SQL) by column evidence. Cross-grain impossibilities land in the per-control `excluded[]` with a reason and are kept OUT of the `scope` allowlist — gate 7 neither asserts the impossible nor passes it silently. Date-typed slicer columns (TMSL `dataType`) → date-range controls.
  - **(iii)** visual-interaction exceptions: PBIR `page.json visualInteractions` (and classic `sections[].config.visualInteractions`, type `3` → none, ids remapped onto synthesized visual ids) are extracted and honored — an interaction edited to none excludes that visual from intended scope with a NOTE (master-level wiring cannot exempt a master-sharing visual; flagged for verification). Absent = PBI defaults (slicer filters its page).
- `migrate-powerbi.rb` master-map fixes found live during E2E: posted-dm-spec display names are now the authority (raw SQL-element aliases broke refs); nameless Custom-SQL elements match positionally (the old `dm_elements.first` fallback overwrote the fact master's columns); the join-View resolution is registered as an **alt** instead of primary (single-table visuals keep their source grain — fixed a live median divergence 73,500 vs 73,000); DAX `SEARCH/FIND` 3rd start-arg stripped (Sigma `Find` takes 2 args — converter gap, see below).

### PBI sidecar sample (live run)
```json
{ "version": 1, "source": "powerbi", "sourceFilterSignals": 2,
  "controls": [
    { "controlId": "DepartmentFilter", "sourceName": "slicer Filter: Department (a0sl000000000001) column EMPLOYEES.DEPARTMENT",
      "status": "wired", "reachableTables": ["EMPLOYEES", "ABSENCE_RECORDS"],
      "wiredMasters": ["EMPLOYEES", "ABSENCE_RECORDS", "ABSENCE_RECORDS View", "Dense Rank DEPARTMENT"],
      "unwiredMasters": [], "scope": ["el-0000016f84f7", "… all 9 same-page charts"], "excluded": [] },
    { "controlId": "ShiftFilter", "wiredMasters": ["EMPLOYEES", "ABSENCE_RECORDS View"],
      "unwiredMasters": ["ABSENCE_RECORDS"],   // cross-grain: no SHIFT column at absence grain — loud WARN
      "scope": ["… same 9"], "excluded": [] } ] }
```

### PBI E2E (KEPT: DM `2b01de83-a27a-4f81-b46e-3a5c0c33f499`, workbook `d8eca052-dce7-4069-bf4d-76b189737728`)
"Workforce Comp & Distribution" full migration (cached `/tmp/pbiauth` token; live `executeQueries` expected rows). Extract-mode parity **9/9 PASS** (drifts are stale-snapshot-shaped: dataset 12 days stale, refresh failing on expired Snowflake creds). `assert-phase6-ran.rb` (`--allow-extract`): **all 7 gates green**, incl. `[OK] gate 7/7: control lint clean (2 control(s) …)`. Live readback confirms DepartmentFilter carries 4 master targets, ShiftFilter 2.

probe-controls: both PASS (`flip="Finance"` / `"Day"`). Verbatim flips (export `parameters`):
```
bar (emp-sourced)            BEFORE 6 rows: Customer Service,60000.0 / Engineering,101200.0 / Finance,82500.0
  DepartmentFilter=Finance   AFTER  1 row : Finance,82500.0
distribution table           BEFORE 6 rows: …  AFTER 1 row: Finance,43,82500.0,129785.8,…
scatter (restructured grouped-source CHAIN)
  BEFORE 30 rows: AP/AR Specialist,9,54600.0 / Account Executive,12,73945.0 / …
  AFTER   8 rows: AP/AR Specialist,9,54600.0 / CS Representative,1,62470.0 / Controller,9,130400.0 …
pivot | ShiftFilter=Night    BEFORE cols Day,Night,Swing,Total → AFTER cols Night,Total (values match Night)
```
(The roles/bands side: `Dense Rank DEPARTMENT` — the restructured bands-flavored SQL element — is wired; `SalaryBands` itself has NO model relationship to EMPLOYEES, so its charts are correctly out of scope by the contract.)

## Contract feedback (no lint changes made; vendored files untouched)
- The contract worked as-is. Two follow-ups for the lint owners to consider:
  1. `probe-controls.rb` SKIPs `date-range` controls (no auto flip value). Export `parameters` accepts `"min:YYYY-MM-DD,max:YYYY-MM-DD"` for them (live-verified above) — auto-pick could synthesize that from the bound column's min/max.
  2. `scripts/lib/sigma_rest.rb`: qlik's pre-existing `vendor/lib` copy carries a 429/Cloudflare backoff the shared `scripts/lib` copy lacks — worth upstreaming to all plugins in the lint repo's next md5 sweep (kept byte-identical to the other plugins here).

## Deferred
- PBI slicer types beyond column lists (hierarchy/relative-date slicers) keep their previous behavior; date slicers now map via TMSL dataType but none existed in the live fixture (covered by code path only).
- Converter gap (filed in the commit, not fixed here): DAX `SEARCH/FIND` translates with its start argument; Sigma `Find()` takes 2 — the builder strips it as a workaround.
- Qlik alternate-state filterpanes remain manual by design (no Sigma equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)