### PR TITLE
powerbi-to-sigma: offline warehouse-SQL parity oracle (no Power BI service)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -147,7 +147,17 @@ A workbook that POSTs 200 and passes numeric parity can still be visually broken
 
 ## Phase 6 — Verify (mandatory)
 - `sigma-mcp-v2 query` each element → confirm real rows (not blank).
-- True parity: PBI `POST /v1.0/myorg/groups/{ws}/datasets/{id}/executeQueries` (DAX) vs the same Sigma aggregation. DAX-only; breaks under service-principal if RLS.
+- **Two ways to get the `expected` (source-of-truth) side — pick by whether you can reach Power BI online:**
+  - **Warehouse-SQL oracle (DEFAULT for warehouse-backed models — OFFLINE, no Power BI):** the warehouse is what BOTH PBI and Sigma read, so the aggregate computed directly in SQL is a valid independent expected value. No `api.powerbi.com`, Entra app, or workspace/dataset id.
+    ```
+    ruby scripts/build-oracle-sql.rb --in oracle-input.json --out chart-oracle-sql.json   # DAX→SQL (aggregate measures); --dm-spec seeds fqn
+    # run each `sql` via mcp__sigma-mcp-v2__query {type:connection, connectionId:<the DM's conn>} → save rows to parity-expected.json
+    ruby scripts/phase6-parity-pbi.rb --local-sql --expected parity-expected.json --workbook-id <wb> --out plan.json
+    # collect Sigma actuals (one MCP query per chart) → parity-actuals.json, then --finalize (below)
+    ```
+    `build-oracle-sql.rb` covers SUM/AVG/MIN/MAX/COUNT/DISTINCTCOUNT/COUNTROWS + DIVIDE with an optional GROUP BY; anything else (RANKX/CALCULATE/time-intel) is flagged `supported:false` → use the online path or waive it. **Pass an explicit `column_map`** when columns are renamed/auto-named (`Table.PromoteHeaders` → C1/C2, see `pbi-dm-signature.py`); without one it falls back to a NAME→UPPER_SNAKE heuristic and warns.
+  - **Online DAX (high-fidelity / import-only models):** PBI `POST /v1.0/myorg/groups/{ws}/datasets/{id}/executeQueries` (DAX) via `--emit-dax`, vs the same Sigma aggregation. DAX-only; breaks under service-principal if RLS; needs the workspace/dataset (auto-wired from `freshness.json`).
+- **Finalize (both paths):** `ruby scripts/phase6-parity-pbi.rb --finalize --plan plan.json --actuals parity-actuals.json --out-dir <dir>` → writes `parity-final.json` (`source` records which oracle was used).
 - Hard gate: `ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <wb>` — 7 gates incl. layout lint (6) and **control lint (7**: dead controls / ghost targets / partial same-page reach / `control-scope.json` coverage; `--skip-control-lint` escape; see `refs/control-parity.md`**)**.
 - Optional flip test when the report has slicers→controls: `ruby scripts/probe-controls.rb --workbook-id <wb> --check-out-of-closure` — runtime proof a control actually filters (in-closure export changes under a non-default `parameters` value, out-of-closure doesn't). MCP query can NOT flip controls (defaults only) — export API `parameters` is the only mechanism.
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-oracle-sql.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-oracle-sql.rb
@@ -1,0 +1,141 @@
+#!/usr/bin/env ruby
+# build-oracle-sql.rb — transpile aggregate Power BI DAX measures into warehouse
+# SQL so Phase 6 parity can use the SOURCE WAREHOUSE as the oracle instead of the
+# live Power BI service (executeQueries). The warehouse is what BOTH Power BI and
+# Sigma read, so for warehouse-backed models the aggregate computed directly in
+# SQL is a valid, independent "expected" value — no api.powerbi.com, no Entra
+# app, no workspace/dataset id required.
+#
+# The agent runs each emitted SQL via `mcp__sigma-mcp-v2__query` (type:connection,
+# the SAME connectionId the data model uses) to produce parity-expected.json, then
+# feeds it to `phase6-parity-pbi.rb --local-sql --expected ...`.
+#
+# SCOPE: the common aggregate grammar — SUM / AVERAGE / MIN / MAX / COUNT /
+# DISTINCTCOUNT / COUNTROWS over Table[Col], and DIVIDE(<agg>,<agg>) — with an
+# optional single GROUP BY dimension. Anything outside it (RANKX, CALCULATE with
+# filter context, time-intelligence, iterators) is marked supported:false so the
+# caller falls back to the online DAX path (--emit-dax) or the waiver. We FLAG,
+# never silently approximate.
+#
+# Usage:
+#   ruby build-oracle-sql.rb --in <oracle-input.json> --out <chart-oracle-sql.json>
+#
+# oracle-input.json:
+#   {
+#     "connectionId": "<sigma connection uuid>",      # echoed for the agent's MCP call
+#     "column_map": { "Order Id": "ORDER_ID", ... },   # OPTIONAL display->warehouse col.
+#                                                       # REQUIRED for PromoteHeaders /
+#                                                       # renamed columns (see --dm-spec).
+#     "charts": {
+#       "Total Sales":     { "fqn": "DB.SCH.TBL", "dax": "SUM(Orders[Sales])" },
+#       "Sales by Region": { "fqn": "DB.SCH.TBL", "dax": "SUM(Orders[Sales])", "dim": "Region" }
+#     }
+#   }
+#
+# Optionally pass --dm-spec <dm-spec.json> to auto-derive a default fqn from the
+# data model's warehouse-table element(s).
+
+require 'json'
+
+module OracleSql
+  AGG = { 'SUM' => 'SUM', 'AVERAGE' => 'AVG', 'MIN' => 'MIN', 'MAX' => 'MAX',
+          'COUNT' => 'COUNT', 'DISTINCTCOUNT' => 'COUNT', 'COUNTROWS' => 'COUNT' }.freeze
+
+  # display name -> warehouse column. Explicit map wins; else Sigma's normal
+  # transform inverse: "Order Id" -> ORDER_ID. NOT safe for PromoteHeaders /
+  # renamed columns — those MUST be supplied via column_map (caller warns).
+  def self.normalize_col(display)
+    display.to_s.strip.gsub(/[^A-Za-z0-9]+/, '_').upcase.gsub(/^_+|_+$/, '')
+  end
+
+  def self.wh_col(display, col_map, fallback)
+    return col_map[display] if col_map.key?(display)
+    fallback << display
+    normalize_col(display)
+  end
+
+  # Transpile a DAX measure body to a SQL select-expression, or nil if unsupported.
+  # `fallback` (optional array) collects display names that used the heuristic.
+  def self.transpile(dax, col_map = {}, fallback = [])
+    d = dax.to_s.strip
+    if (m = d.match(/\ADIVIDE\s*\(\s*(.+?)\s*,\s*(.+?)\s*\)\z/i))
+      a = transpile(m[1], col_map, fallback)
+      b = transpile(m[2], col_map, fallback)
+      return (a && b) ? "#{a} / NULLIF(#{b},0)" : nil
+    end
+    return 'COUNT(*)' if d =~ /\ACOUNTROWS\s*\(\s*'?[^'\[\)]+'?\s*\)\z/i
+    if (m = d.match(/\A([A-Za-z]+)\s*\(\s*'?[^'\[]+'?\s*\[\s*([^\]]+?)\s*\]\s*\)\z/))
+      fn = m[1].upcase
+      return nil unless AGG.key?(fn)
+      col = wh_col(m[2], col_map, fallback)
+      return "COUNT(DISTINCT #{col})" if fn == 'DISTINCTCOUNT'
+      return "#{AGG[fn]}(#{col})"
+    end
+    nil
+  end
+
+  # Build the per-chart oracle descriptor. Returns a hash with supported:true +
+  # sql/dim_col/val_col, or supported:false + reason.
+  def self.chart_sql(name, dax, fqn, dim: nil, col_map: {}, fallback: [])
+    return { 'supported' => false, 'reason' => 'no fqn (pass per-chart fqn or --dm-spec)' } unless fqn
+    expr = transpile(dax, col_map, fallback)
+    return { 'supported' => false, 'reason' => "unsupported DAX (outside aggregate grammar): #{dax}" } if expr.nil?
+    if dim
+      dcol = wh_col(dim, col_map, fallback)
+      sql = %(SELECT #{dcol} AS "#{dim}", #{expr} AS "#{name}" FROM #{fqn} GROUP BY #{dcol} ORDER BY 2 DESC)
+      { 'supported' => true, 'sql' => sql, 'dim_col' => dim, 'val_col' => name }
+    else
+      { 'supported' => true, 'sql' => %(SELECT #{expr} AS "#{name}" FROM #{fqn}), 'dim_col' => nil, 'val_col' => name }
+    end
+  end
+end
+
+# --------------------------------------------------------------------------- CLI
+if __FILE__ == $PROGRAM_NAME
+  require 'optparse'
+  opts = {}
+  OptionParser.new do |p|
+    p.on('--in PATH')  { |v| opts[:in] = v }
+    p.on('--out PATH') { |v| opts[:out] = v }
+    p.on('--dm-spec PATH', 'optional DM spec — derive a default fqn from warehouse-table elements') { |v| opts[:dm] = v }
+  end.parse!
+  %i[in out].each { |k| abort("missing --#{k}") unless opts[k] }
+
+  input = JSON.parse(File.read(opts[:in]))
+  col_map = input['column_map'] || {}
+
+  default_fqn = nil
+  if opts[:dm]
+    dm = JSON.parse(File.read(opts[:dm]))
+    (dm['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        src = el['source'] || {}
+        default_fqn ||= src['path'].join('.') if src['kind'] == 'warehouse-table' && src['path']
+      end
+    end
+  end
+
+  fallback = []
+  charts = {}
+  input.fetch('charts', {}).each do |name, c|
+    charts[name] = OracleSql.chart_sql(name, c['dax'], c['fqn'] || default_fqn,
+                                       dim: c['dim'], col_map: col_map, fallback: fallback)
+  end
+  out = { '_connectionId' => input['connectionId'], '_charts' => charts }
+  File.write(opts[:out], JSON.pretty_generate(out))
+
+  supported = charts.values.count { |v| v['supported'] }
+  unsupported = charts.reject { |_, v| v['supported'] }
+  warn "[build-oracle-sql] #{supported}/#{charts.size} chart(s) -> warehouse SQL; " \
+       "#{unsupported.size} need the online DAX fallback."
+  unsupported.each { |n, v| warn "  [fallback] #{n}: #{v['reason']}" }
+  unless fallback.uniq.empty?
+    warn "[build-oracle-sql] WARNING: no explicit column_map for #{fallback.uniq.size} column(s) " \
+         "(#{fallback.uniq.join(', ')}) — used the NAME->UPPER_SNAKE heuristic. If the warehouse " \
+         "columns are renamed/auto-named (Table.PromoteHeaders -> C1/C2, see pbi-dm-signature.py), pass " \
+         'an explicit column_map or the oracle SQL will reference columns that do not exist.'
+  end
+  warn "[build-oracle-sql] wrote #{opts[:out]} — run each `sql` via mcp__sigma-mcp-v2__query " \
+       "{type:connection, connectionId:#{input['connectionId'].inspect}}, save rows to parity-expected.json, " \
+       'then: phase6-parity-pbi.rb --local-sql --expected parity-expected.json --workbook-id <id> --out plan.json'
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
@@ -49,6 +49,8 @@ require 'time'
 opts = { extract: false, tol: 0.02 }
 OptionParser.new do |p|
   p.on('--emit-dax')            { opts[:emit] = true }
+  p.on('--local-sql', 'OFFLINE oracle: build the plan from warehouse-SQL `expected` rows (--expected) instead of Power BI executeQueries. No api.powerbi.com / Entra / workspace id needed — use for warehouse-backed models.') { opts[:local_sql] = true }
+  p.on('--expected PATH', 'warehouse-SQL oracle results { "<chart>": [[dim,val],...] } — produced by running build-oracle-sql.rb output via mcp__sigma-mcp-v2__query (type:connection). Used with --local-sql.') { |v| opts[:expected] = v }
   p.on('--finalize')            { opts[:finalize] = true }
   p.on('--workspace ID')        { |v| opts[:ws] = v }
   p.on('--dataset ID')          { |v| opts[:ds] = v }
@@ -149,6 +151,34 @@ def write_harness
   File.write(HARNESS, HARNESS_SRC) unless File.exist?(HARNESS) && File.read(HARNESS) == HARNESS_SRC
 end
 
+if opts[:local_sql]
+  # OFFLINE warehouse-SQL oracle (no Power BI service). `expected` rows were
+  # produced by running build-oracle-sql.rb's SQL via mcp__sigma-mcp-v2__query
+  # (type:connection) against the SAME warehouse the data model reads. Build the
+  # exact same plan the DAX path produces so --finalize is unchanged.
+  %i[expected wb out].each { |k| abort("missing --#{k}") unless opts[k] }
+  expected = JSON.parse(File.read(opts[:expected]))
+  charts = expected.keys.map do |name|
+    { 'chart' => name, 'expected' => expected[name], 'workbook_id' => opts[:wb] }
+  end
+  abort("--expected #{opts[:expected]} has no charts") if charts.empty?
+  plan = { 'extract' => opts[:extract], 'source' => 'warehouse-sql-oracle', 'charts' => charts }
+  File.write(opts[:out], JSON.pretty_generate(plan))
+  warn "[phase6-pbi] wrote plan with WAREHOUSE-SQL `expected` rows (offline oracle, no Power BI) -> #{opts[:out]}"
+  freshness_banner
+  puts '=' * 70
+  puts 'PHASE 6 (warehouse-SQL oracle) — collect Sigma actuals, one MCP query per chart:'
+  puts '=' * 70
+  charts.each_with_index do |c, i|
+    puts "  [#{i + 1}/#{charts.size}] #{c['chart']}  (expected #{c['expected'].size} row(s) from warehouse SQL)"
+  end
+  puts ''
+  puts 'Save actuals to parity-actuals.json: { "<chart name>": [[dim,val],...] }'
+  puts "Then: ruby scripts/phase6-parity-pbi.rb --finalize --plan #{opts[:out]} \\"
+  puts "        --actuals <actuals> --out-dir <dir>#{opts[:extract] ? ' --extract-mode --extract-tol ' + opts[:tol].to_s : ''}"
+  exit 0
+end
+
 if opts[:emit]
   # E-11: the workspace + dataset ids needed for DAX parity ARE captured earlier —
   # pbi-freshness.py writes them into freshness.json (keys workspace/dataset). Auto-
@@ -178,7 +208,7 @@ if opts[:emit]
     end
     { 'chart' => name, 'expected' => exp, 'workbook_id' => opts[:wb] }
   end
-  plan = { 'extract' => opts[:extract], 'charts' => charts }
+  plan = { 'extract' => opts[:extract], 'source' => 'powerbi-executequeries', 'charts' => charts }
   File.write(opts[:out], JSON.pretty_generate(plan))
   warn "[phase6-pbi] wrote plan with PBI `expected` rows -> #{opts[:out]}"
   freshness_banner # bead fmte — staleness leads, before any side-by-side
@@ -260,7 +290,7 @@ if opts[:finalize]
   summary = {
     'workbook_id' => plan.dig('charts', 0, 'workbook_id'),
     'ran_at' => Time.now.utc.iso8601,
-    'source' => 'powerbi-executequeries',
+    'source' => plan['source'] || 'powerbi-executequeries',
     'mode' => opts[:extract] ? 'extract' : 'strict',
     'charts_total' => total, 'charts_pass' => passed.size, 'charts_fail' => divergent,
     'charts_stale_explained' => stale_expl,

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-oracle-sql.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-oracle-sql.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+# test-build-oracle-sql.rb — unit smoke test for build-oracle-sql.rb (DAX→warehouse
+# SQL oracle for offline Phase 6 parity). Pure, no network. Run:
+#   ruby scripts/test-build-oracle-sql.rb
+require_relative 'build-oracle-sql'
+
+$fail = 0
+def ok(name, cond); puts((cond ? '  ok  ' : 'FAIL  ') + name); $fail += 1 unless cond; end
+
+# ---- transpile(): aggregate grammar ----
+ok 'SUM',            OracleSql.transpile('SUM(Orders[Sales])') == 'SUM(SALES)'
+ok 'AVERAGE->AVG',   OracleSql.transpile('AVERAGE(Orders[Discount])') == 'AVG(DISCOUNT)'
+ok 'MIN',            OracleSql.transpile('MIN(Orders[Sales])') == 'MIN(SALES)'
+ok 'DISTINCTCOUNT',  OracleSql.transpile('DISTINCTCOUNT(Orders[Order Id])') == 'COUNT(DISTINCT ORDER_ID)'
+ok 'COUNTROWS->*',   OracleSql.transpile('COUNTROWS(Orders)') == 'COUNT(*)'
+ok 'DIVIDE ratio',   OracleSql.transpile('DIVIDE(SUM(Orders[Profit]), SUM(Orders[Sales]))') == 'SUM(PROFIT) / NULLIF(SUM(SALES),0)'
+ok 'quoted table',   OracleSql.transpile("SUM('Fact Orders'[Sales])") == 'SUM(SALES)'
+
+# ---- transpile(): unsupported -> nil (forces online/waiver fallback) ----
+ok 'RANKX nil',      OracleSql.transpile('RANKX(ALL(Orders[Region]), [Total Sales])').nil?
+ok 'CALCULATE nil',  OracleSql.transpile('CALCULATE(SUM(Orders[Sales]), Orders[Region]="West")').nil?
+ok 'SAMEPERIOD nil', OracleSql.transpile('CALCULATE(SUM(F[Net]), SAMEPERIODLASTYEAR(D[Date]))').nil?
+
+# ---- explicit column_map wins over the heuristic (PromoteHeaders / renamed) ----
+ok 'column_map honored', OracleSql.transpile('SUM(Cust[Customer Name])', { 'Customer Name' => 'C2' }) == 'SUM(C2)'
+fb = []
+OracleSql.transpile('SUM(Orders[Sales])', {}, fb)
+ok 'fallback tracked',   fb == ['Sales']
+
+# ---- chart_sql(): scalar + grouped + unsupported ----
+sc = OracleSql.chart_sql('Total Sales', 'SUM(Orders[Sales])', 'DB.SCH.T')
+ok 'scalar sql', sc['supported'] && sc['sql'] == 'SELECT SUM(SALES) AS "Total Sales" FROM DB.SCH.T' && sc['dim_col'].nil?
+
+gr = OracleSql.chart_sql('Sales by Region', 'SUM(Orders[Sales])', 'DB.SCH.T', dim: 'Region')
+ok 'grouped sql', gr['supported'] &&
+   gr['sql'] == 'SELECT REGION AS "Region", SUM(SALES) AS "Sales by Region" FROM DB.SCH.T GROUP BY REGION ORDER BY 2 DESC' &&
+   gr['dim_col'] == 'Region'
+
+uns = OracleSql.chart_sql('Exotic', 'RANKX(ALL(Orders[Region]),[X])', 'DB.SCH.T')
+ok 'unsupported flagged', uns['supported'] == false && uns['reason'].include?('unsupported DAX')
+
+nofqn = OracleSql.chart_sql('NoFqn', 'SUM(Orders[Sales])', nil)
+ok 'missing fqn flagged', nofqn['supported'] == false && nofqn['reason'].include?('no fqn')
+
+puts(($fail.zero? ? 'ALL PASS' : "#{$fail} FAILED"))
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
## Why
Phase 6 parity required the **live Power BI service** (`executeQueries` against `api.powerbi.com` + an Entra app + workspace/dataset id). When that's unreachable, the *mandatory* gate can't be satisfied — exactly what a tester hit on a real run. My earlier PR (#139) only *unblocked* the gate (auto-wire ids + `--skip-parity-gate` waiver); it didn't remove the online dependency.

For **warehouse-backed models** the warehouse is the source of truth both Power BI and Sigma read, so the aggregate computed directly in SQL is a valid, independent `expected` value — with **zero** Power BI dependency.

## What
- **`build-oracle-sql.rb`** (new) — transpile aggregate DAX measures → warehouse SQL. Covers `SUM/AVG/MIN/MAX/COUNT/DISTINCTCOUNT/COUNTROWS` + `DIVIDE`, optional single `GROUP BY`. Out-of-grammar measures (`RANKX`, `CALCULATE` filter context, time-intel) are flagged `supported:false` → online fallback or waiver. **Flags, never approximates.** Honors an explicit `column_map` for renamed/`PromoteHeaders` (C1/C2) columns and warns when it falls back to the NAME→UPPER_SNAKE heuristic.
- **`phase6-parity-pbi.rb`** — `--local-sql` / `--expected`: builds the *same* plan the DAX path produces, but `expected` comes from the warehouse (agent runs the emitted SQL via `mcp__sigma-mcp-v2__query` `type:connection` — the same connection the DM uses). Plan records `source=warehouse-sql-oracle`; `--finalize` and `assert-phase6-ran.rb` are unchanged.
- **`test-build-oracle-sql.rb`** (new) — 16 transpiler unit cases.
- **SKILL.md** Phase 6 — documents the offline oracle as the default for warehouse-backed models; online DAX stays as the high-fidelity / import-only path.

## Validated live (tj-wells-1989, `TJ.PUBLIC.SAMPLE_SUPERSTORE`)
- DAX→SQL → warehouse values matched a **real posted Sigma workbook exactly** across 8 measures (Total Sales / Profit / Orders / Profit Margin / Sales-by-Region ×4).
- Full `--local-sql` → `--finalize` → `assert-phase6-ran` gate **passes**, and correctly **FAILs** on an injected divergence — no Power BI calls anywhere.
- Transpiler unit tests (16) + existing `test-dax-restructure.rb` pass; `ruby -c` clean.

## Scope / follow-ups
- Aggregate grammar only (by design); exotic measures route to the online path or waiver.
- Auto-generating `oracle-input.json` from the model (so the agent needn't author it) is a natural follow-up; this PR keeps it agent-authored, consistent with `chart-dax.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)