### PR TITLE
fix(layout-lint): band fill measured against container's own grid (sidebar false-positive)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -74,6 +74,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-table-calc-translation.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-id-namespacing.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
           )
           fail=0

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/layout_lint.rb
@@ -87,6 +87,21 @@ module LayoutLint
 
   # Top-level GridContainers of a page block with their direct children:
   # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
   def containers(page_xml)
     out = []
     s = page_xml.to_s
@@ -94,6 +109,7 @@ module LayoutLint
     while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
       attrs, close = m[1], m[2]
       eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
       r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
       r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
       inner = ''
@@ -109,7 +125,7 @@ module LayoutLint
          le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
          le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
       end
-      out << { eid: eid, r0: r0, r1: r1, children: children }
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
     end
     out
   end
@@ -173,11 +189,16 @@ module LayoutLint
         kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
                    kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
         next if kpi_band
-        covered = Array.new(GRID_COLS, false)
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
         kids.each do |_eid, c0, c1, _r0, _r1|
-          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
         end
-        fill = covered.count(true).to_f / GRID_COLS
+        fill = covered.count(true).to_f / ncols
         next if fill >= MIN_BAND_FILL
         empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
         violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
@@ -185,7 +206,7 @@ module LayoutLint
                              're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
                              b[:eid], page_id,
                              kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
-                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
                              empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/layout_lint.rb
@@ -87,6 +87,21 @@ module LayoutLint
 
   # Top-level GridContainers of a page block with their direct children:
   # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
   def containers(page_xml)
     out = []
     s = page_xml.to_s
@@ -94,6 +109,7 @@ module LayoutLint
     while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
       attrs, close = m[1], m[2]
       eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
       r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
       r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
       inner = ''
@@ -109,7 +125,7 @@ module LayoutLint
          le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
          le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
       end
-      out << { eid: eid, r0: r0, r1: r1, children: children }
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
     end
     out
   end
@@ -173,11 +189,16 @@ module LayoutLint
         kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
                    kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
         next if kpi_band
-        covered = Array.new(GRID_COLS, false)
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
         kids.each do |_eid, c0, c1, _r0, _r1|
-          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
         end
-        fill = covered.count(true).to_f / GRID_COLS
+        fill = covered.count(true).to_f / ncols
         next if fill >= MIN_BAND_FILL
         empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
         violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
@@ -185,7 +206,7 @@ module LayoutLint
                              're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
                              b[:eid], page_id,
                              kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
-                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
                              empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/layout_lint.rb
@@ -87,6 +87,21 @@ module LayoutLint
 
   # Top-level GridContainers of a page block with their direct children:
   # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
   def containers(page_xml)
     out = []
     s = page_xml.to_s
@@ -94,6 +109,7 @@ module LayoutLint
     while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
       attrs, close = m[1], m[2]
       eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
       r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
       r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
       inner = ''
@@ -109,7 +125,7 @@ module LayoutLint
          le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
          le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
       end
-      out << { eid: eid, r0: r0, r1: r1, children: children }
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
     end
     out
   end
@@ -173,11 +189,16 @@ module LayoutLint
         kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
                    kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
         next if kpi_band
-        covered = Array.new(GRID_COLS, false)
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
         kids.each do |_eid, c0, c1, _r0, _r1|
-          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
         end
-        fill = covered.count(true).to_f / GRID_COLS
+        fill = covered.count(true).to_f / ncols
         next if fill >= MIN_BAND_FILL
         empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
         violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
@@ -185,7 +206,7 @@ module LayoutLint
                              're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
                              b[:eid], page_id,
                              kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
-                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
                              empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout_lint.rb
@@ -87,6 +87,21 @@ module LayoutLint
 
   # Top-level GridContainers of a page block with their direct children:
   # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
   def containers(page_xml)
     out = []
     s = page_xml.to_s
@@ -94,6 +109,7 @@ module LayoutLint
     while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
       attrs, close = m[1], m[2]
       eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
       r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
       r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
       inner = ''
@@ -109,7 +125,7 @@ module LayoutLint
          le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
          le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
       end
-      out << { eid: eid, r0: r0, r1: r1, children: children }
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
     end
     out
   end
@@ -173,11 +189,16 @@ module LayoutLint
         kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
                    kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
         next if kpi_band
-        covered = Array.new(GRID_COLS, false)
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
         kids.each do |_eid, c0, c1, _r0, _r1|
-          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
         end
-        fill = covered.count(true).to_f / GRID_COLS
+        fill = covered.count(true).to_f / ncols
         next if fill >= MIN_BAND_FILL
         empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
         violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
@@ -185,7 +206,7 @@ module LayoutLint
                              're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
                              b[:eid], page_id,
                              kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
-                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
                              empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/layout_lint.rb
@@ -87,6 +87,21 @@ module LayoutLint
 
   # Top-level GridContainers of a page block with their direct children:
   # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
   def containers(page_xml)
     out = []
     s = page_xml.to_s
@@ -94,6 +109,7 @@ module LayoutLint
     while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
       attrs, close = m[1], m[2]
       eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
       r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
       r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
       inner = ''
@@ -109,7 +125,7 @@ module LayoutLint
          le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
          le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
       end
-      out << { eid: eid, r0: r0, r1: r1, children: children }
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
     end
     out
   end
@@ -173,11 +189,16 @@ module LayoutLint
         kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
                    kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
         next if kpi_band
-        covered = Array.new(GRID_COLS, false)
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
         kids.each do |_eid, c0, c1, _r0, _r1|
-          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
         end
-        fill = covered.count(true).to_f / GRID_COLS
+        fill = covered.count(true).to_f / ncols
         next if fill >= MIN_BAND_FILL
         empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
         violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
@@ -185,7 +206,7 @@ module LayoutLint
                              're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
                              b[:eid], page_id,
                              kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
-                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
                              empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/layout_lint.rb
@@ -87,6 +87,21 @@ module LayoutLint
 
   # Top-level GridContainers of a page block with their direct children:
   # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
   def containers(page_xml)
     out = []
     s = page_xml.to_s
@@ -94,6 +109,7 @@ module LayoutLint
     while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
       attrs, close = m[1], m[2]
       eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
       r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
       r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
       inner = ''
@@ -109,7 +125,7 @@ module LayoutLint
          le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
          le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
       end
-      out << { eid: eid, r0: r0, r1: r1, children: children }
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
     end
     out
   end
@@ -173,11 +189,16 @@ module LayoutLint
         kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
                    kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
         next if kpi_band
-        covered = Array.new(GRID_COLS, false)
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
         kids.each do |_eid, c0, c1, _r0, _r1|
-          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
         end
-        fill = covered.count(true).to_f / GRID_COLS
+        fill = covered.count(true).to_f / ncols
         next if fill >= MIN_BAND_FILL
         empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
         violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
@@ -185,7 +206,7 @@ module LayoutLint
                              're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
                              b[:eid], page_id,
                              kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
-                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
                              empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout_lint.rb
@@ -87,6 +87,21 @@ module LayoutLint
 
   # Top-level GridContainers of a page block with their direct children:
   # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
   def containers(page_xml)
     out = []
     s = page_xml.to_s
@@ -94,6 +109,7 @@ module LayoutLint
     while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
       attrs, close = m[1], m[2]
       eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
       r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
       r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
       inner = ''
@@ -109,7 +125,7 @@ module LayoutLint
          le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
          le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
       end
-      out << { eid: eid, r0: r0, r1: r1, children: children }
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
     end
     out
   end
@@ -173,11 +189,16 @@ module LayoutLint
         kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
                    kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
         next if kpi_band
-        covered = Array.new(GRID_COLS, false)
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
         kids.each do |_eid, c0, c1, _r0, _r1|
-          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
         end
-        fill = covered.count(true).to_f / GRID_COLS
+        fill = covered.count(true).to_f / ncols
         next if fill >= MIN_BAND_FILL
         empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
         violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
@@ -185,7 +206,7 @@ module LayoutLint
                              're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
                              b[:eid], page_id,
                              kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
-                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
                              empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb
@@ -1,0 +1,107 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Offline regression tests for lib/layout_lint.rb (the shared layout-quality
+# gate, vendored byte-identical across every migration plugin). Creds-free —
+# runs in the corpus-check unit-tests job.
+#
+# Guards in particular the vertical-rail false-positive: a nested container
+# declaring gridTemplateColumns="repeat(1, 1fr)" whose children fill its single
+# column must read as 100% full, NOT 1/24. That bug hard-failed every dashboard
+# with a left filter rail / sidebar (caught end-to-end against a real shipped
+# workbook before this test existed).
+
+require_relative 'lib/layout_lint'
+
+$failures = 0
+def check(name)
+  v = yield
+  if v
+    puts "  ok  - #{name}"
+  else
+    puts "  FAIL- #{name}"
+    $failures += 1
+  end
+end
+
+def lint(spec)
+  LayoutLint.lint(spec)
+end
+
+def has?(viol, frag)
+  viol.any? { |x| x.include?(frag) }
+end
+
+# --- 1. vertical rail (repeat(1,1fr)) is CLEAN — the regression -------------
+rail = {
+  'layout' => <<~XML,
+    <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" id="p1">
+      <GridContainer elementId="hero" type="grid" gridColumn="1 / 25" gridRow="1 / 5" gridTemplateColumns="repeat(24, 1fr)">
+        <LayoutElement elementId="title" gridColumn="1 / 25" gridRow="1 / 5"/>
+      </GridContainer>
+      <GridContainer elementId="rail" type="grid" gridColumn="1 / 6" gridRow="5 / 30" gridTemplateColumns="repeat(1, 1fr)">
+        <LayoutElement elementId="ctlA" gridColumn="1 / 2" gridRow="1 / 6"/>
+        <LayoutElement elementId="ctlB" gridColumn="1 / 2" gridRow="6 / 11"/>
+      </GridContainer>
+      <GridContainer elementId="content" type="grid" gridColumn="6 / 25" gridRow="5 / 30" gridTemplateColumns="repeat(24, 1fr)">
+        <LayoutElement elementId="t1" gridColumn="1 / 25" gridRow="1 / 25"/>
+      </GridContainer>
+    </Page>
+  XML
+  'pages' => [{ 'id' => 'p1', 'name' => 'Partner Summary', 'elements' => [
+    { 'id' => 'title', 'kind' => 'text', 'body' => '# EDNA Partner Bookings' },
+    { 'id' => 'ctlA', 'kind' => 'control', 'name' => 'Region' },
+    { 'id' => 'ctlB', 'kind' => 'control', 'name' => 'Channel' },
+    { 'id' => 't1', 'kind' => 'pivot-table', 'name' => 'By Partner' }
+  ] }]
+}
+rv = lint(rail)
+check('vertical rail (repeat(1,1fr)) lints clean') { rv.empty? }
+
+# --- 2. a genuinely under-filled 24-col band still FAILS --------------------
+bad = {
+  'layout' => <<~XML,
+    <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" id="p1">
+      <GridContainer elementId="hdr" type="grid" gridColumn="1 / 25" gridRow="1 / 3" gridTemplateColumns="repeat(24, 1fr)">
+        <LayoutElement elementId="hdrtext" gridColumn="1 / 25" gridRow="1 / 3"/>
+      </GridContainer>
+      <GridContainer elementId="band1" type="grid" gridColumn="1 / 25" gridRow="3 / 9" gridTemplateColumns="repeat(24, 1fr)">
+        <LayoutElement elementId="smallbar" gridColumn="1 / 6" gridRow="1 / 6"/>
+      </GridContainer>
+      <LayoutElement elementId="loosectl" gridColumn="1 / 5" gridRow="20 / 22"/>
+    </Page>
+  XML
+  'pages' => [{ 'id' => 'p1', 'name' => 'Partner Summary', 'elements' => [
+    { 'id' => 'hdrtext', 'kind' => 'text', 'body' => '# Page 1' },
+    { 'id' => 'smallbar', 'kind' => 'bar-chart', 'name' => 'a1b2c3d4e5f6' },
+    { 'id' => 'loosectl', 'kind' => 'control', 'name' => 'Region' }
+  ] }]
+}
+bv = lint(bad)
+check('under-filled 24-col band fails')      { has?(bv, 'band under-filled') }
+check('raw-id display name flagged')         { has?(bv, 'raw-id display name') }
+check('orphan control flagged')              { has?(bv, 'orphan control') }
+check('generic header title flagged')        { has?(bv, 'generic header title') }
+check('dead zone flagged')                   { has?(bv, 'dead zone') }
+
+# --- 3. explicit multi-track template counts its own tracks -----------------
+three = {
+  'layout' => <<~XML,
+    <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" id="p1">
+      <GridContainer elementId="b" type="grid" gridColumn="1 / 25" gridRow="1 / 6" gridTemplateColumns="1fr 1fr 1fr">
+        <LayoutElement elementId="x" gridColumn="1 / 2" gridRow="1 / 6"/>
+        <LayoutElement elementId="y" gridColumn="2 / 3" gridRow="1 / 6"/>
+        <LayoutElement elementId="z" gridColumn="3 / 4" gridRow="1 / 6"/>
+      </GridContainer>
+    </Page>
+  XML
+  'pages' => [{ 'id' => 'p1', 'name' => 'P', 'elements' => [
+    { 'id' => 'x', 'kind' => 'table', 'name' => 'X' },
+    { 'id' => 'y', 'kind' => 'table', 'name' => 'Y' },
+    { 'id' => 'z', 'kind' => 'table', 'name' => 'Z' }
+  ] }]
+}
+check('explicit 3-track band (all filled) lints clean') { lint(three).none? { |x| x.include?('band under-filled') } }
+
+puts($failures.zero? ? "\nlayout-lint: all tests passed" : "\nlayout-lint: #{$failures} FAILED")
+exit($failures.zero? ? 0 : 1)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/layout_lint.rb
@@ -87,6 +87,21 @@ module LayoutLint
 
   # Top-level GridContainers of a page block with their direct children:
   # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
   def containers(page_xml)
     out = []
     s = page_xml.to_s
@@ -94,6 +109,7 @@ module LayoutLint
     while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
       attrs, close = m[1], m[2]
       eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
       r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
       r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
       inner = ''
@@ -109,7 +125,7 @@ module LayoutLint
          le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
          le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
       end
-      out << { eid: eid, r0: r0, r1: r1, children: children }
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
     end
     out
   end
@@ -173,11 +189,16 @@ module LayoutLint
         kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
                    kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
         next if kpi_band
-        covered = Array.new(GRID_COLS, false)
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
         kids.each do |_eid, c0, c1, _r0, _r1|
-          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
         end
-        fill = covered.count(true).to_f / GRID_COLS
+        fill = covered.count(true).to_f / ncols
         next if fill >= MIN_BAND_FILL
         empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
         violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
@@ -185,7 +206,7 @@ module LayoutLint
                              're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
                              b[:eid], page_id,
                              kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
-                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
                              empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
       end
 


### PR DESCRIPTION
## The bug (found by an end-to-end test)
The shared `layout_lint.rb` band-fill check divided every container's covered columns by a hardcoded `GRID_COLS = 24`. But a nested container declares its **own** `gridTemplateColumns`, and a child's `gridColumn` is local to that container. So a left filter rail / sidebar declared `repeat(1, 1fr)` — whose children correctly fill its single column — read as **"1 of 24 = 4%"** and **hard-failed the layout gate** (`exit 4` in `post-and-readback`, `exit 8` in `assert-phase6-ran` gate 6) on every dashboard with a sidebar.

This is the gate that runs across **all 8 migration plugins** (byte-identical vendored lib), so the false-positive hit every converter.

## How it surfaced
Linting a **real shipped workbook** — the live readback of the EDNA Partner-Summary demo (`fc3a2add`) — failed on exactly one thing: its left control rail. Every other check was clean. That's the false-positive in production.

## Fix
- Parse each `GridContainer`'s `gridTemplateColumns` → its local column count (`repeat(N, …)` → N; explicit track list → token count; absent → page default 24).
- Measure band fill against **that** count.
- Re-vendored **byte-identical to all 8 plugins** (single md5).

## Validation
- **Before:** real EDNA workbook → `band under-filled: rail … 1 of 24 (4%)` → exit 1.
- **After:** real EDNA workbook → `layout lint: clean`.
- A genuinely under-filled **24-col** band (5/24) still fails — detection not weakened.
- New offline **`test-layout-lint.rb`** (rail clean / under-fill fails / raw-id / orphan-control / generic-header / dead-zone all fire), added to the creds-free `corpus-check` unit-tests job — `layout_lint` had **no** test before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)