### PR TITLE
quicksight-to-sigma: aggregate measures (#10), boolean flags (#3), Insight→text (#11)

### DIFF
--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -38,6 +38,7 @@ OptionParser.new do |o|
   o.on('--filters F') { |v| opts[:filters] = v }
   o.on('--folder-id ID') { |v| opts[:folder] = v }
   o.on('--master-name NAME') { |v| opts[:mname] = v }
+  o.on('--discover-dir D') { |v| opts[:discover] = v }   # datasets/*.json -> BOOLEAN_COLS (RCA #3)
   o.on('--out F') { |v| opts[:out] = v }
 end.parse!
 %i[an rb out].each { |k| abort "missing --#{k}" unless opts[k] }
@@ -60,6 +61,24 @@ rb = JSON.parse(File.read(opts[:rb]))
 dm_id = rb['dataModelId']
 
 def disp(raw); raw.to_s.gsub(/[_.]/, ' ').split.map { |w| w[0..0].upcase + w[1..-1].to_s.downcase }.join(' '); end
+
+# Boolean columns (display names), derived from the discovery datasets' PhysicalTable
+# InputColumns where Type==BOOLEAN. QS OutputColumns coerce booleans to INTEGER, so a
+# calc-field predicate `{FLAG}=1` would emit `[Flag] = 1` and throw at query time on the
+# real boolean column. qs_expr_to_sigma uses this set to rewrite the predicate to the
+# bare boolean (RCA #3, bead 3goo.3). Empty (no --discover-dir) => no rewrite, no change.
+BOOLEAN_COLS = Set.new
+if opts[:discover]
+  Dir[File.join(opts[:discover], 'datasets', '*.json')].sort.each do |f|
+    j = JSON.parse(File.read(f)) rescue next
+    ds = j['DataSet'] || j
+    (ds['PhysicalTableMap'] || {}).each_value do |pt|
+      rt = pt['RelationalTable'] || pt['CustomSql'] || {}
+      (rt['InputColumns'] || []).each { |c| BOOLEAN_COLS << disp(c['Name']) if c['Type'].to_s.upcase == 'BOOLEAN' }
+    end
+  end
+  STDERR.puts "boolean-cols: #{BOOLEAN_COLS.size} BOOLEAN column(s) detected from discovery datasets" unless BOOLEAN_COLS.empty?
+end
 
 # ---- derive the columns the dashboard actually references (raw col names) ----
 def visual_cols(inner)
@@ -194,6 +213,21 @@ def qs_expr_to_sigma(expr, dmel, params = {})
    %w[percentOfTotal PercentOfTotal], %w[count Count], %w[sum Sum], %w[avg Avg],
    %w[min Min], %w[max Max]].each do |qs, sig|
     s = s.gsub(/(?<![A-Za-z0-9_.\/])#{Regexp.escape(qs)}\s*\(/i, "#{sig}(")
+  end
+  # Boolean-flag predicates: a warehouse BOOLEAN column compared `= 1`/`= 0` (QS's idiom
+  # for a flag it coerced to INTEGER) throws at query time in Sigma. Rewrite to the bare
+  # boolean / Not() for columns known boolean (RCA #3, bead 3goo.3).
+  if defined?(BOOLEAN_COLS) && !BOOLEAN_COLS.empty?
+    s = s.gsub(/\[([^\]]+)\]\s*(=|!=)\s*(1|0|true|false)\b/i) do
+      ref = Regexp.last_match(1); op = Regexp.last_match(2); val = Regexp.last_match(3).downcase
+      if BOOLEAN_COLS.include?(ref.split('/').last)
+        truthy = %w[1 true].include?(val)
+        truthy = !truthy if op == '!='
+        truthy ? "[#{ref}]" : "Not([#{ref}])"
+      else
+        Regexp.last_match(0)
+      end
+    end
   end
   s = s.gsub(/'([^']*)'/) { "\"#{Regexp.last_match(1)}\"" }
   s
@@ -658,8 +692,25 @@ def date_dim_col(role, calc, mc, dmel, m)
      'format' => { 'kind' => 'datetime', 'formatString' => fmt } }, id]
 end
 
+# A calc field whose translated expression is ALREADY a top-level aggregate
+# (distinct_countIf/sum/etc.) must be emitted DIRECTLY as the chart measure over the
+# master's base columns — wrapping it in the well's aggregation (Sum([m/<calc>])) yields
+# an invalid nested aggregate (RCA #10, bead 3goo.10).
+AGG_EXPR = /\A\s*(CountDistinctIf|CountDistinct|CountIf|Count|SumIf|Sum|AvgIf|Avg|MinIf|Min|MaxIf|Max|Median|StdDev\w*|Variance\w*)\s*\(/
+
 def meas_col(role, calc, mc, dmel, m)
-  _, col, agg = role; ref = master_ref(col, calc, mc, dmel); id = nid('m')
+  _, col, agg = role
+  if calc.key?(col) && !qs_window_func?(calc[col])
+    expr = qs_expr_to_sigma(calc[col], m, defined?(PARAM_DEFAULTS) ? PARAM_DEFAULTS : {})
+    if expr =~ AGG_EXPR
+      # land each base column the aggregate references on the master, then emit the
+      # aggregate itself as the measure (refs resolve to the master via the `m` prefix).
+      calc[col].scan(/\{([^}]+)\}/).flatten.each { |bc| master_ref(bc.strip, calc, mc, dmel) }
+      id = nid('m')
+      return [{ 'id' => id, 'formula' => expr, 'name' => col, 'format' => NUM.(fmt_for(col)) }, id]
+    end
+  end
+  ref = master_ref(col, calc, mc, dmel); id = nid('m')
   # a neutralized window calc field can't be aggregated as a live formula either
   if ref['_window']
     return [{ 'id' => id, 'formula' => 'Null', 'name' => ref['name'],

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -193,6 +193,15 @@ def qs_window_func?(expr)
 end
 
 # minimal QuickSight-expr → Sigma-formula translator for calc fields referenced by visuals
+# QuickSight/moment date-format tokens -> Sigma strftime (RCA #11). Longest-first.
+def qs_datefmt_to_strftime(fmt)
+  return nil if fmt.nil? || fmt.to_s.strip.empty?
+  s = fmt.dup
+  [%w[MMMM %B], %w[MMM %b], %w[MM %m], ['DD', '%d'], ['D', '%-d'],
+   %w[YYYY %Y], %w[YY %y], %w[HH %H], %w[mm %M], %w[ss %S]].each { |q, c| s = s.gsub(q, c) }
+  s
+end
+
 def qs_expr_to_sigma(expr, dmel, params = {})
   s = expr.to_s.dup
   # ${Param} -> inlined default constant (what-if parameters have no DM-formula equivalent).
@@ -606,6 +615,46 @@ route_master = lambda do |inner|
   MASTERS[e['id']]
 end
 
+# RCA #11 / bead 3goo.11: a QS InsightVisual with a single MAX/MIN computation + a
+# CustomNarrative ("Report Date: <expr>") is reproducible as a Sigma TEXT element with a
+# {{Agg([master/col]) | strftime}} dynamic value — not a hard drop. Returns the text body
+# or nil (skip) when the computation isn't a simple single-value one OR the column isn't
+# covered by a registered master (e.g. its dataset wasn't migrated). Conservative: emits
+# only when a master already covers the column, so it never emits a broken ref.
+qs_insight_text = lambda do |inner|
+  cfg = inner['InsightConfiguration'] || {}
+  comps = cfg['Computations'] || []
+  narr = cfg.dig('CustomNarrative', 'Narrative')
+  return nil if comps.size != 1 || narr.nil? || narr.to_s.strip.empty?
+  ckey, comp = comps.first.first
+  agg = ckey == 'MaximumMinimum' ? (comp['Type'].to_s.upcase == 'MINIMUM' ? 'Min' : 'Max') : nil
+  return nil unless agg
+  colname = nil; datefmt = nil
+  walk = lambda do |o|
+    if o.is_a?(Hash)
+      colname ||= o.dig('Column', 'ColumnName')
+      datefmt ||= o.dig('FormatConfiguration', 'DateTimeFormat') || o['DateTimeFormat']
+      o.each_value { |v| walk.call(v) }
+    elsif o.is_a?(Array) then o.each { |v| walk.call(v) }
+    end
+  end
+  walk.call(comp)
+  return nil unless colname
+  dname = disp(colname)
+  target = MASTERS.values.find { |mm| mm[:labels].include?(dname) }
+  return nil unless target   # dataset not migrated (e.g. Arine REPORT_RUN_DATES) -> skip
+  master_ref(colname, {}, target[:cols], target[:dmel])  # land the column on that master
+  fmt = qs_datefmt_to_strftime(datefmt)
+  val = "#{agg}([#{target[:name]}/#{dname}])"
+  value = fmt ? "{{#{val} | #{fmt}}}" : "{{#{val}}}"
+  prefix = narr.gsub(%r{<expression>.*?</expression>}m, '').gsub(/<[^>]+>/, '')
+  { '&amp;' => '&', '&nbsp;' => ' ', '&#39;' => "'", '&quot;' => '"' }
+    .each { |k, v| prefix = prefix.gsub(k, v) }
+  prefix = prefix.tr(" ", ' ').gsub(/\s+/, ' ').strip
+  align = narr =~ /align="right"/ ? 'right' : (narr =~ /align="center"/ ? 'center' : 'left')
+  "<p style=\"text-align: #{align}\"><span style=\"font-size: 16px\">#{prefix} #{value}</span></p>"
+end
+
 def fmt_for(name)
   case name
   when /margin|pct|percent|ratio|rate/i then '.1%'
@@ -951,6 +1000,16 @@ defn['Sheets'].each_with_index do |sh, sheet_idx|
       reason = QS_UNSUPPORTED[vtype] || "unrecognized QuickSight visual type '#{vtype}'"
       build_warnings << { 'visual' => title, 'type' => vtype, 'reason' => reason }
       unless fk
+        # RCA #11: a simple single-computation Insight narrative -> Sigma text element.
+        if vtype == 'InsightVisual' && (ibody = qs_insight_text.call(inner))
+          tid = nid('txt')
+          elements << { 'id' => tid, 'kind' => 'text', 'name' => 'Insight', 'body' => ibody }
+          vis_map[inner['VisualId']] = tid
+          build_warnings.pop   # supersede the generic "dropped" warning we just queued
+          build_warnings << { 'visual' => title, 'type' => vtype, 'reason' => 'migrated as a dynamic text element (single-computation narrative)' }
+          STDERR.puts "  ~ InsightVisual (#{title}): migrated as dynamic text"
+          next
+        end
         STDERR.puts "  ! skipped #{vtype} (#{title}): #{reason}"
         next
       end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
@@ -468,6 +468,7 @@ build = ['ruby', File.join(HERE, 'build-workbook-from-quicksight.rb'),
          '--analysis', File.join(WORK, 'analysis.json'),
          '--dm-readback', dm_readback, '--out', wb_spec]
 build += ['--dm-spec', dm_spec] if File.exist?(dm_spec)
+build += ['--discover-dir', WORK]   # datasets/*.json -> boolean-flag predicate rewrite (RCA #3)
 build += ['--folder-id', opts[:folder]] if opts[:folder]
 filters = File.join(WORK, 'dm-filters.json')
 build += ['--filters', filters] if File.exist?(filters)


### PR DESCRIPTION
Third batch of the Arine RCA hardening (epic `beads-sigma-3goo`). Follows #140, #141. All verified against the **orders** single-dataset fixture (unchanged) + Arine.

## #10 — Aggregate calc fields inlined as the measure (`3goo.10`)
A charted measure referencing an aggregate-level calc field (`distinct_countIf`/`sum`/…) was wrapped in the well's aggregation → invalid nested aggregate `Sum([m/<calc>])`. `meas_col` now emits the aggregate **directly** over the master's base columns when the calc's translated expr is a top-level aggregate.

## #3 — Boolean-flag predicates (`3goo.3`)
Warehouse BOOLEAN flags that QuickSight coerced to INTEGER produced `[flag] = 1` predicates that throw at query time. Auto-detect boolean columns from the discovery datasets' `PhysicalTable.InputColumns` (`Type=BOOLEAN` — the true warehouse type; OutputColumns coerce to INTEGER) via `--discover-dir`, and rewrite `= 1/0/true/false` (and `!=`) to the bare boolean / `Not()`. **Default off** (no `--discover-dir`) so offline/single-dataset runs are unchanged; `migrate-quicksight.rb` passes it automatically.

Together, Arine's "Weekly Tasks" combo now auto-generates `CountDistinctIf([m/Task Id], [m/Closed Task Flag])` — byte-identical to the hand-fix verified to render real weekly data.

## #11 — Insight narrative → dynamic text (`3goo.11`)
A QS `InsightVisual` with one MAX/MIN computation + a `CustomNarrative` ("Report Date: <expr>") now emits a Sigma **text element** with `{{Agg([master/col]) | strftime}}` instead of being dropped. Conservative: emits only when a registered master covers the column (never a broken ref), else skips with a clear reason. QS date tokens → strftime.

## Verification
- **orders fixture (regression):** identical data-page master count + dash element kinds, validates clean — no behavior change.
- **Arine:** combo measures correct + bare-boolean; Insight skip/emit paths both correct; specs validate 0 errors.

## Remaining on the epic
- **#9** calc-ref case normalization — lives in the **converter** (`quicksight.ts`), separate repo/PR.
- **#12** theme palette — blocked on the customer's `describe-theme`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)