### PR TITLE
feat(thoughtspot): map conditional formatting -> conditionalFormats

### DIFF
--- a/docs/thoughtspot-feature-coverage.md
+++ b/docs/thoughtspot-feature-coverage.md
@@ -26,7 +26,7 @@ equivalent → sensible down-convert **and the migration flags it**) · ❌ gap
 | GEO_BUBBLE | region-map | 🟡 | choropleth not bubbles; point-map needs lat/long TS doesn't supply for a region name — region-map is the faithful degrade |
 | PIVOT_TABLE | pivot-table | ✅ | wb ee2e9596 |
 | TABLE / ADVANCED_COLUMN | table | ✅ | wb ee2e9596 |
-| WATERFALL, FUNNEL, TREEMAP, HEATMAP, HISTOGRAM, GAUGE, SANKEY, PARETO, CANDLESTICK, SPIDER_WEB | table **+ `[<TYPE> → table: no Sigma chart equivalent]`** | 🟡 (was ❌ silent bar) | **FIXED** ts_common.py `_NO_SIGMA_EQUIV` + `_element_core`; unit-tested all 10 → flagged table |
+| WATERFALL, FUNNEL, TREEMAP, HEATMAP, HISTOGRAM, GAUGE, SANKEY, PARETO, CANDLESTICK, SPIDER_WEB | table **+ `[<TYPE> → table: no Sigma chart equivalent]`** | 🟡 (was ❌ silent bar) | **FIXED** ts_common.py `_NO_SIGMA_EQUIV` + `_element_core`; flagged table. NOTE: Sigma the product HAS waterfall in the UI, but it is **not in the workbook spec API kind enum** (verified: `waterfall`/`waterfall-chart` → "Invalid kind"), so the spec-based converter can't emit it. Revisit when Sigma adds it to the spec |
 
 ## Calculations / formulas (live value-parity)
 
@@ -59,7 +59,7 @@ equivalent → sensible down-convert **and the migration flags it**) · ❌ gap
 | Sorting | ✅ | xAxis.sort carries |
 | Number / currency / percent format | ✅ | `$`/`%`/thousands render |
 | Colors (by-category + by-measure) | ✅ | category legend + measure gradient |
-| Conditional formatting | 🟡 (was ❌ silent-drop) | **FIXED** — now FLAGGED (`[FLAGGED: conditional formatting not converted]`); Sigma conditionalFormats exist only on pivot/input tables, not the `kind:table` TS tables map to — full map is a follow-up |
+| Conditional formatting | ✅ (was ❌ silent-drop) | **MAPPED** — TS `client_state` `conditionalFormatting.rows[]` (operator/value/solidBackground) → Sigma `conditionalFormats` (`type:single`, condition, value, `style.backgroundColor`). The host table is emitted as a `pivot-table` (CF only rides pivot/input tables). Live-verified coloring renders. Gradient/data-bar variants still flagged |
 | Dynamic / expression title | 🟡 (flagged) | a `{{token}}` title is now FLAGGED (`[FLAGGED: dynamic title not converted]`) — Sigma element titles are plain strings in the spec, no title-templating; flag-not-drop so the literal isn't shipped silently |
 
 ## Gaps found → fixed this round

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/ts_common.py
@@ -212,7 +212,14 @@ def parse_ts_viz(v, resolver=None):
     color = next((d for d in (ax.get("color") or []) if d in dims), None)
     if color:
         dims = [d for d in dims if d != color] + [color]    # color dim LAST
-    if has_cf_rule(a):
+    cond_formats = parse_conditional_formats(a)
+    if cond_formats and ctype not in ("TABLE", "ADVANCED_COLUMN"):
+        # mappable CF but the host isn't a table — Sigma conditionalFormats only ride
+        # pivot/input tables, so we can't attach it to a chart → flag instead.
+        flagged.append({"name": a.get("name", ""), "fn": "conditional formatting"})
+        cond_formats = []
+    elif not cond_formats and has_cf_rule(a):
+        # CF present but it's a gradient/data-bar variant we don't map → flag.
         flagged.append({"name": a.get("name", ""), "fn": "conditional formatting"})
     # A ThoughtSpot title with a `{{token}}` (a filter/parameter reference) is a
     # DYNAMIC title. A Sigma element `name` is a plain string in the spec — there's
@@ -240,7 +247,7 @@ def parse_ts_viz(v, resolver=None):
     return {"name": a.get("name", "Viz"), "chart": ctype, "dims": dims, "measures": measures,
             "filters": filters, "sorts": parse_sorts(a),
             "mtypes": mtypes, "row_formulas": row_formulas, "flagged": flagged,
-            "color_dim": color, "topn": topn, "date_col": date_col,
+            "color_dim": color, "topn": topn, "date_col": date_col, "conditional_formats": cond_formats,
             "refmarks": parse_refmarks(a, measures, dims),
             "measure_color": parse_measure_color(a, measures),
             "af_names": sorted(af.keys())}
@@ -383,6 +390,48 @@ def has_cf_rule(a):
             if cp.get("conditionalFormatting") or prop.get("conditionalFormatting"):
                 return True
     return False
+
+# ThoughtSpot CF operator → Sigma conditionalFormats `condition`.
+_TS_CF_OP = {"LESS_THAN": "<", "GREATER_THAN": ">", "LESS_THAN_EQUAL": "<=", "LESS_THAN_OR_EQUAL": "<=",
+             "GREATER_THAN_EQUAL": ">=", "GREATER_THAN_OR_EQUAL": ">=", "EQUAL": "=", "EQUALS": "=",
+             "NOT_EQUAL": "!=", "NOT_EQUALS": "!=", "BETWEEN": "Between", "NOT_BETWEEN": "NotBetween"}
+
+def _cf_num(v):
+    try:
+        return float(v) if v not in (None, "") and "." in str(v) else int(v)
+    except (TypeError, ValueError):
+        return v
+
+def parse_conditional_formats(a):
+    """Real TS per-cell conditional formatting lives in client_state columnProperties:
+    `columnProperty.conditionalFormatting.rows[] = {operator, value, solidBackgroundAttrs:{color}}`.
+    Map SOLID-background threshold rules → [{col, condition, value, color}] (the col is the
+    measure display name, paren/Total-stripped). Gradient/data-bar rows return nothing (the
+    caller flags those). Sigma carries these as conditionalFormats on a pivot-table."""
+    out = []
+    for cs in _client_states(a):
+        if not isinstance(cs, dict):
+            continue
+        for cp in (cs.get("columnProperties") or []):
+            if not isinstance(cp, dict):
+                continue
+            col = _strip_total(cp.get("columnId") or "")
+            prop = cp.get("columnProperty") if isinstance(cp.get("columnProperty"), dict) else {}
+            cf = prop.get("conditionalFormatting") or cp.get("conditionalFormatting") or {}
+            for row in (cf.get("rows") or []):
+                if not isinstance(row, dict):
+                    continue
+                op = _TS_CF_OP.get(str(row.get("operator", "")).upper())
+                color = ((row.get("solidBackgroundAttrs") or {}).get("color")
+                         or (row.get("solidColorAttrs") or {}).get("color"))
+                if not (op and color and col):
+                    continue                      # gradient / data-bar / unmapped → skip (flagged)
+                if op in ("Between", "NotBetween"):
+                    val = [_cf_num(row.get("min", row.get("value"))), _cf_num(row.get("max"))]
+                else:
+                    val = _cf_num(row.get("value"))
+                out.append({"col": col, "condition": op, "value": val, "color": color})
+    return out
 
 def parse_sorts(a):
     """Carry the answer's sorts: (1) `sort by [Col] descending` tokens in the
@@ -736,11 +785,24 @@ def _element_core(spec, resolver, master="OFV"):
         return {"id": nid(), "kind": "pivot-table", "name": name, "source": src, "columns": cols,
                 "rowsBy": [{"id": rid}], "columnsBy": [{"id": cidd}], "values": mids}
     if chart in ("TABLE", "ADVANCED_COLUMN"):
-        dids, cols, mids = [], [], []
+        dids, cols, mids, midbyname = [], [], [], {}
         for d in dims:
             did = nid("d"); cols.append({"id": did, "formula": dref(d), "name": d}); dids.append(did)
         for m in meas:
-            mid = nid("m"); cols.append({"id": mid, "formula": mref(m), "name": m, "format": _fmt(_resolve(resolver, m))}); mids.append(mid)
+            mid = nid("m"); cols.append({"id": mid, "formula": mref(m), "name": m, "format": _fmt(_resolve(resolver, m))})
+            mids.append(mid); midbyname[m] = mid; midbyname[_strip_total(m)] = mid
+        cfs = spec.get("conditional_formats") or []
+        if cfs and dids and mids:
+            # Sigma conditionalFormats ride only pivot-table/input-table — emit the CF
+            # table as a pivot (rows=dims, values=measures) to carry the cell coloring.
+            cfmt = []
+            for r in cfs:
+                tgt = midbyname.get(r["col"]) or midbyname.get(_strip_total(r["col"])) or mids[0]
+                cfmt.append({"type": "single", "columnIds": [tgt], "condition": r["condition"],
+                             "value": r["value"], "style": {"backgroundColor": r["color"]}})
+            if cfmt:
+                return {"id": nid(), "kind": "pivot-table", "name": name, "source": src, "columns": cols,
+                        "rowsBy": [{"id": d} for d in dids], "values": mids, "conditionalFormats": cfmt}
         return {"id": nid(), "kind": "table", "name": name, "source": src, "columns": cols,
                 "groupings": [{"id": nid(), "groupBy": dids, "calculations": mids}]}
     # Scatter / bubble — measure-vs-measure with the dimension as the POINT


### PR DESCRIPTION
TS per-cell conditional formatting (client_state `conditionalFormatting.rows[]`) is now **carried into Sigma** rather than flagged-and-dropped:
- operator→condition map, solid background color, threshold value(s)
- a CF table is emitted as a **pivot-table** (CF rides only pivot/input tables) with `conditionalFormats: [{type:single, columnIds, condition, value, style.backgroundColor}]`

Spec shapes POST+render verified (coloring shows). Proven on the 16-viz sample: 'Sales and Unit Sales by Store' → pivot-table with the exact TS rule (`Total sales < 5,500,000 → #FFCCB3`).

**Waterfall**: stays a flagged degrade — Sigma's waterfall is UI-only, **not in the workbook spec API** kind enum yet (`waterfall`/`waterfall-chart` → "Invalid kind"). Revisit when Sigma exposes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)