### PR TITLE
fix(qlik): hard-fail discovery on empty/inaccessible load script (silent tables=0)

### DIFF
--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/QUICKSTART.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/QUICKSTART.md
@@ -165,6 +165,16 @@ Duration: 3
 - **Building Qlik fixtures:** charts created via the API render only as `auto-chart`
   (concrete `bar`/`line`/`pie` come up blank); sheets must be UI-created (or impersonated)
   to list in the hub; copy an app to clone its data without a reload.
+- **"tables=0" / empty data model = the identity can't read the app's load script.**
+  Discovery fetches the app's load script (the data-model source of truth) via the
+  Qlik engine `GetScript`. If the connecting identity doesn't own the app (someone
+  else's app, unpublished), `GetScript` returns `GENERIC ACCESS DENIED` and discovery
+  now **hard-fails** (`FATAL: load script is empty`, exit 3) instead of silently
+  building an empty model. Fix: run discovery as the **app owner**, copy/transfer the
+  app so your identity owns it, or publish it to a managed space your identity can read.
+  This is the #1 cause of a Qlik migration "running but producing nothing useful" —
+  the M2M client must act as a user who can actually read the app (see Prerequisites).
+  DirectQuery apps legitimately have no load script and are exempt.
 
 ## The techniques worth carrying forward
 Duration: 1

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/qlik-discover.py
@@ -117,8 +117,10 @@ def qlik_run(args, attempts=4):
 
 def qlik(*args, parse_json=True):
     out = qlik_run(list(args))
-    if out.returncode != 0 and parse_json:
-        sys.stderr.write(f"WARN {' '.join(args)} -> {out.stderr[:160]}\n")
+    if out.returncode != 0:
+        # Warn on ANY non-zero exit — including parse_json=False calls like the
+        # load-script fetch, whose failure was previously swallowed silently.
+        sys.stderr.write(f"WARN {' '.join(str(x) for x in args)} -> {((out.stderr or out.stdout) or '')[:200]}\n")
     if not parse_json:
         return out.stdout
     try:
@@ -398,7 +400,9 @@ def main():
     results = {}
     def _script():
         with stage("script"):
-            results["script"] = qlik("app", "script", "get", "-a", a.app, *ctx, parse_json=False)
+            out = qlik_run(["app", "script", "get", "-a", a.app, *ctx])
+            results["script"] = out.stdout if out.returncode == 0 else ""
+            results["script_error"] = None if out.returncode == 0 else ((out.stderr or out.stdout) or "unknown error").strip()[:200]
 
     def _items():
         with stage("app-meta"):
@@ -443,6 +447,25 @@ def main():
     awrite(os.path.join(a.out, "dimensions.json"), dims_raw)
     app_meta = results["app_meta"]
     awrite(os.path.join(a.out, "app-meta.json"), app_meta)
+
+    # HARD FAIL if the load script — the data-model source of truth — is empty.
+    # A silent empty script yields tables=0 and a Sigma data model with no data
+    # (the "migration ran but produced nothing useful" failure). The usual cause
+    # is GetScript "GENERIC ACCESS DENIED": the app is owned by another user /
+    # unpublished and the connecting identity lacks read rights. DirectQuery apps
+    # legitimately carry no load script, so they are exempt.
+    if not script.strip() and not app_meta.get("isDirectQueryMode"):
+        sys.stderr.write("\nFATAL: load script is empty — cannot build a data model (tables=0).\n")
+        if results.get("script_error"):
+            sys.stderr.write(f"  GetScript failed: {results['script_error']}\n")
+        sys.stderr.write(
+            "  The load script is the data-model source of truth; without it the converter\n"
+            "  produces an empty model. Most common cause: the connecting identity cannot read\n"
+            "  this app (owned by another user / unpublished -> 'GENERIC ACCESS DENIED').\n"
+            "  Fix one of: (a) run discovery as the app OWNER, (b) copy/transfer the app so the\n"
+            "  connecting identity owns it, or (c) publish it to a managed space that identity\n"
+            "  can read. (DirectQuery apps have no script and are exempt.)\n")
+        sys.exit(3)
 
     # sheets first, so each chart can be annotated with its sheet
     charts, sheets, obj_sheet = [], [], {}


### PR DESCRIPTION
## What was happening
`qlik-discover.py` fetched the app load script — the data-model source of truth — via `qlik(..., parse_json=False)`, whose non-zero-exit WARN was gated on `parse_json` being **true**. A failed `GetScript` (e.g. `GENERIC ACCESS DENIED` when the connecting identity can't read the app) was swallowed entirely:

- `script.qvs` written as **0 bytes** → `parse_script("")` → **tables=0**
- discovery printed a cheerful `tables=0 … Next: run migrate-qlik.rb`
- the converter then built a Sigma data model **with no data** — no clue why.

## Fix
- `qlik()` now warns on **any** non-zero exit (incl. `parse_json=False` calls).
- `_script()` captures the GetScript error text.
- Discovery **hard-fails (exit 3)** when the script is empty AND the app isn't DirectQuery, printing the GetScript error + three concrete fixes (run as owner / copy-own the app / publish to a readable space). DirectQuery apps are exempt.
- QUICKSTART "Reference & gotchas" documents this as the #1 cause of an empty Qlik migration.

## Scope
This is the qlik half of #101, split out so it can land on its own. The cognos layout-lint half is in a separate PR. No shared files; CI (corpus + syntax) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)