### PR TITLE
powerbi-to-sigma: classic stacking signal + mandatory visual-compare gate

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -86,6 +86,29 @@ Then: `tableau-to-sigma/scripts/post-and-readback.rb --type datamodel`. See `ref
 ## Phase 5d — Layout (do NOT skip — stacked ≠ done)
 Map each visual's `x,y,w,h` → 24-col grid (`COL_UNIT = page_w/24`, `ROW_UNIT ≈ 30`) → single top-level `layout` XML (one `<Page>` per page, server page IDs) → `tableau-to-sigma/scripts/put-layout.rb`. Math + snap rules in `research/powerbi-visual-layout.md §4`.
 
+## Phase 5e — VISUAL COMPARE vs the SOURCE (MANDATORY — numbers lie about looks)
+Phase 6 proves the NUMBERS; this phase proves the PAGES. A conversion shipped
+with exact query parity and still looked broken (collapsed KPIs, stacked bars
+that should be clustered, alphabetical months) — caught only by putting full
+pages next to the Power BI renders. Do this BEFORE Phase 6, every run:
+
+1. Export the SOURCE pages: `"$PY" scripts/export-pbi-pages.py --report <reportId> --out-dir $WORK/visual-qa`
+   (PNG is commonly tenant-disabled — the script falls through to PDF; per-page when pypdf is installed).
+2. Export EVERY Sigma page: `"$PY" scripts/sigma-export-png.py --workbook <wbId> --page <pageId> --out $WORK/visual-qa/sigma-<page>.png`.
+3. **Read both images for each page, side by side.** Check, per page: same
+   elements in the same spots; charts show MARKS (not just axes); clustered vs
+   stacked matches the source; axis order (months Jan→Dec, not alphabetical);
+   KPI tiles show value AND label; no giant decorative text; no dead bands.
+4. Write `$WORK/visual-qa/visual-compare.json`: `[{page, verdict: PASS|ACCEPTED|FAIL, deltas: ["…"]}]`
+   — ACCEPTED means the user explicitly OK'd a listed delta (e.g. zip
+   choropleth instead of PBI's bubble map; theme colors). FAIL = fix and re-export.
+5. Gate: `ruby scripts/assert-visual-compare.rb --dir $WORK/visual-qa --signals $WORK/signals.json`
+   must print GREEN before Phase 6 may be declared.
+
+Layout escalation if the compare fails on arrangement: the builder's default
+`--layout clean` preserves the source positions inside a normalized grid; use
+`--layout pbi` for literal 1:1 canvas geometry; `--layout banded` is legacy.
+
 ## Phase 6 — Verify (mandatory)
 - `sigma-mcp-v2 query` each element → confirm real rows (not blank).
 - True parity: PBI `POST /v1.0/myorg/groups/{ws}/datasets/{id}/executeQueries` (DAX) vs the same Sigma aggregation. DAX-only; breaks under service-principal if RLS.
@@ -222,6 +245,8 @@ The conversion is script-driven (mirrors `tableau-to-sigma/scripts/`). `scripts/
 | `fabric-extract-batch.py` | 1 batch | Fleet extraction: every requested report → 2 artifact tasks (model TMSL + report def) on ONE 4-wide pool; report→model binding via PBI REST `datasetId` (name-match fallback); `manifest.json` + `timings.json`. 3 reports = 7.5s measured. |
 | `extract-pbir.py` | 1 extract | Fetch a report's PBIR (or parse one already on disk) → normalized `signals.json` (per-visual `sigma_kind` + role bindings + x/y/w/h). Live fetch uses the `pbi_fabric` fast LRO path. The PBI analog of `parse-twb-layout.rb`. |
 | `pbi-freshness.py` | 1.5 preflight | SOURCE-FRESHNESS: refresh history (incl. FAILED/creds-expired refreshes) + cheap executeQueries row-count/max-date snapshot (**4-wide parallel per-table probes**) → `freshness.json`. Launched **non-blocking** by run.sh/migrate-powerbi.rb (consumed at parity). Leads the parity output; deltas classify MATCH / STALE-EXPLAINED / DIVERGENT (bead fmte). |
+| `export-pbi-pages.py` | 5e compare | SOURCE page renders via ExportToFile (PNG → PDF fallback; per-page split with pypdf) for the mandatory visual compare. |
+| `assert-visual-compare.rb` | 5e gate | HARD GATE: blocks Phase 6 unless visual-compare.json has a PASS/ACCEPTED verdict (with explained deltas) for every content page. |
 | `convert-model.rb` | 2–3 convert/post | MODE A prints the exact `convert_powerbi_to_sigma` MCP call for a `model.bim`; MODE B takes the converter output and applies the 3 fixups (schemaVersion + folderId/ownerId via a ref-DM harvest + base-element names) → postable DM spec. |
 | `build-workbook-from-pbir.rb` | 4 build | `signals.json` + a `master-map.json` → full workbook spec + 24-col layout XML. Applies the measure-translation patterns in `refs/measure-patterns.md`; **line charts default to a single series** (`beads-sigma-c07`) unless PBI bound a Series/Legend role. **Carries the PBI visual sort** (`f972` — PBIR `query.sortDefinition` / classic `prototypeQuery.OrderBy` → chart `xAxis.sort`/`color.sort`; grouped table → `groupings[0].sort` — element-level sort is rejected on grouped tables). Analog of `build-charts-from-signals.rb`. |
 | `phase6-parity-pbi.rb` | 7 parity | executeQueries(DAX) adapter: `--emit-dax` runs the PBI side and writes the parity plan's `expected` rows; `--finalize` injects Sigma actuals and runs the shared `verify-parity.rb`. The PBI analog of Tableau's view-CSV parity adapter. |

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-visual-compare.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-visual-compare.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# Hard gate for Phase 5e (visual compare vs the SOURCE report). The agent MUST
+# run this before Phase 6 parity sign-off. Blocks unless:
+#   1. visual-compare.json exists in --dir
+#   2. it has an entry for EVERY content page in --signals (Data page exempt)
+#   3. every entry has verdict PASS or ACCEPTED (a delta the user explicitly
+#      accepted, with a non-empty `deltas` list explaining what differs)
+# Numbers-only verification shipped dashboards that LOOKED broken (customer QS
+# feedback, 2026-06-12) — eyes on full pages are part of GREEN now.
+require 'json'
+require 'optparse'
+opts = {}
+OptionParser.new do |p|
+  p.on('--dir D') { |v| opts[:dir] = v }
+  p.on('--signals S') { |v| opts[:sig] = v }
+end.parse!
+abort('need --dir and --signals') unless opts[:dir] && opts[:sig]
+path = File.join(opts[:dir], 'visual-compare.json')
+abort("BLOCKED: #{path} missing — run Phase 5e (export source + Sigma pages, eyeball, write verdicts)") unless File.exist?(path)
+vc = JSON.parse(File.read(path))
+entries = vc.is_a?(Array) ? vc : (vc['pages'] || [])
+by_page = entries.group_by { |e| e['page'] }
+signals = JSON.parse(File.read(opts[:sig]))
+missing = []
+signals['pages'].each do |pg|
+  next if (pg['visuals'] || []).empty?
+  missing << pg['page_title'] unless by_page.key?(pg['page_title']) || by_page.key?(pg['page_id'])
+end
+abort("BLOCKED: no visual-compare entry for page(s): #{missing.join(', ')}") unless missing.empty?
+bad = entries.reject { |e| %w[PASS ACCEPTED].include?(e['verdict'].to_s.upcase) }
+abort("BLOCKED: non-passing verdict(s): #{bad.map { |e| "#{e['page']}=#{e['verdict']}" }.join(', ')}") unless bad.empty?
+unexplained = entries.select { |e| e['verdict'].to_s.upcase == 'ACCEPTED' && Array(e['deltas']).empty? }
+abort("BLOCKED: ACCEPTED verdict without deltas[] explaining what differs: #{unexplained.map { |e| e['page'] }.join(', ')}") unless unexplained.empty?
+puts "visual-compare GREEN: #{entries.length} page(s) verified against the source render."

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/export-pbi-pages.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/export-pbi-pages.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""export-pbi-pages.py — download the SOURCE Power BI report's rendered pages
+for the Phase 5e visual compare.
+
+Uses the ExportToFile API. PNG export is commonly DISABLED at tenant level
+("Export report to image is disabled") — PDF almost never is, and a per-page
+PDF is fine for the compare (the agent Reads PDFs/PNGs the same way). When
+pypdf is importable the PDF is split into one file per page; otherwise the
+single multi-page PDF is kept (Read it with the `pages` parameter).
+
+Requires the report's workspace to be on capacity (Fabric trial/premium).
+
+Usage:
+  python3 export-pbi-pages.py --report <reportId> --out-dir ./visual-qa
+"""
+import truststore; truststore.inject_into_ssl()
+import argparse, os, sys, time
+import msal, requests
+
+CACHE = os.environ.get("PBI_TOKEN_CACHE", "/tmp/pbiauth/cache.bin")
+CLIENT = "ea0616ba-638b-4df5-95b9-636659ae5121"
+
+
+def token():
+    cache = msal.SerializableTokenCache()
+    if os.path.exists(CACHE):
+        cache.deserialize(open(CACHE).read())
+    app = msal.PublicClientApplication(
+        CLIENT, authority="https://login.microsoftonline.com/organizations", token_cache=cache)
+    for a in app.get_accounts():
+        r = app.acquire_token_silent(["https://analysis.windows.net/powerbi/api/.default"], account=a)
+        if r and "access_token" in r:
+            return r["access_token"]
+    flow = app.initiate_device_flow(scopes=["https://analysis.windows.net/powerbi/api/.default"])
+    print(">>> " + flow["verification_uri"] + " code " + flow["user_code"], file=sys.stderr)
+    return app.acquire_token_by_device_flow(flow)["access_token"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--report", required=True)
+    ap.add_argument("--workspace", default=None, help="group id; omit for My workspace")
+    ap.add_argument("--out-dir", default="./visual-qa")
+    a = ap.parse_args()
+    tok = token()
+    H = {"Authorization": f"Bearer {tok}"}
+    base = ("https://api.powerbi.com/v1.0/myorg" if not a.workspace
+            else f"https://api.powerbi.com/v1.0/myorg/groups/{a.workspace}")
+    os.makedirs(a.out_dir, exist_ok=True)
+
+    fmt_order = ["PNG", "PDF"]  # PNG preferred; tenant-disabled falls through to PDF
+    for fmt in fmt_order:
+        r = requests.post(f"{base}/reports/{a.report}/ExportTo",
+                          headers={**H, "Content-Type": "application/json"}, json={"format": fmt})
+        if r.status_code == 403 and "disabled" in r.text:
+            print(f"[export] {fmt} disabled at tenant level — trying next format", file=sys.stderr)
+            continue
+        r.raise_for_status()
+        eid = r.json()["id"]
+        st = {}
+        for _ in range(80):
+            st = requests.get(f"{base}/reports/{a.report}/exports/{eid}", headers=H).json()
+            if st.get("status") in ("Succeeded", "Failed"):
+                break
+            time.sleep(5)
+        if st.get("status") != "Succeeded":
+            sys.exit(f"export failed: {st}")
+        data = requests.get(f"{base}/reports/{a.report}/exports/{eid}/file", headers=H).content
+        if data[:2] == b"PK":  # PNG multi-page comes back zipped
+            import io, zipfile
+            zipfile.ZipFile(io.BytesIO(data)).extractall(a.out_dir)
+            print(f"[export] unzipped page PNGs -> {a.out_dir}", file=sys.stderr)
+        elif fmt == "PDF":
+            pdf = os.path.join(a.out_dir, "powerbi-report.pdf")
+            open(pdf, "wb").write(data)
+            try:
+                from pypdf import PdfReader, PdfWriter
+                rd = PdfReader(pdf)
+                for i, pg in enumerate(rd.pages, 1):
+                    w = PdfWriter(); w.add_page(pg)
+                    with open(os.path.join(a.out_dir, f"powerbi-page{i}.pdf"), "wb") as f:
+                        w.write(f)
+                print(f"[export] {len(rd.pages)} page PDFs -> {a.out_dir}", file=sys.stderr)
+            except ImportError:
+                print(f"[export] wrote {pdf} (pypdf not installed — Read it with pages=N)", file=sys.stderr)
+        else:
+            open(os.path.join(a.out_dir, "powerbi-report.png"), "wb").write(data)
+        print(os.listdir(a.out_dir))
+        return
+    sys.exit("all export formats disabled for this tenant")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
@@ -37,6 +37,19 @@ VISUAL_KIND = {
 
 # *Bar* = horizontal, *Column* = vertical (Sigma default). Sigma's bar-chart
 # `orientation` accepts only "horizontal"; vertical = omit the field.
+# PBI visualType -> Sigma `stacking` enum (none|stacked|normalized). Classic
+# files encode it in the TYPE NAME; without an explicit value Sigma defaults
+# multi-series bars to STACKED, corrupting clustered PBI charts (customer
+# catch on the Retail sample's clustered variance chart).
+def _stacking(vtype):
+    v = (vtype or "")
+    if v.startswith("hundredPercentStacked"):
+        return "normalized"
+    if v.startswith("stacked"):
+        return "stacked"
+    return "none"
+
+
 HBAR_TYPES = {"barChart", "clusteredBarChart", "stackedBarChart",
               "hundredPercentStackedBarChart"}
 
@@ -223,6 +236,7 @@ def extract(report):
                 "bindings": _projections(sv, vt),
                 # bead f972: visual sort ({queryRef, direction asc|desc}) or None
                 "sort": _sort_signal(sv),
+                "stacking": _stacking(vt) if VISUAL_KIND.get(vt) == "bar" else None,
                 "formats": {},
                 # bead n9u9: PBI data-label toggle (objects.labels show) — true/false/None
                 "data_labels": _obj_flag(sv, "labels"),


### PR DESCRIPTION
- Classic extractor now emits `stacking` from the visual type name — clustered PBI charts stopped rendering stacked (Sigma's multi-series default).
- Phase 5e visual compare promoted from the opt-in Phase E checklist to a **mandatory core gate**: source renders via `export-pbi-pages.py` + Sigma pages via `sigma-export-png.py`, eyeballed side-by-side, per-page verdicts in `visual-compare.json`, hard-asserted by `assert-visual-compare.rb` before Phase 6 may be declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)