### PR TITLE
fix: promote agent-neutral get-token.sh to thoughtspot (both skills)

### DIFF
--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get-token.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get-token.sh
@@ -5,6 +5,14 @@
 
 set -euo pipefail
 
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
 : "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh
@@ -5,9 +5,17 @@
 
 set -euo pipefail
 
-: "${SIGMA_BASE_URL:?Set SIGMA_BASE_URL (e.g. source ~/.sigma-migration/env)}"
-: "${SIGMA_CLIENT_ID:?Set SIGMA_CLIENT_ID (e.g. source ~/.sigma-migration/env)}"
-: "${SIGMA_CLIENT_SECRET:?Set SIGMA_CLIENT_SECRET (e.g. source ~/.sigma-migration/env)}"
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 


### PR DESCRIPTION
Both thoughtspot copies of `get-token.sh` were stale — missing the **agent-neutral credential bootstrap** the other 7 plugins carry:

```bash
if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
  . "$HOME/.sigma-migration/env"
fi
```

Without it, token exchange only works under Claude Code (which auto-loads creds from `~/.claude/settings.json`); Cursor / Cortex Code / plain-shell agents hit an unset-credential abort. The `thoughtspot-to-sigma` copy also still had the older "Set SIGMA_BASE_URL" error wording.

`get-token.sh` is a tool-agnostic Sigma-auth helper, so both copies take the canonical version verbatim. **All 9 copies repo-wide are now byte-identical.**

**Live-verified:** the promoted thoughtspot `get-token.sh` fetches a valid bearer token (1387-char) and passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)