### PR TITLE
fix(qlik): visual-QA gate rendered nothing — use local wb-spec + explicit token

### DIFF
--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -574,21 +574,25 @@ mark('phase5-layout')
 # ---------------------------------------------------------------------------
 unless opts[:dry_run]
   vqa = File.join(WORK, 'visual-qa'); FileUtils.mkdir_p(vqa)
-  live = (Sigma.request(:get, "/v2/workbooks/#{WB_ID}/spec") rescue {})
-  wbspec = live.is_a?(Hash) ? (live['spec'] || live) : {}
+  # Page ids come from the LOCAL spec the builder wrote — deterministic. (The
+  # live GET /spec readback proved flaky inside the pipeline, silently yielding
+  # zero pages; POST preserves these ids so the local copy is authoritative.)
+  wbspec = (JSON.parse(File.read(File.join(WORK, 'wb-spec.json'))) rescue {})
   content_pages = (wbspec['pages'] || []).reject { |p| p['id'].to_s.downcase.include?('data') }
+  tok = (Sigma.auth_token rescue ENV['SIGMA_API_TOKEN'])
   pngs = []
   content_pages.each do |pg|
     out = File.join(vqa, "#{pg['id']}.png")
-    _o, st = Open3.capture2e('python3', File.join(HERE, 'sigma-export-png.py'),
+    _o, st = Open3.capture2e({ 'SIGMA_API_TOKEN' => tok.to_s }, 'python3',
+                             File.join(HERE, 'sigma-export-png.py'),
                              '--workbook', WB_ID, '--page', pg['id'], '--out', out, '--w', '1800', '--h', '1000')
-    st.success? ? pngs << out : (puts "   [warn] visual-QA render failed for page #{pg['id']}")
+    st.success? ? (pngs << out) : (puts "   [warn] visual-QA render failed for page #{pg['id']}")
   end
+  puts "   ✓ rendered #{pngs.size}/#{content_pages.size} full-page PNG(s) for visual QA → #{vqa}"
   if pngs.any?
-    puts "   ✓ rendered #{pngs.size} full-page PNG(s) → #{vqa}"
     puts '   VISUAL QA (mandatory review — do not skip): open each PNG and check vs'
-    puts '   refs/layout-visual-qa.md AND the source Qlik sheet — populated controls, titles'
-    puts '   present, right chart kinds, sensible colors/heights, no overlaps/dead zones.'
+    puts '   refs/layout-visual-qa.md AND the source Qlik sheet capture — populated controls,'
+    puts '   titles present, right chart kinds, sensible colors/heights, no overlaps/dead zones.'
   end
 end
 mark('phase5b-visual-qa')


### PR DESCRIPTION
Caught running the full pipeline on a real app (Exec Overview): Phase 5b produced **zero PNGs** (`phase5b=0.0s`, empty `visual-qa/`). The block read page ids from the **live** `GET /spec` readback, which inside the pipeline silently yielded zero pages (the `rescue {}` swallowed it) → render loop never ran → no-op gate.

Fix: page ids from the **local** `wb-spec.json` the builder wrote (deterministic; POST preserves ids), pass `SIGMA_API_TOKEN` explicitly to the render child (don't rely on inherited ENV — same gap that bit `build-sigma-dm.py`), and **always print the rendered N/total** so a zero is never silent again.

**Verified live**: a full `migrate-qlik.rb` run now renders **5/5** full-page PNGs. `ruby -c` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)