### PR TITLE
quicksight-to-sigma: fix #9 prune dropping synthesized SQL/join element columns

### DIFF
--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/convert-model.rb
@@ -263,10 +263,14 @@ if opts[:fixup]
     id_to_name[el['id']] = el['name']
   end
 
-  # Valid bracket-ref prefixes: every element's display name AND its raw warehouse name
-  # (source.path tail) — passthrough refs use the raw name, cross-element refs the display.
+  # Valid bracket-ref prefixes: every element's display name, its raw warehouse name
+  # (source.path tail), AND the "Custom SQL" self-reference idiom that kind:sql elements
+  # (incl. the synthesized join element) use for their own output columns — without it the
+  # prune wrongly drops every legit join-element column (regression caught on a live 3-way
+  # join). Passthrough refs use the raw name; cross-element refs the display name.
   known_refs = all_els.flat_map { |e| [e['name'], (e.dig('source', 'path') || []).last] }
                       .compact.map { |n| n.downcase }.to_set
+  known_refs << 'custom sql'
 
   all_els.each do |el|
     src = el['source'] || {}


### PR DESCRIPTION
Hotfix for #144. The unresolvable-ref prune didn't whitelist the `Custom SQL` self-reference idiom kind:sql elements use, so it dropped every column of the synthesized join element — caught on the **first live AWS run** (D4: ORDER_FACT ⋈ CUSTOMER_DIM ⋈ DATE_DIM). Add `custom sql` to `known_refs`.

Verified: live D4 keeps all 9 join columns + validates clean; Arine still drops its 2 broken aggregate-rate cols. orders fixture unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)