### PR TITLE
feat(powerbi): reference/trend lines + by-measure colors + auto visual-QA gate (P3+P4+P1)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -385,6 +385,70 @@ def measure_formula(fs)
   end
 end
 
+# bead (A) reference lines: PBI analytics-pane constant lines (rec['ref_lines'],
+# captured by extract-pbir._reference_lines) -> Sigma `refMarks`. VERIFIED shape
+# (ported from build-charts-from-signals.rb + qlik-to-sigma qlik_refmarks,
+# 2026-06-15): `value` MUST be the wrapped object form ({type:formula,formula} —
+# a bare number 400s; value.type:column is rejected too, so a column threshold
+# goes through `formula`), and `label.visibility` MUST be 'shown' (the docs'
+# bare-number/string forms are rejected by the live API). axis is carried from
+# the PBI axis ('series' for y-axis lines, 'axis' for x). Only emitted for the
+# cartesian kinds Sigma supports refMarks on.
+def build_ref_marks(rec)
+  Array(rec['ref_lines']).map do |rl|
+    val = rl['value']
+    # constant numbers go through verbatim; anything else is treated as a Sigma
+    # formula (a measure-bound threshold the agent can refine).
+    formula = val.to_s
+    next nil if formula.strip.empty?
+    rm = { 'type' => 'line', 'axis' => (rl['axis'] || 'series'),
+           'value' => { 'type' => 'formula', 'formula' => formula } }
+    line = {}
+    line['color'] = rl['color'] if rl['color']
+    rm['line'] = line.merge('width' => 2) unless line.empty?
+    label = { 'visibility' => 'shown' }
+    label['text'] = rl['label'] if rl['label'] && !rl['label'].to_s.empty?
+    rm['label'] = label
+    rm
+  end.compact
+end
+
+# bead (A) trend line: PBI 'Trend line' analytics toggle -> Sigma trendlines[].
+# The verified shape (build-charts-from-signals.rb) keys the trendline to a
+# value column id with model + shown label/value. PBI offers only a linear trend.
+def build_trendlines(rec, ycids)
+  return [] unless rec['trend_line'] && ycids && !ycids.empty?
+  model = (rec['trend_line']['model'] || 'linear').to_s
+  ycids.map do |cid|
+    real = cid.is_a?(Hash) ? cid['columnId'] : cid   # combo: {columnId,type} form
+    { 'columnId' => real, 'model' => model,
+      'label' => { 'visibility' => 'shown' }, 'value' => { 'visibility' => 'shown' } }
+  end
+end
+
+# bead (B) by-measure color: PBI 'Color saturation' / FX fill-by-value
+# (rec['measure_color'] = {queryRef, scheme[], reverse}) -> Sigma
+# color:{by:scale, column:<dup measure>, scheme}. Ported from qlik-to-sigma's
+# qlik_color: a Sigma column can't be on BOTH yAxis and color, so the driving
+# measure is DUPLICATED into a new (hidden) column referenced by the scale.
+# Mutates `cols` (appends the dup column) and returns the color hash, or nil.
+def measure_color_channel(rec, fields, master, vfmts, eid, cols, ycids)
+  mc = rec['measure_color']
+  return nil unless mc && mc['queryRef'] && ycids && !ycids.empty?
+  fs = field_spec(mc['queryRef'], fields, master)
+  scheme = Array(mc['scheme']).dup
+  scheme = ['#ffffcc', '#fd8d3c', '#bd0026'] if scheme.empty?
+  scheme.reverse! if mc['reverse']
+  base_cid = ycids.first.is_a?(Hash) ? ycids.first['columnId'] : ycids.first
+  base = cols.find { |c| c['id'] == base_cid }
+  cid = "#{eid}-clr"
+  dup = { 'id' => cid, 'name' => "#{qr_leaf(mc['queryRef'], 'Value')} (color)",
+          'formula' => (base ? base['formula'] : measure_formula(fs)), 'hidden' => true }
+  apply_fmt(dup, mc['queryRef'], fields, vfmts)
+  cols << dup
+  { 'by' => 'scale', 'column' => cid, 'scheme' => scheme }
+end
+
 # Deterministic, collision-free short id from a PBIR visual id. PBIR visual ids
 # often share a long common prefix (e.g. a1b2c3d4e5f60001 / ...0002), so a naive
 # prefix-truncate collides. Take a stable suffix of the sanitized id plus a short
@@ -802,7 +866,17 @@ def build_element(rec, fields, masters, extra_data = [])
       cols << { 'id' => scid, 'formula' => sfs['ref'], 'name' => qr_leaf(series, 'Series') }
       qr_cids[series] = scid
       el['color'] = { 'by' => 'category', 'column' => scid }
+    else
+      # bead (B) by-measure color: only when PBI did NOT bind a categorical
+      # Series/Legend (that wins — a column can't be on color twice).
+      cc = measure_color_channel(rec, fields, master, vfmts, eid, cols, ycids)
+      el['color'] = cc if cc
     end
+    # bead (A) reference lines / trend line -> Sigma refMarks / trendlines.
+    rms = build_ref_marks(rec)
+    el['refMarks'] = rms unless rms.empty?
+    tls = build_trendlines(rec, ycids)
+    el['trendlines'] = tls unless tls.empty?
   when 'combo-chart'
     # bead 6v5u: PBI lineClustered/StackedColumnComboChart -> Sigma combo. Roles:
     # Category (x), Y (columns -> primary/left axis), Y2 (lines -> secondary/right
@@ -837,6 +911,14 @@ def build_element(rec, fields, masters, extra_data = [])
     end
     el['xAxis'] = { 'columnId' => dcid }
     el['yAxis'] = { 'columnIds' => ycids }
+    # bead (B) by-measure color on the combo's primary bars.
+    cc = measure_color_channel(rec, fields, master, vfmts, eid, cols, ycids)
+    el['color'] = cc if cc
+    # bead (A) reference lines / trend line.
+    rms = build_ref_marks(rec)
+    el['refMarks'] = rms unless rms.empty?
+    tls = build_trendlines(rec, ycids)
+    el['trendlines'] = tls unless tls.empty?
   when 'scatter-chart'
     # bead 14w(b): scatter -> xAxis (measure), yAxis (measure), point category for
     # color/detail. PBI scatter binds X + Y (both measures) and a Category/Details.
@@ -919,6 +1001,9 @@ def build_element(rec, fields, masters, extra_data = [])
     # PBI legend.show=false -> hide the Sigma legend (the detail-on-color split
     # otherwise surfaces a legend PBI did not show).
     el['legend'] = { 'visibility' => 'hidden' } if rec['legend'] == false
+    # bead (A) reference lines on a scatter (e.g. a margin-target line at x=0.45).
+    rms = build_ref_marks(rec)
+    el['refMarks'] = rms unless rms.empty?
   when 'pie-chart', 'donut-chart'
     dim = (b['Category'] || b['Legend'] || []).first
     val = (b['Values'] || b['Y'] || []).first

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
@@ -215,6 +215,126 @@ def _proj_format(proj):
     return fmt if isinstance(fmt, str) and fmt else None
 
 
+def _literal(prop):
+    """Unwrap a PBI property's literal value: {expr:{Literal:{Value:"'x'"}}} -> "x".
+    Numeric literals come through as "400D"/"0.45L" — strip the type suffix."""
+    if not isinstance(prop, dict):
+        return None
+    v = (prop.get("expr") or {}).get("Literal", {}).get("Value")
+    if v is None:
+        return None
+    s = str(v).strip()
+    if s.startswith("'") and s.endswith("'"):
+        return s[1:-1]
+    # numeric literal with a trailing type tag (D=double, L=long, M=decimal)
+    m = __import__("re").fullmatch(r"(-?\d+(?:\.\d+)?)[DLMF]?", s)
+    return m.group(1) if m else s
+
+
+def _color_literal(prop):
+    """A PBI color property is either a flat literal ('#RRGGBB') or a themed
+    solid color {solid:{color:{expr:{Literal:{Value:"'#...'"}}}}}. Return the hex
+    string or None."""
+    if not isinstance(prop, dict):
+        return None
+    direct = _literal(prop)
+    if direct and str(direct).startswith("#"):
+        return direct
+    solid = (prop.get("solid") or {}).get("color")
+    return _color_literal(solid) if solid else None
+
+
+# bead (A) reference lines: PBI analytics-pane lines live in the visual's
+# `objects` under axis-scoped keys. Each is a list of instances; each instance's
+# `properties` carries {value, displayName, lineColor, show, ...}. A `value`
+# literal -> a constant Sigma refMark; a measure-bound line (no flat value) is
+# flagged via expr (the builder formula-wraps it). axis maps to Sigma's
+# refMarks.axis: y-axis lines -> 'series', x-axis lines -> 'axis'.
+REFLINE_OBJECT_AXIS = {
+    "y1AxisReferenceLine": "series", "yAxisReferenceLine": "series",
+    "y2AxisReferenceLine": "series2",
+    "xAxisReferenceLine": "axis",
+    "referenceLine": "series",          # generic (cartesian) constant line
+}
+
+
+def _reference_lines(visual):
+    """PBI analytics-pane constant lines -> [{axis, value|expr, label, color, show}].
+    Best-effort: PBIR records each line as objects.<key>[].properties with a
+    `value` literal (constant) and optional displayName/lineColor."""
+    out = []
+    objs = visual.get("objects", {})
+    for key, axis in REFLINE_OBJECT_AXIS.items():
+        for item in objs.get(key, []):
+            props = item.get("properties", {}) if isinstance(item, dict) else {}
+            show = _literal(props.get("show", {}))
+            if str(show).lower() == "false":
+                continue
+            value = _literal(props.get("value", {}))
+            label = _literal(props.get("displayName", {})) or _literal(props.get("text", {}))
+            color = _color_literal(props.get("lineColor", {})) or _color_literal(props.get("color", {}))
+            if value is None:
+                continue   # measure-bound / styling-only line — skip (no constant to plot)
+            out.append({"axis": axis, "value": value,
+                        "label": label, "color": color})
+    return out
+
+
+def _trend_line(visual):
+    """PBI 'Trend line' analytics toggle (objects.trend show:true) -> {model}.
+    PBI only offers a linear trend; Sigma's trendlines[].model = 'linear'."""
+    for item in visual.get("objects", {}).get("trend", []):
+        props = item.get("properties", {}) if isinstance(item, dict) else {}
+        show = _literal(props.get("show", {}))
+        if str(show).lower() == "true":
+            return {"model": "linear"}
+    return None
+
+
+def _measure_color(visual):
+    """bead (B) by-measure color: PBI 'Color saturation' / conditional fill-by-value
+    on a bar/column/combo. PBIR encodes it under objects.dataPoint[].properties.fill
+    as a fillRule whose gradient stops bind a measure (FieldDef/Aggregation), OR a
+    flat colorSaturation. Returns {queryRef, scheme[], reverse} or None — the builder
+    duplicates that measure onto a color:{by:scale} channel.
+
+    We don't reproduce PBI's exact stops; we map to a 3-stop sequential scheme
+    (low->high) and let the agent tune in Sigma. The signal we need is just WHICH
+    measure drives the saturation."""
+    objs = visual.get("objects", {})
+    for item in objs.get("dataPoint", []) + objs.get("colorSaturation", []):
+        props = item.get("properties", {}) if isinstance(item, dict) else {}
+        fill = props.get("fill") or props.get("fillRule") or props.get("colorSaturation") or {}
+        # the fillRule carries the driving measure under a FieldDef/Aggregation
+        rule = (fill.get("fillRule") if isinstance(fill, dict) else None) or fill
+        qr = _fillrule_measure(rule)
+        if qr:
+            stops = (rule.get("linearGradient2") or rule.get("linearGradient3") or {}) if isinstance(rule, dict) else {}
+            lo = _color_literal((stops.get("min") or {}).get("color", {})) if isinstance(stops, dict) else None
+            hi = _color_literal((stops.get("max") or {}).get("color", {})) if isinstance(stops, dict) else None
+            scheme = [c for c in (lo, hi) if c] or ["#ffffcc", "#fd8d3c", "#bd0026"]
+            return {"queryRef": qr, "scheme": scheme, "reverse": False}
+    return None
+
+
+def _fillrule_measure(rule):
+    """The queryRef of the measure a fillRule's gradient binds, or None."""
+    if not isinstance(rule, dict):
+        return None
+    # gradient stops nest the field under .min/.mid/.max .value, OR the rule
+    # carries a top-level Aggregation/Measure under .field.
+    for grad_key in ("linearGradient2", "linearGradient3"):
+        grad = rule.get(grad_key)
+        if isinstance(grad, dict):
+            for stop in ("min", "mid", "max"):
+                fld = (grad.get(stop) or {}).get("value") or (grad.get(stop) or {}).get("field")
+                qr = _expr_queryref(fld) if fld else None
+                if qr:
+                    return qr
+    fld = rule.get("field") or rule.get("expr")
+    return _expr_queryref(fld) if fld else None
+
+
 def extract(pbir_dir):
     defn = os.path.join(pbir_dir, "definition")
     if not os.path.isdir(defn):
@@ -264,6 +384,14 @@ def extract(pbir_dir):
                 "data_labels": _obj_flag(visual, "labels"),
                 # bead ry0n: PBI legend toggle (objects.legend show) — true/false/None
                 "legend": _obj_flag(visual, "legend"),
+                # bead (A) reference lines: PBI analytics-pane constant lines ->
+                # Sigma refMarks (wrapped value, label.visibility:'shown').
+                "ref_lines": _reference_lines(visual),
+                # bead (A) trend line: PBI 'Trend line' analytics toggle.
+                "trend_line": _trend_line(visual),
+                # bead (B) by-measure color: 'Color saturation' / FX fill-by-value
+                # -> Sigma color:{by:scale, column:<dup measure>, scheme}.
+                "measure_color": _measure_color(visual),
             }
             if rec["sigma_kind"] == "text":
                 rec["text"] = _textbox_body(visual)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -1005,12 +1005,47 @@ puts "   workbookId = #{wb_id}"
 hdr(5, TOTAL, 'Layout')
 run!(['ruby', File.join(HERE, 'put-layout.rb'), '--workbook', wb_id, '--layout', layout], env: ENV.to_h)
 puts "   layout applied to workbook #{wb_id}"
+require 'sigma_rest'
+
+# ---------------------------------------------------------------------------
+# Phase 5b — Visual QA: auto-render each content page to a FULL-PAGE PNG so the
+# layout can be reviewed against refs/layout-visual-qa.md AND compared to the
+# source PBI page captures (SKILL.md Phase 5e/5f gate). Matches qlik/tableau
+# Phase 5b. NON-FATAL — a transient export failure must not sink a green
+# migration; the REVIEW (reading each PNG) is the actual gate. Page ids come
+# from the LOCAL spec the builder wrote (deterministic; POST preserves them) —
+# the live GET /spec readback has proven flaky mid-pipeline.
+# ---------------------------------------------------------------------------
+begin
+  vqa = File.join(WORK, 'visual-qa')
+  FileUtils.mkdir_p(vqa)
+  local_spec = (JSON.parse(File.read(wb_spec)) rescue {})
+  content_pages_qa = (local_spec['pages'] || []).reject { |p| p['id'].to_s.downcase.include?('data') }
+  tok = (Sigma.auth_token rescue ENV['SIGMA_API_TOKEN'])
+  pngs = []
+  content_pages_qa.each do |pg|
+    out = File.join(vqa, "#{pg['id']}.png")
+    _o, st = Open3.capture2e({ 'SIGMA_API_TOKEN' => tok.to_s }, PY,
+                             File.join(HERE, 'sigma-export-png.py'),
+                             '--workbook', wb_id, '--page', pg['id'], '--out', out,
+                             '--w', '1800', '--h', '1000')
+    st.success? ? (pngs << out) : (puts "   [warn] visual-QA render failed for page #{pg['id']}")
+  end
+  puts "   rendered #{pngs.size}/#{content_pages_qa.size} full-page PNG(s) for visual QA -> #{vqa}"
+  if pngs.any?
+    puts '   VISUAL QA (mandatory review — do not skip): open each PNG and check vs'
+    puts '   refs/layout-visual-qa.md AND the source PBI page captures (export-pbi-pages.py) —'
+    puts '   no overlaps/stacking, no clipped titles, controls in their own band, right chart'
+    puts '   kinds/colors, even heights. See assert-visual-compare.rb for the source-vs-target gate.'
+  end
+rescue StandardError => e
+  puts "   [warn] visual-QA render skipped: #{e.message[0, 120]}"
+end
 
 # ---------------------------------------------------------------------------
 # Phase 6 — Parity (freshness banner FIRST, then formula guard + warehouse compare)
 # ---------------------------------------------------------------------------
 hdr(6, TOTAL, 'Parity')
-require 'sigma_rest'
 require 'date'
 
 # ---- join the NON-BLOCKING Phase-1.5 freshness lane (launched pre-Convert) --


### PR DESCRIPTION
extract-pbir captures analytics-pane constant/trend lines + measure color-saturation; builder emits `refMarks`+`trendlines`+`color:{by:scale}`; `migrate-powerbi.rb` Phase 5b auto-renders full-page PNGs (local spec ids, explicit token, non-fatal). `ruby -c`+`py_compile` clean; harness-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)