### PR TITLE
Add local governance git hooks (pre-commit + pre-push)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Local governance gate (shared-lib drift + skill conformance). Enable once per
+# clone: git config core.hooksPath .githooks  (see CONTRIBUTING.md).
+exec "$(git rev-parse --show-toplevel)/.githooks/run-governance-checks.sh"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Final local gate before sharing (shared-lib drift + skill conformance).
+# Enable once per clone: git config core.hooksPath .githooks (see CONTRIBUTING.md).
+exec "$(git rev-parse --show-toplevel)/.githooks/run-governance-checks.sh"

--- a/.githooks/run-governance-checks.sh
+++ b/.githooks/run-governance-checks.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared local gate run by the pre-commit and pre-push hooks. Runs the same
+# creds-free governance checks CI runs (shared-lib drift + skill conformance),
+# so violations are caught locally in ~1s instead of after a push. Bypass with
+# `git commit --no-verify` / `git push --no-verify` if you must.
+set -uo pipefail
+
+# repo root (works from a normal clone or a linked worktree)
+root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+cd "$root" || exit 0
+
+# Nothing to check if the governance tools aren't present (older checkout).
+[ -f tools/check-shared.rb ] || exit 0
+
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "governance hook: ruby not found — skipping local checks (CI still enforces)." >&2
+  exit 0
+fi
+
+fail=0
+ruby tools/check-shared.rb || fail=1
+ruby tools/lint-skills.rb   || fail=1
+if [ "$fail" -ne 0 ]; then
+  echo "" >&2
+  echo "governance checks failed — fix above, or bypass with --no-verify (CI will still gate)." >&2
+  exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,19 @@ registers the shared infra, and adds a `docs/phase-schema.md` stub. Then do the
 printed human TODOs: marketplace entry, `AGENTS.md` row, a `corpus/` case, and
 fill the SKILL.md prose.
 
+## Local hooks (recommended — catch gate failures before you push)
+
+Enable the repo's git hooks once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+`pre-commit` and `pre-push` then run the same creds-free governance checks CI
+runs (`tools/check-shared.rb` + `tools/lint-skills.rb`, ~1s) so shared-lib drift
+or a missing gate is caught locally. Bypass with `--no-verify` if you must — CI
+still enforces.
+
 ## Regression: the corpus
 
 Changing a converter/builder? Run `./corpus/run-corpus.sh --check` and reconvert


### PR DESCRIPTION
`.githooks/{pre-commit,pre-push}` run the creds-free governance checks (`tools/check-shared.rb` + `tools/lint-skills.rb`) so shared-lib drift or a missing mandatory gate is caught locally in ~1s — before CI.

Enable per clone:
```
git config core.hooksPath .githooks
```
`--no-verify` bypasses; CI still enforces. Documented in CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)