### PR TITLE
fix(thoughtspot): flag dynamic {{token}} titles

### DIFF
--- a/docs/thoughtspot-feature-coverage.md
+++ b/docs/thoughtspot-feature-coverage.md
@@ -56,7 +56,7 @@ equivalent → sensible down-convert **and the migration flags it**) · ❌ gap
 | Number / currency / percent format | ✅ | `$`/`%`/thousands render |
 | Colors (by-category + by-measure) | ✅ | category legend + measure gradient |
 | Conditional formatting | 🟡 (was ❌ silent-drop) | **FIXED** — now FLAGGED (`[FLAGGED: conditional formatting not converted]`); Sigma conditionalFormats exist only on pivot/input tables, not the `kind:table` TS tables map to — full map is a follow-up |
-| Dynamic / expression title | 🟡 | passes through as literal string (no `{{token}}` interpolation); graceful, never blank — low-priority follow-up |
+| Dynamic / expression title | 🟡 (flagged) | a `{{token}}` title is now FLAGGED (`[FLAGGED: dynamic title not converted]`) — Sigma element titles are plain strings in the spec, no title-templating; flag-not-drop so the literal isn't shipped silently |
 
 ## Gaps found → fixed this round
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
@@ -202,6 +202,13 @@ def parse_ts_viz(v, resolver=None):
         dims = [d for d in dims if d != color] + [color]    # color dim LAST
     if has_cf_rule(a):
         flagged.append({"name": a.get("name", ""), "fn": "conditional formatting"})
+    # A ThoughtSpot title with a `{{token}}` (a filter/parameter reference) is a
+    # DYNAMIC title. A Sigma element `name` is a plain string in the spec — there's
+    # no title-templating — so it would render the literal `{{token}}`. Flag it
+    # (flag-not-drop) so the migration surfaces that the title won't update live,
+    # rather than shipping a confusing literal.
+    if re.search(r"\{\{.*?\}\}", a.get("name", "") or ""):
+        flagged.append({"name": a.get("name", ""), "fn": "dynamic title"})
     m = re.search(r"\btop\s+(\d+)\b", a.get("search_query", "") or "", re.I)
     return {"name": a.get("name", "Viz"), "chart": ctype, "dims": dims, "measures": measures,
             "filters": parse_filters(a.get("search_query", "")), "sorts": parse_sorts(a),


### PR DESCRIPTION
Closes the last 🟡 from the ThoughtSpot feature-coverage matrix. A `{{token}}` viz title (dynamic in TS) can't be made dynamic in a Sigma element `name` (plain string, no spec-level templating), so it's now flagged `[FLAGGED: dynamic title not converted]` rather than rendering the literal silently. Normal titles unaffected (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)