### PR TITLE
control-parity.md x7: numeric list-target silent-strip gotcha

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/control-parity.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/control-parity.md
@@ -91,3 +91,9 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/control-parity.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/control-parity.md
@@ -91,3 +91,9 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/control-parity.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/control-parity.md
@@ -91,3 +91,9 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/control-parity.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/control-parity.md
@@ -91,3 +91,9 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/control-parity.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/control-parity.md
@@ -91,3 +91,9 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/control-parity.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/control-parity.md
@@ -91,3 +91,9 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/control-parity.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/control-parity.md
@@ -91,3 +91,9 @@ Consequences:
 
 After any repair: flip-test the workbook
 (`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)


### PR DESCRIPTION
Doc-only sync: the MSTR retrofit's gate 7 caught list-control filter targets on NUMERIC columns being silently stripped (PUT 200, filters:null readback) — same class as the datetime strip. Fix recipe: hidden Text() cast column. All 7 vendored copies byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)