### PR TITLE
fix: verify-parity coerces numeric-string dims (scatter x false-DIVERGE)

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-parity.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-parity.rb
@@ -93,10 +93,14 @@ end
 
 def round_row(row)
   # Convert all numerics to Float-rounded so Integer 11 and Float 11.0 compare equal in the set,
-  # and canonicalize date-like dim strings so equivalent monthly buckets match.
+  # canonicalize date-like dim strings so equivalent monthly buckets match, and
+  # coerce purely-numeric STRINGS to floats (a scatter x-axis value reads back as a
+  # string in the workbook query and must compare equal to the numeric expected side).
   row.map do |v|
     if v.is_a?(Numeric)
       v.to_f.round(2)
+    elsif v.is_a?(String) && v.strip.match?(/\A-?\d+(\.\d+)?\z/)
+      v.strip.to_f.round(2)   # numeric-string (e.g. a scatter x-axis value) -> float, so it compares equal to the numeric side
     else
       canonicalize_dim(v)
     end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-parity.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-parity.rb
@@ -93,10 +93,14 @@ end
 
 def round_row(row)
   # Convert all numerics to Float-rounded so Integer 11 and Float 11.0 compare equal in the set,
-  # and canonicalize date-like dim strings so equivalent monthly buckets match.
+  # canonicalize date-like dim strings so equivalent monthly buckets match, and
+  # coerce purely-numeric STRINGS to floats (a scatter x-axis value reads back as a
+  # string in the workbook query and must compare equal to the numeric expected side).
   row.map do |v|
     if v.is_a?(Numeric)
       v.to_f.round(2)
+    elsif v.is_a?(String) && v.strip.match?(/\A-?\d+(\.\d+)?\z/)
+      v.strip.to_f.round(2)   # numeric-string (e.g. a scatter x-axis value) -> float, so it compares equal to the numeric side
     else
       canonicalize_dim(v)
     end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-parity.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-parity.rb
@@ -93,10 +93,14 @@ end
 
 def round_row(row)
   # Convert all numerics to Float-rounded so Integer 11 and Float 11.0 compare equal in the set,
-  # and canonicalize date-like dim strings so equivalent monthly buckets match.
+  # canonicalize date-like dim strings so equivalent monthly buckets match, and
+  # coerce purely-numeric STRINGS to floats (a scatter x-axis value reads back as a
+  # string in the workbook query and must compare equal to the numeric expected side).
   row.map do |v|
     if v.is_a?(Numeric)
       v.to_f.round(2)
+    elsif v.is_a?(String) && v.strip.match?(/\A-?\d+(\.\d+)?\z/)
+      v.strip.to_f.round(2)   # numeric-string (e.g. a scatter x-axis value) -> float, so it compares equal to the numeric side
     else
       canonicalize_dim(v)
     end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-parity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-parity.rb
@@ -93,10 +93,14 @@ end
 
 def round_row(row)
   # Convert all numerics to Float-rounded so Integer 11 and Float 11.0 compare equal in the set,
-  # and canonicalize date-like dim strings so equivalent monthly buckets match.
+  # canonicalize date-like dim strings so equivalent monthly buckets match, and
+  # coerce purely-numeric STRINGS to floats (a scatter x-axis value reads back as a
+  # string in the workbook query and must compare equal to the numeric expected side).
   row.map do |v|
     if v.is_a?(Numeric)
       v.to_f.round(2)
+    elsif v.is_a?(String) && v.strip.match?(/\A-?\d+(\.\d+)?\z/)
+      v.strip.to_f.round(2)   # numeric-string (e.g. a scatter x-axis value) -> float, so it compares equal to the numeric side
     else
       canonicalize_dim(v)
     end


### PR DESCRIPTION
The live looker scatter migration exposed this: a scatter's x-axis value reads back from the workbook query as a **string** (`"31649.57"`) while the expected side is numeric, so `verify-parity` false-**FAILED** a correct scatter (5 distinct points, exact matching values).

`round_row` now coerces purely-numeric strings to float (the coercion thoughtspot already had, promoted to tableau/looker/powerbi/quicksight). Date-like strings still route to `canonicalize_dim` (numeric regex has no dashes — no conflict).

**Verified:** the exact looker scatter case now **PASSes** instead of DIVERGE. `ruby -c` clean ×4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)