### PR TITLE
feat(tableau): ask where to build — shared destination picker (Phase 0b)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -133,6 +133,7 @@ which calc translation, which layout) — not orchestration.
 | `scripts/build-dashboard-layout.rb` | **MANDATORY in Phase 5d** (dashboard-fidelity mode) — auto-build the Sigma layout XML from the parsed Tableau zone tree (`dashboard-layout.json`) + the workbook readback IDs (`wb-ids.json`). Positions each chart at the grid cell derived from its zone's x/y/w/h%. Without this step, the workbook PUTs without a top-level layout and Sigma renders elements as a single-column stack — see `assert-phase6-ran.rb` gate 4 (beads-sigma-bw3). |
 | `scripts/build-story-pages.rb` | **Story workbooks only** — when `parse-twb-layout.rb` wrote `story-plan.json`, emit one Sigma page per story point: pass 1 (`--spec`/`--out`) appends caption-named pages (annotation text atop + cloned elements with fresh ids/controlIds) to the workbook spec pre-POST; pass 2 (`--wb-ids`/`--layout-out`) emits the banded per-page layout + container sidecar post-readback. See `refs/story-points.md`. |
 | `scripts/export-chart-png.rb` | Phase 6d (visual): export PNG screenshots of every chart in the converted Sigma workbook via `/v2/workbooks/{wb}/export` → `/v2/query/{q}/download`. Catches visual regressions CSV value parity can miss (silently-dropped log scale, missing data labels, wrong chart kind, palette drift). Output: per-element PNGs + `_manifest.json`. Pair with the Tableau MCP `get-view-image` to side-by-side compare source vs target. **Mandatory gate: Read each PNG and check it against `refs/layout-visual-qa.md`, then loop-fix-and-re-render until clean — never declare done on HTTP 200.** |
+| `scripts/pick-destination.rb` | **Phase 0b:** list build destinations (`list` → workspaces + editable folders + My Documents) and create folders (`create --name [--parent]`). Drives the "where should this land?" prompt when no `--folder`/`SIGMA_FOLDER_ID` is given. `folderId` accepts a workspace id (workspace root) or a folder id. Shared across the migration skills. |
 | `scripts/find-or-pick-dm.rb` | Phase 1.5: scan existing DMs in the org and recommend reuse when one already covers the workbook's columns. Score = 0.7·column-overlap + 0.2·table-overlap + 0.1·metric-overlap. Parallel-fetches DM specs (~2s for 50 DMs). Output: `dm-match.json` with ranked candidates + recommendation. Non-destructive. Reuse skips Phase 2 + 3 entirely. `--auto-pick` flag (with tie-window safety) skips the user-confirm step when there's a clear winner. |
 | `scripts/inspect-dm-shape.rb` | Phase 1.5b (MANDATORY when reusing): inspect the reused DM's element graph and emit a denormalization plan classifying every column as `fact` (direct ref) or `dim` (needs Lookup). Output: `dm-denorm-plan.json` with the exact Lookup formula per dim column. Eliminates the 2–3 min spec-rework loop when the reused DM has separate dim elements (a non-pre-denormalized DM shape). |
 | `scripts/scan-customer-style.rb` | Phase 0c: sample N recent workbooks in the customer's Sigma org and aggregate style signals (color palettes, number-format strings, layout grids, chart-kind mix, dataLabel preference, element naming case, density). Lets the converter emit specs that match house conventions instead of generic defaults. |
@@ -262,6 +263,32 @@ Categories emitted:
 
 Share the markdown report with the customer up front to set expectations.
 Save the JSON for the subagent.
+
+## Phase 0b — Choose where to build (MANDATORY when no destination given)
+
+Never silently dump the migrated data model + workbook into an auto-picked
+folder. If the user did **not** supply a destination (no `--folder <id>` on
+`migrate-tableau.rb` and no `SIGMA_FOLDER_ID`), ASK first:
+
+1. List candidates:
+   ```bash
+   ruby scripts/pick-destination.rb list
+   # -> { "workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}], "myDocuments": <id|null> }
+   ```
+2. Present the options to the user and let them pick ONE:
+   - a **workspace** (content lands in the workspace root — pass its `id` as the folder)
+   - an existing **folder** (use its `id`; `parentName` shows its workspace)
+   - **My Documents** (only when `myDocuments` is non-null — null for service-account tokens)
+   - **create a new folder** (optionally inside a chosen workspace/folder):
+     ```bash
+     ruby scripts/pick-destination.rb create --name "<name>" [--parent <workspace-or-folder-id>]
+     # -> { "id", "name", "parentId" }
+     ```
+3. Pass the chosen id to the migration as `--folder <id>` — it flows into both
+   the DM and workbook POSTs.
+
+`folderId` accepts a workspace id (lands in the root) **or** a folder id. If the
+user already passed `--folder` / `SIGMA_FOLDER_ID`, honor it silently — do NOT ask.
 
 > **Data blending:** when the scanner writes `blend-plan.json`, route each
 > blend BEFORE Phase 2 using its `route` field — (a) `same-warehouse-repoint`

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/pick-destination.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/pick-destination.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Shared destination picker for the *-to-sigma migration skills.
+# Produces the folderId where a migrated data model + workbook should land.
+# The SKILL drives the *asking*; this script just lists candidates and creates folders.
+#
+#   ruby pick-destination.rb list
+#       -> JSON { "workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}],
+#                 "myDocuments": "<id>"|null }
+#       Only folders the token can EDIT are returned. folderId in a DM/workbook POST
+#       accepts either a workspace id (lands in the workspace root) or a folder id.
+#
+#   ruby pick-destination.rb create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+#       -> JSON { "id", "name", "parentId" }
+#       Creates a folder. --parent may be a workspace id, a folder id, or omitted
+#       (then it lands in My Documents when resolvable, else org root).
+#
+# Env: SIGMA_BASE_URL + SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (or SIGMA_API_TOKEN).
+require 'json'
+require_relative 'lib/sigma_rest'
+
+def my_documents_id
+  # Only resolvable for a user-bound token; service-account tokens return nil.
+  uid = (Sigma.request(:get, '/v2/whoami') rescue {})&.dig('userId')
+  return nil unless uid && !uid.to_s.empty?
+  entries = ((Sigma.request(:get, "/v2/members/#{uid}/files?typeFilters=folder&limit=500") rescue {}) || {})['entries'] || []
+  hit = entries.find { |e| e['name'] == 'My Documents' || e['path'] == 'My Documents' }
+  hit && hit['id']
+rescue StandardError
+  nil
+end
+
+def cmd_list
+  workspaces = (((Sigma.request(:get, '/v2/workspaces?limit=500') rescue {}) || {})['entries'] || [])
+               .map { |w| { 'id' => w['workspaceId'] || w['id'], 'name' => w['name'] } }
+  ws_name = workspaces.each_with_object({}) { |w, h| h[w['id']] = w['name'] }
+  folders = (((Sigma.request(:get, '/v2/files?typeFilters=folder&limit=500') rescue {}) || {})['entries'] || [])
+            .select { |f| f['permission'] == 'edit' }
+            .map { |f| { 'id' => f['id'], 'name' => f['name'], 'parentId' => f['parentId'],
+                         'parentName' => ws_name[f['parentId']] } }
+  puts JSON.pretty_generate('workspaces' => workspaces, 'folders' => folders,
+                            'myDocuments' => my_documents_id)
+end
+
+def cmd_create(argv)
+  name = nil
+  parent = nil
+  i = 0
+  while i < argv.length
+    case argv[i]
+    when '--name'   then name = argv[i + 1]; i += 2
+    when '--parent' then parent = argv[i + 1]; i += 2
+    else i += 1
+    end
+  end
+  abort('pick-destination create: --name is required') if name.nil? || name.empty?
+  parent ||= my_documents_id
+  body = { 'type' => 'folder', 'name' => name }
+  body['parentId'] = parent if parent && !parent.to_s.empty?
+  res = Sigma.request(:post, '/v2/files', body: JSON.dump(body))
+  puts JSON.pretty_generate('id' => res['id'], 'name' => res['name'], 'parentId' => res['parentId'])
+end
+
+case ARGV[0]
+when 'list', nil then cmd_list
+when 'create'    then cmd_create(ARGV[1..])
+else abort("usage: pick-destination.rb [list | create --name NAME [--parent ID]]")
+end


### PR DESCRIPTION
First of two PRs (reference-first rollout). Adds a **"where should this land?"** step so migration skills stop silently auto-picking a destination folder.

## What
- **`scripts/pick-destination.rb`** (shared helper):
  - `list` → workspaces + editable folders (grouped by workspace) + My Documents
  - `create --name "<n>" [--parent <id>]` → create a folder (parent may be a workspace or folder id)
- **tableau SKILL.md Phase 0b** (mandatory when no `--folder`/`SIGMA_FOLDER_ID`): list candidates → ask the user (workspace / existing folder / My Documents / create new) → pass the chosen id as `--folder`.

## Verified live
- `folderId` in a DM/workbook POST accepts a **workspace id** (lands in the workspace root) or a **folder id**.
- `list` returns 7 workspaces + 33 editable folders + resolved My Documents; `create` makes a folder under a workspace and returns its id (round-tripped + cleaned up).
- My Documents is null for service-account tokens (handled gracefully).
- If `--folder`/`SIGMA_FOLDER_ID` is set, it's honored silently (preserves automation).

## Next
PR 2 rolls this out to the other 7 skills (Ruby/Python/Node ports of the helper + a Phase 0b step each), and removes the two hard-abort-without-folder paths (microstrategy, quicksight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)