### PR TITLE
quicksight-to-sigma: calc-ref fixup (#9) + multi-master control fan-out, bars-only/unstacked combo

### DIFF
--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -263,6 +263,17 @@ def qs_visual_title(inner, vtype)
   (inner.is_a?(Hash) ? inner['VisualId'] : nil) || vtype
 end
 
+# QS BarsArrangement -> Sigma bar `stacking`. Sigma defaults bars to STACKED, so an
+# unspecified or CLUSTERED QS arrangement must be set to 'none' to render side-by-side
+# (the QS spec + screenshot show clustered bars — RCA).
+def qs_bars_stacking(inner)
+  case inner.dig('ChartConfiguration', 'BarsArrangement').to_s.upcase
+  when 'STACKED' then 'stacked'
+  when 'STACKED_PERCENT' then 'normalized'
+  else 'none'
+  end
+end
+
 def field_role(f)
   if (mf = f['NumericalMeasureField'])
     [:meas, mf['Column']['ColumnName'], (mf.dig('AggregationFunction', 'SimpleNumericalAggregation') || 'SUM')]
@@ -1102,6 +1113,7 @@ defn['Sheets'].each_with_index do |sh, sheet_idx|
       if kind == 'bar-chart'
         qs_orient = (inner['ChartConfiguration'] || {})['Orientation']
         el['orientation'] = 'horizontal' if qs_orient.to_s.upcase == 'HORIZONTAL'
+        el['stacking'] = qs_bars_stacking(inner)   # CLUSTERED -> unstacked (Sigma defaults to stacked)
       end
       # B-gap COLOR: by-measure (ColorScale dup column) / by-dimension (Colors well).
       cclr = qs_color(inner, w, el, [did], ycids, calc, mc_, dmel_, m_)
@@ -1136,6 +1148,7 @@ defn['Sheets'].each_with_index do |sh, sheet_idx|
       # bars-only QS combo (e.g. Arine "Weekly Tasks": Tasks Closed + Generated) would show a
       # spurious line. Emit bar-chart when there are no line series.
       el['kind'] = 'bar-chart' if lines.empty?
+      el['stacking'] = qs_bars_stacking(inner)   # QS BarsArrangement: CLUSTERED -> unstacked
       cclr = qs_color(inner, w, el, [did], [], calc, mc_, dmel_, m_)  # combo: by-dimension only
       el['color'] = cclr if cclr && cclr['by'] == 'category'
       rms = qs_reference_lines(inner, calc, mc_, dmel_, m_, title, build_warnings)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -916,7 +916,7 @@ end
 # Pushes a control-scope CONTRACT row (scope/sourceName/status) or an `unbound` row so the
 # signal is NEVER silently dropped. Dedupes by target column (the same column filtered by
 # two controls is one Sigma control — controlIds are unique).
-def build_qs_control(wrap, master_cols, calc, dmel, scope, unbound, seen_cols, warnings)
+def build_qs_control(wrap, master_cols, calc, dmel, scope, unbound, seen_cols, warnings, masters = {})
   ctype, body = nil, nil
   raw_col = nil; src_kind = :filter
   QS_CONTROL_WRAPS.each do |k|
@@ -964,9 +964,21 @@ def build_qs_control(wrap, master_cols, calc, dmel, scope, unbound, seen_cols, w
                             'source' => { 'kind' => 'table', 'elementId' => 'master' }, 'columnId' => col_id },
               'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'master' }, 'columnId' => col_id }])
   end
+  # Cross-master control fan-out (RCA #4 follow-up): a QS sheet control is GLOBAL, so it
+  # must also drive any SECONDARY master that carries the same column — else charts on a
+  # second dataset (e.g. the Weekly Tasks combo on the aggregation table) ignore the filter
+  # and render all-data instead of the controlled slice. Append a filter target per
+  # secondary master that has the column.
+  wired = [{ 'elementId' => 'master', 'columnId' => col_id }]
+  (masters || {}).each_value do |mm|
+    next if mm[:sid] == 'master' || !mm[:labels].include?(disp(raw_col))
+    scol = master_ref(raw_col, calc, mm[:cols], mm[:dmel])
+    el['filters'] << { 'source' => { 'kind' => 'table', 'elementId' => mm[:sid] }, 'columnId' => scol['id'] }
+    wired << { 'elementId' => mm[:sid], 'columnId' => scol['id'] }
+  end
   scope << { 'controlId' => ctl_id, 'sourceName' => sig, 'status' => 'wired',
              'controlType' => el['controlType'], 'scope' => 'page', 'mustReach' => [],
-             'wired' => [{ 'elementId' => 'master', 'columnId' => col_id }] }
+             'wired' => wired }
   el
 end
 
@@ -1119,6 +1131,11 @@ defn['Sheets'].each_with_index do |sh, sheet_idx|
       bars.each  { |mv| c, id = meas_col(mv, calc, mc_, dmel_, m_); cols << c; ycids << id }
       lines.each { |mv| c, id = meas_col(mv, calc, mc_, dmel_, m_); cols << c; ycids << { 'columnId' => id, 'type' => 'line' } }
       el = base.merge('columns' => cols, 'xAxis' => { 'columnId' => did }, 'yAxis' => { 'columnIds' => ycids })
+      # A QS ComboChartVisual with NO LineValues (all measures in BarValues) is a clustered
+      # BAR chart, not a combo — Sigma renders a combo-chart's extra series as a line, so a
+      # bars-only QS combo (e.g. Arine "Weekly Tasks": Tasks Closed + Generated) would show a
+      # spurious line. Emit bar-chart when there are no line series.
+      el['kind'] = 'bar-chart' if lines.empty?
       cclr = qs_color(inner, w, el, [did], [], calc, mc_, dmel_, m_)  # combo: by-dimension only
       el['color'] = cclr if cclr && cclr['by'] == 'category'
       rms = qs_reference_lines(inner, calc, mc_, dmel_, m_, title, build_warnings)
@@ -1265,7 +1282,7 @@ defn['Sheets'].each_with_index do |sh, sheet_idx|
     next unless wrap.is_a?(Hash)
     n_control_signals += 1
     ctl = build_qs_control(wrap, master_cols, calc, DMEL,
-                           control_scope, control_unbound, control_seen_cols, build_warnings)
+                           control_scope, control_unbound, control_seen_cols, build_warnings, MASTERS)
     if ctl
       elements.unshift(ctl)   # controls render at the top of the page band
       vis_map[ctl['controlId']] = ctl['id']   # layout step can place it if QS gives coords
@@ -1355,11 +1372,12 @@ secondary_masters = MASTERS.values.reject { |mm| mm[:sid] == 'master' || mm[:col
     'columns' => mm[:cols].values }
 end
 STDERR.puts "multi-master: routed visuals across #{1 + secondary_masters.size} master(s) (#{secondary_masters.map { |s| s['name'] }.join(', ')})" unless secondary_masters.empty?
-# QS sheet controls are global; this builder wires them to the PRIMARY master only, so
-# charts on a SECONDARY master are not yet driven by the page controls — surface it loud.
+# Page controls fan out to every master that SHARES the control's column (build_qs_control).
+# A control whose column exists ONLY on the primary still won't constrain a secondary
+# master (that dataset lacks the column) — surface it so the gap is understood, not silent.
 unless secondary_masters.empty?
   build_warnings << { 'visual' => '(controls)', 'type' => 'MultiMasterControlScope',
-                      'reason' => "page controls filter the primary master only; #{secondary_masters.size} secondary master(s) (#{secondary_masters.map { |s| s['name'] }.join(', ')}) are NOT yet driven by the controls — re-author cross-master control targets in Sigma if needed" }
+                      'reason' => "page controls fan out to secondary master(s) (#{secondary_masters.map { |s| s['name'] }.join(', ')}) for SHARED columns; a control on a column that exists only on the primary does not constrain a secondary master that lacks it — verify cross-dataset filter coverage in Sigma" }
 end
 
 # Scatter charts emit a hidden GROUPED source table (one row per point dim). Park

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
@@ -32,6 +32,7 @@
 #   ruby scripts/convert-model.rb --fixup --in converter-out.json --discover-dir DIR --folder-id ID --out dm-spec.json
 require 'json'
 require 'optparse'
+require 'set'
 
 opts = {}
 OptionParser.new do |o|
@@ -262,6 +263,11 @@ if opts[:fixup]
     id_to_name[el['id']] = el['name']
   end
 
+  # Valid bracket-ref prefixes: every element's display name AND its raw warehouse name
+  # (source.path tail) — passthrough refs use the raw name, cross-element refs the display.
+  known_refs = all_els.flat_map { |e| [e['name'], (e.dig('source', 'path') || []).last] }
+                      .compact.map { |n| n.downcase }.to_set
+
   all_els.each do |el|
     src = el['source'] || {}
     cols = el['columns'] || []
@@ -272,6 +278,46 @@ if opts[:fixup]
         c['name'] = titleize(alias_raw) unless alias_raw.nil? || alias_raw.empty?
       end
       c['name'] = sanitize_name(c['name']) if c['name']
+    end
+
+    # RCA #9 / bead 3goo.9: normalize calc-column bracket refs to the EXACT sibling display
+    # name (case-insensitive resolution). The converter sometimes emits `[Hours to Close]`
+    # while the sibling column is "Hours To Close" — "not a sibling column" at POST. Only
+    # rewrites the column part of an existing [..]/[Elem/..] ref that matches a sibling under
+    # a different case; cross-element refs to non-siblings are left untouched.
+    sib = {}
+    cols.each { |c| (sib[c['name'].to_s.strip.downcase] = c['name']) if c['name'] }
+    cols.each do |c|
+      next unless c['formula'].is_a?(String)
+      c['formula'] = c['formula'].gsub(/\[([^\]\/]*\/)?([^\]\/]+)\]/) do
+        pre = Regexp.last_match(1); nm = Regexp.last_match(2)
+        canon = sib[nm.strip.downcase]
+        canon && canon != nm ? "[#{pre}#{canon}]" : Regexp.last_match(0)
+      end
+    end
+
+    # Drop calc columns whose bracket refs can't resolve — a ref with `/` must name a known
+    # element (prefix before the first `/`), a bare ref must be a sibling. These are
+    # aggregate-of-aggregate / metric-style calc fields the converter emitted but can't be
+    # row-level DM columns (e.g. an "Outreach/Task Rate" dividing two distinct_countIf
+    # metrics); they fail POST regardless. Drop + warn rather than emit an unpostable spec
+    # (RCA #9/#10, bead 3goo.9 — matches the manual Arine fix).
+    dropped = []
+    el['columns'] = cols.reject do |c|
+      next false unless c['formula'].is_a?(String)
+      bad = c['formula'].scan(/\[([^\]]+)\]/).flatten.any? do |ref|
+        if ref.include?('/')
+          !known_refs.include?(ref.split('/', 2).first.strip.downcase)
+        else
+          !sib.key?(ref.strip.downcase)
+        end
+      end
+      dropped << c['name'] if bad
+      bad
+    end
+    unless dropped.empty?
+      el['order'] = (el['order'] || []).reject { |oid| el['columns'].none? { |c| c['id'] == oid } } if el['order']
+      STDERR.puts "fixup: dropped #{dropped.size} calc column(s) with unresolvable refs on \"#{el['name']}\": #{dropped.join(', ')}"
     end
 
     # NOTE: window/table-calc neutralization, [Custom SQL/RAW] ref rewriting,


### PR DESCRIPTION
Fourth batch of the Arine RCA hardening (epic `beads-sigma-3goo`). Follows #140/#141/#143. Verified on the **orders** single-dataset fixture (unchanged) + Arine.

## #9 — calc-col ref normalization + prune (`3goo.9`)
`convert-model.rb --fixup` now (a) normalizes calc-column bracket refs to the exact sibling display name (case-insensitive) — fixes `[Hours to Close]` vs the column `Hours To Close` ("not a sibling column" at POST); and (b) drops calc columns whose refs can't resolve (aggregate-of-aggregate "rate" calc fields the converter can't make row-level — they fail POST regardless). Arine DM now validates 0 errors with no manual intervention.

## Multi-master follow-ups (RCA #4)
- **Cross-master control fan-out:** a QS sheet control is global, so `build_qs_control` now appends a filter target for every secondary master that shares the control's column. Without it the Arine "Weekly Tasks" combo (on the aggregation master) ignored the Organization filter and showed all-org data. Verified: the Organization control filters **both** masters; the combo's weekly values now match the customer screenshot.
- **Bars-only combo:** a QS `ComboChartVisual` with no `LineValues` is a clustered bar chart, not a combo (Sigma draws a combo's extra series as a line). Emit `bar-chart` when there are no line series.
- **`BarsArrangement`:** Sigma defaults bars to stacked; map QS `BarsArrangement` → `stacking` (`CLUSTERED`/absent → `none`, `STACKED` → `stacked`, `STACKED_PERCENT` → `normalized`) so clustered QS bars render side-by-side.

## Verification
- **Arine:** DM 0 errors; combo = unstacked bar-chart, org-filtered (matches screenshot); workbook validates 0 errors.
- **orders fixture:** identical structure, validates clean — no regression.

This closes the actionable RCA backlog except **#12** (theme palette — blocked on the customer's `describe-theme`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)