### PR TITLE
powerbi-to-sigma: harden against post-mortem failure modes (+ orphan-PUT for tableau/quicksight)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -65,7 +65,18 @@ Pulls the refresh history (`GET datasets/{id}/refreshes` via the cached token) �
 
 ## Phase 3 — Convert (MCP)
 `convert_powerbi_to_sigma(model_json, connection_id, database, schema)`.
+
+> ⚠️ **`--converter-out` takes the MCP converter's output — never a hand-authored spec.**
+> The flag exists so you can run the `convert_powerbi_to_sigma` MCP tool, save its
+> result, and resume the pipeline with it (`convert-model.rb --converter-out <that file>`).
+> It is **not** an invitation to write `dm-raw.json` by hand. Hand-authored specs skip
+> the converter's column-name/SQL/formula-prefix guarantees and reliably produce
+> `Missing "kind" field`, `source.statement: undefined`, and `dependency not found`
+> errors (validate-spec.rb now catches the first two, but the right fix is to feed it
+> real converter output). If the MCP tool is unavailable, STOP and gate — don't fabricate.
+
 - DAX measures → Sigma metrics. ~70% mechanical; see `refs/dax-to-sigma-coverage.md` and `fixtures/MANIFEST.md` (test oracle: 94 DAX expressions bucketed a/b/c).
+- **PromoteHeaders**: if `pbi-dm-signature.py` reports `promoted_header_tables` (the model's M-query used `Table.PromoteHeaders`), the warehouse table's real columns are auto-named (`C1`, `C2`, …) with the semantic names in row 0 — the TMSL `sourceColumn` names will NOT resolve. Verify the landed table's real columns and remap with `convert-model.rb --table-map` (in Sigma formulas the columns appear as `C 1`, `C 2`, … and in JOIN SQL alias them, e.g. `c.C2 AS CUSTOMER_NAME`).
 - **Known gap `j89`**: the Snowflake `Snowflake.Databases(...) + Navigation` M pattern isn't parsed → pass `database`/`schema` explicitly until fixed.
 - **DAX gaps → gap-scout**: for measures the converter buckets `b` (restructure) or `c` (no-equivalent) — `RANKX`, `ALLEXCEPT`, `SUMMARIZE`, `USERELATIONSHIP`, `PATH*` — spawn the **gap-scout** sub-agent (`scripts/gap-scout.md`): it proposes a Sigma translation, validates it against the live API (`scripts/scout-validate.py`), and persists the rule to `~/.powerbi-to-sigma/learned-rules.yaml` (loaded by `scripts/learned-rules.py`) so future conversions auto-apply it. Time-intelligence (YTD/SPLY) is usually translatable — see `refs/measure-patterns.md`, not the scout.
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -107,64 +107,72 @@ OptionParser.new do |p|
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
+  p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 DAX parity) — REQUIRED reason string. Use ONLY when DAX parity is genuinely unavailable (e.g. no Power BI workspace/dataset access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
 summary_path = File.join(opts[:tab], 'parity-final.json')
 
-unless File.exist?(summary_path)
-  warn "[FAIL] Phase 6 skipped — #{summary_path} does not exist."
-  warn "       Run: ruby scripts/phase6-parity.rb --tableau #{opts[:tab]} --workbook-id <id>"
-  warn "       then collect actuals via mcp__sigma-mcp-v2__query and re-run with --finalize."
-  warn "       See SKILL.md Phase 6. This is the hard gate (beads-sigma-4pm)."
-  exit 1
-end
-
-begin
-  summary = JSON.parse(File.read(summary_path))
-rescue JSON::ParserError => e
-  warn "[FAIL] #{summary_path} is malformed JSON: #{e.message}"
-  exit 3
-end
-
-total = summary['charts_total'].to_i
-passed = summary['charts_pass'].to_i
-status = summary['status'].to_s
-mode = summary['mode'].to_s
-
-if total <= 0
-  warn "[FAIL] parity-final.json reports charts_total=#{total} — no charts were verified."
-  warn "       This usually means auto-parity-plan.rb matched zero Tableau views."
-  warn "       Phase 6 must verify at least one chart to declare GREEN."
-  exit 2
-end
-
-if mode == 'extract' && !opts[:allow_extract]
-  warn "[FAIL] parity ran in extract-mode but --allow-extract was not passed."
-  warn "       Extract-mode permits up to ±#{((summary['extract_tol'] || 0.30) * 100).to_i}% drift —"
-  warn "       only acceptable when the source Tableau workbook has hasExtracts=true."
-  exit 2
-end
-
-pass_rate = passed.to_f / total
-# status=PASS requires 100% — when the caller explicitly accepts a lower
-# pass-rate (--min-pass-rate, for honest NAMED divergences like LOD
-# placeholders / cross-grain semantics), the rate is the gate, not the status.
-rate_gate_only = opts[:min_pass_rate] < 1.0
-if (rate_gate_only ? pass_rate < opts[:min_pass_rate] : (status != 'PASS' || pass_rate < opts[:min_pass_rate]))
-  warn "[FAIL] parity status=#{status} pass-rate=#{(pass_rate * 100).round(1)}% (#{passed}/#{total})"
-  warn "       Required: #{rate_gate_only ? '' : 'status=PASS and '}pass-rate >= #{(opts[:min_pass_rate] * 100).to_i}%"
-  if (fail_names = summary['fail_names']) && !fail_names.empty?
-    warn "       Failing charts: #{fail_names.join(', ')}"
-  end
-  exit 2
-end
-
-if rate_gate_only && status != 'PASS'
-  puts "[OK] gate 1/7: Phase 6 ran — #{passed}/#{total} charts PASS (>= #{(opts[:min_pass_rate] * 100).to_i}% accepted); " \
-       "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
+if opts[:skip_parity]
+  puts "[SKIP] gate 1/7: Phase 6 DAX parity WAIVED via --skip-parity-gate (#{opts[:skip_parity]})."
+  puts "       This waiver MUST be named in the migration report — the workbook was NOT numerically verified vs Power BI."
 else
-  puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  unless File.exist?(summary_path)
+    warn "[FAIL] Phase 6 skipped — #{summary_path} does not exist."
+    warn "       Run: ruby scripts/phase6-parity.rb --tableau #{opts[:tab]} --workbook-id <id>"
+    warn "       then collect actuals via mcp__sigma-mcp-v2__query and re-run with --finalize."
+    warn "       See SKILL.md Phase 6. This is the hard gate (beads-sigma-4pm)."
+    warn "       If PBI parity is genuinely unavailable (no workspace/dataset access), waive"
+    warn "       with --skip-parity-gate \"<reason>\" and name it in the report."
+    exit 1
+  end
+
+  begin
+    summary = JSON.parse(File.read(summary_path))
+  rescue JSON::ParserError => e
+    warn "[FAIL] #{summary_path} is malformed JSON: #{e.message}"
+    exit 3
+  end
+
+  total = summary['charts_total'].to_i
+  passed = summary['charts_pass'].to_i
+  status = summary['status'].to_s
+  mode = summary['mode'].to_s
+
+  if total <= 0
+    warn "[FAIL] parity-final.json reports charts_total=#{total} — no charts were verified."
+    warn "       This usually means auto-parity-plan.rb matched zero Tableau views."
+    warn "       Phase 6 must verify at least one chart to declare GREEN."
+    exit 2
+  end
+
+  if mode == 'extract' && !opts[:allow_extract]
+    warn "[FAIL] parity ran in extract-mode but --allow-extract was not passed."
+    warn "       Extract-mode permits up to ±#{((summary['extract_tol'] || 0.30) * 100).to_i}% drift —"
+    warn "       only acceptable when the source Tableau workbook has hasExtracts=true."
+    exit 2
+  end
+
+  pass_rate = passed.to_f / total
+  # status=PASS requires 100% — when the caller explicitly accepts a lower
+  # pass-rate (--min-pass-rate, for honest NAMED divergences like LOD
+  # placeholders / cross-grain semantics), the rate is the gate, not the status.
+  rate_gate_only = opts[:min_pass_rate] < 1.0
+  if (rate_gate_only ? pass_rate < opts[:min_pass_rate] : (status != 'PASS' || pass_rate < opts[:min_pass_rate]))
+    warn "[FAIL] parity status=#{status} pass-rate=#{(pass_rate * 100).round(1)}% (#{passed}/#{total})"
+    warn "       Required: #{rate_gate_only ? '' : 'status=PASS and '}pass-rate >= #{(opts[:min_pass_rate] * 100).to_i}%"
+    if (fail_names = summary['fail_names']) && !fail_names.empty?
+      warn "       Failing charts: #{fail_names.join(', ')}"
+    end
+    exit 2
+  end
+
+  if rate_gate_only && status != 'PASS'
+    puts "[OK] gate 1/7: Phase 6 ran — #{passed}/#{total} charts PASS (>= #{(opts[:min_pass_rate] * 100).to_i}% accepted); " \
+         "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
+  else
+    puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  end
 end
 
 # ---------------------------------------------------------------------------
@@ -378,7 +386,7 @@ end
 # charts and parity still reports PASS (every chart it knows about passes —
 # it just doesn't know about the dropped one).
 # ---------------------------------------------------------------------------
-census = summary['tile_census']
+census = summary && summary['tile_census']  # summary is nil when gate 1 was waived
 if census.nil?
   puts "[SKIP] gate 5/7: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
 else

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -610,6 +610,24 @@ def build_element(rec, fields, masters, extra_data = [])
   end
 
   master = visual_master(rec, fields)
+  # E-06: a value-driven visual with NO resolvable field binding would emit a
+  # source-less element with a "[]" formula column (an empty PBI `kpi {}` or a
+  # cardVisual->bar approximation), which the API rejects with
+  # `source: Invalid value: undefined`. Skip it loudly rather than ship a broken
+  # element. (control/text/image are handled elsewhere and legitimately carry no
+  # value binding, so they are NOT in this set.)
+  value_driven = %w[kpi-chart bar-chart line-chart area-chart combo-chart
+                    scatter-chart pie-chart donut-chart region-map point-map
+                    table pivot-table].include?(kind)
+  if value_driven
+    all_qrs = (rec['bindings'] || {}).values.flatten.compact
+    if all_qrs.empty? || master.nil?
+      why = all_qrs.empty? ? 'no field bindings' : 'no resolvable master element'
+      warn "[build-workbook] WARN visual '#{rec['title'] || rec['visual_id']}' (#{kind}) has " \
+           "#{why} — element SKIPPED (would emit a source-less \"[]\" column the API rejects)."
+      return nil
+    end
+  end
   # bead 8vzj: a Sigma element sources exactly ONE master. visual_master picks the
   # one covering the MOST fields, but any bound field that cannot resolve on it
   # (not its master and not among its `alts`) is silently DROPPED. Warn loudly so
@@ -1045,6 +1063,26 @@ def build_element(rec, fields, masters, extra_data = [])
       end
     end
     if !group_ids.empty? && !calc_ids.empty?
+      # E-08: a time-intelligence calc (DateLookback / CumulativeSum) needs a DATE
+      # column in the grouping or it compiles to type:error at runtime. Warn when
+      # one is inlined into a purely categorical grouping (e.g. "Revenue vs PY %"
+      # in a customer/segment table) — the measure should instead be routed
+      # through a date-grouped prior-period element (see dax-restructure-patterns.rb).
+      time_intel = /\b(DateLookback|CumulativeSum)\s*\(/i
+      grouped_on_date = group_ids.any? do |gid|
+        f = (cols.find { |c| c['id'] == gid } || {})['formula'].to_s
+        f =~ /\b(date|month|year|quarter|week|day)\b/i || f =~ /DateTrunc\s*\(/i
+      end
+      unless grouped_on_date
+        cols.each do |c|
+          next unless calc_ids.include?(c['id']) && c['formula'].to_s =~ time_intel
+          dim_names = group_ids.map { |g| (cols.find { |x| x['id'] == g } || {})['name'] }.compact.join(', ')
+          warn "[build-workbook] WARN visual '#{name}': time-intel column '#{c['name']}' is inlined " \
+               "into a table grouped only by categorical column(s) (#{dim_names}) — Sigma " \
+               "DateLookback/CumulativeSum needs a date-grouped context and will compile to " \
+               "type:error. Route this measure through a date-grouped prior-period element."
+        end
+      end
       el['groupings'] = [{ 'id' => "#{eid}-g", 'groupBy' => group_ids, 'calculations' => calc_ids }]
     end
   when 'pivot-table'

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -1065,6 +1065,14 @@ build += ['--folder-id', wb_folder] if wb_folder
 # workbook against this DM (see SKILL.md). Never worse than the proven agent path.
 begin
   build_log = run_wb!(build)
+  # Validate the WORKBOOK spec before POST — previously only the DM spec was
+  # validated, so workbook-shape defects (source-less "[]" elements, dangling
+  # grouping refs, missing kind) went straight to the API. The DM readback gives
+  # the cross-ref context (master/DM element names + ids).
+  dm_ctx = File.join(WORK, 'dm-context.json')
+  File.write(dm_ctx, JSON.generate(dm_rb))
+  run_wb!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'workbook',
+           '--dm-context', dm_ctx, wb_spec])
   wb_readback = File.join(WORK, 'wb-readback.json')
   rb_log = run_wb!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
                     '--spec', wb_spec, '--out', wb_readback, '--workdir', WORK], env: ENV.to_h)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi-dm-signature.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi-dm-signature.py
@@ -42,7 +42,7 @@ def main():
     ap.add_argument("--bim", required=True); ap.add_argument("--out", required=True)
     a = ap.parse_args()
     model = json.load(open(a.bim)); mdl = model.get("model", model)
-    tables, cols, measures = [], [], []
+    tables, cols, measures, promoted = [], [], [], []
     for t in mdl.get("tables", []):
         name = t.get("name", "")
         # skip auto date tables / calc tables (no warehouse source)
@@ -52,6 +52,12 @@ def main():
         fqn = _fqn(m_expr)
         if fqn:
             tables.append(fqn.upper())
+        # E-04: Table.PromoteHeaders in the M-query means the warehouse table was
+        # loaded with AUTO-GENERATED column names (C1, C2, ...) and the semantic
+        # names sit in row 0 — so TMSL sourceColumn names will NOT match the
+        # warehouse columns and downstream refs/SQL break. Flag it.
+        if re.search(r'Table\.PromoteHeaders', m_expr):
+            promoted.append(name)
         for c in t.get("columns", []):
             sc = c.get("sourceColumn") or c.get("name")
             if sc:
@@ -65,10 +71,18 @@ def main():
     sig = {"tableau_workbook": mdl.get("name") or "Power BI model",
            "warehouse_tables": sorted(set(tables)),
            "referenced_columns": sorted(set(cols)),
-           "measures": measures}
+           "measures": measures,
+           "promoted_header_tables": sorted(set(promoted))}
     json.dump(sig, open(a.out, "w"), indent=2)
     print(f"[pbi-dm-signature] {len(sig['warehouse_tables'])} table(s), "
           f"{len(sig['referenced_columns'])} col(s), {len(measures)} measure(s) -> {a.out}", file=sys.stderr)
+    if promoted:
+        print(f"[pbi-dm-signature] WARNING: {len(promoted)} table(s) use Table.PromoteHeaders "
+              f"({', '.join(promoted)}). Their warehouse columns are likely auto-named (C1, C2, ...) "
+              f"with semantic names in row 0 — TMSL sourceColumn names will NOT match the warehouse. "
+              f"Verify the landed table's real column names and use convert-model.rb --table-map "
+              f"(or a column rename) before the workbook refs resolve. See SKILL.md PromoteHeaders.",
+              file=sys.stderr)
 
 if __name__ == "__main__":
     main()

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
@@ -150,6 +150,15 @@ def write_harness
 end
 
 if opts[:emit]
+  # E-11: the workspace + dataset ids needed for DAX parity ARE captured earlier —
+  # pbi-freshness.py writes them into freshness.json (keys workspace/dataset). Auto-
+  # wire them so the parity gate isn't a dead-end when --workspace/--dataset aren't
+  # repeated on the command line. An explicit flag always wins.
+  opts[:ws] ||= FRESH['workspace']
+  opts[:ds] ||= FRESH['dataset']
+  if (opts[:ws].nil? || opts[:ds].nil?) && opts[:fresh].nil?
+    warn '[phase6-pbi] tip: pass --freshness <work>/freshness.json to auto-fill --workspace/--dataset'
+  end
   %i[ws ds cdax wb out].each { |k| abort("missing --#{k}") unless opts[k] }
   write_harness
   chart_dax = JSON.parse(File.read(opts[:cdax]))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/post-and-readback.rb
@@ -22,6 +22,7 @@ OptionParser.new do |p|
   p.on('--skip-layout-lint') { opts[:skip_lint] = true }
   p.on('--skip-control-lint') { opts[:skip_control_lint] = true }
   p.on('--control-scope P', 'control-scope.json sidecar (default: <workdir>/control-scope.json if present)') { |v| opts[:control_scope] = v }
+  p.on('--update-id ID', 'PUT the spec to this existing workbook/DM id instead of POSTing a new one (retry-safe; avoids orphan workbooks). For workbooks, if omitted, the last id in posted-workbooks.jsonl is reused automatically.') { |v| opts[:update_id] = v }
 end.parse!
 %i[type spec out].each { |k| abort("missing --#{k}") unless opts[k] }
 opts[:workdir] ||= File.dirname(File.expand_path(opts[:spec]))
@@ -48,6 +49,7 @@ def http(method, path, body = nil, accept_json: false)
     uri = URI("#{BASE}#{path}")
     req = case method
           when :post then r = Net::HTTP::Post.new(uri); r.body = body; r['Content-Type'] = 'application/json'; r
+          when :put  then r = Net::HTTP::Put.new(uri);  r.body = body; r['Content-Type'] = 'application/json'; r
           when :get  then Net::HTTP::Get.new(uri)
           end
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
@@ -71,41 +73,33 @@ prior_ids = []
 if posted_log && File.exist?(posted_log)
   prior_ids = File.readlines(posted_log).map { |l| JSON.parse(l)['id'] rescue nil }.compact
 end
-if prior_ids.any?
-  warn ''
-  warn '============================================================'
-  warn "WARN — orphan workbook risk (beads-sigma-38a)"
-  warn '============================================================'
-  warn "This is invocation ##{prior_ids.size + 1} of post-and-readback for this"
-  warn "conversion. Each POST creates a NEW workbook. Already created:"
-  prior_ids.each { |id| warn "  - #{id}" }
-  warn ''
-  warn 'If you are RETRYING after a spec error, you should be using PUT,'
-  warn 'not POST:'
-  warn ''
-  warn "  curl -X PUT -H \"Authorization: Bearer $SIGMA_API_TOKEN\" \\"
-  warn "    -H 'Content-Type: application/json' \\"
-  warn "    -d @#{opts[:spec]} \\"
-  warn "    \"$SIGMA_BASE_URL/v2/workbooks/#{prior_ids.last}/spec\""
-  warn ''
-  warn "If you genuinely meant to create a parallel workbook, ignore this."
-  warn "Otherwise, run scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:workdir]}"
-  warn "to delete the orphans before declaring done — assert-phase6-ran.rb"
-  warn "will FAIL the gate if uncleaned orphans remain."
-  warn '============================================================'
-  warn ''
-end
+# Decide POST (create) vs PUT (update existing). An explicit --update-id always
+# wins; otherwise, for a workbook retry, auto-reuse the last id we posted in this
+# conversion so a re-run UPDATES the workbook in place instead of orphaning it
+# (beads-sigma-38a — the 3-workbook customer regression). DM updates require an
+# explicit --update-id (Phase 3 normally reuses a DM via the ref-dm path).
+update_id = opts[:update_id] || (prior_ids.last if opts[:type] == 'workbook' && prior_ids.any?)
 
-resp = http(:post, POST_PATH, File.read(opts[:spec]))
-parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
-oid = parsed[ID_FIELD] or abort("POST failed: #{parsed.inspect}")
-warn "POST ok: #{ID_FIELD}=#{oid}"
+if update_id
+  warn "UPDATE mode: PUT #{opts[:type]} #{update_id} (no new #{opts[:type]} created)"
+  resp = http(:put, format(GET_PATH, update_id), File.read(opts[:spec]))
+  parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+  oid = parsed[ID_FIELD] || update_id
+  abort("PUT failed (HTTP #{resp.code}): #{parsed.inspect}") unless resp.is_a?(Net::HTTPSuccess)
+  warn "PUT ok: #{ID_FIELD}=#{oid}"
+else
+  resp = http(:post, POST_PATH, File.read(opts[:spec]))
+  parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+  oid = parsed[ID_FIELD] or abort("POST failed: #{parsed.inspect}")
+  warn "POST ok: #{ID_FIELD}=#{oid}"
 
-# Append the new ID to the per-conversion log. Newline-delimited JSON so
-# multiple processes can append safely (atomic append on POSIX).
-if posted_log
-  File.open(posted_log, 'a') do |f|
-    f.puts(JSON.generate({ 'id' => oid, 'ran_at' => Time.now.utc.iso8601 }))
+  # Append the new ID to the per-conversion log. Newline-delimited JSON so
+  # multiple processes can append safely (atomic append on POSIX). Only on
+  # create — a PUT reuses an existing id and adds no orphan to track.
+  if posted_log
+    File.open(posted_log, 'a') do |f|
+      f.puts(JSON.generate({ 'id' => oid, 'ran_at' => Time.now.utc.iso8601 }))
+    end
   end
 end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/validate-spec.rb
@@ -49,7 +49,14 @@ end
 errors = []
 all_element_names = []
 spec.fetch('pages', []).each do |page|
-  page.fetch('elements', []).each { |el| all_element_names << el['name'] if el['name'] }
+  page.fetch('elements', []).each do |el|
+    all_element_names << el['name'] if el['name']
+    # Workbook formulas reference a master/source element by its ELEMENT ID
+    # (e.g. [master-4e5cfb1f/Sales]), not its display name — so the element id is
+    # itself a valid cross-ref prefix. Without this the prefix check false-flags
+    # every chart that sources a master (it only knew the names).
+    all_element_names << el['id'] if el['id']
+  end
 end
 all_known_prefixes = (all_element_names + external_names).to_set rescue (all_element_names + external_names)
 require 'set' rescue nil
@@ -64,12 +71,26 @@ spec.fetch('pages', []).each do |page|
     cols = (el['columns'] || []) + (el['metrics'] || [])
     sibling_names = Set.new(cols.map { |c| c['name'] }.compact)
 
+    # E-01: every element must carry a `kind`. A missing kind is silently
+    # coerced to '' below and slips past all the equality checks, then the API
+    # rejects the POST with `Missing "kind" field`. Catch it here.
+    errors << "#{name}: element missing required `kind` field" if (el['kind'] || '').to_s.strip.empty?
+
     src = el['source'] || {}
     own_prefixes = Set.new
     if src['kind'] == 'warehouse-table' && src['path']
       own_prefixes << src['path'].last
     end
-    own_prefixes << 'Custom SQL' if src['kind'] == 'sql'
+    # E-02: a SQL source element must carry a non-empty `statement`. The common
+    # mistake is using the key `sql` (API rejects with `source.statement:
+    # Invalid string: undefined`).
+    if src['kind'] == 'sql'
+      own_prefixes << 'Custom SQL'
+      if src['statement'].to_s.strip.empty?
+        hint = src.key?('sql') ? ' (found a `sql` key — Sigma expects `statement`)' : ''
+        errors << "#{name}: sql source element has empty/missing `statement`#{hint}"
+      end
+    end
     # bead 1t6c: a master sourcing a DM element (kind: data-model) carries
     # pass-through column formulas like [EMPLOYEES/Department] whose prefix is the
     # DM element's source-table name — that lives INSIDE the data model, not this
@@ -121,7 +142,12 @@ spec.fetch('pages', []).each do |page|
           # fuzzy-matches case/underscore variants. So a bare ref that isn't a
           # named sibling is still valid here; don't flag it (Bug E: SQL-output
           # columns are intentionally nameless, binding to their alias).
-          if src['kind'] != 'sql' && !sibling_names.include?(ref)
+          #
+          # Scope to DM specs only: in a WORKBOOK, a chart legitimately carries
+          # cross-element measure refs ([DM Element.Measure]) that resolve against
+          # the data model / master scope this validator can't see — flagging them
+          # as "not a sibling" false-positives every real generated workbook.
+          if opts[:type] == 'datamodel' && src['kind'] != 'sql' && !sibling_names.include?(ref)
             errors << "#{name}.#{col['name']}: bare ref [#{ref}] not a sibling column"
           end
         end
@@ -232,6 +258,24 @@ spec.fetch('pages', []).each do |page|
           errors << "#{name}: pivot-table #{key} entries use {id: ...}, not {columnId: ...} (got #{bad.inspect})"
         elsif bad
           errors << "#{name}: pivot-table #{key} entry missing id key (got #{bad.inspect})"
+        end
+      end
+    end
+
+    # E-09: a grouping's calculations[] must reference column IDs that still
+    # exist on the element. When a column is removed (e.g. an error-typed
+    # DateLookback col) but its grouping entry is left behind, the API rejects
+    # with `groupings[N].calculations[M]: Column or folder not found`.
+    valid_col_ids = Set.new(cols.map { |c| c['id'] }.compact)
+    (el['groupings'] || []).each_with_index do |grp, gi|
+      next unless grp.is_a?(Hash)
+      calcs = grp['calculations'].is_a?(Array) ? grp['calculations'] : []
+      calcs.each do |calc|
+        cid = calc.is_a?(Hash) ? (calc['columnId'] || calc['id']) : calc
+        next if cid.nil? || cid.to_s.empty?
+        unless valid_col_ids.include?(cid)
+          errors << "#{name}: groupings[#{gi}].calculations references columnId \"#{cid}\" " \
+                    "not present in this element's columns[] (dangling ref — column likely removed)"
         end
       end
     end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/post-and-readback.rb
@@ -22,6 +22,7 @@ OptionParser.new do |p|
   p.on('--skip-layout-lint') { opts[:skip_lint] = true }
   p.on('--skip-control-lint') { opts[:skip_control_lint] = true }
   p.on('--control-scope P', 'control-scope.json sidecar (default: <workdir>/control-scope.json if present)') { |v| opts[:control_scope] = v }
+  p.on('--update-id ID', 'PUT the spec to this existing workbook/DM id instead of POSTing a new one (retry-safe; avoids orphan workbooks). For workbooks, if omitted, the last id in posted-workbooks.jsonl is reused automatically.') { |v| opts[:update_id] = v }
 end.parse!
 %i[type spec out].each { |k| abort("missing --#{k}") unless opts[k] }
 opts[:workdir] ||= File.dirname(File.expand_path(opts[:spec]))
@@ -48,6 +49,7 @@ def http(method, path, body = nil, accept_json: false)
     uri = URI("#{BASE}#{path}")
     req = case method
           when :post then r = Net::HTTP::Post.new(uri); r.body = body; r['Content-Type'] = 'application/json'; r
+          when :put  then r = Net::HTTP::Put.new(uri);  r.body = body; r['Content-Type'] = 'application/json'; r
           when :get  then Net::HTTP::Get.new(uri)
           end
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
@@ -71,41 +73,33 @@ prior_ids = []
 if posted_log && File.exist?(posted_log)
   prior_ids = File.readlines(posted_log).map { |l| JSON.parse(l)['id'] rescue nil }.compact
 end
-if prior_ids.any?
-  warn ''
-  warn '============================================================'
-  warn "WARN — orphan workbook risk (beads-sigma-38a)"
-  warn '============================================================'
-  warn "This is invocation ##{prior_ids.size + 1} of post-and-readback for this"
-  warn "conversion. Each POST creates a NEW workbook. Already created:"
-  prior_ids.each { |id| warn "  - #{id}" }
-  warn ''
-  warn 'If you are RETRYING after a spec error, you should be using PUT,'
-  warn 'not POST:'
-  warn ''
-  warn "  curl -X PUT -H \"Authorization: Bearer $SIGMA_API_TOKEN\" \\"
-  warn "    -H 'Content-Type: application/json' \\"
-  warn "    -d @#{opts[:spec]} \\"
-  warn "    \"$SIGMA_BASE_URL/v2/workbooks/#{prior_ids.last}/spec\""
-  warn ''
-  warn "If you genuinely meant to create a parallel workbook, ignore this."
-  warn "Otherwise, run scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:workdir]}"
-  warn "to delete the orphans before declaring done — assert-phase6-ran.rb"
-  warn "will FAIL the gate if uncleaned orphans remain."
-  warn '============================================================'
-  warn ''
-end
+# Decide POST (create) vs PUT (update existing). An explicit --update-id always
+# wins; otherwise, for a workbook retry, auto-reuse the last id we posted in this
+# conversion so a re-run UPDATES the workbook in place instead of orphaning it
+# (beads-sigma-38a — the 3-workbook customer regression). DM updates require an
+# explicit --update-id (Phase 3 normally reuses a DM via the ref-dm path).
+update_id = opts[:update_id] || (prior_ids.last if opts[:type] == 'workbook' && prior_ids.any?)
 
-resp = http(:post, POST_PATH, File.read(opts[:spec]))
-parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
-oid = parsed[ID_FIELD] or abort("POST failed: #{parsed.inspect}")
-warn "POST ok: #{ID_FIELD}=#{oid}"
+if update_id
+  warn "UPDATE mode: PUT #{opts[:type]} #{update_id} (no new #{opts[:type]} created)"
+  resp = http(:put, format(GET_PATH, update_id), File.read(opts[:spec]))
+  parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+  oid = parsed[ID_FIELD] || update_id
+  abort("PUT failed (HTTP #{resp.code}): #{parsed.inspect}") unless resp.is_a?(Net::HTTPSuccess)
+  warn "PUT ok: #{ID_FIELD}=#{oid}"
+else
+  resp = http(:post, POST_PATH, File.read(opts[:spec]))
+  parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+  oid = parsed[ID_FIELD] or abort("POST failed: #{parsed.inspect}")
+  warn "POST ok: #{ID_FIELD}=#{oid}"
 
-# Append the new ID to the per-conversion log. Newline-delimited JSON so
-# multiple processes can append safely (atomic append on POSIX).
-if posted_log
-  File.open(posted_log, 'a') do |f|
-    f.puts(JSON.generate({ 'id' => oid, 'ran_at' => Time.now.utc.iso8601 }))
+  # Append the new ID to the per-conversion log. Newline-delimited JSON so
+  # multiple processes can append safely (atomic append on POSIX). Only on
+  # create — a PUT reuses an existing id and adds no orphan to track.
+  if posted_log
+    File.open(posted_log, 'a') do |f|
+      f.puts(JSON.generate({ 'id' => oid, 'ran_at' => Time.now.utc.iso8601 }))
+    end
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -22,6 +22,7 @@ OptionParser.new do |p|
   p.on('--skip-layout-lint') { opts[:skip_lint] = true }
   p.on('--skip-control-lint') { opts[:skip_control_lint] = true }
   p.on('--control-scope P', 'control-scope.json sidecar (default: <workdir>/control-scope.json if present)') { |v| opts[:control_scope] = v }
+  p.on('--update-id ID', 'PUT the spec to this existing workbook/DM id instead of POSTing a new one (retry-safe; avoids orphan workbooks). For workbooks, if omitted, the last id in posted-workbooks.jsonl is reused automatically.') { |v| opts[:update_id] = v }
 end.parse!
 %i[type spec out].each { |k| abort("missing --#{k}") unless opts[k] }
 opts[:workdir] ||= File.dirname(File.expand_path(opts[:spec]))
@@ -48,6 +49,7 @@ def http(method, path, body = nil, accept_json: false)
     uri = URI("#{BASE}#{path}")
     req = case method
           when :post then r = Net::HTTP::Post.new(uri); r.body = body; r['Content-Type'] = 'application/json'; r
+          when :put  then r = Net::HTTP::Put.new(uri);  r.body = body; r['Content-Type'] = 'application/json'; r
           when :get  then Net::HTTP::Get.new(uri)
           end
     req['Authorization'] = "Bearer #{Sigma.auth_token}"
@@ -71,41 +73,33 @@ prior_ids = []
 if posted_log && File.exist?(posted_log)
   prior_ids = File.readlines(posted_log).map { |l| JSON.parse(l)['id'] rescue nil }.compact
 end
-if prior_ids.any?
-  warn ''
-  warn '============================================================'
-  warn "WARN — orphan workbook risk (beads-sigma-38a)"
-  warn '============================================================'
-  warn "This is invocation ##{prior_ids.size + 1} of post-and-readback for this"
-  warn "conversion. Each POST creates a NEW workbook. Already created:"
-  prior_ids.each { |id| warn "  - #{id}" }
-  warn ''
-  warn 'If you are RETRYING after a spec error, you should be using PUT,'
-  warn 'not POST:'
-  warn ''
-  warn "  curl -X PUT -H \"Authorization: Bearer $SIGMA_API_TOKEN\" \\"
-  warn "    -H 'Content-Type: application/json' \\"
-  warn "    -d @#{opts[:spec]} \\"
-  warn "    \"$SIGMA_BASE_URL/v2/workbooks/#{prior_ids.last}/spec\""
-  warn ''
-  warn "If you genuinely meant to create a parallel workbook, ignore this."
-  warn "Otherwise, run scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:workdir]}"
-  warn "to delete the orphans before declaring done — assert-phase6-ran.rb"
-  warn "will FAIL the gate if uncleaned orphans remain."
-  warn '============================================================'
-  warn ''
-end
+# Decide POST (create) vs PUT (update existing). An explicit --update-id always
+# wins; otherwise, for a workbook retry, auto-reuse the last id we posted in this
+# conversion so a re-run UPDATES the workbook in place instead of orphaning it
+# (beads-sigma-38a — the 3-workbook customer regression). DM updates require an
+# explicit --update-id (Phase 3 normally reuses a DM via the ref-dm path).
+update_id = opts[:update_id] || (prior_ids.last if opts[:type] == 'workbook' && prior_ids.any?)
 
-resp = http(:post, POST_PATH, File.read(opts[:spec]))
-parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
-oid = parsed[ID_FIELD] or abort("POST failed: #{parsed.inspect}")
-warn "POST ok: #{ID_FIELD}=#{oid}"
+if update_id
+  warn "UPDATE mode: PUT #{opts[:type]} #{update_id} (no new #{opts[:type]} created)"
+  resp = http(:put, format(GET_PATH, update_id), File.read(opts[:spec]))
+  parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+  oid = parsed[ID_FIELD] || update_id
+  abort("PUT failed (HTTP #{resp.code}): #{parsed.inspect}") unless resp.is_a?(Net::HTTPSuccess)
+  warn "PUT ok: #{ID_FIELD}=#{oid}"
+else
+  resp = http(:post, POST_PATH, File.read(opts[:spec]))
+  parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+  oid = parsed[ID_FIELD] or abort("POST failed: #{parsed.inspect}")
+  warn "POST ok: #{ID_FIELD}=#{oid}"
 
-# Append the new ID to the per-conversion log. Newline-delimited JSON so
-# multiple processes can append safely (atomic append on POSIX).
-if posted_log
-  File.open(posted_log, 'a') do |f|
-    f.puts(JSON.generate({ 'id' => oid, 'ran_at' => Time.now.utc.iso8601 }))
+  # Append the new ID to the per-conversion log. Newline-delimited JSON so
+  # multiple processes can append safely (atomic append on POSIX). Only on
+  # create — a PUT reuses an existing id and adds no orphan to track.
+  if posted_log
+    File.open(posted_log, 'a') do |f|
+      f.puts(JSON.generate({ 'id' => oid, 'ran_at' => Time.now.utc.iso8601 }))
+    end
   end
 end
 


### PR DESCRIPTION
## Why
Triage of a customer `powerbi-to-sigma` run (migration post-mortem). The single most important finding: **that run bypassed the converter** — it fed `--converter-out` a hand-authored `dm-raw.json`. That flag takes the MCP converter's *output*, never a hand-built spec (now documented in SKILL.md), which explains ~half the reported errors.

I validated every RCA claim against current code (two claims — E-07 dual-SALES and E-05 formula-prefix — turned out to be non-issues / already-implemented, so they're untouched), then implemented and tested the rest.

## Fixes
- **post-and-readback.rb** — `--update-id` + a `PUT` branch; workbook retries auto-PUT to the last posted id instead of orphaning (beads-sigma-38a). Applied to all 3 vendored copies (powerbi+tableau byte-identical/md5-synced; quicksight differs only in pre-existing banner text).
- **migrate-powerbi.rb** — validate the **workbook** spec before POST (was DM-only); failures route to the existing graceful agent fallback.
- **validate-spec.rb** — guard missing `kind`, SQL `statement` presence, dangling `groupings.calculations` ids; **fixed a latent bug** — the prefix check only knew element *names*, not `master-<id>` ids, so wiring it onto workbooks would have false-blocked every master-sourced chart → added element IDs to the known-set; scoped the bare-ref "not a sibling" rule to DM specs (legal cross-element refs in workbooks).
- **build-workbook-from-pbir.rb** — skip value-driven visuals with no resolvable binding/master (source-less `formula:"[]"` elements the API rejects); warn when a time-intel calc (DateLookback/CumulativeSum) is inlined into a categorical-only table grouping.
- **phase6-parity-pbi.rb** — auto-wire `--workspace`/`--dataset` from `freshness.json`.
- **assert-phase6-ran.rb** — add `--skip-parity-gate REASON` waiver (gate 1 was the only gate without an escape hatch); keep `summary` nil-safe on the skip path.
- **pbi-dm-signature.py** — detect `Table.PromoteHeaders` and warn (auto-named C1/C2 columns).

## Testing
- New validate-spec guards fire on bad fixtures; **6 real prior workbook specs + 7 DM specs validate 0 errors**; builder re-run on 6 dirs (no crash, 0 false E-06 skips on the 5 that posted); E-08 + PUT-branch unit-tested.
- **Live on tj-wells-1989**: posted a fresh DM (clean) + workbook through the new validate gate, then re-ran post-and-readback → **UPDATE-mode PUT, no duplicate**; cleaned up after.
- Code-reviewed (no critical/major findings; two minor hand-authored-spec hardening items applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)