### PR TITLE
tableau-to-sigma: surface + gate row-level security (stop silent drop)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -70,6 +70,7 @@ jobs:
           set -uo pipefail
           tests=(
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-swap-translation.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rls-wiring.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
           )
           fail=0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/apply_sigma_rls.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/apply_sigma_rls.py
@@ -297,7 +297,26 @@ def main():
     ap.add_argument("--apply", action="store_true", help="PATCH the RLS calc col + filter into the DM element spec")
     ap.add_argument("--from-security", help="path to a converter result.security[] JSON (batch RLS+CLS apply)")
     ap.add_argument("--provision", action="store_true", help="create missing user attributes / teams (with --from-security)")
+    ap.add_argument("--print-plan", action="store_true", help="OFFLINE: parse --from-security and print the rules + attributes/teams to provision (no API, no --dm-id)")
     a = ap.parse_args()
+
+    # Offline review: parse a security.json and print what WOULD be provisioned +
+    # applied, with no API call (no token / --dm-id needed). Lets you sanity-check
+    # the converter's RLS output (and is the CI-portable test entrypoint).
+    if a.from_security and a.print_plan:
+        raw = json.load(open(a.from_security))
+        security = raw.get("security", raw) if isinstance(raw, dict) else raw
+        attrs, teams, n_email = set(), set(), 0
+        print(f"RLS/CLS plan from {a.from_security}: {len(security)} rule(s)")
+        for r in security:
+            rls = r.get("rls", {})
+            for x in (rls.get("userAttributes") or []): attrs.add(x)
+            for t in (rls.get("teams") or []): teams.add(t)
+            if rls.get("usesCurrentUserEmail"): n_email += 1
+            print(f"  • {rls.get('name') or r.get('source')} → element '{r.get('elementName')}': {rls.get('formula','')[:90]}")
+        print(f"provision: {len(attrs)} user attribute(s) {sorted(attrs)}; {len(teams)} team(s) {sorted(teams)}; "
+              f"{n_email} rule(s) use CurrentUserEmail (no provisioning)")
+        return
 
     # Batch mode: ingest a converter's result.security[] and provision + apply all rules.
     if a.from_security:

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -163,7 +163,10 @@ module MechanicalSpecs
       });
       const bare = out.model || out.sigmaDataModel || out;
       writeFileSync(#{raw_out.to_json}, JSON.stringify(bare, null, 2));
-      writeFileSync(#{meta_out.to_json}, JSON.stringify({ model: bare, warnings: out.warnings || [], stats: out.stats || {} }, null, 2));
+      // Capture out.security too — detected RLS/CLS rules (architecture B:
+      // reported, not injected). Dropping it here is how RLS silently
+      // vanished from the orchestrated path; the orchestrator now gates on it.
+      writeFileSync(#{meta_out.to_json}, JSON.stringify({ model: bare, warnings: out.warnings || [], stats: out.stats || {}, security: out.security || [] }, null, 2));
     JS
     o, e, st = Open3.capture3('node', shim)
     raise "converter failed: #{e}#{o}" unless st.success?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -542,6 +542,35 @@ if mechanical
   line "mechanical converter: #{st['elements']} element(s), #{st['columns']} column(s), " \
        "#{st['metrics']} metric(s), #{st['relationships']} relationship(s); #{(conv['warnings'] || []).size} warning(s)"
 
+  # ---- RLS gate (never silently drop) -------------------------------------
+  # The converter detects row-level security (USERNAME/USERATTRIBUTE/ISMEMBEROF
+  # calcs) and reports it in conv['security'] (architecture B: reported, not
+  # injected). Persist it to security.json and surface a LOUD, un-missable
+  # checkpoint — RLS is provisioned + applied by scripts/apply_sigma_rls.py, NOT
+  # by this converter. Also surface the cross-element warnings (an RLS calc over
+  # a joined-dim column that needs manual placement on the owning element), so
+  # those can't hide inside the warnings count either.
+  rls_rules = conv['security'] || []
+  rls_xelem = (conv['warnings'] || []).grep(/row-level security but references a related-table/)
+  $rls_pending = rls_rules.any? || rls_xelem.any?
+  if $rls_pending
+    sec_path = File.join(WORK, 'security.json')
+    File.write(sec_path, JSON.pretty_generate(rls_rules))
+    line ''
+    line '🔐 ROW-LEVEL SECURITY DETECTED — NOT yet applied to the Sigma model'
+    rls_rules.each do |r|
+      nm = r.dig('rls', 'name') || r['source']
+      attrs = (r.dig('rls', 'userAttributes') || []).join(', ')
+      line "   • #{nm}#{attrs.empty? ? '' : "  (user attribute(s): #{attrs})"}"
+    end
+    rls_xelem.each { |w| line "   • #{w[0, 150]}" }
+    line "   wrote #{sec_path} (#{rls_rules.size} emit-ready rule(s); #{rls_xelem.size} cross-element rule(s) need manual placement)"
+    line '   PROVISION + APPLY before this model is safe to share:'
+    line "     python3 scripts/apply_sigma_rls.py --from-security #{sec_path} --dm-id <dataModelId>            # plan"
+    line "     python3 scripts/apply_sigma_rls.py --from-security #{sec_path} --dm-id <dataModelId> --provision --apply"
+    line ''
+  end
+
   # Mechanical DM fixup NOW (so dropped calcs feed the checkpoint): resolve
   # raw-table-name prefixes + GUID sibling refs, and DROP calc columns that
   # still cannot resolve (unknown functions / unresolved refs).
@@ -1360,6 +1389,10 @@ puts '================ RESULT (pass 1 — parity PENDING) ================'
 puts "dataModelId : #{dm_id}#{reuse_dm_id ? '  (REUSED existing DM)' : ''}"
 puts "workbookId  : #{wb_id}"
 puts "structural  : PASS (#{total_cols} cols resolve, #{chart_els.size} charts compile)"
+if $rls_pending
+  puts "RLS         : DETECTED, NOT APPLIED — see #{File.join(WORK, 'security.json')}; provision + apply"
+  puts '              via scripts/apply_sigma_rls.py before sharing (the model returns ALL rows until then)'
+end
 puts 'PARITY      : PENDING — the pooled collector filled parity-actuals.json for every'
 puts '              exportable chart; run the REMAINING mcp-v2 queries printed above'
 puts "              (if any), merge into #{File.join(WORK, 'parity-actuals.json')}, then:"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rls-wiring.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rls-wiring.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# Regression test for the RLS surfacing pipeline (2026-06-16). Deterministic +
+# offline — no Tableau/Sigma/converter calls. Guards against the "RLS silently
+# dropped" regression found on the EDNA-mirror fixture:
+#
+#   - mechanical-specs.rb run_converter must CARRY out.security into conv-meta
+#     (it previously captured only model/warnings/stats → RLS vanished).
+#   - migrate-tableau.rb must SURFACE detected RLS: write security.json + a loud
+#     gate + an RLS line in the RESULT banner (never silently proceed).
+#   - apply_sigma_rls.py --print-plan parses a security.json offline and reports
+#     the rules + attributes/teams to provision (the security.json -> apply
+#     handoff + the CI-portable behavioral check).
+#
+# Usage:  ruby scripts/test-rls-wiring.rb
+
+require 'json'
+require 'tempfile'
+
+DIR = __dir__
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# ---- Part A: orchestrator wiring contract (source-level guards) -------------
+puts 'Part A — orchestrator carries + surfaces RLS'
+mech = File.read(File.join(DIR, 'mechanical-specs.rb'))
+check(mech.include?('security: out.security'),
+      'run_converter shim captures out.security into conv-meta', fails)
+
+mig = File.read(File.join(DIR, 'migrate-tableau.rb'))
+check(mig.match?(/conv\[['"]security['"]\]/),
+      'migrate-tableau reads conv[\'security\']', fails)
+check(mig.include?("File.join(WORK, 'security.json')"),
+      'migrate-tableau writes security.json', fails)
+check(mig.match?(/ROW-LEVEL SECURITY DETECTED/i),
+      'migrate-tableau emits a loud RLS gate', fails)
+check(mig.match?(/RLS\s+:.*DETECTED, NOT APPLIED/),
+      'RESULT banner flags RLS detected-but-not-applied', fails)
+
+# ---- Part B: apply_sigma_rls.py --print-plan parses security.json offline ----
+puts 'Part B — apply_sigma_rls.py --print-plan (offline)'
+security = [
+  { 'kind' => 'rls', 'source' => 'Tableau calc "RLS Channel Access"', 'elementName' => 'Order Fact',
+    'rls' => { 'name' => 'RLS Channel Access',
+               'formula' => 'CurrentUserAttributeText("order_channel") = [Order Channel]',
+               'userAttributes' => ['order_channel'] } },
+  { 'kind' => 'rls', 'source' => 'Tableau calc "RLS User Allowlist"', 'elementName' => 'Order Fact',
+    'rls' => { 'name' => 'RLS User Allowlist',
+               'formula' => 'Contains([Order Status], CurrentUserEmail())',
+               'usesCurrentUserEmail' => true } }
+]
+tmp = Tempfile.new(['security-', '.json'])
+tmp.write(JSON.generate(security)); tmp.close
+out = `python3 #{File.join(DIR, 'apply_sigma_rls.py').inspect} --from-security #{tmp.path.inspect} --print-plan 2>&1`
+ok = $?.success?
+tmp.unlink
+check(ok, 'print-plan exits 0 with no token / --dm-id (offline)', fails)
+check(out.include?('2 rule(s)'), 'reports both RLS rules', fails)
+check(out.match?(/order_channel/), 'identifies the order_channel user attribute to provision', fails)
+check(out.match?(/1 rule\(s\) use CurrentUserEmail/), 'identifies the CurrentUserEmail rule (no provisioning)', fails)
+
+puts
+if fails.empty?
+  puts 'OK — RLS wiring + apply-plan parsing all pass'
+  exit 0
+else
+  warn "FAIL — #{fails.size} check(s) failed:"
+  fails.each { |f| warn "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
## Summary

Found on the EDNA-mirror fixture while validating whether `Partner Landscape.twb`'s **RLS** (`AUTHORIZED_USERS` + `Username()`) can migrate. The converter *does* detect Tableau RLS and report it in `result.security`, but the **orchestrated one-shot path silently dropped it**:

- `mechanical-specs.rb` `run_converter` captured only `model` / `warnings` / `stats` — `security[]` never reached `migrate-tableau.rb`.
- No `security.json` was written and there was **no gate**, so the migrated model would return **all rows** with RLS effectively gone (only a buried line inside a "N warnings" count).

This is the cardinal "never silently drop RLS" violation.

## Fixes

- **`mechanical-specs.rb`** — `run_converter` shim now carries `out.security` into `conv-meta.json`.
- **`migrate-tableau.rb`** — RLS gate: writes `security.json`, emits a loud `🔐 ROW-LEVEL SECURITY DETECTED — NOT applied` block with the exact `apply_sigma_rls.py` command, and flags `RLS: DETECTED, NOT APPLIED` in the RESULT banner. Also surfaces cross-element RLS warnings (an RLS calc over a joined-dim column that needs manual placement) so they can't hide either.
- **`apply_sigma_rls.py`** — new offline `--print-plan` (parse a `security.json`, list rules + attributes/teams to provision; no API, no `--dm-id`) for offline review and as the CI-portable test entrypoint.
- **`test-rls-wiring.rb` + CI** — regression test guarding the wiring contract + the print-plan parse; added to the corpus-check offline unit-test job.

## Verified on the EDNA-mirror fixture

Two RLS calcs detected + translated correctly:
- `USERATTRIBUTE("order_channel") = [Order Channel]` → `CurrentUserAttributeText("order_channel") = [Order Channel]` (provisions user attribute `order_channel`)
- `CONTAINS([Order Status], USERNAME())` → `Contains([Order Status], CurrentUserEmail())` (EDNA's `Username()` pattern)

`security.json` written, gate fired, RESULT flagged, and `apply_sigma_rls.py --print-plan` reproduces the plan offline.

## Note

This fixes **surfacing/gating** (the silent-drop bug). Provisioning + applying the rules is the pre-existing `apply_sigma_rls.py` (plan handoff verified here). Cross-element RLS (calc over a joined-dim column) is still flagged for manual placement by design — EDNA's fact-level `AUTHORIZED_USERS` avoids that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)