### PR TITLE
fix: scatter collapse in looker/quicksight/thoughtspot/cognos (grouped-source port)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
@@ -54,8 +54,9 @@ interface WbElement {
   yAxis?: { columnIds: string[] };
   value?: { id?: string; columnId?: string };                                              // pie/donut {id} · kpi {columnId}
   color?: any; stacking?: string; orientation?: string;                                    // bar styling
-  latitude?: { id: string }; longitude?: { id: string }; size?: { id: string };            // point-map
+  latitude?: { id: string }; longitude?: { id: string }; size?: { id: string };            // point-map / scatter
   region?: { id: string; regionType: string }; geography?: { id: string };                 // region-map / geography-map
+  visibleAsSource?: boolean;                                                                // hidden grouped source (scatter)
 }
 interface WbPage { id: string; name: string; elements: WbElement[]; }
 export interface CognosReportResult {
@@ -603,12 +604,51 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
       if (colorId) el.color = { id: colorId };
       if (valId) el.value = { id: valId };
     } else if (kind === 'scatter-chart') {
-      const xId = addCol(xs[0] || cats[0], false);
-      const yId = addCol(ys[0] || vals[0] || sizes[0], true);
+      // A Cognos bubble/scatter is measure-vs-measure with the series/color slot as
+      // the POINT identity. Sigma's scatter axes are a GROUPING axis: putting an
+      // aggregate directly on xAxis evaluates it per source row and every point
+      // collapses to the DM grain (verified Qlik-side, bead ry0n). Correct,
+      // UI-verified shape: bind the scatter to a hidden grouped SOURCE table (one
+      // row per point dim) and reference the grouped columns with RAW refs; the dim
+      // stays on color:{by:category} so points don't merge.
+      const dimSlot = series[0] || colorSlot[0];
+      const xId = addCol(xs[0] || cats[0], true);                  // x measure (Sum-wrapped per point)
+      const yId = addCol(ys[0] || vals[0] || sizes[0], true);      // y measure
+      const dId = dimSlot ? addCol(dimSlot, false) : undefined;    // point identity (category)
+      const szId = sizes[0] && sizes[0] !== (ys[0] || vals[0]) ? addCol(sizes[0], true) : undefined;
+      if (xId && yId && dId) {
+        // hidden grouped source: one row per dim, x/y(/size) aggregated.
+        const grpId = sigmaShortId();
+        const srcName = `${vizName} (scatter source)`;
+        const src: WbElement = {
+          id: sigmaShortId(), kind: 'table', name: srcName, source: chartSource(q),
+          columns: cols, order: cols.map((c) => c.id),
+          groupings: [{ id: grpId, groupBy: [dId], calculations: szId ? [xId, yId, szId] : [xId, yId] }],
+          visibleAsSource: false,
+        };
+        applyQueryFilters(src, q);   // carry detail filters onto the source grain
+        // scatter element: raw refs back to the grouped source columns by display name.
+        const byId = new Map(cols.map((c) => [c.id, c]));
+        const raw = (srcColId: string) => {
+          const sc = byId.get(srcColId)!;
+          return { id: sigmaShortId(), name: sc.name, formula: `[${srcName}/${sc.name}]` };
+        };
+        const sDim = raw(dId), sX = raw(xId), sY = raw(yId);
+        const scols: WbColumn[] = [sDim, sX, sY];
+        el.source = { kind: 'table', elementId: src.id, groupingId: grpId };
+        el.xAxis = { columnId: sX.id };
+        el.yAxis = { columnIds: [sY.id] };
+        el.color = { by: 'category', column: sDim.id };
+        if (szId) { const sSz = raw(szId); scols.push(sSz); el.size = { id: sSz.id }; }
+        el.columns = scols; el.order = scols.map((c) => c.id);
+        pageEls.push(src);
+        pageEls.push(el);
+        continue;   // self-contained: skip the shared el.columns=cols assignment below
+      }
+      // <2 measures or no category dim: fall back to a plain ungrouped scatter.
       if (xId) el.xAxis = { columnId: xId };
       if (yId) el.yAxis = { columnIds: [yId] };
-      const cId = addCol(series[0] || colorSlot[0], false);
-      if (cId) el.color = { by: 'category', column: cId };
+      if (dId) el.color = { by: 'category', column: dId };
     } else {
       // cartesian: bar / line / area / combo
       const xId = addCol(cats[0], false, true);

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -478,6 +478,8 @@ def main():
     # Looker pixel heights and axis labels render.
     ROW_SCALE = 2
     elements, layout_items = [], []
+    scatter_srcs = []   # hidden grouped SOURCE tables for measure-vs-measure scatters
+                        # (one row per point dim); parked on the Data page, no layout slot
 
     # API-created dashboards that were never arranged in the Looker UI have
     # layout components with NULL row/column/width/height — auto-flow those
@@ -587,24 +589,69 @@ def main():
                 warnings.append(f"tile '{el['name']}': Looker show_comparison ({el.get('comparisonType')}) — "
                                 f"Sigma KPI spec has no comparison/delta slot; add a second KPI side-by-side or set it in the UI")
         elif kind == "scatter-chart":
-            # both axes are measures; the (optional) dimension becomes the color split
+            # both axes are measures; the (optional) dimension becomes the point split.
             xf = ms[0] if ms else None
             yf = ms[1] if len(ms) > 1 else None
-            xid, yid, cols = sid("x"), sid("y"), []
-            xcol = {"id": xid, "formula": formula_for(xf, ex) if xf else "Count()",
-                    "name": disp(leaf(xf)) if xf else "X"}
-            ycol = {"id": yid, "formula": formula_for(yf, ex) if yf else "Count()",
-                    "name": disp(leaf(yf)) if yf else "Y"}
-            if xf: apply_fmt(xcol, xf)
-            if yf: apply_fmt(ycol, yf)
-            cols.append(xcol); cols.append(ycol)
-            base["columns"] = cols
-            base["xAxis"] = {"columnId": xid}; base["yAxis"] = {"columnIds": [yid]}
-            if ds:
-                clr = sid("clr")
-                cols.append({"id": clr, "formula": formula_for(ds[0], ex), "name": col_display(ds[0], ex)})
-                base["color"] = {"by": "category", "column": clr}
-            for mf in (ms[:2] or []): _warn_count(mf, el)
+            sf = ms[2] if len(ms) > 2 else None     # optional size measure
+            if ds and xf and yf:
+                # Sigma's scatter axis is a GROUPING axis: putting an aggregate
+                # (Sum(...)) directly on xAxis makes it evaluate per source row and
+                # every point collapses to one x — the spec POSTs but renders wrong
+                # (proven on qlik; bead ry0n). Correct shape: bind the scatter to a
+                # hidden grouped SOURCE table (one row per point dim) and reference
+                # the grouped columns with RAW refs; the dim stays on
+                # color:{by:category} so points don't merge.
+                src_id = eid + "-src"
+                src_name = master_of(ex)["name"] + " Scatter " + eid[-6:]
+                grp_id = src_id + "-g"
+                dimid, sxid, syid = sid("d"), sid("x"), sid("y")
+                dim_col = {"id": dimid, "formula": formula_for(ds[0], ex), "name": col_display(ds[0], ex)}
+                src_xcol = apply_fmt({"id": sxid, "formula": formula_for(xf, ex), "name": disp(leaf(xf))}, xf)
+                src_ycol = apply_fmt({"id": syid, "formula": formula_for(yf, ex), "name": disp(leaf(yf))}, yf)
+                src_cols = [dim_col, src_xcol, src_ycol]
+                calc_ids = [sxid, syid]
+                src_sz = None
+                if sf:
+                    szid = sid("s")
+                    src_sz = apply_fmt({"id": szid, "formula": formula_for(sf, ex), "name": disp(leaf(sf))}, sf)
+                    src_cols.append(src_sz); calc_ids.append(szid)
+                scatter_srcs.append({
+                    "id": src_id, "kind": "table", "name": src_name,
+                    "source": {"elementId": master_of(ex)["id"], "kind": "table"},
+                    "columns": src_cols,
+                    "groupings": [{"id": grp_id, "groupBy": [dimid], "calculations": calc_ids}],
+                    "visibleAsSource": False,
+                })
+                # scatter element: RAW refs to the grouped source's columns
+                def _raw(col):
+                    return {"id": sid("c"), "formula": f"[{src_name}/{col['name']}]", "name": col["name"]}
+                r_dim, r_x, r_y = _raw(dim_col), _raw(src_xcol), _raw(src_ycol)
+                scols = [r_dim, r_x, r_y]
+                base["source"] = {"elementId": src_id, "kind": "table", "groupingId": grp_id}
+                base["xAxis"] = {"columnId": r_x["id"]}; base["yAxis"] = {"columnIds": [r_y["id"]]}
+                base["color"] = {"by": "category", "column": r_dim["id"]}
+                if src_sz is not None:
+                    r_sz = _raw(src_sz); scols.append(r_sz); base["size"] = {"id": r_sz["id"]}
+                base["columns"] = scols
+                for mf in [m for m in (xf, yf, sf) if m]: _warn_count(mf, el)
+            else:
+                # no point dimension (or <2 measures): a single aggregate point is
+                # correct, so keep the ungrouped measure-vs-measure shape.
+                xid, yid, cols = sid("x"), sid("y"), []
+                xcol = {"id": xid, "formula": formula_for(xf, ex) if xf else "Count()",
+                        "name": disp(leaf(xf)) if xf else "X"}
+                ycol = {"id": yid, "formula": formula_for(yf, ex) if yf else "Count()",
+                        "name": disp(leaf(yf)) if yf else "Y"}
+                if xf: apply_fmt(xcol, xf)
+                if yf: apply_fmt(ycol, yf)
+                cols.append(xcol); cols.append(ycol)
+                base["columns"] = cols
+                base["xAxis"] = {"columnId": xid}; base["yAxis"] = {"columnIds": [yid]}
+                if ds:
+                    clr = sid("clr")
+                    cols.append({"id": clr, "formula": formula_for(ds[0], ex), "name": col_display(ds[0], ex)})
+                    base["color"] = {"by": "category", "column": clr}
+                for mf in (ms[:2] or []): _warn_count(mf, el)
         elif kind in ("bar-chart", "area-chart", "line-chart"):
             cols, ymids = [], []
             xid = sid("x"); xf = ds[0] if ds else (el["fields"][0] if el["fields"] else None)
@@ -997,7 +1044,9 @@ def main():
                      "formula": f"[{master_of(ex)['name']}/{d}]"}
                     for d in master_of(ex)["needed"]],
     } for (ex, _lset), sc in scope_tables.items()]
-    spec["pages"][0]["elements"] = master_elements + scope_elements
+    # scatter grouped sources (one row per point dim) live on the Data page next
+    # to the masters — visibleAsSource:False, so they need no layout slot.
+    spec["pages"][0]["elements"] = master_elements + scope_elements + scatter_srcs
 
     open(a.out, "w").write(json.dumps(spec, indent=2))
     # intended-scope contract for the control-coverage lint — MUST be the

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -393,6 +393,13 @@ QS_FALLBACK = {
   'RadarChartVisual'    => 'table'
 }.freeze
 build_warnings = []
+# Hidden GROUPED source tables emitted for scatter-charts (one row per point dim),
+# appended to the Data page next to the master. See the scatter branch below
+# (ported from the live-verified qlik-to-sigma builder, bead ry0n): Sigma's scatter
+# axis is a GROUPING axis, so an aggregate (Sum(...)) over the UNGROUPED master
+# collapses every point to one x. The scatter must instead bind to a hidden grouped
+# source whose groupBy is the point dimension.
+scatter_sources = []
 
 master_cols = {}   # colname(raw or calc) -> {id, formula, name}
 def fmt_for(name)
@@ -627,17 +634,55 @@ defn['Sheets'].each_with_index do |sh, sheet_idx|
       xs = rol.('XAxis'); ys = rol.('YAxis'); cat = rol.('Category'); sz = rol.('Size')
       (next if xs.empty? || ys.empty?)
       xc, xid = meas_col(xs[0], calc, master_cols, DMEL, M); yc, yid = meas_col(ys[0], calc, master_cols, DMEL, M)
-      el = base.merge('columns' => [xc, yc], 'xAxis' => { 'columnId' => xid }, 'yAxis' => { 'columnIds' => [yid] })
       if cat.any?
-        dc, did = dim_col(cat[0], calc, master_cols, DMEL, M); el['columns'] << dc; el['color'] = { 'by' => 'category', 'column' => did }
-      end
-      # D8: QuickSight scatter Size (bubble radius). Sigma scatter has no verified spec
-      # size/radius channel (mirrors bar/line shape: xAxis+yAxis+color only), so we PROJECT
-      # the size measure as a column (data migrates + available in the element) and record a
-      # warning that bubble-sizing itself is a Sigma UI-only/limitation, not data loss.
-      if sz.any?
-        szc, _szid = meas_col(sz[0], calc, master_cols, DMEL, M); el['columns'] << szc
-        build_warnings << { 'visual' => title, 'type' => 'ScatterBubbleSize', 'reason' => "QuickSight scatter bubble-size ('#{sz[0][1]}') has no Sigma scatter size channel; the measure is projected as a column but bubbles render uniform-size (Sigma limitation)" }
+        # A QuickSight scatter is measure-vs-measure with the Category field as the POINT
+        # identity. Sigma's scatter axis is a GROUPING axis: an aggregate (Sum(...)) over
+        # the UNGROUPED master evaluates per-row and every point collapses to one x — the
+        # spec POSTs but renders wrong (bead ry0n; ported from the live-verified
+        # qlik-to-sigma builder, 2026-06-15). Correct shape: bind the scatter to a HIDDEN
+        # GROUPED source table (one row per point dim) and reference its grouped columns
+        # with raw refs; the dim stays on color:{by:category} so points don't merge.
+        dc, did = dim_col(cat[0], calc, master_cols, DMEL, M)
+        gcols = [dc, xc, yc]          # group dim + x + y (+ size); columns live on the source
+        gcids = [xid, yid]            # aggregated calculations (size appended below)
+        szc = nil
+        if sz.any?
+          szc, szid = meas_col(sz[0], calc, master_cols, DMEL, M)
+          gcols << szc; gcids << szid
+        end
+        src_id = "#{eid}-src"; src_name = "Scatter Source #{eid[-6..-1]}"
+        grp_id = "#{src_id}-g"
+        scatter_sources << { 'id' => src_id, 'kind' => 'table', 'name' => src_name,
+                             'visibleAsSource' => false,
+                             'source' => { 'elementId' => 'master', 'kind' => 'table' },
+                             'columns' => gcols,
+                             'groupings' => [{ 'id' => grp_id, 'groupBy' => [did], 'calculations' => gcids }] }
+        # RAW (non-aggregating) refs into the grouped source, one per channel.
+        raw = lambda do |col|
+          { 'id' => "#{eid}-#{col['id']}", 'formula' => "[#{src_name}/#{col['name']}]", 'name' => col['name'] }
+        end
+        s_dim = raw.(dc); s_x = raw.(xc); s_y = raw.(yc)
+        scols = [s_dim, s_x, s_y]
+        el = base.merge('source' => { 'elementId' => src_id, 'kind' => 'table', 'groupingId' => grp_id },
+                        'xAxis' => { 'columnId' => s_x['id'] }, 'yAxis' => { 'columnIds' => [s_y['id']] },
+                        'color' => { 'by' => 'category', 'column' => s_dim['id'] })
+        # D8 (now a real channel): QuickSight scatter Size becomes a Sigma scatter
+        # size:{id} channel over the grouped source's size aggregate.
+        if szc
+          s_sz = raw.(szc); scols << s_sz; el['size'] = { 'id' => s_sz['id'] }
+        end
+        el['columns'] = scols
+      else
+        # No point dimension: keep the prior measure-vs-measure-on-master behavior
+        # (a single ungrouped scatter point is still the faithful migration here).
+        el = base.merge('columns' => [xc, yc], 'xAxis' => { 'columnId' => xid }, 'yAxis' => { 'columnIds' => [yid] })
+        # D8: QuickSight scatter Size (bubble radius) with no grouping. Sigma scatter has no
+        # verified ungrouped size channel, so we PROJECT the size measure as a column (data
+        # migrates) and record a warning that bubble-sizing renders uniform.
+        if sz.any?
+          szc, _szid = meas_col(sz[0], calc, master_cols, DMEL, M); el['columns'] << szc
+          build_warnings << { 'visual' => title, 'type' => 'ScatterBubbleSize', 'reason' => "QuickSight scatter bubble-size ('#{sz[0][1]}') has no Sigma scatter size channel (no point dimension to group on); the measure is projected as a column but bubbles render uniform-size (Sigma limitation)" }
+        end
       end
     when 'table'
       cf_fieldmap = {}   # QS FieldId -> Sigma column id (for D19 conditional formatting)
@@ -778,9 +823,14 @@ if dash_pages.empty?
   sheet_pages = [{ 'pageId' => 'page-dash', 'name' => (an['Name'] || 'Dashboard'), 'sheetIndex' => 0, 'elements' => [] }]
 end
 
+# Scatter charts emit a hidden GROUPED source table (one row per point dim). Park
+# them on the Data page next to the master (visibleAsSource:false, so they need no
+# layout slot) — they're sourced by the scatter element via {elementId, groupingId}.
+data_elements = [master] + scatter_sources
+
 spec = { 'name' => (an['Name'] || 'QuickSight Migration') + ' (from QuickSight)',
          'schemaVersion' => 1,
-         'pages' => [{ 'id' => 'page-data', 'name' => 'Data', 'elements' => [master] }] + dash_pages }
+         'pages' => [{ 'id' => 'page-data', 'name' => 'Data', 'elements' => data_elements }] + dash_pages }
 spec['folderId'] = opts[:folder] if opts[:folder]
 
 File.write(opts[:out], JSON.pretty_generate(spec))

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -174,8 +174,11 @@ def migrate_liveboard(lb_doc, dm, denorm_id, denorm_name, resolver, prefix, fall
     specs = [ps for _, ps in viz_specs]
     master = ts_common.master_element(specs, resolver, dm, denorm_id, denorm_name)
     elements = [ts_common.sigma_element(s, resolver) for s in specs]
+    # Hidden grouped scatter-source tables must live on the SAME page as the
+    # m-ofv master they source (visibleAsSource:False → no layout slot needed).
+    data_elems = [master] + ts_common.drain_scatter_sources()
     spec = {"name": f"{prefix}{display} (from ThoughtSpot)", "folderId": folder, "schemaVersion": 1,
-            "pages": [{"id": "p-data", "name": "Data", "elements": [master]},
+            "pages": [{"id": "p-data", "name": "Data", "elements": data_elems},
                       {"id": "p-main", "name": display[:40], "elements": elements}]}
     wb = post_workbook(spec, wd)
     tiles = lb_tiles(lb, viz_specs, elements)
@@ -237,9 +240,11 @@ def migrate_answer(ans_id, dm, denorm_id, denorm_name, resolver, prefix, folder,
     display = ans.get("name") or ("Answer " + ans_id[:8])
     spec_v = ts_common.parse_ts_viz({"answer": ans}, resolver)
     master = ts_common.master_element([spec_v], resolver, dm, denorm_id, denorm_name)
+    main_el = ts_common.sigma_element(spec_v, resolver)
+    data_elems = [master] + ts_common.drain_scatter_sources()  # park any hidden scatter source by the master
     spec = {"name": f"{prefix}{display} (from ThoughtSpot)", "folderId": folder, "schemaVersion": 1,
-            "pages": [{"id": "p-data", "name": "Data", "elements": [master]},
-                      {"id": "p-main", "name": display[:40], "elements": [ts_common.sigma_element(spec_v, resolver)]}]}
+            "pages": [{"id": "p-data", "name": "Data", "elements": data_elems},
+                      {"id": "p-main", "name": display[:40], "elements": [main_el]}]}
     wb = post_workbook(spec, wd)
     apply_layouts.apply(wb)
     return wb, display

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
@@ -28,6 +28,23 @@ def sigma_display_name(s):
 def nid(p="el"):
     return p + "-" + "".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(8))
 
+# Hidden grouped SOURCE tables emitted for scatter/bubble charts. A measure-vs-
+# measure scatter sourced directly off the shared denorm master ("m-ofv") with
+# NO grouping over-plots/collapses (every row becomes a point). The correct,
+# live-verified shape (qlik-to-sigma build-sigma-workbook.py, bead ry0n) is to
+# bind the scatter to a hidden grouped source (one row per point dim). These get
+# parked on whatever page carries the master (visibleAsSource:False → no layout
+# slot). drain_scatter_sources() empties this onto that page after element build.
+_SCATTER_SRC = []
+
+def drain_scatter_sources():
+    """Pop the hidden grouped scatter-source tables accumulated by _element_core.
+    Call after building every element, then extend the master's page with the
+    result (they must live on the SAME page as the m-ofv master they source)."""
+    out = list(_SCATTER_SRC)
+    _SCATTER_SRC.clear()
+    return out
+
 _CUR = {"USD": "$", "CAD": "$", "AUD": "$", "NZD": "$", "EUR": "€", "GBP": "£",
         "JPY": "¥", "CNY": "¥", "INR": "₹", "KRW": "₩", "BRL": "R$"}
 
@@ -282,14 +299,19 @@ def sigma_element(spec, resolver, master="OFV"):
     # Show value labels on bar/pie/donut (Sigma defaults them OFF). Lines stay clean.
     if el.get("kind") in ("bar-chart", "pie-chart", "donut-chart"):
         el["dataLabel"] = {"labels": "shown"}
+    # A grouped scatter sources a hidden grouped table (not the master), so its
+    # search-query filters must be applied to that SOURCE (pre-grouping, master
+    # grain) — a [OFV/…] ref on the scatter element itself would not resolve.
+    grp = el.get("source", {}).get("groupingId")
+    ftarget = next((s for s in _SCATTER_SRC if s["id"] == el["source"].get("elementId")), el) if grp else el
     for f in spec.get("filters", []):
         e = _resolve(resolver, f["col"])
-        existing = next((c for c in el["columns"] if c.get("name") == f["col"]), None)
+        existing = next((c for c in ftarget["columns"] if c.get("name") == f["col"]), None)
         if existing:
             col_id = existing["id"]
         else:
-            col_id = nid("f"); el["columns"].append({"id": col_id, "formula": f"[{master}/{e['friendly']}]", "name": f["col"]})
-        el.setdefault("filters", []).append({"id": nid(), "columnId": col_id, "kind": "list",
+            col_id = nid("f"); ftarget["columns"].append({"id": col_id, "formula": f"[{master}/{e['friendly']}]", "name": f["col"]})
+        ftarget.setdefault("filters", []).append({"id": nid(), "columnId": col_id, "kind": "list",
                                              "mode": f["mode"], "values": f["values"]})
     _apply_sorts(el, spec)
     return el
@@ -389,18 +411,53 @@ def _element_core(spec, resolver, master="OFV"):
             mid = nid("m"); cols.append({"id": mid, "formula": mref(m), "name": m, "format": _fmt(_resolve(resolver, m))}); mids.append(mid)
         return {"id": nid(), "kind": "table", "name": name, "source": src, "columns": cols,
                 "groupings": [{"id": nid(), "groupBy": dids, "calculations": mids}]}
-    # Scatter / bubble — plot two measures (x vs y) with an optional category color.
-    # Falls through to the default axis chart when there aren't two measures.
+    # Scatter / bubble — measure-vs-measure with the dimension as the POINT
+    # identity (ThoughtSpot measure order = x, y, size). Sigma's scatter axis is
+    # a GROUPING axis: putting an aggregate (Sum(...)) straight on xAxis makes it
+    # evaluate per source row, so every point collapses to one x (or over-plots).
+    # Correct, UI-verified shape (qlik bead ry0n): bind the scatter to a hidden
+    # grouped SOURCE table (one row per point dim) sourced off the shared master,
+    # reference the grouped columns with RAW refs, and keep the dim on
+    # color:{by:category} so distinct points don't merge. BUBBLE's 3rd measure →
+    # size:{id}. With no point dim, fall through to the plain axis scatter.
+    if chart in ("SCATTER", "BUBBLE") and len(meas) >= 2 and dims:
+        eid = nid()
+        src_name = "Scatter Source " + re.sub(r'[^A-Za-z0-9]', '', eid)[-6:]
+        src_id = eid + "-src"; grp_id = eid + "-g"
+        # grouped source columns (live on the hidden table): dim + measures over master
+        sdc = nid("c"); sxc = nid("c"); syc = nid("c")
+        scols = [{"id": sdc, "formula": dref(dims[0]), "name": dims[0]},
+                 {"id": sxc, "formula": mref(meas[0]), "name": meas[0], "format": _fmt(_resolve(resolver, meas[0]))},
+                 {"id": syc, "formula": mref(meas[1]), "name": meas[1], "format": _fmt(_resolve(resolver, meas[1]))}]
+        scalc = [sxc, syc]
+        size_meas = None
+        if chart == "BUBBLE" and len(meas) >= 3:
+            ssz = nid("c"); size_meas = meas[2]
+            scols.append({"id": ssz, "formula": mref(meas[2]), "name": meas[2],
+                          "format": _fmt(_resolve(resolver, meas[2]))})
+            scalc.append(ssz)
+        _SCATTER_SRC.append({"id": src_id, "kind": "table", "name": src_name, "source": src,
+                             "columns": scols, "visibleAsSource": False,
+                             "groupings": [{"id": grp_id, "groupBy": [sdc], "calculations": scalc}]})
+        # scatter element: RAW refs into the grouped source, sourced by groupingId
+        def _raw(col):
+            return {"id": nid("c"), "formula": f"[{src_name}/{col['name']}]", "name": col["name"]}
+        r_dim, r_x, r_y = _raw(scols[0]), _raw(scols[1]), _raw(scols[2])
+        cols = [r_dim, r_x, r_y]
+        el = {"id": eid, "kind": "scatter-chart", "name": name,
+              "source": {"elementId": src_id, "kind": "table", "groupingId": grp_id},
+              "columns": cols, "xAxis": {"columnId": r_x["id"]}, "yAxis": {"columnIds": [r_y["id"]]},
+              "color": {"by": "category", "column": r_dim["id"]}}
+        if size_meas is not None:
+            r_sz = _raw(scols[3]); cols.append(r_sz); el["size"] = {"id": r_sz["id"]}
+        return el
     if chart in ("SCATTER", "BUBBLE") and len(meas) >= 2:
+        # no point dimension: plain measure-vs-measure cartesian off the master
         xc = nid("c"); yc = nid("c")
         cols = [{"id": xc, "formula": mref(meas[0]), "name": meas[0], "format": _fmt(_resolve(resolver, meas[0]))},
                 {"id": yc, "formula": mref(meas[1]), "name": meas[1], "format": _fmt(_resolve(resolver, meas[1]))}]
-        el = {"id": nid(), "kind": "scatter-chart", "name": name, "source": src, "columns": cols,
-              "xAxis": {"columnId": xc}, "yAxis": {"columnIds": [yc]}}
-        if dims:
-            dc = nid("c"); cols.append({"id": dc, "formula": dref(dims[0]), "name": dims[0]})
-            el["color"] = {"by": "category", "column": dc}
-        return el
+        return {"id": nid(), "kind": "scatter-chart", "name": name, "source": src, "columns": cols,
+                "xAxis": {"columnId": xc}, "yAxis": {"columnIds": [yc]}}
     # Combo (column + line) — first measure as bars, remaining measures as line series.
     if chart in ("LINE_COLUMN", "LINE_STACKED_COLUMN") and dims and len(meas) >= 2:
         xc = nid("c"); cols = [{"id": xc, "formula": dref(dims[0]), "name": dims[0]}]; ycids = []


### PR DESCRIPTION
The audit found the **same scatter regression** in four builders: a measure-vs-measure scatter sourced from the **ungrouped** master. Sigma's scatter axis is a grouping axis, so aggregate x/y over an ungrouped source evaluates per-row and **every point collapses to one x** — POSTs fine, renders wrong.

Ports the qlik-proven pattern to each: when a point dimension exists, emit a **hidden grouped source** (groupBy dim, calcs x/y/size, `visibleAsSource:false`) and bind the scatter via `source.groupingId` with raw-ref columns, `color:{by:category}` (required), `size:{id}`. No-dimension case keeps prior single-point behavior.

Per-converter:
- **looker** — closure-local accumulator → page-data.
- **quicksight** — also fixes **size** (was a bare column + warning) → real `size:{id}`.
- **thoughtspot** — BUBBLE size mapped; search-query filters routed to the hidden source (master grain).
- **cognos** — TypeScript port; `tsc --noEmit` clean.

**Validation:** each builder harness-emits the correct structure (`source.groupingId` + hidden grouped source + `color:{by:category}` + `size:{id}`, fallback preserved) — the same structure proven to render **un-collapsed live in qlik (64 distinct points)**. `py_compile`/`ruby -c`/`tsc` clean. Live per-converter render validation to follow (looker against hakkoda1 first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)