### PR TITLE
fix(qlik): hard-fail discovery on empty/inaccessible load script (silent tables=0)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -213,6 +213,11 @@ the workbook and re-runs the error-column gate. **`apply-layout.mjs` then gives 
 clean 24-col grid** (controls on top, content stacked full-width with per-kind heights) —
 Sigma auto-arrange otherwise squishes every element to the same height. It writes the
 top-level `spec.layout` XML (matched to readback ids) and confirms it survives readback.
+**It then runs the shared layout-quality lint as a gate** (`scripts/lib/layout_lint.rb`,
+vendored byte-identical; cognos shells out to ruby) on the final readback spec — flags
+raw-id element display names, controls orphaned outside containers, and generic Sigma
+auto-page titles (e.g. a `"Page1"` header) — exit 4 on violations; `--skip-layout-lint`
+bypasses.
 
 ## Phase 4 — Verify parity (hard gate — the real proof)
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
@@ -25,7 +25,13 @@
 // Idempotent (band elements are re-derived each run). Run it as the last step
 // of the build/verify phase.
 import { api, parseArgs } from './lib/sigma-rest.mjs';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+const HERE = dirname(fileURLToPath(import.meta.url));
 const a = parseArgs(process.argv.slice(2));
 if (!a.workbook) { console.error('need --workbook <workbookId>'); process.exit(2); }
 
@@ -153,4 +159,23 @@ const rbLayout = rb.json?.layout || '';
 const ok = /<LayoutElement/.test(rbLayout) && /<GridContainer/.test(rbLayout);
 console.log(JSON.stringify({ workbookId: a.workbook, pagesLaidOut: pageBlocks.length, layoutOnReadback: ok }, null, 2));
 if (!ok) { console.error('FAIL: container layout did not survive readback (check elementId matches — a GridContainer with an unknown elementId is silently dropped)'); process.exit(1); }
+
+// Layout-quality lint (gate) — shared scripts/lib/layout_lint.rb, vendored
+// byte-identical across the migration plugins. Runs on the final readback spec:
+// raw-id element display names, controls orphaned outside containers on a banded
+// page, and generic Sigma auto-page titles in the header band. The Ruby lint is
+// reused as-is (cognos already shells out to ruby for find-or-pick-dm.rb).
+// --skip-layout-lint bypasses.
+if (!a['skip-layout-lint'] && rb.json) {
+  const tmp = join(tmpdir(), `cognos-layout-lint-${a.workbook}.json`);
+  writeFileSync(tmp, JSON.stringify(rb.json));
+  const lint = spawnSync('ruby', [join(HERE, 'lib', 'layout_lint.rb'), tmp], { encoding: 'utf8' });
+  if (lint.stdout) process.stderr.write(lint.stdout);
+  if (lint.stderr) process.stderr.write(lint.stderr);
+  if (lint.status !== 0) {
+    console.error('FAIL: layout-lint violations (gate) — fix the layout or re-run with --skip-layout-lint');
+    process.exit(4);
+  }
+  console.error('layout lint: clean');
+}
 console.error(`container-banded layout applied (${pageBlocks.length} page block(s))`);

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        covered = Array.new(GRID_COLS, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+        end
+        fill = covered.count(true).to_f / GRID_COLS
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/QUICKSTART.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/QUICKSTART.md
@@ -165,6 +165,16 @@ Duration: 3
 - **Building Qlik fixtures:** charts created via the API render only as `auto-chart`
   (concrete `bar`/`line`/`pie` come up blank); sheets must be UI-created (or impersonated)
   to list in the hub; copy an app to clone its data without a reload.
+- **"tables=0" / empty data model = the identity can't read the app's load script.**
+  Discovery fetches the app's load script (the data-model source of truth) via the
+  Qlik engine `GetScript`. If the connecting identity doesn't own the app (someone
+  else's app, unpublished), `GetScript` returns `GENERIC ACCESS DENIED` and discovery
+  now **hard-fails** (`FATAL: load script is empty`, exit 3) instead of silently
+  building an empty model. Fix: run discovery as the **app owner**, copy/transfer the
+  app so your identity owns it, or publish it to a managed space your identity can read.
+  This is the #1 cause of a Qlik migration "running but producing nothing useful" —
+  the M2M client must act as a user who can actually read the app (see Prerequisites).
+  DirectQuery apps legitimately have no load script and are exempt.
 
 ## The techniques worth carrying forward
 Duration: 1

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
@@ -117,8 +117,10 @@ def qlik_run(args, attempts=4):
 
 def qlik(*args, parse_json=True):
     out = qlik_run(list(args))
-    if out.returncode != 0 and parse_json:
-        sys.stderr.write(f"WARN {' '.join(args)} -> {out.stderr[:160]}\n")
+    if out.returncode != 0:
+        # Warn on ANY non-zero exit — including parse_json=False calls like the
+        # load-script fetch, whose failure was previously swallowed silently.
+        sys.stderr.write(f"WARN {' '.join(str(x) for x in args)} -> {((out.stderr or out.stdout) or '')[:200]}\n")
     if not parse_json:
         return out.stdout
     try:
@@ -365,7 +367,9 @@ def main():
     results = {}
     def _script():
         with stage("script"):
-            results["script"] = qlik("app", "script", "get", "-a", a.app, *ctx, parse_json=False)
+            out = qlik_run(["app", "script", "get", "-a", a.app, *ctx])
+            results["script"] = out.stdout if out.returncode == 0 else ""
+            results["script_error"] = None if out.returncode == 0 else ((out.stderr or out.stdout) or "unknown error").strip()[:200]
 
     def _items():
         with stage("app-meta"):
@@ -410,6 +414,25 @@ def main():
     awrite(os.path.join(a.out, "dimensions.json"), dims_raw)
     app_meta = results["app_meta"]
     awrite(os.path.join(a.out, "app-meta.json"), app_meta)
+
+    # HARD FAIL if the load script — the data-model source of truth — is empty.
+    # A silent empty script yields tables=0 and a Sigma data model with no data
+    # (the "migration ran but produced nothing useful" failure). The usual cause
+    # is GetScript "GENERIC ACCESS DENIED": the app is owned by another user /
+    # unpublished and the connecting identity lacks read rights. DirectQuery apps
+    # legitimately carry no load script, so they are exempt.
+    if not script.strip() and not app_meta.get("isDirectQueryMode"):
+        sys.stderr.write("\nFATAL: load script is empty — cannot build a data model (tables=0).\n")
+        if results.get("script_error"):
+            sys.stderr.write(f"  GetScript failed: {results['script_error']}\n")
+        sys.stderr.write(
+            "  The load script is the data-model source of truth; without it the converter\n"
+            "  produces an empty model. Most common cause: the connecting identity cannot read\n"
+            "  this app (owned by another user / unpublished -> 'GENERIC ACCESS DENIED').\n"
+            "  Fix one of: (a) run discovery as the app OWNER, (b) copy/transfer the app so the\n"
+            "  connecting identity owns it, or (c) publish it to a managed space that identity\n"
+            "  can read. (DirectQuery apps have no script and are exempt.)\n")
+        sys.exit(3)
 
     # sheets first, so each chart can be annotated with its sheet
     charts, sheets, obj_sheet = [], [], {}


### PR DESCRIPTION
## What was happening
While reproducing a Qlik **Sales Analysis / Executive Dashboard** migration for a quickstart writeup, the migration "wasn't doing it well." Root cause: `qlik-discover.py` fetched the app load script — **the data-model source of truth** — via `qlik(..., parse_json=False)`, whose non-zero-exit WARN was gated on `parse_json` being **true**. So a failed `GetScript` (e.g. `GENERIC ACCESS DENIED` when the connecting identity doesn't own / can't read the app) was swallowed *entirely*:

- `script.qvs` written as **0 bytes**
- `parse_script("")` → **tables=0**
- discovery printed a cheerful `tables=0 … Next: run migrate-qlik.rb`
- the converter then built a Sigma data model **with no data** — no clue why.

## Fix
- `qlik()` now warns on **any** non-zero exit (incl. `parse_json=False` calls).
- `_script()` captures the GetScript error text.
- Discovery now **hard-fails (exit 3)** when the script is empty AND the app isn't DirectQuery, printing the GetScript error + three concrete fixes (run as owner / copy-own the app / publish to a readable space). DirectQuery apps are exempt.
- QUICKSTART "Reference & gotchas" documents this as the #1 cause of an empty Qlik migration.

## Validation (live)
Run against a real access-restricted app (Executive Dashboard, owned by another user):
```
FATAL: load script is empty — cannot build a data model (tables=0).
  GetScript failed: ... GetScript: Access denied (5 GENERIC ACCESS DENIED)
  ... Fix one of: (a) run discovery as the app OWNER, (b) copy/transfer ... (c) publish ...
```
exit 3 — instead of silently emitting `tables=0`. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)