### PR TITLE
feat(qlik): carry Qlik reference lines -> Sigma refMarks (e.g. Margin Target)

### DIFF
--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -288,6 +288,29 @@ def qlik_color(color, dim_ids, mids, el):
         return {"by": "category", "column": dim_ids[0]}
     return None
 
+def qlik_refmarks(c):
+    """Qlik reference lines -> Sigma refMarks. X-axis lines -> axis 'axis',
+    measure/Y lines -> 'series'. value MUST be the wrapped {type:formula,...}
+    form (a bare number 400s); label.visibility must be 'shown'. Verified
+    2026-06-15."""
+    rl = c.get("refLines") or {}
+    out = []
+    for axis, key in (("axis", "x"), ("series", "y")):
+        for r in (rl.get(key) or []):
+            if r.get("show") is False:
+                continue
+            val = r.get("value")
+            formula = str(val) if isinstance(val, (int, float)) else (r.get("expr") or "")
+            if not formula:
+                continue
+            rm = {"type": "line", "axis": axis,
+                  "value": {"type": "formula", "formula": formula},
+                  "line": {"color": r.get("color") or "#ef4444", "width": 2}}
+            if r.get("label"):
+                rm["label"] = {"visibility": "shown", "text": r["label"]}
+            out.append(rm)
+    return out
+
 def build_element(c, resolve, warnings):
     """One Qlik chart object -> one Sigma element (or None + warning)."""
     title = c.get("title") or c.get("vizType")
@@ -429,6 +452,8 @@ def build_element(c, resolve, warnings):
             if len(mids) >= 3:
                 s_sz = _raw(mids[2]); scols.append(s_sz); sc["size"] = {"id": s_sz["id"]}
             sc["columns"] = scols
+            rm = qlik_refmarks(c)
+            if rm: sc["refMarks"] = rm   # e.g. a Margin Target line at x=0.45
             return sc
         # <2 measures or no dim: fall back to a plain dim-on-x cartesian
         el["xAxis"] = {"columnId": dim_ids[0] if dim_ids else mids[0]}
@@ -441,6 +466,8 @@ def build_element(c, resolve, warnings):
     if kind == "bar-chart": el["dataLabel"] = {"labels": "shown"}
     cc = qlik_color(c.get("color"), dim_ids, mids, el)
     if cc: el["color"] = cc
+    rm = qlik_refmarks(c)
+    if rm: el["refMarks"] = rm
     return el
 
 # ---- container-banded layout (layout-playbook.md, verified 2026-06-10) -----

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
@@ -127,6 +127,21 @@ def qlik(*args, parse_json=True):
         return None
 
 
+def _reflines(refline):
+    """Normalize a Qlik object's refLine config -> {x:[...], y:[...]} of
+    {show,label,color,value,expr}. refLinesX = X-axis lines, refLines = Y/measure."""
+    def conv(arr):
+        out = []
+        for r in (arr or []):
+            e = r.get("refLineExpr") or {}
+            out.append({"show": r.get("show", True),
+                        "label": r.get("label") or e.get("label"),
+                        "color": r.get("color") or (r.get("paletteColor") or {}).get("color"),
+                        "value": e.get("value"), "expr": e.get("label")})
+        return out
+    return {"x": conv(refline.get("refLinesX")), "y": conv(refline.get("refLines"))}
+
+
 def awrite(path, obj):
     """Atomic JSON write — orchestrators poll for these files from a
     concurrent lane and must never observe a half-written artifact."""
@@ -502,6 +517,11 @@ def main():
             # color encoding (byMeasure gradient / byDimension category) so the
             # builder can reproduce the Qlik chart's color, not default it.
             "color": props.get("color"),
+            # reference lines (e.g. a "Margin Target" at x=0.45). refLinesX sit on
+            # the X axis, refLines on the measure/Y axis. The builder emits Sigma
+            # refMarks from these. value comes from refLineExpr.value (a constant)
+            # or refLineExpr.label (an expression string).
+            "refLines": _reflines(props.get("refLine") or {}),
         }
         # Filter objects (control-targeting wave): a listbox's field lives on
         # qListObjectDef (NOT the hypercube), and an alternate-state object


### PR DESCRIPTION
Qlik reference lines (the Sales Analysis scatter's **Margin Target** at x=0.45) were dropped — discovery didn't capture them, builder emitted no refMarks.

- **discovery**: `_reflines()` normalizes refLine config → `{x:[...],y:[...]}` (refLinesX=X-axis, refLines=Y/measure).
- **builder**: `qlik_refmarks()` emits refMarks — X→axis `axis`, Y→`series`, value wrapped `{type:formula,formula}` (bare number 400s), `label.visibility:shown`. Applied to scatter + bar/line.

Harness-verified the captured Margin Target emits the live-verified refMark shape. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)