### PR TITLE
powerbi-to-sigma: real maps, PBI-fidelity layout, sortByColumn, image elements

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -56,6 +56,8 @@ OptionParser.new do |p|
   p.on('--signals PATH')     { |v| opts[:sig] = v }
   p.on('--master-map PATH')  { |v| opts[:mmap] = v }
   p.on('--bim PATH', 'model.bim — geo dataCategory lookup so PBI map visuals emit real Sigma region/point maps') { |v| opts[:bim] = v }
+  p.on('--image-map PATH', 'JSON {registeredResourceName: hostedUrl} — PBI image visuals become Sigma image elements (no map: skipped with a note)') { |v| opts[:imap] = v }
+  p.on('--layout MODE', 'pbi (default: flat canvas-proportional, matches the PBI page 1:1) | banded (legacy header+row-band containers)') { |v| opts[:layout_mode] = v }
   p.on('--data-model ID')    { |v| opts[:dm] = v }
   p.on('--out PATH')         { |v| opts[:out] = v }
   p.on('--layout-out PATH')  { |v| opts[:layout_out] = v }
@@ -78,6 +80,7 @@ end.parse!
 %i[sig mmap out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
 
 signals = JSON.parse(File.read(opts[:sig]))
+$image_map = (opts[:imap] && File.exist?(opts[:imap])) ? JSON.parse(File.read(opts[:imap])) : {}
 if opts[:bim] && File.exist?(opts[:bim])
   $geo_categories ||= {}
   $sort_by_column ||= {}
@@ -195,7 +198,7 @@ SIGMA_KIND = {
   'area' => 'area-chart', 'combo' => 'combo-chart', 'scatter' => 'scatter-chart',
   'pie' => 'pie-chart', 'donut' => 'donut-chart',
   'table' => 'table', 'pivot-table' => 'pivot-table', 'text' => 'text',
-  'control' => 'control', 'map' => 'map'
+  'control' => 'control', 'map' => 'map', 'image' => 'image'
 }.freeze
 
 # PBI role -> (dim_role?, value_role?) per visual kind handled below.
@@ -523,8 +526,23 @@ def build_element(rec, fields, masters, extra_data = [])
   name  = title.empty? ? (derived_title(rec, kind) || KIND_LABEL[kind] || 'Chart') : title
 
   if kind == 'text'
-    body = rec['text'] ? "## #{rec['text']}" : '## '
-    return { 'id' => eid, 'kind' => 'text', 'body' => body }
+    # Size-aware: PBI textboxes are titles OR small decorative labels
+    # (copyright lines, urls). Rendering every one as an H2 made tiny footer
+    # text huge and overlapping (customer QS feedback). Boxes under ~60px tall
+    # render as plain body text.
+    txt = rec['text'].to_s
+    body = (rec['h'].to_f >= 60 ? "## #{txt}" : txt)
+    return { 'id' => eid, 'kind' => 'text', 'body' => body.empty? ? ' ' : body }
+  end
+
+  if kind == 'image'
+    url = ($image_map || {})[rec['resource']]
+    unless url
+      warn "[build-workbook] visual '#{rec['visual_id']}': image asset '#{rec['resource']}' " \
+           'skipped — supply --image-map {resource: hostedUrl} to embed it (Sigma images are URL-only).'
+      return nil
+    end
+    return { 'id' => eid, 'kind' => 'image', 'url' => url }
   end
 
   master = visual_master(rec, fields)
@@ -1174,6 +1192,51 @@ pages_xml = signals['pages'].map do |pg|
     items = items.select { |i| built_ids.include?(i[0]) }
   end
   next nil if items.empty?
+
+  # ---- PBI-fidelity FLAT layout (default) ---------------------------------
+  # The page mirrors the PBI canvas 1:1: flat LayoutElements at the canvas-
+  # proportional grid coords (exactly the shape Sigma's own UI writes), no
+  # header band, no row containers. Band containers with auto rows COLLAPSE
+  # around short content (KPIs lost their titles; map/scatter bands rendered
+  # blank in page exports) — verified against the PBI page renders.
+  if (opts[:layout_mode] || 'pbi') != 'banded'
+    kind_of = {}
+    (page_spec ? page_spec['elements'] : []).each { |e| kind_of[e['id']] = e['kind'] }
+    # Sigma needs more vertical room than PBI's compact widgets: clamp minimum
+    # row spans per kind (KPI value+title needs ~5 rows; charts breathe at 6+).
+    min_rows = { 'kpi-chart' => 4, 'scatter-chart' => 8, 'region-map' => 8, 'point-map' => 8,
+                 'pie-chart' => 6, 'bar-chart' => 6, 'line-chart' => 6, 'area-chart' => 6,
+                 'combo-chart' => 6 }
+    items = items.map do |id, c0, c1, r0, r1|
+      need = min_rows[kind_of[id]]
+      r1 = r0 + need if need && (r1 - r0) < need
+      c1 = c0 + 2 if c1 - c0 < 2
+      [id, c0, c1, r0, r1]
+    end
+    # Sigma rejects overlapping LayoutElements ("Element collisions") while a
+    # PBI canvas freely z-stacks (decorative text over chart corners). Resolve
+    # deterministically: later/lower items push DOWN past whatever they hit.
+    items = items.sort_by { |i| [i[3], i[1]] }
+    10.times do
+      moved = false
+      items.each_with_index do |a, ai|
+        items.each_with_index do |b, bi|
+          next if bi <= ai
+          cols = a[1] < b[2] && b[1] < a[2]
+          rows = a[3] < b[4] && b[3] < a[4]
+          next unless cols && rows
+          delta = a[4] - b[3]
+          b[3] += delta; b[4] += delta
+          moved = true
+        end
+      end
+      items = items.sort_by { |i| [i[3], i[1]] }
+      break unless moved
+    end
+    inner = items.map { |i| SigmaLayout.le(i[0], i[1], i[2], i[3], i[4]) }.join("\n")
+    next SigmaLayout.page_xml(page_id, inner)
+  end
+  # ---- legacy banded layout (--layout banded) ------------------------------
   # phase-e layout-quality fix: a short title TEXTBOX at the top of the source
   # canvas becomes the header band's text (white-on-dark), MOVED out of band 1
   # (never left behind as a dead zone). The candidate may start up to one grid

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -55,6 +55,7 @@ opts = {}
 OptionParser.new do |p|
   p.on('--signals PATH')     { |v| opts[:sig] = v }
   p.on('--master-map PATH')  { |v| opts[:mmap] = v }
+  p.on('--bim PATH', 'model.bim — geo dataCategory lookup so PBI map visuals emit real Sigma region/point maps') { |v| opts[:bim] = v }
   p.on('--data-model ID')    { |v| opts[:dm] = v }
   p.on('--out PATH')         { |v| opts[:out] = v }
   p.on('--layout-out PATH')  { |v| opts[:layout_out] = v }
@@ -77,6 +78,22 @@ end.parse!
 %i[sig mmap out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
 
 signals = JSON.parse(File.read(opts[:sig]))
+if opts[:bim] && File.exist?(opts[:bim])
+  $geo_categories ||= {}
+  $sort_by_column ||= {}
+  _bim = JSON.parse(File.read(opts[:bim]))
+  _model = _bim['model'] || _bim
+  (_model['tables'] || []).each do |t|
+    (t['columns'] || []).each do |c|
+      $geo_categories["#{t['name']}.#{c['name']}".downcase] = c['dataCategory'] if c['dataCategory']
+      # PBI sort-by-column ("FiscalMonth" sorts by "Period") — without it Sigma
+      # sorts month names ALPHABETICALLY (Apr, Aug, Feb…), a top complaint on
+      # converted dashboards. Recorded as 'table.field' -> 'table.sortfield'.
+      $sort_by_column["#{t['name']}.#{c['name']}".downcase] = "#{t['name']}.#{c['sortByColumn']}" if c['sortByColumn']
+    end
+  end
+  warn "[build-workbook] geo metadata: #{$geo_categories.length} dataCategory, #{$sort_by_column.length} sortByColumn column(s) from #{opts[:bim]}"
+end
 mmap    = JSON.parse(File.read(opts[:mmap]))
 fields  = mmap['fields'] || {}
 masters = mmap['masters'] || {}
@@ -178,7 +195,7 @@ SIGMA_KIND = {
   'area' => 'area-chart', 'combo' => 'combo-chart', 'scatter' => 'scatter-chart',
   'pie' => 'pie-chart', 'donut' => 'donut-chart',
   'table' => 'table', 'pivot-table' => 'pivot-table', 'text' => 'text',
-  'control' => 'control'
+  'control' => 'control', 'map' => 'map'
 }.freeze
 
 # PBI role -> (dim_role?, value_role?) per visual kind handled below.
@@ -425,6 +442,10 @@ def apply_sort(el, kind, rec, qr_cids, name)
   case kind
   when 'bar-chart', 'line-chart', 'area-chart', 'combo-chart'
     return warn_sort_miss(name, srt) unless cid
+    # A visual-level sort BY THE DIM ITSELF must not clobber the model's
+    # sortByColumn axis order (PBI sorts FiscalMonth via Period; re-sorting by
+    # the month NAME would go alphabetical).
+    return if cid == el.dig('xAxis', 'columnId') && el.dig('xAxis', 'sort', 'by').to_s.end_with?('-sortcol')
     (el['xAxis'] ||= {})['sort'] = { 'by' => cid, 'direction' => dir }
   when 'pie-chart', 'donut-chart'
     return warn_sort_miss(name, srt) unless cid
@@ -450,8 +471,47 @@ end
 # accumulator array: branches that need a HIDDEN helper element on the Data page
 # (bead ry0n: the scatter grouped-source table) push it there; the page assembly
 # appends extra_data to the Data page's elements.
+# PBI dataCategory -> Sigma region-map regionType. Loaded from --bim into
+# $geo_categories ('table.field' downcased -> dataCategory). PBI geocodes
+# arbitrary place text via Bing at render time; Sigma matches region NAMES to
+# built-in shapes — so only category-tagged columns can become real maps.
+GEO_REGION_TYPE = {
+  'postalcode' => 'us-zipcode', 'city' => 'us-postal-place', 'place' => 'us-postal-place',
+  'stateorprovince' => 'us-state', 'county' => 'us-county',
+  'country' => 'country', 'countryregion' => 'country'
+}.freeze
+$geo_categories ||= {}
+$sort_by_column ||= {}
+
+# Resolve a 'map' visual to region-map / point-map / bar-chart fallback.
+# Mutates rec['bindings'] for the fallback (legend becomes the bar category,
+# matching the old downgrade behavior).
+def resolve_map_kind(rec, name)
+  b = rec['bindings'] || {}
+  lat = (b['Latitude'] || []).first
+  lng = (b['Longitude'] || []).first
+  return 'point-map' if lat && lng
+  loc = (b['Category'] || b['Location'] || []).first
+  cat = loc && $geo_categories[loc.to_s.downcase]
+  rt  = cat && GEO_REGION_TYPE[cat.to_s.downcase]
+  if rt
+    rec['_region_type'] = rt
+    warn "[build-workbook] visual '#{name}': PBI map -> Sigma region-map (#{rt}) on '#{loc}'"          "#{rt.start_with?('us-') ? ' — US region layer assumed (PBI dataCategory carries no country)' : ''}."
+    return 'region-map'
+  end
+  why = loc.nil? ? 'no location binding' : ($geo_categories.empty? ? 'no --bim geo metadata supplied' : "'#{loc}' has no geocodable dataCategory")
+  warn "[build-workbook] WARN visual '#{name}': PBI map downgraded to bar chart — #{why}. "        'Sigma maps need a region-typed column (country/state/county/zip/place) or lat+long; '        'PBI relied on Bing geocoding which Sigma does not do.'
+  series = (b['Series'] || b['Legend'] || []).first
+  b['Category'] = [series] if series  # old downgrade kept the legend as the bar category
+  'bar-chart'
+end
+
 def build_element(rec, fields, masters, extra_data = [])
   kind = SIGMA_KIND[rec['sigma_kind']] || 'bar-chart'
+  if kind == 'map'
+    t0 = rec['title'].to_s.strip
+    kind = resolve_map_kind(rec, t0.empty? ? rec['visual_id'] : t0)
+  end
   vid  = rec['visual_id']
   eid  = "el-#{short(vid)}"
   vfmts = rec['formats'] || {}
@@ -616,6 +676,43 @@ def build_element(rec, fields, masters, extra_data = [])
     # Invalid string"; live readback also normalizes to columnId). NB: pie/donut
     # `value` uses `{id}` — do not change that one.
     el['value'] = { 'columnId' => cid }
+  when 'region-map'
+    loc = (b['Category'] || b['Location'] || []).first
+    meas = (b['Y'] || b['Values'] || []).first
+    dfs = field_spec(loc, fields, master)
+    dcid = "#{eid}-r"
+    cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => qr_leaf(loc, 'Region') }
+    qr_cids[loc] = dcid
+    el['region'] = { 'id' => dcid, 'regionType' => rec['_region_type'] }
+    if meas
+      fs = field_spec(meas, fields, master)
+      vcid = "#{eid}-v"
+      col = { 'id' => vcid, 'formula' => measure_formula(fs), 'name' => qr_leaf(meas) }
+      apply_fmt(col, meas, fields, vfmts)
+      cols << col
+      qr_cids[meas] = vcid
+      el['color'] = { 'by' => 'scale', 'column' => vcid }
+    end
+    if (srs = (b['Series'] || b['Legend'] || []).first)
+      warn "[build-workbook] WARN visual '#{name}': region-map colors by the measure scale — "            "PBI legend '#{srs}' dropped (no categorical legend on a Sigma region map)."
+    end
+  when 'point-map'
+    latq = (b['Latitude'] || []).first
+    lngq = (b['Longitude'] || []).first
+    lfs = field_spec(latq, fields, master); gfs = field_spec(lngq, fields, master)
+    lcid = "#{eid}-lat"; gcid = "#{eid}-lng"
+    cols << { 'id' => lcid, 'formula' => lfs['ref'], 'name' => qr_leaf(latq, 'Latitude') }
+    cols << { 'id' => gcid, 'formula' => gfs['ref'], 'name' => qr_leaf(lngq, 'Longitude') }
+    el['latitude'] = { 'id' => lcid }
+    el['longitude'] = { 'id' => gcid }
+    if (szq = (b['Size'] || b['Y'] || b['Values'] || []).first)
+      fs = field_spec(szq, fields, master)
+      scid = "#{eid}-sz"
+      col = { 'id' => scid, 'formula' => measure_formula(fs), 'name' => qr_leaf(szq, 'Size') }
+      apply_fmt(col, szq, fields, vfmts)
+      cols << col
+      el['size'] = { 'id' => scid }
+    end
   when 'bar-chart', 'line-chart', 'area-chart'
     # b['Group'] is the treemap/funnel category role (1zh9) — alias it to the dim
     # so a treemap-as-bar fallback keeps its category instead of emitting '[]'.
@@ -649,6 +746,18 @@ def build_element(rec, fields, masters, extra_data = [])
     end
     el['xAxis'] = { 'columnId' => dcid }
     el['yAxis'] = { 'columnIds' => ycids }
+    # PBI sort-by-column: bind the hidden sort field and order the axis by it
+    # (model FiscalMonth sorts by Period; alphabetical months otherwise).
+    if dim && (sort_qr = ($sort_by_column || {})[dim.to_s.downcase])
+      sfs = fields[sort_qr] || fields.find { |k, _| k.to_s.downcase == sort_qr.downcase }&.last
+      if sfs && (sfs['master'] == master || Array(sfs['alts']).any? { |a| a['master'] == master })
+        scol_id = "#{eid}-sortcol"
+        cols << { 'id' => scol_id, 'formula' => (sfs['master'] == master ? sfs['ref'] : Array(sfs['alts']).find { |a| a['master'] == master }['ref']), 'name' => qr_leaf(sort_qr, 'Sort'), 'hidden' => true }
+        el['xAxis']['sort'] = { 'by' => scol_id, 'direction' => 'ascending' }
+      else
+        warn "[build-workbook] WARN visual '#{name}': model sorts '#{dim}' by '#{sort_qr}' but that field is not in the master-map — axis will sort alphabetically; add it to fields to fix."
+      end
+    end
     # PBI *Bar* visuals are horizontal; *Column* visuals vertical. Sigma keeps the
     # same xAxis(category)/yAxis(value) binding and flips rendering via this flag.
     # Only "horizontal" is a valid value — vertical = omit (Sigma default).

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
@@ -49,7 +49,7 @@ VISUAL_KIND = {
     "pieChart": "pie", "donutChart": "donut", "scatterChart": "scatter",
     "tableEx": "table", "pivotTable": "pivot-table", "matrix": "pivot-table",
     "slicer": "control",
-    "map": "bar", "filledMap": "bar", "shapeMap": "bar", "azureMap": "bar",
+    "map": "map", "filledMap": "map", "shapeMap": "map", "azureMap": "map",
 }
 
 # PBI bar families: *Bar* visuals render HORIZONTALLY; *Column* visuals render

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
@@ -18,7 +18,7 @@ Usage:
   python3 extract-report-classic.py --report-json /tmp/pbir-orders/report.json \
       --out /tmp/pbir-orders/signals.json
 """
-import argparse, json, sys
+import argparse, json, re, sys
 
 # Same visualType -> Sigma element kind table as extract-pbir.py.
 VISUAL_KIND = {
@@ -179,11 +179,28 @@ def extract(report):
             cfg = json.loads(vc.get("config", "{}"))
             sv = cfg.get("singleVisual", {})
             vt = sv.get("visualType", "unknown")
-            # bead a1cv: image visuals are static assets (StaticResources) — the
-            # 'bar' fallback would emit a junk empty chart. Skip with a note.
+            # bead a1cv: image visuals are static assets (StaticResources). Emit a
+            # kind='image' record carrying the registered-resource name — the
+            # builder turns it into a Sigma image element when --image-map
+            # supplies a hosted URL for it, and skips it (with a note) otherwise.
             if vt == "image":
-                print(f"[classic] skipping image visual on page '{s.get('displayName')}'"
-                      " (static asset; not portable)", file=sys.stderr)
+                # resource name lives at objects.general[].properties.imageUrl
+                # .expr.ResourcePackageItem.ItemName (classic) — regex fallback
+                # for any RegisteredResources path form.
+                m = re.search(r'"ItemName":\s*"([^"]+)"', json.dumps(cfg)) \
+                    or re.search(r"RegisteredResources/([\w.\-]+)", json.dumps(cfg))
+                ipos = (cfg.get("layouts", [{}])[0] or {}).get("position", {})
+                rec = {
+                    "visual_id": f"p{len(out_pages)}v{len(visuals)}image",
+                    "visual_type": vt, "title": None, "sigma_kind": "image",
+                    "orientation": None,
+                    "x": vc.get("x") or ipos.get("x", 0), "y": vc.get("y") or ipos.get("y", 0),
+                    "w": vc.get("width") or ipos.get("width", 0), "h": vc.get("height") or ipos.get("height", 0),
+                    "z": vc.get("z") or ipos.get("z", 0), "parent_group": None, "bindings": {},
+                    "sort": None, "formats": {}, "data_labels": None, "legend": None,
+                    "resource": m.group(1) if m else None,
+                }
+                visuals.append((cfg.get("name"), rec))
                 continue
             # position: prefer vc top-level x/y/w/h, fall back to config layouts
             x = vc.get("x"); y = vc.get("y"); w = vc.get("width"); h = vc.get("height")

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
@@ -32,7 +32,7 @@ VISUAL_KIND = {
     "pieChart": "pie", "donutChart": "donut", "scatterChart": "scatter",
     "tableEx": "table", "pivotTable": "pivot-table", "matrix": "pivot-table",
     "slicer": "control",
-    "map": "bar", "filledMap": "bar", "shapeMap": "bar", "azureMap": "bar",
+    "map": "map", "filledMap": "map", "shapeMap": "map", "azureMap": "map",
 }
 
 # *Bar* = horizontal, *Column* = vertical (Sigma default). Sigma's bar-chart
@@ -45,10 +45,8 @@ HBAR_TYPES = {"barChart", "clusteredBarChart", "stackedBarChart",
 # but ONLY for map visuals (bead ry0n): on a scatterChart, Size is the real
 # bubble-size role and Series the legend; remapping them corrupts the scatter.
 ROLE_REMAP = {
-    "Series": "Category",
     "Size": "Y",
     "Location": "Category",
-    "Latitude": "Category",
 }
 MAP_TYPES = {"map", "filledMap", "shapeMap", "azureMap"}
 


### PR DESCRIPTION
The visual-fidelity round, driven by full-page side-by-side QA against actual PBI renders (customer QS feedback: conversions looked bad even when numbers were exact).

- **Real Sigma maps** from PBI map visuals — regionType from model `dataCategory` (PostalCode→us-zipcode, City→us-postal-place, State→us-state, lat/long→point-map); bar fallback only when no geo metadata resolves. PNG-verified.
- **PBI-fidelity flat layout (new default)** — band containers with auto rows collapsed (clipped KPIs, blank map/scatter bands). Flat canvas-proportional LayoutElements mirror the PBI page 1:1; per-kind min row spans; deterministic push-down collision resolver (Sigma rejects overlaps that PBI z-stacks). `--layout banded` keeps the legacy form.
- **Model sortByColumn** → hidden sort column + axis sort (months in Jan→Aug order, not alphabetical).
- **Image visuals** → Sigma image elements via `--image-map` (hosted URLs); extractor emits the RegisteredResources ItemName + canvas box.
- Size-aware textboxes (small decorative text stops rendering as giant H2s).

Verified: all 4 Retail Analysis Sample pages export-compared against the PBI PDF renders — see visual-qa side-by-sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)