### PR TITLE
fix: promote bead-s6fo verify-parity day-grain/full-width fix to stale plugins

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-parity.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-parity.rb
@@ -48,27 +48,47 @@ MONTH_NUM = {
   'jul' => 7, 'aug' => 8, 'sep' => 9, 'sept' => 9, 'oct' => 10, 'nov' => 11, 'dec' => 12
 }.freeze
 
-# Canonicalize date-like dimension values so monthly buckets compare equal across
-# representations (e.g. Sigma raw SQL "2026-01-01T00:00:00.000" vs Tableau view
-# label "January 2026" both → "2026-01"). Non-date strings pass through.
+# Canonicalize date-like dimension values to a DAY-grain key so buckets compare
+# equal across representations:
+#   Sigma raw SQL "2026-01-04T00:00:00.000"   → "2026-01-04"
+#   Tableau weekly label "February 4, 2024"   → "2024-02-04"
+#   Tableau monthly label "January 2026"      → "2026-01"
+# Weekly grains MUST keep the underlying date value (bead s6fo) — the old
+# collapse-day-1-to-month rule turned the "January 1" WEEK bucket into a month
+# bucket and every weekly chart diverged. Month-label vs first-of-month is
+# reconciled by strict_compare's month-grain fallback, not here.
 def canonicalize_dim(v)
   return v unless v.is_a?(String)
   s = v.strip
-  # ISO datetime, day=1, midnight → month bucket (T or space separator)
-  if (m = s.match(/\A(\d{4})-(\d{2})-01[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
-    return "#{m[1]}-#{m[2]}"
+  # ISO datetime at midnight → day bucket (T or space separator)
+  if (m = s.match(/\A(\d{4})-(\d{2})-(\d{2})[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
+    return "#{m[1]}-#{m[2]}-#{m[3]}"
   end
-  # ISO date, first of month → month bucket
-  if (m = s.match(/\A(\d{4})-(\d{2})-01\z/))
-    return "#{m[1]}-#{m[2]}"
+  # ISO date stays a day bucket
+  return s if s.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+  # "February 4, 2024" / "Feb 4, 2024" (Tableau day/week labels)
+  if (m = s.match(/\A([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
+    return format('%s-%02d-%02d', m[3], mnum, m[2].to_i)
   end
-  # "January 2026" / "Jan 2026"
+  # "January 2026" / "Jan 2026" → month bucket
   if (m = s.match(/\A([A-Za-z]+)\s+(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
     return format('%s-%02d', m[2], mnum)
+  end
+  # "2024 Q1" (Tableau quarter label) → first-of-quarter DAY bucket so it
+  # compares equal to Sigma's DateTrunc("quarter") value ("2024-01-01T00:00:00"
+  # canonicalizes to "2024-01-01" above). Added for window-function pivots
+  # (WINPROBE MaxMin: Region × Quarter grid).
+  if (m = s.match(/\A(\d{4})\s+Q([1-4])\z/i))
+    return format('%s-%02d-01', m[1], ((m[2].to_i - 1) * 3) + 1)
   end
   # Already-canonical "YYYY-MM"
   return s if s.match?(/\A\d{4}-\d{2}\z/)
   v
+end
+
+# Truncate a canonical day key to its month bucket (month-grain fallback).
+def month_grain(v)
+  v.is_a?(String) && v.match?(/\A\d{4}-\d{2}-\d{2}\z/) ? v[0, 7] : v
 end
 
 def round_row(row)
@@ -84,15 +104,33 @@ def round_row(row)
 end
 
 def strict_compare(exp, act)
-  exp_set = Set.new(exp.map { |r| r.first(2) })
-  act_set = Set.new(act.map { |r| r.first(2) })
-  if exp_set == act_set
-    { status: 'PASS', only_in_tableau: [], only_in_sigma: [] }
-  else
-    { status: 'DIVERGE',
-      only_in_tableau: (exp_set - act_set).to_a,
-      only_in_sigma:   (act_set - exp_set).to_a }
+  # Compare the FULL tuple width the plan carries (bead s6fo): 3-channel charts
+  # (stacked color / pivot row+col+value / scatter dim+x+y) must compare every
+  # channel — the old first(2) slice compared two dims and ignored the measure.
+  width = [(exp.map(&:size) + act.map(&:size)).max || 2, 2].max
+  exp_set = Set.new(exp.map { |r| r.first(width) })
+  act_set = Set.new(act.map { |r| r.first(width) })
+  return { status: 'PASS', only_in_tableau: [], only_in_sigma: [] } if exp_set == act_set
+
+  # Month-grain fallback — REPRESENTATION mismatches only: a monthly chart's
+  # Tableau label ("January 2026" → "2026-01") vs Sigma's DateTrunc value
+  # ("2026-01-01"). Applies ONLY when one side carries month-form keys and the
+  # other day-form keys — two day-form sides (e.g. weekly buckets shifted a
+  # day) must keep diverging.
+  month_form = ->(set) { set.any? { |r| r[0].is_a?(String) && r[0].match?(/\A\d{4}-\d{2}\z/) } }
+  day_form   = ->(set) { set.any? { |r| r[0].is_a?(String) && r[0].match?(/\A\d{4}-\d{2}-\d{2}\z/) } }
+  if (month_form.call(exp_set) && day_form.call(act_set)) ||
+     (day_form.call(exp_set) && month_form.call(act_set))
+    to_month = ->(set) { Set.new(set.map { |r| [month_grain(r[0]), *r[1..]] }) }
+    if to_month.call(exp_set) == to_month.call(act_set)
+      return { status: 'PASS', only_in_tableau: [], only_in_sigma: [],
+               notes: ['matched at month grain (label vs first-of-month representation)'] }
+    end
   end
+
+  { status: 'DIVERGE',
+    only_in_tableau: (exp_set - act_set).to_a,
+    only_in_sigma:   (act_set - exp_set).to_a }
 end
 
 # Extract-mode: same row count + same dim set + same dim sort. Measure values

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-parity.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-parity.rb
@@ -48,27 +48,47 @@ MONTH_NUM = {
   'jul' => 7, 'aug' => 8, 'sep' => 9, 'sept' => 9, 'oct' => 10, 'nov' => 11, 'dec' => 12
 }.freeze
 
-# Canonicalize date-like dimension values so monthly buckets compare equal across
-# representations (e.g. Sigma raw SQL "2026-01-01T00:00:00.000" vs Tableau view
-# label "January 2026" both → "2026-01"). Non-date strings pass through.
+# Canonicalize date-like dimension values to a DAY-grain key so buckets compare
+# equal across representations:
+#   Sigma raw SQL "2026-01-04T00:00:00.000"   → "2026-01-04"
+#   Tableau weekly label "February 4, 2024"   → "2024-02-04"
+#   Tableau monthly label "January 2026"      → "2026-01"
+# Weekly grains MUST keep the underlying date value (bead s6fo) — the old
+# collapse-day-1-to-month rule turned the "January 1" WEEK bucket into a month
+# bucket and every weekly chart diverged. Month-label vs first-of-month is
+# reconciled by strict_compare's month-grain fallback, not here.
 def canonicalize_dim(v)
   return v unless v.is_a?(String)
   s = v.strip
-  # ISO datetime, day=1, midnight → month bucket (T or space separator)
-  if (m = s.match(/\A(\d{4})-(\d{2})-01[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
-    return "#{m[1]}-#{m[2]}"
+  # ISO datetime at midnight → day bucket (T or space separator)
+  if (m = s.match(/\A(\d{4})-(\d{2})-(\d{2})[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
+    return "#{m[1]}-#{m[2]}-#{m[3]}"
   end
-  # ISO date, first of month → month bucket
-  if (m = s.match(/\A(\d{4})-(\d{2})-01\z/))
-    return "#{m[1]}-#{m[2]}"
+  # ISO date stays a day bucket
+  return s if s.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+  # "February 4, 2024" / "Feb 4, 2024" (Tableau day/week labels)
+  if (m = s.match(/\A([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
+    return format('%s-%02d-%02d', m[3], mnum, m[2].to_i)
   end
-  # "January 2026" / "Jan 2026"
+  # "January 2026" / "Jan 2026" → month bucket
   if (m = s.match(/\A([A-Za-z]+)\s+(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
     return format('%s-%02d', m[2], mnum)
+  end
+  # "2024 Q1" (Tableau quarter label) → first-of-quarter DAY bucket so it
+  # compares equal to Sigma's DateTrunc("quarter") value ("2024-01-01T00:00:00"
+  # canonicalizes to "2024-01-01" above). Added for window-function pivots
+  # (WINPROBE MaxMin: Region × Quarter grid).
+  if (m = s.match(/\A(\d{4})\s+Q([1-4])\z/i))
+    return format('%s-%02d-01', m[1], ((m[2].to_i - 1) * 3) + 1)
   end
   # Already-canonical "YYYY-MM"
   return s if s.match?(/\A\d{4}-\d{2}\z/)
   v
+end
+
+# Truncate a canonical day key to its month bucket (month-grain fallback).
+def month_grain(v)
+  v.is_a?(String) && v.match?(/\A\d{4}-\d{2}-\d{2}\z/) ? v[0, 7] : v
 end
 
 def round_row(row)
@@ -84,15 +104,33 @@ def round_row(row)
 end
 
 def strict_compare(exp, act)
-  exp_set = Set.new(exp.map { |r| r.first(2) })
-  act_set = Set.new(act.map { |r| r.first(2) })
-  if exp_set == act_set
-    { status: 'PASS', only_in_tableau: [], only_in_sigma: [] }
-  else
-    { status: 'DIVERGE',
-      only_in_tableau: (exp_set - act_set).to_a,
-      only_in_sigma:   (act_set - exp_set).to_a }
+  # Compare the FULL tuple width the plan carries (bead s6fo): 3-channel charts
+  # (stacked color / pivot row+col+value / scatter dim+x+y) must compare every
+  # channel — the old first(2) slice compared two dims and ignored the measure.
+  width = [(exp.map(&:size) + act.map(&:size)).max || 2, 2].max
+  exp_set = Set.new(exp.map { |r| r.first(width) })
+  act_set = Set.new(act.map { |r| r.first(width) })
+  return { status: 'PASS', only_in_tableau: [], only_in_sigma: [] } if exp_set == act_set
+
+  # Month-grain fallback — REPRESENTATION mismatches only: a monthly chart's
+  # Tableau label ("January 2026" → "2026-01") vs Sigma's DateTrunc value
+  # ("2026-01-01"). Applies ONLY when one side carries month-form keys and the
+  # other day-form keys — two day-form sides (e.g. weekly buckets shifted a
+  # day) must keep diverging.
+  month_form = ->(set) { set.any? { |r| r[0].is_a?(String) && r[0].match?(/\A\d{4}-\d{2}\z/) } }
+  day_form   = ->(set) { set.any? { |r| r[0].is_a?(String) && r[0].match?(/\A\d{4}-\d{2}-\d{2}\z/) } }
+  if (month_form.call(exp_set) && day_form.call(act_set)) ||
+     (day_form.call(exp_set) && month_form.call(act_set))
+    to_month = ->(set) { Set.new(set.map { |r| [month_grain(r[0]), *r[1..]] }) }
+    if to_month.call(exp_set) == to_month.call(act_set)
+      return { status: 'PASS', only_in_tableau: [], only_in_sigma: [],
+               notes: ['matched at month grain (label vs first-of-month representation)'] }
+    end
   end
+
+  { status: 'DIVERGE',
+    only_in_tableau: (exp_set - act_set).to_a,
+    only_in_sigma:   (act_set - exp_set).to_a }
 end
 
 # Extract-mode: same row count + same dim set + same dim sort. Measure values

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-parity.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-parity.rb
@@ -48,27 +48,47 @@ MONTH_NUM = {
   'jul' => 7, 'aug' => 8, 'sep' => 9, 'sept' => 9, 'oct' => 10, 'nov' => 11, 'dec' => 12
 }.freeze
 
-# Canonicalize date-like dimension values so monthly buckets compare equal across
-# representations (e.g. Sigma raw SQL "2026-01-01T00:00:00.000" vs Tableau view
-# label "January 2026" both → "2026-01"). Non-date strings pass through.
+# Canonicalize date-like dimension values to a DAY-grain key so buckets compare
+# equal across representations:
+#   Sigma raw SQL "2026-01-04T00:00:00.000"   → "2026-01-04"
+#   Tableau weekly label "February 4, 2024"   → "2024-02-04"
+#   Tableau monthly label "January 2026"      → "2026-01"
+# Weekly grains MUST keep the underlying date value (bead s6fo) — the old
+# collapse-day-1-to-month rule turned the "January 1" WEEK bucket into a month
+# bucket and every weekly chart diverged. Month-label vs first-of-month is
+# reconciled by strict_compare's month-grain fallback, not here.
 def canonicalize_dim(v)
   return v unless v.is_a?(String)
   s = v.strip
-  # ISO datetime, day=1, midnight → month bucket (T or space separator)
-  if (m = s.match(/\A(\d{4})-(\d{2})-01[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
-    return "#{m[1]}-#{m[2]}"
+  # ISO datetime at midnight → day bucket (T or space separator)
+  if (m = s.match(/\A(\d{4})-(\d{2})-(\d{2})[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
+    return "#{m[1]}-#{m[2]}-#{m[3]}"
   end
-  # ISO date, first of month → month bucket
-  if (m = s.match(/\A(\d{4})-(\d{2})-01\z/))
-    return "#{m[1]}-#{m[2]}"
+  # ISO date stays a day bucket
+  return s if s.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+  # "February 4, 2024" / "Feb 4, 2024" (Tableau day/week labels)
+  if (m = s.match(/\A([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
+    return format('%s-%02d-%02d', m[3], mnum, m[2].to_i)
   end
-  # "January 2026" / "Jan 2026"
+  # "January 2026" / "Jan 2026" → month bucket
   if (m = s.match(/\A([A-Za-z]+)\s+(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
     return format('%s-%02d', m[2], mnum)
+  end
+  # "2024 Q1" (Tableau quarter label) → first-of-quarter DAY bucket so it
+  # compares equal to Sigma's DateTrunc("quarter") value ("2024-01-01T00:00:00"
+  # canonicalizes to "2024-01-01" above). Added for window-function pivots
+  # (WINPROBE MaxMin: Region × Quarter grid).
+  if (m = s.match(/\A(\d{4})\s+Q([1-4])\z/i))
+    return format('%s-%02d-01', m[1], ((m[2].to_i - 1) * 3) + 1)
   end
   # Already-canonical "YYYY-MM"
   return s if s.match?(/\A\d{4}-\d{2}\z/)
   v
+end
+
+# Truncate a canonical day key to its month bucket (month-grain fallback).
+def month_grain(v)
+  v.is_a?(String) && v.match?(/\A\d{4}-\d{2}-\d{2}\z/) ? v[0, 7] : v
 end
 
 def round_row(row)
@@ -84,15 +104,33 @@ def round_row(row)
 end
 
 def strict_compare(exp, act)
-  exp_set = Set.new(exp.map { |r| r.first(2) })
-  act_set = Set.new(act.map { |r| r.first(2) })
-  if exp_set == act_set
-    { status: 'PASS', only_in_tableau: [], only_in_sigma: [] }
-  else
-    { status: 'DIVERGE',
-      only_in_tableau: (exp_set - act_set).to_a,
-      only_in_sigma:   (act_set - exp_set).to_a }
+  # Compare the FULL tuple width the plan carries (bead s6fo): 3-channel charts
+  # (stacked color / pivot row+col+value / scatter dim+x+y) must compare every
+  # channel — the old first(2) slice compared two dims and ignored the measure.
+  width = [(exp.map(&:size) + act.map(&:size)).max || 2, 2].max
+  exp_set = Set.new(exp.map { |r| r.first(width) })
+  act_set = Set.new(act.map { |r| r.first(width) })
+  return { status: 'PASS', only_in_tableau: [], only_in_sigma: [] } if exp_set == act_set
+
+  # Month-grain fallback — REPRESENTATION mismatches only: a monthly chart's
+  # Tableau label ("January 2026" → "2026-01") vs Sigma's DateTrunc value
+  # ("2026-01-01"). Applies ONLY when one side carries month-form keys and the
+  # other day-form keys — two day-form sides (e.g. weekly buckets shifted a
+  # day) must keep diverging.
+  month_form = ->(set) { set.any? { |r| r[0].is_a?(String) && r[0].match?(/\A\d{4}-\d{2}\z/) } }
+  day_form   = ->(set) { set.any? { |r| r[0].is_a?(String) && r[0].match?(/\A\d{4}-\d{2}-\d{2}\z/) } }
+  if (month_form.call(exp_set) && day_form.call(act_set)) ||
+     (day_form.call(exp_set) && month_form.call(act_set))
+    to_month = ->(set) { Set.new(set.map { |r| [month_grain(r[0]), *r[1..]] }) }
+    if to_month.call(exp_set) == to_month.call(act_set)
+      return { status: 'PASS', only_in_tableau: [], only_in_sigma: [],
+               notes: ['matched at month grain (label vs first-of-month representation)'] }
+    end
   end
+
+  { status: 'DIVERGE',
+    only_in_tableau: (exp_set - act_set).to_a,
+    only_in_sigma:   (act_set - exp_set).to_a }
 end
 
 # Extract-mode: same row count + same dim set + same dim sort. Measure values

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-parity.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-parity.rb
@@ -48,27 +48,47 @@ MONTH_NUM = {
   'jul' => 7, 'aug' => 8, 'sep' => 9, 'sept' => 9, 'oct' => 10, 'nov' => 11, 'dec' => 12
 }.freeze
 
-# Canonicalize date-like dimension values so monthly buckets compare equal across
-# representations (e.g. Sigma raw SQL "2026-01-01T00:00:00.000" vs Tableau view
-# label "January 2026" both → "2026-01"). Non-date strings pass through.
+# Canonicalize date-like dimension values to a DAY-grain key so buckets compare
+# equal across representations:
+#   Sigma raw SQL "2026-01-04T00:00:00.000"   → "2026-01-04"
+#   Tableau weekly label "February 4, 2024"   → "2024-02-04"
+#   Tableau monthly label "January 2026"      → "2026-01"
+# Weekly grains MUST keep the underlying date value (bead s6fo) — the old
+# collapse-day-1-to-month rule turned the "January 1" WEEK bucket into a month
+# bucket and every weekly chart diverged. Month-label vs first-of-month is
+# reconciled by strict_compare's month-grain fallback, not here.
 def canonicalize_dim(v)
   return v unless v.is_a?(String)
   s = v.strip
-  # ISO datetime, day=1, midnight → month bucket (T or space separator)
-  if (m = s.match(/\A(\d{4})-(\d{2})-01[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
-    return "#{m[1]}-#{m[2]}"
+  # ISO datetime at midnight → day bucket (T or space separator)
+  if (m = s.match(/\A(\d{4})-(\d{2})-(\d{2})[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
+    return "#{m[1]}-#{m[2]}-#{m[3]}"
   end
-  # ISO date, first of month → month bucket
-  if (m = s.match(/\A(\d{4})-(\d{2})-01\z/))
-    return "#{m[1]}-#{m[2]}"
+  # ISO date stays a day bucket
+  return s if s.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+  # "February 4, 2024" / "Feb 4, 2024" (Tableau day/week labels)
+  if (m = s.match(/\A([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
+    return format('%s-%02d-%02d', m[3], mnum, m[2].to_i)
   end
-  # "January 2026" / "Jan 2026"
+  # "January 2026" / "Jan 2026" → month bucket
   if (m = s.match(/\A([A-Za-z]+)\s+(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
     return format('%s-%02d', m[2], mnum)
+  end
+  # "2024 Q1" (Tableau quarter label) → first-of-quarter DAY bucket so it
+  # compares equal to Sigma's DateTrunc("quarter") value ("2024-01-01T00:00:00"
+  # canonicalizes to "2024-01-01" above). Added for window-function pivots
+  # (WINPROBE MaxMin: Region × Quarter grid).
+  if (m = s.match(/\A(\d{4})\s+Q([1-4])\z/i))
+    return format('%s-%02d-01', m[1], ((m[2].to_i - 1) * 3) + 1)
   end
   # Already-canonical "YYYY-MM"
   return s if s.match?(/\A\d{4}-\d{2}\z/)
   v
+end
+
+# Truncate a canonical day key to its month bucket (month-grain fallback).
+def month_grain(v)
+  v.is_a?(String) && v.match?(/\A\d{4}-\d{2}-\d{2}\z/) ? v[0, 7] : v
 end
 
 def round_row(row)
@@ -88,15 +108,33 @@ def round_row(row)
 end
 
 def strict_compare(exp, act)
-  exp_set = Set.new(exp.map { |r| r.first(2) })
-  act_set = Set.new(act.map { |r| r.first(2) })
-  if exp_set == act_set
-    { status: 'PASS', only_in_tableau: [], only_in_sigma: [] }
-  else
-    { status: 'DIVERGE',
-      only_in_tableau: (exp_set - act_set).to_a,
-      only_in_sigma:   (act_set - exp_set).to_a }
+  # Compare the FULL tuple width the plan carries (bead s6fo): 3-channel charts
+  # (stacked color / pivot row+col+value / scatter dim+x+y) must compare every
+  # channel — the old first(2) slice compared two dims and ignored the measure.
+  width = [(exp.map(&:size) + act.map(&:size)).max || 2, 2].max
+  exp_set = Set.new(exp.map { |r| r.first(width) })
+  act_set = Set.new(act.map { |r| r.first(width) })
+  return { status: 'PASS', only_in_tableau: [], only_in_sigma: [] } if exp_set == act_set
+
+  # Month-grain fallback — REPRESENTATION mismatches only: a monthly chart's
+  # Tableau label ("January 2026" → "2026-01") vs Sigma's DateTrunc value
+  # ("2026-01-01"). Applies ONLY when one side carries month-form keys and the
+  # other day-form keys — two day-form sides (e.g. weekly buckets shifted a
+  # day) must keep diverging.
+  month_form = ->(set) { set.any? { |r| r[0].is_a?(String) && r[0].match?(/\A\d{4}-\d{2}\z/) } }
+  day_form   = ->(set) { set.any? { |r| r[0].is_a?(String) && r[0].match?(/\A\d{4}-\d{2}-\d{2}\z/) } }
+  if (month_form.call(exp_set) && day_form.call(act_set)) ||
+     (day_form.call(exp_set) && month_form.call(act_set))
+    to_month = ->(set) { Set.new(set.map { |r| [month_grain(r[0]), *r[1..]] }) }
+    if to_month.call(exp_set) == to_month.call(act_set)
+      return { status: 'PASS', only_in_tableau: [], only_in_sigma: [],
+               notes: ['matched at month grain (label vs first-of-month representation)'] }
+    end
   end
+
+  { status: 'DIVERGE',
+    only_in_tableau: (exp_set - act_set).to_a,
+    only_in_sigma:   (act_set - exp_set).to_a }
 end
 
 # Extract-mode: same row count + same dim set + same dim sort. Measure values


### PR DESCRIPTION
## Problem
`verify-parity.rb` had drifted: the **tableau** copy carries the bead-s6fo correctness fixes, but **looker / powerbi / quicksight / thoughtspot** were stale and silently wrong.

## Demonstration (crafted plan — expected: DIVERGE / PASS / DIVERGE)
| Chart | Stale verdict | Fixed verdict |
|---|---|---|
| weekly (Sigma week shifted 1 day) | DIVERGE | DIVERGE |
| monthly (label vs first-of-month) | PASS | PASS |
| 3-channel (measure 20 vs 999) | **PASS** ❌ | DIVERGE ✅ |

The critical bug: stale `strict_compare` sliced `first(2)` — comparing two dims and **ignoring the measure** — so a multi-channel chart whose measure diverged reported PASS. Stale date canonicalization also collapsed day-1-of-month into a month bucket, mis-bucketing weekly grains.

## Fix
Brings day-grain date keys (weekly buckets keep their date), Tableau day/week/quarter label parsing, full-tuple-width comparison, and a month-grain fallback for label-vs-first-of-month representation diffs.

- **looker / powerbi / quicksight** — take the tableau version wholesale (already tableau-named copies, no tool-specific logic).
- **thoughtspot** — same fix **merged** with its tool-specific numeric-string→float coercion (`"2024"` vs `2024.0`), preserved and re-verified.

## Validation (live)
All 4 give correct bead-s6fo verdicts; thoughtspot's numeric coercion still PASSes while tableau (correctly) does not coerce. md5: tableau/looker/powerbi/quicksight now byte-identical; thoughtspot differs by exactly the documented coercion branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)