### PR TITLE
feat(tableau): wire the visual-QA full-page PNG gate (P1; script was missing)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -1274,6 +1274,30 @@ end
 mark('phase5-layout')
 
 # ---------------------------------------------------------------------------
+# Phase 5b — Visual QA: render each content page to a full-page PNG so the
+# layout can be reviewed against refs/layout-visual-qa.md AND compared to the
+# source Tableau dashboard — the cross-converter visual-QA gate. Page ids come
+# from the LOCAL wb-spec.json (deterministic; the live /spec readback is flaky
+# and returns YAML); token via get-token.sh inside sigma_run!. Non-fatal — a
+# transient export failure must not sink a green migration; the REVIEW is the gate.
+# ---------------------------------------------------------------------------
+hdr('5b', 'Visual QA')
+vqa = File.join(WORK, 'visual-qa'); FileUtils.mkdir_p(vqa)
+wbspec_local = (JSON.parse(File.read(wb_spec_path)) rescue {})
+content_pages = (wbspec_local['pages'] || []).reject { |p| p['id'].to_s.downcase.include?('data') }
+rendered = 0
+content_pages.each do |pg|
+  out = File.join(vqa, "#{pg['id']}.png")
+  _o, st = sigma_run!(['python3', File.join(HERE, 'sigma-export-png.py'),
+                       '--workbook', wb_id, '--page', pg['id'], '--out', out, '--w', '1800', '--h', '1000'],
+                      allow_fail: true)
+  st.success? ? (rendered += 1) : line("WARN: visual-QA render failed for page #{pg['id']}")
+end
+line "rendered #{rendered}/#{content_pages.size} full-page PNG(s) → #{vqa}"
+line 'VISUAL QA (review, do not skip): open each PNG; check vs refs/layout-visual-qa.md AND the source Tableau dashboard — titles, right chart kinds, colors, no overlaps/dead zones.' if rendered.positive?
+mark('phase5b-visual-qa')
+
+# ---------------------------------------------------------------------------
 # Phase 6 — Parity, PASS 1 of 2. Structural hard signals first (live /columns
 # type=error re-check after the layout PUT + per-chart compile check), then
 # phase6-parity.rb pass 1 builds the parity plan and emits the per-chart MCP

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/sigma-export-png.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/sigma-export-png.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""sigma-export-png.py — render a Sigma workbook page or element to PNG via the
+REST export API, for VISUAL QA of a migrated workbook (Phase 4: side-by-side
+against the source Looker dashboard).
+
+A PNG is more reliable than an MCP SQL query for catching LAYOUT/render problems —
+hidden KPI titles, orphaned filters, overlapping tiles, wrong chart kinds — that a
+numeric parity check can't see.
+
+POST /v2/workbooks/{id}/export {pageId|elementId, format:{type:"png",pixelWidth,pixelHeight}}
+  -> {queryId, jobComplete}; then GET /v2/query/{queryId}/download until the PNG is ready.
+
+Env: SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/get-token.sh)").
+Usage:
+  python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png
+  python3 sigma-export-png.py --workbook <id> --element <elId> --out /tmp/x.png [--w 1600 --h 900]
+"""
+import argparse, os, sys, time, requests
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook", required=True)
+    ap.add_argument("--page"); ap.add_argument("--element")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--w", type=int, default=1600); ap.add_argument("--h", type=int, default=900)
+    a = ap.parse_args()
+    base = os.environ["SIGMA_BASE_URL"]; tok = os.environ["SIGMA_API_TOKEN"]
+    h = {"Authorization": f"Bearer {tok}", "Content-Type": "application/json"}
+    fmt = {"type": "png", "pixelWidth": a.w, "pixelHeight": a.h}
+    body = {"format": fmt}
+    if a.element: body["elementId"] = a.element
+    elif a.page:  body["pageId"] = a.page
+    else: sys.exit("need --page or --element")
+    r = requests.post(f"{base}/v2/workbooks/{a.workbook}/export", headers=h, json=body)
+    if r.status_code != 200: sys.exit(f"export POST {r.status_code}: {r.text[:300]}")
+    qid = r.json()["queryId"]
+    dl = f"{base}/v2/query/{qid}/download"
+    for i in range(60):
+        g = requests.get(dl, headers={"Authorization": f"Bearer {tok}"})
+        ct = g.headers.get("Content-Type", "")
+        if g.status_code == 200 and ("image" in ct or g.content[:8] == b"\x89PNG\r\n\x1a\n"):
+            open(a.out, "wb").write(g.content)
+            print(f"[png] {len(g.content)} bytes -> {a.out}"); return
+        time.sleep(3)
+    sys.exit("timed out waiting for PNG")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The tableau skill documented a mandatory visual-QA gate and referenced `sigma-export-png.py` (SKILL.md, layout-visual-qa.md, enhance-apply.rb) — but **the script didn't exist in the plugin** (only in qlik-to-sigma), and `migrate-tableau.rb` never auto-rendered. The strongest layout safety net dead-ended on a missing file.

- Vendored `sigma-export-png.py` (byte-identical to qlik's).
- `migrate-tableau.rb` **Phase 5b**: after layout, render every content page to a full-page PNG (page ids from the **local** `wb-spec.json` — the live `/spec` readback returns YAML and is flaky; token via `get-token.sh` in `sigma_run!`). Non-fatal; prints `rendered N/total` + review prompt.

First step of the P1 rollout in `docs/chart-fidelity-rubric.md`. `ruby -c` + `py_compile` clean; mirrors the qlik gate verified live (5/5 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)