### PR TITLE
powerbi-to-sigma: area-chart stacking fidelity

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -786,7 +786,7 @@ def build_element(rec, fields, masters, extra_data = [])
     # Stacking enum is none|stacked|normalized (OpenAPI BarChart.stacking;
     # "normalized" = scaled to 100%). extract-pbir already maps PBI 100%-stacked
     # -> "normalized", so pass it through verbatim (bead pi8v).
-    el['stacking'] = rec['stacking'] if kind == 'bar-chart' && rec['stacking']
+    el['stacking'] = rec['stacking'] if %w[bar-chart area-chart].include?(kind) && rec['stacking']
     # bead n9u9: honor the PBI per-visual data-label signal (objects.labels show)
     # when the extractor provided one: true -> shown, false -> omit (Sigma default
     # is off). Verified `dataLabel:{labels:"shown"}` persists + renders for bar AND

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
@@ -66,7 +66,7 @@ HBAR_TYPES = {"barChart", "clusteredBarChart", "stackedBarChart",
 # NOT valid — the API rejects it as "Invalid value: string" (beads-sigma-pi8v).
 # IMPORTANT: emit "none" explicitly — a multi-series Sigma bar defaults to
 # STACKED, so a clustered PBI chart comes out stacked otherwise.
-STACKED_TYPES = {"stackedBarChart", "stackedColumnChart",
+STACKED_TYPES = {"stackedBarChart", "stackedColumnChart", "stackedAreaChart",
                  "hundredPercentStackedBarChart", "hundredPercentStackedColumnChart"}
 PCT_STACKED_TYPES = {"hundredPercentStackedBarChart", "hundredPercentStackedColumnChart"}
 
@@ -251,7 +251,7 @@ def extract(pbir_dir):
                 "title": _visual_title(visual),
                 "sigma_kind": VISUAL_KIND.get(vtype, "bar"),
                 "orientation": "horizontal" if vtype in HBAR_TYPES else None,
-                "stacking": _stacking(vtype) if VISUAL_KIND.get(vtype) == "bar" else None,
+                "stacking": _stacking(vtype) if VISUAL_KIND.get(vtype) in ("bar", "area") else None,
                 "x": pos.get("x", 0), "y": pos.get("y", 0),
                 "w": pos.get("width", 0), "h": pos.get("height", 0),
                 "z": pos.get("z", 0),

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-report-classic.py
@@ -236,7 +236,7 @@ def extract(report):
                 "bindings": _projections(sv, vt),
                 # bead f972: visual sort ({queryRef, direction asc|desc}) or None
                 "sort": _sort_signal(sv),
-                "stacking": _stacking(vt) if VISUAL_KIND.get(vt) == "bar" else None,
+                "stacking": _stacking(vt) if VISUAL_KIND.get(vt) in ("bar", "area") else None,
                 "formats": {},
                 # bead n9u9: PBI data-label toggle (objects.labels show) — true/false/None
                 "data_labels": _obj_flag(sv, "labels"),


### PR DESCRIPTION
PBI `areaChart` overlaps series; Sigma stacks multi-series areas by default — the Retail sample's TY/LY area read ~7M at the top edge instead of ~3.4M despite exact underlying numbers. Extractors now emit `stacking` for area kinds; builder applies it to `area-chart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)