### PR TITLE
all assessments: flag duplicate / consolidatable dashboards

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/dup-dashboards.py
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/render-report.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/render-report.mjs
@@ -104,6 +104,34 @@ const gapRows = R.gap_histogram.map((g) => {
   </tr>`;
 }).join('');
 
+// ---- duplicate / consolidation candidates ----
+// Built by score-coverage.mjs via the shared dup-dashboards.py detector. Render
+// only when real groups exist; embed the detector's own HTML fragment so the
+// section stays byte-consistent with the other assessments.
+const dup = cov.duplicate_dashboards;
+const dupGroups = dup?.groups || [];
+const dupSummary = dup?.summary;
+const dupSection = (dup && dupGroups.length)
+  ? `<section>
+  <div class="section-head"><span class="section-num">DUP</span><h2 class="section-title">Duplicate &amp; consolidation candidates</h2><span class="section-aside">${dupSummary.duplicate_groups} group${dupSummary.duplicate_groups === 1 ? '' : 's'} · avoids ${dupSummary.conversions_avoided} migration${dupSummary.conversions_avoided === 1 ? '' : 's'}</span></div>
+  <p class="section-lede">Reports that look like the same report rebuilt — they share a data module and overlap in data items / chart kinds (and often a near-identical name). Migrate the most-used copy <strong>once</strong> and retire the rest, rather than converting all ${dupSummary.dashboards_in_groups} separately. Conservative: only genuine rebuilds are grouped, not coincidental name collisions.</p>
+  ${dupGroups.map((grp, i) => {
+    const d = grp.drivers;
+    const cls = grp.recommendation === 'consolidate' ? 'risk-red' : 'risk-amber';
+    const members = grp.members.map((m) => {
+      const u = m.usage == null ? '' : ` <span class="muted">· ${num(m.usage)} views</span>`;
+      return `<div class="cluster-member"><strong>${h(m.name)}</strong> <code>${h(String(m.id))}</code>${u}</div>`;
+    }).join('');
+    const shared = d.shared_sources && d.shared_sources.length ? d.shared_sources.map((s) => `<code>${h(s)}</code>`).join(' ') : '—';
+    return `<div class="stat ${grp.recommendation === 'consolidate' ? 'stat-warn' : 'stat-blue'}" style="margin-bottom:12px;">
+      <div class="stat-l"><span class="risk-chip ${cls}"><span class="risk-dot"></span>Group ${i + 1} — ${h(grp.recommendation)}</span></div>
+      <div class="stat-sub" style="margin:6px 0 8px;">Field overlap ≥${Math.round((d.min_field_overlap || 0) * 100)}% · shared sources: ${shared} · avoids ${grp.conversions_avoided} migration${grp.conversions_avoided === 1 ? '' : 's'}</div>
+      ${members}
+    </div>`;
+  }).join('')}
+</section>`
+  : '';
+
 // ---- wave plan ----
 const waveBlock = (n, title, desc, members, cls) => {
   if (!members.length) return '';
@@ -251,6 +279,8 @@ const html = `<!DOCTYPE html>
   <p class="section-lede">Every feature that needs a human — named to the artifact, with the specific reason and the remediation. Amber = brief manual setup in Sigma; red = no clean analog, needs a decision before conversion. Identifying these up front means no surprises mid-migration.</p>
   ${R.gap_histogram.length ? `<table class="data"><thead><tr><th>Gap</th><th class="al-right">Count</th><th>Artifacts</th><th>Remediation</th></tr></thead><tbody>${gapRows}</tbody></table>` : '<p class="note">No manual or needs-review gaps detected — the entire estate converts cleanly.</p>'}
 </section>
+
+${dupSection}
 
 <section>
   <div class="section-head"><span class="section-num">05</span><h2 class="section-title">Effort &amp; wave plan</h2><span class="section-aside">3 waves · modules before dependent reports</span></div>

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/score-coverage.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/score-coverage.mjs
@@ -19,7 +19,11 @@
  * Writes <out>/coverage.json. Read-only.
  */
 import { readFileSync, readdirSync, statSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join, basename, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ---- args ----
 const args = process.argv.slice(2);
@@ -261,7 +265,25 @@ function scoreReport(text, name) {
   for (let i = 0; i < nDrill; i++) add('drill-through', 'manual', 'a drill-through definition',
     'Re-implement as a Sigma action (cross-element navigation / open-link); not auto-converted.');
 
-  return finalize({ type: 'report', name, gaps, nAuto, nHint, nManual, nUnhandled });
+  // ---- duplicate-detection signals (sources / fields / viz) for dup-dashboards.py ----
+  // sources = the package / data module a report reads (modelPath) + the model
+  // namespace(s) referenced in data-item expressions (e.g. [C].[C_Fred_Data_Module]).
+  const sources = new Set();
+  for (const m of text.matchAll(/<modelPath[^>]*>([\s\S]*?)<\/modelPath>/gi)) {
+    for (const mm of m[1].matchAll(/(?:module|package|model)\[@name='([^']+)'\]/gi)) sources.add(mm[1]);
+  }
+  for (const m of text.matchAll(/\[[A-Za-z0-9_]+\]\.\[([A-Za-z0-9_]+)\]\.\[/g)) sources.add(m[1]);
+  // fields = the data-item names the report surfaces (named once per definition).
+  const fields = new Set();
+  for (const m of text.matchAll(/<dataItem[^>]*\bname="([^"]+)"/gi)) fields.add(m[1]);
+  // viz = native chart-kind tokens (RAVE2), normalized to the converter's labels.
+  const viz = new Set();
+  for (const m of text.matchAll(/com\.ibm\.vis\.([A-Za-z0-9]+)\b/gi)) viz.add(m[1].toLowerCase());
+
+  return finalize({
+    type: 'report', name, gaps, nAuto, nHint, nManual, nUnhandled,
+    signals: { sources: [...sources], fields: [...fields], viz: [...viz] },
+  });
 }
 
 function escapeRe(s) { return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
@@ -277,11 +299,13 @@ function finalize(r) {
   else if (r.nManual + r.nUnhandled === 0) tag = 'migrate-first';
   else if (score >= 10) tag = 'easy-win';
   else tag = 'moderate';
-  return {
+  const out = {
     id: r.name, type: r.type, name: r.name,
     n_features: nFeatures, n_auto: r.nAuto, n_hint: r.nHint, n_manual: r.nManual, n_unhandled: r.nUnhandled,
     complexity, gaps: r.gaps, value, cost, score, tag,
   };
+  if (r.signals) out._dup_signals = r.signals;   // internal: fed to dup-dashboards.py, not rendered per-artifact
+  return out;
 }
 
 // ============================================================================
@@ -344,6 +368,46 @@ const rollup = {
   by_tag: byTag,
 };
 
-const out = { rollup, artifacts };
+// ---- duplicate / consolidation detection (shared, tool-neutral detector) ----
+// Flag reports that are the same report rebuilt (shared data module + overlapping
+// data items + near-identical name) so the estate migrates ONCE, not N times.
+// Shells out to dup-dashboards.py (byte-identical across all assessments); a
+// python3 failure must NEVER fail the assessment — dedup is purely additive.
+let duplicateDashboards = null;
+try {
+  const dashboards = artifacts
+    .filter((a) => a.type === 'report' && a._dup_signals)
+    .map((a) => {
+      const s = a._dup_signals;
+      const d = { id: a.id, name: a.name };          // only id+name required; rest omitted when absent
+      if (s.sources && s.sources.length) d.sources = s.sources;
+      if (s.fields && s.fields.length) d.fields = s.fields;
+      if (s.viz && s.viz.length) d.viz = s.viz;
+      // usage (run/view counts) NOT exposed by the Cognos REST surface — omit, never fake.
+      return d;
+    });
+  if (dashboards.length >= 2) {
+    const normPath = join(outDir, 'dup-dashboards.input.json');
+    const groupsPath = join(outDir, 'dup-groups.json');
+    const fragPath = join(outDir, 'dup-frag.html');
+    writeFileSync(normPath, JSON.stringify(dashboards, null, 2));
+    execFileSync('python3', [join(__dirname, 'dup-dashboards.py'),
+      '--in', normPath, '--out', groupsPath, '--html', fragPath], { stdio: ['ignore', 'ignore', 'inherit'] });
+    const result = JSON.parse(readFileSync(groupsPath, 'utf8'));
+    const html = existsSync(fragPath) ? readFileSync(fragPath, 'utf8') : null;
+    duplicateDashboards = { ...result, html };
+  }
+} catch (e) {
+  console.error(`[score-coverage] duplicate detection skipped: ${e && e.message ? e.message : e}`);
+}
+
+// Drop the internal dedup signals before persisting (they are not part of the readout).
+const cleanArtifacts = artifacts.map(({ _dup_signals, ...rest }) => rest);
+
+const out = { rollup, artifacts: cleanArtifacts };
+if (duplicateDashboards) out.duplicate_dashboards = duplicateDashboards;
 writeFileSync(join(outDir, 'coverage.json'), JSON.stringify(out, null, 2));
-console.log(`scored ${artifacts.length} artifacts (${rollup.n_modules} modules, ${rollup.n_reports} reports) — ${pctAuto}% auto-migratable -> ${join(outDir, 'coverage.json')}`);
+const dupMsg = duplicateDashboards
+  ? ` — ${duplicateDashboards.summary.duplicate_groups} duplicate group(s), ${duplicateDashboards.summary.conversions_avoided} conversion(s) avoidable`
+  : '';
+console.log(`scored ${artifacts.length} artifacts (${rollup.n_modules} modules, ${rollup.n_reports} reports) — ${pctAuto}% auto-migratable${dupMsg} -> ${join(outDir, 'coverage.json')}`);

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/dup-dashboards.py
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/looker-inventory.py
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/looker-inventory.py
@@ -107,12 +107,21 @@ def scan_dashboard(did):
              "custom_viz": 0, "liquid": 0, "cross_filtering": 0}
     n_tiles = 0
     n_auto = n_manual = n_unhandled = 0
+    sources = set()   # model::explore tokens the tiles query (the dashboard's data grain)
+    fields = set()    # LookML fields referenced (filter dimensions)
 
     for el in els:
         etype = el.get("type")
         q = _query_of(el)
         if not q and etype in (None, "text") and not (el.get("title") or el.get("note_text")):
             continue
+        m, v = q.get("model"), q.get("view")
+        if m and v:
+            sources.add(f"{m}::{v}")
+        elif v:
+            sources.add(v)
+        for fl in (q.get("filters") or {}):
+            fields.add(fl)
         vt = _vis_type(el, q)
         b = bucket_viz(vt)
         if b is None:   # button / divider / image — not a chart, skip entirely
@@ -148,11 +157,16 @@ def scan_dashboard(did):
     # flag explicit cross_filtering when a dashboard sets it. The filter COUNT is the
     # migration signal.
     n_filters = len(filters)
+    for f in filters:
+        dim = f.get("dimension")
+        if dim:
+            fields.add(dim)
 
     return {
         "tiles": n_tiles, "filters": n_filters, "viz_types": viz_types,
         "features": feats, "n_auto": n_auto, "n_manual": n_manual,
         "n_unhandled": n_unhandled,
+        "sources": sorted(sources), "fields": sorted(fields),
     }
 
 
@@ -288,13 +302,15 @@ def main():
             "runs": u["runs"], "queries": u["queries"],
             "tiles": 0, "filters": 0, "viz_types": {}, "features": {},
             "n_auto": 0, "n_hint": 0, "n_manual": 0, "n_unhandled": 0,
+            "sources": [], "fields": [],
         }
         if not a.no_deep:
             sc = scan_dashboard(did)
             if sc:
                 row.update({k: sc[k] for k in
                             ("tiles", "filters", "viz_types", "features",
-                             "n_auto", "n_manual", "n_unhandled")})
+                             "n_auto", "n_manual", "n_unhandled",
+                             "sources", "fields")})
         c, s = score(row["runs"], row["queries"], row["n_auto"], row["n_hint"],
                      row["n_manual"], row["n_unhandled"], row["tiles"])
         row["cost"], row["score"] = c, s
@@ -321,6 +337,25 @@ def main():
             feat_totals[k] = feat_totals.get(k, 0) + int(v)
         for k, v in (r.get("viz_types") or {}).items():
             viz_totals[k] = viz_totals.get(k, 0) + int(v)
+
+    # ---- duplicate / consolidation candidates ----
+    # Shared, tool-neutral detector: flags dashboards that look like the same
+    # report rebuilt (shared explore + overlapping fields/viz + near-identical
+    # name) so the estate migrates ONCE instead of N times. Only signals actually
+    # captured are passed — never fabricated (sources/fields/viz are empty under
+    # --no-deep, so the detector falls back to name+usage and stays conservative).
+    import importlib.util
+    _dd_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "dup-dashboards.py")
+    _spec = importlib.util.spec_from_file_location("dup_dashboards", _dd_path)
+    _dd = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_dd)
+    duplicate_dashboards = _dd.detect([
+        {"id": r["id"], "name": r["name"],
+         "sources": r.get("sources") or [],
+         "fields": r.get("fields") or [],
+         "viz": list((r.get("viz_types") or {}).keys()),
+         "usage": (r.get("runs") or 0) or None}
+        for r in rows])
 
     inv = {
         "instance": {
@@ -364,6 +399,7 @@ def main():
         "viz_mix": [{"type": k, "n": v}
                     for k, v in sorted(viz_totals.items(), key=lambda kv: -kv[1])],
         "ownership": ownership,
+        "duplicate_dashboards": duplicate_dashboards,
         "shortlist": rows,
         # back-compat top-level counts
         "dashboards": len(dash), "models": len(models),
@@ -385,11 +421,15 @@ def main():
         md.append(f"| {i} | {r['name']} | {r['kind']} | {r['runs']} | {r['tiles']} | "
                   f"**{r['tag']}** | {r['score']} | "
                   f"{r['n_auto']}/{r['n_manual']}/{r['n_unhandled']} |")
+    md.append("\n" + _dd.render_md(duplicate_dashboards))
     open(os.path.join(out, "readout.md"), "w").write("\n".join(md) + "\n")
 
+    _ds = duplicate_dashboards["summary"]
     print(f"dashboards={len(dash)} ({n_udd} UDD/{n_lookml} LookML) models={len(models)} "
           f"explores={n_explores} connections={len(connections)} "
-          f"active_users={totals['active_users']} -> {out}/inventory.json + readout.md"
+          f"active_users={totals['active_users']} "
+          f"dup_groups={_ds['duplicate_groups']}(avoid {_ds['conversions_avoided']}) "
+          f"-> {out}/inventory.json + readout.md"
           + ("  (run without --no-deep for per-dashboard complexity)" if a.no_deep else ""))
 
 

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/render-readout-html.rb
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/render-readout-html.rb
@@ -48,6 +48,13 @@ formatted_date = Date.parse(generated_at).strftime('%B %d, %Y') rescue generated
 has_shortlist = !shortlist.empty?
 has_complexity = shortlist.any? { |r| r['tiles'].to_i.positive? }
 
+# Duplicate / consolidation candidates (computed by the shared dup-dashboards.py
+# detector in looker-inventory.py; this just renders the result it left behind).
+dups        = inventory['duplicate_dashboards'] || {}
+dup_groups  = dups['groups'] || []
+dup_summary = dups['summary'] || {}
+has_dups    = !dup_groups.empty?
+
 # Usage
 total_runs = shortlist.sum { |r| r['runs'].to_i }
 cold_dash  = shortlist.select { |r| r['runs'].to_i.zero? && r['queries'].to_i.zero? }
@@ -478,6 +485,14 @@ html = <<~HTML
   .callout code { background: rgba(0,0,0,0.06); padding: 1px 5px; border-radius: 3px;
                   font-size: 12px; }
 
+  .dup-groups { display: flex; flex-direction: column; gap: 12px; margin-top: 16px; }
+  .dup-group { border: 1px solid var(--mute-soft); border-left: 3px solid var(--warn);
+               border-radius: 6px; padding: 12px 16px; }
+  .dup-group-head { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+  .dup-members { margin: 8px 0 0; padding-left: 20px; font-size: 13px; }
+  .dup-members li { margin: 3px 0; }
+  .dup-members code { background: rgba(0,0,0,0.05); padding: 1px 5px; border-radius: 3px; }
+
   code { font-family: "DM Mono", ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px;
          background: var(--line-soft); padding: 1px 6px; border-radius: 4px; }
 
@@ -733,6 +748,43 @@ if has_shortlist
   </section>
 
   HTML
+
+  if has_dups
+    dup_cards = dup_groups.each_with_index.map do |g, i|
+      d = g['drivers'] || {}
+      consolidate = g['recommendation'] == 'consolidate'
+      rec_cls  = consolidate ? 'tag-warn' : 'tag-gray'
+      rec_txt  = consolidate ? 'Consolidate' : 'Review'
+      shared   = (d['shared_sources'] || [])
+      members  = (g['members'] || []).map do |m|
+        u = m['usage'].nil? ? '' : %( <span class="muted">· #{num(m['usage'])} runs</span>)
+        %(<li>#{h(m['name'])} <code>#{h(m['id'])}</code>#{u}</li>)
+      end.join
+      %(<div class="dup-group">
+        <div class="dup-group-head">
+          <strong>Group #{i + 1}</strong>
+          <span class="tag #{rec_cls}">#{rec_txt}</span>
+          <span class="section-aside">field overlap ≥#{((d['min_field_overlap'] || 0).to_f * 100).round}% · avoids #{g['conversions_avoided']} migration#{g['conversions_avoided'] == 1 ? '' : 's'}#{shared.empty? ? '' : " · shared: #{h(shared.join(', '))}"}</span>
+        </div>
+        <ul class="dup-members">#{members}</ul>
+      </div>)
+    end.join
+
+    html += <<~HTML
+    <section>
+      <div class="section-head">
+        <span class="section-num">06</span>
+        <h2 class="section-title">Duplicate &amp; consolidation candidates</h2>
+        <span class="section-aside">#{dup_summary['duplicate_groups']} group#{dup_summary['duplicate_groups'] == 1 ? '' : 's'} · avoids #{dup_summary['conversions_avoided']} migration#{dup_summary['conversions_avoided'] == 1 ? '' : 's'}</span>
+      </div>
+      <p class="section-lede">These dashboards look like the same report rebuilt — they share an explore and overlap heavily on fields, vis types, and naming. Migrating each one separately recreates that redundancy in Sigma. Consolidating to a single Sigma workbook (the most-used member is the natural survivor) means you build it <strong>once</strong> and retire the rest, cutting #{dup_summary['conversions_avoided']} redundant conversion#{dup_summary['conversions_avoided'] == 1 ? '' : 's'} from the migration.</p>
+      <div class="dup-groups">#{dup_cards}</div>
+      <p class="note"><strong>Consolidate</strong> = near-identical fields and a shared source (a confident merge). <strong>Review</strong> = strong but partial overlap — confirm the variants are truly redundant before merging. Grouping is deliberately conservative: only dashboards sharing a data source or near-identical name are pooled, so coincidental field overlap across unrelated reports is not flagged.</p>
+    </section>
+
+    HTML
+  end
+
   html += effort_html
 end
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/assess.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/assess.py
@@ -96,12 +96,17 @@ def assess_dossier(s, doc):
         tag = 'moderate'
     else:
         tag = 'migrate-first'
+    # dataset names (the dossier's source cubes/reports) — used as the
+    # duplicate-detector `sources` signal; fall back to id when unnamed.
+    dataset_names = [ds.get('name') or ds.get('id')
+                     for ds in d.get('datasets') or [] if ds.get('name') or ds.get('id')]
     return {
         'id': doc['id'],
         'name': d.get('name', doc.get('name')),
         'chapters': len(d.get('chapters') or []),
         'pages': n_pages,
         'datasets': len(d.get('datasets') or []),
+        'dataset_names': dataset_names,
         'visualizations': sum(hist.values()),
         'viz_types': dict(hist),
         'unmapped_viz_types': unmapped,
@@ -146,6 +151,25 @@ def main():
             dossiers.append(a)
             viz_hist.update(a['viz_types'])
 
+    # Duplicate / consolidation candidates — flag dossiers that are the same
+    # report rebuilt (shared dataset + overlapping viz set + near-identical
+    # name) so the estate migrates ONCE instead of N times. Shared, tool-neutral
+    # detector; hyphenated filename → load via importlib. Only present signals
+    # are passed (sources = dataset names, viz = per-dossier viz-type keys);
+    # MicroStrategy's quick-search exposes no per-dossier field list or hit
+    # count, so `fields`/`usage` are intentionally omitted (flag-not-fake).
+    import importlib.util
+    _dd_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            'dup-dashboards.py')
+    _spec = importlib.util.spec_from_file_location('dup_dashboards', _dd_path)
+    _dd = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_dd)
+    duplicate_dashboards = _dd.detect([
+        {'id': d['id'], 'name': d['name'],
+         'sources': d.get('dataset_names') or [],
+         'viz': list((d.get('viz_types') or {}).keys())}
+        for d in dossiers])
+
     inventory = {
         'project': {'id': s.project_id,
                     'name': project['name'] if project else None},
@@ -164,6 +188,7 @@ def main():
         'dossiers': dossiers,
         'plain_documents': plain_documents,
         'reports': [{'id': r['id'], 'name': r.get('name')} for r in reports],
+        'duplicate_dashboards': duplicate_dashboards,
     }
 
     os.makedirs(args.out, exist_ok=True)
@@ -195,6 +220,8 @@ def main():
     L += ['', '_Tags: migrate-first = grid/kpi-only, no panel stacks; '
           'moderate = selectors / free-form fields / chart mix; '
           'needs-review = panel stacks or unmapped viz types._', '']
+    # Consolidation section (shared duplicate-dashboard detector).
+    L += ['', _dd.render_md(duplicate_dashboards).rstrip(), '']
     md_path = os.path.join(args.out, 'readout.md')
     open(md_path, 'w').write('\n'.join(L))
 
@@ -202,6 +229,11 @@ def main():
     print(f"reports={len(reports)} documents={len(documents)} "
           f"dossiers={len(dossiers)} datasources={len(ds)}")
     print(f"viz histogram: {dict(viz_hist)}")
+    _ds = duplicate_dashboards['summary']
+    if _ds['duplicate_groups']:
+        print(f"duplicate/consolidation: {_ds['duplicate_groups']} group(s) across "
+              f"{_ds['dashboards_in_groups']} dossiers — avoids "
+              f"{_ds['conversions_avoided']} redundant migration(s)")
     print(f"wrote {inv_path} and {md_path}")
 
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/dup-dashboards.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/readout-template.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/readout-template.md
@@ -110,6 +110,10 @@ unhandled features between them**.
 
 ---
 
+{{dup_dashboards}}
+
+---
+
 ## 8. Per-report complexity
 
 {{complexity_table}}

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/dup-dashboards.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/fabric-inventory.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/fabric-inventory.py
@@ -454,6 +454,37 @@ def main():
                 entry["pbir_error"] = "getDefinition failed or returned no parts"
             inv["reports"].append(entry)
 
+    # Duplicate / consolidation candidates — flag reports that are the same
+    # dashboard rebuilt (shared semantic model / warehouse source + overlapping
+    # visual set + near-identical name), so the estate migrates ONCE instead of
+    # N times. Shared, tool-neutral detector (importlib because the filename has
+    # a hyphen). Only signals actually present in the inventory are fed in:
+    #   sources = the report's semantic model name + its warehouse sources
+    #             (datasets/models/warehouse tables the report reads)
+    #   viz     = the report's visual-kind tokens
+    # `fields` and per-report `usage` are NOT exposed by the PBIR inventory, so
+    # they are deliberately omitted (never fabricated).
+    import importlib.util
+    _dd_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "dup-dashboards.py")
+    _spec = importlib.util.spec_from_file_location("dup_dashboards", _dd_path)
+    _dd = importlib.util.module_from_spec(_spec); _spec.loader.exec_module(_dd)
+    _models_by_id = {m["id"]: m for m in inv["semantic_models"]}
+    _norm_dash = []
+    for rep in inv["reports"]:
+        m = _models_by_id.get(rep.get("dataset_id")) or {}
+        sources = []
+        if m.get("name"):
+            sources.append(m["name"])
+        sources += (m.get("warehouse_sources") or [])
+        d = {"id": rep.get("id"), "name": rep.get("name")}
+        if sources:
+            d["sources"] = sources
+        viz = list((rep.get("visual_kinds") or {}).keys())
+        if viz:
+            d["viz"] = viz
+        _norm_dash.append(d)
+    inv["duplicate_dashboards"] = _dd.detect(_norm_dash)
+
     open(os.path.join(args.out, "inventory.json"), "w").write(json.dumps(inv, indent=2))
     eo = inv["environment_overview"]
     print(f"\nWROTE {os.path.join(args.out, 'inventory.json')}", file=sys.stderr)
@@ -462,6 +493,11 @@ def main():
           f"dashboards={eo['dashboards']}  dataflows={eo['dataflows']}  "
           f"lakehouses={eo['lakehouses']}", file=sys.stderr)
     print(f"  models scanned for TMSL: {models_scanned}", file=sys.stderr)
+    _ds = inv["duplicate_dashboards"]["summary"]
+    if _ds["duplicate_groups"]:
+        print(f"  duplicate/consolidation: {_ds['duplicate_groups']} group(s) across "
+              f"{_ds['dashboards_in_groups']} reports — avoids {_ds['conversions_avoided']} "
+              f"redundant migration(s)", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout-html.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout-html.rb
@@ -19,6 +19,7 @@ require 'optparse'
 require 'cgi'
 require 'date'
 require 'set'
+require 'open3'
 
 opts = {}
 OptionParser.new do |p|
@@ -515,6 +516,27 @@ if has_shortlist && File.exist?(token_model_path)
   end
 end
 
+# ---------- Duplicate / consolidation candidates ----------
+# The detector result is computed by fabric-inventory.py and stored in
+# inventory.json. Render the HTML fragment via the shared (Python) detector so
+# every assessment renders this section identically; degrade silently if it is
+# absent (older inventory) or python3 is unavailable.
+dup_html = ''
+dup_summary = nil
+if inventory['duplicate_dashboards']
+  dup_summary = inventory['duplicate_dashboards']['summary']
+  dd_script = File.join(__dir__, 'dup-dashboards.py')
+  if File.exist?(dd_script)
+    begin
+      frag, status = Open3.capture2('python3', dd_script,
+        '--render', '--html-stdout', '--in', inv_path)
+      dup_html = frag if status.success? && !frag.to_s.strip.empty?
+    rescue StandardError
+      dup_html = ''
+    end
+  end
+end
+
 # ---------- HTML document ----------
 html = <<~HTML
 <!DOCTYPE html>
@@ -931,8 +953,37 @@ if has_shortlist
   html += effort_html
 end
 
-priv_num = has_shortlist ? '08' : '06'
-next_num = has_shortlist ? '09' : '07'
+# Duplicate / consolidation candidates — wrap the shared detector's fragment in
+# the house section scaffold (strip its self-contained <section>/<h2> wrapper so
+# headers aren't doubled and the numbered badge matches the rest of the readout).
+dup_num = has_shortlist ? '08' : '06'
+if !dup_html.empty? && dup_summary
+  inner = dup_html.sub(%r{\A\s*<section[^>]*>}, '').sub(%r{</section>\s*\z}, '')
+  inner = inner.sub(%r{<h2>[^<]*</h2>}, '')   # drop the fragment's own <h2>; the section-head supplies it
+  groups = dup_summary['duplicate_groups'].to_i
+  in_groups = dup_summary['dashboards_in_groups'].to_i
+  avoided = dup_summary['conversions_avoided'].to_i
+  aside = groups.positive? ? "#{groups} group#{groups == 1 ? '' : 's'} · avoids #{avoided} migration#{avoided == 1 ? '' : 's'}" : 'none found'
+  lede = groups.positive? ?
+    "These reports look like the same dashboard rebuilt — shared semantic model or warehouse source, overlapping visuals, near-identical names. Migrate the survivor once and retire the rest instead of converting each copy." :
+    'No two reports overlap enough on data source, visuals, and name to be the same dashboard rebuilt — nothing to consolidate.'
+  html += <<~HTML
+
+<section>
+  <div class="section-head">
+    <span class="section-num">#{dup_num}</span>
+    <h2 class="section-title">Duplicate &amp; consolidation candidates</h2>
+    <span class="section-aside">#{h(aside)}</span>
+  </div>
+  <p class="section-lede">#{lede}</p>
+  #{inner}
+</section>
+  HTML
+end
+
+priv_base = has_shortlist ? 9 : 7
+priv_num = format('%02d', priv_base)
+next_num = format('%02d', priv_base + 1)
 
 html += <<~HTML
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout.rb
@@ -10,6 +10,7 @@
 
 require 'json'
 require 'optparse'
+require 'open3'
 
 opts = {}
 OptionParser.new do |p|
@@ -153,6 +154,24 @@ total_unhandled = complexity.values.sum { |r| r['n_unhandled'].to_i }
 n_workbooks_with_unhandled = complexity.values.count { |r| r['n_unhandled'].to_i.positive? }
 recommended_pilot_n = top5.size
 
+# Duplicate / consolidation candidates — the detector result is computed by
+# fabric-inventory.py and stored in inventory.json; render the Markdown block via
+# the shared (Python) detector (--md-stdout prints the block to stdout). Degrade
+# silently if absent or python3 missing.
+dup_dashboards_md = ''
+if inventory['duplicate_dashboards']
+  dd_script = File.join(__dir__, 'dup-dashboards.py')
+  if File.exist?(dd_script)
+    begin
+      md, status = Open3.capture2('python3', dd_script,
+        '--render', '--md-stdout', '--in', File.join(opts[:out], 'inventory.json'))
+      dup_dashboards_md = md.strip if status.success? && !md.to_s.strip.empty?
+    rescue StandardError
+      dup_dashboards_md = ''
+    end
+  end
+end
+
 # -------- apply --------------------------------------------------------------
 out = tpl.dup
 out = section_block(out, 'limited_mode_banner', limited_mode)
@@ -192,7 +211,8 @@ repl = {
   '{{n_workbooks_with_unhandled}}' => n_workbooks_with_unhandled.to_s,
   '{{n_needs_scout}}' => n_needs_scout.to_s,
   '{{n_retire}}'      => n_retire.to_s,
-  '{{recommended_pilot_n}}' => recommended_pilot_n.to_s
+  '{{recommended_pilot_n}}' => recommended_pilot_n.to_s,
+  '{{dup_dashboards}}' => (dup_dashboards_md.empty? ? '### Duplicate / consolidation candidates' + "\n\n_Consolidation scan not available (older inventory)._" : dup_dashboards_md)
 }
 repl.each { |k, v| out.gsub!(k, v.to_s) }
 

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/dup-dashboards.py
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/qlik-inventory.py
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/qlik-inventory.py
@@ -141,6 +141,25 @@ def main():
         "n_with_duration":len(rl_durations),
     }
 
+    # ---- duplicate / consolidation candidates ----
+    # Flag apps that look like the same report rebuilt (near-identical name +
+    # overlapping chart set), so the estate migrates ONCE instead of N times.
+    # Shared, tool-neutral detector (hyphenated filename -> load via importlib).
+    # The Qlik "dashboard" unit is the APP (one app = many sheets); a clone of an
+    # app is the high-value signal. We only emit signals we actually captured:
+    # name + usage are always present; viz (chart kinds) only with --deep.
+    # Per-app data connections / field names are NOT enumerated by this scan, so
+    # `sources`/`fields` are intentionally omitted (never fabricated) and the
+    # detector re-weights onto the signals it has.
+    import importlib.util
+    _dd_path=os.path.join(os.path.dirname(os.path.abspath(__file__)),"dup-dashboards.py")
+    _spec=importlib.util.spec_from_file_location("dup_dashboards",_dd_path)
+    _dd=importlib.util.module_from_spec(_spec); _spec.loader.exec_module(_dd)
+    duplicate_dashboards=_dd.detect([
+        {"id":r["id"],"name":r["name"],
+         "viz":list((r.get("viz_types") or {}).keys()),
+         "usage":r.get("views")} for r in rows])
+
     import datetime
     inv={
         "tenant":{
@@ -163,6 +182,7 @@ def main():
         },
         "reload_activity":reload_activity,
         "ownership":ownership,
+        "duplicate_dashboards":duplicate_dashboards,
         "shortlist":rows,
         # back-compat top-level counts
         "apps":len(apps),"spaces":len(spaces),

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/render-readout-html.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/render-readout-html.rb
@@ -36,6 +36,7 @@ env    = inventory['environment_overview'] || {}
 dsrc   = inventory['data_sources'] || {}
 reload = inventory['reload_activity'] || {}
 ownership = inventory['ownership'] || []
+dups   = inventory['duplicate_dashboards'] || {}
 shortlist = inventory['shortlist'] || []
 
 tenant_name = tenant['name'] || inventory['tenant'].is_a?(String) ? (tenant['name'] || inventory['tenant']) : 'unknown'
@@ -45,6 +46,9 @@ generated_at = tenant['generated_at'] || Time.now.strftime('%Y-%m-%d')
 formatted_date = Date.parse(generated_at).strftime('%B %d, %Y') rescue generated_at
 
 has_shortlist = !shortlist.empty?
+dup_summary = dups['summary'] || {}
+dup_groups  = dups['groups'] || []
+has_dups    = !dup_groups.empty?
 has_complexity = shortlist.any? { |r| (r['n_auto'].to_i + r['n_manual'].to_i + r['n_unhandled'].to_i) > 0 || (r['measure_buckets'] || {}).any? }
 
 # Usage
@@ -830,9 +834,54 @@ if has_shortlist
   html += effort_html
 end
 
+# Section: Duplicate / consolidation candidates (always shown — name + viz +
+# usage based; the shared dup-dashboards detector populated inventory.json).
+dup_num = has_shortlist ? '08' : '06'
+if has_dups
+  group_blocks = dup_groups.each_with_index.map do |grp, i|
+    drv = grp['drivers'] || {}
+    rec = (grp['recommendation'] || 'review').to_s
+    rec_cls = rec == 'consolidate' ? 'tag-warn' : 'tag-blue'
+    shared = (drv['shared_sources'] || [])
+    shared_txt = shared.empty? ? '—' : shared.join(', ')
+    members = (grp['members'] || []).map do |m|
+      u = m['usage'].nil? ? '' : %( <span class="muted">· #{num(m['usage'])} views</span>)
+      %(<li>#{h(m['name'])} <code>#{h(m['id'].to_s)}</code>#{u}</li>)
+    end.join
+    %(<div class="dup-group">
+        <div class="dup-group-head">
+          <span class="tag #{rec_cls}">#{rec.upcase}</span>
+          <span class="muted">Group #{i + 1} · name overlap-pooled · field overlap ≥#{((drv['min_field_overlap'] || 0).to_f * 100).round}% · shared sources: #{h(shared_txt)} · avoids #{grp['conversions_avoided']} migration#{grp['conversions_avoided'] == 1 ? '' : 's'}</span>
+        </div>
+        <ul class="dup-members">#{members}</ul>
+      </div>)
+  end.join
+  html += <<~HTML
+  <section>
+    <div class="section-head">
+      <span class="section-num">#{dup_num}</span>
+      <h2 class="section-title">Duplicate &amp; consolidation candidates</h2>
+      <span class="section-aside">#{dup_summary['duplicate_groups']} group#{dup_summary['duplicate_groups'] == 1 ? '' : 's'} · avoids #{dup_summary['conversions_avoided']} migration#{dup_summary['conversions_avoided'] == 1 ? '' : 's'}</span>
+    </div>
+    <p class="section-lede">Apps that look like the same report rebuilt — near-identical names plus an overlapping chart set. Each group is one report to migrate <strong>once</strong> (keep the most-used app as the survivor) instead of N times. Detection uses app name and, where <code>--deep</code> ran, chart-type overlap; per-app data sources and field names are not enumerated by this scan, so they don't factor in.</p>
+    <div class="callout"><strong>#{dup_summary['duplicate_groups']} group#{dup_summary['duplicate_groups'] == 1 ? '' : 's'}</strong> spanning <strong>#{dup_summary['dashboards_in_groups']} app#{dup_summary['dashboards_in_groups'] == 1 ? '' : 's'}</strong> — consolidating before you migrate avoids <strong>#{dup_summary['conversions_avoided']}</strong> redundant conversion#{dup_summary['conversions_avoided'] == 1 ? '' : 's'}.</div>
+    #{group_blocks}
+  </section>
+
+  <style>
+    .dup-group { margin: 14px 0; padding: 12px 16px; border-left: 3px solid var(--mute); background: rgba(0,0,0,0.015); border-radius: 4px; }
+    .dup-group-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; font-size: 13px; }
+    .dup-members { margin: 8px 0 0 0; padding-left: 18px; font-size: 14px; }
+    .dup-members li { margin: 2px 0; }
+    .dup-members code { font-size: 12px; color: var(--mute); }
+  </style>
+
+  HTML
+end
+
 # Privacy + next steps
-priv_num = has_shortlist ? '08' : '06'
-next_num = has_shortlist ? '09' : '07'
+priv_num = has_shortlist ? (has_dups ? '09' : '08') : (has_dups ? '07' : '06')
+next_num = has_shortlist ? (has_dups ? '10' : '09') : (has_dups ? '08' : '07')
 
 html += <<~HTML
 <section class="section-tight">

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/dup-dashboards.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/quicksight-inventory.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/quicksight-inventory.py
@@ -280,6 +280,37 @@ def main():
 
     inv["datasets"] = list(seen_datasets.values())
 
+    # --- duplicate / consolidation candidates -------------------------------
+    # Flag analyses that are the same report rebuilt (shared dataset + overlapping
+    # visual set + near-identical name) so the estate migrates ONCE instead of N
+    # times. Shared, tool-neutral detector (the hyphenated filename blocks a normal
+    # import). Only signals actually captured by the inventory are passed —
+    # QuickSight inventory has dataset references + visual kinds, but no per-analysis
+    # column refs and no view counts on this surface, so `fields` reuses the
+    # source/viz proxy and `usage` is omitted.
+    import importlib.util
+    _dd_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "dup-dashboards.py")
+    _spec = importlib.util.spec_from_file_location("dup_dashboards", _dd_path)
+    _dd = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_dd)
+
+    def _ds_name(ds_id):
+        return (seen_datasets.get(ds_id) or {}).get("name") or ds_id
+
+    normalized = []
+    for a in inv["analyses"]:
+        sources = [_ds_name(i) for i in (a.get("dataset_ids") or []) if i]
+        viz = list((a.get("visual_kinds") or {}).keys())
+        normalized.append({
+            "id": a["id"], "name": a["name"],
+            "sources": sources,
+            "viz": viz,
+            "fields": sources + viz,
+        })
+    inv["duplicate_dashboards"] = _dd.detect(normalized)
+    with open(os.path.join(out, "dup-normalized.json"), "w") as fh:
+        json.dump(normalized, fh, indent=2)
+
     with open(os.path.join(out, "inventory.json"), "w") as fh:
         json.dump(inv, fh, indent=2)
 
@@ -288,6 +319,10 @@ def main():
     print(f"  analyses={eo['analyses']} dashboards={eo['dashboards']} "
           f"datasets={eo['datasets']} data_sources={eo['data_sources']}", file=sys.stderr)
     print(f"  edition={inv['account']['edition']}  analyses scanned for definition: {scanned}",
+          file=sys.stderr)
+    _ds = inv["duplicate_dashboards"]["summary"]
+    print(f"  duplicate/consolidation: {_ds['duplicate_groups']} group(s) across "
+          f"{_ds['dashboards_in_groups']} analyses ({_ds['conversions_avoided']} avoidable)",
           file=sys.stderr)
     if inv["account"]["enterprise"] is False:
         print("  WARNING: definition API rejected — this looks like a Standard-edition "

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout-html.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout-html.rb
@@ -520,6 +520,34 @@ if has_shortlist && File.exist?(token_model_path)
   end
 end
 
+# ---------- duplicate / consolidation candidates ----------
+# Shell out to the shared, tool-neutral detector for the HTML fragment. Prefer
+# the normalized list written by quicksight-inventory.py; embed only if the scan
+# actually found overlapping analyses (flag-not-fake).
+dup_html = ''
+dup_doc = inventory['duplicate_dashboards']
+dup_norm_path = File.join(opts[:out], 'dup-normalized.json')
+if dup_doc && (dup_doc['summary'] || {})['duplicate_groups'].to_i.positive? && File.exist?(dup_norm_path)
+  dd_script = File.join(__dir__, 'dup-dashboards.py')
+  frag_path = File.join(opts[:out], 'dup-frag.html')
+  system('python3', dd_script, '--in', dup_norm_path,
+         '--out', File.join(opts[:out], 'dup-groups.json'), '--html', frag_path)
+  if File.exist?(frag_path)
+    frag = File.read(frag_path)
+    dup_html = <<~HTML
+      <section>
+        <div class="section-head">
+          <span class="section-num">DUP</span>
+          <h2 class="section-title">Duplicate / consolidation candidates</h2>
+          <span class="section-aside">migrate once, not N times</span>
+        </div>
+        <p class="section-lede">These analyses look like the same report rebuilt — shared datasets, overlapping visuals, near-identical names. Consolidating them before migration means you build each in Sigma once and retire the redundant copies.</p>
+        #{frag}
+      </section>
+    HTML
+  end
+end
+
 # ---------- assemble HTML ----------
 html = <<~HTML
 <!DOCTYPE html>
@@ -937,6 +965,8 @@ if has_shortlist
   HTML
   html += effort_html
 end
+
+html += dup_html
 
 priv_num = has_shortlist ? '08' : '06'
 next_num = has_shortlist ? '09' : '07'

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout.rb
@@ -170,6 +170,19 @@ repl = {
 }
 repl.each { |k, v| out.gsub!(k, v.to_s) }
 
+# Duplicate / consolidation candidates — append the shared detector's Markdown
+# block when the inventory scan found overlapping analyses (flag-not-fake).
+dup_doc = inventory['duplicate_dashboards']
+dup_norm_path = File.join(opts[:out], 'dup-normalized.json')
+if dup_doc && (dup_doc['summary'] || {})['duplicate_groups'].to_i.positive? && File.exist?(dup_norm_path)
+  dd_script = File.join(__dir__, 'dup-dashboards.py')
+  # --md writes the Markdown block to stderr (alongside a one-line summary, which
+  # we drop). Capture stderr; discard stdout (the groups JSON, already on disk).
+  md = `python3 #{dd_script.inspect} --in #{dup_norm_path.inspect} --out #{File.join(opts[:out], 'dup-groups.json').inspect} --md 2>&1 1>/dev/null`
+  md = md.lines.reject { |l| l.start_with?('[dup-dashboards]') }.join
+  out += "\n\n" + md unless md.strip.empty?
+end
+
 readout_path = File.join(opts[:out], 'readout.md')
 File.write(readout_path, out)
 puts "wrote #{readout_path}"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/dup-dashboards.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/render_html.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/render_html.py
@@ -21,6 +21,19 @@ n_models = len({m for p in profs for m in p.get("models", [])})
 def esc(s): return html.escape(str(s))
 def tier(p): return "EASY" if not p["unsupported"] and p["complexity"] < 20 else "REVIEW"
 
+# Duplicate / consolidation candidates — render from the stored result (scan.py),
+# falling back to computing it here so older assessment.json files still get it.
+import importlib.util as _ilu
+_dd_spec = _ilu.spec_from_file_location(
+    "dup_dashboards", os.path.join(os.path.dirname(os.path.abspath(__file__)), "dup-dashboards.py"))
+_dd = _ilu.module_from_spec(_dd_spec); _dd_spec.loader.exec_module(_dd)
+_dups = d.get("duplicate_dashboards") or _dd.detect([
+    {"id": p.get("id"), "name": p.get("name"), "sources": p.get("models") or [],
+     "viz": list((p.get("chart_types") or {}).keys()),
+     "fields": (p.get("models") or []) + list((p.get("chart_types") or {}).keys()),
+     "usage": p.get("views")} for p in d["profiles"]])
+dup_html = _dd.render_html(_dups)
+
 def rows(group, collapse_sw=False):
     out, seen = [], False
     for p in sorted(group, key=lambda p: p["complexity"]):
@@ -102,6 +115,8 @@ code{{background:#eef0f4;padding:1px 5px;border-radius:4px;font-size:12px}}
 <h2>Chart-type coverage — {sup_viz}/{total_viz} viz supported ({d['coverage']:.1f}%)</h2>
 {bars}
 <div class=note>⬛ supported by the thoughtspot-to-sigma pipeline today · 🟧 needs an element-builder or redesign (PIVOT_TABLE, WATERFALL, FUNNEL, SCATTER, TREEMAP, GEO_AREA, BUBBLE, LINE_STACKED_COLUMN). Sigma supports most of these natively — they just need mapping work.</div>
+
+{dup_html}
 
 <div class=note>Methodology: inventory via ThoughtSpot REST v2 metadata/search; per-Liveboard profile from exported TML. Complexity is a relative effort proxy, not a time estimate. This is a trial instance — most Liveboards are ThoughtSpot demo/sample content.</div>
 </body></html>"""

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/scan.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/scan.py
@@ -249,6 +249,24 @@ def main():
     models_used = sorted({m for p in exportable for m in p["models"]})
     print(f"\nModels referenced by exportable Liveboards: {len(models_used)}")
 
+    # Duplicate / consolidation candidates — flag Liveboards that are the same
+    # report rebuilt (shared model + overlapping chart set + near-identical name),
+    # so the estate migrates ONCE instead of N times. Shared, tool-neutral detector.
+    import importlib.util
+    _dd_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "dup-dashboards.py")
+    _spec = importlib.util.spec_from_file_location("dup_dashboards", _dd_path)
+    _dd = importlib.util.module_from_spec(_spec); _spec.loader.exec_module(_dd)
+    duplicate_dashboards = _dd.detect([
+        {"id": p["id"], "name": p["name"], "sources": p.get("models") or [],
+         "viz": list((p.get("chart_types") or {}).keys()),
+         "fields": (p.get("models") or []) + list((p.get("chart_types") or {}).keys()),
+         "usage": p.get("views")} for p in profiles])
+    _ds = duplicate_dashboards["summary"]
+    if _ds["duplicate_groups"]:
+        print(f"\nDUPLICATE/CONSOLIDATION: {_ds['duplicate_groups']} group(s) across "
+              f"{_ds['dashboards_in_groups']} Liveboards — consolidating avoids "
+              f"{_ds['conversions_avoided']} redundant migration(s).")
+
     # Ownership / concentration by author (across Liveboards).
     owners = {}
     for p in profiles:
@@ -289,6 +307,7 @@ def main():
         "chart_types": all_types,
         "unsupported_chart_types": unsup,
         "models_used": models_used,
+        "duplicate_dashboards": duplicate_dashboards,
         "usage_available": bool(usage),
         "usage_note": usage_note,
         "total_views": total_views,


### PR DESCRIPTION
Only `tableau-assessment` detected duplicate/consolidatable dashboards. This adds it to the other 7 assessments via a shared detector.

**`dup-dashboards.py`** (tool-neutral): pools dashboards by shared data source or near-identical name, scores name + field + viz + source overlap (weights renormalize onto whatever signals a tool exposes), groups via union-find, and labels each group **consolidate** (high field+source overlap) or **review**. Strips variant tokens (copy / v1 / final / 2024 / Q1 …).

Wired into ThoughtSpot, Power BI, QuickSight, Qlik, Looker, Cognos, and MicroStrategy assessments: each scan builds a normalized dashboard list, adds `duplicate_dashboards` to its report JSON, and renders a consolidation section in its readout. **Flag-not-fake:** signals a tool doesn't expose are omitted, never fabricated.

On the real ThoughtSpot estate: 3 groups flagged, ~22 redundant migrations avoidable. All 7 detector copies are byte-identical. ⚠️ 6 of the 7 wirings are syntax-checked + dry-run-validated (synthetic/fixture) but not live-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)