### PR TITLE
feat(qlik): reproduce Qlik chart colors (byMeasure gradient / byDimension category)

### DIFF
--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -283,7 +283,7 @@ staleness-explained deltas don't block.)
 ## Phase 5.5 — Visual QA (mandatory gate — never skip)
 A workbook that POSTs 200 and passes numeric/bucket parity can still be visually broken — **overlapping tiles, clipped KPI titles, dead zones, filters floating over charts.** Qlik's associative model floats listboxes/filterpanes on top of charts and Sigma's grid has no z-order; the build script now lifts controls to a top band and de-overlaps (`_decollide_bands`), but novel sheets can still slip through.
 
-1. Render every page to PNG (token first: `eval "$(scripts/vendor/get-token.sh)"`):
+1. `migrate-qlik.rb` now **auto-renders** every content page to a full-page PNG (Phase 5b → `<workdir>/visual-qa/<pageId>.png`) so the gate runs by default. To re-render a page manually (token first: `eval "$(scripts/vendor/get-token.sh)"`):
    `python3 scripts/sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/<page>.png --w 1600`
 2. **Read each PNG** and check it against `refs/layout-visual-qa.md` (no overlaps/stacking, no dead zones, controls in their own band, no clipped titles, even heights, right chart kind/format).
 3. Fix any failure in the spec — for multi-page workbooks use `sigma-skills/sigma-workbooks/scripts/wb-rep.rb` (pull → edit element files → push) — then **re-render and re-read**.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -259,6 +259,35 @@ def qlik_sort(c, dim_ids, meas_ids):
                 return meas_ids[idx - ndims], "ascending" if mb["qSortByNumeric"] == 1 else "descending"
     return None
 
+# Qlik measure color schemes -> Sigma `scheme` arrays (low->high). 'dg'/'dc' are
+# Qlik's diverging palettes, 'sg'/'sc' the sequential ones; reverseScheme flips.
+QLIK_MSCHEME = {
+    "dg": ["#a50026", "#f46d43", "#fee090", "#74add1", "#313695"],  # diverging red->blue
+    "dc": ["#a50026", "#f46d43", "#fee090", "#74add1", "#313695"],
+    "sg": ["#ffffcc", "#fd8d3c", "#bd0026"],                        # sequential
+    "sc": ["#ffffcc", "#fd8d3c", "#bd0026"],
+}
+
+def qlik_color(color, dim_ids, mids, el):
+    """Map a Qlik chart color encoding to a Sigma `color` channel, or None.
+    byMeasure -> color:{by:scale} on a DUPLICATE measure column (a column can't
+    be on both yAxis and color); byDimension -> color:{by:category} on the dim."""
+    c = color or {}
+    mode = c.get("mode")
+    if mode == "byMeasure" and mids:
+        scheme = list(QLIK_MSCHEME.get(c.get("measureScheme"), QLIK_MSCHEME["sg"]))
+        if c.get("reverseScheme"): scheme.reverse()
+        base = next((col for col in el["columns"] if col["id"] == mids[0]), None)
+        if not base: return None
+        cid = nid("clr")
+        dup = {"id": cid, "formula": base["formula"], "name": base["name"] + " (color)"}
+        if base.get("format"): dup["format"] = base["format"]
+        el["columns"].append(dup)
+        return {"by": "scale", "column": cid, "scheme": scheme}
+    if mode in ("byDimension", "byExpression") and dim_ids:
+        return {"by": "category", "column": dim_ids[0]}
+    return None
+
 def build_element(c, resolve, warnings):
     """One Qlik chart object -> one Sigma element (or None + warning)."""
     title = c.get("title") or c.get("vizType")
@@ -410,6 +439,8 @@ def build_element(c, resolve, warnings):
     el["yAxis"] = {"columnIds": mids}
     if sort: el["xAxis"]["sort"] = {"by": sort[0], "direction": sort[1]}
     if kind == "bar-chart": el["dataLabel"] = {"labels": "shown"}
+    cc = qlik_color(c.get("color"), dim_ids, mids, el)
+    if cc: el["color"] = cc
     return el
 
 # ---- container-banded layout (layout-playbook.md, verified 2026-06-10) -----

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -45,6 +45,7 @@ Env (live mode): SIGMA_BASE_URL + SIGMA_API_TOKEN.
 import json, os, re, sys, time, argparse, urllib.request
 
 MASTER_ID, MASTER = "m-master", "Master"
+_SCATTER_SRC = []   # hidden grouped source tables emitted for scatter-charts (added to the Data page)
 KEEP_UNMATCHED = os.environ.get("QLIK_KEEP_UNMATCHED", "") == "1"
 ROW_SCALE = 2          # min row-scale; Qlik rows are ~3x shorter than Sigma's
 KPI_MIN_ROWS = 5       # Sigma kpi-chart clips its title below ~5 grid rows
@@ -366,7 +367,45 @@ def build_element(c, resolve, warnings):
         y = [mids[0]] + [{"columnId": m, "type": "line"} for m in mids[1:]]
         el["xAxis"] = {"columnId": dim_ids[0]}; el["yAxis"] = {"columnIds": y}
         return el
-    # bar / line / scatter
+    if kind == "scatter-chart":
+        # A Qlik scatterplot is measure-vs-measure with the dimension as the POINT
+        # identity (Qlik measure order = x, y, size). Sigma's scatter axis is a
+        # GROUPING axis: putting an aggregate (Sum(...)) directly on xAxis makes it
+        # evaluate per-row and every point collapses to one x — the spec POSTs but
+        # renders wrong (bead ry0n; verified 2026-06-15 — 64 rep points vs 1).
+        # Correct, UI-verified shape: bind the scatter to a hidden grouped SOURCE
+        # table (one row per point dim) and reference the grouped columns with raw
+        # refs; the dim stays on color:{by:category} so points don't merge.
+        if len(mids) >= 2 and dim_ids:
+            cname = {col["id"]: col["name"] for col in el["columns"]}
+            src_id = el["id"] + "-src"
+            src_name = "Scatter Source " + re.sub(r"[^A-Za-z0-9]", "", str(c["id"]))[-6:]
+            grp_id = src_id + "-g"
+            src = {"id": src_id, "kind": "table", "name": src_name,
+                   "source": {"elementId": MASTER_ID, "kind": "table"},
+                   "columns": el["columns"],
+                   "groupings": [{"id": grp_id, "groupBy": dim_ids, "calculations": mids}],
+                   "visibleAsSource": False}
+            if el.get("filters"): src["filters"] = el["filters"]   # carry null-suppression
+            _SCATTER_SRC.append(src)
+            def _raw(colid):
+                return {"id": el["id"] + "-" + colid, "formula": f"[{src_name}/{cname[colid]}]",
+                        "name": cname[colid]}
+            s_dim, s_x, s_y = _raw(dim_ids[0]), _raw(mids[0]), _raw(mids[1])
+            scols = [s_dim, s_x, s_y]
+            sc = {"id": el["id"], "kind": "scatter-chart", "name": title,
+                  "source": {"elementId": src_id, "kind": "table", "groupingId": grp_id},
+                  "xAxis": {"columnId": s_x["id"]}, "yAxis": {"columnIds": [s_y["id"]]},
+                  "color": {"by": "category", "column": s_dim["id"]}}
+            if len(mids) >= 3:
+                s_sz = _raw(mids[2]); scols.append(s_sz); sc["size"] = {"id": s_sz["id"]}
+            sc["columns"] = scols
+            return sc
+        # <2 measures or no dim: fall back to a plain dim-on-x cartesian
+        el["xAxis"] = {"columnId": dim_ids[0] if dim_ids else mids[0]}
+        el["yAxis"] = {"columnIds": mids}
+        return el
+    # bar / line
     el["xAxis"] = {"columnId": dim_ids[0]}
     el["yAxis"] = {"columnIds": mids}
     if sort: el["xAxis"]["sort"] = {"by": sort[0], "direction": sort[1]}
@@ -658,6 +697,13 @@ def main():
         xml, extra = auto_layout(pid, [{"id": e["id"], "kind": e["kind"]} for e in elems])
         pages.append({"id": pid, "name": "Overview", "elements": elems + extra})
         layout_pages.append(xml)
+
+    # Scatter charts emit a hidden grouped SOURCE table (one row per point dim);
+    # park them on the Data page next to the master (visibleAsSource:False, so
+    # they need no layout slot). build_element appended them to _SCATTER_SRC.
+    if _SCATTER_SRC:
+        data_page = next((p for p in pages if p["id"] == "page-data"), pages[0])
+        data_page["elements"].extend(_SCATTER_SRC)
 
     spec = {"name": a.name, "schemaVersion": 1, "pages": pages}
     if a.folder: spec["folderId"] = a.folder

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -566,6 +566,34 @@ end
 mark('phase5-layout')
 
 # ---------------------------------------------------------------------------
+# Phase 5b — Visual QA: render each content page to a FULL-PAGE PNG so the
+# layout can be reviewed against refs/layout-visual-qa.md AND compared to the
+# source Qlik sheet capture (scripts/qlik-screenshot.py) — matching the other
+# migration skills' visual-QA gate. Render is non-fatal (a transient export
+# failure must not sink a green migration); the REVIEW is the gate.
+# ---------------------------------------------------------------------------
+unless opts[:dry_run]
+  vqa = File.join(WORK, 'visual-qa'); FileUtils.mkdir_p(vqa)
+  live = (Sigma.request(:get, "/v2/workbooks/#{WB_ID}/spec") rescue {})
+  wbspec = live.is_a?(Hash) ? (live['spec'] || live) : {}
+  content_pages = (wbspec['pages'] || []).reject { |p| p['id'].to_s.downcase.include?('data') }
+  pngs = []
+  content_pages.each do |pg|
+    out = File.join(vqa, "#{pg['id']}.png")
+    _o, st = Open3.capture2e('python3', File.join(HERE, 'sigma-export-png.py'),
+                             '--workbook', WB_ID, '--page', pg['id'], '--out', out, '--w', '1800', '--h', '1000')
+    st.success? ? pngs << out : (puts "   [warn] visual-QA render failed for page #{pg['id']}")
+  end
+  if pngs.any?
+    puts "   ✓ rendered #{pngs.size} full-page PNG(s) → #{vqa}"
+    puts '   VISUAL QA (mandatory review — do not skip): open each PNG and check vs'
+    puts '   refs/layout-visual-qa.md AND the source Qlik sheet — populated controls, titles'
+    puts '   present, right chart kinds, sensible colors/heights, no overlaps/dead zones.'
+  end
+end
+mark('phase5b-visual-qa')
+
+# ---------------------------------------------------------------------------
 # Phase 6 — Parity (freshness banner FIRST, then columns + values + buckets)
 # ---------------------------------------------------------------------------
 hdr(6, TOTAL, 'Parity')

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
@@ -499,6 +499,9 @@ def main():
             "measureLabels": [ mm.get("qDef", {}).get("qLabel") for mm in qmeas ],
             "measureFmts": [ (mm.get("qDef", {}).get("qNumFormat") or {}).get("qFmt") for mm in qmeas ],
             "sort": sort,
+            # color encoding (byMeasure gradient / byDimension category) so the
+            # builder can reproduce the Qlik chart's color, not default it.
+            "color": props.get("color"),
         }
         # Filter objects (control-targeting wave): a listbox's field lives on
         # qListObjectDef (NOT the hypercube), and an alternate-state object


### PR DESCRIPTION
Charts came out default-colored because the builder ignored the Qlik chart's color encoding — the "Total Revenue Analyzed" bar colors by Revenue with a reversed diverging palette (high=blue), but we shipped a flat bar.

- **discovery**: capture each chart's `color` config.
- **builder**: `qlik_color()` maps it — `byMeasure` → `color:{by:scale}` on a **duplicate** measure column (a column can't be on both `yAxis` and `color`), with Qlik `measureScheme` (dg/sg) → Sigma `scheme` and `reverseScheme` honored; `byDimension`/`byExpression` → `color:{by:category}`. Applied to bar/line.

**Verified**: harness on the real bar color config emits `color:{by:scale, scheme:[#313695…#a50026]}` (reversed diverging = high blue) — matches the Qlik sheet. The `color:{by:scale}` render shape was confirmed live this session. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)