### PR TITLE
feat(thoughtspot): reference lines + colors + interactive controls + auto visual-QA gate

### DIFF
--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
@@ -184,7 +184,20 @@ def auto_items(elems):
         row += 11
     return items
 
-def build_layout(spec, tiles=None):
+def controls_band(control_ids, row=1):
+    """Lay out interactive controls (gap C) edge-to-edge in a single full-width
+    band — ThoughtSpot Liveboard filters apply globally, so they sit above the
+    tiles (Sigma's grid has no z-order; floating them over charts would stack).
+    Returns (items, next_row). Each control is ~3 rows tall."""
+    items, n = [], len(control_ids)
+    if not n:
+        return items, row
+    for i, cid in enumerate(control_ids):
+        c0 = 1 + (24 * i // n); c1 = 1 + (24 * (i + 1) // n)
+        items.append([cid, c0, c1, row, row + 3])
+    return items, row + 3
+
+def build_layout(spec, tiles=None, controls=None):
     """Returns (layout_xml, main_page, extra_spec_elements)."""
     pages = spec["pages"]
     data = next((p for p in pages if p.get("name") == "Data"), None)
@@ -195,20 +208,29 @@ def build_layout(spec, tiles=None):
         lines.append(f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{data["id"]}">')
         lines.append(f'  <LayoutElement elementId="{mid}" gridColumn="1 / 25" gridRow="1 / 21"/>')
         lines.append('</Page>')
+    control_ids = list(controls or [])
+    ctl_items, base_row = controls_band(control_ids)
     if tiles:
         items = tiles_items(tiles, kinds={e["id"]: e.get("kind") for e in main["elements"]})
     else:
         elems = [{"id": e["id"], "kind": e["kind"]} for e in main["elements"]
-                 if e.get("kind") != "container" and not str(e.get("id", "")).startswith("band-")]
+                 if e.get("kind") not in ("container", "control")
+                 and not str(e.get("id", "")).startswith("band-")]
         items = auto_items(elems)
+    if ctl_items:
+        # drop the tiles/charts below the controls band so nothing overlaps it
+        shift = base_row - (min(i[3] for i in items) if items else base_row)
+        if items:
+            items = [[i[0], i[1], i[2], i[3] + shift, i[4] + shift] for i in items]
+        items = ctl_items + items
     title = main.get("name") or spec.get("name") or "Dashboard"
     page, extra = banded_page(main["id"], items, title)
     lines.append(page)
     return "\n".join(lines) + "\n", main, extra
 
-def apply(wb, tiles=None):
+def apply(wb, tiles=None, controls=None):
     spec = json.loads(req("GET", f"/v2/workbooks/{wb}/spec"))
-    xml, main, extra = build_layout(spec, tiles=tiles)
+    xml, main, extra = build_layout(spec, tiles=tiles, controls=controls)
     # idempotent: drop previously-injected band elements, then add this run's
     main["elements"] = [e for e in main["elements"]
                         if not (str(e.get("id", "")).startswith("band-")
@@ -228,18 +250,19 @@ def main():
     ap.add_argument("workbooks", nargs="*", help="specific workbook ids (auto grid; skips the manifest)")
     a = ap.parse_args()
     if a.workbooks:
-        jobs = [(wb, None) for wb in a.workbooks]
+        jobs = [(wb, None, None) for wb in a.workbooks]
     else:
         wd = os.path.abspath(os.path.expanduser(a.workdir or os.environ.get("TS_WORKDIR")
                              or os.path.join(os.getcwd(), "ts-migration")))
         manifest = os.path.join(wd, "migrate_out.json")
         m = json.load(open(manifest))
         results = m.get("results", m)          # new manifest nests under "results"
-        jobs = [(r["workbook"], r.get("tiles")) for r in results.values() if r.get("workbook")]
+        jobs = [(r["workbook"], r.get("tiles"), r.get("controls"))
+                for r in results.values() if r.get("workbook")]
     ok = 0
-    for wb, tiles in jobs:
+    for wb, tiles, controls in jobs:
         try:
-            apply(wb, tiles=tiles); ok += 1
+            apply(wb, tiles=tiles, controls=controls); ok += 1
             print(f"✓ laid out {wb} ({'TML tiles' if tiles else 'auto grid'})")
         except Exception as e:
             print(f"✗ {wb}: {e}")

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -153,6 +153,56 @@ def post_workbook(spec, wd):
         f.write(json.dumps({"id": wb, "name": spec.get("name")}) + "\n")
     return wb
 
+def render_page_png(wb, page_id, out, w=1800, h=1000):
+    """Render one workbook PAGE to a PNG via the REST export API (token explicit
+    via the same SIGMA_API_TOKEN the rest of the run uses). Returns True on a
+    real PNG, False otherwise — NON-FATAL (a transient export must not sink a
+    green migration). Promotes compare.py's element render to a full-page one."""
+    base, tok = need_env("SIGMA_BASE_URL", "SIGMA_API_TOKEN")
+    body = json.dumps({"pageId": page_id,
+                       "format": {"type": "png", "pixelWidth": w, "pixelHeight": h}}).encode()
+    try:
+        r = urllib.request.Request(base + f"/v2/workbooks/{wb}/export", data=body, method="POST",
+            headers={"Authorization": "Bearer " + tok, "Content-Type": "application/json"})
+        qid = json.loads(urllib.request.urlopen(r, context=_SSL).read().decode()).get("queryId")
+    except Exception as ex:
+        print(f"     [warn] visual-QA export POST failed for page {page_id}: {ex}")
+        return False
+    for _ in range(40):
+        try:
+            g = urllib.request.Request(base + f"/v2/query/{qid}/download",
+                                       headers={"Authorization": "Bearer " + tok})
+            data = urllib.request.urlopen(g, context=_SSL).read()
+            if data[:4] == b"\x89PNG":
+                open(out, "wb").write(data)
+                return True
+        except urllib.error.HTTPError as e:
+            if e.code not in (202, 204, 404):
+                print(f"     [warn] visual-QA download {e.code} for page {page_id}"); return False
+        time.sleep(2)
+    return False
+
+def visual_qa(wb, local_spec, wd, display):
+    """Phase-5b-style visual-QA gate: render every CONTENT page (ids from the
+    LOCAL posted spec — deterministic; a live /spec readback proved flaky in the
+    qlik pipeline) to a full-page PNG under <wd>/visual-qa/. Non-fatal; the
+    human/agent REVIEW of the PNGs is the actual gate (refs/layout-visual-qa.md)."""
+    vqa = os.path.join(wd, "visual-qa"); os.makedirs(vqa, exist_ok=True)
+    content = [p for p in local_spec.get("pages", []) if (p.get("name") or "") != "Data"]
+    pngs = []
+    safe = re.sub(r"[^A-Za-z0-9]+", "-", display)[:40].strip("-") or wb[:8]
+    for pg in content:
+        out = os.path.join(vqa, f"{safe}-{pg['id']}.png")
+        if render_page_png(wb, pg["id"], out):
+            pngs.append(out)
+    if pngs:
+        print(f"     ✓ visual-QA: {len(pngs)}/{len(content)} full-page PNG(s) → {vqa}")
+        print(f"       REVIEW (do not skip): open each PNG, check vs refs/layout-visual-qa.md")
+        print(f"       and the source Liveboard — populated controls, titles, ref-lines, colors, no overlaps.")
+    else:
+        print(f"     [warn] visual-QA: no pages rendered for {wb} (export transient/disabled)")
+    return pngs
+
 def lb_tiles(lb, viz_specs, elements):
     """Map the Liveboard's layout.tiles (ThoughtSpot 12-col grid) to the built
     Sigma elements, in viz order. Returns None when geometry is incomplete
@@ -172,18 +222,29 @@ def migrate_liveboard(lb_doc, dm, denorm_id, denorm_name, resolver, prefix, fall
     display = lb.get("name") or fallback_name          # never name a workbook after a UUID
     viz_specs = [(v.get("id"), ps) for v in lb["visualizations"] if (ps := ts_common.parse_ts_viz(v, resolver))]
     specs = [ps for _, ps in viz_specs]
+    # gap C: Liveboard page filters become INTERACTIVE Sigma controls. When a
+    # column is governed by a Liveboard-level filter, drop the matching static
+    # per-viz search-query filter (the control now governs it globally) so the
+    # workbook isn't both hard-filtered AND control-filtered on the same column.
+    lb_filters = ts_common.parse_liveboard_filters(lb)
+    controlled = {f["col"] for f in lb_filters}
+    for s in specs:
+        s["filters"] = [vf for vf in s.get("filters", []) if vf["col"] not in controlled]
     master = ts_common.master_element(specs, resolver, dm, denorm_id, denorm_name)
     elements = [ts_common.sigma_element(s, resolver) for s in specs]
+    controls = ts_common.liveboard_controls(lb_filters, resolver, master)
     # Hidden grouped scatter-source tables must live on the SAME page as the
     # m-ofv master they source (visibleAsSource:False → no layout slot needed).
     data_elems = [master] + ts_common.drain_scatter_sources()
     spec = {"name": f"{prefix}{display} (from ThoughtSpot)", "folderId": folder, "schemaVersion": 1,
             "pages": [{"id": "p-data", "name": "Data", "elements": data_elems},
-                      {"id": "p-main", "name": display[:40], "elements": elements}]}
+                      {"id": "p-main", "name": display[:40], "elements": controls + elements}]}
     wb = post_workbook(spec, wd)
     tiles = lb_tiles(lb, viz_specs, elements)
-    apply_layouts.apply(wb, tiles=tiles)
-    return wb, display, len(specs), tiles
+    control_ids = [c["id"] for c in controls]
+    apply_layouts.apply(wb, tiles=tiles, controls=control_ids)
+    visual_qa(wb, spec, wd, display)               # Phase-5b: render full-page PNGs (non-fatal)
+    return wb, display, len(specs), tiles, control_ids
 
 def collect_liveboards(a, model_name):
     """Liveboard candidate selection + TML export — runs as a LANE concurrent
@@ -247,6 +308,7 @@ def migrate_answer(ans_id, dm, denorm_id, denorm_name, resolver, prefix, folder,
                       {"id": "p-main", "name": display[:40], "elements": [main_el]}]}
     wb = post_workbook(spec, wd)
     apply_layouts.apply(wb)
+    visual_qa(wb, spec, wd, display)               # Phase-5b: render full-page PNG (non-fatal)
     return wb, display
 
 def main():
@@ -332,10 +394,12 @@ def main():
         lb_path = os.path.join(lbdir, f"lb-{i + 1}.tml")
         open(lb_path, "w").write(lb_doc)
         try:
-            wb, display, n, tiles = migrate_liveboard(lb_doc, dm, denorm_id, denorm_name,
+            wb, display, n, tiles, control_ids = migrate_liveboard(lb_doc, dm, denorm_id, denorm_name,
                                                       resolver, prefix, fallback, folder, wd)
-            results[display] = {"workbook": wb, "viz": n, "tiles": tiles, "lb_tml": lb_path}
-            print(f"  ✓ {display[:34]:34s} WB {wb} ({n} viz, layout={'TML tiles' if tiles else 'auto grid'})")
+            results[display] = {"workbook": wb, "viz": n, "tiles": tiles,
+                                "controls": control_ids, "lb_tml": lb_path}
+            print(f"  ✓ {display[:34]:34s} WB {wb} ({n} viz, {len(control_ids)} control(s), "
+                  f"layout={'TML tiles' if tiles else 'auto grid'})")
         except Exception as ex:
             results[fallback] = {"error": str(ex), "lb_tml": lb_path}
             print(f"  ✗ {fallback[:34]:34s} {ex}")

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
@@ -310,11 +310,21 @@ def parse_measure_color(a, measures):
     # client_state per-column color → single-hue scale on that measure
     for cs in _client_states(a):
         for cp in (cs.get("columnProperties") or []) if isinstance(cs, dict) else []:
-            prop = cp.get("columnProperty") or {}
+            if not isinstance(cp, dict):   # real TML: columnProperties entries are not always objects
+                continue
+            prop = cp.get("columnProperty")
+            prop = prop if isinstance(prop, dict) else {}
             hue = prop.get("color") or prop.get("columnColor")
             col = _strip_total(cp.get("columnId") or "")
             if hue and col in measure_set:
                 return {"col": col, "scheme": ["#ffffff", hue]}
+    # NOTE: a real TS `conditional_formatting` rule has the shape
+    # {rule:[{range:{min,max}, color, plotAsBand}]} — that is per-value CONDITIONAL
+    # FORMATTING (color a value band), NOT a measure gradient or a reference line.
+    # We intentionally do NOT map it to color:{by:scale} or a refMark (that would be
+    # semantically wrong); it falls through to None / no-op until a genuine gradient
+    # (a list of {color} stops) or reference line is present. Verified against live
+    # team2 Liveboards (Sample Retail, Performance Tracking) 2026-06-15.
     return None
 
 def parse_sorts(a):

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
@@ -205,7 +205,117 @@ def parse_ts_viz(v, resolver=None):
             "filters": parse_filters(a.get("search_query", "")), "sorts": parse_sorts(a),
             "mtypes": mtypes, "row_formulas": row_formulas, "flagged": flagged,
             "color_dim": color, "topn": int(m.group(1)) if m else None,
+            "refmarks": parse_refmarks(a, measures, dims),
+            "measure_color": parse_measure_color(a, measures),
             "af_names": sorted(af.keys())}
+
+# ── Reference / threshold lines (gap A) ──────────────────────────────────────
+# ThoughtSpot draws a target value or limit range as a line on a chart via two
+# routes: (1) `answer.conditional_formatting` with a per-metric `simple_threshold`
+# / `range` carrying an operator, value(s) and a HEX color; (2) the chart's own
+# `client_state_v2` JSON, which encodes them under `referenceLines` /
+# `refLines` (each {value|expr, label, color, axis}). Both are surfaced here as
+# {value, label, color, axis} dicts; the builder (ts_refmarks) turns each into a
+# Sigma refMark. Defensive about the exact key spelling (the public TML docs do
+# not expose the client_state internals — same posture as parse_sorts).
+def _client_states(a):
+    out = []
+    for holder in (a.get("chart") or {}), (a.get("table") or {}):
+        for key in ("client_state_v2", "client_state"):
+            raw = holder.get(key) or ""
+            if isinstance(raw, dict):
+                out.append(raw); continue
+            if not str(raw).strip():
+                continue
+            try:
+                out.append(json.loads(raw, strict=False))
+            except (ValueError, TypeError):
+                continue
+    return out
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+def parse_refmarks(a, measures, dims):
+    """→ [{value(float|str), label, color, axis('series'|'axis'), col(optional)}].
+    A threshold on a MEASURE → a y/series line; on a dimension → an x/axis line."""
+    out = []
+    measure_set = set(measures)
+    # (1) conditional_formatting metrics with a threshold operator that draws a line
+    for met in (a.get("conditional_formatting") or {}).get("metric", []) \
+            if isinstance(a.get("conditional_formatting"), dict) \
+            else (a.get("conditional_formatting") or []):
+        if not isinstance(met, dict):
+            continue
+        col = _strip_total(met.get("column_id") or met.get("column") or "")
+        rules = met.get("simple_threshold") or met.get("thresholds") or met.get("range") or []
+        if isinstance(rules, dict):
+            rules = [rules]
+        for r in rules:
+            if not isinstance(r, dict):
+                continue
+            val = r.get("value")
+            if val is None:
+                val = r.get("min") if r.get("min") is not None else r.get("max")
+            n = _num(val)
+            if n is None:
+                continue
+            axis = "axis" if col and col not in measure_set and col in dims else "series"
+            out.append({"value": n, "label": r.get("label") or met.get("label") or col,
+                        "color": r.get("color") or met.get("color"), "axis": axis, "col": col})
+    # (2) client_state reference lines
+    for cs in _client_states(a):
+        if not isinstance(cs, dict):
+            continue
+        for rl in (cs.get("referenceLines") or cs.get("refLines") or []):
+            if not isinstance(rl, dict) or rl.get("show") is False:
+                continue
+            val = rl.get("value")
+            n = _num(val)
+            formula = n if n is not None else (rl.get("expr") or rl.get("formula"))
+            if formula in (None, ""):
+                continue
+            ax = (rl.get("axis") or rl.get("axisType") or "Y").upper()
+            out.append({"value": formula, "label": rl.get("label") or rl.get("name"),
+                        "color": rl.get("color"), "axis": "axis" if ax.startswith("X") else "series",
+                        "col": _strip_total(rl.get("columnId") or rl.get("column") or "")})
+    return out
+
+# ── Per-measure color scale (gap B) ──────────────────────────────────────────
+# A by-measure color encoding: a conditional_formatting `range` on a measure (a
+# low→high gradient) or a per-column color set in client_state columnProperties.
+# Surfaced as {col, scheme(list[hex])}; the builder turns it into a Sigma
+# color:{by:scale} on a DUPLICATE measure column (a column can't be on both the
+# value/yAxis well and the color well). By-dimension category colors already
+# flow through `color_dim` → color:{by:category}.
+def parse_measure_color(a, measures):
+    measure_set = set(measures)
+    # conditional_formatting range gradient on a measure
+    cf = a.get("conditional_formatting")
+    metrics = cf.get("metric", []) if isinstance(cf, dict) else (cf or [])
+    for met in metrics if isinstance(metrics, list) else []:
+        if not isinstance(met, dict):
+            continue
+        col = _strip_total(met.get("column_id") or met.get("column") or "")
+        if col not in measure_set:
+            continue
+        rng = met.get("range") or met.get("gradient")
+        scheme = [r.get("color") for r in rng if isinstance(r, dict) and r.get("color")] \
+            if isinstance(rng, list) else None
+        if scheme and len(scheme) >= 2:
+            return {"col": col, "scheme": scheme}
+    # client_state per-column color → single-hue scale on that measure
+    for cs in _client_states(a):
+        for cp in (cs.get("columnProperties") or []) if isinstance(cs, dict) else []:
+            prop = cp.get("columnProperty") or {}
+            hue = prop.get("color") or prop.get("columnColor")
+            col = _strip_total(cp.get("columnId") or "")
+            if hue and col in measure_set:
+                return {"col": col, "scheme": ["#ffffff", hue]}
+    return None
 
 def parse_sorts(a):
     """Carry the answer's sorts: (1) `sort by [Col] descending` tokens in the
@@ -280,6 +390,59 @@ def _fmt(entry):
 def _resolve(resolver, base):
     return resolver.get(base) or {"measure": True, "ofv": base, "friendly": re.sub(r'[()]', '', base).strip()}
 
+# Sigma refMark axes: a measure/Y threshold → "series"; a dimension/X line →
+# "axis". value MUST be the wrapped {type:formula, formula} form (a bare number
+# 400s) and label.visibility must be "shown" (qlik-to-sigma qlik_refmarks, bead-
+# verified 2026-06-15).
+def ts_refmarks(refmark_specs):
+    out = []
+    for r in refmark_specs or []:
+        val = r.get("value")
+        if isinstance(val, float) and val.is_integer():
+            formula = str(int(val))                 # 80000.0 → "80000" (clean axis label)
+        elif isinstance(val, (int, float)):
+            formula = repr(val)
+        else:
+            formula = str(val or "")
+        if not formula.strip():
+            continue
+        rm = {"type": "line", "axis": r.get("axis") or "series",
+              "value": {"type": "formula", "formula": formula},
+              "line": {"color": r.get("color") or "#ef4444", "width": 2}}
+        if r.get("label"):
+            rm["label"] = {"visibility": "shown", "text": str(r["label"])}
+        out.append(rm)
+    return out
+
+# Charts that take an x/y axis (refMarks apply) vs the donut/pie/table/kpi kinds
+# where a reference line has no axis to hang on.
+_AXIS_KINDS = {"bar-chart", "line-chart", "area-chart", "combo-chart", "scatter-chart"}
+
+def _apply_measure_color(el, spec, resolver):
+    """gap B — by-measure color scale → color:{by:scale} on a DUPLICATE measure
+    column (a column can't sit on both the yAxis and color wells). Only for axis
+    charts that don't already carry a category color (color_dim)."""
+    mc = spec.get("measure_color")
+    if not mc or el.get("kind") not in _AXIS_KINDS or el.get("color"):
+        return
+    base = next((c for c in el.get("columns", []) if c.get("name") == mc["col"]), None)
+    if not base:
+        return
+    dup_id = nid("c")
+    dup = {"id": dup_id, "formula": base["formula"], "name": base["name"] + " (color)"}
+    if base.get("format"):
+        dup["format"] = base["format"]
+    el["columns"].append(dup)
+    el["color"] = {"by": "scale", "column": dup_id, "scheme": list(mc["scheme"])}
+
+def _apply_refmarks(el, spec):
+    """gap A — attach Sigma refMarks for axis charts."""
+    if el.get("kind") not in _AXIS_KINDS:
+        return
+    rm = ts_refmarks(spec.get("refmarks"))
+    if rm:
+        el["refMarks"] = rm
+
 def sigma_element(spec, resolver, master="OFV"):
     """Build the element, then apply any ThoughtSpot search-query filters as
     Sigma element list-filters (adds the filter column if not already present).
@@ -314,6 +477,8 @@ def sigma_element(spec, resolver, master="OFV"):
         ftarget.setdefault("filters", []).append({"id": nid(), "columnId": col_id, "kind": "list",
                                              "mode": f["mode"], "values": f["values"]})
     _apply_sorts(el, spec)
+    _apply_measure_color(el, spec, resolver)   # gap B: by-measure color scale
+    _apply_refmarks(el, spec)                  # gap A: reference / threshold lines
     return el
 
 def _apply_sorts(el, spec):
@@ -483,6 +648,89 @@ def _element_core(spec, resolver, master="OFV"):
         cc = nid("c"); cols.append({"id": cc, "formula": dref(color_dim), "name": color_dim})
         el["color"] = {"by": "category", "column": cc}
     return el
+
+# ── Liveboard filters → interactive Sigma list controls (gap C) ──────────────
+# A ThoughtSpot Liveboard carries page-level filters (liveboard.filters[]) that
+# apply across every tile. The OLD path turned a viz search-query clause into a
+# STATIC per-element list-filter — non-interactive (no dropdown, can't change).
+# An interactive Sigma control instead points its VALUE LIST at the master
+# column via the double-nested source shape (verified, qlik-to-sigma
+# build_control):
+#   source: {kind:"source", source:{kind:"table", elementId:<master>}, columnId:<c>}
+# so the dropdown populates from the data, AND carries a `filters` target so the
+# selection propagates to every chart that sources the master (the single shared
+# OFV master = global reach, matching the Liveboard's cross-tile semantics).
+_TS_FILTER_OP = {"IN": "include", "EQ": "include", "=": "include", "EQUALS": "include",
+                 "NOT_IN": "exclude", "NE": "exclude", "!=": "exclude", "NOT_EQUALS": "exclude"}
+
+def parse_liveboard_filters(lb):
+    """Liveboard page filters → [{col, mode, values, type}]. Defensive about the
+    TML spelling (filters / runtime_filters; column / column_name; operator /
+    type; values / value). Date columns are tagged type='date' so the builder
+    emits a date-range control instead of a list."""
+    out = []
+    raw = lb.get("filters") or lb.get("runtime_filters") or lb.get("filter") or []
+    if isinstance(raw, dict):
+        raw = raw.get("filters") or raw.get("runtime_filters") or [raw]
+    for f in raw:
+        if not isinstance(f, dict):
+            continue
+        col = f.get("column") or f.get("column_name") or f.get("columnName") or f.get("name")
+        if isinstance(col, list):
+            col = col[0] if col else None
+        if not col:
+            continue
+        col = _strip_total(col)
+        op = str(f.get("operator") or f.get("oper") or f.get("type") or "IN").upper()
+        vals = f.get("values")
+        if vals is None:
+            vals = f.get("value")
+        if vals is None and isinstance(f.get("filter_content"), dict):
+            vals = f["filter_content"].get("values")
+        if isinstance(vals, (str, int, float)):
+            vals = [vals]
+        is_date = bool(re.search(r"date|month|year|quarter|week|day|time", col, re.I))
+        out.append({"col": col, "mode": _TS_FILTER_OP.get(op, "include"),
+                    "values": [v for v in (vals or []) if v not in (None, "")],
+                    "type": "date" if is_date else "list"})
+    return out
+
+def liveboard_controls(lb_filters, resolver, master_el, master="OFV"):
+    """Build interactive Sigma controls from Liveboard filters. Returns a list of
+    control elements; each is wired to the master so it reaches every chart that
+    sources the master. Ensures the target column exists on the master element
+    (adds it if a viz didn't already surface it). Dedups by column."""
+    controls, seen = [], set()
+    for f in lb_filters:
+        col = f["col"]
+        if col in seen:
+            continue
+        seen.add(col)
+        e = _resolve(resolver, col)
+        mcol = next((c for c in master_el["columns"] if c.get("name") in (e["friendly"], col)), None)
+        if not mcol:
+            mcol = {"id": "ofv-%d" % len(master_el["columns"]), "name": e["friendly"],
+                    "formula": f"[{master}/{e['friendly']}]"}
+            master_el["columns"].append(mcol)
+        cid = mcol["id"]
+        ctl_id = re.sub(r"[^A-Za-z0-9]", "", col.title()) + "Filter"
+        el = {"id": nid("ctl"), "kind": "control", "controlId": ctl_id, "name": col,
+              "filters": [{"source": {"kind": "table", "elementId": master_el["id"]},
+                           "columnId": cid}]}
+        if f["type"] == "date":
+            # date-range needs a flat `mode` and NO value-list source (the column
+            # comes from the filter binding); a list control on a datetime target
+            # is silently stripped (cross-tool gotcha).
+            el.update({"controlType": "date-range", "mode": "between",
+                       "includeNulls": "when-no-value-is-selected"})
+        else:
+            el.update({"controlType": "list", "mode": f["mode"], "selectionMode": "multiple",
+                       "values": f.get("values") or [],
+                       "source": {"kind": "source",
+                                  "source": {"kind": "table", "elementId": master_el["id"]},
+                                  "columnId": cid}})
+        controls.append(el)
+    return controls
 
 def master_element(specs, resolver, dm_id, denorm_elem, denorm_name="Order Fact View"):
     """Master table fed by the DM denorm view. Plain columns pass through; the


### PR DESCRIPTION
Emits `refMarks`, by-measure `color:{by:scale}`, Liveboard filters → interactive list controls (double-nested source), and a Phase-5b visual-QA gate. `py_compile` clean; harness-verified.

**CAVEAT — needs live-fixture validation before production:** TML capture keys (conditional_formatting / client_state referenceLines / liveboard filters) aren't in TS public docs — parsers try several spellings and **no-op safely on a miss** (existing migrations unaffected), but confirm the exact keys against a real exported Liveboard. control-scope sidecar for the new controls not yet wired (gate 7 won't assert their reach) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)