### PR TITLE
Control targeting per source scope: looker listen:, tableau roots/zones/actions, enhancer extension (workstream C)

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-orders/skilltest_orders.dashboard.lookml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-orders/skilltest_orders.dashboard.lookml
@@ -20,6 +20,13 @@
     field: order_fact.order_channel
     allow_multiple_values: true
 
+  - name: First Order Date
+    title: First Order Date
+    type: date_filter
+    model: skilltest_orders
+    explore: order_fact
+    field: customer_dim.first_order
+
   elements:
   - name: Total Net Revenue
     title: Total Net Revenue
@@ -30,6 +37,7 @@
     listen:
       Region: customer_dim.region
       Order Channel: order_fact.order_channel
+      First Order Date: customer_dim.first_order_date
     row: 0
     col: 0
     width: 8
@@ -44,6 +52,7 @@
     listen:
       Region: customer_dim.region
       Order Channel: order_fact.order_channel
+      First Order Date: customer_dim.first_order_date
     row: 0
     col: 8
     width: 8
@@ -58,6 +67,7 @@
     listen:
       Region: customer_dim.region
       Order Channel: order_fact.order_channel
+      First Order Date: customer_dim.first_order_date
     row: 0
     col: 16
     width: 8

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-orders/views/customer_dim.view.lkml
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/fixtures/skilltest-orders/views/customer_dim.view.lkml
@@ -13,6 +13,12 @@ view: customer_dim {
     sql: ${TABLE}.REGION ;;
   }
 
+  dimension_group: first_order {
+    type: time
+    timeframes: [raw, date, month, year]
+    sql: ${TABLE}.FIRST_ORDER_DATE ;;
+  }
+
   dimension: customer_segment {
     type: string
     sql: ${TABLE}.CUSTOMER_SEGMENT ;;

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/control-parity.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/control-parity.md
@@ -78,8 +78,14 @@ Consequences:
   control should govern (the column must exist on each); elements sourcing
   from those masters inherit via the closure.
 - **partial reach, chart bypasses the master** (sources the DM directly) →
-  either re-source the chart from the master or add a filter target on the
-  chart element itself with that element's own columnId.
+  either re-source the chart from the master or re-root it through a hidden
+  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
+  carrying passthrough columns; the chart re-sourced through it) and target
+  the table. Control filter targets may only point at TABLE elements — a
+  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
+  (live-verified 2026-06-12; the looker builder's listen-scope tables and
+  enhance-apply's `ensure_base_table!` are the two automated forms of this
+  pattern).
 - **intentional narrow control** (grain switcher driving one chart by
   formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -14,11 +14,23 @@ placeholders so the spec generates locally); wire them to a real converted DM
 before POSTing. Tile->kind, filter->control, and layout maps follow
 refs/dashboard-contract.md and research/looker-dashboard-layout.md.
 """
-import argparse, json, os, re, secrets, string, glob
+import argparse, json, os, re, secrets, string, sys, glob
 
 def sid(p="el"): return p + "-" + "".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(8))
 def disp(seg):  return " ".join(w.capitalize() for w in str(seg).split("_"))
 def leaf(field): return field.split(".")[-1]            # users.traffic_source -> traffic_source
+
+# dimension_group timeframe expansion — MIRRORS the DM converter (lookml.ts
+# TIMEFRAME_MAP / DEFAULT_TIMEFRAMES): a `dimension_group: order_date` with >1
+# timeframes becomes DM columns "Order Date Raw" / "Order Date Date" /
+# "Order Date Month" / ...; with <=1 timeframes it stays ONE raw column named
+# after the physical SQL column. Dashboard filters routinely reference the
+# BARE group name (`order_fact.order_date`) while tiles reference expanded
+# fields (`order_fact.order_date_month`) — both must resolve to a real DM
+# column display name or the filter binding dies.
+TIMEFRAME_SUFFIX = {"raw": "Raw", "time": "Time", "date": "Date", "week": "Week",
+                    "month": "Month", "quarter": "Quarter", "year": "Year"}
+DEFAULT_TIMEFRAMES = ["raw", "time", "date", "week", "month", "quarter", "year"]
 
 TILE_KIND = {
     "single_value": "kpi-chart", "looker_column": "bar-chart", "looker_bar": "bar-chart",
@@ -112,6 +124,8 @@ def build_field_index(view_files):
     view_pk = {}    # "view" -> primary-key dimension name
     yesno = set()   # "view.field" of type:yesno dims — the DM converter names
                     # their boolean calc column "<label> (T-F)"
+    dim_groups = {} # "view.group" -> {"timeframes": [...], "phys": display name
+                    #   of the physical column (the single-column fallback name)}
     for path in view_files:
         txt = open(path).read()
         txt = re.sub(r"#[^\n]*", "", txt)               # strip comments
@@ -120,6 +134,26 @@ def build_field_index(view_files):
         view = vm.group(1)
         for d in re.finditer(r"\b(dimension|dimension_group)\s*:\s*(\w+)", txt):
             dims.add(f"{view}.{d.group(2)}")
+        # dimension_group blocks: capture timeframes + physical column so field
+        # refs (bare group OR expanded `<group>_<timeframe>`) resolve to the DM
+        # column names the converter actually emits (see TIMEFRAME_SUFFIX).
+        for m in re.finditer(r"dimension_group:\s*(\w+)\s*\{", txt):
+            name = m.group(1); start = m.end(); depth, i = 1, start
+            while i < len(txt) and depth:
+                depth += {"{": 1, "}": -1}.get(txt[i], 0); i += 1
+            block = txt[start:i]
+            if re.search(r"type:\s*duration\b", block):
+                continue          # duration groups expand to Days/Hours/… columns
+            tfm = re.search(r"timeframes:\s*\[([^\]]*)\]", block)
+            tfs = ([t.strip().lower() for t in tfm.group(1).split(",") if t.strip()]
+                   if tfm else list(DEFAULT_TIMEFRAMES))
+            tfs = [t for t in tfs if t in TIMEFRAME_SUFFIX]
+            sqlm = re.search(r"sql:\s*(.+?);;", block, re.S)
+            phys = None
+            if sqlm:
+                r2 = re.search(r"\$\{TABLE\}\.(\w+)", sqlm.group(1))
+                if r2: phys = disp(r2.group(1))
+            dim_groups[f"{view}.{name}"] = {"timeframes": tfs, "phys": phys or disp(name)}
         # primary key / yesno: scan each dimension block
         for m in re.finditer(r"dimension:\s*(\w+)\s*\{", txt):
             name = m.group(1); start = m.end(); depth, i = 1, start
@@ -171,7 +205,7 @@ def build_field_index(view_files):
                     measures[key] = (agg, disp(tc.group(2)),
                                      f"{tc.group(1)}(${{TABLE}}.{tc.group(2)})", mfilters)
                     formats.setdefault(key, tfmt)
-    return measures, dims, view_pk, formats, yesno
+    return measures, dims, view_pk, formats, yesno, dim_groups
 
 def main():
     ap = argparse.ArgumentParser()
@@ -190,10 +224,13 @@ def main():
     ap.add_argument("--master-name", default="Data")
     ap.add_argument("--folder-id", default="<FOLDER_ID>")
     ap.add_argument("--out", default="/tmp/workbook.spec.json")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit non-zero when a dashboard filter cannot be bound "
+                         "(default: drop the control with a loud warning)")
     a = ap.parse_args()
 
     dash = json.load(open(a.contract))
-    measures, dims, view_pk, formats, yesno_dims = build_field_index(sorted(glob.glob(os.path.join(a.views, "*.view.lkml"))))
+    measures, dims, view_pk, formats, yesno_dims, dim_groups = build_field_index(sorted(glob.glob(os.path.join(a.views, "*.view.lkml"))))
     warnings = []
 
     # ── per-explore masters ────────────────────────────────────────────────────
@@ -267,6 +304,30 @@ def main():
         view = f.split(".")[0]
         return [f"{view}.{r}" for r in re.findall(r"\$\{(\w+)\}", measures[f][2])
                 if f"{view}.{r}" in measures]
+    def dimgroup_display(f):
+        """DM column display name for a dimension_group field, or None when `f`
+        isn't one. Mirrors the converter's timeframe expansion (lookml.ts):
+        multi-timeframe groups expand to '<Group> <Suffix>' columns; a single-
+        timeframe group keeps ONE raw column named after the physical column.
+        Accepts the BARE group name (dashboard filters: `view.order_date`) and
+        expanded timeframe fields (`view.order_date_month`). A bare-group ref
+        (no timeframe) prefers the day-grain 'Date' column, then 'Raw'/'Time'."""
+        view = f.split(".")[0]; lf = leaf(f)
+        entry = dim_groups.get(f"{view}.{lf}"); tf = None; base = lf
+        if entry is None:
+            m = re.match(r"^(.*)_(\w+)$", lf)
+            if m and m.group(2).lower() in TIMEFRAME_SUFFIX:
+                entry = dim_groups.get(f"{view}.{m.group(1)}")
+                tf, base = m.group(2).lower(), m.group(1)
+            if entry is None:
+                return None
+        tfs = entry["timeframes"]
+        if len(tfs) <= 1:
+            return entry["phys"]                  # converter emits one raw column
+        if tf is None or tf not in tfs:
+            tf = next((t for t in ("date", "raw", "time") if t in tfs), tfs[0])
+        return f"{disp(base)} {TIMEFRAME_SUFFIX[tf]}"
+
     def col_display(f, explore):
         """Display name of the MASTER column a field maps to. Joined-view columns
         in the denormalized DM element are disambiguated as '<Field> (<joinAlias>)'
@@ -277,6 +338,9 @@ def main():
             if is_ratio(f): return None           # composite — components needed separately
             base = measures[f][1]                 # base column (None for plain count)
             return (base + suf) if base else None
+        dg = dimgroup_display(f)
+        if dg is not None:
+            return dg + suf
         return disp(leaf(f)) + suf
     def pk_display(view, explore):
         """Display name of a view's primary-key column in the denorm element."""
@@ -481,10 +545,12 @@ def main():
             for f in kpis:
                 kid = sid(); cid = sid("v")
                 col = apply_fmt({"id": cid, "formula": formula_for(f, ex), "name": disp(leaf(f))}, f)
-                elements.append({"id": kid, "kind": "kpi-chart",
-                                 "name": f"{el['name']} · {disp(leaf(f))}",
-                                 "source": {"elementId": master_of(ex)["id"], "kind": "table"},
-                                 "columns": [col], "value": {"columnId": cid}})
+                kpi_el = {"id": kid, "kind": "kpi-chart",
+                          "name": f"{el['name']} · {disp(leaf(f))}",
+                          "source": {"elementId": master_of(ex)["id"], "kind": "table"},
+                          "columns": [col], "value": {"columnId": cid}}
+                elements.append(kpi_el)
+                el.setdefault("_emitted", []).append(kpi_el)   # control-targeting (listen:)
                 c0 = int(round(L["col"] + slot * w)) + 1
                 c1 = int(round(L["col"] + (slot + 1) * w)) + 1
                 layout_items.append((kid, c0, c1, r0, r1, "kpi-chart"))
@@ -669,39 +735,142 @@ def main():
                 continue
             base.setdefault("columns", []).append({"id": sid("tc"), "formula": sig.strip(), "name": label})
         elements.append(base)
+        el.setdefault("_emitted", []).append(base)   # control-targeting (listen:)
 
         # newspaper -> 24-col grid (rows scaled — see ROW_SCALE above)
         L = _layout_of(el); c0 = L["col"] + 1; c1 = L["col"] + 1 + L["width"]
         r0 = L["row"] * ROW_SCALE + 1; r1 = r0 + L["height"] * ROW_SCALE
         layout_items.append((eid, c0, c1, r0, r1, kind))
 
-    # ── controls from dashboard filters ──
-    controls = []
+    # ── controls from dashboard filters (listen-scoped, never dead) ──
+    # A Looker dashboard filter applies to EXACTLY the tiles that `listen:` to
+    # it, on the per-tile field the listen entry names. The old emission bound
+    # ONE master-level target — wrong scope (a master filter propagates into
+    # EVERY tile, including non-listeners) AND shipped a dead, untargeted
+    # control whenever the master display-name lookup missed. Now:
+    #   * tiles are partitioned by their listen-SET; each partition that needs
+    #     its own scope is re-sourced through a hidden LISTEN-SCOPE TABLE on
+    #     the Data page (control filters may only target TABLE elements — a
+    #     chart/KPI target 400s with "Dependency not found", live-verified),
+    #     and each control targets exactly the scope tables (or the master,
+    #     when every tile of the explore shares one listen-set) of the tiles
+    #     that listen; non-listening tiles stay un-targeted BY DESIGN
+    #   * an unbindable filter NEVER ships as a dead control: it is DROPPED
+    #     with a loud warning naming the unbound field (--strict exits 2)
+    #   * the intended scope contract is written to control-scope.json next to
+    #     --out: per control {controlId, source_signal, intended/excluded
+    #     element matchers} — the downstream coverage lint consumes it
+    filter_names = {f["name"] for f in dash["filters"]}
+
+    def listen_set(el):
+        return frozenset(k for k in (el.get("listen") or {}) if k in filter_names)
+
+    groups = {}            # (explore, listen-set) -> [contract tiles]
+    explore_lsets = {}     # explore -> {listen-set, ...}
+    for el in dash["elements"]:
+        if not el.get("_emitted"):
+            continue
+        groups.setdefault((el["explore"], listen_set(el)), []).append(el)
+        explore_lsets.setdefault(el["explore"], set()).add(listen_set(el))
+
+    scope_tables = {}      # (explore, listen-set) -> {"id","name","explore","needed":{}}
+
+    def scope_for(ex, lset):
+        """The hidden scope table for a tile partition — or None when the tile
+        can stay on the master (single uniform listen-set per explore, or a
+        tile that listens to nothing and is therefore never targeted)."""
+        if len(explore_lsets[ex]) == 1 or not lset:
+            return None
+        key = (ex, lset)
+        if key not in scope_tables:
+            n = len(scope_tables) + 1
+            scope_tables[key] = {"id": f"scope-{n}", "explore": ex, "needed": {},
+                                 "name": f"{master_of(ex)['name']} Scope {n}"}
+        return scope_tables[key]
+
+    # Re-source partitioned tiles through their scope table (formulas rewritten
+    # [<Master>/…] -> [<Scope>/…]; the scope passes every master column through).
+    for (ex, lset), tiles in groups.items():
+        sc = scope_for(ex, lset)
+        if sc is None:
+            continue
+        mname = master_of(ex)["name"]
+        for el in tiles:
+            el["_scope"] = sc
+            for sp in el["_emitted"]:
+                sp["source"] = {"kind": "table", "elementId": sc["id"]}
+                for c in sp.get("columns", []):
+                    if isinstance(c.get("formula"), str):
+                        c["formula"] = c["formula"].replace(f"[{mname}/", f"[{sc['name']}/")
+
+    controls, control_scope, dropped_controls = [], [], []
     for flt in dash["filters"]:
         fld = flt.get("dimension") or flt.get("field") or flt.get("_resolvedField")
-        fex = flt.get("explore") or flt.get("_resolvedExplore") or (fld.split(".")[0] if fld else "")
-        cdisp = col_display(fld, fex) if fld else None
-        fmaster = master_of(fex)
-        col_id = fmaster["needed"].get(cdisp)
         ctype = "date-range" if flt["type"] == "date_filter" else "list"
-        ctrl = {"kind": "control", "id": sid("ctrl"), "controlId": flt["name"].lower().replace(" ", "-"),
-                "name": flt["title"], "controlType": ctype}
-        if col_id:
-            ctrl["filters"] = [{"source": {"kind": "table", "elementId": fmaster["id"]}, "columnId": col_id}]
-            if ctype == "list":
-                ctrl.update({"mode": "include", "selectionMode": "multiple", "values": [],
-                             "source": {"kind": "source", "source": {"kind": "table", "elementId": fmaster["id"]}, "columnId": col_id}})
-            else:
-                ctrl["mode"] = "between"
-        else:
-            # An unbound control is furniture — a user changes it and nothing
-            # reacts (it also fails post-and-readback's control lint / gate 7
-            # of assert-phase6-ran.rb). Dropping it loudly is more honest than
-            # shipping a dead control; record the gap so the report names it.
-            warnings.append(f"filter '{flt['name']}': could not bind to a master column — "
-                            "control DROPPED (dead control; add the column to the master or migrate the filter by hand)")
+        cid = flt["name"].lower().replace(" ", "-")
+        entry = {"controlId": cid, "name": flt["title"], "controlType": ctype,
+                 "source_signal": f"looker dashboard filter '{flt['name']}' (per-tile listen: scope)",
+                 "intended": [], "excluded": [], "unresolved": []}
+        targets, seen_targets, domain = [], set(), None   # domain = (master, colId) for the list value source
+        for el in dash["elements"]:
+            emitted = el.get("_emitted") or []
+            if not emitted:
+                continue
+            lf = (el.get("listen") or {}).get(flt["name"])
+            if not lf:
+                entry["excluded"].extend(
+                    {"element_id": sp["id"], "element_name": sp.get("name") or el["name"],
+                     "reason": "tile does not listen: to this filter (un-targeted by design)"}
+                    for sp in emitted)
+                continue
+            d = col_display(lf, el["explore"])
+            if d is None:
+                warnings.append(f"⚠ filter '{flt['name']}': tile '{el['name']}' listens via "
+                                f"'{lf}' which maps to no master column — tile NOT wired")
+                entry["unresolved"].append({"element_name": el["name"], "field": lf})
+                continue
+            mcol = need(d, el["explore"])               # master carries the field
+            if domain is None:
+                domain = (master_of(el["explore"]), mcol)
+            sc = el.get("_scope")
+            if sc is not None:                          # filter lands on the scope table
+                tcol = sc["needed"].setdefault(d, sid("sc"))
+                tkey = (sc["id"], tcol)
+            else:                                       # uniform listen-set: the master
+                tcol = mcol
+                tkey = (master_of(el["explore"])["id"], tcol)
+            if tkey not in seen_targets:
+                seen_targets.add(tkey)
+                targets.append({"source": {"kind": "table", "elementId": tkey[0]},
+                                "columnId": tcol})
+            entry["intended"].extend(
+                {"element_id": sp["id"], "element_name": sp.get("name") or el["name"],
+                 "via_column": d, "target_element": tkey[0]}
+                for sp in emitted)
+        if not targets:
+            why = (f"listening tile field(s) unresolvable: "
+                   f"{', '.join(u['field'] for u in entry['unresolved'])}"
+                   if entry["unresolved"] else "no tile listens: to it")
+            warnings.append(f"⚠⚠ DROPPED control '{flt['name']}'"
+                            + (f" (field '{fld}')" if fld else "") + f" — {why}. "
+                            "A control that filters nothing never ships; fix the field "
+                            "mapping or the listen: wiring, or re-run without the filter.")
+            entry.update({"status": "dropped", "reason": why})
+            dropped_controls.append(flt["name"])
+            control_scope.append(entry)
             continue
+        ctrl = {"kind": "control", "id": sid("ctrl"), "controlId": cid,
+                "name": flt["title"], "controlType": ctype, "filters": targets}
+        if ctype == "list":
+            ctrl.update({"mode": "include", "selectionMode": "multiple", "values": [],
+                         "source": {"kind": "source",
+                                    "source": {"kind": "table", "elementId": domain[0]["id"]},
+                                    "columnId": domain[1]}})
+        else:
+            ctrl["mode"] = "between"
+        entry["status"] = "emitted"
         controls.append(ctrl)
+        control_scope.append(entry)
 
     # ── layout finalize: container bands (layout-playbook.md, 2026-06-10) ──
     # The raw newspaper→grid math (above) honors Looker's pixel positions; the
@@ -805,7 +974,11 @@ def main():
         "layout": layout_xml,
         "pages": [
             {"id": "page-data", "name": "Data", "elements": []},  # filled below
-            {"id": page_id, "name": dash["title"], "elements": controls + elements + band_els},
+            # tiles BEFORE controls: controls now target tile columns directly
+            # (per-tile listen: scope) and Sigma resolves spec dependencies in
+            # array order — a control referencing a later element 400s with
+            # "Dependency not found".
+            {"id": page_id, "name": dash["title"], "elements": elements + controls + band_els},
         ],
     }
     master_elements = [{
@@ -814,16 +987,58 @@ def main():
         "columns": [{"id": cid, "formula": master_ref(d, ex), "name": d}
                     for d, cid in m["needed"].items()],
     } for ex, m in masters.items()]
-    spec["pages"][0]["elements"] = master_elements
+    # listen-scope tables: full passthrough of the master (so every re-sourced
+    # tile formula resolves) — control-targeted columns keep the ids registered
+    # in the control loop; the rest get fresh ids.
+    scope_elements = [{
+        "id": sc["id"], "name": sc["name"], "kind": "table",
+        "source": {"kind": "table", "elementId": master_of(ex)["id"]},
+        "columns": [{"id": sc["needed"].get(d) or sid("sc"), "name": d,
+                     "formula": f"[{master_of(ex)['name']}/{d}]"}
+                    for d in master_of(ex)["needed"]],
+    } for (ex, _lset), sc in scope_tables.items()]
+    spec["pages"][0]["elements"] = master_elements + scope_elements
 
     open(a.out, "w").write(json.dumps(spec, indent=2))
+    # intended-scope contract for the control-coverage lint — MUST be the
+    # control_lint.rb CONTRACT shape (a Hash; a bare array is silently ignored
+    # by the lint and every by-design exclusion would flag PARTIAL):
+    #   * sourceFilterSignals = every dashboard filter (incl. dropped ones —
+    #     they ARE source signals; the loud build warning + --strict cover them)
+    #   * per emitted control: scope = "page" when every tile listens, else the
+    #     allowlist of intended (listening) tile element ids; mustReach = those
+    #     same ids as hard reach assertions; rich detail keys (intended/
+    #     excluded/unresolved) ride along — the lint ignores unknown keys.
+    #   * dropped controls live under "dropped" (NOT "controls" — a sidecar
+    #     control absent from the spec is a gate-7 "missing control" failure;
+    #     the drop is already loud at build time).
+    for e in control_scope:
+        if e["status"] != "emitted":
+            continue
+        e["sourceName"] = e["source_signal"]
+        reach_ids = sorted({t["element_id"] for t in e["intended"]})
+        e["mustReach"] = reach_ids
+        e["scope"] = "page" if not e["excluded"] and not e["unresolved"] else reach_ids
+    sidecar = {"version": 1, "source": "looker",
+               "sourceFilterSignals": len(dash["filters"]),
+               "controls": [e for e in control_scope if e["status"] == "emitted"],
+               "dropped": [e for e in control_scope if e["status"] != "emitted"]}
+    scope_path = os.path.join(os.path.dirname(os.path.abspath(a.out)), "control-scope.json")
+    json.dump(sidecar, open(scope_path, "w"), indent=2)
     print(f"wrote {a.out}")
-    print(f"  masters: {len(master_elements)} ({', '.join(m['name'] + ':' + str(len(m['columns'])) + ' cols' for m in master_elements)})  tiles: {len(elements)}  controls: {len(controls)}")
+    print(f"  masters: {len(master_elements)} ({', '.join(m['name'] + ':' + str(len(m['columns'])) + ' cols' for m in master_elements)})  tiles: {len(elements)}  controls: {len(controls)}"
+          + (f"  listen-scope tables: {len(scope_elements)}" if scope_elements else ""))
+    print(f"  control-scope: {scope_path} ({len(controls)} emitted"
+          + (f", {len(dropped_controls)} DROPPED: {', '.join(dropped_controls)}" if dropped_controls else "")
+          + ")")
     for e in elements:
         print(f"    {e['kind']:11} {e.get('name', '(text)')}")
     if warnings:
         print("\n  WARNINGS:")
         for w in warnings: print("   -", w)
+    if a.strict and dropped_controls:
+        sys.exit(f"--strict: {len(dropped_controls)} dashboard filter(s) could not be bound: "
+                 + ", ".join(dropped_controls))
 
 if __name__ == "__main__":
     main()

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -467,7 +467,7 @@ def main():
     if not os.path.isdir(views_dir):
         views_dir = lookml_dir
     view_files = sorted(glob.glob(os.path.join(views_dir, "*.view.lkml")))
-    measures, _dims, view_pk, _formats, _yesno = build_field_index(view_files)
+    measures, _dims, view_pk, _formats, _yesno, _dim_groups = build_field_index(view_files)
     print(f"   '{dash['title']}': {len(dash['elements'])} tile(s), {len(dash['filters'])} filter(s), "
           f"explore '{explore}' · {len(view_files)} view file(s), {len(measures)} measure(s) · workdir {wd}")
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/control-parity.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/control-parity.md
@@ -78,8 +78,14 @@ Consequences:
   control should govern (the column must exist on each); elements sourcing
   from those masters inherit via the closure.
 - **partial reach, chart bypasses the master** (sources the DM directly) →
-  either re-source the chart from the master or add a filter target on the
-  chart element itself with that element's own columnId.
+  either re-source the chart from the master or re-root it through a hidden
+  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
+  carrying passthrough columns; the chart re-sourced through it) and target
+  the table. Control filter targets may only point at TABLE elements — a
+  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
+  (live-verified 2026-06-12; the looker builder's listen-scope tables and
+  enhance-apply's `ensure_base_table!` are the two automated forms of this
+  pattern).
 - **intentional narrow control** (grain switcher driving one chart by
   formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-apply.rb
@@ -38,7 +38,7 @@
 # Exit codes: 0 = done (clone created; accepted items applied or cleanly
 # reverted; parity-unchanged gate green; layout lint clean); 2 = nothing
 # accepted; 3 = the parity-unchanged gate could not be restored (clone left
-# for inspection, report says so); 4 = layout lint violations on the clone
+# for inspection, report says so); 4 = layout or control lint violations on the clone
 # (fix + re-PUT, then re-lint); other = error.
 
 require 'json'
@@ -390,6 +390,208 @@ def find_element(spec, element_id)
   nil
 end
 
+# ---------------------------------------------------------------------------
+# Control-coverage extension (control-targeting fix, workstream C).
+#
+# add_elements can introduce charts/KPIs whose source chain NEVER reaches the
+# elements the workbook's controls filter — audit-proven: enhancement KPIs
+# added with a DM-direct source were dead to the dashboard's Region/State
+# controls. After adding a viz element, every existing filtering control is
+# EXTENDED to cover it:
+#   - if the element's source chain already reaches one of the control's
+#     targets, Sigma's downstream propagation covers it — nothing to do;
+#   - else target the element's sourcing ROOT (the element itself when it is
+#     its own root, e.g. DM-direct) on the column matching the control's
+#     filter column by name — adding a hidden passthrough column when the
+#     root sources the SAME data-model element as a targeted element (its
+#     column formula is valid verbatim there);
+#   - grain/drill switchers (add_control_and_rewire) are value providers wired
+#     through formulas, not filter targets — deliberately EXEMPT.
+# Every extension/exemption is merged into <workdir>/control-scope.enhanced.json
+# (contract shape — see merged_control_scope!) and linted on the clone.
+# ---------------------------------------------------------------------------
+VIZ_EXTENDABLE = %w[bar-chart line-chart area-chart pie-chart donut-chart combo-chart
+                    scatter-chart kpi-chart table pivot-table box-chart funnel-chart
+                    waterfall-chart region-map point-map].freeze
+$control_scope_notes = []
+
+def spec_elements_by_id(spec)
+  (spec['pages'] || []).flat_map { |p| p['elements'] || [] }.to_h { |e| [e['id'], e] }
+end
+
+# Element ids on `el`'s source chain (excluding el itself); stops at a
+# data-model source or an id not present in the spec.
+def source_chain_ids(spec, el)
+  by_id = spec_elements_by_id(spec)
+  ids = []
+  cur = el
+  loop do
+    src = cur['source'] || {}
+    break if src['kind'] == 'data-model' || src['elementId'].nil?
+    nid = src['elementId']
+    break if ids.include?(nid)
+    ids << nid
+    cur = by_id[nid] or break
+  end
+  ids
+end
+
+def norm_colname(s)
+  s.to_s.strip.downcase.gsub(/[^a-z0-9]+/, '')
+end
+
+# Control filter targets may only point at TABLE elements — a chart/KPI
+# target 400s at PUT with "Dependency not found" (live-verified here AND in
+# the looker builder, which re-sources tiles through hidden scope tables for
+# the same reason). So a DM-direct added viz is covered via the estate
+# repair's hidden SHARED-BASE-TABLE pattern: a hidden table on the Data page
+# sourcing the same DM element, the added viz re-sourced through it (formula
+# prefixes rewritten), and the control targeting the table.
+def ensure_base_table!(spec, el, dm_src, cand_id)
+  base_name = "#{el['name'] || el['id']} Base (#{cand_id})"
+  base = { 'id' => "phasee-base-#{el['id']}".gsub(/[^A-Za-z0-9_-]+/, '-')[0, 60],
+           'kind' => 'table', 'name' => base_name,
+           'source' => JSON.parse(JSON.generate(dm_src)), 'columns' => [] }
+  # Pass through every DM column the viz references, then rewrite the viz's
+  # refs ([<DM element name>/<col>] -> [<base name>/<col>]) and re-source it.
+  refs = (el['columns'] || []).flat_map { |c| c['formula'].to_s.scan(%r{\[([^\]\[/]+)/([^\]]+)\]}) }.uniq
+  seen = {}
+  refs.each do |prefix, colname|
+    next if seen[colname]
+    seen[colname] = true
+    base['columns'] << { 'id' => "#{base['id']}-c#{base['columns'].size}",
+                         'name' => colname, 'formula' => "[#{prefix}/#{colname}]" }
+  end
+  (el['columns'] || []).each do |c|
+    next unless c['formula'].is_a?(String)
+    c['formula'] = c['formula'].gsub(%r{\[[^\]\[/]+/([^\]]+)\]}) { "[#{base_name}/#{Regexp.last_match(1)}]" }
+  end
+  el['source'] = { 'kind' => 'table', 'elementId' => base['id'] }
+  # The base lives on the Data page (same convention as the master and the
+  # looker scope tables); page order puts it before every dashboard page, so
+  # control filter targets resolve in Sigma's array-order dependency walk.
+  data_page = (spec['pages'] || []).find { |p| (p['elements'] || []).any? { |e| e['id'] == 'master' } } ||
+              (spec['pages'] || []).first
+  (data_page['elements'] ||= []) << base
+  base
+end
+
+def extend_controls_for_added!(spec, added_els, cand_id)
+  by_id = spec_elements_by_id(spec)
+  ctrls = by_id.values.select { |e| e['kind'] == 'control' && Array(e['filters']).any? }
+  notes = []
+  added_els.each do |el|
+    next unless VIZ_EXTENDABLE.include?(el['kind'])
+    chain = source_chain_ids(spec, el)
+    root = chain.empty? ? el : (by_id[chain.last] || el)
+    root_src = root['source'] || {}
+    base = nil # lazily-built hidden shared base table (one per added viz)
+    ctrls.each do |ctl|
+      next if Array(ctl['filters']).any? do |f|
+        tid = f.dig('source', 'elementId')
+        tid == el['id'] || chain.include?(tid) # propagation already covers it
+      end
+      # Resolve the control's filter column (name + formula) from its first target.
+      tgt = ctl['filters'].first
+      tgt_el = by_id[tgt.dig('source', 'elementId')]
+      tgt_col = tgt_el && (tgt_el['columns'] || []).find { |c| c['id'] == tgt['columnId'] }
+      unless tgt_col
+        notes << { 'controlId' => ctl['controlId'], 'candidate' => cand_id,
+                   'element' => el['id'], 'status' => 'not-extended',
+                   'reason' => 'control target column not resolvable from the spec' }
+        next
+      end
+      same_dm = root_src['kind'] == 'data-model' &&
+                (tgt_el['source'] || {})['kind'] == 'data-model' &&
+                (tgt_el['source'] || {})['elementId'] == root_src['elementId']
+      col = nil
+      target_id = nil
+      if root['kind'] == 'table' && root['id'] != el['id']
+        # Root is already a table (hidden helper) — target it directly, adding
+        # a passthrough filter column when it shares the control's DM element.
+        col = (root['columns'] || []).find { |c| norm_colname(c['name']) == norm_colname(tgt_col['name']) }
+        if col.nil? && same_dm
+          col = { 'id' => "phasee-ctlext-#{ctl['controlId']}-#{root['id']}".gsub(/[^A-Za-z0-9_-]+/, '-')[0, 60],
+                  'name' => tgt_col['name'], 'formula' => tgt_col['formula'], 'hidden' => true }
+          (root['columns'] ||= []) << col
+        end
+        target_id = root['id']
+      elsif same_dm
+        # DM-direct viz: re-root it through the hidden shared base table and
+        # target that (chart/KPI elements cannot be filter targets).
+        base ||= ensure_base_table!(spec, el, root_src, cand_id)
+        col = base['columns'].find { |c| norm_colname(c['name']) == norm_colname(tgt_col['name']) }
+        unless col
+          col = { 'id' => "#{base['id']}-f#{base['columns'].size}",
+                  'name' => tgt_col['name'], 'formula' => tgt_col['formula'], 'hidden' => true }
+          base['columns'] << col
+        end
+        target_id = base['id']
+      end
+      if col
+        ctl['filters'] << { 'source' => { 'kind' => 'table', 'elementId' => target_id },
+                            'columnId' => col['id'] }
+        notes << { 'controlId' => ctl['controlId'], 'candidate' => cand_id,
+                   'element' => el['id'], 'element_name' => el['name'],
+                   'status' => 'extended', 'target_root' => target_id,
+                   'via_column' => tgt_col['name'] }
+      else
+        notes << { 'controlId' => ctl['controlId'], 'candidate' => cand_id,
+                   'element' => el['id'], 'element_name' => el['name'],
+                   'status' => 'not-extended',
+                   'reason' => "sourcing root '#{root['id']}' has no '#{tgt_col['name']}' column " \
+                               'and is not the same data-model element as the control target — wire manually' }
+      end
+    end
+  end
+  notes
+end
+
+# Merge the enhancement's control-scope notes into the builder's sidecar
+# contract (lib/control_lint.rb CONTRACT shape) and write the result as
+# control-scope.enhanced.json — a SEPARATE file because the workdir's
+# control-scope.json must keep describing the ORIGINAL workbook (its gate-7
+# re-runs would otherwise trip over mustReach entries naming elements that
+# only exist on the clone). Returns the merged contract Hash so the finalize
+# can run the control lint on the live clone spec against it.
+#   extended -> the covering control gains a mustReach hard assertion (and an
+#               allowlist slot when its scope is a narrow array)
+#   exempt   -> grain/drill switchers added by add_control_and_rewire get a
+#               scope:[rewired element] allowlist entry (formula-wired value
+#               providers — deliberately NOT filter-extended)
+#   not-extended -> recorded under enhancement_notes only; a page-scoped
+#               control stays honestly PARTIAL in the lint
+def merged_control_scope!(notes)
+  base = File.join(File.dirname(OUT), 'control-scope.json')
+  scope = File.exist?(base) ? (JSON.parse(File.read(base)) rescue nil) : nil
+  scope = { 'version' => 1, 'source' => 'enhance-apply', 'sourceFilterSignals' => 0 } unless scope.is_a?(Hash)
+  scope['controls'] ||= []
+  notes.each do |n|
+    case n['status']
+    when 'extended'
+      entry = scope['controls'].find { |c| c['controlId'] == n['controlId'] }
+      unless entry
+        entry = { 'controlId' => n['controlId'], 'scope' => 'page',
+                  'sourceName' => 'existing workbook control (extended by phase-e add_elements)' }
+        scope['controls'] << entry
+      end
+      (entry['mustReach'] ||= []) << n['element'] unless Array(entry['mustReach']).include?(n['element'])
+      entry['scope'] << n['element'] if entry['scope'].is_a?(Array) && !entry['scope'].include?(n['element'])
+    when 'exempt'
+      next if scope['controls'].any? { |c| c['controlId'] == n['controlId'] }
+      scope['controls'] << {
+        'controlId' => n['controlId'], 'mechanism' => 'formula',
+        'sourceName' => "phase-e #{n['candidate']} grain/drill switcher (formula-wired value provider)",
+        'scope' => [n['element']].compact
+      }
+    end
+    (scope['enhancement_notes'] ||= []) << n
+  end
+  File.write(File.join(File.dirname(OUT), 'control-scope.enhanced.json'),
+             JSON.pretty_generate(scope))
+  scope
+end
+
 # Apply one candidate's patch to a working spec (in place). Returns a
 # human-readable description, or raises with the reason it cannot apply.
 def apply_patch!(spec, cand)
@@ -409,7 +611,27 @@ def apply_patch!(spec, cand)
       (page['elements'] ||= []) << el
       place_added_element!(spec, page, el, hints[el['id']])
     end
-    "added #{Array(patch['elements']).size} element(s) into page #{page['id']}'s bands"
+    # Extend existing controls to cover the added charts/KPIs (or their
+    # sourcing root) — an enhancement must never ship outside the dashboard's
+    # filter closure (see extend_controls_for_added!).
+    ext_notes = extend_controls_for_added!(spec, Array(patch['elements']), cand['id'])
+    $control_scope_notes.concat(ext_notes)
+    ext = ext_notes.count { |n| n['status'] == 'extended' }
+    missed = ext_notes.count { |n| n['status'] == 'not-extended' }
+    warn "   [#{cand['id']}] control extension: #{missed} added element/control pair(s) NOT coverable — see control-scope.json" if missed.positive?
+    if ext.positive?
+      # Sigma resolves spec dependencies in ARRAY ORDER: a control whose
+      # `filters` target an element appended LATER in the page 400s at PUT with
+      # "Dependency not found" (live-verified; same rule the looker builder
+      # honors by emitting tiles before controls). Stable-move controls to the
+      # end of the page so every extended target precedes its control. Formula
+      # references ([controlId] in a chart calc) do NOT need array order —
+      # the grain-switcher control already PUTs fine after its chart.
+      page['elements'] = page['elements'].reject { |e| e['kind'] == 'control' } +
+                         page['elements'].select { |e| e['kind'] == 'control' }
+    end
+    "added #{Array(patch['elements']).size} element(s) into page #{page['id']}'s bands" \
+      "#{ext.positive? ? " + extended #{ext} control target(s)" : ''}"
   when 'set_column_formula'
     _pg, el = find_element(spec, patch['element_id'])
     raise "element #{patch['element_id']} not found" unless el
@@ -439,6 +661,16 @@ def apply_patch!(spec, cand)
       band = ensure_band!(spec, pg, CTRL_BAND_PREFIX)
       band_add!(spec, pg['id'], band, ctrl['id'], hint['grid_column'] || '17 / 25', hint['height'] || 3)
     end
+    # Grain/drill switchers are value providers wired through the chart's
+    # FORMULA, not filter targets — deliberately exempt from control-coverage
+    # extension; record the exemption so the lint allowlists it.
+    $control_scope_notes << {
+      'controlId' => ctrl['controlId'], 'candidate' => cand['id'],
+      'status' => 'exempt', 'mechanism' => 'formula',
+      'element' => el['id'], 'element_name' => el['name'],
+      'reason' => 'grain/drill switcher — value provider wired through the chart formula, ' \
+                  'not a filter target (deliberately exempt from control extension)'
+    }
     "added control #{ctrl['controlId']} #{placed ? "inside #{el['id']}'s container" : 'to the control band'} + rewired #{el['id']}"
   when 'set_element_prop'
     _pg, el = find_element(spec, patch['element_id'])
@@ -565,11 +797,13 @@ gate_green = true
 accepted.each do |cand|
   print "   [#{cand['id']}] "
   prev = JSON.parse(JSON.generate(current))
+  notes_mark = $control_scope_notes.length # discard this item's scope notes on skip/revert
   begin
     desc = apply_patch!(current, cand)
   rescue StandardError => e
     skipped << { 'id' => cand['id'], 'risk' => cand['risk'], 'reason' => "not applied: #{e.message}" }
     current = prev
+    $control_scope_notes.slice!(notes_mark..)
     puts "SKIP (#{e.message})"
     next
   end
@@ -578,6 +812,7 @@ accepted.each do |cand|
   rescue StandardError => e
     current = prev
     (put_spec(clone_id, current) rescue nil) # restore server state if the PUT half-landed
+    $control_scope_notes.slice!(notes_mark..)
     reverted << { 'id' => cand['id'], 'reason' => "PUT rejected: #{e.message.to_s.gsub(/\s+/, ' ')[0, 200]}" }
     puts 'REVERTED (PUT rejected)'
     next
@@ -587,6 +822,7 @@ accepted.each do |cand|
   diffs = probe_diffs(pair)
   if diffs.any?
     current = prev
+    $control_scope_notes.slice!(notes_mark..)
     begin
       put_spec(clone_id, current)
       recheck = probe_diffs(probe_pair(clone_id, ORIG_WB, probes))
@@ -619,6 +855,18 @@ if lint_violations.any?
   lint_violations.each { |v| warn "  - #{v}" }
 end
 
+# Control-wiring lint on the CLONE (gate-7 grade — the pipeline's gate 7 ran
+# on the ORIGINAL before Phase E; the clone now carries extended/added
+# controls and added elements, so it gets its own lint against the merged
+# contract). Applied items only — reverts were truncated from the notes.
+merged_scope = merged_control_scope!($control_scope_notes)
+require 'control_lint'
+control_violations = ControlLint.lint(live_spec, scope: merged_scope)
+if control_violations.any?
+  warn "enhance-apply FINALIZE FAIL — control lint: #{control_violations.size} violation(s) on the clone:"
+  control_violations.each { |v| warn "  - #{v}" }
+end
+
 final_pair = probe_pair(clone_id, ORIG_WB, probes)
 final_ok = probe_diffs(final_pair).empty?
 gate_green &&= final_ok
@@ -635,6 +883,7 @@ report = {
   'applied' => applied,
   'skipped' => skipped,
   'reverted' => reverted,
+  'control_scope_notes' => $control_scope_notes,
   'descoped_notes' => enh['descoped_notes'] || [],
   'parity_unchanged_gate' => {
     'probe_elements' => probes,
@@ -644,6 +893,11 @@ report = {
   'layout_lint' => {
     'violations' => lint_violations,
     'green' => lint_violations.empty?
+  },
+  'control_lint' => {
+    'violations' => control_violations,
+    'scope_sidecar' => File.join(File.dirname(OUT), 'control-scope.enhanced.json'),
+    'green' => control_violations.empty?
   },
   'original_untouched' => {
     'updatedAt_before' => orig_meta_before['updatedAt'],
@@ -659,6 +913,7 @@ puts "enhance-apply: #{applied.size} applied, #{skipped.size} skipped, #{reverte
 puts "   clone: '#{clone_name}' (#{clone_id})"
 puts "   parity-unchanged gate: #{gate_green ? 'GREEN' : 'NOT GREEN (see report)'}; original untouched: #{orig_untouched}"
 puts "   layout lint: #{lint_violations.empty? ? 'CLEAN' : "#{lint_violations.size} violation(s) — FIX BEFORE DECLARING DONE"}"
+puts "   control lint: #{control_violations.empty? ? 'CLEAN' : "#{control_violations.size} violation(s) — FIX BEFORE DECLARING DONE"}"
 puts "   report -> #{OUT}"
 puts
 puts '──────────────── HARD SCREENSHOT CHECKLIST (Phase E finalize) ────────────────'
@@ -673,4 +928,4 @@ puts '      (grain/drill switchers INSIDE their chart\'s container)'
 puts '  [ ] no orphan elements below the fold (nothing dumped at the page foot)'
 puts '  [ ] no dead zones; row heights look even across each band'
 puts '──────────────────────────────────────────────────────────────────────────────'
-exit(lint_violations.any? ? 4 : (gate_green ? 0 : 3))
+exit((lint_violations.any? || control_violations.any?) ? 4 : (gate_green ? 0 : 3))

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/control-parity.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/control-parity.md
@@ -78,8 +78,14 @@ Consequences:
   control should govern (the column must exist on each); elements sourcing
   from those masters inherit via the closure.
 - **partial reach, chart bypasses the master** (sources the DM directly) →
-  either re-source the chart from the master or add a filter target on the
-  chart element itself with that element's own columnId.
+  either re-source the chart from the master or re-root it through a hidden
+  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
+  carrying passthrough columns; the chart re-sourced through it) and target
+  the table. Control filter targets may only point at TABLE elements — a
+  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
+  (live-verified 2026-06-12; the looker builder's listen-scope tables and
+  enhance-apply's `ensure_base_table!` are the two automated forms of this
+  pattern).
 - **intentional narrow control** (grain switcher driving one chart by
   formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/control-parity.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/control-parity.md
@@ -78,8 +78,14 @@ Consequences:
   control should govern (the column must exist on each); elements sourcing
   from those masters inherit via the closure.
 - **partial reach, chart bypasses the master** (sources the DM directly) →
-  either re-source the chart from the master or add a filter target on the
-  chart element itself with that element's own columnId.
+  either re-source the chart from the master or re-root it through a hidden
+  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
+  carrying passthrough columns; the chart re-sourced through it) and target
+  the table. Control filter targets may only point at TABLE elements — a
+  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
+  (live-verified 2026-06-12; the looker builder's listen-scope tables and
+  enhance-apply's `ensure_base_table!` are the two automated forms of this
+  pattern).
 - **intentional narrow control** (grain switcher driving one chart by
   formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -2597,6 +2597,105 @@ if title_text
   }
 end
 
+# ---- Control targeting: intended-scope closure ------------------------------
+# A control filter applied to an element propagates to every element that
+# SOURCES it (verified Sigma propagation), so the old emission hardcoded ONE
+# target — opts[:master_id]. That goes DEAD for any chart whose source chain
+# never reaches the master: DM-direct elements and dim-grain helpers source
+# the data model itself (audit-proven case: a master-targeted Region control
+# never filtered 'Monthly Revenue Trend'). Targeting now walks every emitted
+# chart's source chain to its ROOT and targets the set of roots the control's
+# INTENDED charts actually use. Intended scope per source signal:
+#   * shared-view quick filters apply PER-DASHBOARD: the dashboards whose zone
+#     tree carries that filter zone; no zone info → shared-view default (all)
+#   * worksheet-level `[Action (X)]` filters: the sheets the .twb scopes the
+#     action to join the closure even without a quick-filter zone
+# The contract is recorded in <tableau-dir>/control-scope.json per control
+# ({controlId, source_signal, intended matchers, targets, unreachable}) so the
+# downstream coverage lint can assert it and allowlist by-design gaps.
+control_scope_records = []
+helpers_by_id = data_elements.to_h { |d| [d['id'], d] }
+norm_cap = ->(s) { s.to_s.strip.downcase.gsub(/[^a-z0-9]+/, '') }
+# Chart-id/page snapshot for the sidecar's scope decision (taken BEFORE the
+# page-mode emitters strip the _dashboard tags).
+ctl_chart_index = elements.select { |e| e['source'] }
+                          .map { |e| { 'id' => e['id'], 'dash' => e['_dashboard'], 'ws' => e['_worksheet'] } }
+
+# The element a filter must target so it propagates into `el`: chains through
+# hidden helpers; the master and any data-model-sourced element are roots.
+root_of = lambda do |el|
+  cur = el
+  seen = {}
+  loop do
+    src = cur['source'] || {}
+    return cur['id'] if src['kind'] == 'data-model'
+    nxt_id = src['elementId']
+    return cur['id'] if nxt_id.nil?
+    return opts[:master_id] if nxt_id == opts[:master_id]
+    nxt = helpers_by_id[nxt_id]
+    return nxt_id if nxt.nil? || seen[nxt_id] # unknown id — treat as its own root
+    seen[nxt_id] = true
+    cur = nxt
+  end
+end
+
+# Filter-target spec for caption `cap` on a root, or nil when the root carries
+# no matching column (caller records it as unreachable — NEVER guess a column).
+target_on_root = lambda do |root_id, cap, mcol|
+  if root_id == opts[:master_id]
+    return mcol && { 'source' => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+                     'columnId' => mcol['id'] }
+  end
+  rel = helpers_by_id[root_id] || elements.find { |e| e['id'] == root_id }
+  col = rel && (rel['columns'] || []).find { |c| norm_cap.call(c['name']) == norm_cap.call(cap) }
+  col && { 'source' => { 'kind' => 'table', 'elementId' => root_id }, 'columnId' => col['id'] }
+end
+
+# Dashboards whose zone tree carries a quick-filter zone for this caption.
+filter_zone_dashboards = lambda do |cap|
+  (layout || []).select do |d|
+    (d['zones'] || []).any? do |z|
+      z['kind'] == 'filter' && norm_cap.call(z['filter_column_caption']) == norm_cap.call(cap)
+    end
+  end.map { |d| d['dashboard'] }
+end
+
+# Worksheets whose own view filters carry `[Action (<cap>)]` — the .twb scopes
+# those cross-sheet filter actions to specific sheets.
+action_worksheets = lambda do |cap|
+  (meta['worksheets'] || {}).select do |_ws, w|
+    (w['filters'] || []).any? do |f|
+      f['is_action'] && f['raw_param'].to_s.include?("[Action (#{cap.to_s.strip})]")
+    end
+  end.keys
+end
+
+# Closure for one source filter: [targets, intended, unreachable, zone_dashes,
+# action_ws]. `mcol` is the master-map entry (nil → master can't be a target).
+control_targets = lambda do |cap, mcol|
+  zd = filter_zone_dashboards.call(cap)
+  aw = action_worksheets.call(cap)
+  in_scope = elements.select do |e|
+    e['source'] && ((zd.empty? || zd.include?(e['_dashboard'])) || aw.include?(e['_worksheet']))
+  end
+  roots = {}
+  in_scope.each { |e| (roots[root_of.call(e)] ||= []) << e }
+  targets, unreachable = [], []
+  roots.each do |rid, els|
+    t = target_on_root.call(rid, cap, mcol)
+    if t
+      targets << t
+    else
+      unreachable << { 'root' => rid, 'elements' => els.map { |e| e['name'] } }
+    end
+  end
+  intended = in_scope.map do |e|
+    { 'element_id' => e['id'], 'name' => e['name'], 'root' => root_of.call(e),
+      'dashboard' => e['_dashboard'], 'worksheet' => e['_worksheet'] }
+  end
+  [targets, intended, unreachable, zd, aw]
+end
+
 # ---- Auto-generated parameter controls (--auto-controls) ------------------
 # Tableau parameters become Sigma controls. The control's name matches the
 # parameter caption so any translated `Switch([Param Caption], ...)` formula
@@ -2653,6 +2752,18 @@ if opts[:auto_controls]
       spec['value'] = p['default_value']
     end
     param_controls << spec
+    # Parameters drive charts through FORMULA references, not filter targets —
+    # record the formula-consumer set so the coverage lint knows the mechanism.
+    control_scope_records << {
+      'controlId' => spec['controlId'], 'name' => cap, 'mechanism' => 'formula',
+      'source_signal' => "tableau parameter '#{cap}' (referenced by worksheet calcs)",
+      # Translated calcs reference the control by its CONTROL ID (line ~541's
+      # "[ctl-param-<slug>]" form), not by caption — match what the lint's
+      # formula-ref reach walk will actually see.
+      'intended' => elements.select { |e|
+        (e['columns'] || []).any? { |c| c['formula'].to_s.include?("[#{spec['controlId']}]") }
+      }.map { |e| { 'element_id' => e['id'], 'name' => e['name'] } }
+    }
   end
 end
 
@@ -2672,12 +2783,43 @@ if opts[:auto_controls]
       next
     end
     slug = cap.downcase.gsub(/\W+/, '-').sub(/-$/, '')
+    # Intended-scope closure (see the control-targeting section above): targets
+    # = the sourcing ROOTS of every chart this filter is meant to reach, not a
+    # hardcoded master. A filter with NO reachable target never ships dead.
+    targets, intended, unreachable, zone_dashes, action_ws = control_targets.call(cap, m)
+    unreachable.each do |u|
+      warnings << "control '#{cap}' cannot reach #{u['elements'].join(', ')} — their sourcing root " \
+                  "'#{u['root']}' has no '#{cap}' column; wire manually or add the column to the helper"
+    end
+    if targets.empty?
+      warnings << "DROPPED auto-control '#{cap}' — no chart root carries a matching column " \
+                  '(a control that filters nothing never ships); see control-scope.json'
+      control_scope_records << {
+        'controlId' => "ctl-#{slug}", 'name' => cap.strip, 'mechanism' => 'filters',
+        'source_signal' => "tableau shared-view quick filter '#{cap}'",
+        'status' => 'dropped', 'intended' => intended, 'unreachable' => unreachable
+      }
+      next
+    end
     spec = {
       'id'           => "el-ctl-#{slug}",
       'kind'         => 'control',
       'controlId'    => "ctl-#{slug}",
       'name'         => cap.strip,
       'includeNulls' => 'when-no-value-is-selected'
+    }
+    # Quick-filter zones apply per-dashboard: place the control only on the
+    # dashboard pages whose zone tree shows it (page-per-dashboard mode);
+    # empty = no zone info → shared-view default (every page).
+    spec['_scope_dashboards'] = zone_dashes
+    control_scope_records << {
+      'controlId' => spec['controlId'], 'name' => cap.strip, 'mechanism' => 'filters',
+      'source_signal' => "tableau shared-view quick filter '#{cap}'" +
+                         (zone_dashes.any? ? " (zones on: #{zone_dashes.join(', ')})" : ' (no zone parsed — shared-view default: all dashboards)') +
+                         (action_ws.any? ? "; [Action (#{cap.to_s.strip})] scoped to: #{action_ws.join(', ')}" : ''),
+      'intended' => intended, 'targets' => targets,
+      'zone_dashboards' => zone_dashes, 'action_worksheets' => action_ws,
+      'unreachable' => unreachable, 'status' => 'emitted'
     }
     case f['kind']
     when 'list'
@@ -2690,10 +2832,7 @@ if opts[:auto_controls]
         'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
         'columnId' => m['id']
       }
-      spec['filters'] = [{
-        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
-        'columnId' => m['id']
-      }]
+      spec['filters'] = targets
     when 'relative-date'
       # Tableau "this year" / "this month" / "this quarter" → Sigma date-range
       # control with `mode: "current"` + `unit: <period>`. E2E re-verified
@@ -2706,10 +2845,7 @@ if opts[:auto_controls]
       # verified rolling-control shape for yet.
       spec['controlType'] = 'date-range'
       period = (f['period_type'] || 'year').downcase
-      spec['filters'] = [{
-        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
-        'columnId' => m['id']
-      }]
+      spec['filters'] = targets
       if f['first_period'].to_i.zero? && f['last_period'].to_i.zero?
         spec['mode'] = 'current'
         spec['unit'] = period
@@ -2729,10 +2865,7 @@ if opts[:auto_controls]
       end
     when 'number-range'
       spec['controlType'] = 'range-slider'
-      spec['filters'] = [{
-        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
-        'columnId' => m['id']
-      }]
+      spec['filters'] = targets
     end
     auto_controls << spec
   end
@@ -2745,6 +2878,21 @@ end
 if opts[:controls]
   controls = JSON.parse(File.read(opts[:controls]))
   controls.each_with_index do |c, i|
+    # Explicit controls carry no per-dashboard scope signal — intended scope is
+    # EVERY chart, so the target list is every sourcing root in the workbook
+    # (master + DM-direct/grain-helper roots that carry a matching column),
+    # not the master alone.
+    col_name = c['column_name'] ||
+               (mmap.values.find { |v| v['id'] == c['column'] } || {})['name'] ||
+               c['name']
+    mcol_entry = { 'id' => c['column'] }
+    targets, intended, unreachable, _zone_dashes, ctl_action_ws = control_targets.call(col_name, mcol_entry)
+    targets = [{ 'source' => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+                 'columnId' => c['column'] }] if targets.empty?
+    unreachable.each do |u|
+      warnings << "control '#{c['name']}' cannot reach #{u['elements'].join(', ')} — their sourcing " \
+                  "root '#{u['root']}' has no '#{col_name}' column; wire manually"
+    end
     spec = {
       'id'          => "el-ctl-#{c['name'] ? c['name'].downcase.gsub(/\W+/, '-') : "f#{i}"}",
       'kind'        => 'control',
@@ -2752,12 +2900,14 @@ if opts[:controls]
       'name'        => c['name'] || "Filter #{i + 1}",
       'controlType' => c['type'] || 'list',
       'includeNulls' => 'when-no-value-is-selected',
-      'filters' => [
-        {
-          'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
-          'columnId' => c['column']
-        }
-      ]
+      'filters' => targets
+    }
+    control_scope_records << {
+      'controlId' => spec['controlId'], 'name' => spec['name'], 'mechanism' => 'filters',
+      'source_signal' => 'explicit --controls entry (no per-dashboard scope signal: all charts intended)',
+      'intended' => intended, 'targets' => targets,
+      'action_worksheets' => ctl_action_ws,
+      'unreachable' => unreachable, 'status' => 'emitted'
     }
     case spec['controlType']
     when 'list'
@@ -2818,10 +2968,13 @@ if opts[:pages_mode] == :worksheet
     ctl_rewrites = {}
     (param_controls + auto_controls).each do |c|
       dup = JSON.parse(c.to_json)
+      dup.delete('_scope_dashboards') # page-per-worksheet has no dashboard scope
       original_cid = dup['controlId']
       dup['id']        = "#{dup['id']}-#{ws_slug}"
       dup['controlId'] = "#{dup['controlId']}-#{ws_slug}"
       ctl_rewrites[original_cid] = dup['controlId']
+      base = control_scope_records.find { |r| r['controlId'] == original_cid }
+      (base['page_instances'] ||= []) << { 'page' => ws_name, 'controlId' => dup['controlId'] } if base
       page_extras << dup
     end
     # Rewrite Switch / If formulas on this page's chart calc columns.
@@ -2862,11 +3015,18 @@ elsif opts[:pages_mode] == :dashboard
     }]
     ctl_rewrites = {}
     (param_controls + auto_controls).each do |c|
+      # Quick-filter zones apply per-dashboard: skip pages whose zone tree
+      # doesn't carry the filter (empty scope = shared-view default, all pages).
+      sd = c['_scope_dashboards']
+      next if sd.is_a?(Array) && sd.any? && !sd.include?(dash_name)
       dup = JSON.parse(c.to_json)
+      dup.delete('_scope_dashboards')
       original_cid = dup['controlId']
       dup['id']        = "#{dup['id']}-#{d_slug[0..20]}"
       dup['controlId'] = "#{dup['controlId']}-#{d_slug[0..20]}"
       ctl_rewrites[original_cid] = dup['controlId']
+      base = control_scope_records.find { |r| r['controlId'] == original_cid }
+      (base['page_instances'] ||= []) << { 'page' => dash_name, 'controlId' => dup['controlId'] } if base
       page_extras << dup
     end
     els.each do |el|
@@ -2882,6 +3042,7 @@ elsif opts[:pages_mode] == :dashboard
   warn "wrote #{opts[:out]} (page-per-dashboard: #{pages.size} page(s), #{data_elements.size} hidden data element(s), #{(param_controls + auto_controls).size} controls per page)"
 else
   elements.each { |e| e.delete('_worksheet'); e.delete('_dashboard') }
+  all_extras.each { |e| e.delete('_scope_dashboards') }
   all_elements = all_extras + elements
   File.write(opts[:out], JSON.pretty_generate(all_elements))
   warn "wrote #{opts[:out]}  (#{all_elements.size} elements: #{all_extras.size} controls/text + #{elements.size} charts)"
@@ -2890,6 +3051,64 @@ else
     File.write(side, JSON.pretty_generate(data_elements))
     warn "wrote #{side} (#{data_elements.size} HIDDEN data-page element(s) — scatter grouped sources; add them to the workbook's Data page)"
   end
+end
+
+# ---- Intended-scope contract (control-scope.json) ---------------------------
+# Emitted in the lib/control_lint.rb CONTRACT shape (a Hash — a bare array is
+# silently ignored by the lint):
+#   * sourceFilterSignals = every source signal we saw (parameters, quick
+#     filters, explicit --controls entries — dropped ones included: they ARE
+#     signals; the loud build warning covers the drop)
+#   * per emitted control: scope = "page" when the control's reachable intent
+#     covers every chart on its page, else the allowlist of reachable intended
+#     element ids (zone-scoped quick filters, formula-driven parameters, and
+#     unreachable-root exclusions are all by-design narrow scopes — recorded,
+#     never silent); mustReach = the [Action (X)]-scoped worksheets' charts —
+#     the sheet-scoped-filter closure is a hard assertion, not a default
+#   * page-mode runs emit one entry per page INSTANCE (the per-page rewritten
+#     controlId is what the posted spec actually carries)
+#   * dropped controls live under "dropped", NOT "controls" (a sidecar control
+#     missing from the spec is a lint failure by design — the drop is already
+#     loud above); rich detail keys ride along, the lint ignores unknown keys.
+unless control_scope_records.empty?
+  unreach_names = ->(r) { Array(r['unreachable']).flat_map { |u| u['elements'] || [] } }
+  page_chart_ids = lambda do |page|
+    page ? ctl_chart_index.select { |c| c['dash'] == page || c['ws'] == page }.map { |c| c['id'] }
+         : ctl_chart_index.map { |c| c['id'] }
+  end
+  to_contract = lambda do |r, cid, page|
+    ints = Array(r['intended'])
+    # page is a dashboard name (page-per-dashboard) or a worksheet name
+    # (page-per-worksheet); parameter records carry neither key — keep those.
+    ints = ints.select { |i| (i['dashboard'] || i['worksheet']).nil? || i['dashboard'] == page || i['worksheet'] == page } if page
+    bad = unreach_names.call(r)
+    reached = ints.reject { |i| bad.include?(i['name']) }
+    reached_ids = reached.map { |i| i['element_id'] }.uniq
+    e = r.merge('controlId' => cid, 'sourceName' => r['source_signal'])
+    e.delete('page_instances')
+    e['scope'] = (page_chart_ids.call(page) - reached_ids).empty? ? 'page' : reached_ids
+    aws = Array(r['action_worksheets'])
+    must = reached.select { |i| aws.include?(i['worksheet']) }.map { |i| i['element_id'] }.uniq
+    e['mustReach'] = must if must.any?
+    e
+  end
+  emitted_rs, dropped_rs = control_scope_records.partition { |r| r['status'] != 'dropped' }
+  contract_controls = emitted_rs.flat_map do |r|
+    if (insts = Array(r['page_instances'])).any?
+      insts.map { |pi| to_contract.call(r, pi['controlId'], pi['page']) }
+    else
+      [to_contract.call(r, r['controlId'], nil)]
+    end
+  end
+  sidecar = {
+    'version' => 1, 'source' => 'tableau',
+    'sourceFilterSignals' => control_scope_records.size,
+    'controls' => contract_controls,
+    'dropped' => dropped_rs
+  }
+  scope_path = File.join(opts[:tab], 'control-scope.json')
+  File.write(scope_path, JSON.pretty_generate(sidecar))
+  warn "wrote #{scope_path} (#{contract_controls.size} control scope entr(y/ies), #{dropped_rs.size} dropped)"
 end
 warnings.each { |w| warn "  WARN  #{w}" }
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-apply.rb
@@ -38,7 +38,7 @@
 # Exit codes: 0 = done (clone created; accepted items applied or cleanly
 # reverted; parity-unchanged gate green; layout lint clean); 2 = nothing
 # accepted; 3 = the parity-unchanged gate could not be restored (clone left
-# for inspection, report says so); 4 = layout lint violations on the clone
+# for inspection, report says so); 4 = layout or control lint violations on the clone
 # (fix + re-PUT, then re-lint); other = error.
 
 require 'json'
@@ -390,6 +390,208 @@ def find_element(spec, element_id)
   nil
 end
 
+# ---------------------------------------------------------------------------
+# Control-coverage extension (control-targeting fix, workstream C).
+#
+# add_elements can introduce charts/KPIs whose source chain NEVER reaches the
+# elements the workbook's controls filter — audit-proven: enhancement KPIs
+# added with a DM-direct source were dead to the dashboard's Region/State
+# controls. After adding a viz element, every existing filtering control is
+# EXTENDED to cover it:
+#   - if the element's source chain already reaches one of the control's
+#     targets, Sigma's downstream propagation covers it — nothing to do;
+#   - else target the element's sourcing ROOT (the element itself when it is
+#     its own root, e.g. DM-direct) on the column matching the control's
+#     filter column by name — adding a hidden passthrough column when the
+#     root sources the SAME data-model element as a targeted element (its
+#     column formula is valid verbatim there);
+#   - grain/drill switchers (add_control_and_rewire) are value providers wired
+#     through formulas, not filter targets — deliberately EXEMPT.
+# Every extension/exemption is merged into <workdir>/control-scope.enhanced.json
+# (contract shape — see merged_control_scope!) and linted on the clone.
+# ---------------------------------------------------------------------------
+VIZ_EXTENDABLE = %w[bar-chart line-chart area-chart pie-chart donut-chart combo-chart
+                    scatter-chart kpi-chart table pivot-table box-chart funnel-chart
+                    waterfall-chart region-map point-map].freeze
+$control_scope_notes = []
+
+def spec_elements_by_id(spec)
+  (spec['pages'] || []).flat_map { |p| p['elements'] || [] }.to_h { |e| [e['id'], e] }
+end
+
+# Element ids on `el`'s source chain (excluding el itself); stops at a
+# data-model source or an id not present in the spec.
+def source_chain_ids(spec, el)
+  by_id = spec_elements_by_id(spec)
+  ids = []
+  cur = el
+  loop do
+    src = cur['source'] || {}
+    break if src['kind'] == 'data-model' || src['elementId'].nil?
+    nid = src['elementId']
+    break if ids.include?(nid)
+    ids << nid
+    cur = by_id[nid] or break
+  end
+  ids
+end
+
+def norm_colname(s)
+  s.to_s.strip.downcase.gsub(/[^a-z0-9]+/, '')
+end
+
+# Control filter targets may only point at TABLE elements — a chart/KPI
+# target 400s at PUT with "Dependency not found" (live-verified here AND in
+# the looker builder, which re-sources tiles through hidden scope tables for
+# the same reason). So a DM-direct added viz is covered via the estate
+# repair's hidden SHARED-BASE-TABLE pattern: a hidden table on the Data page
+# sourcing the same DM element, the added viz re-sourced through it (formula
+# prefixes rewritten), and the control targeting the table.
+def ensure_base_table!(spec, el, dm_src, cand_id)
+  base_name = "#{el['name'] || el['id']} Base (#{cand_id})"
+  base = { 'id' => "phasee-base-#{el['id']}".gsub(/[^A-Za-z0-9_-]+/, '-')[0, 60],
+           'kind' => 'table', 'name' => base_name,
+           'source' => JSON.parse(JSON.generate(dm_src)), 'columns' => [] }
+  # Pass through every DM column the viz references, then rewrite the viz's
+  # refs ([<DM element name>/<col>] -> [<base name>/<col>]) and re-source it.
+  refs = (el['columns'] || []).flat_map { |c| c['formula'].to_s.scan(%r{\[([^\]\[/]+)/([^\]]+)\]}) }.uniq
+  seen = {}
+  refs.each do |prefix, colname|
+    next if seen[colname]
+    seen[colname] = true
+    base['columns'] << { 'id' => "#{base['id']}-c#{base['columns'].size}",
+                         'name' => colname, 'formula' => "[#{prefix}/#{colname}]" }
+  end
+  (el['columns'] || []).each do |c|
+    next unless c['formula'].is_a?(String)
+    c['formula'] = c['formula'].gsub(%r{\[[^\]\[/]+/([^\]]+)\]}) { "[#{base_name}/#{Regexp.last_match(1)}]" }
+  end
+  el['source'] = { 'kind' => 'table', 'elementId' => base['id'] }
+  # The base lives on the Data page (same convention as the master and the
+  # looker scope tables); page order puts it before every dashboard page, so
+  # control filter targets resolve in Sigma's array-order dependency walk.
+  data_page = (spec['pages'] || []).find { |p| (p['elements'] || []).any? { |e| e['id'] == 'master' } } ||
+              (spec['pages'] || []).first
+  (data_page['elements'] ||= []) << base
+  base
+end
+
+def extend_controls_for_added!(spec, added_els, cand_id)
+  by_id = spec_elements_by_id(spec)
+  ctrls = by_id.values.select { |e| e['kind'] == 'control' && Array(e['filters']).any? }
+  notes = []
+  added_els.each do |el|
+    next unless VIZ_EXTENDABLE.include?(el['kind'])
+    chain = source_chain_ids(spec, el)
+    root = chain.empty? ? el : (by_id[chain.last] || el)
+    root_src = root['source'] || {}
+    base = nil # lazily-built hidden shared base table (one per added viz)
+    ctrls.each do |ctl|
+      next if Array(ctl['filters']).any? do |f|
+        tid = f.dig('source', 'elementId')
+        tid == el['id'] || chain.include?(tid) # propagation already covers it
+      end
+      # Resolve the control's filter column (name + formula) from its first target.
+      tgt = ctl['filters'].first
+      tgt_el = by_id[tgt.dig('source', 'elementId')]
+      tgt_col = tgt_el && (tgt_el['columns'] || []).find { |c| c['id'] == tgt['columnId'] }
+      unless tgt_col
+        notes << { 'controlId' => ctl['controlId'], 'candidate' => cand_id,
+                   'element' => el['id'], 'status' => 'not-extended',
+                   'reason' => 'control target column not resolvable from the spec' }
+        next
+      end
+      same_dm = root_src['kind'] == 'data-model' &&
+                (tgt_el['source'] || {})['kind'] == 'data-model' &&
+                (tgt_el['source'] || {})['elementId'] == root_src['elementId']
+      col = nil
+      target_id = nil
+      if root['kind'] == 'table' && root['id'] != el['id']
+        # Root is already a table (hidden helper) — target it directly, adding
+        # a passthrough filter column when it shares the control's DM element.
+        col = (root['columns'] || []).find { |c| norm_colname(c['name']) == norm_colname(tgt_col['name']) }
+        if col.nil? && same_dm
+          col = { 'id' => "phasee-ctlext-#{ctl['controlId']}-#{root['id']}".gsub(/[^A-Za-z0-9_-]+/, '-')[0, 60],
+                  'name' => tgt_col['name'], 'formula' => tgt_col['formula'], 'hidden' => true }
+          (root['columns'] ||= []) << col
+        end
+        target_id = root['id']
+      elsif same_dm
+        # DM-direct viz: re-root it through the hidden shared base table and
+        # target that (chart/KPI elements cannot be filter targets).
+        base ||= ensure_base_table!(spec, el, root_src, cand_id)
+        col = base['columns'].find { |c| norm_colname(c['name']) == norm_colname(tgt_col['name']) }
+        unless col
+          col = { 'id' => "#{base['id']}-f#{base['columns'].size}",
+                  'name' => tgt_col['name'], 'formula' => tgt_col['formula'], 'hidden' => true }
+          base['columns'] << col
+        end
+        target_id = base['id']
+      end
+      if col
+        ctl['filters'] << { 'source' => { 'kind' => 'table', 'elementId' => target_id },
+                            'columnId' => col['id'] }
+        notes << { 'controlId' => ctl['controlId'], 'candidate' => cand_id,
+                   'element' => el['id'], 'element_name' => el['name'],
+                   'status' => 'extended', 'target_root' => target_id,
+                   'via_column' => tgt_col['name'] }
+      else
+        notes << { 'controlId' => ctl['controlId'], 'candidate' => cand_id,
+                   'element' => el['id'], 'element_name' => el['name'],
+                   'status' => 'not-extended',
+                   'reason' => "sourcing root '#{root['id']}' has no '#{tgt_col['name']}' column " \
+                               'and is not the same data-model element as the control target — wire manually' }
+      end
+    end
+  end
+  notes
+end
+
+# Merge the enhancement's control-scope notes into the builder's sidecar
+# contract (lib/control_lint.rb CONTRACT shape) and write the result as
+# control-scope.enhanced.json — a SEPARATE file because the workdir's
+# control-scope.json must keep describing the ORIGINAL workbook (its gate-7
+# re-runs would otherwise trip over mustReach entries naming elements that
+# only exist on the clone). Returns the merged contract Hash so the finalize
+# can run the control lint on the live clone spec against it.
+#   extended -> the covering control gains a mustReach hard assertion (and an
+#               allowlist slot when its scope is a narrow array)
+#   exempt   -> grain/drill switchers added by add_control_and_rewire get a
+#               scope:[rewired element] allowlist entry (formula-wired value
+#               providers — deliberately NOT filter-extended)
+#   not-extended -> recorded under enhancement_notes only; a page-scoped
+#               control stays honestly PARTIAL in the lint
+def merged_control_scope!(notes)
+  base = File.join(File.dirname(OUT), 'control-scope.json')
+  scope = File.exist?(base) ? (JSON.parse(File.read(base)) rescue nil) : nil
+  scope = { 'version' => 1, 'source' => 'enhance-apply', 'sourceFilterSignals' => 0 } unless scope.is_a?(Hash)
+  scope['controls'] ||= []
+  notes.each do |n|
+    case n['status']
+    when 'extended'
+      entry = scope['controls'].find { |c| c['controlId'] == n['controlId'] }
+      unless entry
+        entry = { 'controlId' => n['controlId'], 'scope' => 'page',
+                  'sourceName' => 'existing workbook control (extended by phase-e add_elements)' }
+        scope['controls'] << entry
+      end
+      (entry['mustReach'] ||= []) << n['element'] unless Array(entry['mustReach']).include?(n['element'])
+      entry['scope'] << n['element'] if entry['scope'].is_a?(Array) && !entry['scope'].include?(n['element'])
+    when 'exempt'
+      next if scope['controls'].any? { |c| c['controlId'] == n['controlId'] }
+      scope['controls'] << {
+        'controlId' => n['controlId'], 'mechanism' => 'formula',
+        'sourceName' => "phase-e #{n['candidate']} grain/drill switcher (formula-wired value provider)",
+        'scope' => [n['element']].compact
+      }
+    end
+    (scope['enhancement_notes'] ||= []) << n
+  end
+  File.write(File.join(File.dirname(OUT), 'control-scope.enhanced.json'),
+             JSON.pretty_generate(scope))
+  scope
+end
+
 # Apply one candidate's patch to a working spec (in place). Returns a
 # human-readable description, or raises with the reason it cannot apply.
 def apply_patch!(spec, cand)
@@ -409,7 +611,27 @@ def apply_patch!(spec, cand)
       (page['elements'] ||= []) << el
       place_added_element!(spec, page, el, hints[el['id']])
     end
-    "added #{Array(patch['elements']).size} element(s) into page #{page['id']}'s bands"
+    # Extend existing controls to cover the added charts/KPIs (or their
+    # sourcing root) — an enhancement must never ship outside the dashboard's
+    # filter closure (see extend_controls_for_added!).
+    ext_notes = extend_controls_for_added!(spec, Array(patch['elements']), cand['id'])
+    $control_scope_notes.concat(ext_notes)
+    ext = ext_notes.count { |n| n['status'] == 'extended' }
+    missed = ext_notes.count { |n| n['status'] == 'not-extended' }
+    warn "   [#{cand['id']}] control extension: #{missed} added element/control pair(s) NOT coverable — see control-scope.json" if missed.positive?
+    if ext.positive?
+      # Sigma resolves spec dependencies in ARRAY ORDER: a control whose
+      # `filters` target an element appended LATER in the page 400s at PUT with
+      # "Dependency not found" (live-verified; same rule the looker builder
+      # honors by emitting tiles before controls). Stable-move controls to the
+      # end of the page so every extended target precedes its control. Formula
+      # references ([controlId] in a chart calc) do NOT need array order —
+      # the grain-switcher control already PUTs fine after its chart.
+      page['elements'] = page['elements'].reject { |e| e['kind'] == 'control' } +
+                         page['elements'].select { |e| e['kind'] == 'control' }
+    end
+    "added #{Array(patch['elements']).size} element(s) into page #{page['id']}'s bands" \
+      "#{ext.positive? ? " + extended #{ext} control target(s)" : ''}"
   when 'set_column_formula'
     _pg, el = find_element(spec, patch['element_id'])
     raise "element #{patch['element_id']} not found" unless el
@@ -439,6 +661,16 @@ def apply_patch!(spec, cand)
       band = ensure_band!(spec, pg, CTRL_BAND_PREFIX)
       band_add!(spec, pg['id'], band, ctrl['id'], hint['grid_column'] || '17 / 25', hint['height'] || 3)
     end
+    # Grain/drill switchers are value providers wired through the chart's
+    # FORMULA, not filter targets — deliberately exempt from control-coverage
+    # extension; record the exemption so the lint allowlists it.
+    $control_scope_notes << {
+      'controlId' => ctrl['controlId'], 'candidate' => cand['id'],
+      'status' => 'exempt', 'mechanism' => 'formula',
+      'element' => el['id'], 'element_name' => el['name'],
+      'reason' => 'grain/drill switcher — value provider wired through the chart formula, ' \
+                  'not a filter target (deliberately exempt from control extension)'
+    }
     "added control #{ctrl['controlId']} #{placed ? "inside #{el['id']}'s container" : 'to the control band'} + rewired #{el['id']}"
   when 'set_element_prop'
     _pg, el = find_element(spec, patch['element_id'])
@@ -565,11 +797,13 @@ gate_green = true
 accepted.each do |cand|
   print "   [#{cand['id']}] "
   prev = JSON.parse(JSON.generate(current))
+  notes_mark = $control_scope_notes.length # discard this item's scope notes on skip/revert
   begin
     desc = apply_patch!(current, cand)
   rescue StandardError => e
     skipped << { 'id' => cand['id'], 'risk' => cand['risk'], 'reason' => "not applied: #{e.message}" }
     current = prev
+    $control_scope_notes.slice!(notes_mark..)
     puts "SKIP (#{e.message})"
     next
   end
@@ -578,6 +812,7 @@ accepted.each do |cand|
   rescue StandardError => e
     current = prev
     (put_spec(clone_id, current) rescue nil) # restore server state if the PUT half-landed
+    $control_scope_notes.slice!(notes_mark..)
     reverted << { 'id' => cand['id'], 'reason' => "PUT rejected: #{e.message.to_s.gsub(/\s+/, ' ')[0, 200]}" }
     puts 'REVERTED (PUT rejected)'
     next
@@ -587,6 +822,7 @@ accepted.each do |cand|
   diffs = probe_diffs(pair)
   if diffs.any?
     current = prev
+    $control_scope_notes.slice!(notes_mark..)
     begin
       put_spec(clone_id, current)
       recheck = probe_diffs(probe_pair(clone_id, ORIG_WB, probes))
@@ -619,6 +855,18 @@ if lint_violations.any?
   lint_violations.each { |v| warn "  - #{v}" }
 end
 
+# Control-wiring lint on the CLONE (gate-7 grade — the pipeline's gate 7 ran
+# on the ORIGINAL before Phase E; the clone now carries extended/added
+# controls and added elements, so it gets its own lint against the merged
+# contract). Applied items only — reverts were truncated from the notes.
+merged_scope = merged_control_scope!($control_scope_notes)
+require 'control_lint'
+control_violations = ControlLint.lint(live_spec, scope: merged_scope)
+if control_violations.any?
+  warn "enhance-apply FINALIZE FAIL — control lint: #{control_violations.size} violation(s) on the clone:"
+  control_violations.each { |v| warn "  - #{v}" }
+end
+
 final_pair = probe_pair(clone_id, ORIG_WB, probes)
 final_ok = probe_diffs(final_pair).empty?
 gate_green &&= final_ok
@@ -635,6 +883,7 @@ report = {
   'applied' => applied,
   'skipped' => skipped,
   'reverted' => reverted,
+  'control_scope_notes' => $control_scope_notes,
   'descoped_notes' => enh['descoped_notes'] || [],
   'parity_unchanged_gate' => {
     'probe_elements' => probes,
@@ -644,6 +893,11 @@ report = {
   'layout_lint' => {
     'violations' => lint_violations,
     'green' => lint_violations.empty?
+  },
+  'control_lint' => {
+    'violations' => control_violations,
+    'scope_sidecar' => File.join(File.dirname(OUT), 'control-scope.enhanced.json'),
+    'green' => control_violations.empty?
   },
   'original_untouched' => {
     'updatedAt_before' => orig_meta_before['updatedAt'],
@@ -659,6 +913,7 @@ puts "enhance-apply: #{applied.size} applied, #{skipped.size} skipped, #{reverte
 puts "   clone: '#{clone_name}' (#{clone_id})"
 puts "   parity-unchanged gate: #{gate_green ? 'GREEN' : 'NOT GREEN (see report)'}; original untouched: #{orig_untouched}"
 puts "   layout lint: #{lint_violations.empty? ? 'CLEAN' : "#{lint_violations.size} violation(s) — FIX BEFORE DECLARING DONE"}"
+puts "   control lint: #{control_violations.empty? ? 'CLEAN' : "#{control_violations.size} violation(s) — FIX BEFORE DECLARING DONE"}"
 puts "   report -> #{OUT}"
 puts
 puts '──────────────── HARD SCREENSHOT CHECKLIST (Phase E finalize) ────────────────'
@@ -673,4 +928,4 @@ puts '      (grain/drill switchers INSIDE their chart\'s container)'
 puts '  [ ] no orphan elements below the fold (nothing dumped at the page foot)'
 puts '  [ ] no dead zones; row heights look even across each band'
 puts '──────────────────────────────────────────────────────────────────────────────'
-exit(lint_violations.any? ? 4 : (gate_green ? 0 : 3))
+exit((lint_violations.any? || control_violations.any?) ? 4 : (gate_green ? 0 : 3))

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/control-parity.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/control-parity.md
@@ -78,8 +78,14 @@ Consequences:
   control should govern (the column must exist on each); elements sourcing
   from those masters inherit via the closure.
 - **partial reach, chart bypasses the master** (sources the DM directly) →
-  either re-source the chart from the master or add a filter target on the
-  chart element itself with that element's own columnId.
+  either re-source the chart from the master or re-root it through a hidden
+  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
+  carrying passthrough columns; the chart re-sourced through it) and target
+  the table. Control filter targets may only point at TABLE elements — a
+  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
+  (live-verified 2026-06-12; the looker builder's listen-scope tables and
+  enhance-apply's `ensure_base_table!` are the two automated forms of this
+  pattern).
 - **intentional narrow control** (grain switcher driving one chart by
   formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
 


### PR DESCRIPTION
Workstream C of the control-targeting wave (companion to the control lint / gate 7, #73). Controls are now targeted per the SOURCE artifact's intended scope, both builders emit the `control-scope.json` contract sidecar, and the enhancement phase extends controls to cover what it adds.

## Looker — `build_workbook.py`
- **`listen:` scope honored**: tiles are partitioned by listen-set; partitions are re-sourced through hidden listen-scope TABLES (control filter targets may only be table elements — chart/KPI targets 400). Each dashboard filter targets exactly the tiles that `listen:` to it; non-listening tiles stay un-targeted BY DESIGN and are recorded in the sidecar `scope` allowlist so gate 7 stays clean.
- **Binding improved before dropping**: `dimension_group` timeframe display-name resolution (mirrors the converter's TIMEFRAME_MAP/DEFAULT_TIMEFRAMES — bare group refs and `<group>_<timeframe>` fields both resolve, incl. joined-view `(view)` suffixes); date filters → date-range controls (list-on-datetime is silently stripped). Unbindable filters still DROP loudly (`--strict` exits 2) — builds on the estate-repair behavior, no regression.
- Sidecar emitted in the `control_lint.rb` CONTRACT shape; dropped controls live under `"dropped"` (a contract `controls` entry missing from the spec is a gate-7 failure by design).

## Tableau — `build-charts-from-signals.rb`
- Control targets = the sourcing **roots** of the charts each source filter is meant to reach (source-chain walk; master + DM-direct/helper roots) instead of hardcoded `opts[:master_id]`; a filter with no reachable target never ships dead; unreachable roots are warned + recorded.
- **Quick-filter zones apply per-dashboard** (per-page emission via `_scope_dashboards` in page-per-dashboard mode); **sheet-scoped `[Action (X)]` filters** emit `mustReach` hard assertions — the proven case: Region must reach "Monthly Revenue Trend".
- Contract sidecar incl. per-page-instance entries (page modes rewrite controlIds) and parameter records matched by `[controlId]` formula refs (what the lint's reach walk actually sees).

## Enhancer — `enhance-apply.rb` (tableau + pbi, byte-identical, md5 `3443787a2b2d7601836772bd120bc587`)
- `add_elements` now **extends existing controls** to cover added viz elements: already-in-closure → no-op; table root → direct target (+ hidden passthrough column when same DM element); **DM-direct viz → re-rooted through a hidden shared BASE TABLE** on the Data page (`ensure_base_table!`) — live-verified that control filter targets on chart/KPI elements 400 at PUT with "Dependency not found"; controls are stable-moved to the end of the page (Sigma resolves spec deps in array order).
- Grain/drill switchers are deliberately **exempt** (formula-wired value providers) and recorded as a sidecar `scope` allowlist entry.
- Merged contract → `control-scope.enhanced.json` (the original's sidecar keeps describing the original) + a gate-7-grade `ControlLint` run on the live clone at finalize (exit 4 on violations).
- `refs/control-parity.md` (all 5 vendored copies): the "chart bypasses the master" repair recipe now prescribes the hidden shared-base-table pattern.

## E2E evidence (live, tj-wells-1989 — all KEPT)
**Looker fixtures one-command** (`migrate-looker.py`, fixture extended with a `first_order` dimension_group + date filter):
- parity 5/5 strict; all gates green incl. `gate 7/7: control lint clean (3 control(s) … source scope honored)`
- flip tests (probe-controls.rb, `--check-out-of-closure`): `region PASS flip="South" … in-closure export differs` / `region OK … out-of-closure export unchanged (no leak)` (non-listening "Net Revenue by Region" untouched); same for `order-channel`; `first-order-date PASS` via `--value min:2024-01-01,max:2024-12-31`
- kept: **CTLC Looker SKILLTEST Looker Orders Pulse (from Looker)** `c4e7e36a-6e09-49af-a387-3392927b1a0f` (DM `dc6350b2`); PNG read + checklist pass

**Tableau "Orders Conversion Test" one-command with `--enhance --enhance-accept all-low-risk`**:
- parity 6/6 strict (incl. Monthly Revenue Trend, rebuilt from a VDS-recovered CSV after the known empty-view-export quirk, honoring the dashboard's "this year" relative-date filter); all 7 gates green; sidecar `ctl-region…` carries `mustReach: [... el-monthly-revenue-trend ...]`
- Phase E: clone with 6 applied / 0 reverted; layout + control lint CLEAN on the clone
- flip tests (export `parameters`, baseline byte-exact vs parity values when no parameter set):
  - Region → Monthly Revenue Trend (previously-dead case): Jan 2026 `2031.84 → 1471.9`, Feb `3406.8 → 1628.91`, Mar `3256.59 → 569.86`
  - Region → enhancement-added KPI "Latest Month Gross Revenue": `7409.57 → 2189.78`
  - synthetic DM-direct KPI candidate (extension branch): 3 controls extended via `phasee-base-el-synth-dm-kpi`, flip `36279.94 → 13198.84` (test clone deleted)
- kept: **CTLC Tableau Orders Conversion Test** `59bfa13e-cf5b-4740-9db6-2a8e47584808` + **— Enhanced** clone `6dc56276-f8bc-4209-823a-9fae5097b695` (DM `8d331710`); PNGs read + checklist pass

No changes to `control_lint.rb` / `assert-phase6-ran.rb` / `post-and-readback.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)