### PR TITLE
tableau-to-sigma: don't pick a date/time dim as the fact; trim shelf refs

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -73,6 +73,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rls-wiring.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-table-calc-translation.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-id-namespacing.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
           )
           fail=0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1242,6 +1242,11 @@ def resolve_shelf_field(field, meta, mmap)
                                  .gsub(/^\[|\]$/, '')
                                  .sub(/^[a-z]+:/i, '')
                                  .sub(/:[a-z]+$/i, '')
+  # Tableau captions sometimes carry trailing/leading whitespace (e.g. the
+  # skeleton's "Order Date "), and the master column is the trimmed name — so a
+  # bare [Master/Order Date ] ref won't resolve. Trim before matching + as the
+  # fallback name (map_column already trims internally for the lookup).
+  cap_for_field = cap_for_field.to_s.strip
   m = map_column(cap_for_field, mmap)
   m ||= { 'id' => "m-#{cap_for_field.downcase.gsub(/\W+/, '-')}", 'name' => cap_for_field }
   [m, cap_for_field]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -130,12 +130,18 @@ module MechanicalSpecs
   def pick_fact(model)
     els = all_elements(model)
     return nil if els.empty?
+    # A dimension element's name is "<X> Dim" (trailing) OR "Dim <X>" (leading,
+    # e.g. "Dim Time") — exclude BOTH so a narrow date/time dim can never be
+    # chosen as the fact (the date-crosstab regression: "Dim Time" slipped past a
+    # trailing-only / Dim$/ and won max_by, making the workbook master source the
+    # wrong element).
+    dim_re = /(^Dim\b| Dim$)/i
     derived = els.select { |e| e.dig('source', 'kind') == 'table' && e.dig('source', 'elementId') }
-                 .reject { |e| elem_name(e) =~ / Dim$/i }
+                 .reject { |e| elem_name(e) =~ dim_re }
     return derived.max_by { |e| (e['columns'] || []).size } if derived.any?
     base = els.select { |e| e.dig('source', 'kind') == 'warehouse-table' }
     return nil if base.empty?
-    facts = base.reject { |e| elem_name(e) =~ / Dim$/i }
+    facts = base.reject { |e| elem_name(e) =~ dim_re }
     (facts.empty? ? base : facts).max_by { |e| (e['columns'] || []).size }
   end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -1060,7 +1060,12 @@ if reuse_dm_id
   File.write(dm_ids_path, JSON.pretty_generate(dm_ids))
   dm_id = reuse_dm_id
   dm_els = dm_ids['pages'].flat_map { |p| p['elements'] }
-  fact = dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
+  # The fact is the WIDEST non-dim element. Exclude both "<X> Dim" and "Dim <X>"
+  # (so a date/time dim like "Dim Time" can't be picked) and tie-break by column
+  # count, not list order.
+  dim_re = /(^Dim\b| Dim$)/i
+  fact = dm_els.reject { |e| e['name'] =~ dim_re }.max_by { |e| (e['columnLabels'] || []).size } ||
+         dm_els.find { |e| e['name'] !~ dim_re } || dm_els.first
   fact_eid = fact['id']
   line "REUSED dataModelId = #{dm_id}  (fact element '#{fact['name']}' = #{fact_eid}, name-heuristic pick)"
 elsif mechanical
@@ -1136,10 +1141,18 @@ unless reuse_dm_id
     # derived "<Fact> View" when present). Match it into the readback by name.
     cf = MechanicalSpecs.pick_fact(conv['model'])
     cf_name = cf && (cf['name'] || MechanicalSpecs.elem_name(cf))
+    # Fallback (when the exact name match misses): the fact is the WIDEST non-dim
+    # element — never a narrow date/time dim. Match pick_fact's dim test (both
+    # "<X> Dim" and "Dim <X>") and tie-break by column count, not list order, so
+    # "Dim Time" can't win just by appearing first.
+    dim_re = /(^Dim\b| Dim$)/i
     fact = dm_els.find { |e| e['name'] == cf_name } ||
-           dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
+           dm_els.reject { |e| e['name'] =~ dim_re }.max_by { |e| (e['columnLabels'] || []).size } ||
+           dm_els.max_by { |e| (e['columnLabels'] || []).size } || dm_els.first
   else
-    fact = dm_els.find { |e| e['name'] !~ / Dim$/i } || dm_els.first
+    dim_re = /(^Dim\b| Dim$)/i
+    fact = dm_els.reject { |e| e['name'] =~ dim_re }.max_by { |e| (e['columnLabels'] || []).size } ||
+           dm_els.find { |e| e['name'] !~ dim_re } || dm_els.first
   end
   fact_eid = fact['id']
   line "dataModelId = #{dm_id}  (fact element '#{fact['name']}' = #{fact_eid})"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# Regression test for fact-element picking (2026-06-17). Deterministic + offline.
+# Guards the date-crosstab regression: a narrow time dimension named "Dim Time"
+# (or "Date Dim", "Dim Date") must NEVER be chosen as the fact/master element —
+# its name doesn't end in " Dim" so a trailing-only / Dim$/ test let it slip
+# through and win max_by, making the workbook master source the wrong element
+# ("Dependency not found: 'dim time/...'" on POST).
+#
+# Part A: MechanicalSpecs.pick_fact excludes "Dim Time" and picks the widest
+#         non-dim element (the real fact view).
+# Part B: source-guard — both migrate-tableau fact-resolution paths (fresh +
+#         reuse) use the leading+trailing dim test and tie-break by column count.
+#
+# Usage:  ruby scripts/test-fact-pick.rb
+
+require_relative 'mechanical-specs'
+
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+puts 'Part A — pick_fact never returns a dim, prefers the widest view'
+# A converter-shaped model: dims (incl. the tricky "Dim Time"), a base fact, and
+# the wide flattened "Order Fact View" derived element.
+cols = ->(n) { Array.new(n) { |i| { 'id' => "c#{i}", 'name' => "c#{i}" } } }
+model = { 'pages' => [{ 'elements' => [
+  { 'id' => 'e-dimtime', 'name' => 'Dim Time',        'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ DIM_TIME] },   'columns' => cols.call(8) },
+  { 'id' => 'e-custdim', 'name' => 'Customer Dim',    'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ CUSTOMER_DIM] }, 'columns' => cols.call(18) },
+  { 'id' => 'e-ordfact', 'name' => 'Order Fact',      'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ ORDER_FACT] },   'columns' => cols.call(36) },
+  { 'id' => 'e-ofview',  'name' => 'Order Fact View', 'source' => { 'kind' => 'table', 'elementId' => 'e-ordfact' },                  'columns' => cols.call(94) }
+] }] }
+fact = MechanicalSpecs.pick_fact(model)
+check(fact && fact['name'] == 'Order Fact View', "picks 'Order Fact View' (got #{fact && fact['name'].inspect})", fails)
+check(fact && fact['name'] != 'Dim Time', "does NOT pick 'Dim Time'", fails)
+
+# Even with NO derived view, a base fact must beat the narrow time dim.
+model2 = { 'pages' => [{ 'elements' => [
+  { 'id' => 'e-dimtime', 'name' => 'Dim Time',   'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ DIM_TIME] }, 'columns' => cols.call(8) },
+  { 'id' => 'e-ordfact', 'name' => 'Order Fact', 'source' => { 'kind' => 'warehouse-table', 'path' => %w[CSA TJ ORDER_FACT] }, 'columns' => cols.call(36) }
+] }] }
+f2 = MechanicalSpecs.pick_fact(model2)
+check(f2 && f2['name'] == 'Order Fact', "base-only: picks 'Order Fact' over 'Dim Time' (got #{f2 && f2['name'].inspect})", fails)
+
+puts 'Part B — migrate-tableau fact-resolution guards (both paths)'
+mig = File.read(File.join(__dir__, 'migrate-tableau.rb'))
+check(mig.scan(/\(\^Dim\\b\| Dim\$\)/i).size >= 2, 'both fresh + reuse paths use the leading+trailing dim test', fails)
+check(mig.match?(/max_by \{ \|e\| \(e\['columnLabels'\] \|\| \[\]\)\.size \}/),
+      'fact fallback tie-breaks by column count, not list order', fails)
+
+puts
+if fails.empty?
+  puts 'OK — fact-pick guards all pass'; exit 0
+else
+  warn "FAIL — #{fails.size} check(s) failed:"; fails.each { |f| warn "  - #{f}" }; exit 1
+end


### PR DESCRIPTION
Found validating the EDNA period-crosstab page — two bugs that break a clean migration of any dashboard using a date/time dimension (≈ every EDNA page).

**1. Fact-pick chose "Dim Time".** `pick_fact` / the workbook master resolution excluded only names *ending* in " Dim" — "Dim Time" (leading "Dim") slipped through and won `max_by`, so the workbook master sourced the narrow time dim and every pass-through column became `[Dim Time/<col>]` → *Dependency not found* on POST. Fix: exclude both `<X> Dim` and `Dim <X>` (`/(^Dim\b| Dim$)/i`) and tie-break the readback fallback by **column count**, not list order — in `pick_fact` (mechanical-specs) **and** both fact-resolution paths in migrate-tableau (fresh build + DM reuse).

**2. Trailing-space shelf ref.** `resolve_shelf_field` built `[Master/Order Date ]` (the Tableau caption carries a trailing space) which didn't match the trimmed master column. Strip before matching + as the fallback name.

**Verified E2E:** a Region×Channel pivot crosstab now builds as a Sigma `pivot-table` (rowsBy/columnsBy/values + Grand-Total & subtotals), posts clean (167 wb cols, 0 error-typed), and queries real data — proving EDNA's two big period-comparison tables convert from layout + calc.

Adds offline `test-fact-pick.rb` to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)