### PR TITLE
feat: roll out destination picker (Phase 0) to the remaining 7 migration skills

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -11,6 +11,19 @@ user-invocable: true
 
 # Cognos → Sigma migration
 
+## Phase 0 — Choose where to build (ask first when no destination given)
+
+Don't silently land the migrated data model + workbook in My Documents.
+If the user didn't supply a destination (no `--folder <id>`), ASK before building:
+
+1. `node scripts/pick-destination.mjs list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root),
+   an existing **folder**, **My Documents** (when non-null — null for service tokens), or
+   **create a new folder**: `node scripts/pick-destination.mjs create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Pass the chosen id as `--folder <id>`. `folderId` accepts a workspace id or a folder id.
+
+If a destination is already supplied, honor it silently — don't ask.
+
 Convert a Cognos **Data Module** into a Sigma **data model**, then convert the Cognos
 **report** that sits on it into a matching Sigma **workbook**. Translate what maps
 cleanly; **flag what doesn't** (runtime macros, running-totals, localization) instead

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/pick-destination.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/pick-destination.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Shared destination picker for the *-to-sigma migration skills (Node port).
+// Produces the folderId where a migrated data model + workbook should land.
+// The SKILL drives the *asking*; this script lists candidates and creates folders.
+//
+//   node pick-destination.mjs list
+//       -> { workspaces:[{id,name}], folders:[{id,name,parentId,parentName}], myDocuments }
+//   node pick-destination.mjs create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+//       -> { id, name, parentId }
+//
+// Auth: SIGMA_API_TOKEN + SIGMA_BASE_URL if set; else minted from
+// SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (sourced from ~/.sigma-migration/env).
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function loadNeutralEnv() {
+  if (process.env.SIGMA_CLIENT_ID || process.env.SIGMA_API_TOKEN) return;
+  const p = path.join(os.homedir(), '.sigma-migration', 'env');
+  if (!fs.existsSync(p)) return;
+  for (const line of fs.readFileSync(p, 'utf8').split('\n')) {
+    const t = line.trim();
+    if (!t || t.startsWith('#') || !t.includes('=')) continue;
+    const idx = t.indexOf('=');
+    const k = t.slice(0, idx).trim();
+    const v = t.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+    if (process.env[k] === undefined) process.env[k] = v;
+  }
+}
+
+const BASE = () => (process.env.SIGMA_BASE_URL || 'https://aws-api.sigmacomputing.com').replace(/\/$/, '');
+let TOK = null;
+async function token() {
+  if (process.env.SIGMA_API_TOKEN) return process.env.SIGMA_API_TOKEN;
+  loadNeutralEnv();
+  const body = new URLSearchParams({ grant_type: 'client_credentials',
+    client_id: process.env.SIGMA_CLIENT_ID, client_secret: process.env.SIGMA_CLIENT_SECRET });
+  const r = await fetch(BASE() + '/v2/auth/token', { method: 'POST', body });
+  return (await r.json()).access_token;
+}
+async function call(method, p, body) {
+  if (!TOK) TOK = await token();
+  const r = await fetch(BASE() + p, { method,
+    headers: { Authorization: 'Bearer ' + TOK, 'Content-Type': 'application/json' },
+    body: body !== undefined ? JSON.stringify(body) : undefined });
+  const raw = await r.text();
+  if (!r.ok) { console.error(`${method} ${p} -> ${r.status} ${raw.slice(0, 300)}`); process.exit(1); }
+  return raw ? JSON.parse(raw) : {};
+}
+async function myDocumentsId() {
+  try {
+    const uid = (await call('GET', '/v2/whoami'))?.userId;
+    if (!uid) return null;
+    const entries = (await call('GET', `/v2/members/${uid}/files?typeFilters=folder&limit=500`))?.entries || [];
+    const hit = entries.find(e => e.name === 'My Documents' || e.path === 'My Documents');
+    return hit ? hit.id : null;
+  } catch { return null; }
+}
+async function cmdList() {
+  const ws = ((await call('GET', '/v2/workspaces?limit=500')).entries || [])
+    .map(w => ({ id: w.workspaceId || w.id, name: w.name }));
+  const wsName = Object.fromEntries(ws.map(w => [w.id, w.name]));
+  const folders = ((await call('GET', '/v2/files?typeFilters=folder&limit=500')).entries || [])
+    .filter(f => f.permission === 'edit')
+    .map(f => ({ id: f.id, name: f.name, parentId: f.parentId, parentName: wsName[f.parentId] || null }));
+  console.log(JSON.stringify({ workspaces: ws, folders, myDocuments: await myDocumentsId() }, null, 2));
+}
+async function cmdCreate(argv) {
+  let name = null, parent = null;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--name') { name = argv[++i]; }
+    else if (argv[i] === '--parent') { parent = argv[++i]; }
+  }
+  if (!name) { console.error('pick-destination create: --name is required'); process.exit(1); }
+  if (!parent) parent = await myDocumentsId();
+  const body = { type: 'folder', name };
+  if (parent) body.parentId = parent;
+  const res = await call('POST', '/v2/files', body);
+  console.log(JSON.stringify({ id: res.id, name: res.name, parentId: res.parentId }, null, 2));
+}
+const cmd = process.argv[2] || 'list';
+if (cmd === 'list') await cmdList();
+else if (cmd === 'create') await cmdCreate(process.argv.slice(3));
+else { console.error('usage: pick-destination.mjs [list | create --name NAME [--parent ID]]'); process.exit(1); }

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -14,6 +14,19 @@ user-invocable: true
 
 # Looker → Sigma Conversion
 
+## Phase 0 — Choose where to build (ask first when no destination given)
+
+Don't silently land the migrated data model + workbook in an auto-picked folder.
+If the user didn't supply a destination (no `--folder <id>` and no `SIGMA_FOLDER_ID`), ASK before building:
+
+1. `python3 scripts/pick_destination.py list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root),
+   an existing **folder**, **My Documents** (when non-null — null for service tokens), or
+   **create a new folder**: `python3 scripts/pick_destination.py create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Pass the chosen id as `--folder <id>`. `folderId` accepts a workspace id or a folder id.
+
+If a destination is already supplied, honor it silently — don't ask.
+
 Convert a Looker LookML semantic model into a Sigma data model, then build Sigma
 workbook(s) that mirror the Looker dashboards (user-defined OR LookML-defined) as
 closely as possible — and verify the numbers match Looker AND the warehouse.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/pick_destination.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/pick_destination.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Shared destination picker for the *-to-sigma migration skills (Python port).
+Produces the folderId where a migrated data model + workbook should land.
+The SKILL drives the *asking*; this script lists candidates and creates folders.
+
+  python3 pick_destination.py list
+      -> {"workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}],
+          "myDocuments": "<id>"|null}
+      Only EDIT-able folders are returned. folderId in a DM/workbook POST accepts
+      a workspace id (lands in the workspace root) or a folder id.
+
+  python3 pick_destination.py create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+      -> {"id","name","parentId"}
+
+Auth: SIGMA_API_TOKEN + SIGMA_BASE_URL if set (e.g. via get-token.sh); otherwise
+minted from SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (sourced from ~/.sigma-migration/env).
+"""
+import json, os, sys, urllib.request, urllib.parse, urllib.error
+
+def _load_neutral_env():
+    if os.environ.get("SIGMA_CLIENT_ID") or os.environ.get("SIGMA_API_TOKEN"):
+        return
+    p = os.path.expanduser("~/.sigma-migration/env")
+    if os.path.exists(p):
+        for line in open(p):
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+def _base():
+    return os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com").rstrip("/")
+
+def _token():
+    tok = os.environ.get("SIGMA_API_TOKEN")
+    if tok:
+        return tok
+    _load_neutral_env()
+    data = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "client_id": os.environ["SIGMA_CLIENT_ID"],
+        "client_secret": os.environ["SIGMA_CLIENT_SECRET"],
+    }).encode()
+    req = urllib.request.Request(_base() + "/v2/auth/token", data=data)
+    return json.load(urllib.request.urlopen(req))["access_token"]
+
+_TOK = None
+def call(method, path, body=None):
+    global _TOK
+    if _TOK is None:
+        _TOK = _token()
+    url = _base() + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method,
+        headers={"Authorization": "Bearer " + _TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"{method} {path} -> {e.code} {e.read().decode()[:300]}")
+
+def my_documents_id():
+    try:
+        uid = (call("GET", "/v2/whoami") or {}).get("userId")
+        if not uid:
+            return None
+        entries = (call("GET", f"/v2/members/{uid}/files?typeFilters=folder&limit=500") or {}).get("entries", [])
+        for e in entries:
+            if e.get("name") == "My Documents" or e.get("path") == "My Documents":
+                return e.get("id")
+    except Exception:
+        return None
+    return None
+
+def cmd_list():
+    ws = (call("GET", "/v2/workspaces?limit=500") or {}).get("entries", [])
+    workspaces = [{"id": w.get("workspaceId") or w.get("id"), "name": w.get("name")} for w in ws]
+    ws_name = {w["id"]: w["name"] for w in workspaces}
+    fl = (call("GET", "/v2/files?typeFilters=folder&limit=500") or {}).get("entries", [])
+    folders = [{"id": f["id"], "name": f["name"], "parentId": f.get("parentId"),
+                "parentName": ws_name.get(f.get("parentId"))}
+               for f in fl if f.get("permission") == "edit"]
+    print(json.dumps({"workspaces": workspaces, "folders": folders,
+                      "myDocuments": my_documents_id()}, indent=2))
+
+def cmd_create(argv):
+    name = parent = None
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--name":
+            name = argv[i + 1]; i += 2
+        elif argv[i] == "--parent":
+            parent = argv[i + 1]; i += 2
+        else:
+            i += 1
+    if not name:
+        raise SystemExit("pick_destination create: --name is required")
+    if not parent:
+        parent = my_documents_id()
+    body = {"type": "folder", "name": name}
+    if parent:
+        body["parentId"] = parent
+    res = call("POST", "/v2/files", body)
+    print(json.dumps({"id": res.get("id"), "name": res.get("name"), "parentId": res.get("parentId")}, indent=2))
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "list"
+    if cmd == "list":
+        cmd_list()
+    elif cmd == "create":
+        cmd_create(sys.argv[2:])
+    else:
+        raise SystemExit("usage: pick_destination.py [list | create --name NAME [--parent ID]]")

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -13,6 +13,19 @@ user-invocable: true
 
 # MicroStrategy → Sigma migration
 
+## Phase 0 — Choose where to build (ask first; `--folder-id` is required downstream)
+
+Don't pick the destination folder for the user. `convert.py` requires `--folder-id`,
+so resolve it WITH the user before building:
+
+1. `python3 scripts/pick_destination.py list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root),
+   an existing **folder**, **My Documents** (when non-null — null for service tokens), or
+   **create a new folder**: `python3 scripts/pick_destination.py create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Pass the chosen id as `--folder-id <id>`. `folderId` accepts a workspace id or a folder id.
+
+If the user already named a destination, honor it silently — don't ask.
+
 Extract a MicroStrategy **dossier + its full semantic model** into one
 `bundle.json`, convert it to a Sigma **data model** (table sources + joins +
 metrics) and a matching **workbook**, then **verify row-level parity** against

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/pick_destination.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/pick_destination.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Shared destination picker for the *-to-sigma migration skills (Python port).
+Produces the folderId where a migrated data model + workbook should land.
+The SKILL drives the *asking*; this script lists candidates and creates folders.
+
+  python3 pick_destination.py list
+      -> {"workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}],
+          "myDocuments": "<id>"|null}
+      Only EDIT-able folders are returned. folderId in a DM/workbook POST accepts
+      a workspace id (lands in the workspace root) or a folder id.
+
+  python3 pick_destination.py create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+      -> {"id","name","parentId"}
+
+Auth: SIGMA_API_TOKEN + SIGMA_BASE_URL if set (e.g. via get-token.sh); otherwise
+minted from SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (sourced from ~/.sigma-migration/env).
+"""
+import json, os, sys, urllib.request, urllib.parse, urllib.error
+
+def _load_neutral_env():
+    if os.environ.get("SIGMA_CLIENT_ID") or os.environ.get("SIGMA_API_TOKEN"):
+        return
+    p = os.path.expanduser("~/.sigma-migration/env")
+    if os.path.exists(p):
+        for line in open(p):
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+def _base():
+    return os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com").rstrip("/")
+
+def _token():
+    tok = os.environ.get("SIGMA_API_TOKEN")
+    if tok:
+        return tok
+    _load_neutral_env()
+    data = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "client_id": os.environ["SIGMA_CLIENT_ID"],
+        "client_secret": os.environ["SIGMA_CLIENT_SECRET"],
+    }).encode()
+    req = urllib.request.Request(_base() + "/v2/auth/token", data=data)
+    return json.load(urllib.request.urlopen(req))["access_token"]
+
+_TOK = None
+def call(method, path, body=None):
+    global _TOK
+    if _TOK is None:
+        _TOK = _token()
+    url = _base() + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method,
+        headers={"Authorization": "Bearer " + _TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"{method} {path} -> {e.code} {e.read().decode()[:300]}")
+
+def my_documents_id():
+    try:
+        uid = (call("GET", "/v2/whoami") or {}).get("userId")
+        if not uid:
+            return None
+        entries = (call("GET", f"/v2/members/{uid}/files?typeFilters=folder&limit=500") or {}).get("entries", [])
+        for e in entries:
+            if e.get("name") == "My Documents" or e.get("path") == "My Documents":
+                return e.get("id")
+    except Exception:
+        return None
+    return None
+
+def cmd_list():
+    ws = (call("GET", "/v2/workspaces?limit=500") or {}).get("entries", [])
+    workspaces = [{"id": w.get("workspaceId") or w.get("id"), "name": w.get("name")} for w in ws]
+    ws_name = {w["id"]: w["name"] for w in workspaces}
+    fl = (call("GET", "/v2/files?typeFilters=folder&limit=500") or {}).get("entries", [])
+    folders = [{"id": f["id"], "name": f["name"], "parentId": f.get("parentId"),
+                "parentName": ws_name.get(f.get("parentId"))}
+               for f in fl if f.get("permission") == "edit"]
+    print(json.dumps({"workspaces": workspaces, "folders": folders,
+                      "myDocuments": my_documents_id()}, indent=2))
+
+def cmd_create(argv):
+    name = parent = None
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--name":
+            name = argv[i + 1]; i += 2
+        elif argv[i] == "--parent":
+            parent = argv[i + 1]; i += 2
+        else:
+            i += 1
+    if not name:
+        raise SystemExit("pick_destination create: --name is required")
+    if not parent:
+        parent = my_documents_id()
+    body = {"type": "folder", "name": name}
+    if parent:
+        body["parentId"] = parent
+    res = call("POST", "/v2/files", body)
+    print(json.dumps({"id": res.get("id"), "name": res.get("name"), "parentId": res.get("parentId")}, indent=2))
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "list"
+    if cmd == "list":
+        cmd_list()
+    elif cmd == "create":
+        cmd_create(sys.argv[2:])
+    else:
+        raise SystemExit("usage: pick_destination.py [list | create --name NAME [--parent ID]]")

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -6,6 +6,19 @@ user-invocable: true
 
 # Power BI → Sigma
 
+## Phase 0 — Choose where to build (ask first when no destination given)
+
+Don't silently land the migrated data model + workbook in an auto-picked folder.
+If the user didn't supply a destination (no `--folder <id>`), ASK before building:
+
+1. `ruby scripts/pick-destination.rb list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root),
+   an existing **folder**, **My Documents** (when non-null — null for service tokens), or
+   **create a new folder**: `ruby scripts/pick-destination.rb create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Pass the chosen id as `--folder <id>`. `folderId` accepts a workspace id or a folder id.
+
+If a destination is already supplied, honor it silently — don't ask.
+
 > Status: **foundation** (validated end-to-end 2026-05-31 on the "Employee Dashboard" workforce report).
 > Beads: build = `beads-sigma-cs2`; converter gaps = `j89` (M-Snowflake path), `tkd` (element names / schemaVersion / folderId).
 > Defers to: `sigma-workbooks` (canonical workbook spec), `sigma-data-models` (DM spec), the `convert_powerbi_to_sigma` MCP tool, and `tableau-to-sigma/scripts/*` (reused verbatim for posting + layout + parity).

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pick-destination.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pick-destination.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Shared destination picker for the *-to-sigma migration skills.
+# Produces the folderId where a migrated data model + workbook should land.
+# The SKILL drives the *asking*; this script just lists candidates and creates folders.
+#
+#   ruby pick-destination.rb list
+#       -> JSON { "workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}],
+#                 "myDocuments": "<id>"|null }
+#       Only folders the token can EDIT are returned. folderId in a DM/workbook POST
+#       accepts either a workspace id (lands in the workspace root) or a folder id.
+#
+#   ruby pick-destination.rb create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+#       -> JSON { "id", "name", "parentId" }
+#       Creates a folder. --parent may be a workspace id, a folder id, or omitted
+#       (then it lands in My Documents when resolvable, else org root).
+#
+# Env: SIGMA_BASE_URL + SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (or SIGMA_API_TOKEN).
+require 'json'
+require_relative 'lib/sigma_rest'
+
+def my_documents_id
+  # Only resolvable for a user-bound token; service-account tokens return nil.
+  uid = (Sigma.request(:get, '/v2/whoami') rescue {})&.dig('userId')
+  return nil unless uid && !uid.to_s.empty?
+  entries = ((Sigma.request(:get, "/v2/members/#{uid}/files?typeFilters=folder&limit=500") rescue {}) || {})['entries'] || []
+  hit = entries.find { |e| e['name'] == 'My Documents' || e['path'] == 'My Documents' }
+  hit && hit['id']
+rescue StandardError
+  nil
+end
+
+def cmd_list
+  workspaces = (((Sigma.request(:get, '/v2/workspaces?limit=500') rescue {}) || {})['entries'] || [])
+               .map { |w| { 'id' => w['workspaceId'] || w['id'], 'name' => w['name'] } }
+  ws_name = workspaces.each_with_object({}) { |w, h| h[w['id']] = w['name'] }
+  folders = (((Sigma.request(:get, '/v2/files?typeFilters=folder&limit=500') rescue {}) || {})['entries'] || [])
+            .select { |f| f['permission'] == 'edit' }
+            .map { |f| { 'id' => f['id'], 'name' => f['name'], 'parentId' => f['parentId'],
+                         'parentName' => ws_name[f['parentId']] } }
+  puts JSON.pretty_generate('workspaces' => workspaces, 'folders' => folders,
+                            'myDocuments' => my_documents_id)
+end
+
+def cmd_create(argv)
+  name = nil
+  parent = nil
+  i = 0
+  while i < argv.length
+    case argv[i]
+    when '--name'   then name = argv[i + 1]; i += 2
+    when '--parent' then parent = argv[i + 1]; i += 2
+    else i += 1
+    end
+  end
+  abort('pick-destination create: --name is required') if name.nil? || name.empty?
+  parent ||= my_documents_id
+  body = { 'type' => 'folder', 'name' => name }
+  body['parentId'] = parent if parent && !parent.to_s.empty?
+  res = Sigma.request(:post, '/v2/files', body: JSON.dump(body))
+  puts JSON.pretty_generate('id' => res['id'], 'name' => res['name'], 'parentId' => res['parentId'])
+end
+
+case ARGV[0]
+when 'list', nil then cmd_list
+when 'create'    then cmd_create(ARGV[1..])
+else abort("usage: pick-destination.rb [list | create --name NAME [--parent ID]]")
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -12,6 +12,19 @@ user-invocable: true
 
 # Qlik → Sigma Conversion
 
+## Phase 0 — Choose where to build (ask first when no destination given)
+
+Don't silently land the migrated data model + workbook in an auto-picked folder.
+If the user didn't supply a destination (no `--folder <id>`), ASK before building:
+
+1. `ruby scripts/pick-destination.rb list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root),
+   an existing **folder**, **My Documents** (when non-null — null for service tokens), or
+   **create a new folder**: `ruby scripts/pick-destination.rb create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Pass the chosen id as `--folder <id>`. `folderId` accepts a workspace id or a folder id.
+
+If a destination is already supplied, honor it silently — don't ask.
+
 > **STATUS: VALIDATED end-to-end (2026-06-02; generalized + re-validated 2026-06-10).**
 > The full flow below was proven on a real migration ("Retail Orders (Qlik)" → Sigma)
 > with **exact parity** to the Snowflake source at the data-model, denormalized-element,

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/pick-destination.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/pick-destination.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Shared destination picker for the *-to-sigma migration skills.
+# Produces the folderId where a migrated data model + workbook should land.
+# The SKILL drives the *asking*; this script just lists candidates and creates folders.
+#
+#   ruby pick-destination.rb list
+#       -> JSON { "workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}],
+#                 "myDocuments": "<id>"|null }
+#       Only folders the token can EDIT are returned. folderId in a DM/workbook POST
+#       accepts either a workspace id (lands in the workspace root) or a folder id.
+#
+#   ruby pick-destination.rb create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+#       -> JSON { "id", "name", "parentId" }
+#       Creates a folder. --parent may be a workspace id, a folder id, or omitted
+#       (then it lands in My Documents when resolvable, else org root).
+#
+# Env: SIGMA_BASE_URL + SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (or SIGMA_API_TOKEN).
+require 'json'
+require_relative 'lib/sigma_rest'
+
+def my_documents_id
+  # Only resolvable for a user-bound token; service-account tokens return nil.
+  uid = (Sigma.request(:get, '/v2/whoami') rescue {})&.dig('userId')
+  return nil unless uid && !uid.to_s.empty?
+  entries = ((Sigma.request(:get, "/v2/members/#{uid}/files?typeFilters=folder&limit=500") rescue {}) || {})['entries'] || []
+  hit = entries.find { |e| e['name'] == 'My Documents' || e['path'] == 'My Documents' }
+  hit && hit['id']
+rescue StandardError
+  nil
+end
+
+def cmd_list
+  workspaces = (((Sigma.request(:get, '/v2/workspaces?limit=500') rescue {}) || {})['entries'] || [])
+               .map { |w| { 'id' => w['workspaceId'] || w['id'], 'name' => w['name'] } }
+  ws_name = workspaces.each_with_object({}) { |w, h| h[w['id']] = w['name'] }
+  folders = (((Sigma.request(:get, '/v2/files?typeFilters=folder&limit=500') rescue {}) || {})['entries'] || [])
+            .select { |f| f['permission'] == 'edit' }
+            .map { |f| { 'id' => f['id'], 'name' => f['name'], 'parentId' => f['parentId'],
+                         'parentName' => ws_name[f['parentId']] } }
+  puts JSON.pretty_generate('workspaces' => workspaces, 'folders' => folders,
+                            'myDocuments' => my_documents_id)
+end
+
+def cmd_create(argv)
+  name = nil
+  parent = nil
+  i = 0
+  while i < argv.length
+    case argv[i]
+    when '--name'   then name = argv[i + 1]; i += 2
+    when '--parent' then parent = argv[i + 1]; i += 2
+    else i += 1
+    end
+  end
+  abort('pick-destination create: --name is required') if name.nil? || name.empty?
+  parent ||= my_documents_id
+  body = { 'type' => 'folder', 'name' => name }
+  body['parentId'] = parent if parent && !parent.to_s.empty?
+  res = Sigma.request(:post, '/v2/files', body: JSON.dump(body))
+  puts JSON.pretty_generate('id' => res['id'], 'name' => res['name'], 'parentId' => res['parentId'])
+end
+
+case ARGV[0]
+when 'list', nil then cmd_list
+when 'create'    then cmd_create(ARGV[1..])
+else abort("usage: pick-destination.rb [list | create --name NAME [--parent ID]]")
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -6,6 +6,19 @@ user-invocable: true
 
 # QuickSight → Sigma
 
+## Phase 0 — Choose where to build (ask first when no destination given)
+
+Don't silently land the migrated data model + workbook in an auto-picked folder.
+If the user didn't supply a destination (no `--folder <id-or-name>`), ASK before building:
+
+1. `ruby scripts/pick-destination.rb list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root),
+   an existing **folder**, **My Documents** (when non-null — null for service tokens), or
+   **create a new folder**: `ruby scripts/pick-destination.rb create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Pass the chosen id as `--folder <id>` (the downstream `--fixup` step requires a folderId).
+
+If a destination is already supplied, honor it silently — don't ask.
+
 > Status: **foundation** (converter MCP + browser shipped 2026-05-28).
 > Beads: converter = `beads-sigma-j5e`; CustomSql/DIRECT_QUERY fixup = `beads-sigma-vy4k`.
 > Defers to: `sigma-workbooks` (canonical workbook spec), `sigma-data-models` (DM spec), the `convert_quicksight_to_sigma` MCP tool, and the shared vendor-neutral Sigma-side scripts (`post-and-readback.rb`, `put-layout.rb`, `find-or-pick-dm.rb`, `verify-parity.rb`) reused across the migration skills.

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/pick-destination.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/pick-destination.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Shared destination picker for the *-to-sigma migration skills.
+# Produces the folderId where a migrated data model + workbook should land.
+# The SKILL drives the *asking*; this script just lists candidates and creates folders.
+#
+#   ruby pick-destination.rb list
+#       -> JSON { "workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}],
+#                 "myDocuments": "<id>"|null }
+#       Only folders the token can EDIT are returned. folderId in a DM/workbook POST
+#       accepts either a workspace id (lands in the workspace root) or a folder id.
+#
+#   ruby pick-destination.rb create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+#       -> JSON { "id", "name", "parentId" }
+#       Creates a folder. --parent may be a workspace id, a folder id, or omitted
+#       (then it lands in My Documents when resolvable, else org root).
+#
+# Env: SIGMA_BASE_URL + SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (or SIGMA_API_TOKEN).
+require 'json'
+require_relative 'lib/sigma_rest'
+
+def my_documents_id
+  # Only resolvable for a user-bound token; service-account tokens return nil.
+  uid = (Sigma.request(:get, '/v2/whoami') rescue {})&.dig('userId')
+  return nil unless uid && !uid.to_s.empty?
+  entries = ((Sigma.request(:get, "/v2/members/#{uid}/files?typeFilters=folder&limit=500") rescue {}) || {})['entries'] || []
+  hit = entries.find { |e| e['name'] == 'My Documents' || e['path'] == 'My Documents' }
+  hit && hit['id']
+rescue StandardError
+  nil
+end
+
+def cmd_list
+  workspaces = (((Sigma.request(:get, '/v2/workspaces?limit=500') rescue {}) || {})['entries'] || [])
+               .map { |w| { 'id' => w['workspaceId'] || w['id'], 'name' => w['name'] } }
+  ws_name = workspaces.each_with_object({}) { |w, h| h[w['id']] = w['name'] }
+  folders = (((Sigma.request(:get, '/v2/files?typeFilters=folder&limit=500') rescue {}) || {})['entries'] || [])
+            .select { |f| f['permission'] == 'edit' }
+            .map { |f| { 'id' => f['id'], 'name' => f['name'], 'parentId' => f['parentId'],
+                         'parentName' => ws_name[f['parentId']] } }
+  puts JSON.pretty_generate('workspaces' => workspaces, 'folders' => folders,
+                            'myDocuments' => my_documents_id)
+end
+
+def cmd_create(argv)
+  name = nil
+  parent = nil
+  i = 0
+  while i < argv.length
+    case argv[i]
+    when '--name'   then name = argv[i + 1]; i += 2
+    when '--parent' then parent = argv[i + 1]; i += 2
+    else i += 1
+    end
+  end
+  abort('pick-destination create: --name is required') if name.nil? || name.empty?
+  parent ||= my_documents_id
+  body = { 'type' => 'folder', 'name' => name }
+  body['parentId'] = parent if parent && !parent.to_s.empty?
+  res = Sigma.request(:post, '/v2/files', body: JSON.dump(body))
+  puts JSON.pretty_generate('id' => res['id'], 'name' => res['name'], 'parentId' => res['parentId'])
+end
+
+case ARGV[0]
+when 'list', nil then cmd_list
+when 'create'    then cmd_create(ARGV[1..])
+else abort("usage: pick-destination.rb [list | create --name NAME [--parent ID]]")
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -6,6 +6,19 @@ user-invocable: true
 
 # ThoughtSpot → Sigma migration
 
+## Phase 0 — Choose where to build (ask first when no destination given)
+
+Don't silently land the migrated data model + workbook in an auto-picked folder.
+If the user didn't supply a destination (no `SIGMA_FOLDER_ID`), ASK before building:
+
+1. `python3 scripts/pick_destination.py list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root),
+   an existing **folder**, **My Documents** (when non-null — null for service tokens), or
+   **create a new folder**: `python3 scripts/pick_destination.py create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Export the chosen id as `SIGMA_FOLDER_ID=<id>`. `folderId` accepts a workspace id or a folder id.
+
+If `SIGMA_FOLDER_ID` is already set, honor it silently — don't ask.
+
 Recreate a ThoughtSpot **model/worksheet** as a Sigma **data model**, and its
 **Liveboards** as Sigma **workbooks**, with parity verified against the live
 warehouse.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/pick_destination.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/pick_destination.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Shared destination picker for the *-to-sigma migration skills (Python port).
+Produces the folderId where a migrated data model + workbook should land.
+The SKILL drives the *asking*; this script lists candidates and creates folders.
+
+  python3 pick_destination.py list
+      -> {"workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}],
+          "myDocuments": "<id>"|null}
+      Only EDIT-able folders are returned. folderId in a DM/workbook POST accepts
+      a workspace id (lands in the workspace root) or a folder id.
+
+  python3 pick_destination.py create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+      -> {"id","name","parentId"}
+
+Auth: SIGMA_API_TOKEN + SIGMA_BASE_URL if set (e.g. via get-token.sh); otherwise
+minted from SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (sourced from ~/.sigma-migration/env).
+"""
+import json, os, sys, urllib.request, urllib.parse, urllib.error
+
+def _load_neutral_env():
+    if os.environ.get("SIGMA_CLIENT_ID") or os.environ.get("SIGMA_API_TOKEN"):
+        return
+    p = os.path.expanduser("~/.sigma-migration/env")
+    if os.path.exists(p):
+        for line in open(p):
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+def _base():
+    return os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com").rstrip("/")
+
+def _token():
+    tok = os.environ.get("SIGMA_API_TOKEN")
+    if tok:
+        return tok
+    _load_neutral_env()
+    data = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "client_id": os.environ["SIGMA_CLIENT_ID"],
+        "client_secret": os.environ["SIGMA_CLIENT_SECRET"],
+    }).encode()
+    req = urllib.request.Request(_base() + "/v2/auth/token", data=data)
+    return json.load(urllib.request.urlopen(req))["access_token"]
+
+_TOK = None
+def call(method, path, body=None):
+    global _TOK
+    if _TOK is None:
+        _TOK = _token()
+    url = _base() + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method,
+        headers={"Authorization": "Bearer " + _TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"{method} {path} -> {e.code} {e.read().decode()[:300]}")
+
+def my_documents_id():
+    try:
+        uid = (call("GET", "/v2/whoami") or {}).get("userId")
+        if not uid:
+            return None
+        entries = (call("GET", f"/v2/members/{uid}/files?typeFilters=folder&limit=500") or {}).get("entries", [])
+        for e in entries:
+            if e.get("name") == "My Documents" or e.get("path") == "My Documents":
+                return e.get("id")
+    except Exception:
+        return None
+    return None
+
+def cmd_list():
+    ws = (call("GET", "/v2/workspaces?limit=500") or {}).get("entries", [])
+    workspaces = [{"id": w.get("workspaceId") or w.get("id"), "name": w.get("name")} for w in ws]
+    ws_name = {w["id"]: w["name"] for w in workspaces}
+    fl = (call("GET", "/v2/files?typeFilters=folder&limit=500") or {}).get("entries", [])
+    folders = [{"id": f["id"], "name": f["name"], "parentId": f.get("parentId"),
+                "parentName": ws_name.get(f.get("parentId"))}
+               for f in fl if f.get("permission") == "edit"]
+    print(json.dumps({"workspaces": workspaces, "folders": folders,
+                      "myDocuments": my_documents_id()}, indent=2))
+
+def cmd_create(argv):
+    name = parent = None
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--name":
+            name = argv[i + 1]; i += 2
+        elif argv[i] == "--parent":
+            parent = argv[i + 1]; i += 2
+        else:
+            i += 1
+    if not name:
+        raise SystemExit("pick_destination create: --name is required")
+    if not parent:
+        parent = my_documents_id()
+    body = {"type": "folder", "name": name}
+    if parent:
+        body["parentId"] = parent
+    res = call("POST", "/v2/files", body)
+    print(json.dumps({"id": res.get("id"), "name": res.get("name"), "parentId": res.get("parentId")}, indent=2))
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "list"
+    if cmd == "list":
+        cmd_list()
+    elif cmd == "create":
+        cmd_create(sys.argv[2:])
+    else:
+        raise SystemExit("usage: pick_destination.py [list | create --name NAME [--parent ID]]")


### PR DESCRIPTION
Second of two PRs (follows #88, which did tableau). Every `*-to-sigma` skill now **asks where to build** — workspace / existing folder / My Documents / create-new — when no destination is supplied.

## What
- Shared `pick-destination` helper ported to all 7 (identical JSON shape as tableau's):
  - **Ruby** (`pick-destination.rb`, via `lib/sigma_rest.rb`): powerbi, quicksight, qlik
  - **Python** (`pick_destination.py`, self-contained token): looker, thoughtspot, microstrategy
  - **Node** (`pick-destination.mjs`, self-contained token): cognos
- A **Phase 0** step in each SKILL.md: list → ask → pass the chosen id the way that skill already accepts it (`--folder`, microstrategy `--folder-id`, thoughtspot `SIGMA_FOLDER_ID`).
- The two required-folder contracts (microstrategy `--folder-id`, quicksight `--fixup`) are now always satisfied by Phase 0 instead of hitting a silent default / abort.

## Verified
- `list` smoke-tested across **Ruby / Python / Node** against the live org — identical results (7 workspaces, 33 editable folders, My Documents resolved).
- All scripts pass `ruby -c` / `py_compile` / `node --check`.
- `folderId` accepts a workspace id (workspace root) or a folder id (verified in #88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)