### PR TITLE
fix(thoughtspot): close 6 feature-coverage gaps (kitchen-sink stress test)

### DIFF
--- a/docs/chart-fidelity-rubric.md
+++ b/docs/chart-fidelity-rubric.md
@@ -79,6 +79,17 @@ in team2 has a target line so it's unvalidated against real TML; controls/colors
 live-validated against real Liveboards (PerfTracking/UserAdoption) + the migrated sample.)
 
 **Progress log:**
+- **2026-06-16 — thoughtspot kitchen-sink feature stress test.** Built TS content
+  exercising every feature (24 chart types, 11 formula classes + RLS, all interactivity)
+  and migrated each live. Found + FIXED 6 real gaps (all re-validated): (1) single-quote
+  string literals corrupted `'Bulk'`→`[Bulk]` in EVERY `if`/`in` calc — `tsWrapColumnRefs`;
+  (2) control on an un-surfaced column 400'd the whole workbook — `liveboard_controls`
+  denorm-qualified ref; (3) `unique count(` space syntax hard-failed the DM POST; (4) 10
+  exotic charts silently became bar — now flagged degrade-to-table; (5) window fns + (6)
+  RLS rules silently dropped — now warn (+ `result.security[]`). Live proof: calc parity
+  (Distinct Custs=26, Cat Flag Yes:10/No:15), interactive wb ab4d2020 (2 controls incl the
+  fixed un-surfaced date filter). Full matrix: docs/thoughtspot-feature-coverage.md. dim-4
+  dynamic-title interpolation remains the only TS ⚠️.
 - **2026-06-15 — thoughtspot #119 MERGED + live-validated.** Fixed a crash in
   `parse_measure_color` (real TML `columnProperties` entries aren't always dicts) that
   would break migrating any CF Liveboard; verified clean parse on PerfTracking (10 vizzes)

--- a/docs/thoughtspot-feature-coverage.md
+++ b/docs/thoughtspot-feature-coverage.md
@@ -1,0 +1,70 @@
+# ThoughtSpot → Sigma feature-coverage matrix
+
+A deliberate "kitchen-sink" stress test: build TS content exercising **every** TS
+feature, migrate it through `thoughtspot-to-sigma`, and score each feature. Run
+against live trial `team2.thoughtspot.cloud` over the retail star model
+`d09e27fd` (CSA.TJ). Established + closed 2026-06-16.
+
+**Verdicts:** ✅ faithful (migrates with parity) · 🟡 flagged degrade (no Sigma
+equivalent → sensible down-convert **and the migration flags it**) · ❌ gap
+(should work, doesn't). All ❌ found below were FIXED + re-validated this round.
+
+## Charts (24 TS chart types)
+
+| TS chart type | Sigma kind | verdict | evidence |
+|---|---|---|---|
+| KPI | kpi-chart | ✅ | wb ee2e9596 |
+| COLUMN / BAR | bar-chart | ✅ | wb ee2e9596 |
+| LINE | line-chart | ✅ | wb ee2e9596 |
+| AREA / STACKED_AREA | area-chart | ✅ | wb ee2e9596 (stacked via color dim) |
+| STACKED_COLUMN / STACKED_BAR | bar-chart | ✅ | wb ee2e9596 (stacked render) |
+| LINE_COLUMN | combo-chart | ✅ | wb ee2e9596 |
+| PIE / DONUT | donut-chart | ✅ | wb ee2e9596 |
+| SCATTER | scatter (grouped) | ✅ | wb ee2e9596 (distinct points, no collapse) |
+| BUBBLE | scatter + size well | ✅ | wb ee2e9596 |
+| GEO_AREA | region-map | ✅ | wb ee2e9596 (US choropleth) |
+| GEO_BUBBLE | region-map | 🟡 | choropleth not bubbles; point-map needs lat/long TS doesn't supply for a region name — region-map is the faithful degrade |
+| PIVOT_TABLE | pivot-table | ✅ | wb ee2e9596 |
+| TABLE / ADVANCED_COLUMN | table | ✅ | wb ee2e9596 |
+| WATERFALL, FUNNEL, TREEMAP, HEATMAP, HISTOGRAM, GAUGE, SANKEY, PARETO, CANDLESTICK, SPIDER_WEB | table **+ `[<TYPE> → table: no Sigma chart equivalent]`** | 🟡 (was ❌ silent bar) | **FIXED** ts_common.py `_NO_SIGMA_EQUIV` + `_element_core`; unit-tested all 10 → flagged table |
+
+## Calculations / formulas (live value-parity)
+
+| class | example | verdict | evidence |
+|---|---|---|---|
+| Row arithmetic | `GROSS_REVENUE - DISCOUNT` | ✅ | parity to 2dp |
+| Row conditional (text) | `if(QTY>10) then 'Bulk' else 'Single'` | ✅ (was ❌ `[Single]`) | **FIXED** thoughtspot.ts `tsWrapColumnRefs`; live `If([Quantity]>10,"Bulk","Single")` → "Single" |
+| safe_divide / ratio | `safe_divide(profit,rev)` | ✅ | parity 8dp |
+| String (concat/substr) | `concat(first,' ',last)` | ✅ | live |
+| Date (year/month/datediff) | `year(date)` | ✅ | live |
+| Logical / in-set | `category in {'Electronics','Apparel'}` | ✅ (was ❌ always `[No]`) | **FIXED** same; live `In([Category],"Electronics","Apparel")` → Yes:10/No:15 |
+| Aggregate ratio-of-sums | `sum(profit)/sum(rev)` | ✅ | routed to metric, parity |
+| Aggregate funcs (avg/min/max) | `average(rev)` | ✅ | parity |
+| Distinct count | `unique count(customer)` | ✅ (was ❌ POST-fail) | **FIXED** thoughtspot.ts space-syntax normalize; live `CountDistinct([Customer Key])` → 26 |
+| Conditional aggregate | `sum_if(returned=1, rev)` | ✅ | arg-swap correct, parity |
+| Window (cumulative_sum/rank/moving_avg) | `cumulative_sum(rev)` | 🟡 (was ❌ silent) | **FIXED** — now emits a warning (Sigma window fns don't resolve in DM elements; recompute in a workbook grouped element) |
+| **RLS** (rls_rules) | row-level security rule | 🟡 (was ❌ silent-drop) | **FIXED** thoughtspot.ts now DETECTS + warns with the rule text + remediation; full auto-port (user-attr + DM filter) via apply_sigma_rls.py is a follow-up |
+
+## Interactivity / formatting
+
+| feature | verdict | evidence |
+|---|---|---|
+| Liveboard filter → interactive control | ✅ | wb ab4d2020 — Region list + Full Date date-range, both render + wired to master |
+| Control on a column no viz surfaces | ✅ (was ❌ workbook 400) | **FIXED** ts_common.py `liveboard_controls` denorm-qualified formula; live wb ab4d2020 (2 controls, was "Dependency not found") |
+| Reference / target line → refMarks | ✅ | wrapped value + label.visibility:shown, renders |
+| Sorting | ✅ | xAxis.sort carries |
+| Number / currency / percent format | ✅ | `$`/`%`/thousands render |
+| Colors (by-category + by-measure) | ✅ | category legend + measure gradient |
+| Conditional formatting | 🟡 (was ❌ silent-drop) | **FIXED** — now FLAGGED (`[FLAGGED: conditional formatting not converted]`); Sigma conditionalFormats exist only on pivot/input tables, not the `kind:table` TS tables map to — full map is a follow-up |
+| Dynamic / expression title | 🟡 | passes through as literal string (no `{{token}}` interpolation); graceful, never blank — low-priority follow-up |
+
+## Gaps found → fixed this round
+
+1. **thoughtspot.ts `tsWrapColumnRefs`** — single-quoted string literals were wrapped as column refs (`'Bulk'`→`[Bulk]`), corrupting every `if/then/else` text branch + `in {…}` set. Now masked + emitted double-quoted. *(highest impact)*
+2. **ts_common.py `liveboard_controls`** — a control on an un-surfaced column emitted `[OFV/<col>]` (master referencing itself) → workbook 400. Now denorm-qualified `[<view>/<ofv col>]`. *(blocking)*
+3. **thoughtspot.ts agg normalize** — TS `unique count(` / `count distinct(` (space) → `[Unique] Count(...)` hard-failed the DM POST. Now normalized to `CountDistinct`.
+4. **ts_common.py `_element_core`** — 10 exotic chart types silently became bar-charts. Now flagged degrade-to-table.
+5. **thoughtspot.ts** — window functions passed through with no warning; RLS rules silently dropped. Both now warn.
+6. **ts_common.py** — conditional formatting silently dropped → now flagged.
+
+**Follow-ups (documented, lower priority):** full CF→pivot-table conditionalFormats map; full RLS auto-port; GEO_BUBBLE point-map (needs lat/long); dynamic-title interpolation.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -289,7 +289,9 @@ region, quarter all match to the cent). Per-run ids land in `<workdir>/migrate_o
 
 Row/column security is **never silently dropped and never silently ported** — and it is handled by the **skill**, not baked into the converted model. The converter (`convert_thoughtspot_to_sigma`) only **detects and reports** security in `result.security[]`; it does **not** inject it into the data-model spec (a stateless converter can't create Sigma user attributes or assign members, so an injected `CurrentUserAttributeText` filter would fail-closed to 0 rows). This skill provisions + applies it after the model is posted.
 
-**What is detected for ThoughtSpot:** `rls_rules` on tables (`ts_username` to `CurrentUserEmail()`, `ts_groups` to `CurrentUserInTeam`), multiple rules OR-combined.
+**What is detected for ThoughtSpot:** `rls_rules` on the model/worksheet or per table (`ts_username` to `CurrentUserEmail()`, `ts_groups` to `CurrentUserInTeam`), multiple rules OR-combined. The converter emits each as a `result.security[]` entry `{kind:'rls', name, expression, table?}`.
+
+> ⚠️ The `rls_rules` TML shape + the `ts_username`/`ts_groups` mapping are validated against a **synthetic** rule (no Liveboard in the team2 trial uses RLS). Treat the auto-mapping as best-effort and use **Customize** to review each rule against the real source before applying.
 
 **Flow (only runs when `result.security` is non-empty — zero overhead otherwise):**
 1. **Convert + post** the data model as usual. Capture the `dataModelId` and the converter's `result.security[]` (write it to `security.json`).

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -232,7 +232,7 @@ def migrate_liveboard(lb_doc, dm, denorm_id, denorm_name, resolver, prefix, fall
         s["filters"] = [vf for vf in s.get("filters", []) if vf["col"] not in controlled]
     master = ts_common.master_element(specs, resolver, dm, denorm_id, denorm_name)
     elements = [ts_common.sigma_element(s, resolver) for s in specs]
-    controls = ts_common.liveboard_controls(lb_filters, resolver, master)
+    controls = ts_common.liveboard_controls(lb_filters, resolver, master, denorm_name=denorm_name)
     # Hidden grouped scatter-source tables must live on the SAME page as the
     # m-ofv master they source (visibleAsSource:False → no layout slot needed).
     data_elems = [master] + ts_common.drain_scatter_sources()

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
@@ -200,6 +200,8 @@ def parse_ts_viz(v, resolver=None):
     color = next((d for d in (ax.get("color") or []) if d in dims), None)
     if color:
         dims = [d for d in dims if d != color] + [color]    # color dim LAST
+    if has_cf_rule(a):
+        flagged.append({"name": a.get("name", ""), "fn": "conditional formatting"})
     m = re.search(r"\btop\s+(\d+)\b", a.get("search_query", "") or "", re.I)
     return {"name": a.get("name", "Viz"), "chart": ctype, "dims": dims, "measures": measures,
             "filters": parse_filters(a.get("search_query", "")), "sorts": parse_sorts(a),
@@ -327,6 +329,27 @@ def parse_measure_color(a, measures):
     # team2 Liveboards (Sample Retail, Performance Tracking) 2026-06-15.
     return None
 
+def has_cf_rule(a):
+    """True if the viz carries ThoughtSpot per-cell CONDITIONAL FORMATTING
+    ({rule:[{range:{min,max}, color, plotAsBand}]}, or a client_state columnProperty
+    conditionalFormatting). Sigma's `conditionalFormats` exist only on
+    pivot-table/input-table — NOT the `kind:table` a TS table maps to — so we can't
+    attach it without changing the element kind. Flag it (flag-not-drop) so the
+    migration surfaces the loss instead of silently dropping the cell coloring."""
+    cf = a.get("conditional_formatting")
+    if isinstance(cf, dict) and cf.get("rule"):
+        return True
+    for cs in _client_states(a):
+        if not isinstance(cs, dict):
+            continue
+        for cp in (cs.get("columnProperties") or []):
+            if not isinstance(cp, dict):
+                continue
+            prop = cp.get("columnProperty") if isinstance(cp.get("columnProperty"), dict) else {}
+            if cp.get("conditionalFormatting") or prop.get("conditionalFormatting"):
+                return True
+    return False
+
 def parse_sorts(a):
     """Carry the answer's sorts: (1) `sort by [Col] descending` tokens in the
     search query; (2) sortInfo entries in the table/chart client_state(_v2)
@@ -377,6 +400,11 @@ KIND = {"KPI": "kpi-chart", "COLUMN": "bar-chart", "BAR": "bar-chart", "LINE": "
         "STACKED_COLUMN": "bar-chart", "STACKED_BAR": "bar-chart",
         "AREA": "area-chart", "STACKED_AREA": "area-chart",
         "ADVANCED_COLUMN": "table", "TABLE": "table"}
+
+# ThoughtSpot chart types Sigma cannot faithfully reproduce → flagged degrade to
+# table (see _element_core). Keep in sync with the assessment's unsupported list.
+_NO_SIGMA_EQUIV = {"WATERFALL", "FUNNEL", "TREEMAP", "HEATMAP", "HISTOGRAM", "GAUGE",
+                   "SANKEY", "PARETO", "CANDLESTICK", "SPIDER_WEB", "RADAR"}
 
 def _region_type(name):
     # Infer a Sigma region-map regionType from the geo dimension's name. Sigma's
@@ -649,6 +677,19 @@ def _element_core(spec, resolver, master="OFV"):
                 {"id": vid, "formula": mref(meas[0]), "name": meas[0], "format": _fmt(_resolve(resolver, meas[0]))}]
         return {"id": nid(), "kind": "region-map", "name": name, "source": src, "columns": cols,
                 "region": {"id": gid, "regionType": _region_type(dims[0])}}
+    # ThoughtSpot chart types with NO faithful Sigma equivalent (Sigma has no
+    # treemap/gauge/waterfall/funnel/sankey/histogram/candlestick/radar — verified
+    # against sigma-workbooks/reference/specification/charts.md). Silently coercing
+    # them to a bar-chart MISREPRESENTS the data (a funnel/gauge/sankey is not a
+    # bar), so down-convert to a TABLE (data preserved + readable) and FLAG it in
+    # the name — same flag-not-drop posture as window formulas — so the assessment
+    # surfaces it instead of shipping a misleading chart.
+    if chart in _NO_SIGMA_EQUIV:
+        cols = [{"id": nid("c"), "formula": dref(d), "name": d} for d in dims]
+        cols += [{"id": nid("c"), "formula": mref(m), "name": m,
+                  "format": _fmt(_resolve(resolver, m))} for m in meas]
+        return {"id": nid(), "kind": "table", "source": src, "columns": cols,
+                "name": f"{name} [{chart} → table: no Sigma chart equivalent]"}
     x = nid("x"); cols = [{"id": x, "formula": dref(dims[0]), "name": dims[0]}]; ymids = []
     for m in meas:
         y = nid("y"); cols.append({"id": y, "formula": mref(m), "name": m, "format": _fmt(_resolve(resolver, m))}); ymids.append(y)
@@ -705,7 +746,7 @@ def parse_liveboard_filters(lb):
                     "type": "date" if is_date else "list"})
     return out
 
-def liveboard_controls(lb_filters, resolver, master_el, master="OFV"):
+def liveboard_controls(lb_filters, resolver, master_el, master="OFV", denorm_name="Order Fact View"):
     """Build interactive Sigma controls from Liveboard filters. Returns a list of
     control elements; each is wired to the master so it reaches every chart that
     sources the master. Ensures the target column exists on the master element
@@ -719,8 +760,13 @@ def liveboard_controls(lb_filters, resolver, master_el, master="OFV"):
         e = _resolve(resolver, col)
         mcol = next((c for c in master_el["columns"] if c.get("name") in (e["friendly"], col)), None)
         if not mcol:
+            # The master element is fed by the denorm VIEW, so a column it doesn't
+            # yet surface must reference that view's column — `[<denorm view>/<ofv col>]`,
+            # exactly like master_element.add_base (NOT `[OFV/<friendly>]`, which makes
+            # the master reference itself and 400s the whole workbook: "Dependency not
+            # found"). Any Liveboard filter on an un-surfaced column hit this.
             mcol = {"id": "ofv-%d" % len(master_el["columns"]), "name": e["friendly"],
-                    "formula": f"[{master}/{e['friendly']}]"}
+                    "formula": f"[{denorm_name}/{e['ofv']}]"}
             master_el["columns"].append(mcol)
         cid = mcol["id"]
         ctl_id = re.sub(r"[^A-Za-z0-9]", "", col.title()) + "Filter"


### PR DESCRIPTION
## What

Built a deliberate "every-feature" ThoughtSpot estate over the retail star model, migrated each through `thoughtspot-to-sigma`, and scored every feature. The stress test surfaced **6 real gaps** (2 broke real migrations) — all fixed and re-validated live.

## Fixed (this repo)
- **Control on un-surfaced column → workbook 400** (`liveboard_controls`): emitted `[OFV/col]` (master referencing itself). Now denorm-qualified `[view/ofv-col]`. Any Liveboard filter on a column no viz already showed hit this.
- **10 exotic charts silently → bar** (`_element_core`): waterfall/funnel/treemap/heatmap/histogram/gauge/sankey/pareto/candlestick/radar now flagged degrade-to-table (Sigma has no equivalent).
- **Conditional formatting silently dropped** → now flagged.
- **SKILL.md** RLS section corrected + scope caveat.

(Companion converter fixes — single-quote literals, `unique count`, window/RLS warnings — are in the sigma-data-model-mcp + browser-tool PRs.)

## Validation
Live against `team2.thoughtspot.cloud` → CSA.TJ: interactive workbook with Region list + Full Date date-range controls (the date filter previously 400'd the whole workbook), exact calc parity. Full matrix: `docs/thoughtspot-feature-coverage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)