### PR TITLE
microstrategy-to-sigma: control-targeting standard + shared gate stack

### DIFF
--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/QUICKSTART.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/QUICKSTART.md
@@ -104,5 +104,9 @@ Duration: 3
 
 - Parity gate: `verify_parity.py` green — all rows, exact (ratios 1e-6).
 - Readback gate: no `type: "error"` columns in the DM or workbook spec.
-- Anything flagged (unmapped viz types, prompts, selectors) is listed in the
-  conversion notes for human follow-up — loud and explicit, never silent.
+- Finalize gate: `assert-phase6-ran.rb` — seven shared gates including the
+  layout lint and the control-wiring lint (dossier selectors/chapter filters
+  convert to Sigma controls wired to their declared viz targets).
+- Anything flagged (unmapped viz types, prompts, panel selectors) is listed
+  in the conversion notes and `control-scope.json` for human follow-up —
+  loud and explicit, never silent.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -31,8 +31,10 @@ logic.
 > dossier flows), `ae-row-collapse.md` (the one MSTR behavior no clean SQL
 > reproduces, and the pinning workflow), `viz-type-mapping.md` (dossier viz →
 > Sigma element lookup), `design-notes.md` (architecture + modeling gotchas +
-> roadmap). For canonical Sigma spec shapes, defer to the companion
-> `sigma-data-models` / `sigma-workbooks` skills.
+> roadmap), `control-parity.md` (shared control-targeting contract: the
+> control lint, the control-scope.json sidecar, and the flip test). For
+> canonical Sigma spec shapes, defer to the companion `sigma-data-models` /
+> `sigma-workbooks` skills.
 
 ---
 
@@ -50,7 +52,9 @@ logic.
   only means something when the Sigma connection reaches the database
   MicroStrategy queries.
 - **Python 3** (stdlib only; `resolve_ae_winners.py` and parity readback also
-  want `PyYAML` for Sigma's YAML spec responses).
+  want `PyYAML` for Sigma's YAML spec responses) and **Ruby** (the shared
+  gate stack: `put-layout.rb`, `assert-phase6-ran.rb`, `probe-controls.rb`,
+  `scripts/lib/*.rb` — vendored byte-identical across the sibling plugins).
 
 ## Phase 0 — Discover
 
@@ -86,9 +90,26 @@ python3 scripts/convert.py --bundle bundle.json \
 Emits `sigma_dm_spec.json` (one table element per logical table, derived
 left-outer joins, a consumable join element, token-parsed metrics with derived
 display formats) + `sigma_workbook_spec.json` (one page per dossier chapter,
-grouped tables mirroring each report template) + `parity_keys.json`. The
-workbook spec carries `{{DATA_MODEL_ID}}` / element-id placeholders until
-Phase 4 re-runs with real ids.
+grouped tables mirroring each report template, **controls** from the dossier's
+filter signals, banded-layout container elements) + `parity_keys.json` +
+`layout.xml` + `control-scope.json`. The workbook spec carries
+`{{DATA_MODEL_ID}}` / element-id placeholders until Phase 4 re-runs with real
+ids.
+
+**Controls** (`refs/control-parity.md` is the contract): MSTR dossiers DECLARE
+selector targets (`selectors[].targets` = viz keys) — the strongest
+source-scope signal of any BI tool — so each selector becomes a Sigma control
+whose `filters` wire to exactly the table elements built from the declared
+vizzes; chapter filter panels cover every element on their chapter's page.
+Verified shapes baked in: filter targets only on TABLE elements; controls
+AFTER their targets in spec order; date attributes → `date-range` with flat
+`mode: between` (list-on-datetime targets are silently stripped); **numeric
+attributes bind through a hidden `Text()` cast column** (a list-control filter
+target on a NUMERIC column also posts 200 and reads back `filters: null` —
+live-verified 2026-06-12). Panel selectors are navigation, not filters —
+flagged MANUAL in the sidecar, never silently dropped. `control-scope.json`
+carries `sourceFilterSignals` + per-control declared scope/`mustReach` for
+gate 7.
 
 Conversion patterns to know (details in `refs/`): grids group by the
 attribute's KEY form and label with `Max([DESC])`; dim-keyed groupings get an
@@ -113,6 +134,9 @@ It re-executes the affected reports in MSTR, computes the clean warehouse
 groups via a throwaway Sigma probe workbook, pins each winner empirically, and
 the converter emits a deterministic SQL element reproducing the grid. Read
 `refs/ae-row-collapse.md` — this is the single biggest parity trap.
+(Fixture path: `fixtures/ae_winners.json` carries the winners pinned during
+the live validation, so the bundled fixture runs end-to-end without a
+Strategy One instance.)
 
 ## Phase 3 — POST the data model + read back ids (hard gate)
 
@@ -140,11 +164,15 @@ python3 scripts/convert.py ... --data-model-id <dataModelId> \
 curl -s -X POST "$SIGMA_BASE_URL/v2/workbooks/spec" \
   -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Content-Type: application/json" \
   -d @sigma_workbook_spec.json      # -> workbookId
+ruby scripts/put-layout.rb --workbook <workbookId> --layout layout.xml
 ```
 
-Read the workbook spec back the same way and confirm no `type: error` columns.
-(Workbook DELETE, if you need to retry, is `DELETE /v2/files/<id>` — not
-`/v2/workbooks/<id>`.)
+The layout PUT applies the banded layout (header band titled from the
+chapter/dossier name, controls band, full-width tables) the converter emitted
+— without it the workbook renders as Sigma's single-column stack and gates
+4/6 fail. Read the workbook spec back the same way and confirm no
+`type: error` columns. (Workbook DELETE, if you need to retry, is
+`DELETE /v2/files/<id>` — not `/v2/workbooks/<id>`.)
 
 ## Phase 5 — Verify parity (hard gate — the real proof)
 
@@ -162,7 +190,32 @@ Exports every workbook element to CSV via the Sigma export API and compares
 row-by-row (money/counts exact; ratio metrics rel 1e-6). **GREEN only when
 every report PASSes** — never on a 200 POST alone. Mind freshness: Sigma reads
 the live warehouse; if rows landed since the MSTR numbers were captured,
-re-capture before calling a delta a failure.
+re-capture before calling a delta a failure (reconcile the delta against the
+post-snapshot rows — the fixture's shared demo tables drift daily).
+
+It also writes the gate sentinels `parity-final.json` + `wb-ids.json` next to
+the report — the contract Phase 6 reads.
+
+## Phase 6 — Finalize (hard gate before declaring GREEN)
+
+```bash
+ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <workbookId>
+```
+
+Seven independent gates (shared, vendored byte-identical): parity ran + PASS,
+no orphan workbooks, no live `type=error` columns, layout applied, tile
+census (skipped — this converter does not emit one), **layout lint** (gate 6:
+no raw-id titles, no orphan controls, no dead zones, no generic "Page N"
+header, no under-filled bands), and **control lint** (gate 7: no dead
+controls, no ghost targets, full declared reach, `control-scope.json`
+coverage — an interactive dossier converting to zero controls FAILS).
+Exit 0 = GREEN. Optional runtime proof after the lint passes:
+
+```bash
+ruby scripts/probe-controls.rb --workbook-id <workbookId> --check-out-of-closure
+# numeric selectors bind via a hidden "<Name> (Filter)" Text() column the
+# auto-picker can't see — pass --value, e.g. --value YearFilter=2024
+```
 
 ---
 
@@ -174,11 +227,15 @@ key columns; facts + token-parsed metrics incl. `Count<Distinct=True>` →
 `CountDistinct` and compound metrics; semantic display formats) · dossier
 chapters → workbook pages with grouped tables (KEY-form grouping + `Max(DESC)`
 labels + null-exclude filters) · AE row-collapse reports → deterministic
-pinned-winner SQL elements.
+pinned-winner SQL elements · **chapter filters + attribute selectors → Sigma
+controls** wired to the selectors' DECLARED viz targets (gate-7-verified +
+flip-tested) with banded layout.
 
 **Flagged / roadmap:** unmapped viz types → flagged table fallback
 (`refs/viz-type-mapping.md`); chart emission (kpi/bar/line/combo) extraction-
-validated but build roadmap; filters/selectors/page-by/prompts; the newer
+validated but build roadmap; metric-condition selectors / page-by / prompts
+(metric qualification selectors land in `control-scope.json` `unbound` as
+MANUAL); panel selectors (navigation — flagged MANUAL); the newer
 REST-authorable "Data Model" object incl. `securityFilters` (the future RLS
 port surface — until then, **ask the customer about security filters
 explicitly**; never assume an estate has none just because the classic extract
@@ -192,5 +249,9 @@ doesn't carry them).
 - Attribute-count metrics (`Count(Customer)`) → cartesian governance aborts —
   count a fact/key column instead; compound denominators need `ZeroToNull()`
   or Snowflake kills the report — `refs/design-notes.md`.
+- A list-control filter target on a DATETIME **or NUMERIC** column posts 200
+  and is SILENTLY STRIPPED (`filters: null` on readback) — dates → date-range
+  controls, numbers → hidden `Text()` cast column (`convert.py` handles both;
+  gate 7 catches escapes).
 - Python 3.13+ rejects some MSTR cloud CA certs (`VERIFY_X509_STRICT`) —
   `mstr.py` handles it.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/ae_winners.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/ae_winners.json
@@ -1,0 +1,23 @@
+{
+ "Monthly Revenue Trend": {
+  "quirkKeyCol": "MONTH_NUMBER",
+  "quirkDescCol": "MONTH_NAME",
+  "parentKeyCols": [
+   "YEAR"
+  ],
+  "winners": [
+   {"Month Number": 1, "Year": 2024},
+   {"Month Number": 2, "Year": 2026},
+   {"Month Number": 3, "Year": 2025},
+   {"Month Number": 4, "Year": 2026},
+   {"Month Number": 5, "Year": 2026},
+   {"Month Number": 6, "Year": 2024},
+   {"Month Number": 7, "Year": 2025},
+   {"Month Number": 8, "Year": 2024},
+   {"Month Number": 9, "Year": 2025},
+   {"Month Number": 10, "Year": 2025},
+   {"Month Number": 11, "Year": 2025},
+   {"Month Number": 12, "Year": 2025}
+  ]
+ }
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/bundle.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/bundle.json
@@ -304,7 +304,16 @@
       ]
      }
     ],
-    "filters": []
+    "filters": [
+     {
+      "key": "K201",
+      "name": "Region",
+      "source": {
+       "id": "6140BFA7309B406AA76A90454BC7BB53",
+       "name": "Region"
+      }
+     }
+    ]
    },
    {
     "key": "K69",
@@ -318,6 +327,24 @@
         "key": "K121",
         "name": "Visualization 1",
         "visualizationType": "grid"
+       }
+      ],
+      "selectors": [
+       {
+        "key": "K124",
+        "name": "Year",
+        "selectorType": "attribute_selector_lists",
+        "source": {
+         "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+         "name": "Year"
+        },
+        "multiSelectionAllowed": true,
+        "hasAll": true,
+        "targets": [
+         {
+          "key": "K121"
+         }
+        ]
        }
       ]
      }
@@ -336,6 +363,30 @@
         "key": "K159",
         "name": "Visualization 1",
         "visualizationType": "grid"
+       }
+      ],
+      "selectors": [
+       {
+        "key": "K160",
+        "name": "Order Channel",
+        "selectorType": "attribute_selector_lists",
+        "source": {
+         "id": "E951AA8437BF46BB860E98F0DB349617",
+         "name": "Order Channel"
+        },
+        "multiSelectionAllowed": true,
+        "hasAll": true,
+        "targets": [
+         {
+          "key": "K159"
+         }
+        ]
+       },
+       {
+        "key": "K162",
+        "name": "Panel Selector 1",
+        "selectorType": "panel_selector_button_bar",
+        "targets": []
        }
       ]
      }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/dossier_definition.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/fixtures/dossier_definition.json
@@ -303,7 +303,16 @@
      ]
     }
    ],
-   "filters": []
+   "filters": [
+    {
+     "key": "K201",
+     "name": "Region",
+     "source": {
+      "id": "6140BFA7309B406AA76A90454BC7BB53",
+      "name": "Region"
+     }
+    }
+   ]
   },
   {
    "key": "K69",
@@ -317,6 +326,24 @@
        "key": "K121",
        "name": "Visualization 1",
        "visualizationType": "grid"
+      }
+     ],
+     "selectors": [
+      {
+       "key": "K124",
+       "name": "Year",
+       "selectorType": "attribute_selector_lists",
+       "source": {
+        "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+        "name": "Year"
+       },
+       "multiSelectionAllowed": true,
+       "hasAll": true,
+       "targets": [
+        {
+         "key": "K121"
+        }
+       ]
       }
      ]
     }
@@ -335,6 +362,30 @@
        "key": "K159",
        "name": "Visualization 1",
        "visualizationType": "grid"
+      }
+     ],
+     "selectors": [
+      {
+       "key": "K160",
+       "name": "Order Channel",
+       "selectorType": "attribute_selector_lists",
+       "source": {
+        "id": "E951AA8437BF46BB860E98F0DB349617",
+        "name": "Order Channel"
+       },
+       "multiSelectionAllowed": true,
+       "hasAll": true,
+       "targets": [
+        {
+         "key": "K159"
+        }
+       ]
+      },
+      {
+       "key": "K162",
+       "name": "Panel Selector 1",
+       "selectorType": "panel_selector_button_bar",
+       "targets": []
       }
      ]
     }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/control-parity.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/control-parity.md
@@ -1,0 +1,93 @@
+# Control parity — lint, flip test, and the MCP/export answer
+
+SHARED ref, vendored byte-identical into every covered plugin's `refs/`
+(md5 discipline). Companion to `scripts/lib/control_lint.rb` (gate 7 /
+post-and-readback control lint) and `scripts/probe-controls.rb` (flip test).
+
+## Why this exists
+
+A migrated workbook can pass data parity, the column-type guard, and the
+layout lint and still ship **broken interactivity**. The 2026-06 estate audit
+of tj-wells-1989 found 86 controls across 36 kept workbooks: 8 DEAD (no
+filter target, no formula reference — pure furniture), 18 PARTIAL (same-page
+charts outside the control's reach; 8 of them bugs), and the Qlik class
+(source dashboards full of listboxes migrated with zero controls). None of
+the existing gates noticed, because every existing gate evaluates elements in
+their default state.
+
+## The three layers
+
+1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
+   dead controls, ghost filter targets, source-closure reach vs same-page
+   queryable elements, and source-signal coverage via the
+   `control-scope.json` sidecar. Runs automatically in
+   `post-and-readback.rb --type workbook` (exit 4) and as
+   `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
+2. **control-scope.json contract** — emitted by the builder next to the
+   workbook spec. Carries (a) `sourceFilterSignals`: how many filter-like
+   signals the SOURCE artifact had (Tableau quick filters + actions, PBI
+   slicers, Qlik listboxes, QuickSight/Cognos parameters+prompts, Looker
+   dashboard filters, TS Liveboard filters) — `>0` with zero spec controls
+   FAILS the lint; (b) per-control intent: `scope: "page"` (default — the
+   control must reach every same-page queryable element) or
+   `scope: ["Element name or id", ...]` (the **single-chart-switcher
+   allowlist** for intentional narrow controls like grain/geo-level toggles)
+   plus optional `mustReach` hard assertions. Full schema in the
+   `control_lint.rb` header CONTRACT block. The in-spec `controlScope` key on
+   a control element means the same thing but does NOT survive Sigma
+   readback — the sidecar is the durable form.
+3. **Flip test** (`scripts/probe-controls.rb`) — OPTIONAL Phase-6 runtime
+   evidence, not the mandatory inner loop. Exports one in-closure element CSV
+   with and without `parameters:{<controlId>: <first non-default value>}` —
+   they must differ; with `--check-out-of-closure`, an out-of-closure element
+   must NOT differ. Use it after hand-wiring controls, after estate repairs,
+   or when the lint's static reach needs runtime confirmation.
+
+## The MCP question — definitive answer (verified 2026-06-12, tj-wells-1989)
+
+Tested by setting a saved default (`values: ["West"]`) on a live workbook's
+Region list control (PHASEE, `64e78398`), then querying/exporting the same
+in-closure bar chart every way available:
+
+| Path | Control defaults applied? | Can set a control value? |
+|---|---|---|
+| `mcp__sigma-mcp-v2__query` (type=workbook) | **YES** — returned only the West row | **NO** — schema is `{type, workbookId, sql}` only; no parameter mechanism exists in the MCP query path |
+| REST export, no `parameters` | **YES** — only the West row | n/a |
+| REST `POST /v2/workbooks/{id}/export` with `"parameters": {"<controlId>": "<value>"}` | starts from defaults | **YES** — and the parameter **REPLACES** the saved default (parameters `{"ctl-region":"South"}` over a West default returned only South — no intersection) |
+
+Consequences:
+
+- MCP is fine for **default-state parity** (Phase 6 uses exactly that), and
+  default-state MCP rows DO move if you change a control's saved default.
+- MCP can NOT exercise a non-default control value — flip testing MUST go
+  through the export API's `parameters` map. That is why probe-controls.rb is
+  built on export.
+- A parameter value that matches no data row returns an EMPTY (header-only)
+  CSV, not an error — pick flip values from the column's actual domain
+  (probe-controls.rb auto-picks from the control's value-source column).
+
+## Repair recipes (what the lint tells you to do)
+
+- **dead control, column exists on a master** → add
+  `filters: [{source: {kind: "table", elementId: "<master>"}, columnId: "<col>"}]`
+  (and point the control's own `source` at the same column for its value
+  list).
+- **dead control, column does NOT exist anywhere** → REMOVE the control.
+  Honest beats decorative; do not fake-wire to an unrelated column.
+- **partial reach, multi-master page** → add one filter target per master the
+  control should govern (the column must exist on each); elements sourcing
+  from those masters inherit via the closure.
+- **partial reach, chart bypasses the master** (sources the DM directly) →
+  either re-source the chart from the master or re-root it through a hidden
+  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
+  carrying passthrough columns; the chart re-sourced through it) and target
+  the table. Control filter targets may only point at TABLE elements — a
+  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
+  (live-verified 2026-06-12; the looker builder's listen-scope tables and
+  enhance-apply's `ensure_base_table!` are the two automated forms of this
+  pattern).
+- **intentional narrow control** (grain switcher driving one chart by
+  formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
+
+After any repair: flip-test the workbook
+(`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/design-notes.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/design-notes.md
@@ -60,6 +60,15 @@ MSTR REST ──extract.py──> bundle.json ──convert.py──> sigma_dm_s
    source for customers who've adopted it; (b) `securityFilters` is the
    surface for an RLS detect→ask→port flow (same principles as the sibling
    converters: never silently dropped, never silently ported).
-3. **Filters, selectors targeting vizzes, page-by, prompts** — extracted
-   structurally (the assessment counts selectors/panel stacks) but not yet
-   converted.
+3. **Page-by, prompts, metric-condition selectors** — extracted structurally
+   but not converted (metric-condition selectors land in
+   `control-scope.json` `unbound` as MANUAL). Chapter filters + attribute
+   selectors ARE converted (2026-06-12): selectors' declared `targets` viz
+   lists drive the Sigma control filter wiring, `control-scope.json` is the
+   intended-scope contract, and gate 7 (`scripts/lib/control_lint.rb`) +
+   `scripts/probe-controls.rb` enforce/prove it. Verified strip gotcha: a
+   list-control filter target on a DATETIME or NUMERIC column posts 200 and
+   reads back `filters: null` — dates become date-range controls, numbers
+   bind through a hidden `Text()` cast column. (The numeric variant is NOT
+   yet in the shared `refs/control-parity.md` — candidate for the next
+   cross-plugin sync.)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/viz-type-mapping.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/viz-type-mapping.md
@@ -54,9 +54,12 @@ any type not in this table as custom and flag it.
 of these; converter coverage noted): selectors 51% of dossiers, chapter
 filters 49%, multi-dataset 42%, free-form `fields` — text 65% / image 54% /
 shape 33% / **html 11%** — and nested panelStacks 23%. Free-form text →
-Sigma `text` elements; images/shapes/html are flagged; selectors/filters →
-Sigma controls (roadmap); multi-dataset chapters → one Sigma element per
-dataset-backed viz (each viz names its dataset).
+Sigma `text` elements; images/shapes/html are flagged; **attribute selectors
++ chapter filters → Sigma controls** (CONVERTED — wired to the selectors'
+declared `targets` viz lists, `control-scope.json` sidecar, gate 7 +
+flip-test; panel selectors and metric-condition selectors are flagged MANUAL
+in the sidecar); multi-dataset chapters → one Sigma element per dataset-backed
+viz (each viz names its dataset).
 
 `fixtures/BUILD_SPEC.md` is the drag-and-drop spec for an "every viz type"
 fixture dossier (REST cannot author visualizations — Library UI only); use it

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,0 +1,546 @@
+#!/usr/bin/env ruby
+# Hard gate that proves a tableau-to-sigma conversion is actually complete.
+# The subagent MUST run this script before declaring GREEN. It checks seven
+# independent things — failing ANY of them blocks the GREEN declaration:
+#
+#   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
+#      → beads-sigma-4pm
+#   2. No orphan workbooks left in the customer's My Documents
+#      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
+#      cleanup ran with no failed deletes)  → beads-sigma-38a
+#   3. The live workbook's /columns endpoint shows no column with
+#      type=error (catches circular refs / runtime errors introduced
+#      AFTER the initial POST's column-type guard ran)  → beads-sigma-38a
+#   4. The workbook has a non-empty layout XML applied (catches the
+#      "elements just listed in a single column" regression where the
+#      agent forgot to PUT a layout)  → beads-sigma-bw3
+#   5. Tile census — parity-final.json's `tile_census` field (emitted by the
+#      converter's phase6 finalize when a dashboard zone tree is available)
+#      shows no unexplained dashboard zones without a matching chart in the
+#      parity plan. Catches the "empty view CSV silently dropped a tile and
+#      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
+#      (with a note) when the converter doesn't emit a census.
+#   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
+#      display names, no input controls outside the GridContainer bands on a
+#      banded page, no dead zones (>25% empty grid rows between a page's
+#      first and last element), no generic header-band title ("Page 1" /
+#      "Sheet 3" / "Dashboard 2" must never title a dashboard), and no
+#      under-filled band (<60% of the 24 grid columns covered; deliberate
+#      KPI bands of <=4 tiles exempt). Catches the "PHASEE PBI Employee
+#      Dashboard" visual-mess regression (and its PHASEE2 sequel: "Page 1"
+#      header + a lone small chart beside a 19-column hole) that every data
+#      gate waved through.
+#   7. Control lint (scripts/lib/control_lint.rb, shared) — no dead controls
+#      (a control with no resolving `filters` target AND no [controlId]
+#      formula reference is furniture: the "Orders Overview (from Looker)"
+#      estate shipped three of them), no ghost filter targets, and no control
+#      whose source-closure misses same-page queryable elements (the PHASEE
+#      "Action(Region) -> Monthly Revenue Trend" escape). Honors the
+#      control-scope sidecar (<workdir>/control-scope.json or
+#      --control-scope) for source-signal coverage (zero controls built from
+#      an interactive source = FAIL, the Qlik class) and per-control
+#      scope:[...] allowlists (intentional single-chart switchers like grain
+#      controls). See the lib header CONTRACT.
+#
+# Usage:
+#   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
+#     [--workbook-id <id>]     # override; default = read from wb-ids.json
+#     [--min-pass-rate 1.0]    # default 1.0 (every chart must PASS)
+#     [--allow-extract]        # treat extract-mode as acceptable
+#     [--skip-column-check]    # skip the live /columns type=error scan
+#     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
+#                              # that genuinely want multiple workbooks)
+#     [--skip-layout-check]    # skip the layout-applied scan
+#     [--skip-layout-lint]     # skip gate 6 (layout-quality lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
+#     [--skip-control-lint]    # skip gate 7 (control-wiring lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
+#     [--control-scope PATH]   # control-scope.json sidecar for gate 7
+#                              # (default: <workdir>/control-scope.json)
+#     [--min-layout-elements N] default 2 — single-page bare-element layouts
+#                              # often have just the page wrapper; require this
+#                              # many <LayoutElement> tags
+#     [--allow-missing-tiles N] default 0 — tolerate up to N unmatched dashboard
+#                              # zones in the tile census (for legitimately
+#                              # unbuildable zones; name them in your report)
+#
+# Exit codes:
+#   0  every gate passes — conversion is allowed to declare GREEN
+#   1  parity-final.json missing (Phase 6 skipped — the regression case)
+#   2  parity-final.json exists but status=FAIL / pass-rate below min /
+#      extract-mode without --allow-extract / charts_total==0
+#   3  parity-final.json malformed
+#   4  orphan workbooks left uncleaned (beads-sigma-38a)
+#   5  live workbook has column(s) with type=error (beads-sigma-38a)
+#   6  live workbook has no layout applied — single-column fallback
+#      (beads-sigma-bw3)
+#   7  tile census shows unexplained unmatched dashboard zones beyond
+#      --allow-missing-tiles (bead gjhe)
+#   8  layout lint violations — raw-id display names / orphan controls /
+#      dead zones (gate 6; scripts/lib/layout_lint.rb)
+#   9  control lint violations — dead controls / ghost targets / partial
+#      reach / source filter signals with zero controls
+#      (gate 7; scripts/lib/control_lint.rb)
+#
+# Prints a per-gate summary to stdout regardless of exit code.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
+         allow_missing_tiles: 0 }
+OptionParser.new do |p|
+  p.on('--tableau DIR')              { |v| opts[:tab] = v }
+  p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
+  p.on('--workbook-id ID')           { |v| opts[:wb] = v }
+  p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--allow-extract')            { opts[:allow_extract] = true }
+  p.on('--skip-column-check')        { opts[:skip_column] = true }
+  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
+  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
+  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+  p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
+end.parse!
+abort('--workdir (or --tableau) required') unless opts[:tab]
+
+summary_path = File.join(opts[:tab], 'parity-final.json')
+
+unless File.exist?(summary_path)
+  warn "[FAIL] Phase 6 skipped — #{summary_path} does not exist."
+  warn "       Run: ruby scripts/phase6-parity.rb --tableau #{opts[:tab]} --workbook-id <id>"
+  warn "       then collect actuals via mcp__sigma-mcp-v2__query and re-run with --finalize."
+  warn "       See SKILL.md Phase 6. This is the hard gate (beads-sigma-4pm)."
+  exit 1
+end
+
+begin
+  summary = JSON.parse(File.read(summary_path))
+rescue JSON::ParserError => e
+  warn "[FAIL] #{summary_path} is malformed JSON: #{e.message}"
+  exit 3
+end
+
+total = summary['charts_total'].to_i
+passed = summary['charts_pass'].to_i
+status = summary['status'].to_s
+mode = summary['mode'].to_s
+
+if total <= 0
+  warn "[FAIL] parity-final.json reports charts_total=#{total} — no charts were verified."
+  warn "       This usually means auto-parity-plan.rb matched zero Tableau views."
+  warn "       Phase 6 must verify at least one chart to declare GREEN."
+  exit 2
+end
+
+if mode == 'extract' && !opts[:allow_extract]
+  warn "[FAIL] parity ran in extract-mode but --allow-extract was not passed."
+  warn "       Extract-mode permits up to ±#{((summary['extract_tol'] || 0.30) * 100).to_i}% drift —"
+  warn "       only acceptable when the source Tableau workbook has hasExtracts=true."
+  exit 2
+end
+
+pass_rate = passed.to_f / total
+# status=PASS requires 100% — when the caller explicitly accepts a lower
+# pass-rate (--min-pass-rate, for honest NAMED divergences like LOD
+# placeholders / cross-grain semantics), the rate is the gate, not the status.
+rate_gate_only = opts[:min_pass_rate] < 1.0
+if (rate_gate_only ? pass_rate < opts[:min_pass_rate] : (status != 'PASS' || pass_rate < opts[:min_pass_rate]))
+  warn "[FAIL] parity status=#{status} pass-rate=#{(pass_rate * 100).round(1)}% (#{passed}/#{total})"
+  warn "       Required: #{rate_gate_only ? '' : 'status=PASS and '}pass-rate >= #{(opts[:min_pass_rate] * 100).to_i}%"
+  if (fail_names = summary['fail_names']) && !fail_names.empty?
+    warn "       Failing charts: #{fail_names.join(', ')}"
+  end
+  exit 2
+end
+
+if rate_gate_only && status != 'PASS'
+  puts "[OK] gate 1/7: Phase 6 ran — #{passed}/#{total} charts PASS (>= #{(opts[:min_pass_rate] * 100).to_i}% accepted); " \
+       "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
+else
+  puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 2 — orphan workbooks (beads-sigma-38a)
+# ---------------------------------------------------------------------------
+unless opts[:skip_orphan]
+  log = File.join(opts[:tab], 'posted-workbooks.jsonl')
+  if File.exist?(log)
+    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    unique_ids = posted.map { |e| e['id'] }.uniq
+    if unique_ids.length > 1
+      marker_path = File.join(opts[:tab], 'cleanup-marker.json')
+      unless File.exist?(marker_path)
+        warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "       posted-workbooks.jsonl entries:"
+        unique_ids.each { |id| warn "         - #{id}" }
+        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        warn "       See beads-sigma-38a."
+        exit 4
+      end
+      marker = JSON.parse(File.read(marker_path)) rescue {}
+      if marker['failed'] && !marker['failed'].empty?
+        warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "       Orphan workbooks are still in the customer's My Documents:"
+        marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
+        exit 4
+      end
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+        exit 4
+      end
+      kept = marker['kept'] || '(unknown)'
+      deleted = (marker['deleted'] || []).length
+      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+    else
+      puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+    end
+  else
+    puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+  end
+else
+  puts "[SKIP] gate 2/7: --skip-orphan-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 3 — live /columns type=error scan (beads-sigma-38a)
+# Catches circular references and runtime errors that the initial post-and-
+# readback column-type guard missed because they were introduced by later
+# PUTs (layout updates, spec edits during error recovery).
+# ---------------------------------------------------------------------------
+unless opts[:skip_column]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 3/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        cols = (JSON.parse(res.body)['entries'] rescue []) || []
+        error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
+        if error_cols.any?
+          warn "[FAIL] gate 3/7: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
+          warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
+          error_cols.first(10).each do |c|
+            warn "         element=#{c['elementId']} col=#{c['columnId']} label=#{c['label'].inspect}"
+            warn "           formula: #{c['formula']}"
+          end
+          warn "       See beads-sigma-38a."
+          exit 5
+        end
+        puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+      else
+        warn "[SKIP] gate 3/7: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 3/7: --skip-column-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 4 — layout applied (beads-sigma-bw3)
+# Fetches the live workbook spec and confirms a non-empty top-level `layout`
+# XML is set, with at least --min-layout-elements <LayoutElement> tags.
+# Catches the "agent forgot to PUT a layout" regression where elements
+# render as a single-column stack instead of the dashboard grid.
+# ---------------------------------------------------------------------------
+unless opts[:skip_layout]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 4/7: no workbook ID resolvable for layout check"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 4/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        body = res.body.to_s
+        spec =
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+          end
+        layout_xml = spec['layout'].to_s
+        elem_count = layout_xml.scan(/<LayoutElement\b/).length
+
+        # Detect the Sigma "auto-generated single-column stack" layout that
+        # the server produces when a workbook is POSTed without a layout.
+        # Signature: every non-Data page has all its elements at the same
+        # gridColumn value (typically "1 / 13" — left half, vertically stacked).
+        # Note: per-page detection — a workbook with one element per content
+        # page is structurally fine (degenerate case, not a stack).
+        # Container-banded pages (<GridContainer> bands per layout-playbook.md)
+        # are exempt: full-width band containers (and single-chart rows inside
+        # them) legitimately share gridColumn="1 / 25" — that is deliberate
+        # banding, not the auto-stack regression.
+        non_data_stack_pages = []
+        # Walk one page at a time using the <Page id="..."> blocks
+        layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
+          next if page_id.to_s.downcase.include?('data')
+          next if page_body.include?('<GridContainer')
+          cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
+          elems_on_page = page_body.scan(/<LayoutElement\b/).length
+          if elems_on_page >= 2 && cols_on_page.length == 1
+            non_data_stack_pages << [page_id, cols_on_page.first, elems_on_page]
+          end
+        end
+
+        if layout_xml.empty?
+          warn "[FAIL] gate 4/7: live workbook #{wb_id} has NO top-level layout XML."
+          warn "       Elements render as a single-column stack instead of the"
+          warn "       dashboard grid. Rebuild the layout with this skill's layout"
+          warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
+          warn "       then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} \\"
+          warn "           --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        elsif elem_count < opts[:min_layout_elements]
+          warn "[FAIL] gate 4/7: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
+          warn "       The layout likely covers only the Data page — chart page is unstyled."
+          exit 6
+        elsif non_data_stack_pages.any?
+          warn "[FAIL] gate 4/7: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "       single-column stack layout (multiple elements at the same gridColumn"
+          warn "       on a non-Data page). This is what Sigma defaults to when you POST"
+          warn "       a workbook without a layout — exactly the CoCo regression."
+          non_data_stack_pages.each do |pid, col, n|
+            warn "         page=#{pid.inspect}: #{n} elements all at gridColumn=#{col.inspect}"
+          end
+          warn "       Rebuild the layout with this skill's layout builder (see SKILL.md —"
+          warn "       layout phase) into #{opts[:tab]}/layout.xml, then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        else
+          puts "[OK] gate 4/7: layout XML applied with #{elem_count} positioned element(s)"
+        end
+      else
+        warn "[SKIP] gate 4/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 4/7: --skip-layout-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 5 — tile census (bead gjhe)
+# parity-final.json's `tile_census` field compares the source dashboard's
+# chart-zone count against the charts that made it into the parity plan.
+# Catches the empty-view-CSV escape where the builder silently emits N-1
+# charts and parity still reports PASS (every chart it knows about passes —
+# it just doesn't know about the dropped one).
+# ---------------------------------------------------------------------------
+census = summary['tile_census']
+if census.nil?
+  puts "[SKIP] gate 5/7: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+else
+  zones     = census['zones_total'].to_i
+  built     = census['charts_built'].to_i
+  unmatched = census['zones_unmatched'].to_i
+  names     = Array(census['unmatched_zone_names'])
+  if unmatched > opts[:allow_missing_tiles]
+    warn "[FAIL] gate 5/7: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    names.each { |n| warn "         - #{n}" }
+    warn "       A zone that rendered in the source dashboard has NO matching chart in the"
+    warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
+    warn "       (re-fetch the view data and rebuild), or the tile was renamed without"
+    warn "       passing --rename to phase6-parity.rb / build-dashboard-layout.rb."
+    warn "       If #{unmatched} zone(s) are legitimately unbuildable, re-run with"
+    warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
+    exit 7
+  elsif unmatched > 0
+    puts "[OK] gate 5/7: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+  else
+    puts "[OK] gate 5/7: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 6 — layout-quality lint (scripts/lib/layout_lint.rb, shared)
+# A workbook can pass every data gate above and still ship as a visual mess:
+# raw element ids as chart titles, controls dumped loose at the page foot,
+# dead zones between elements (the "PHASEE PBI Employee Dashboard" escape).
+# This gate mechanizes those checks on the LIVE spec.
+# ---------------------------------------------------------------------------
+if opts[:skip_lint]
+  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 6/7: no workbook ID resolvable for layout lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 6/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/layout_lint'
+    rescue LoadError
+      warn "[SKIP] gate 6/7: scripts/lib/layout_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(LayoutLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        violations = LayoutLint.lint(spec)
+        if violations.any?
+          warn "[FAIL] gate 6/7: layout lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the spec/layout and re-PUT (raw-id names -> derive human titles;"
+          warn "       loose controls -> place into a band/container; dead zones -> re-band the page),"
+          warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
+          exit 8
+        end
+        puts '[OK] gate 6/7: layout lint clean (no raw-id names, no orphan controls, no dead zones, ' \
+             'no generic header title, no under-filled bands)'
+      else
+        warn "[SKIP] gate 6/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7 — control-wiring lint (scripts/lib/control_lint.rb, shared)
+# A workbook can pass every gate above and still ship controls that do
+# NOTHING (dead controls: no resolving filter target, no [controlId] formula
+# reference — the "Orders Overview (from Looker)" estate escape) or controls
+# that silently skip same-page charts (the PHASEE "Action(Region) ->
+# Monthly Revenue Trend" escape). This gate mechanizes those checks on the
+# LIVE spec, plus source-signal coverage when a control-scope sidecar exists
+# (zero controls built from an interactive source = FAIL, the Qlik class).
+# ---------------------------------------------------------------------------
+if opts[:skip_control_lint]
+  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 7/7: no workbook ID resolvable for control lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 7/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/control_lint'
+    rescue LoadError
+      warn "[SKIP] gate 7/7: scripts/lib/control_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(ControlLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        scope_path = opts[:control_scope] || File.join(opts[:tab], 'control-scope.json')
+        scope = nil
+        if File.exist?(scope_path)
+          scope = JSON.parse(File.read(scope_path)) rescue nil
+          warn "[WARN] gate 7/7: #{scope_path} is not valid JSON — linting without source scope" if scope.nil?
+        end
+        violations = ControlLint.lint(spec, scope: scope)
+        if violations.any?
+          warn "[FAIL] gate 7/7: control lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the control wiring and re-PUT (dead controls -> add filters targets"
+          warn "       ({source:{elementId}, columnId}) or remove the control; partial reach ->"
+          warn "       wire the uncovered elements or annotate controlScope in control-scope.json;"
+          warn "       see scripts/lib/control_lint.rb CONTRACT), then re-run this gate."
+          warn "       Flip-test the wiring live with: ruby scripts/probe-controls.rb --workbook-id #{wb_id}"
+          warn "       Escape hatch (legacy workbooks only): --skip-control-lint."
+          exit 9
+        end
+        n_controls = ControlLint.controls_report(spec).length
+        puts "[OK] gate 7/7: control lint clean (#{n_controls} control(s); no dead controls, no ghost " \
+             "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
+      else
+        warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+puts "[OK] all gates pass — conversion may declare GREEN"
+exit 0

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/convert.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/convert.py
@@ -12,6 +12,16 @@ Everything is derived programmatically from the bundle:
     metric object references + Distinct=True parameter -> CountDistinct).
   - Workbook pages: one page per dossier chapter; each chapter's dataset report's
     dataTemplate units give the grouping attributes + metric columns.
+  - Controls: dossier chapter filters + page/panel selectors -> Sigma controls.
+    MSTR selectors DECLARE their targets (targets: [{key}] viz refs) — the
+    strongest source-scope signal of any BI tool — so each control's filter
+    targets are wired to exactly the table elements built from the declared
+    vizzes (chapter filters reach every viz in their chapter). The intended
+    scope is emitted as control-scope.json (contract:
+    scripts/lib/control_lint.rb header + refs/control-parity.md).
+  - Layout: container-banded pages (header band titled from the chapter /
+    dossier name, controls band, full-width tables) -> layout.xml, applied
+    after the workbook POST via scripts/put-layout.rb.
 
 Usage:
   python3 convert.py --connection-id <uuid> --database CSA --folder-id <uuid> \
@@ -369,6 +379,96 @@ class Bundle:
             return {"kind": "number", "formatString": ",.0f"}
         return None
 
+    # ---- dossier filter signals (chapter filters + selectors)
+    @staticmethod
+    def _walk_selectors(node):
+        """Selectors on a dossier page/panel, panelStacks walked recursively
+        (panels nest further panelStacks — same walk as the assessment)."""
+        out = list(node.get("selectors") or [])
+        for ps in node.get("panelStacks") or []:
+            for p in ps.get("panels") or []:
+                out.extend(Bundle._walk_selectors(p))
+        return out
+
+    @staticmethod
+    def _walk_viz_keys(node):
+        out = [v["key"] for v in node.get("visualizations") or [] if v.get("key")]
+        for ps in node.get("panelStacks") or []:
+            for p in ps.get("panels") or []:
+                out.extend(Bundle._walk_viz_keys(p))
+        return out
+
+    def filter_signals(self):
+        """Every filter-like signal in the dossier, normalized:
+        {kind: chapter-filter|selector, chapter, name, selectorType,
+         source_id, targets: [viz keys] or None (None = whole chapter)}.
+        Panel selectors are navigation, not data filters — returned with
+        kind=panel-selector so the caller can flag them MANUAL without
+        counting them as filter signals."""
+        signals = []
+        for ch in self.dossier.get("chapters", []):
+            for f in ch.get("filters") or []:
+                signals.append({
+                    "kind": "chapter-filter", "chapter": ch["name"],
+                    "name": f.get("name"), "key": f.get("key"),
+                    "source_id": (f.get("source") or {}).get("id"),
+                    "targets": None,
+                })
+            for pg in ch.get("pages") or []:
+                for sel in self._walk_selectors(pg):
+                    st = sel.get("selectorType", "")
+                    kind = ("panel-selector" if st.startswith("panel_selector")
+                            else "selector")
+                    signals.append({
+                        "kind": kind, "chapter": ch["name"],
+                        "name": sel.get("name"), "key": sel.get("key"),
+                        "selectorType": st,
+                        "source_id": (sel.get("source") or {}).get("id"),
+                        "targets": [t["key"] for t in sel.get("targets") or []]
+                                   or None,
+                    })
+        return signals
+
+    def viz_chapter(self):
+        """visualization key -> chapter name (declared selector targets are
+        viz keys; the converter builds one table element per chapter)."""
+        out = {}
+        for ch in self.dossier.get("chapters", []):
+            for pg in ch.get("pages") or []:
+                for k in self._walk_viz_keys(pg):
+                    out[k] = ch["name"]
+        return out
+
+    def resolve_attribute(self, source_id=None, name=None):
+        if source_id and source_id in self.attributes:
+            return source_id
+        if name:
+            for aid, a in self.attributes.items():
+                if a["information"]["name"] == name:
+                    return aid
+        return None
+
+    def attribute_ctl_type(self, aid):
+        """'date' | 'number' | 'text' for the column the control binds (the
+        rendered DESC form, falling back to the key). Drives the control
+        shape: a Sigma `list` control whose filter target is a DATETIME *or
+        NUMERIC* column posts 200 but Sigma SILENTLY STRIPS the target
+        (datetime: cross-plugin estate gotcha in refs/control-parity.md;
+        numeric: live-verified on this converter 2026-06-12 — re-PUTting the
+        filter returns 200 and reads back `filters: null`). Dates become
+        date-range controls; numbers bind through a hidden Text() cast."""
+        a = self.attributes[aid]
+        forms = a["forms"]
+        key = next((f for f in forms if f.get("category") == "ID"), forms[0])
+        desc = next((f for f in forms if f.get("category") == "DESC"), None)
+        f = desc or key  # the control filters the rendered (DESC) column
+        dt = ((f.get("dataType") or {}).get("type") or "").lower()
+        if dt in ("date", "time", "timestamp") or f.get("displayFormat") == "date":
+            return "date"
+        if dt and not any(t in dt for t in ("char", "text", "string", "binary")):
+            return "number"
+        return "text"
+
     # ---- attribute key + display columns for a report unit
     def attribute_unit_cols(self, aid):
         """Returns (key_col, desc_col_or_None) physical column names.
@@ -390,6 +490,269 @@ class Bundle:
 # ------------------------------------------------------------------- emitters
 def ae_element_name(report_name):
     return f"{report_name} (MSTR AE)"
+
+
+def join_column_names(b: "Bundle"):
+    """Display names available on the consumable join element (mirrors
+    build_dm_spec's add_join_col walk)."""
+    names = {friendly(c) for c in b.table_columns(b.fact_tid)}
+    join_key_lookup = {(j["lookup_tid"], j["lookup_col"]) for j in b.derive_joins()}
+    for j in b.derive_joins():
+        for c in b.table_columns(j["lookup_tid"]):
+            if (j["lookup_tid"], c) in join_key_lookup:
+                continue
+            names.add(friendly(c))
+    return names
+
+
+# ---- dossier selectors / chapter filters -> Sigma controls ------------------
+def emit_controls(b: "Bundle", pages, page_ctx, warnings):
+    """Wire every dossier filter signal to Sigma controls (verified shapes:
+    refs/control-parity.md). MSTR selectors carry DECLARED viz targets, so
+    filter targets go to exactly the table elements built from those vizzes;
+    chapter filters cover every element on their chapter's page. Controls are
+    appended AFTER their target tables in spec order (POST requirement).
+    Returns (n_signals, scope_entries, unbound) for control-scope.json."""
+    viz_ch = b.viz_chapter()
+    scope_entries, unbound, used_ctl_ids = [], [], set()
+    n_signals = 0
+
+    def ctl_id_for(name):
+        base = re.sub(r"[^A-Za-z0-9]", "", str(name).title()) + "Filter"
+        cid, n = base, 2
+        while cid in used_ctl_ids:
+            cid, n = f"{base}{n}", n + 1
+        used_ctl_ids.add(cid)
+        return cid
+
+    def find_or_add_col(ctx, col, as_text=False):
+        """Column for `friendly(col)` on the target element — reuse the
+        grouping passthrough when present, else add a hidden passthrough.
+        as_text wraps the reference in Text() (always a fresh hidden column):
+        a list-control filter target on a NUMERIC column is silently stripped
+        by Sigma (200 on POST/PUT, `filters: null` on readback — live-
+        verified 2026-06-12), so numeric attribute selectors bind through a
+        text cast. Returns columnId or None when the element can't carry the
+        column."""
+        fr = friendly(col)
+        if fr not in ctx["available"]:
+            # the grouping column may still exist (e.g. AE alias) — check
+            if not any(c.get("formula") == ctx["ref"](fr)
+                       for c in ctx["element"]["columns"]):
+                return None
+        if as_text:
+            formula = f"Text({ctx['ref'](fr)})"
+            for c in ctx["element"]["columns"]:
+                if c.get("formula") == formula:
+                    return c["id"]
+            cid = f"ctlt-{slug(ctx['element']['id'])}-{slug(col)}"
+            ctx["element"]["columns"].append(
+                {"id": cid, "name": f"{fr} (Filter)", "formula": formula,
+                 "hidden": True})
+            return cid
+        formula = ctx["ref"](fr)
+        for c in ctx["element"]["columns"]:
+            if c.get("formula") == formula:
+                return c["id"]
+        cid = f"ctlc-{slug(ctx['element']['id'])}-{slug(col)}"
+        ctx["element"]["columns"].append(
+            {"id": cid, "name": fr, "formula": formula, "hidden": True})
+        return cid
+
+    for sig in b.filter_signals():
+        label = sig.get("name") or "Selector"
+        src = f"{sig['kind']} '{label}' (chapter '{sig['chapter']}')"
+        if sig["kind"] == "panel-selector":
+            # navigation between panels, not a data filter — flagged MANUAL,
+            # not counted as a filter signal
+            unbound.append({"sourceName": src, "status": "manual",
+                            "reason": "panel selector switches panels (navigation), "
+                                      "not a data filter — no Sigma control emitted; "
+                                      "panels land as separate elements"})
+            continue
+        n_signals += 1
+        st = sig.get("selectorType", "")
+        aid = b.resolve_attribute(sig.get("source_id"), sig.get("name"))
+        if aid is None:
+            reason = ("metric qualification selector — Sigma has no direct "
+                      "equivalent; port by hand (e.g. a number-range control "
+                      "wired to the metric's base column)"
+                      if "metric" in st else
+                      "source attribute not resolvable in the bundle — wire "
+                      "manually rather than guessing a column")
+            warnings.append(f"control {src}: {reason}")
+            unbound.append({"sourceName": src, "status": "unbound",
+                            "reason": reason})
+            continue
+
+        # targets: declared viz keys -> chapter tables; none -> own chapter
+        if sig["targets"]:
+            tgt_chapters, dropped = [], []
+            for k in sig["targets"]:
+                (tgt_chapters if k in viz_ch else dropped).append(
+                    viz_ch.get(k, k))
+            if dropped:
+                warnings.append(f"control {src}: declared target viz key(s) "
+                                f"{dropped} not found in the dossier — skipped")
+            tgt_chapters = list(dict.fromkeys(tgt_chapters))
+        else:
+            tgt_chapters = [sig["chapter"]]
+        ctxs = [page_ctx[c] for c in tgt_chapters if c in page_ctx]
+        if not ctxs:
+            warnings.append(f"control {src}: no target elements resolvable — "
+                            "not emitted")
+            unbound.append({"sourceName": src, "status": "unbound",
+                            "reason": "declared targets resolve to no built element"})
+            continue
+
+        key_col, desc_col = b.attribute_unit_cols(aid)
+        ctl_col = desc_col or key_col   # what MSTR renders in the selector
+        ctl_type = b.attribute_ctl_type(aid)
+        filters, wired = [], []
+        for ctx in ctxs:
+            cid = find_or_add_col(ctx, ctl_col, as_text=(ctl_type == "number"))
+            if cid is None:
+                warnings.append(
+                    f"control {src}: column {friendly(ctl_col)!r} not available "
+                    f"on element '{ctx['element']['name']}' — target skipped")
+                continue
+            filters.append({"source": {"kind": "table",
+                                       "elementId": ctx["element"]["id"]},
+                            "columnId": cid})
+            wired.append({"elementId": ctx["element"]["id"], "columnId": cid})
+        if not filters:
+            unbound.append({"sourceName": src, "status": "unbound",
+                            "reason": f"column {friendly(ctl_col)!r} not on any "
+                                      "target element — dropped loudly rather "
+                                      "than wired to a wrong column"})
+            continue
+
+        ctl = {"id": f"ctl-{slug(sig['chapter'])}-{slug(label)}",
+               "kind": "control", "controlId": ctl_id_for(label),
+               "name": label,
+               "filters": filters}
+        if ctl_type == "date":
+            # date-range needs no `source` but DOES require a flat `mode` —
+            # without it the POST fails with the misleading "Invalid kind:
+            # control" (live-verified cross-plugin; see control-parity.md)
+            ctl.update({"controlType": "date-range", "mode": "between",
+                        "includeNulls": "when-no-value-is-selected"})
+        else:
+            ctl.update({"controlType": "list", "mode": "include",
+                        "selectionMode": "multiple", "values": [],
+                        "source": {"kind": "source",
+                                   "source": filters[0]["source"],
+                                   "columnId": filters[0]["columnId"]}})
+
+        # the control lives on its own chapter's page, AFTER the tables
+        home = page_ctx[sig["chapter"]]["page"]
+        home["elements"].append(ctl)
+
+        # CONTRACT entry (lib/control_lint.rb header): declared targets that
+        # cover every queryable element on the control's page = scope "page";
+        # a narrower declared set = the scope allowlist (selector-scoped-by-
+        # design). mustReach always asserts the DECLARED targets.
+        target_ids = [c["element"]["id"] for c in ctxs]
+        page_tables = [e["id"] for e in home["elements"]
+                       if e.get("kind") == "table"]
+        full_page = set(page_tables) <= set(target_ids)
+        scope_entries.append({
+            "controlId": ctl["controlId"], "sourceName": src,
+            "status": "wired", "controlType": ctl["controlType"],
+            "scope": "page" if full_page else target_ids,
+            "mustReach": target_ids, "wired": wired,
+        })
+    return n_signals, scope_entries, unbound
+
+
+# ---- container-banded layout (layout-playbook.md shapes, shared across
+# plugins; python port of the qlik builder's banded_page) ---------------------
+HEADER_STYLE = {"backgroundColor": "#0F172A", "borderRadius": "round"}
+HEADER_ROWS = 3
+GENERIC_TITLE = re.compile(r"^(?:page|sheet|dashboard)\s*\d+$", re.I)
+
+
+def _le(eid, c0, c1, r0, r1):
+    return (f'  <LayoutElement elementId="{eid}" gridColumn="{c0} / {c1}" '
+            f'gridRow="{r0} / {r1}"/>')
+
+
+def _gc(cid, c0, c1, r0, r1, inner):
+    return (f'<GridContainer elementId="{cid}" type="grid" '
+            f'gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}" '
+            f'gridTemplateColumns="repeat(24, 1fr)" '
+            f'gridTemplateRows="auto">\n{inner}\n</GridContainer>')
+
+
+def _cluster_bands(items):
+    bands = []
+    for it in sorted(items, key=lambda i: (i[3], i[1])):
+        if bands and it[3] < bands[-1]["r1"]:
+            bands[-1]["items"].append(it)
+            bands[-1]["r1"] = max(bands[-1]["r1"], it[4])
+        else:
+            bands.append({"r0": it[3], "r1": it[4], "items": [it]})
+    return [bb["items"] for bb in bands]
+
+
+def banded_page(page_id, items, title, id_prefix=None):
+    """Header band + one full-width GridContainer per row band, children
+    container-relative. Returns (page_xml, extra_spec_elements)."""
+    pfx = id_prefix or f"band-{page_id}"
+    extra, children = [], []
+    offset = 0
+    if title:
+        hdr, txt = f"{pfx}-hdr", f"{pfx}-hdrtext"
+        extra.append({"id": hdr, "kind": "container",
+                      "style": dict(HEADER_STYLE)})
+        extra.append({"id": txt, "kind": "text",
+                      "body": f'# <span style="color: #FFFFFF">{title}</span>'})
+        children.append(_gc(hdr, 1, 25, 1, 1 + HEADER_ROWS,
+                            _le(txt, 1, 25, 1, 1 + HEADER_ROWS)))
+        offset = HEADER_ROWS
+    if items:
+        offset += 1 - min(i[3] for i in items)
+    for n, band in enumerate(_cluster_bands(items), 1):
+        cid = f"{pfx}-{n}"
+        extra.append({"id": cid, "kind": "container"})
+        r0 = min(i[3] for i in band)
+        r1 = max(i[4] for i in band)
+        inner = "\n".join(_le(i[0], i[1], i[2], i[3] - r0 + 1, i[4] - r0 + 1)
+                          for i in band)
+        children.append(_gc(cid, 1, 25, r0 + offset, r1 + offset, inner))
+    body = "\n".join(children)
+    return (f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" '
+            f'gridTemplateRows="auto" id="{page_id}">\n{body}\n</Page>', extra)
+
+
+def build_layout(pages, dossier_name):
+    """Banded layout for every workbook page: controls band (split evenly),
+    then full-width tables. Header title = the chapter name (never a generic
+    "Page N" auto-name — those fall back to the dossier name). Mutates each
+    page's elements to add the container/header placeholders and returns the
+    layout XML for scripts/put-layout.rb."""
+    xml_pages = []
+    for pg in pages:
+        ctls = [e for e in pg["elements"] if e.get("kind") == "control"]
+        tables = [e for e in pg["elements"] if e.get("kind") != "control"]
+        items, row = [], 1
+        if ctls:
+            w = 24 // len(ctls)
+            for i, e in enumerate(ctls):
+                c0 = 1 + i * w
+                c1 = c0 + w if i < len(ctls) - 1 else 25
+                items.append([e["id"], c0, c1, row, row + 3])
+            row += 3
+        for e in tables:
+            items.append([e["id"], 1, 25, row, row + 12])
+            row += 12
+        title = pg["name"]
+        if not title or GENERIC_TITLE.match(title.strip()):
+            title = dossier_name
+        xml, extra = banded_page(pg["id"], items, title)
+        pg["elements"] = pg["elements"] + extra
+        xml_pages.append(xml)
+    return ('<?xml version="1.0" encoding="utf-8"?>\n' + "\n".join(xml_pages))
 
 
 def build_dm_spec(b: Bundle, args, inode_map, ae_winners=None):
@@ -600,6 +963,8 @@ def build_workbook_spec(b: Bundle, args, ae_winners=None, dm_element_ids=None):
 
     pages = []
     report_keys = {}  # report name -> ordered display column names of its keys
+    page_ctx = {}     # chapter name -> {page, element, ref, available}
+    avail_join = join_column_names(b)
     # chapter -> dataset/report mapping comes from the dossier datasets by name
     report_by_name = {r["information"]["name"]: (rid, r)
                       for rid, r in b.reports.items()}
@@ -610,9 +975,22 @@ def build_workbook_spec(b: Bundle, args, ae_winners=None, dm_element_ids=None):
         units = report["dataSource"]["dataTemplate"]["units"]
 
         if ae_winners and rname in ae_winners:
-            pages.append(build_ae_page(b, args, ch_name, report,
-                                       ae_winners[rname], dm_id, el_ref,
-                                       report_keys))
+            page = build_ae_page(b, args, ch_name, report,
+                                 ae_winners[rname], dm_id, el_ref,
+                                 report_keys)
+            pages.append(page)
+            ae_name = ae_element_name(rname)
+            cfg = ae_winners[rname]
+            _au, metric_units = b.report_attr_units(report)
+            ae_avail = ({friendly(c) for c in cfg["parentKeyCols"]}
+                        | {friendly(cfg["quirkKeyCol"]),
+                           friendly(cfg["quirkDescCol"])}
+                        | {el["name"] for el in metric_units})
+            page_ctx[ch_name] = {
+                "page": page, "element": page["elements"][0],
+                "ref": (lambda n, _e=ae_name: f"[{_e}/{n}]"),
+                "available": ae_avail,
+            }
             continue
 
         columns, group_ids, calc_ids, key_names = [], [], [], []
@@ -688,18 +1066,31 @@ def build_workbook_spec(b: Bundle, args, ae_winners=None, dm_element_ids=None):
         }
         if filters:
             element["filters"] = filters
-        pages.append({
+        page = {
             "id": f"pg-{slug(ch_name)}",
             "name": ch_name,
             "elements": [element],
-        })
+        }
+        pages.append(page)
+        page_ctx[ch_name] = {"page": page, "element": element,
+                             "ref": wb_ref, "available": avail_join}
+
+    # dossier selectors / chapter filters -> Sigma controls (+ sidecar data),
+    # then the banded layout (mutates pages: containers + header text)
+    warnings = []
+    n_signals, scope_entries, unbound = emit_controls(b, pages, page_ctx,
+                                                      warnings)
+    layout_xml = build_layout(pages, b.dossier.get("name", "MicroStrategy"))
+    control_scope = {"version": 1, "source": "microstrategy",
+                     "sourceFilterSignals": n_signals,
+                     "controls": scope_entries, "unbound": unbound}
 
     return {
         "name": args.wb_name,
         "folderId": args.folder_id,
         "schemaVersion": 1,
         "pages": pages,
-    }, report_keys
+    }, report_keys, layout_xml, control_scope, warnings
 
 
 def main():
@@ -724,6 +1115,11 @@ def main():
                     help="ae_winners.json from resolve_ae_winners.py")
     ap.add_argument("--out-dm", default="sigma_dm_spec.json")
     ap.add_argument("--out-wb", default="sigma_workbook_spec.json")
+    ap.add_argument("--out-layout", default="layout.xml",
+                    help="banded layout XML for scripts/put-layout.rb")
+    ap.add_argument("--control-scope-out", default="control-scope.json",
+                    help="intended-scope contract for the control lint "
+                         "(scripts/lib/control_lint.rb CONTRACT)")
     args = ap.parse_args()
 
     b = Bundle(json.load(open(args.bundle)))
@@ -736,10 +1132,13 @@ def main():
                       if args.dm_element_ids else None)
 
     dm = build_dm_spec(b, args, inode_map, ae_winners)
-    wb, report_keys = build_workbook_spec(b, args, ae_winners, dm_element_ids)
+    wb, report_keys, layout_xml, control_scope, warnings = \
+        build_workbook_spec(b, args, ae_winners, dm_element_ids)
     json.dump(dm, open(args.out_dm, "w"), indent=1)
     json.dump(wb, open(args.out_wb, "w"), indent=1)
     json.dump(report_keys, open("parity_keys.json", "w"), indent=1)
+    open(args.out_layout, "w").write(layout_xml)
+    json.dump(control_scope, open(args.control_scope_out, "w"), indent=1)
 
     print(f"fact table: {b.table_info[b.fact_tid]['name']}")
     for j in b.derive_joins():
@@ -748,7 +1147,17 @@ def main():
     for el in dm["pages"][0]["elements"]:
         for m in el.get("metrics", []):
             print(f"metric: {m['name']} = {m['formula']}")
-    print(f"wrote {args.out_dm}, {args.out_wb}")
+    for c in control_scope["controls"]:
+        print(f"control: {c['controlId']} ({c['controlType']}) -> "
+              f"{[w['elementId'] for w in c['wired']]} scope={c['scope']}")
+    for u in control_scope["unbound"]:
+        print(f"control UNBOUND [{u['status']}]: {u['sourceName']} — {u['reason']}")
+    for w in warnings:
+        print(f"WARN: {w}")
+    print(f"signals: {control_scope['sourceFilterSignals']} filter signal(s), "
+          f"{len(control_scope['controls'])} control(s) emitted")
+    print(f"wrote {args.out_dm}, {args.out_wb}, {args.out_layout}, "
+          f"{args.control_scope_out}")
 
 
 if __name__ == "__main__":

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
@@ -1,0 +1,304 @@
+# frozen_string_literal: true
+#
+# control_lint.rb — mechanized control-wiring lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as layout_lint.rb / sigma_rest.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the layout lint
+#   - assert-phase6-ran.rb gate 7 (with a --skip-control-lint escape)
+#   - scripts/probe-controls.rb (reuses the reach computation to pick its
+#     in-closure / out-of-closure probe elements)
+#
+# It exists because a workbook can pass parity + layout gates and still ship
+# controls that DO NOTHING (the "Orders Overview (from Looker)" estate escape:
+# three list controls bound to no element at all) or controls that silently
+# skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
+# escape, and the Qlik class: source full of listboxes, spec with zero
+# controls). Three checks:
+#
+#   (a) dead control — every kind:control element must have >=1 `filters`
+#       target resolving to a REAL element id in the spec, OR be referenced
+#       as [controlId] in at least one non-control element (formula / spec
+#       reference). A control with neither is furniture: a user changes it
+#       and nothing on the page reacts.
+#   (b) reach — source-closure walk from the control's targets (filter
+#       targets + formula-referencing elements, expanded downstream through
+#       source.elementId chains). Any same-page QUERYABLE element outside
+#       the closure flags PARTIAL with the element names. Intentional
+#       single-chart switchers (grain / geo-level segmented controls) are
+#       allow-listed via the controlScope annotation (CONTRACT below).
+#   (c) source-scope coverage — when a control-scope sidecar is provided
+#       (emitted by the builder from the SOURCE BI artifact's filter
+#       signals), FAIL if the source had filter signals but the spec has
+#       zero controls, if an annotated control is missing from the spec,
+#       or if an annotated mustReach element is not in that control's
+#       closure.
+#
+# CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
+# to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
+# up from the workdir automatically, or take --control-scope PATH):
+#
+#   {
+#     "version": 1,
+#     "source": "qlik",               // provenance tag, free-form
+#     "sourceFilterSignals": 3,       // count of filter-like signals detected
+#                                     //   in the source artifact (listboxes,
+#                                     //   quick filters, actions, slicers,
+#                                     //   prompts, dashboard filters...).
+#                                     //   >0 with zero spec controls = FAIL.
+#     "controls": [
+#       {
+#         "controlId": "ctl-region",           // spec controlId (required)
+#         "sourceName": "Region quick filter", // optional, for messages
+#         "scope": "page",                     // "page" (default): the reach
+#                                              //   check applies to every
+#                                              //   same-page queryable element
+#                                              // OR an array of element ids /
+#                                              //   display names the control
+#                                              //   is INTENDED to affect — the
+#                                              //   single-chart-switcher
+#                                              //   allowlist (grain controls)
+#         "mustReach": ["Monthly Revenue Trend"] // optional hard assertions:
+#                                              //   each must be in the closure
+#       }
+#     ]
+#   }
+#
+# In-spec alternative (pre-POST local specs only): a control element may carry
+#   "controlScope": ["Element Name", ...]   // or "page"
+# with the same meaning as scope. NOTE: Sigma strips unknown keys on readback,
+# so the SIDECAR is the durable form — builders should emit both when the
+# allowlist must survive a live re-lint of the posted workbook.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on tj-wells-1989):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query) evaluates a workbook
+# element WITH the workbook's saved control DEFAULTS applied and exposes NO
+# parameter mechanism to override them. The REST export API
+# (POST /v2/workbooks/{id}/export with `"parameters": {"<controlId>": "<value>"}`)
+# IS the only programmatic way to exercise a non-default control value — which
+# is why probe-controls.rb (the flip test) is built on export, not MCP.
+#
+# API:
+#   report     = ControlLint.controls_report(spec)   # per-control reach rows
+#   violations = ControlLint.lint(spec, scope: nil)  # scope = parsed sidecar
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/control_lint.rb <spec.json|spec.yaml> [control-scope.json]
+require 'json'
+require 'set'
+
+module ControlLint
+  QUERYABLE = %w[
+    table pivot-table input-table bar-chart line-chart pie-chart donut-chart
+    area-chart scatter-chart combo-chart kpi-chart box-chart funnel-chart
+    gauge-chart waterfall-chart sankey-chart region-map point-map viz chart
+    treemap-chart heatmap-chart word-cloud
+  ].to_set.freeze
+
+  module_function
+
+  # { element_id => {el:, page:, kind:, name:, srcel:} } for every element.
+  def elements(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        eid = el['id'] || el['elementId']
+        next unless eid
+        out[eid] = { el: el, page: pg['name'] || pg['id'],
+                     kind: (el['kind'] || el['type']).to_s,
+                     name: el['name'], srcel: source_element_id(el) }
+      end
+    end
+    out
+  end
+
+  # Unwraps {kind:"source", source:{elementId}} and direct {elementId} forms.
+  def source_element_id(el)
+    src = el['source']
+    return nil unless src.is_a?(Hash)
+    src = src['source'] if src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src.is_a?(Hash) ? src['elementId'] : nil
+  end
+
+  def control?(info)
+    info[:kind].include?('control')
+  end
+
+  # Transitive closure of elements sourcing (directly or via chains) from any
+  # element in `roots`. Returns roots + downstream ids.
+  def closure(elems, roots)
+    reach = roots.to_set
+    loop do
+      grew = false
+      elems.each do |eid, info|
+        next if reach.include?(eid)
+        next unless info[:srcel] && reach.include?(info[:srcel])
+        reach << eid
+        grew = true
+      end
+      break unless grew
+    end
+    reach
+  end
+
+  # Non-control elements whose serialized spec references [controlId] —
+  # catches formula refs (If([GeoLevel]="State",...)) and any other spec-level
+  # binding that names the control.
+  def formula_refs(elems, cid)
+    return [] if cid.nil? || cid.to_s.empty?
+    pat = /\[#{Regexp.escape(cid)}\]/
+    elems.select { |_eid, info| !control?(info) && JSON.generate(info[:el]).match?(pat) }
+         .keys
+  end
+
+  # Per-control reach report. Each row:
+  #   { control_element_id:, control_id:, name:, page:, control_type:,
+  #     filter_targets: [ids], ghost_targets: [ids], formula_refs: [ids],
+  #     reach: Set[ids], page_queryable: [ids], uncovered: [ids] }
+  def controls_report(spec)
+    elems = elements(spec)
+    rows = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      cid = el['controlId']
+      tgt_ids = (el['filters'] || []).map { |t| t.is_a?(Hash) ? t.dig('source', 'elementId') : nil }.compact
+      live    = tgt_ids.select { |t| elems.key?(t) }
+      frefs   = formula_refs(elems, cid)
+      roots   = (live + frefs).uniq
+      reach   = roots.empty? ? Set.new : closure(elems, roots)
+      page_q  = elems.select do |qid, i|
+        qid != eid && i[:page] == info[:page] && QUERYABLE.include?(i[:kind])
+      end.keys
+      rows << { control_element_id: eid, control_id: cid, name: info[:name],
+                page: info[:page], control_type: el['controlType'],
+                filter_targets: live, ghost_targets: tgt_ids - live,
+                formula_refs: frefs, reach: reach, page_queryable: page_q,
+                uncovered: page_q.reject { |q| reach.include?(q) } }
+    end
+    rows
+  end
+
+  # Resolve a sidecar element reference (id or display name) to element ids.
+  def resolve_ref(elems, ref)
+    return [ref] if elems.key?(ref)
+    elems.select { |_eid, i| i[:name] == ref }.keys
+  end
+
+  def label(elems, eid)
+    n = elems[eid] && elems[eid][:name]
+    n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
+  end
+
+  def lint(spec, scope: nil)
+    violations = []
+    elems = elements(spec)
+    rows  = controls_report(spec)
+
+    scope_by_cid = {}
+    if scope.is_a?(Hash)
+      Array(scope['controls']).each do |c|
+        scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
+      end
+      # (c) the Qlik class: source had filter signals, spec built zero controls.
+      signals = scope['sourceFilterSignals'].to_i
+      if signals.positive? && rows.empty?
+        violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
+                      '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
+                      'elements — the source dashboard is interactive and the migration shipped a ' \
+                      'static one; build the controls (or set sourceFilterSignals to 0 with a ' \
+                      'reason if the signals are genuinely non-portable)'
+      end
+    end
+
+    rows.each do |r|
+      ann = scope_by_cid.delete(r[:control_id]) || {}
+      ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
+      ctl_label = "control #{label(elems, r[:control_element_id])}#{r[:control_id] ? " [#{r[:control_id]}]" : ''} on page #{r[:page].inspect}"
+
+      r[:ghost_targets].each do |g|
+        violations << "ghost target: #{ctl_label} lists filter target #{g.inspect} which does not " \
+                      'resolve to any element in the spec — fix or drop the target'
+      end
+
+      # (a) dead control --------------------------------------------------------
+      if r[:reach].empty?
+        violations << "dead control: #{ctl_label} has no resolving `filters` target and no " \
+                      '[controlId] reference in any non-control element — a user changes it and ' \
+                      'nothing reacts; wire it (filters: [{source:{elementId}, columnId}]) or, if ' \
+                      'the bound column genuinely does not exist on any element, REMOVE the ' \
+                      'control (honest) instead of shipping furniture'
+        next
+      end
+
+      # (c) mustReach assertions -------------------------------------------------
+      Array(ann['mustReach']).each do |ref|
+        ids = resolve_ref(elems, ref)
+        if ids.empty?
+          violations << "scope mustReach: #{ctl_label} — annotated element #{ref.inspect} does not " \
+                        'exist in the spec'
+        elsif ids.none? { |i| r[:reach].include?(i) }
+          violations << "scope mustReach: #{ctl_label} does NOT reach annotated element " \
+                        "#{ref.inspect} — wire a filter target (or formula ref) so it does"
+        end
+      end
+
+      # (b) reach / PARTIAL --------------------------------------------------------
+      if ann_scope.is_a?(Array)
+        # Explicit allowlist (single-chart switcher): every listed element must
+        # be reached; same-page elements OUTSIDE the list are intentionally
+        # unaffected and not flagged.
+        ann_scope.each do |ref|
+          ids = resolve_ref(elems, ref)
+          if ids.empty?
+            violations << "controlScope: #{ctl_label} — scoped element #{ref.inspect} does not exist " \
+                          'in the spec'
+          elsif ids.none? { |i| r[:reach].include?(i) }
+            violations << "controlScope: #{ctl_label} does NOT reach its scoped element #{ref.inspect}"
+          end
+        end
+      elsif r[:uncovered].any?
+        names = r[:uncovered].map { |u| label(elems, u) }
+        violations << "partial control: #{ctl_label} affects #{r[:page_queryable].length - r[:uncovered].length} " \
+                      "of #{r[:page_queryable].length} same-page queryable element(s); NOT affected: " \
+                      "#{names.join(', ')} — wire those elements (add filter targets on their " \
+                      'sources, matching the source dashboard\'s filter scope) or declare the ' \
+                      'narrow scope intentional via controlScope (sidecar control-scope.json ' \
+                      'scope:[...] — see header CONTRACT)'
+      end
+    end
+
+    # (c) annotated controls that never made it into the spec ------------------
+    scope_by_cid.each do |cid, c|
+      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                    'has no control with that controlId — the source filter was not migrated'
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  abort 'usage: ruby control_lint.rb <workbook-spec.json|yaml> [control-scope.json]' unless ARGV[0] && File.exist?(ARGV[0])
+  body = File.read(ARGV[0])
+  spec =
+    begin
+      JSON.parse(body)
+    rescue JSON::ParserError
+      require 'yaml'
+      require 'date'
+      YAML.safe_load(body, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+  scope = ARGV[1] && File.exist?(ARGV[1]) ? JSON.parse(File.read(ARGV[1])) : nil
+  v = ControlLint.lint(spec, scope: scope)
+  if v.empty?
+    n = ControlLint.controls_report(spec).length
+    puts "control lint: clean (#{n} control(s) checked)"
+  else
+    warn "control lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        covered = Array.new(GRID_COLS, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+        end
+        fill = covered.count(true).to_f / GRID_COLS
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
@@ -1,0 +1,130 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Sigma creds aren't in ENV yet, load
+# them from the neutral cred file written by setup.rb. Existing env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env) do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN'] || refresh_token!
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      @token_mutex.synchronize { @token_override = tok }
+      # Surface the refreshed token to child processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/probe-controls.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/probe-controls.rb
@@ -1,0 +1,236 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# probe-controls.rb — live flip test proving a workbook's controls actually
+# filter what they claim to. OPTIONAL Phase 6 step (not the mandatory inner
+# loop): run it after the control lint (gate 7) passes when you want runtime
+# evidence, after repairing control wiring on a live workbook, or whenever a
+# control's reach was wired by hand.
+#
+# SHARED script, vendored byte-identical into every covered plugin's scripts/
+# (md5 discipline — same as scripts/lib/control_lint.rb, which it reuses).
+#
+# What it does, per control:
+#   1. computes the control's reach (filter targets + [controlId] formula
+#      references, expanded through source.elementId chains —
+#      ControlLint.controls_report)
+#   2. exports one IN-closure queryable element as CSV twice via
+#      POST /v2/workbooks/{id}/export — once with no `parameters` (the saved
+#      control defaults) and once with parameters:{<controlId>: <flip value>}.
+#      The two CSVs MUST differ, or the control is wired but inert -> FAIL.
+#   3. with --check-out-of-closure: also exports one same-page queryable
+#      element OUTSIDE the closure with and without the parameter — those
+#      MUST be identical (the flip must not leak) -> FAIL if they differ
+#      (the closure walk missed an edge; fix control_lint, not the workbook).
+#
+# Flip-value selection ("first non-default value"):
+#   --value <controlId>=<value> beats everything (repeatable).
+#   Otherwise: the control's value-source column (source.columnId, falling
+#   back to the first filter target's columnId) is resolved to its display
+#   label via GET /v2/workbooks/{id}/columns, that element is exported once,
+#   and the first distinct value of that column NOT in the control's saved
+#   defaults (`values`) is used. switch controls flip true<->false. Controls
+#   whose value cannot be auto-picked (date ranges, numeric sliders, missing
+#   labels) are SKIPped with a NOTE — pass --value for those.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on tj-wells-1989):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query / claude.ai Sigma MCP)
+# evaluates workbook elements WITH the saved control defaults applied and
+# exposes NO parameter mechanism to set a control value. The REST export API
+# (POST /v2/workbooks/{id}/export with "parameters": {"<controlId>": "<val>"})
+# is the ONLY programmatic way to exercise a non-default control value —
+# which is why this probe is built on export, not MCP. (MCP is still fine for
+# default-state parity checks — Phase 6 uses it for exactly that.)
+#
+# Usage:
+#   ruby scripts/probe-controls.rb --workbook-id <id> \
+#     [--control <controlId>]        # probe just one control (repeatable)
+#     [--value <controlId>=<value>]  # explicit flip value (repeatable)
+#     [--check-out-of-closure]       # also assert the flip does NOT leak
+#     [--out DIR]                    # CSV evidence dir (default /tmp/probe-controls-<id>)
+#     [--timeout SECS]               # export poll timeout per CSV (default 90)
+#
+# Exit codes: 0 = every probed control flips correctly (skips allowed);
+#             1 = at least one FAIL; 2 = no control could be probed at all.
+require 'json'
+require 'csv'
+require 'optparse'
+require 'net/http'
+require 'uri'
+require 'fileutils'
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+require 'control_lint'
+
+opts = { values: {}, controls: [], timeout: 90 }
+OptionParser.new do |p|
+  p.on('--workbook-id ID')        { |v| opts[:wb] = v }
+  p.on('--control CID')           { |v| opts[:controls] << v }
+  p.on('--value SPEC', '<controlId>=<value>') do |v|
+    cid, val = v.split('=', 2)
+    abort "bad --value #{v.inspect} (want <controlId>=<value>)" unless cid && val
+    opts[:values][cid] = val
+  end
+  p.on('--check-out-of-closure')  { opts[:check_out] = true }
+  p.on('--out DIR')               { |v| opts[:out] = v }
+  p.on('--timeout SECS', Integer) { |v| opts[:timeout] = v }
+end.parse!
+abort('--workbook-id required') unless opts[:wb]
+WB = opts[:wb]
+OUT = opts[:out] || "/tmp/probe-controls-#{WB}"
+FileUtils.mkdir_p(OUT)
+
+# --- Sigma plumbing ---------------------------------------------------------
+
+def fetch_spec(wb)
+  body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'application/json')
+  return body if body.is_a?(Hash)
+  require 'yaml'
+  require 'date'
+  YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {}
+end
+
+# Export an element as CSV (optionally with control parameters), poll the
+# query download until ready, return the CSV text. Raises on timeout/error.
+def export_csv(wb, element_id, params, timeout)
+  body = { 'elementId' => element_id, 'format' => { 'type' => 'csv' } }
+  body['parameters'] = params if params && !params.empty?
+  res = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+  qid = res.is_a?(Hash) && res['queryId']
+  raise "export request failed: #{res.inspect}" unless qid
+  deadline = Time.now + timeout
+  loop do
+    uri = URI("#{Sigma.base_url}/v2/query/#{qid}/download")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    r = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 60) { |h| h.request(req) }
+    return r.body if r.code.to_i == 200
+    raise "export download failed: HTTP #{r.code} #{r.body.to_s[0, 300]}" if r.code.to_i >= 400 && r.code.to_i != 404
+    raise "export timed out after #{timeout}s (queryId=#{qid})" if Time.now > deadline
+    sleep 2
+  end
+end
+
+# Row-order-insensitive CSV signature (filters change row SETS; ordering noise
+# must not mask or fake a flip).
+def csv_sig(text)
+  text.to_s.lines.map(&:chomp).sort
+end
+
+# --- reach + element metadata ------------------------------------------------
+
+spec  = fetch_spec(WB)
+elems = ControlLint.elements(spec)
+rows  = ControlLint.controls_report(spec)
+rows.select! { |r| opts[:controls].include?(r[:control_id]) } if opts[:controls].any?
+abort "no controls found in workbook #{WB}#{opts[:controls].any? ? " matching #{opts[:controls].inspect}" : ''}" if rows.empty?
+
+cols = Sigma.request(:get, "/v2/workbooks/#{WB}/columns")
+col_label = {} # [elementId, columnId] -> display label
+(cols && cols['entries'] || []).each do |c|
+  col_label[[c['elementId'], c['columnId']]] = c['label'] if c['elementId'] && c['columnId']
+end
+
+baseline_cache = {}
+get_baseline = lambda do |eid|
+  baseline_cache[eid] ||= export_csv(WB, eid, nil, opts[:timeout])
+end
+
+# Pick the flip value for a control (returns [value, note] — value nil = skip).
+pick_value = lambda do |r|
+  el = elems[r[:control_element_id]][:el]
+  cid = r[:control_id]
+  return [opts[:values][cid], 'explicit --value'] if opts[:values].key?(cid)
+  defaults = Array(el['values']).map(&:to_s)
+  case el['controlType'].to_s
+  when 'switch'
+    return [(defaults.first.to_s.downcase == 'true' ? 'false' : 'true'), 'switch flip']
+  when 'list', 'segmented', 'text'
+    src = el['source']
+    src = src['source'].merge('columnId' => src['columnId']) if src.is_a?(Hash) && src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src = (el['filters'] || []).map { |f| f.is_a?(Hash) ? (f['source'] || {}).merge('columnId' => f['columnId']) : nil }.compact.first if !src.is_a?(Hash) || !src['columnId']
+    return [nil, 'no value-source column resolvable — pass --value'] unless src.is_a?(Hash) && src['elementId'] && src['columnId']
+    label = col_label[[src['elementId'], src['columnId']]]
+    return [nil, "no /columns label for #{src['elementId']}/#{src['columnId']} — pass --value"] unless label
+    csv = CSV.parse(get_baseline.call(src['elementId']), headers: true)
+    return [nil, "column #{label.inspect} not in export of #{src['elementId']} — pass --value"] unless csv.headers.include?(label)
+    distinct = csv.map { |row| row[label] }.compact.map(&:to_s).reject(&:empty?).uniq
+    val = distinct.find { |v| !defaults.include?(v) }
+    val ? [val, "auto-picked from #{label.inspect}"] : [nil, 'no non-default value found — pass --value']
+  else
+    [nil, "controlType=#{el['controlType'].inspect} has no auto flip value — pass --value"]
+  end
+end
+
+# --- probe loop ----------------------------------------------------------------
+
+failures = 0
+probed = 0
+results = []
+rows.each do |r|
+  cid = r[:control_id]
+  ctl = "#{r[:name].inspect} [#{cid}]"
+  if r[:reach].empty?
+    results << { control: cid, result: 'FAIL', note: 'dead control — empty reach (run the control lint)' }
+    failures += 1
+    next
+  end
+
+  in_el = (r[:reach] & r[:page_queryable]).first ||
+          r[:reach].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+  if in_el.nil?
+    results << { control: cid, result: 'SKIP', note: 'no queryable element in closure' }
+    next
+  end
+
+  val, note = pick_value.call(r)
+  if val.nil?
+    results << { control: cid, result: 'SKIP', note: note }
+    next
+  end
+
+  probed += 1
+  base = get_baseline.call(in_el)
+  flip = export_csv(WB, in_el, { cid => val }, opts[:timeout])
+  File.write(File.join(OUT, "#{cid}--#{in_el}--base.csv"), base)
+  File.write(File.join(OUT, "#{cid}--#{in_el}--flip.csv"), flip)
+  changed = csv_sig(base) != csv_sig(flip)
+  if changed
+    results << { control: cid, result: 'PASS', element: in_el, value: val,
+                 note: "#{note}; in-closure export differs (#{base.lines.count - 1} -> #{flip.lines.count - 1} rows)" }
+  else
+    failures += 1
+    results << { control: cid, result: 'FAIL', element: in_el, value: val,
+                 note: "#{note}; in-closure export IDENTICAL with #{cid}=#{val.inspect} — control is wired but inert" }
+  end
+
+  next unless opts[:check_out]
+  out_el = r[:uncovered].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+  if out_el.nil?
+    results << { control: cid, result: 'OK', note: 'out-of-closure: none on page (full reach) — nothing to check' }
+  else
+    obase = get_baseline.call(out_el)
+    oflip = export_csv(WB, out_el, { cid => val }, opts[:timeout])
+    File.write(File.join(OUT, "#{cid}--#{out_el}--out-base.csv"), obase)
+    File.write(File.join(OUT, "#{cid}--#{out_el}--out-flip.csv"), oflip)
+    if csv_sig(obase) == csv_sig(oflip)
+      results << { control: cid, result: 'OK', element: out_el, note: 'out-of-closure export unchanged (no leak)' }
+    else
+      failures += 1
+      results << { control: cid, result: 'FAIL', element: out_el,
+                   note: 'out-of-closure export CHANGED — the closure walk missed an edge (fix control_lint, not the workbook)' }
+    end
+  end
+end
+
+puts format('%-22s %-6s %-34s %s', 'CONTROL', 'RESULT', 'ELEMENT', 'NOTE')
+results.each do |x|
+  puts format('%-22s %-6s %-34s %s', x[:control], x[:result], x[:element] || '-', [x[:value] && "flip=#{x[:value].inspect}", x[:note]].compact.join('; '))
+end
+File.write(File.join(OUT, 'probe-results.json'), JSON.pretty_generate(results))
+puts "evidence: #{OUT}/ (CSVs + probe-results.json)"
+
+exit 1 if failures.positive?
+exit 2 if probed.zero?
+exit 0

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/put-layout.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/put-layout.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+# GET a workbook spec, replace per-page layouts with a single top-level layout
+# XML (provided), strip read-only fields, PUT back.
+#
+# Container layouts: a <GridContainer> in the layout XML must be paired with a
+# `kind: container` placeholder element in the spec (else it is silently
+# dropped — layout-playbook.md). Layout builders that emit GridContainers
+# write a sidecar `<layout>.elements.json` ({pageId: [element, ...]}) next to
+# the layout XML; this script injects those elements (containers + header
+# text) into the matching pages before the PUT. Pass --elements to override
+# the sidecar path. Injection is idempotent (existing element ids are kept).
+#
+# Usage:
+#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml> \
+#     [--elements <elements.json>]
+
+require 'json'
+require 'yaml'
+require 'date'
+require 'optparse'
+# sigma_rest self-exchanges SIGMA_CLIENT_ID/SECRET (auto-loading
+# ~/.sigma-migration/env) exactly like the phase 1-4 scripts — SIGMA_API_TOKEN
+# is optional, not a hard requirement (bead eqom).
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook ID') { |v| opts[:wb] = v }
+  p.on('--layout PATH') { |v| opts[:layout] = v }
+  p.on('--elements PATH', 'spec elements to inject (default: <layout>.elements.json if present)') { |v| opts[:elements] = v }
+end.parse!
+%i[wb layout].each { |k| abort("missing --#{k}") unless opts[k] }
+
+def http(method, path, body = nil)
+  Sigma.request(method, path, body: body, binary: true)
+end
+
+xml = File.read(opts[:layout])
+abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
+
+spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec"))
+spec['pages'].each { |p| p.delete('layout') }
+spec['layout'] = xml
+
+# Inject container/header-text spec elements (see header comment).
+elements_path = opts[:elements] || "#{opts[:layout]}.elements.json"
+if File.exist?(elements_path)
+  inject = JSON.parse(File.read(elements_path))
+  injected = 0
+  inject.each do |page_id, els|
+    page = spec['pages'].find { |p| p['id'] == page_id }
+    unless page
+      warn "WARN: elements sidecar references unknown page #{page_id.inspect} — skipped"
+      next
+    end
+    page['elements'] ||= []
+    existing = page['elements'].map { |e| e['id'] }
+    els.each do |el|
+      next if existing.include?(el['id'])
+      page['elements'] << el
+      injected += 1
+    end
+  end
+  puts "injected #{injected} container/header element(s) from #{elements_path}"
+end
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
+
+begin
+  resp_body = http(:put, "/v2/workbooks/#{opts[:wb]}/spec", JSON.pretty_generate(spec))
+rescue Sigma::Error => e
+  puts "ERROR: #{e.message}"
+  exit 1
+end
+parsed = YAML.safe_load(resp_body, permitted_classes: [Date, Time])
+puts parsed['workbookId'] ? "PUT ok: workbookId=#{parsed['workbookId']}" : "ERROR: #{parsed.inspect}"
+exit(parsed['workbookId'] ? 0 : 1)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify_parity.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify_parity.py
@@ -5,6 +5,11 @@ export API and compare against expected_parity.json (MicroStrategy ground truth)
 
 Money / counts: exact. Profit Margin Pct: relative tolerance 1e-6.
 
+Also writes the cross-plugin gate sentinels next to --report:
+  parity-final.json  {status, mode, charts_total, charts_pass, fail_names}
+  wb-ids.json        {workbookId}
+so scripts/assert-phase6-ran.rb (gates 1-7, shared) can prove this phase ran.
+
 Usage: python3 verify_parity.py --workbook-id <id> [--report parity_report.md]
 Requires SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/get-token.sh)").
 """
@@ -95,7 +100,11 @@ def main():
     el_by_name = {}
     for pg in spec["pages"]:
         for el in pg["elements"]:
-            el_by_name[el["name"]] = el["id"]
+            # skip layout containers / header text / controls (no name or
+            # not a queryable element)
+            if el.get("name") and el.get("kind") not in ("container", "text",
+                                                         "control"):
+                el_by_name[el["name"]] = el["id"]
 
     os.makedirs(args.save_csv_dir, exist_ok=True)
     lines = ["# MicroStrategy -> Sigma Parity Report", "",
@@ -189,9 +198,26 @@ def main():
     lines.append("Tolerances: money and counts exact; Profit Margin Pct relative 1e-6.")
 
     open(args.report, "w").write("\n".join(lines) + "\n")
+
+    # gate sentinels (contract: scripts/assert-phase6-ran.rb gate 1 reads
+    # parity-final.json; gates 3/4/6/7 resolve the workbook via wb-ids.json)
+    outdir = os.path.dirname(os.path.abspath(args.report))
+    n_pass = sum(1 for _n, m, t, _x, st_ in summary
+                 if st_ == "PASS" and m == t)
+    json.dump({
+        "status": "PASS" if all_green else "FAIL",
+        "mode": "live",
+        "charts_total": len(summary),
+        "charts_pass": n_pass,
+        "fail_names": [n for n, _m, _t, _x, st_ in summary if st_ != "PASS"],
+        "generated_by": "verify_parity.py",
+    }, open(os.path.join(outdir, "parity-final.json"), "w"), indent=1)
+    json.dump({"workbookId": args.workbook_id},
+              open(os.path.join(outdir, "wb-ids.json"), "w"), indent=1)
+
     for name, m, t, _x, st_ in summary:
         print(f"{st_}: {name} {m}/{t}")
-    print(f"report -> {args.report}")
+    print(f"report -> {args.report} (+ parity-final.json, wb-ids.json)")
     sys.exit(0 if all_green else 1)
 
 


### PR DESCRIPTION
Retrofits the microstrategy-to-sigma converter with the control-targeting standard and the shared gate stack every other converter plugin now carries. Reconciled against `tj/microstrategy-plugin` (fully merged into main — no unmerged in-flight work; based directly on main). No core conversion/parity logic changed beyond what control wiring required.

## Audit gap (before this PR)

| Dossier signal | Extracted? | Emitted? |
|---|---|---|
| Chapter filter panels (`chapters[].filters`) | yes (whole definition in bundle) | **nothing** |
| Attribute selectors + DECLARED viz targets (`pages[].selectors[].targets`) | yes | **nothing** |
| Panel selectors | yes | nothing, silently |
| Layout | n/a | no layout at all (Sigma single-column stack) |
| Gates | parity + readback only | no layout/control lint, no assert gate, no sentinels |

MSTR is the only tool that *declares* selector→viz targets explicitly — the converter now wires controls to exactly those targets.

## Changes

- **convert.py** — chapter filters + attribute selectors → Sigma controls (filter targets = the declared vizzes' chapter tables; chapter filters = page scope); `control-scope.json` sidecar (sourceFilterSignals, scope/mustReach, `unbound` MANUAL entries for panel/metric-condition selectors); banded layout (header band titled from the chapter/dossier name — never "Page N" — controls band, full-width tables) → `layout.xml`.
- **NEW verified gotcha** — a list-control filter target on a **NUMERIC** column is silently stripped (PUT 200, `filters: null` on readback), same class as the documented datetime strip. Numeric selectors bind through a hidden `Text()` cast column; dates → `date-range` with flat `mode: between`. Candidate for the next shared `control-parity.md` sync (kept byte-identical here).
- **verify_parity.py** — emits `parity-final.json` + `wb-ids.json` (the assert-gate sentinel contract); skips layout containers when mapping elements.
- **Vendored byte-identical** (md5-verified against the canonical copies): `lib/control_lint.rb`, `lib/layout_lint.rb`, `lib/sigma_rest.rb`, `probe-controls.rb`, `assert-phase6-ran.rb`, `refs/control-parity.md`; plus `put-layout.rb` (quicksight self-token variant). `lib/layout.rb` deliberately not vendored — the layout path is python (qlik precedent).
- **Fixtures** — dossier gains a chapter filter, two attribute selectors with declared targets, and a panel selector (documented MSTR REST shapes; the same features `BUILD_SPEC.md` plans for the live fixture dossier). `fixtures/ae_winners.json` = the live-validated AE winners so the bundled fixture path runs end-to-end without a Strategy One instance.
- **Docs** — SKILL.md (control emission, layout PUT, Phase 6 gate), refs, QUICKSTART.

## E2E evidence (fixture path; no live MSTR creds on this machine)

Frozen `MSTRCTL.TJ` snapshot of the drifting CSA.TJ demo star (the 2026-06-11 generator rows were reconciled to the byte: +579.79 rev / +12 units / +6 orders explained every delta), conn `bc0319f8`:

- Parity: **PASS 19/19 + 30/30 + 3/3** (exact; same numbers as the original validation)
- `assert-phase6-ran.rb`: **gates 1-7 GREEN** (gate 5 tile census honestly SKIPped — converter emits none). Gate 7 caught the numeric-strip escape live before the fix.
- Flip test (`probe-controls.rb`): RegionFilter 19→5 rows, OrderChannelFilter 3→1, YearFilter 30→12 (explicit `--value`, hidden Text cast); cross-page no-leak: Monthly Revenue Trend identical under `OrderChannelFilter=App`.
- Kept pair: DM `77528097-3928-4dd4-abe7-0078999a1279`, workbook `a02d7066-389c-47a4-bdf2-d164f5ae21e9` ("MSTRCTL Orders Performance Overview (MSTR)"); PNGs in `~/migration-visual-qa/ctl-wave/` (header bands, banded controls, no raw ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)