### PR TITLE
Run-each-time gap-scout gate across all migration plugins (beads-sigma-5l5e)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/gap-scout.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/gap-scout.md
@@ -37,6 +37,7 @@ INPUTS
 - A real warehouse table on the customer's Sigma connection to test against:
   --connection <connectionId>  --table-path <DB.SCHEMA.TABLE>
 - Sigma folder id: <folder-id>
+- Gate id + workdir: <expr:... and --workdir from migrate-cognos.mjs's GAP-SCOUT REQUIRED block>
 
 PROCEDURE
 1. Read refs/expression-dsl.md (the Cognos→Sigma mapping table) and
@@ -51,7 +52,8 @@ PROCEDURE
      --template '<Sigma template using $1,$2 for captures>' \
      --test-formula '<the candidate with a REAL column from --table-path>' \
      --connection <connectionId> --table-path <DB.SCHEMA.TABLE> \
-     --folder <folder-id> --description '<one line>' --hint '<caveat>'
+     --folder <folder-id> --description '<one line>' --hint '<caveat>' \
+     --gap-id '<expr:... from the GAP-SCOUT REQUIRED list>' --workdir <migration workdir>
 4. Parse the JSON result:
    - status=validated → success; rule is now in ~/.cognos-to-sigma/learned-rules.json
    - status=escalated → try a different candidate (≤3 attempts). The last result
@@ -62,6 +64,25 @@ One paragraph: feature, candidate, status (validated / escalated / abandoned-aft
 and — if escalated — the `escalation.dry_run_cmd` so the main agent can offer the
 user a tracking issue.
 ```
+
+## Run-each-time gate (bead beads-sigma-5l5e) — why `--gap-id` + `--workdir` matter
+
+A flagged expression surfaces in `migrate-cognos.mjs`'s OPEN QUESTIONS as an
+`expression_flagged` decision whose default is "proceed … close via gap-scout
+later". To stop `--yes` from silently shipping that placeholder, `migrate-cognos.mjs`
+**STOPS** (exit 11) with a `GAP-SCOUT REQUIRED` block listing each unscouted gap's
+`--gap-id` (`expr:<first 80 chars of the warning>`) and the `--workdir`, **before**
+any Sigma object is created.
+
+`scout-validate-and-persist.mjs` appends its result (`validated` or `escalated`) to
+`<workdir>/scout-ledger.jsonl` keyed by that `--gap-id` (via `lib/scout_gate.mjs`,
+the Node mirror of the shared `scout_gate.rb`/`.py` JSONL contract). So you MUST pass
+the `--gap-id` and `--workdir` the STOP block printed — otherwise the ledger entry
+won't match the flagged expression and the re-run will STOP again. The gate cannot be
+skipped with `--yes`: an unscouted gap always stops; once every flagged expression is
+scouted (validated → translated and persisted, or escalated → genuinely-hard and
+flagged) the re-run proceeds to the normal decision checkpoint. Flow: build → STOP →
+scout each gap → re-run → proceed.
 
 ## Opt-in issue filing
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/scout_gate.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/scout_gate.mjs
@@ -1,0 +1,68 @@
+// Shared "run-each-time gap-scout gate" (bead beads-sigma-5l5e) — Node side.
+//
+// Mirrors scout_gate.rb / scout_gate.py EXACTLY: a per-conversion JSONL ledger at
+// <workdir>/scout-ledger.jsonl, one row per scouted gap:
+//   { "gap_id": ..., "feature": ..., "status": "validated"|"escalated", "at": ... }
+//
+// The orchestrator (migrate-cognos.mjs) maps its own gap representation to a list
+// of stable gap-id strings and calls classify(); the scout
+// (scout-validate-and-persist.mjs) appends to the ledger via record(). The JSONL
+// format is the language-neutral contract — a Ruby/Python/Node scout all write
+// rows the others can read. Kept dependency-free so it can be vendored unchanged.
+import { existsSync, statSync, readFileSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const LEDGER = 'scout-ledger.jsonl';
+
+export function ledgerPath(workdir) {
+  return join(String(workdir || ''), LEDGER);
+}
+
+// Append one scout result. Non-fatal on error — a failed ledger write must never
+// crash a scout that otherwise succeeded.
+export function record(workdir, { gapId, feature, status }) {
+  try {
+    if (!workdir || !existsSync(workdir) || !statSync(workdir).isDirectory()) return false;
+    const row = {
+      gap_id: String(gapId || feature),
+      feature: String(feature),
+      status: String(status),
+      at: new Date().toISOString(),
+    };
+    appendFileSync(ledgerPath(workdir), JSON.stringify(row) + '\n');
+    return true;
+  } catch (e) {
+    console.error(`scout-ledger write failed (non-fatal): ${e.message}`);
+    return false;
+  }
+}
+
+export function readLedger(workdir) {
+  const p = ledgerPath(workdir);
+  if (!existsSync(p)) return [];
+  const out = [];
+  for (const line of readFileSync(p, 'utf8').split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try { out.push(JSON.parse(t)); } catch { /* skip malformed */ }
+  }
+  return out;
+}
+
+// gapIds: string[] — the unhandled gaps the scout was supposed to cover.
+// Returns three disjoint buckets of gap-ids (mirrors scout_gate.rb#classify):
+//   unscouted — no ledger row at all (scout never ran) → hard STOP
+//   escalated — scouted, every row is 'escalated' (tried, unsolved) → needs --yes/--force
+//   validated — has at least one 'validated' row (solved locally)
+export function classify(workdir, gapIds) {
+  const by = {};
+  for (const e of readLedger(workdir)) {
+    const k = String(e.gap_id);
+    (by[k] = by[k] || []).push(e);
+  }
+  const unscouted = gapIds.filter((id) => !by[String(id)]);
+  const rest = gapIds.filter((id) => by[String(id)]);
+  const validated = rest.filter((id) => by[String(id)].some((x) => x.status === 'validated'));
+  const escalated = rest.filter((id) => !validated.includes(id));
+  return { unscouted, escalated, validated };
+}

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
@@ -57,6 +57,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'no
 import { homedir } from 'node:os';
 import { dirname, join, resolve, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import * as scoutGate from './lib/scout_gate.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const CONV = join(HERE, '..', 'converter');
@@ -388,6 +389,37 @@ if (securityDetected.length) {
     default: 'proceed (port security via apply_sigma_rls.py after the post)',
   });
 }
+// ---------------------------------------------------------------------------
+// RUN-EACH-TIME GAP-SCOUT GATE (bead beads-sigma-5l5e). A flagged expression's
+// default answer is "proceed ... close via gap-scout later" — but --yes would
+// otherwise let the agent skip the scout entirely and ship the placeholder. So
+// every expression_flagged gap must be SCOUTED first: the gap-scout attempts a
+// Sigma translation (scripts/gap-scout.md → scout-validate-and-persist.mjs,
+// which records to <WORK>/scout-ledger.jsonl). --yes does NOT skip this gate; it
+// only accepts gaps the scout already tried (validated locally, or escalated).
+// An unscouted flagged expression always STOPS, before any Sigma object exists.
+// (skipped under --dry-run: it ships nothing to Sigma and the scout needs a live
+// connection to validate — the real build below is what the gate must guard.)
+const exprGaps = opt['dry-run'] ? [] : questions.filter((q) => q.id === 'expression_flagged');
+if (exprGaps.length) {
+  const gid = (q) => 'expr:' + String(q.detail).replace(/\s+/g, ' ').trim().slice(0, 80);
+  const gapIds = [...new Set(exprGaps.map(gid))];
+  const buckets = scoutGate.classify(WORK, gapIds);
+  if (buckets.unscouted.length) {
+    console.log('\n==================== GAP-SCOUT REQUIRED ====================');
+    console.log(`${buckets.unscouted.length} of ${gapIds.length} flagged expression(s) have NOT been scouted —`);
+    console.log('the gap-scout must attempt a Sigma translation before the placeholder is accepted:');
+    buckets.unscouted.forEach((id) => console.log(`  --gap-id '${id}'`));
+    console.log('');
+    console.log('Spawn one gap-scout per expression (scripts/gap-scout.md), passing the exact --gap-id');
+    console.log(`above plus --workdir ${WORK}, then re-run. --yes does NOT skip this gate.`);
+    console.log('===========================================================');
+    console.log('No Sigma objects were created.');
+    process.exit(11);
+  }
+  line(`gap-scout: all ${gapIds.length} flagged expression(s) accounted for (validated or escalated)`);
+}
+
 let answers = null;
 if (opt.answers) { try { answers = JSON.parse(opt.answers); } catch { die('--answers is not valid JSON'); } }
 if (questions.length && !opt.yes && !answers) {

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/scout-validate-and-persist.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/scout-validate-and-persist.mjs
@@ -14,13 +14,20 @@
 //     --template 'CumulativeSum([$1])' \
 //     --test-formula 'CumulativeSum([Net Revenue])' \
 //     --connection <connId> --table-path CSA.TJ.ORDER_FACT \
-//     --folder <folderId> [--description '...'] [--hint '...']
+//     --folder <folderId> [--description '...'] [--hint '...'] \
+//     [--gap-id '<expr:... from migrate-cognos.mjs GAP-SCOUT REQUIRED>'] [--workdir <dir>]
+//
+// --gap-id + --workdir feed the run-each-time gap-scout gate (bead beads-sigma-5l5e):
+// the result (validated|escalated) is appended to <workdir>/scout-ledger.jsonl keyed
+// by --gap-id, so migrate-cognos.mjs's OPEN-QUESTIONS gate sees the flagged
+// expression as scouted and stops blocking it on the re-run.
 //
 // Output (JSON): { status: "validated"|"escalated", rule_path?, escalation? , ... }
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { api, extractId, parseArgs } from './lib/sigma-rest.mjs';
+import * as scoutGate from './lib/scout_gate.mjs';
 
 const a = parseArgs(process.argv.slice(2));
 for (const k of ['feature', 'template', 'test-formula', 'connection', 'table-path', 'folder']) {
@@ -66,11 +73,15 @@ if (resolved) {
   rules.push({ feature: a.feature, pattern: a.pattern || a['test-formula'], template: a.template, flags: 'gi', description: a.description || '', hint: a.hint || '', validatedAt: new Date().toISOString() });
   mkdirSync(join(homedir(), '.cognos-to-sigma'), { recursive: true });
   writeFileSync(RULES, JSON.stringify(rules, null, 2));
+  // Record to the run-each-time gap-scout ledger (bead beads-sigma-5l5e) so
+  // migrate-cognos.mjs's OPEN-QUESTIONS gate sees this gap as scouted.
+  scoutGate.record(a.workdir, { gapId: a['gap-id'], feature: a.feature, status: 'validated' });
   console.log(JSON.stringify({ status: 'validated', feature: a.feature, rule_path: RULES, detail }, null, 2));
   process.exit(0);
 }
 
 // escalation (opt-in; this script does NOT file — it hands back the command)
 const dry = `python3 scripts/escalate-gap.py --skill cognos-to-sigma --category converter --feature ${JSON.stringify(a.feature)} --description ${JSON.stringify(a.description || '')} --source-pattern ${JSON.stringify(a.pattern || '')} --template-attempted ${JSON.stringify(a.template)} --test-formula ${JSON.stringify(a['test-formula'])} --sigma-response ${JSON.stringify(detail)}`;
+scoutGate.record(a.workdir, { gapId: a['gap-id'], feature: a.feature, status: 'escalated' });
 console.log(JSON.stringify({ status: 'escalated', feature: a.feature, detail, escalation: { dry_run_cmd: dry, file_cmd: dry + ' --yes' } }, null, 2));
 process.exit(0);

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/scout_gate.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/scout_gate.py
@@ -1,0 +1,64 @@
+"""Shared run-each-time gap-scout ledger (bead beads-sigma-5l5e) — Python side.
+
+Mirrors scout_gate.rb's contract exactly: a per-conversion JSONL ledger at
+<workdir>/scout-ledger.jsonl, one row per scouted gap:
+    {"gap_id": ..., "feature": ..., "status": "validated"|"escalated", "at": ...}
+
+Ruby orchestrators read it via scout_gate.rb#classify; Python scouts append to
+it via record() below. The JSONL format is the language-neutral contract.
+"""
+import json
+import os
+import datetime
+
+LEDGER = "scout-ledger.jsonl"
+
+
+def record(workdir, gap_id, feature, status):
+    """Append one scout result. Non-fatal on error (never crash a good scout)."""
+    if not workdir or not os.path.isdir(workdir):
+        return False
+    row = {
+        "gap_id": str(gap_id or feature),
+        "feature": str(feature),
+        "status": str(status),
+        "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    try:
+        with open(os.path.join(workdir, LEDGER), "a") as f:
+            f.write(json.dumps(row) + "\n")
+        return True
+    except OSError as e:
+        import sys
+        print("scout-ledger write failed (non-fatal): %s" % e, file=sys.stderr)
+        return False
+
+
+def read_ledger(workdir):
+    p = os.path.join(workdir or "", LEDGER)
+    if not os.path.exists(p):
+        return []
+    out = []
+    with open(p) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except ValueError:
+                pass
+    return out
+
+
+def classify(workdir, gap_ids):
+    """Split unhandled gap-ids into unscouted / escalated / validated buckets.
+    Mirrors scout_gate.rb#classify exactly (same JSONL ledger contract)."""
+    by = {}
+    for e in read_ledger(workdir):
+        by.setdefault(str(e.get("gap_id")), []).append(e)
+    unscouted = [g for g in gap_ids if str(g) not in by]
+    rest = [g for g in gap_ids if str(g) in by]
+    validated = [g for g in rest if any(x.get("status") == "validated" for x in by[str(g)])]
+    escalated = [g for g in rest if g not in validated]
+    return {"unscouted": unscouted, "escalated": escalated, "validated": validated}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -75,6 +75,8 @@ import argparse, csv, glob, io, json, os, re, statistics, subprocess, sys, time
 import urllib.request, urllib.error
 from concurrent.futures import ThreadPoolExecutor
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import scout_gate
 from build_workbook import build_field_index, parse_join_aliases, disp, leaf
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -807,6 +809,31 @@ console.error('stats:', JSON.stringify(res.stats));
           + (f" — {len(errs)} ERROR-typed" if errs else ""))
     for c in errs[:6]:
         print(f"     [{c.get('elementId')}] {c.get('label')}: {c.get('formula')}")
+
+    # RUN-EACH-TIME GAP-SCOUT GATE (bead beads-sigma-5l5e). Looker's converter
+    # passes calc expressions through optimistically (no convert-time degrade
+    # signal); a calc that has no Sigma equivalent surfaces HERE as a type=error
+    # column at readback. Each such column is scout-eligible — the gap-scout must
+    # ATTEMPT a Sigma translation before we accept a broken column. --yes only
+    # accepts columns the scout already tried (validated or escalated); an
+    # unscouted error column always stops. Recorded to the ledger by
+    # scout-validate.py via lib/scout_gate.py.
+    if errs:
+        gid = lambda c: "errcol:%s/%s" % (c.get("elementId"), c.get("label"))
+        gap_ids = list(dict.fromkeys(gid(c) for c in errs))
+        bk = scout_gate.classify(wd, gap_ids)
+        if bk["unscouted"]:
+            print("\n==================== GAP-SCOUT REQUIRED ====================")
+            print("%d of %d ERROR-typed column(s) have NOT been scouted — the gap-scout must"
+                  % (len(bk["unscouted"]), len(gap_ids)))
+            print("attempt a Sigma translation before a broken column ships:")
+            for i in bk["unscouted"]:
+                print("  --gap-id '%s'" % i)
+            print("\nSpawn one gap-scout per column (scripts/gap-scout.md) with the exact --gap-id")
+            print("above plus --workdir %s, then re-run. --yes does NOT skip this gate." % wd)
+            print("===========================================================")
+            sys.exit(11)
+        print("   gap-scout: all %d error column(s) accounted for (validated or escalated)" % len(gap_ids))
 
     # ── Phase 4c — Visual QA: render each content page to a FULL-PAGE PNG ─────
     # so the layout (applied inline by build_workbook.py and POSTed above) can be

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/scout-validate.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/scout-validate.py
@@ -23,6 +23,8 @@ Env: SIGMA_BASE_URL, SIGMA_API_TOKEN (eval get-token.sh first).
 Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the test workbook.
 """
 import json, os, sys, urllib.request, argparse, datetime, re
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import scout_gate
 
 BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
 def api(method, path, body=None, accept_json=True):
@@ -95,6 +97,8 @@ def main():
     ap.add_argument("--kind", default="kpi-chart", choices=["kpi-chart","table"])
     ap.add_argument("--home", default=os.path.expanduser("~/.looker-to-sigma"))
     ap.add_argument("--skill", default="", help="skill name for issue routing (default: derived from --home)")
+    ap.add_argument("--gap-id", default="", help="gap-report row this scout addressed (gate ledger)")
+    ap.add_argument("--workdir", default="", help="conversion working dir; ledger written here")
     a = ap.parse_args()
 
     elem_name, cols = dm_element_master_columns(a.data_model_id, a.element_id)
@@ -152,6 +156,7 @@ def main():
         result["escalation"] = build_escalation(a, err)
     # cleanup test workbook
     api("DELETE", f"/v2/files/{wb}")
+    scout_gate.record(a.workdir, a.gap_id, a.feature, "validated" if status == "validated" else "escalated")
     print(json.dumps({**result,"status":status}, indent=2))
 
 if __name__ == "__main__":

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -205,14 +205,22 @@ python3 scripts/convert.py ... --data-model-id <dataModelId> \
 curl -s -X POST "$SIGMA_BASE_URL/v2/workbooks/spec" \
   -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Content-Type: application/json" \
   -d @sigma_workbook_spec.json      # -> workbookId
+# MANDATORY run-each-time gap-scout gate (bead beads-sigma-5l5e): the converter
+# passes metric function names through, so a function with no Sigma equivalent
+# surfaces HERE as a type=error column. This script STOPS (exit 11) on any
+# UNSCOUTED error column — spawn a gap-scout per the printed --gap-id (see
+# scripts/gap-scout.md), re-run the gate, and only proceed when it exits 0.
+python3 scripts/scout-gate-readback.py --workbook-id <workbookId> --workdir <out-dir>
 ruby scripts/put-layout.rb --workbook <workbookId> --layout layout.xml
 ```
 
 The layout PUT applies the banded layout (header band titled from the
 chapter/dossier name, controls band, full-width tables) the converter emitted
 — without it the workbook renders as Sigma's single-column stack and gates
-4/6 fail. Read the workbook spec back the same way and confirm no
-`type: error` columns. (Workbook DELETE, if you need to retry, is
+4/6 fail. The `scout-gate-readback.py` step above is the **mechanical** version
+of the old "confirm no `type: error` columns" check — do NOT skip it; a broken
+metric must be scouted (translated or escalated) before the workbook ships, not
+waved through. (Workbook DELETE, if you need to retry, is
 `DELETE /v2/files/<id>` — not `/v2/workbooks/<id>`.)
 
 ## Phase 5 — Verify parity (hard gate — the real proof)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/escalate-gap.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/escalate-gap.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""escalate-gap — opt-in GitHub-issue filer for gap-scout escalations.
+
+Shared across every migration skill (vendored identically into each plugin's
+scripts/). When the gap scout can't find a working Sigma translation for a
+source feature, the main agent offers the user the *option* to open a tracking
+issue in the appropriate repo. This script is what turns that "yes" into filed
+issues — with dedupe, repo routing, converter-repo mirroring, and a cross-linked
+bead.
+
+DESIGN: opt-in, never automatic.
+  - Default (no --yes): DRY RUN. Prints the drafted issue(s), the target repo(s),
+    and any existing open issues/beads that already cover this gap. Files NOTHING.
+    This is what the agent shows the user.
+  - With --yes: actually files. Skips any repo where dedupe already found a match
+    (unless --force).
+
+ROUTING (category -> repos):
+  converter  -> twells89/sigma-data-model-manager + twells89/sigma-data-model-mcp
+               (a source expression the *converter* failed to translate — the
+                browser tool and the MCP must stay in sync, so mirror to both)
+  builder    -> twells89/sigma-migration-skills   (workbook/DM spec builder gap)
+  skill      -> twells89/sigma-migration-skills   (skill-logic / discovery gap)
+
+Usage (dry-run draft the agent shows the user):
+  python3 scout/escalate-gap.py \
+    --skill tableau-to-sigma --category converter \
+    --feature WINDOW_AVG --description 'moving average over SUM' \
+    --source-pattern 'WINDOW_AVG(SUM([...]))' \
+    --template-attempted 'MovingAvg(Sum([Master/\\1]), -10, 10)' \
+    --test-formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+    --sigma-response '<failing column type / error json>' \
+    --example-from 'Sales.twb line 412' \
+    --escalation-yaml ~/.tableau-to-sigma/escalations/window_avg.yaml
+
+Then, only if the user says yes, the agent re-runs the same command with --yes.
+
+Requires `gh` on PATH and authed for the target repos. `bd` (beads) optional.
+Exit codes: 0 = ok (drafted or filed), 3 = nothing fileable / gh missing on --yes.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+ROUTES = {
+    "converter": ["twells89/sigma-data-model-manager", "twells89/sigma-data-model-mcp"],
+    "builder":   ["twells89/sigma-migration-skills"],
+    "skill":     ["twells89/sigma-migration-skills"],
+}
+BEADS_DIR = os.path.expanduser("~/.beads-sigma")
+
+
+def have(cmd):
+    return shutil.which(cmd) is not None
+
+
+def run(args, **kw):
+    """Run a command, return (ok, stdout, stderr)."""
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, **kw)
+        return p.returncode == 0, p.stdout.strip(), p.stderr.strip()
+    except Exception as e:  # noqa: BLE001
+        return False, "", str(e)
+
+
+def build_issue(a):
+    title = f"{a.skill} gap: {a.feature}" + (f" ({a.description})" if a.description else "")
+    body = []
+    body.append(f"**Skill:** `{a.skill}`")
+    body.append(f"**Gap category:** `{a.category}`")
+    body.append(f"**Feature:** `{a.feature}`")
+    if a.description:
+        body.append(f"**Description:** {a.description}")
+    if a.source_pattern:
+        body.append(f"**Source pattern:** `{a.source_pattern}`")
+    if a.template_attempted:
+        body.append(f"**Sigma template attempted:** `{a.template_attempted}`")
+    if a.test_formula:
+        body.append(f"**Test formula POSTed:** `{a.test_formula}`")
+    if a.sigma_response:
+        body.append(f"**Sigma response:**\n```\n{a.sigma_response}\n```")
+    body.append(f"**Example source:** {a.example_from or '(not provided)'}")
+    if a.escalation_yaml:
+        body.append(f"**Local escalation record:** `{a.escalation_yaml}`")
+    body.append("\n_Filed via the gap-scout opt-in escalation flow (`escalate-gap.py`)._")
+    return title, "\n\n".join(body)
+
+
+def labels_for(a):
+    return ["gap-scout-escalation", a.skill, f"category:{a.category}"]
+
+
+def ensure_labels(repo, labels):
+    """Best-effort: create labels so `gh issue create --label` won't fail."""
+    for lab in labels:
+        run(["gh", "label", "create", lab, "--repo", repo, "--force"])
+
+
+def find_dupes(repo, feature, skill):
+    """Return list of {number,title,url} open issues that look like this gap."""
+    ok, out, _ = run([
+        "gh", "issue", "list", "--repo", repo, "--state", "open",
+        "--label", "gap-scout-escalation", "--search", feature,
+        "--json", "number,title,url",
+    ])
+    if not ok or not out:
+        return []
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return []
+    feat = feature.lower()
+    return [i for i in items if feat in (i.get("title", "").lower())]
+
+
+def find_bead_dupe(feature):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    ok, out, _ = run(["bd", "list", "--json"], cwd=BEADS_DIR)
+    if not ok or not out:
+        return None
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return None
+    rows = items if isinstance(items, list) else items.get("issues", items.get("beads", []))
+    feat = feature.lower()
+    for b in rows or []:
+        if feat in (str(b.get("title", "")) + str(b.get("summary", ""))).lower():
+            return b.get("id") or b.get("bead_id")
+    return None
+
+
+def create_bead(title, body, skill, category):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    labels = f"sigma-converter,{skill},gap-scout-escalation,category:{category}"
+    ok, out, _ = run([
+        "bd", "create", title, "--priority", "2", "--labels", labels,
+        "--description", body, "--silent",
+    ], cwd=BEADS_DIR)
+    return out.strip() if ok else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--feature", required=True)
+    ap.add_argument("--category", default="converter", choices=list(ROUTES))
+    ap.add_argument("--description", default="")
+    ap.add_argument("--source-pattern", default="")
+    ap.add_argument("--template-attempted", default="")
+    ap.add_argument("--test-formula", default="")
+    ap.add_argument("--sigma-response", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--escalation-yaml", default="")
+    ap.add_argument("--extra-repo", action="append", default=[],
+                    help="additional target repo(s), repeatable")
+    ap.add_argument("--yes", action="store_true",
+                    help="actually file. Without it: dry-run, prints the draft only.")
+    ap.add_argument("--force", action="store_true",
+                    help="file even if a matching open issue already exists")
+    ap.add_argument("--no-beads", action="store_true")
+    a = ap.parse_args()
+
+    repos = list(dict.fromkeys(ROUTES[a.category] + a.extra_repo))
+    title, body = build_issue(a)
+    labels = labels_for(a)
+
+    # Dedupe scan (read-only) up front so the agent can show it to the user.
+    gh_ok = have("gh")
+    dupes = {r: (find_dupes(r, a.feature, a.skill) if gh_ok else []) for r in repos}
+    bead_dupe = None if a.no_beads else find_bead_dupe(a.feature)
+
+    if not a.yes:
+        # DRY RUN — this is what the agent presents to the user.
+        out = {
+            "mode": "draft",
+            "would_file_in": repos,
+            "labels": labels,
+            "title": title,
+            "body": body,
+            "existing_issues": {r: d for r, d in dupes.items() if d},
+            "existing_bead": bead_dupe,
+            "gh_available": gh_ok,
+            "next_step": "re-run with --yes to file (skips repos already covered)",
+        }
+        print(json.dumps(out, indent=2))
+        return 0
+
+    # --yes: actually file.
+    if not gh_ok:
+        print(json.dumps({"status": "error", "error": "gh not on PATH; cannot file"}))
+        return 3
+
+    # Bead first (authoritative tracker), so its id can be embedded in issues.
+    bead_id = bead_dupe
+    if bead_id is None and not a.no_beads:
+        bead_id = create_bead(title, body, a.skill, a.category)
+    issue_body = body + (f"\n\n**Bead:** `{bead_id}`" if bead_id else "")
+
+    filed, skipped = [], []
+    for repo in repos:
+        if dupes.get(repo) and not a.force:
+            skipped.append({"repo": repo, "existing": dupes[repo]})
+            continue
+        ensure_labels(repo, labels)
+        ok, out, err = run([
+            "gh", "issue", "create", "--repo", repo,
+            "--title", title, "--body", issue_body,
+            "--label", ",".join(labels),
+        ])
+        if ok:
+            filed.append({"repo": repo, "url": out.strip()})
+        else:
+            # retry once without labels (in case label creation was denied)
+            ok2, out2, err2 = run([
+                "gh", "issue", "create", "--repo", repo,
+                "--title", title, "--body", issue_body,
+            ])
+            if ok2:
+                filed.append({"repo": repo, "url": out2.strip(), "note": "filed without labels"})
+            else:
+                filed.append({"repo": repo, "error": err or err2})
+
+    # Cross-link mirrored issues to each other.
+    urls = [f["url"] for f in filed if f.get("url")]
+    if len(urls) > 1:
+        for f in filed:
+            if not f.get("url"):
+                continue
+            others = [u for u in urls if u != f["url"]]
+            num = f["url"].rstrip("/").split("/")[-1]
+            link_body = issue_body + "\n\n**Mirrored to:** " + ", ".join(others)
+            run(["gh", "issue", "edit", num, "--repo", f["repo"], "--body", link_body])
+
+    # Cross-link the bead back to the filed issue urls.
+    if bead_id and urls and have("bd"):
+        run(["bd", "update", bead_id, "--description",
+             issue_body + "\n\nFiled issues: " + ", ".join(urls)], cwd=BEADS_DIR)
+
+    print(json.dumps({
+        "status": "filed",
+        "filed": filed,
+        "skipped_existing": skipped,
+        "bead_id": bead_id,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/gap-scout.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/gap-scout.md
@@ -1,0 +1,93 @@
+# gap-scout — guide for the main agent (MicroStrategy → Sigma)
+
+The MSTR converter (`convert.py` `metric_formula`) passes metric **function names**
+through optimistically — it maps an MSTR function token straight to a Sigma function
+name without checking that Sigma has an equivalent. So a metric using a function with
+no clean Sigma mapping does NOT warn at convert time; it surfaces as a **type=error
+column** when the workbook is read back after POST (Phase 4). The mechanical gate
+`scripts/scout-gate-readback.py` STOPS on any such column until a gap-scout has tried
+to translate it.
+
+The scout writes validated rules to `~/.microstrategy-to-sigma/learned-rules.yaml`
+(customer HOME, not the skill repo, so `git pull` never clobbers them).
+`scripts/learned-rules.py` loads them; future conversions apply them before falling
+back to the raw function name.
+
+## What the converter already handles
+Plain object refs (`[TABLE/Col]`), `Sum/Count/Avg/Min/Max`, `Count<Distinct=True>` →
+`CountDistinct`, arithmetic (`+ - * /`), nested-metric inlining (workbook context),
+metric→SQL for AE-emulation sql elements.
+
+## Candidates to scout (MSTR metric function → Sigma)
+| MSTR function | Why it errors | Candidate Sigma translation to validate |
+|---|---|---|
+| `RunningSum / RunningAvg / RunningMax` | window/running calc | `CumulativeSum([Master/Col])` in a date-grouped element |
+| `Rank / RankByValue` | window rank | `Rank([Master/Col])` (grouped-element context) |
+| `Lag / Lead / OffsetValue` | offset | `Lag([Master/Col], n)` in a sorted/date-grouped element |
+| `Median / Percentile / Mode` | distribution | `Median([Master/Col])` / `Percentile([Master/Col], p)` |
+| `StdDev / Variance` | stats | `Stdev([Master/Col])` / `Var([Master/Col])` |
+| `NTile / Quartile` | bucketing | derived bins or `Rank` + ratio; escalate if no 1:1 |
+| `FirstInRange / LastInRange` | windowed first/last | `First`/`Last` in a sorted grouped element |
+| MSTR-specific (`ApplySimple`, `BannerNumber`, …) | passthrough/raw SQL | translate via the warehouse SQL, else escalate |
+
+Spawn ONE scout per distinct error column; run them in parallel (independent).
+
+**Point the scout at the denormalized join element** (e.g. `Orders`), referencing
+columns as `[Master/<Display Name>]`.
+
+## How to spawn (Agent tool, subagent_type 'general-purpose')
+```
+You are a translation scout for a MicroStrategy→Sigma migration. Propose a Sigma
+formula that replaces an MSTR metric function, validate it against the live Sigma
+API, and persist the rule.
+
+INPUTS
+- Error column: <the type=error column's label + its formula from the gate output>
+- Sample MSTR metric expression(s): <2-5 real examples>
+- Sigma data-model id: <dm-id> ; denormalized element id: <denorm-elem-id> ; folder: <id>
+- Gate id + workdir: <errcol:... and --workdir from scout-gate-readback.py's GAP-SCOUT REQUIRED block>
+
+DO
+1. Propose a Sigma formula (see the candidate table above).
+2. Validate (eval get-token.sh first):
+   python3 scripts/scout-validate.py --formula '<sigma>' \
+     --data-model-id <dm> --element-id <denorm> --folder-id <folder> \
+     --feature '<fn>' --pattern '<regex>' --template '<sigma template>' \
+     --description '<fn> -> Sigma' --home ~/.microstrategy-to-sigma \
+     --gap-id '<errcol:... from the GAP-SCOUT REQUIRED list>' --workdir <migration workdir>
+3. If status=validated it's persisted; report the rule. If error, try another form
+   (≤4 attempts). After the last failed attempt the result carries an
+   `escalation.dry_run_cmd` / `escalation.file_cmd`; report it as genuine-(c)
+   needing redesign. Do NOT file anything yourself — see "Opt-in issue filing".
+```
+Validated rules auto-apply on the next migrate via `learned-rules.py`.
+
+## Run-each-time gate (bead beads-sigma-5l5e) — why `--gap-id` + `--workdir` matter
+
+`scout-gate-readback.py` reads the workbook back after POST, finds each type=error
+column, and **STOPS** (exit 11) with a `GAP-SCOUT REQUIRED` block listing each
+unscouted column's `--gap-id` (`errcol:<elementId>/<label>`) and the `--workdir`.
+
+`scout-validate.py` appends its result (`validated` or `escalated`) to
+`<workdir>/scout-ledger.jsonl` keyed by that exact `--gap-id` (via `lib/scout_gate.py`,
+the shared JSONL contract). You MUST pass the `--gap-id` and `--workdir` the STOP block
+printed — otherwise the ledger entry won't match the error column and re-running the
+gate will STOP again. The gate cannot be skipped with `--yes`: an unscouted error
+column always stops; once every error column is scouted (validated → translated and
+persisted, or escalated → genuinely-hard and flagged) the gate passes. Flow: POST →
+gate STOPS → scout each column → re-run the gate → proceed.
+
+## Opt-in issue filing (escalations)
+
+Filing a GitHub issue is **opt-in and confirm-before-file** — never automatic.
+When `scout-validate.py` returns `status=error`, its `escalation` block carries
+ready-to-run commands for the shared `escalate-gap.py` filer. The main agent:
+
+1. Runs `escalation.dry_run_cmd` — files NOTHING; prints the drafted issue, the
+   target repo(s), and any existing open issues/beads that already cover the gap.
+2. Shows the user that draft and asks whether to open the issue.
+3. Only if the user says yes, runs `escalation.file_cmd` (the same command + `--yes`).
+
+MSTR metric gaps are **converter** gaps, so they mirror to both converter repos
+(`sigma-data-model-manager` + `sigma-data-model-mcp`) with a cross-link and a bead as
+the authoritative tracker. See `scripts/escalate-gap.py`.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/learned-rules.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/learned-rules.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""learned-rules — load + apply gap-scout translation rules (MicroStrategy → Sigma).
+
+Rules live in the customer's HOME (`~/.microstrategy-to-sigma/learned-rules.yaml`), NOT
+the skill repo — so `git pull` of the skill never clobbers what a customer's scout has
+discovered, and wins persist across every dossier they migrate. Override the dir
+with the `MICROSTRATEGY_TO_SIGMA_HOME` env var. (Identical loader to the sibling
+Looker/Qlik/Power BI copies; only the default home + env var differ.)
+
+The conversion build step imports this and calls `apply()` on each MSTR metric
+expression before falling back to the converter / a WARN line.
+
+    from learned_rules import load, apply
+    rules = load(home="~/.microstrategy-to-sigma")
+    sigma_formula, hint = apply(rules, mstr_expr)   # (None, None) if no rule matches
+"""
+import os, re, yaml
+
+def home_dir(home=None, env=None):
+    if home: return os.path.expanduser(home)
+    if env and os.environ.get(env): return os.path.expanduser(os.environ[env])
+    return os.path.expanduser("~/.microstrategy-to-sigma")
+
+def load(home=None, env="MICROSTRATEGY_TO_SIGMA_HOME"):
+    path = os.path.join(home_dir(home, env), "learned-rules.yaml")
+    if not os.path.exists(path): return []
+    doc = yaml.safe_load(open(path)) or {}
+    return doc.get("rules", [])
+
+def apply(rules, expr):
+    """Return (translated_formula, hint) for the first matching rule, else (None, None)."""
+    for r in rules:
+        pat = r.get("source_pattern") or r.get("tableau_pattern") or r.get("dax_pattern")
+        tmpl = r.get("sigma_template")
+        if not pat or not tmpl: continue
+        m = re.search(pat, expr, re.IGNORECASE)
+        if m:
+            out = tmpl
+            for i, g in enumerate(m.groups(), start=1):
+                out = out.replace("\\%d" % i, g or "").replace("CAP%d" % i, g or "")
+            return out, r.get("hint", "")
+    return None, None
+
+if __name__ == "__main__":
+    import sys, json
+    rules = load(home=(sys.argv[2] if len(sys.argv) > 2 else None))
+    expr = sys.argv[1] if len(sys.argv) > 1 else ""
+    out, hint = apply(rules, expr)
+    print(json.dumps({"input": expr, "translated": out, "hint": hint, "rules_loaded": len(rules)}, indent=2))

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/scout_gate.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/scout_gate.py
@@ -1,0 +1,64 @@
+"""Shared run-each-time gap-scout ledger (bead beads-sigma-5l5e) — Python side.
+
+Mirrors scout_gate.rb's contract exactly: a per-conversion JSONL ledger at
+<workdir>/scout-ledger.jsonl, one row per scouted gap:
+    {"gap_id": ..., "feature": ..., "status": "validated"|"escalated", "at": ...}
+
+Ruby orchestrators read it via scout_gate.rb#classify; Python scouts append to
+it via record() below. The JSONL format is the language-neutral contract.
+"""
+import json
+import os
+import datetime
+
+LEDGER = "scout-ledger.jsonl"
+
+
+def record(workdir, gap_id, feature, status):
+    """Append one scout result. Non-fatal on error (never crash a good scout)."""
+    if not workdir or not os.path.isdir(workdir):
+        return False
+    row = {
+        "gap_id": str(gap_id or feature),
+        "feature": str(feature),
+        "status": str(status),
+        "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    try:
+        with open(os.path.join(workdir, LEDGER), "a") as f:
+            f.write(json.dumps(row) + "\n")
+        return True
+    except OSError as e:
+        import sys
+        print("scout-ledger write failed (non-fatal): %s" % e, file=sys.stderr)
+        return False
+
+
+def read_ledger(workdir):
+    p = os.path.join(workdir or "", LEDGER)
+    if not os.path.exists(p):
+        return []
+    out = []
+    with open(p) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except ValueError:
+                pass
+    return out
+
+
+def classify(workdir, gap_ids):
+    """Split unhandled gap-ids into unscouted / escalated / validated buckets.
+    Mirrors scout_gate.rb#classify exactly (same JSONL ledger contract)."""
+    by = {}
+    for e in read_ledger(workdir):
+        by.setdefault(str(e.get("gap_id")), []).append(e)
+    unscouted = [g for g in gap_ids if str(g) not in by]
+    rest = [g for g in gap_ids if str(g) in by]
+    validated = [g for g in rest if any(x.get("status") == "validated" for x in by[str(g)])]
+    escalated = [g for g in rest if g not in validated]
+    return {"unscouted": unscouted, "escalated": escalated, "validated": validated}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-gate-readback.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-gate-readback.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""scout-gate-readback — the run-each-time gap-scout gate for MicroStrategy → Sigma
+(bead beads-sigma-5l5e).
+
+MSTR's converter (convert.py metric_formula) passes metric function names through
+optimistically — a function with no Sigma equivalent does NOT surface as a
+convert-time warning; it surfaces as a type=error column when the freshly-POSTed
+workbook is read back. There is no Python orchestrator that POSTs (Phase 4 of
+SKILL.md POSTs the workbook via curl), so this standalone script IS the mechanical
+gate: SKILL.md mandates running it immediately after the workbook POST, replacing
+the prose "check for type:error columns" instruction with a hard, scripted STOP.
+
+Run it after the workbook POST (Phase 4):
+    eval "$(scripts/get-token.sh)"
+    python3 scripts/scout-gate-readback.py --workbook-id <id> --workdir <dir>
+
+Behavior (mirrors the looker / thoughtspot readback gate):
+  - GET /v2/workbooks/{id}/columns, find type=error columns.
+  - gap-id = errcol:<elementId>/<label>; classify against <workdir>/scout-ledger.jsonl.
+  - any UNSCOUTED error column  -> exit 11 (GAP-SCOUT REQUIRED; scout each, re-run).
+    --yes does NOT skip this gate; it only accepts columns the scout already tried.
+  - every error column scouted (validated or escalated) -> exit 0 (proceed).
+  - no error columns -> exit 0.
+
+Env: SIGMA_BASE_URL, SIGMA_API_TOKEN (eval get-token.sh first).
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.request
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import scout_gate
+
+BASE = os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com")
+TOKEN = os.environ.get("SIGMA_API_TOKEN") or sys.exit(
+    'SIGMA_API_TOKEN not set — run: eval "$(scripts/get-token.sh)"')
+
+
+def api(method, path):
+    req = urllib.request.Request(BASE + path, method=method)
+    req.add_header("Authorization", "Bearer " + TOKEN)
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, r.read().decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook-id", required=True)
+    ap.add_argument("--workdir", required=True,
+                    help="conversion working dir holding scout-ledger.jsonl")
+    ap.add_argument("--yes", action="store_true",
+                    help="(does NOT skip the gate; present for parity — an unscouted "
+                         "error column always stops)")
+    a = ap.parse_args()
+
+    st, body = api("GET", f"/v2/workbooks/{a.workbook_id}/columns")
+    if st >= 300:
+        sys.exit(f"FATAL: columns GET failed {st}: {body[:300]}")
+    cols = json.loads(body)
+    entries = cols.get("entries") if isinstance(cols, dict) else cols
+    entries = entries or []
+    errs = [c for c in entries if (c.get("type") or {}).get("type") == "error"]
+    n = len(entries)
+    print(f"workbook {a.workbook_id}: {n - len(errs)}/{n} columns resolve"
+          + (f" — {len(errs)} ERROR-typed" if errs else ""))
+    if not errs:
+        return
+    for c in errs[:6]:
+        print(f"  [{c.get('elementId')}] {c.get('label')}: {c.get('formula')}")
+
+    gid = lambda c: "errcol:%s/%s" % (c.get("elementId"), c.get("label"))
+    gap_ids = list(dict.fromkeys(gid(c) for c in errs))
+    bk = scout_gate.classify(a.workdir, gap_ids)
+    if bk["unscouted"]:
+        print("\n==================== GAP-SCOUT REQUIRED ====================")
+        print("%d of %d ERROR-typed column(s) have NOT been scouted — the gap-scout must"
+              % (len(bk["unscouted"]), len(gap_ids)))
+        print("attempt a Sigma translation before a broken column ships:")
+        for i in bk["unscouted"]:
+            print("  --gap-id '%s'" % i)
+        print("\nSpawn one gap-scout per column (scripts/gap-scout.md) with the exact --gap-id")
+        print("above plus --workdir %s, then re-run this gate. --yes does NOT skip it." % a.workdir)
+        print("===========================================================")
+        sys.exit(11)
+    print("gap-scout: all %d error column(s) accounted for (validated or escalated)" % len(gap_ids))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-validate.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-validate.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""scout-validate — gap-scout validation primitive (MicroStrategy → Sigma).
+
+Validates a candidate Sigma formula against a real data-model element by building a
+throwaway test workbook, checking the column resolves (type != "error"), and — on
+success — persisting the rule to the customer-local learned-rules.yaml. Generic across
+skills via --home.
+
+The MSTR converter (convert.py metric_formula) passes metric function names through
+optimistically — a function with no Sigma equivalent surfaces as a type=error column
+when the workbook is read back. Use this to confirm a candidate replacement resolves.
+
+    python3 scout-validate.py \
+      --formula 'CumulativeSum([Master/Net Revenue])' \
+      --data-model-id <dm> --element-id <denorm-elem-id> --folder-id <folder> \
+      --feature 'RunningSum' --pattern '\\bRunningSum\\s*\\(' \
+      --template 'CumulativeSum([Master/\\1])' --hint 'date-grouped element' \
+      --description 'MSTR RunningSum -> Sigma CumulativeSum' --home ~/.microstrategy-to-sigma
+
+To feed the run-each-time gap-scout gate (bead beads-sigma-5l5e), also pass the
+error column's gate id and the conversion working dir — the result is appended to
+<workdir>/scout-ledger.jsonl so scout-gate-readback.py sees the gap as scouted
+(validated → ok; error → escalated):
+
+      --gap-id 'errcol:<elementId>/<label>' --workdir <wd>
+
+Env: SIGMA_BASE_URL, SIGMA_API_TOKEN (eval get-token.sh first).
+Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the test workbook.
+"""
+import json, os, sys, urllib.request, argparse, datetime, re
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import scout_gate
+
+BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
+def api(method, path, body=None, accept_json=True):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE+path, data=data, method=method,
+        headers={"Authorization":"Bearer "+TOK, "Content-Type":"application/json",
+                 **({"Accept":"application/json"} if accept_json else {})})
+    try:
+        r = urllib.request.urlopen(req); return r.status, r.read().decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+
+def dm_element_master_columns(dm_id, el_id):
+    """Read the DM spec, find the element, return (elementName, [displayName,...])."""
+    st, body = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    spec = json.loads(body)
+    for pg in spec.get("pages", []):
+        for el in pg.get("elements", []):
+            if el.get("id") == el_id:
+                src = el.get("source", {})
+                name = el.get("name") or ("Custom SQL" if src.get("kind")=="sql"
+                       else (src.get("path",["Element"])[-1] if src.get("kind")=="warehouse-table" else "Element"))
+                cols = []
+                for c in el.get("columns", []):
+                    dn = c.get("name") or re.sub(r'.*/', '', c.get("formula","").strip("[]"))
+                    cols.append(dn)
+                return name, cols
+    raise SystemExit("element not found in DM spec")
+
+def build_escalation(a, err):
+    """Record the gap locally and return opt-in escalate-gap.py commands.
+
+    Filing a tracking issue is NOT automatic: the main agent runs dry_run_cmd
+    (drafts the issue + dedupes against open issues/beads), shows the user, and
+    runs file_cmd only if they accept. Source-formula gaps are converter gaps."""
+    import shlex
+    skill = (a.skill or os.path.basename(os.path.normpath(a.home)).lstrip("."))
+    esc_dir = os.path.join(a.home, "escalations"); os.makedirs(esc_dir, exist_ok=True)
+    slug = re.sub(r"[^a-z0-9]+", "-", a.feature.lower()).strip("-") or "gap"
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    esc_path = os.path.join(esc_dir, f"{ts}-{slug}.yaml")
+    payload = {"feature": a.feature, "description": a.description,
+               "source_pattern": a.pattern, "sigma_template_attempted": a.template,
+               "test_formula": a.formula, "example_from": a.example_from,
+               "error_column": err, "escalated_at": ts}
+    try:
+        import yaml; yaml.safe_dump(payload, open(esc_path, "w"), sort_keys=False)
+    except Exception:
+        json.dump(payload, open(esc_path, "w"), indent=2)
+    filer = os.path.join(os.path.dirname(os.path.abspath(__file__)), "escalate-gap.py")
+    cmd = ["python3", filer, "--skill", skill, "--category", "converter",
+           "--feature", a.feature, "--description", a.description or "",
+           "--source-pattern", a.pattern or "", "--template-attempted", a.template or "",
+           "--test-formula", a.formula, "--sigma-response", json.dumps(err)[:1500],
+           "--example-from", a.example_from or "", "--escalation-yaml", esc_path]
+    dry = " ".join(shlex.quote(c) for c in cmd)
+    return {"note": "Gap recorded locally. Filing a tracking issue is opt-in — run "
+                    "dry_run_cmd, show the user, then file_cmd only if they accept.",
+            "escalation_yaml": esc_path, "dry_run_cmd": dry, "file_cmd": dry + " --yes"}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    for f in ["formula","data-model-id","element-id","feature"]:
+        ap.add_argument("--"+f, required=True)
+    ap.add_argument("--folder-id", required=True)
+    ap.add_argument("--pattern"); ap.add_argument("--template")
+    ap.add_argument("--hint", default=""); ap.add_argument("--description", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--kind", default="kpi-chart", choices=["kpi-chart","table"])
+    ap.add_argument("--home", default=os.path.expanduser("~/.microstrategy-to-sigma"))
+    ap.add_argument("--skill", default="", help="skill name for issue routing (default: derived from --home)")
+    ap.add_argument("--gap-id", default="", help="error column this scout addressed (gate ledger; e.g. errcol:<elementId>/<label>)")
+    ap.add_argument("--workdir", default="", help="conversion working dir; ledger written here")
+    a = ap.parse_args()
+
+    elem_name, cols = dm_element_master_columns(a.data_model_id, a.element_id)
+    master = {"id":"m","name":"Master","kind":"table",
+              "source":{"dataModelId":a.data_model_id,"elementId":a.element_id,"kind":"data-model"},
+              "columns":[{"id":f"mc{i}","name":c,"formula":f"[{elem_name}/{c}]"} for i,c in enumerate(cols)]}
+    if a.kind == "kpi-chart":
+        test = {"id":"scout","kind":"kpi-chart","name":"scout","source":{"elementId":"m","kind":"table"},
+                "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}],"value":{"columnId":"sc"}}
+    else:
+        test = {"id":"scout","kind":"table","name":"scout","source":{"elementId":"m","kind":"table"},
+                "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}]}
+    spec = {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id,"schemaVersion":1,
+            "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    st, body = api("POST","/v2/workbooks/spec",spec)
+    wb = None
+    try: wb = json.loads(body).get("workbookId")
+    except Exception: pass
+    if not wb:
+        m = re.search(r'workbookId:\s*(\S+)', body)
+        if m: wb = m.group(1)
+    result = {"feature":a.feature,"formula":a.formula,"workbook_id":wb}
+    if not wb:
+        print(json.dumps({**result,"status":"error","error":"POST failed: "+body[:200]})); return
+    # check the test column's type
+    st2, cbody = api("GET", f"/v2/workbooks/{wb}/elements/scout/columns")
+    err = None
+    try:
+        colsout = json.loads(cbody)
+        entries = colsout.get("entries", colsout) if isinstance(colsout, dict) else colsout
+        for c in (entries or []):
+            t = (c.get("type") or {})
+            if (t.get("type") or t) == "error" or "error" in str(t).lower():
+                err = c
+    except Exception as e:
+        err = {"parse": str(e), "raw": cbody[:200]}
+    status = "error" if err else "validated"
+    # persist on success
+    if status == "validated":
+        if a.pattern and a.template:
+            os.makedirs(a.home, exist_ok=True)
+            import yaml
+            rp = os.path.join(a.home, "learned-rules.yaml")
+            doc = yaml.safe_load(open(rp)) if os.path.exists(rp) else None
+            doc = doc or {"rules":[]}
+            doc["rules"].append({"feature":a.feature,"description":a.description,
+                "source_pattern":a.pattern,"sigma_template":a.template,"hint":a.hint,
+                "validated_at":datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "validated_workbook":wb,"example_from":a.example_from,"confidence":"validated"})
+            yaml.safe_dump(doc, open(rp,"w"), sort_keys=False)
+            result["persisted_to"] = rp
+    else:
+        # opt-in escalation: record the gap locally + hand back ready-to-run filer cmds
+        result["error_column"] = err
+        result["escalation"] = build_escalation(a, err)
+    # cleanup test workbook
+    api("DELETE", f"/v2/files/{wb}")
+    # record to the run-each-time gap-scout ledger (bead beads-sigma-5l5e) so the
+    # scout-gate-readback.py type=error gate sees this gap as scouted.
+    scout_gate.record(a.workdir, a.gap_id, a.feature, "validated" if status == "validated" else "escalated")
+    print(json.dumps({**result,"status":status}, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/gap-scout.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/gap-scout.md
@@ -40,6 +40,7 @@ INPUTS
 - Sigma data-model id: <dm-id>
 - Sigma master element id: <element-id>
 - Sigma folder id: <folder-id>
+- Gate id + workdir: <dax:... and --workdir from migrate-powerbi.rb's GAP-SCOUT REQUIRED block>
 
 PROCEDURE
 1. Read refs/measure-patterns.md + the sibling sigma-workbooks spec (function context rules:
@@ -55,7 +56,8 @@ PROCEDURE
        --hint '<post-publish caveat, e.g. "needs a date-grouped element">' \
        --description '<one-line>' --example-from '<measure name>' \
        --data-model-id <dm-id> --element-id <element-id> --folder-id <folder-id> \
-       --home ~/.powerbi-to-sigma   [--kind table]
+       --home ~/.powerbi-to-sigma   [--kind table] \
+       --gap-id '<dax:... from the GAP-SCOUT REQUIRED list>' --workdir <migration workdir>
 4. Parse JSON: status=validated → done; status=error → retry (≤3). After the last
    failed attempt the result carries an `escalation.dry_run_cmd` / `escalation.file_cmd`
    and the gap is left as a WARN. Do NOT file anything yourself — see "Opt-in issue
@@ -66,6 +68,24 @@ One paragraph: feature, candidate, status, and — if escalated — the
 `escalation.dry_run_cmd` so the main agent can offer the user a tracking issue.
 The validator auto-deletes its test workbook.
 ```
+
+## Run-each-time gate (bead beads-sigma-5l5e) — why `--gap-id` + `--workdir` matter
+
+A flagged DAX measure surfaces in `migrate-powerbi.rb`'s OPEN QUESTIONS as a
+`dax_no_equivalent` (⛔ degrade-to-Null) or `dax_needs_restructure` (⚠) decision
+whose default is "proceed". To stop `--yes` from silently shipping that placeholder,
+`migrate-powerbi.rb` **STOPS** (exit 11) with a `GAP-SCOUT REQUIRED` block listing
+each unscouted measure's `--gap-id` (`dax:<first 80 chars of the warning>`) and the
+`--workdir`, **before** any Sigma object is created.
+
+`scout-validate.py` appends its result (`validated` or `escalated`) to
+`<workdir>/scout-ledger.jsonl` keyed by that `--gap-id` (via `lib/scout_gate.py`,
+the shared JSONL contract). So you MUST pass the `--gap-id` and `--workdir` the STOP
+block printed — otherwise the ledger entry won't match the measure and the re-run
+will STOP again. The gate cannot be skipped with `--yes`: an unscouted measure always
+stops; once every flagged measure is scouted (validated → translated and persisted,
+or escalated → genuinely-hard and flagged) the re-run proceeds to the normal decision
+checkpoint. Flow: build → STOP → scout each gap → re-run → proceed.
 
 ## Opt-in issue filing (escalations)
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/scout_gate.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/scout_gate.py
@@ -1,0 +1,64 @@
+"""Shared run-each-time gap-scout ledger (bead beads-sigma-5l5e) — Python side.
+
+Mirrors scout_gate.rb's contract exactly: a per-conversion JSONL ledger at
+<workdir>/scout-ledger.jsonl, one row per scouted gap:
+    {"gap_id": ..., "feature": ..., "status": "validated"|"escalated", "at": ...}
+
+Ruby orchestrators read it via scout_gate.rb#classify; Python scouts append to
+it via record() below. The JSONL format is the language-neutral contract.
+"""
+import json
+import os
+import datetime
+
+LEDGER = "scout-ledger.jsonl"
+
+
+def record(workdir, gap_id, feature, status):
+    """Append one scout result. Non-fatal on error (never crash a good scout)."""
+    if not workdir or not os.path.isdir(workdir):
+        return False
+    row = {
+        "gap_id": str(gap_id or feature),
+        "feature": str(feature),
+        "status": str(status),
+        "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    try:
+        with open(os.path.join(workdir, LEDGER), "a") as f:
+            f.write(json.dumps(row) + "\n")
+        return True
+    except OSError as e:
+        import sys
+        print("scout-ledger write failed (non-fatal): %s" % e, file=sys.stderr)
+        return False
+
+
+def read_ledger(workdir):
+    p = os.path.join(workdir or "", LEDGER)
+    if not os.path.exists(p):
+        return []
+    out = []
+    with open(p) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except ValueError:
+                pass
+    return out
+
+
+def classify(workdir, gap_ids):
+    """Split unhandled gap-ids into unscouted / escalated / validated buckets.
+    Mirrors scout_gate.rb#classify exactly (same JSONL ledger contract)."""
+    by = {}
+    for e in read_ledger(workdir):
+        by.setdefault(str(e.get("gap_id")), []).append(e)
+    unscouted = [g for g in gap_ids if str(g) not in by]
+    rest = [g for g in gap_ids if str(g) in by]
+    validated = [g for g in rest if any(x.get("status") == "validated" for x in by[str(g)])]
+    escalated = [g for g in rest if g not in validated]
+    return {"unscouted": unscouted, "escalated": escalated, "validated": validated}

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/scout_gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/scout_gate.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+#
+# Shared "run-each-time gap-scout gate" (bead beads-sigma-5l5e).
+#
+# The guarantee: a migration may NOT proceed past its unhandled-feature gaps
+# unless the gap-scout actually ran for EVERY one — either it validated a Sigma
+# translation (`validated`) or it tried and could not (`escalated`). A blanket
+# --force must NOT skip the scout; it may only accept gaps the scout escalated.
+#
+# This module is the reusable core, identical across every migration plugin:
+#   - ScoutGate.record  — scout-validate-and-persist.rb appends one ledger row
+#   - ScoutGate.classify — the orchestrator reads the ledger and splits the
+#                          unhandled gaps into unscouted / escalated / validated
+# Each plugin maps its own gap representation to a list of stable gap-id strings
+# and calls classify; the gap-id naming is the plugin's business, the gate is not.
+#
+# Kept dependency-free (json/time only) so it can be vendored into any plugin's
+# scripts/lib/ unchanged.
+require 'json'
+require 'time'
+
+module ScoutGate
+  LEDGER = 'scout-ledger.jsonl'
+
+  def self.ledger_path(workdir)
+    File.join(workdir.to_s, LEDGER)
+  end
+
+  # Append one scout result to the per-conversion ledger. Non-fatal on error —
+  # a failed ledger write must never crash a scout that otherwise succeeded.
+  def self.record(workdir, gap_id:, feature:, status:)
+    return false unless workdir && Dir.exist?(workdir)
+    row = { 'gap_id' => (gap_id || feature).to_s, 'feature' => feature.to_s,
+            'status' => status.to_s, 'at' => Time.now.utc.iso8601 }
+    File.open(ledger_path(workdir), 'a') { |f| f.puts(JSON.generate(row)) }
+    true
+  rescue StandardError => e
+    warn "scout-ledger write failed (non-fatal): #{e.message}"
+    false
+  end
+
+  def self.read_ledger(workdir)
+    p = ledger_path(workdir)
+    return [] unless File.exist?(p)
+    File.readlines(p).map { |l| JSON.parse(l) rescue nil }.compact
+  end
+
+  # gap_ids: Array<String> — the unhandled gaps the scout was supposed to cover.
+  # Returns a Hash with three disjoint buckets of gap-ids:
+  #   :unscouted — no ledger row at all (the scout never ran) → hard STOP
+  #   :escalated — scouted, every row is 'escalated' (tried, unsolved) → --force
+  #   :validated — has at least one 'validated' row (solved locally)
+  def self.classify(workdir, gap_ids)
+    by = read_ledger(workdir).group_by { |e| e['gap_id'].to_s }
+    unscouted = gap_ids.reject { |id| by[id.to_s] }
+    rest      = gap_ids.select { |id| by[id.to_s] }
+    validated = rest.select { |id| by[id.to_s].any? { |x| x['status'] == 'validated' } }
+    escalated = rest - validated
+    { unscouted: unscouted, escalated: escalated, validated: validated }
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -65,6 +65,7 @@ require 'set'
 
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
+require 'scout_gate' # run-each-time gap-scout gate (bead beads-sigma-5l5e)
 
 opts = { db: '', schema: '' }
 OptionParser.new do |o|
@@ -419,6 +420,33 @@ unless opts[:conn]
   questions << { 'id' => 'connection', 'severity' => 'required',
                  'detail' => 'No Sigma --connection supplied; required to point the DM at the warehouse',
                  'options' => ['supply --connection <id>'], 'default' => nil }
+end
+
+# RUN-EACH-TIME GAP-SCOUT GATE (bead beads-sigma-5l5e). Flagged DAX measures
+# (⛔ no-equivalent → degrade to Null; ⚠ restructure-needed) are scout-eligible —
+# the gap-scout must ATTEMPT a Sigma translation for each before we accept the
+# degradation. --yes does NOT skip this; it only accepts gaps the scout already
+# tried (validated locally, or escalated). The scout records each to
+# <WORK>/scout-ledger.jsonl via scout-validate.py + lib/scout_gate.py.
+dax_gaps = questions.select { |q| %w[dax_no_equivalent dax_needs_restructure].include?(q['id']) }
+unless dax_gaps.empty?
+  gid = ->(q) { 'dax:' + q['detail'].to_s.gsub(/\s+/, ' ').strip[0, 80] }
+  gap_ids = dax_gaps.map { |q| gid.call(q) }.uniq
+  buckets = ScoutGate.classify(WORK, gap_ids)
+  if buckets[:unscouted].any?
+    puts
+    puts '==================== GAP-SCOUT REQUIRED ===================='
+    puts "#{buckets[:unscouted].size} of #{gap_ids.size} flagged DAX measure(s) have NOT been scouted —"
+    puts 'the gap-scout must attempt a Sigma translation before the degradation is accepted:'
+    buckets[:unscouted].each { |id| puts "  --gap-id '#{id}'" }
+    puts ''
+    puts "Spawn one gap-scout per measure (scripts/gap-scout.md), passing the exact --gap-id above"
+    puts "plus --workdir #{WORK}, then re-run. --yes does NOT skip this gate."
+    puts '======================================================='
+    puts 'No Sigma objects were created.'
+    exit 11
+  end
+  puts "   gap-scout: all #{gap_ids.size} flagged DAX measure(s) accounted for (validated or escalated)"
 end
 
 answers = nil

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/scout-validate.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/scout-validate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""scout-validate — gap-scout validation primitive (Qlik & Power BI).
+"""scout-validate — gap-scout validation primitive (Power BI → Sigma).
 
 Validates a candidate Sigma formula against a real data-model element by building a
 throwaway test workbook, checking the column resolves (type != "error"), and — on
@@ -7,16 +7,25 @@ success — persisting the rule to the customer-local learned-rules.yaml. Generi
 skills via --home.
 
     python3 scout-validate.py \
-      --formula 'Avg([Master/Days To Ship])' \
+      --formula 'Rank([Master/Net Revenue])' \
       --data-model-id <dm> --element-id <denorm-elem-id> --folder-id <folder> \
-      --feature 'RangeAvg' --pattern '\\bRangeAvg\\s*\\(\\s*(.+?)\\s*\\)' \
-      --template 'Avg([Master/\\1])' --hint 'aggregate context only' \
-      --description 'Qlik RangeAvg -> Sigma Avg' --home ~/.qlik-to-sigma
+      --feature 'RANKX' --pattern '\\bRANKX\\s*\\(' \
+      --template 'Rank([Master/\\1])' --hint 'grouped-element context' \
+      --description 'DAX RANKX -> Sigma Rank' --home ~/.powerbi-to-sigma
+
+To feed the run-each-time gap-scout gate (bead beads-sigma-5l5e), also pass the
+flagged DAX gap's gate id and the conversion working dir — the result is appended
+to <workdir>/scout-ledger.jsonl so migrate-powerbi.rb's OPEN-QUESTIONS gate sees
+the gap as scouted (validated → ok; error → escalated):
+
+      --gap-id 'dax:<first 80 chars of the converter warning>' --workdir <wd>
 
 Env: SIGMA_BASE_URL, SIGMA_API_TOKEN (eval get-token.sh first).
 Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the test workbook.
 """
 import json, os, sys, urllib.request, argparse, datetime, re
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import scout_gate
 
 BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
 def api(method, path, body=None, accept_json=True):
@@ -87,8 +96,10 @@ def main():
     ap.add_argument("--hint", default=""); ap.add_argument("--description", default="")
     ap.add_argument("--example-from", default="")
     ap.add_argument("--kind", default="kpi-chart", choices=["kpi-chart","table"])
-    ap.add_argument("--home", default=os.path.expanduser("~/.qlik-to-sigma"))
+    ap.add_argument("--home", default=os.path.expanduser("~/.powerbi-to-sigma"))
     ap.add_argument("--skill", default="", help="skill name for issue routing (default: derived from --home)")
+    ap.add_argument("--gap-id", default="", help="flagged DAX gap this scout addressed (gate ledger; e.g. dax:<warning[:80]>)")
+    ap.add_argument("--workdir", default="", help="conversion working dir; ledger written here")
     a = ap.parse_args()
 
     elem_name, cols = dm_element_master_columns(a.data_model_id, a.element_id)
@@ -146,6 +157,9 @@ def main():
         result["escalation"] = build_escalation(a, err)
     # cleanup test workbook
     api("DELETE", f"/v2/files/{wb}")
+    # record to the run-each-time gap-scout ledger (bead beads-sigma-5l5e) so the
+    # migrate-powerbi.rb OPEN-QUESTIONS gate sees this flagged DAX gap as scouted.
+    scout_gate.record(a.workdir, a.gap_id, a.feature, "validated" if status == "validated" else "escalated")
     print(json.dumps({**result,"status":status}, indent=2))
 
 if __name__ == "__main__":

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gap-scout.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gap-scout.md
@@ -44,6 +44,7 @@ INPUTS
 - Sigma data-model id: <dm-id>
 - Sigma denormalized element id: <element-id>   (the master that holds all fields)
 - Sigma folder id: <folder-id>
+- Gate id + workdir: <measure:... and --workdir from migrate-qlik.rb's GAP-SCOUT REQUIRED block>
 
 PROCEDURE
 1. Read refs/sigma-build-gotchas.md (function context rules: *Over window fns error in
@@ -60,7 +61,13 @@ PROCEDURE
        --hint '<post-publish caveat>' \
        --description '<one-line>' --example-from '<app/measure>' \
        --data-model-id <dm-id> --element-id <element-id> --folder-id <folder-id> \
-       --home ~/.qlik-to-sigma   [--kind table]   # default kpi-chart; use table for row-level/dimension formulas
+       --home ~/.qlik-to-sigma   [--kind table] \
+       --gap-id '<measure:... from the GAP-SCOUT REQUIRED list>' --workdir <migration workdir>
+   # --kind: default kpi-chart; use table for row-level/dimension formulas.
+   # --gap-id + --workdir feed the run-each-time gate (bead beads-sigma-5l5e): the
+   # result is recorded to <workdir>/scout-ledger.jsonl keyed by --gap-id, so
+   # migrate-qlik.rb's gate sees the measure as scouted and stops blocking it on
+   # the re-run. Pass the exact --gap-id/--workdir the GAP-SCOUT REQUIRED block printed.
 4. Parse the JSON:
    - status=validated → rule is now in the local YAML; done.
    - status=error     → try a different candidate (≤3 attempts). After the last

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/scout_gate.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/scout_gate.py
@@ -1,0 +1,64 @@
+"""Shared run-each-time gap-scout ledger (bead beads-sigma-5l5e) — Python side.
+
+Mirrors scout_gate.rb's contract exactly: a per-conversion JSONL ledger at
+<workdir>/scout-ledger.jsonl, one row per scouted gap:
+    {"gap_id": ..., "feature": ..., "status": "validated"|"escalated", "at": ...}
+
+Ruby orchestrators read it via scout_gate.rb#classify; Python scouts append to
+it via record() below. The JSONL format is the language-neutral contract.
+"""
+import json
+import os
+import datetime
+
+LEDGER = "scout-ledger.jsonl"
+
+
+def record(workdir, gap_id, feature, status):
+    """Append one scout result. Non-fatal on error (never crash a good scout)."""
+    if not workdir or not os.path.isdir(workdir):
+        return False
+    row = {
+        "gap_id": str(gap_id or feature),
+        "feature": str(feature),
+        "status": str(status),
+        "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    try:
+        with open(os.path.join(workdir, LEDGER), "a") as f:
+            f.write(json.dumps(row) + "\n")
+        return True
+    except OSError as e:
+        import sys
+        print("scout-ledger write failed (non-fatal): %s" % e, file=sys.stderr)
+        return False
+
+
+def read_ledger(workdir):
+    p = os.path.join(workdir or "", LEDGER)
+    if not os.path.exists(p):
+        return []
+    out = []
+    with open(p) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except ValueError:
+                pass
+    return out
+
+
+def classify(workdir, gap_ids):
+    """Split unhandled gap-ids into unscouted / escalated / validated buckets.
+    Mirrors scout_gate.rb#classify exactly (same JSONL ledger contract)."""
+    by = {}
+    for e in read_ledger(workdir):
+        by.setdefault(str(e.get("gap_id")), []).append(e)
+    unscouted = [g for g in gap_ids if str(g) not in by]
+    rest = [g for g in gap_ids if str(g) in by]
+    validated = [g for g in rest if any(x.get("status") == "validated" for x in by[str(g)])]
+    escalated = [g for g in rest if g not in validated]
+    return {"unscouted": unscouted, "escalated": escalated, "validated": validated}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/scout_gate.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/scout_gate.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+#
+# Shared "run-each-time gap-scout gate" (bead beads-sigma-5l5e).
+#
+# The guarantee: a migration may NOT proceed past its unhandled-feature gaps
+# unless the gap-scout actually ran for EVERY one — either it validated a Sigma
+# translation (`validated`) or it tried and could not (`escalated`). A blanket
+# --force must NOT skip the scout; it may only accept gaps the scout escalated.
+#
+# This module is the reusable core, identical across every migration plugin:
+#   - ScoutGate.record  — scout-validate-and-persist.rb appends one ledger row
+#   - ScoutGate.classify — the orchestrator reads the ledger and splits the
+#                          unhandled gaps into unscouted / escalated / validated
+# Each plugin maps its own gap representation to a list of stable gap-id strings
+# and calls classify; the gap-id naming is the plugin's business, the gate is not.
+#
+# Kept dependency-free (json/time only) so it can be vendored into any plugin's
+# scripts/lib/ unchanged.
+require 'json'
+require 'time'
+
+module ScoutGate
+  LEDGER = 'scout-ledger.jsonl'
+
+  def self.ledger_path(workdir)
+    File.join(workdir.to_s, LEDGER)
+  end
+
+  # Append one scout result to the per-conversion ledger. Non-fatal on error —
+  # a failed ledger write must never crash a scout that otherwise succeeded.
+  def self.record(workdir, gap_id:, feature:, status:)
+    return false unless workdir && Dir.exist?(workdir)
+    row = { 'gap_id' => (gap_id || feature).to_s, 'feature' => feature.to_s,
+            'status' => status.to_s, 'at' => Time.now.utc.iso8601 }
+    File.open(ledger_path(workdir), 'a') { |f| f.puts(JSON.generate(row)) }
+    true
+  rescue StandardError => e
+    warn "scout-ledger write failed (non-fatal): #{e.message}"
+    false
+  end
+
+  def self.read_ledger(workdir)
+    p = ledger_path(workdir)
+    return [] unless File.exist?(p)
+    File.readlines(p).map { |l| JSON.parse(l) rescue nil }.compact
+  end
+
+  # gap_ids: Array<String> — the unhandled gaps the scout was supposed to cover.
+  # Returns a Hash with three disjoint buckets of gap-ids:
+  #   :unscouted — no ledger row at all (the scout never ran) → hard STOP
+  #   :escalated — scouted, every row is 'escalated' (tried, unsolved) → --force
+  #   :validated — has at least one 'validated' row (solved locally)
+  def self.classify(workdir, gap_ids)
+    by = read_ledger(workdir).group_by { |e| e['gap_id'].to_s }
+    unscouted = gap_ids.reject { |id| by[id.to_s] }
+    rest      = gap_ids.select { |id| by[id.to_s] }
+    validated = rest.select { |id| by[id.to_s].any? { |x| x['status'] == 'validated' } }
+    escalated = rest - validated
+    { unscouted: unscouted, escalated: escalated, validated: validated }
+  end
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -56,6 +56,7 @@ require 'optparse'
 require 'fileutils'
 require 'open3'
 require 'time'
+require_relative 'lib/scout_gate'
 
 $stdout.sync = true # lane/foreground progress lines interleave correctly
 
@@ -465,6 +466,33 @@ end
 answers = nil
 if opts[:answers]
   answers = (JSON.parse(opts[:answers]) rescue abort('FATAL: --answers is not valid JSON'))
+end
+
+# RUN-EACH-TIME GAP-SCOUT GATE (bead beads-sigma-5l5e). Untranslated measures
+# are scout-eligible — the gap-scout must ATTEMPT a Sigma translation for each
+# before the degradation is accepted. --yes does NOT skip this; it only accepts
+# measures already scouted (validated or escalated). Recorded to the ledger by
+# scout-validate.py via lib/scout_gate.py.
+scout_gaps = questions.select { |q| q['id'] == 'measure_no_sigma_equiv' }
+unless scout_gaps.empty?
+  gid = ->(q) { 'measure:' + (q['measure'] || q['detail'].to_s.gsub(/\s+/, ' ').strip[0, 80]).to_s }
+  gap_ids = scout_gaps.map { |q| gid.call(q) }.uniq
+  buckets = ScoutGate.classify(WORK, gap_ids)
+  if buckets[:unscouted].any?
+    puts
+    puts '==================== GAP-SCOUT REQUIRED ===================='
+    puts "#{buckets[:unscouted].size} of #{gap_ids.size} untranslated measure(s) have NOT been scouted —"
+    puts 'the gap-scout must attempt a Sigma translation before the degradation is accepted:'
+    buckets[:unscouted].each { |id| puts "  --gap-id '#{id}'" }
+    puts ''
+    puts "Spawn one gap-scout per measure (scripts/gap-scout.md), passing the exact --gap-id above"
+    puts "plus --workdir #{WORK}, then re-run. --yes does NOT skip this gate."
+    puts '======================================================='
+    puts 'No Sigma objects were created.'
+    phase_summary
+    exit 11
+  end
+  puts "   gap-scout: all #{gap_ids.size} untranslated measure(s) accounted for (validated or escalated)"
 end
 
 if questions.any? && !opts[:yes] && answers.nil?

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/scout-validate.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/scout-validate.py
@@ -17,6 +17,8 @@ Env: SIGMA_BASE_URL, SIGMA_API_TOKEN (eval get-token.sh first).
 Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the test workbook.
 """
 import json, os, sys, urllib.request, argparse, datetime, re
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import scout_gate
 
 BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
 def api(method, path, body=None, accept_json=True):
@@ -89,6 +91,9 @@ def main():
     ap.add_argument("--kind", default="kpi-chart", choices=["kpi-chart","table"])
     ap.add_argument("--home", default=os.path.expanduser("~/.qlik-to-sigma"))
     ap.add_argument("--skill", default="", help="skill name for issue routing (default: derived from --home)")
+    # Run-each-time gate (bead 5l5e): record this scout to the per-conversion ledger.
+    ap.add_argument("--gap-id", default="", help="the gap-report row this scout addressed (for the gate ledger)")
+    ap.add_argument("--workdir", default="", help="conversion working dir; ledger written here")
     a = ap.parse_args()
 
     elem_name, cols = dm_element_master_columns(a.data_model_id, a.element_id)
@@ -146,6 +151,8 @@ def main():
         result["escalation"] = build_escalation(a, err)
     # cleanup test workbook
     api("DELETE", f"/v2/files/{wb}")
+    # run-each-time gate ledger (bead 5l5e): 'error' → 'escalated' for the ledger.
+    scout_gate.record(a.workdir, a.gap_id, a.feature, "validated" if status == "validated" else "escalated")
     print(json.dumps({**result,"status":status}, indent=2))
 
 if __name__ == "__main__":

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/gap-scout.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/gap-scout.md
@@ -53,7 +53,14 @@ PROCEDURE
      --folder-id <folder-id> \
      --description '<one-line>' \
      --hint '<post-publish caveat, e.g., "non-grouping context only">' \
-     --example-from '<which analysis/field>'
+     --example-from '<which analysis/field>' \
+     --gap-id '<the EXACT --gap-id printed by the GAP-SCOUT REQUIRED gate>' \
+     --workdir '<the conversion working dir printed by the gate>'
+   ⚠ `--gap-id` + `--workdir` are REQUIRED for the run-each-time gate (bead
+   5l5e): they record this scout to `<workdir>/scout-ledger.jsonl` so
+   migrate-quicksight can confirm EVERY degraded calc was scouted before it
+   proceeds. Copy the `--gap-id` value verbatim from the gate output; omitting
+   them means the gate will still see the calc as unscouted and stop again.
 4. Parse the JSON result.
    - status=validated → success; rule is now in the customer's local YAML
    - status=escalated → propose a different candidate (up to 3 attempts). After

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/scout_gate.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/scout_gate.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+#
+# Shared "run-each-time gap-scout gate" (bead beads-sigma-5l5e).
+#
+# The guarantee: a migration may NOT proceed past its unhandled-feature gaps
+# unless the gap-scout actually ran for EVERY one — either it validated a Sigma
+# translation (`validated`) or it tried and could not (`escalated`). A blanket
+# --force must NOT skip the scout; it may only accept gaps the scout escalated.
+#
+# This module is the reusable core, identical across every migration plugin:
+#   - ScoutGate.record  — scout-validate-and-persist.rb appends one ledger row
+#   - ScoutGate.classify — the orchestrator reads the ledger and splits the
+#                          unhandled gaps into unscouted / escalated / validated
+# Each plugin maps its own gap representation to a list of stable gap-id strings
+# and calls classify; the gap-id naming is the plugin's business, the gate is not.
+#
+# Kept dependency-free (json/time only) so it can be vendored into any plugin's
+# scripts/lib/ unchanged.
+require 'json'
+require 'time'
+
+module ScoutGate
+  LEDGER = 'scout-ledger.jsonl'
+
+  def self.ledger_path(workdir)
+    File.join(workdir.to_s, LEDGER)
+  end
+
+  # Append one scout result to the per-conversion ledger. Non-fatal on error —
+  # a failed ledger write must never crash a scout that otherwise succeeded.
+  def self.record(workdir, gap_id:, feature:, status:)
+    return false unless workdir && Dir.exist?(workdir)
+    row = { 'gap_id' => (gap_id || feature).to_s, 'feature' => feature.to_s,
+            'status' => status.to_s, 'at' => Time.now.utc.iso8601 }
+    File.open(ledger_path(workdir), 'a') { |f| f.puts(JSON.generate(row)) }
+    true
+  rescue StandardError => e
+    warn "scout-ledger write failed (non-fatal): #{e.message}"
+    false
+  end
+
+  def self.read_ledger(workdir)
+    p = ledger_path(workdir)
+    return [] unless File.exist?(p)
+    File.readlines(p).map { |l| JSON.parse(l) rescue nil }.compact
+  end
+
+  # gap_ids: Array<String> — the unhandled gaps the scout was supposed to cover.
+  # Returns a Hash with three disjoint buckets of gap-ids:
+  #   :unscouted — no ledger row at all (the scout never ran) → hard STOP
+  #   :escalated — scouted, every row is 'escalated' (tried, unsolved) → --force
+  #   :validated — has at least one 'validated' row (solved locally)
+  def self.classify(workdir, gap_ids)
+    by = read_ledger(workdir).group_by { |e| e['gap_id'].to_s }
+    unscouted = gap_ids.reject { |id| by[id.to_s] }
+    rest      = gap_ids.select { |id| by[id.to_s] }
+    validated = rest.select { |id| by[id.to_s].any? { |x| x['status'] == 'validated' } }
+    escalated = rest - validated
+    { unscouted: unscouted, escalated: escalated, validated: validated }
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
@@ -48,6 +48,7 @@ require 'json'
 require 'optparse'
 require 'fileutils'
 require 'open3'
+require_relative 'lib/scout_gate'
 
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
@@ -289,6 +290,32 @@ unless opts[:folder]
   questions << { 'id' => 'folder', 'severity' => 'required',
                  'detail' => 'No Sigma --folder supplied; DM + workbook will land in My Documents',
                  'options' => ['supply --folder <id>', 'proceed into My Documents'], 'default' => 'proceed into My Documents' }
+end
+
+# RUN-EACH-TIME GAP-SCOUT GATE (bead beads-sigma-5l5e). Degraded calcs are
+# scout-eligible — the gap-scout must ATTEMPT a Sigma translation for each
+# before we accept the Null degradation. --yes does NOT skip this; it only
+# accepts calcs the scout already tried (validated locally, or escalated). The
+# scout records each to <WORK>/scout-ledger.jsonl via scout-validate-and-persist.
+calc_gaps = questions.select { |q| q['id'] == 'calc_degraded' }
+unless calc_gaps.empty?
+  gid = ->(q) { "calc:" + q['detail'].to_s.gsub(/\s+/, ' ').strip[0, 80] }
+  gap_ids = calc_gaps.map { |q| gid.call(q) }.uniq
+  buckets = ScoutGate.classify(WORK, gap_ids)
+  if buckets[:unscouted].any?
+    puts
+    puts '==================== GAP-SCOUT REQUIRED ===================='
+    puts "#{buckets[:unscouted].size} of #{gap_ids.size} degraded calc(s) have NOT been scouted —"
+    puts 'the gap-scout must attempt a Sigma translation before the degradation is accepted:'
+    buckets[:unscouted].each { |id| puts "  --gap-id '#{id}'" }
+    puts ''
+    puts "Spawn one gap-scout per calc (scripts/gap-scout.md), passing the exact --gap-id above"
+    puts "plus --workdir #{WORK}, then re-run. --yes does NOT skip this gate."
+    puts '======================================================='
+    puts 'No Sigma objects were created.'
+    exit 11
+  end
+  puts "   gap-scout: all #{gap_ids.size} degraded calc(s) accounted for (validated or escalated)"
 end
 
 answers = nil

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/scout-validate-and-persist.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/scout-validate-and-persist.rb
@@ -42,6 +42,7 @@ require 'open3'
 require 'shellwords'
 require 'time'
 require_relative 'learned-rules'
+require_relative 'lib/scout_gate'
 
 opts = { max_attempts: 1 }
 OptionParser.new do |p|
@@ -57,9 +58,16 @@ OptionParser.new do |p|
   p.on('--example-from S')         { |v| opts[:example_from] = v }
   p.on('--max-attempts N', Integer){ |v| opts[:max_attempts] = v }
   p.on('--chart-kind S')           { |v| opts[:chart_kind] = v }
+  # Run-each-time gate (bead 5l5e) — see scout_gate.rb.
+  p.on('--gap-id S')               { |v| opts[:gap_id] = v }
+  p.on('--workdir S')              { |v| opts[:workdir] = v }
 end.parse!
 
 %i[feature pattern template test_formula dm_id el_id].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+
+def record_ledger(opts, status)
+  ScoutGate.record(opts[:workdir], gap_id: opts[:gap_id], feature: opts[:feature], status: status)
+end
 
 VALIDATE = File.join(__dir__, 'validate-sigma-formula.rb')
 
@@ -94,6 +102,7 @@ if result['status'] == 'ok'
     'confidence'         => 'validated'
   }
   path = LearnedRules.append(rule)
+  record_ledger(opts, 'validated')
   puts JSON.pretty_generate({
     'status'      => 'validated',
     'rule_path'   => path,
@@ -114,6 +123,7 @@ else
     'escalated_at'    => Time.now.utc.iso8601
   }
   esc_path = LearnedRules.escalate(payload)
+  record_ledger(opts, 'escalated')
 
   # Opt-in escalation (NOT automatic). We record the gap locally and hand the
   # main agent a ready-to-run command for the shared filer. The agent shows the

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -349,6 +349,34 @@ def parse_fixed_lod(formula, columns_by_guid = {})
   { 'dims' => dims, 'agg' => m[2].upcase, 'measure' => meas }
 end
 
+# Parse a RELATIVE LOD — {INCLUDE [dims]: AGG([m])} or {EXCLUDE [dims]: AGG([m])}
+# — which (unlike FIXED) is evaluated relative to the chart's VIEW grain. Returns
+# { 'type'=>'INCLUDE'|'EXCLUDE', 'dims'=>[...], 'agg'=>'SUM'|..., 'measure'=>name }.
+# Supports multiple dims and the full agg set (the WOW case is a multi-dim
+# EXCLUDE MAX). The caller composes grain from the chart's plotted dims.
+def parse_relative_lod(formula, columns_by_guid = {})
+  s = formula.to_s.gsub(/\s+/, ' ').strip
+  m = s.match(/\A\{\s*(INCLUDE|EXCLUDE)\s+(\[[^\]]+\](?:\s*,\s*\[[^\]]+\])*)\s*:\s*(SUM|AVG|MIN|MAX|MEDIAN|COUNTD|COUNT)\s*\(\s*\[([^\]]+)\]\s*\)\s*\}\z/i)
+  return nil unless m
+  resolve = lambda do |ref|
+    if ref =~ /\A[0-9a-f\-]{36}\z/i
+      info = columns_by_guid[ref]
+      info && info['caption'] && info['caption'].strip
+    else
+      ref.strip
+    end
+  end
+  dims = m[2].scan(/\[([^\]]+)\]/).flatten.map { |d| resolve.call(d) }
+  meas = resolve.call(m[4])
+  return nil if dims.empty? || dims.any?(&:nil?) || meas.nil?
+  { 'type' => m[1].upcase, 'dims' => dims, 'agg' => m[3].upcase, 'measure' => meas }
+end
+
+# Aggregations where agg-of-agg == agg, so a two-level grouped helper reproduces
+# the relative-LOD value exactly (Max of per-group Maxes = global Max, etc.).
+# AVG / MEDIAN / COUNTD are NOT composable this way — those stay flagged.
+LOD_COMPOSABLE_AGGS = %w[SUM MAX MIN COUNT].freeze
+
 # Strip the aggregation/date-part prefix off a Tableau CSV header so it can be
 # matched against a worksheet calc name ("Avg. Customer LTV LOD" -> "Customer
 # LTV LOD"). Mirrors auto-parity-plan's header_base.
@@ -661,8 +689,13 @@ def translate_tableau_tc(formula)
   # Tableau bounds are (first, last) offsets; Sigma Moving* takes (back[, fwd])
   # as POSITIVE counts. Forward-only / shifted windows (first > 0 or last < 0)
   # and FIRST()/LAST() bounds have no validated mapping — leave untouched.
+  # NOTE: 'STDEV'/'VAR' here are the SAMPLE variants — Tableau WINDOW_STDEV /
+  # WINDOW_VAR map to Sigma MovingStdDev / MovingVariance. The population forms
+  # WINDOW_STDEVP / WINDOW_VARP stay manual (no `\bWINDOW_VAR\s*\(` match on
+  # "WINDOW_VARP(" — the P breaks the word boundary, so they fall through).
   { 'AVG' => 'MovingAvg', 'SUM' => 'MovingSum', 'MAX' => 'MovingMax',
-    'MIN' => 'MovingMin', 'COUNT' => 'MovingCount', 'STDEV' => 'MovingStdDev' }.each do |tfn, sfn|
+    'MIN' => 'MovingMin', 'COUNT' => 'MovingCount',
+    'STDEV' => 'MovingStdDev', 'VAR' => 'MovingVariance' }.each do |tfn, sfn|
     while (m = s.match(/\bWINDOW_#{tfn}\s*\(\s*((?:[^(),]|\([^()]*\)|\([^()]*\([^()]*\)[^()]*\))+?)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*\)/))
       lo, hi = m[2].to_i, m[3].to_i
       break if lo > 0 || hi < 0 # shifted window — unvalidated, keep Tableau form
@@ -835,14 +868,21 @@ def translate_tableau_tc(formula)
     hints << "FIXED-no-dim LOD → workbook scalar metric #{sigma_agg}([Master/#{m}]) (no group by)"
     changed = true
   end
-  if s =~ /\{\s*INCLUDE\s+\[([^\]]+)\]\s*:\s*(SUM|AVG)\s*\(\[([^\]]+)\]\)\s*\}/i
-    dim, agg, m = $1, $2.upcase, $3
-    hints << "INCLUDE LOD on [#{dim}] → add [Master/#{dim}] to chart grouping, use plain #{agg}([Master/#{m}])"
+  if (mi = s.match(/\{\s*INCLUDE\s+((?:\[[^\]]+\]\s*,?\s*)+):\s*(SUM|AVG|MIN|MAX|MEDIAN|COUNTD|COUNT)\s*\(\[([^\]]+)\]\)\s*\}/i))
+    dims, agg = mi[1].scan(/\[([^\]]+)\]/).flatten.join(', '), mi[2].upcase
+    hints << "INCLUDE LOD on [#{dims}] → AUTO-BUILT as a hidden grouped helper when plotted as a chart measure " \
+             "(inner = INCLUDE dims below the view, 2nd-stage agg at view grain); elsewhere add [#{dims}] to the grouping"
     changed = true
   end
-  if s =~ /\{\s*EXCLUDE\s+\[([^\]]+)\]\s*:\s*(SUM|AVG)\s*\(\[([^\]]+)\]\)\s*\}/i
-    dim, agg, m = $1, $2.upcase, $3
-    hints << "EXCLUDE LOD on [#{dim}] → remove [Master/#{dim}] from chart grouping, use plain #{agg}([Master/#{m}])"
+  if (me = s.match(/\{\s*EXCLUDE\s+((?:\[[^\]]+\]\s*,?\s*)+):\s*(SUM|AVG|MIN|MAX|MEDIAN|COUNTD|COUNT)\s*\(\[([^\]]+)\]\)\s*\}/i))
+    dims, agg = me[1].scan(/\[([^\]]+)\]/).flatten.join(', '), me[2].upcase
+    composable = %w[SUM MAX MIN COUNT].include?(agg)
+    hints << if composable
+               "EXCLUDE LOD on [#{dims}] (#{agg}) → AUTO-BUILT as a hidden grouped helper when plotted (value at " \
+               'view minus the excluded dims, broadcast); composable agg, exact'
+             else
+               "EXCLUDE LOD on [#{dims}] uses #{agg} (not composable as agg-of-agg) → STAYS MANUAL: re-author at the coarser grain"
+             end
     changed = true
   end
 
@@ -884,17 +924,20 @@ end
 # 'Unknown function' in every spec context — never emit those.
 #
 # STAYS MANUAL (flagged, never guessed): WINDOW_MEDIAN / WINDOW_PERCENTILE /
-# WINDOW_CORR / WINDOW_COVAR(P) / WINDOW_VAR(P) / WINDOW_STDEVP,
-# PREVIOUS_VALUE, SIZE(), FIRST()/LAST(), RANK_UNIQUE / RANK_MODIFIED, and any
+# WINDOW_CORR / WINDOW_COVAR(P) / WINDOW_VARP (population) / WINDOW_STDEVP,
+# PREVIOUS_VALUE, SIZE(), FIRST()/LAST(), RANK_MODIFIED, and any
 # compute-using/addressing override beyond the default Table(Across) / simple
 # partition ("restart every", pane-relative, compute-along-non-axis-dim).
+# NOW MAPPED (2026-06-18): RANK_UNIQUE→RowNumber (sort-following, like INDEX),
+# WINDOW_VAR (sample)→MovingVariance — Sigma shipped MovingVariance; the
+# population variant WINDOW_VARP has no validated Sigma window fn, stays manual.
 WINDOW_SIGMA_FNS = %w[
   CumulativeSum CumulativeAvg CumulativeMax CumulativeMin CumulativeCount
-  MovingAvg MovingSum MovingMax MovingMin MovingCount MovingStdDev
+  MovingAvg MovingSum MovingMax MovingMin MovingCount MovingStdDev MovingVariance
   Rank RankDense RankPercentile RowNumber Lag Lead PercentOfTotal
 ].freeze
 
-WINDOW_MANUAL_RE = /\b(?:WINDOW_(?:MEDIAN|PERCENTILE|CORR|COVARP?|VARP?|STDEVP)|PREVIOUS_VALUE|RANK_(?:UNIQUE|MODIFIED))\s*\(|\b(?:SIZE|FIRST|LAST)\s*\(\s*\)/i
+WINDOW_MANUAL_RE = /\b(?:WINDOW_(?:MEDIAN|PERCENTILE|CORR|COVARP?|VARP|STDEVP)|PREVIOUS_VALUE|RANK_MODIFIED)\s*\(|\b(?:SIZE|FIRST|LAST)\s*\(\s*\)/i
 
 # Case-SENSITIVE on purpose: .twb formulas carry canonical UPPERCASE Tableau
 # function names, and the post-rewrite leftover check must not match the
@@ -2044,6 +2087,63 @@ layout.each do |dash|
                     "#{lod_parse['agg']}(#{lod_parse['measure']})}) — auto-built hidden grouped helper '#{src_name}' " \
                     "(inner grain = FIXED dims, 2nd-stage #{stage2} at chart grain) ⚠ exact iff the chart dims are " \
                     'functionally dependent on the FIXED dims — verify in Sigma'
+      elsif (rel = lod_calc && parse_relative_lod(lod_calc['formula'], meta['columns_by_guid'] || {}))
+        # INCLUDE / EXCLUDE LOD — relative to the chart's VIEW grain.
+        map_name = ->(capn) { (mm = map_column(capn, mmap)) ? mm['name'] : capn }
+        rel_meas  = map_name.call(rel['measure'])
+        value_name = header_base(meas_hdr)
+        view_dims = [{ 'name' => dim['name'], 'formula' => dim_formula }]
+        view_dims << { 'name' => color_col_obj['name'], 'formula' => color_col_obj['formula'] } if color_col_obj
+        value_formula = render_agg(LOD_INNER_AGG[rel['agg']], "[Master/#{rel_meas}]")
+        if rel['type'] == 'INCLUDE'
+          # INCLUDE adds dims BELOW the view: inner = INCLUDE dims (nested under
+          # the view), outer = view dims, 2nd stage = the view's aggregation.
+          inner_keys = rel['dims'].map { |d| n = map_name.call(d); { 'name' => n, 'formula' => "[Master/#{n}]" } }
+          stage2 = (SIGMA_AGG[agg_label] unless %w[None User].include?(agg_label.to_s)) || 'Avg'
+          helper, src_name, s2_name = build_two_stage_helper(
+            el_id: el_id, master_id: opts[:master_id], value_name: value_name,
+            value_formula: value_formula, inner_keys: inner_keys,
+            outer_dims: view_dims, stage2_agg: stage2)
+          data_elements << helper
+          chart_source_eid = helper['id']
+          dim_col_obj['formula'] = "[#{src_name}/#{dim['name']}]"
+          color_col_obj['formula'] = "[#{src_name}/#{color_col_obj['name']}]" if color_col_obj
+          measure_formula = "Max([#{src_name}/#{s2_name}])"
+          warnings << "'#{cap}' measure '#{meas_hdr}' is an INCLUDE LOD ({INCLUDE #{rel['dims'].join(', ')} : " \
+                      "#{rel['agg']}(#{rel['measure']})}) — auto-built hidden grouped helper '#{src_name}' " \
+                      "(inner = INCLUDE dims below the view, 2nd-stage #{stage2} at view grain) ⚠ verify in Sigma"
+        else
+          # EXCLUDE removes dims from the view → value at (view − excluded),
+          # broadcast across the excluded dims. Exact only for composable aggs
+          # (SUM/MAX/MIN/COUNT, where agg-of-agg == agg).
+          present = view_dims.select { |d| rel['dims'].map { |x| map_name.call(x) }.include?(d['name']) }
+          if !LOD_COMPOSABLE_AGGS.include?(rel['agg'])
+            warnings << "'#{cap}' EXCLUDE LOD uses #{rel['agg']} (not composable as agg-of-agg) — STAYS MANUAL: " \
+                        're-author at the coarser grain in Sigma'
+          elsif present.empty?
+            # the excluded dims aren't plotted here → EXCLUDE reduces to a plain
+            # aggregate at the view grain.
+            measure_formula = value_formula
+            warnings << "'#{cap}' EXCLUDE LOD on [#{rel['dims'].join(', ')}] — none of those dims are in this view, " \
+                        "so it reduces to #{rel['agg']}(#{rel['measure']}) at view grain"
+          else
+            outer_dims = view_dims.reject { |d| present.any? { |p| p['name'] == d['name'] } }
+            inner_keys = present.map { |d| { 'name' => d['name'], 'formula' => "[Master/#{d['name']}]" } }
+            stage2 = { 'SUM' => 'Sum', 'MAX' => 'Max', 'MIN' => 'Min', 'COUNT' => 'Sum' }[rel['agg']]
+            helper, src_name, s2_name = build_two_stage_helper(
+              el_id: el_id, master_id: opts[:master_id], value_name: value_name,
+              value_formula: value_formula, inner_keys: inner_keys,
+              outer_dims: outer_dims, stage2_agg: stage2)
+            data_elements << helper
+            chart_source_eid = helper['id']
+            dim_col_obj['formula'] = "[#{src_name}/#{dim['name']}]"
+            color_col_obj['formula'] = "[#{src_name}/#{color_col_obj['name']}]" if color_col_obj
+            measure_formula = "Max([#{src_name}/#{s2_name}])"
+            warnings << "'#{cap}' measure '#{meas_hdr}' is an EXCLUDE LOD ({EXCLUDE #{rel['dims'].join(', ')} : " \
+                        "#{rel['agg']}(#{rel['measure']})}) — auto-built hidden grouped helper '#{src_name}' " \
+                        "(value at view minus [#{rel['dims'].join(', ')}], broadcast via #{stage2}) ⚠ verify in Sigma"
+          end
+        end
       elsif sigma_agg == 'Avg' && meas['grain'] &&
             dim['formula'].nil? && dim_trunc.nil? && (aliases_for_dim.nil? || aliases_for_dim.empty?) &&
             dim['grain'] && dim['grain']['element'] == meas['grain']['element'] &&

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/gap-scout.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/gap-scout.md
@@ -55,7 +55,16 @@ PROCEDURE
      --folder-id <folder-id> \
      --description '<one-line>' \
      --hint '<post-publish caveat, e.g., "non-grouping context only">' \
-     --example-from '<which workbook/line>'
+     --example-from '<which workbook/line>' \
+     --gap-id '<the gap-report ROW NAME you are addressing>' \
+     --workdir '<the conversion working dir, e.g. /tmp/<name> — printed in the GAP-SCAN STOP>'
+   ⚠ `--gap-id` + `--workdir` are REQUIRED for the run-each-time gate (bead
+   5l5e). They record this scout to `<workdir>/scout-ledger.jsonl` so
+   migrate-tableau can confirm EVERY unhandled gap was scouted before it
+   proceeds. The gap-id must match the gap-report row name exactly (e.g.
+   "Window calcs with NO validated Sigma mapping"), NOT the function-level
+   --feature. Omitting them means the gate will still see the gap as unscouted
+   and stop again.
 4. Parse the JSON result.
    - status=validated  → success; rule is now in the customer's local YAML
    - status=escalated  → propose a different candidate (up to 3 attempts).

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/scout_gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/scout_gate.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+#
+# Shared "run-each-time gap-scout gate" (bead beads-sigma-5l5e).
+#
+# The guarantee: a migration may NOT proceed past its unhandled-feature gaps
+# unless the gap-scout actually ran for EVERY one — either it validated a Sigma
+# translation (`validated`) or it tried and could not (`escalated`). A blanket
+# --force must NOT skip the scout; it may only accept gaps the scout escalated.
+#
+# This module is the reusable core, identical across every migration plugin:
+#   - ScoutGate.record  — scout-validate-and-persist.rb appends one ledger row
+#   - ScoutGate.classify — the orchestrator reads the ledger and splits the
+#                          unhandled gaps into unscouted / escalated / validated
+# Each plugin maps its own gap representation to a list of stable gap-id strings
+# and calls classify; the gap-id naming is the plugin's business, the gate is not.
+#
+# Kept dependency-free (json/time only) so it can be vendored into any plugin's
+# scripts/lib/ unchanged.
+require 'json'
+require 'time'
+
+module ScoutGate
+  LEDGER = 'scout-ledger.jsonl'
+
+  def self.ledger_path(workdir)
+    File.join(workdir.to_s, LEDGER)
+  end
+
+  # Append one scout result to the per-conversion ledger. Non-fatal on error —
+  # a failed ledger write must never crash a scout that otherwise succeeded.
+  def self.record(workdir, gap_id:, feature:, status:)
+    return false unless workdir && Dir.exist?(workdir)
+    row = { 'gap_id' => (gap_id || feature).to_s, 'feature' => feature.to_s,
+            'status' => status.to_s, 'at' => Time.now.utc.iso8601 }
+    File.open(ledger_path(workdir), 'a') { |f| f.puts(JSON.generate(row)) }
+    true
+  rescue StandardError => e
+    warn "scout-ledger write failed (non-fatal): #{e.message}"
+    false
+  end
+
+  def self.read_ledger(workdir)
+    p = ledger_path(workdir)
+    return [] unless File.exist?(p)
+    File.readlines(p).map { |l| JSON.parse(l) rescue nil }.compact
+  end
+
+  # gap_ids: Array<String> — the unhandled gaps the scout was supposed to cover.
+  # Returns a Hash with three disjoint buckets of gap-ids:
+  #   :unscouted — no ledger row at all (the scout never ran) → hard STOP
+  #   :escalated — scouted, every row is 'escalated' (tried, unsolved) → --force
+  #   :validated — has at least one 'validated' row (solved locally)
+  def self.classify(workdir, gap_ids)
+    by = read_ledger(workdir).group_by { |e| e['gap_id'].to_s }
+    unscouted = gap_ids.reject { |id| by[id.to_s] }
+    rest      = gap_ids.select { |id| by[id.to_s] }
+    validated = rest.select { |id| by[id.to_s].any? { |x| x['status'] == 'validated' } }
+    escalated = rest - validated
+    { unscouted: unscouted, escalated: escalated, validated: validated }
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -76,6 +76,7 @@ require 'fileutils'
 require 'open3'
 require 'date'
 require 'time'
+require_relative 'lib/scout_gate'
 
 $stdout.sync = true # progress lines interleave correctly when piped/captured
 
@@ -761,23 +762,55 @@ end
 # degradation explicitly via --force. (auto/hint/manual statuses flow into the
 # decisions checkpoint below instead.)
 unhandled_gaps = gaps.select { |g| g['status'].to_s == 'unhandled' }
-if unhandled_gaps.any? && !opts[:force]
-  puts
-  puts '==================== GAP-SCAN STOP ===================='
-  puts "#{unhandled_gaps.size} ❌-unhandled feature(s) detected — these do NOT migrate:"
-  unhandled_gaps.each { |g| puts "  - #{g['name']} (×#{g['count']}): #{g['blurb']}" }
-  puts ''
-  puts "Full report: #{gap_report_md || '(see workdir *gaps-report.md)'}"
-  puts 'Options: close the gap via the gap-scout subagent (scripts/gap-scout.md),'
-  puts 'restructure the workbook in Tableau, or re-run with --force to accept the'
-  puts 'degradation (the features above will be missing from the Sigma workbook).'
-  puts '======================================================='
-  puts 'No Sigma objects were created.'
-  mark('phase1-join')
-  phase_summary
-  exit 11
-elsif unhandled_gaps.any?
-  line "--force: proceeding past #{unhandled_gaps.size} ❌-unhandled feature(s) — they will NOT migrate"
+if unhandled_gaps.any?
+  # RUN-EACH-TIME GATE (bead 5l5e): the gap-scout must have run for EVERY
+  # ❌-unhandled feature before the conversion proceeds. scout-validate-and-
+  # persist.rb records each scouted gap to <WORK>/scout-ledger.jsonl as
+  # {gap_id, status: validated|escalated}. --force is NOT a blanket skip: it
+  # only accepts gaps the scout actually tried and escalated — never a gap the
+  # scout never ran for.
+  # Gap-id = the gap-report row name; the scout records under --gap-id '<name>'.
+  by_name = unhandled_gaps.each_with_object({}) { |g, h| h[g['name'].to_s] = g }
+  buckets = ScoutGate.classify(WORK, unhandled_gaps.map { |g| g['name'].to_s })
+  unscouted = buckets[:unscouted].map { |id| by_name[id] }
+  escalated = buckets[:escalated].map { |id| by_name[id] }
+
+  if unscouted.any?
+    puts
+    puts '==================== GAP-SCAN STOP (scout required) ===================='
+    puts "#{unscouted.size} of #{unhandled_gaps.size} ❌-unhandled feature(s) have NOT been scouted:"
+    unscouted.each { |g| puts "  - #{g['name']} (×#{g['count']}): #{g['blurb']}" }
+    puts ''
+    puts "Full report: #{gap_report_md || '(see workdir *gaps-report.md)'}"
+    puts 'Spawn ONE gap-scout subagent per row (scripts/gap-scout.md), passing'
+    puts "  --gap-id '<the row name above>' --workdir #{WORK}"
+    puts 'so each scout records its result to the ledger. Then re-run this command.'
+    puts '--force does NOT skip this gate — it only accepts gaps the scout tried'
+    puts 'and could not auto-translate (escalated).'
+    puts '======================================================='
+    puts 'No Sigma objects were created.'
+    mark('phase1-join')
+    phase_summary
+    exit 11
+  elsif escalated.any? && !opts[:force]
+    puts
+    puts '==================== GAP-SCAN STOP (escalated gaps) ===================='
+    puts "All #{unhandled_gaps.size} unhandled feature(s) were scouted; #{escalated.size} could NOT be"
+    puts 'auto-translated and were escalated (recorded locally; file an issue via escalate-gap.py):'
+    escalated.each { |g| puts "  - #{g['name']} (×#{g['count']})" }
+    puts ''
+    puts 'Re-run with --force to accept these as manual — they will be MISSING/flagged'
+    puts 'in the Sigma workbook. (The validated ones still migrate.)'
+    puts '======================================================='
+    puts 'No Sigma objects were created.'
+    mark('phase1-join')
+    phase_summary
+    exit 11
+  elsif escalated.any?
+    line "--force: proceeding past #{escalated.size} scouted-but-escalated feature(s) — they will NOT migrate"
+  else
+    line "gap-scout: all #{unhandled_gaps.size} ❌-unhandled feature(s) resolved via validated rules"
+  end
 end
 
 # EMPTY-VIEW-CSV preflight (honesty stop): a view whose CSV exported 0 data rows

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scout-validate-and-persist.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scout-validate-and-persist.rb
@@ -42,6 +42,7 @@ require 'open3'
 require 'shellwords'
 require 'time'
 require_relative 'learned-rules'
+require_relative 'lib/scout_gate'
 
 opts = { max_attempts: 1 }
 OptionParser.new do |p|
@@ -57,9 +58,20 @@ OptionParser.new do |p|
   p.on('--example-from S')         { |v| opts[:example_from] = v }
   p.on('--max-attempts N', Integer){ |v| opts[:max_attempts] = v }
   p.on('--chart-kind S')           { |v| opts[:chart_kind] = v }
+  # Run-each-time gate (bead 5l5e): record this scout in a per-conversion
+  # ledger so the orchestrator can prove the scout ran for EVERY unhandled gap
+  # before it proceeds. --gap-id is the gap-report row this scout addressed
+  # (NOT the function-level --feature); --workdir is the conversion working dir.
+  p.on('--gap-id S')               { |v| opts[:gap_id] = v }
+  p.on('--workdir S')              { |v| opts[:workdir] = v }
 end.parse!
 
 %i[feature pattern template test_formula dm_id el_id].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+
+# Append a row to the per-conversion scout ledger via the shared gate module.
+def record_ledger(opts, status)
+  ScoutGate.record(opts[:workdir], gap_id: opts[:gap_id], feature: opts[:feature], status: status)
+end
 
 VALIDATE = File.join(__dir__, 'validate-sigma-formula.rb')
 
@@ -94,6 +106,7 @@ if result['status'] == 'ok'
     'confidence'         => 'validated'
   }
   path = LearnedRules.append(rule)
+  record_ledger(opts, 'validated')
   puts JSON.pretty_generate({
     'status'      => 'validated',
     'rule_path'   => path,
@@ -114,6 +127,7 @@ else
     'escalated_at'    => Time.now.utc.iso8601
   }
   esc_path = LearnedRules.escalate(payload)
+  record_ledger(opts, 'escalated')
 
   # Opt-in escalation (NOT automatic). We record the gap locally and hand the
   # main agent a ready-to-run command for the shared filer. The agent shows the

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/gap-scout.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/gap-scout.md
@@ -44,6 +44,7 @@ INPUTS
 - TML function/pattern: <e.g. "add_days">
 - Sample expressions: <2-5 real examples from the model's formulas>
 - Sigma data-model id: <dm-id> ; denormalized element id: <denorm-elem-id> ; folder: <id>
+- Gate id + workdir: <errcol:... and --workdir from migrate.py's GAP-SCOUT REQUIRED block>
 
 DO
 1. Propose a Sigma formula (see the candidate table in gap-scout.md).
@@ -51,13 +52,30 @@ DO
    python3 scripts/scout-validate.py --formula '<sigma>' \
      --data-model-id <dm> --element-id <denorm> --folder-id <folder> \
      --feature '<fn>' --pattern '<regex>' --template '<sigma template>' \
-     --description '<fn> -> Sigma' --home ~/.thoughtspot-to-sigma
+     --description '<fn> -> Sigma' --home ~/.thoughtspot-to-sigma \
+     --gap-id '<errcol:... from the GAP-SCOUT REQUIRED list>' --workdir <migration workdir>
 3. If status=validated it's persisted; report the rule. If error, try another form
    (≤4 attempts). After the last failed attempt the result carries an
    `escalation.dry_run_cmd` / `escalation.file_cmd`; report it as genuine-(c)
    needing redesign. Do NOT file anything yourself — see "Opt-in issue filing".
 ```
 Validated rules auto-apply on the next migrate via `learned-rules.py`.
+
+## Run-each-time gate (bead beads-sigma-5l5e) — why `--gap-id` + `--workdir` matter
+
+The TML converter passes calc expressions through optimistically — a function with no
+Sigma equivalent does NOT surface as a convert-time warning; it surfaces as a
+**type=error column** when `migrate.py` reads the freshly-POSTed workbook back. At that
+point `migrate.py` **STOPS** (exit 11) with a `GAP-SCOUT REQUIRED` block listing each
+unscouted error column's `--gap-id` (`errcol:<elementId>/<label>`) and the `--workdir`.
+
+`scout-validate.py` appends its result (`validated` or `escalated`) to
+`<workdir>/scout-ledger.jsonl` keyed by that exact `--gap-id`. So you MUST pass the
+`--gap-id` and `--workdir` the STOP block printed — otherwise the ledger entry won't
+match the error column and the re-run will STOP again. The gate cannot be skipped with
+`--yes`/`--force`: an unscouted error column always stops; once every error column is
+scouted (validated → translated and persisted, or escalated → genuinely-hard and
+flagged) the re-run proceeds. Flow: build → STOP → scout each gap → re-run → proceed.
 
 ## Opt-in issue filing (escalations)
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/scout_gate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/scout_gate.py
@@ -1,0 +1,64 @@
+"""Shared run-each-time gap-scout ledger (bead beads-sigma-5l5e) — Python side.
+
+Mirrors scout_gate.rb's contract exactly: a per-conversion JSONL ledger at
+<workdir>/scout-ledger.jsonl, one row per scouted gap:
+    {"gap_id": ..., "feature": ..., "status": "validated"|"escalated", "at": ...}
+
+Ruby orchestrators read it via scout_gate.rb#classify; Python scouts append to
+it via record() below. The JSONL format is the language-neutral contract.
+"""
+import json
+import os
+import datetime
+
+LEDGER = "scout-ledger.jsonl"
+
+
+def record(workdir, gap_id, feature, status):
+    """Append one scout result. Non-fatal on error (never crash a good scout)."""
+    if not workdir or not os.path.isdir(workdir):
+        return False
+    row = {
+        "gap_id": str(gap_id or feature),
+        "feature": str(feature),
+        "status": str(status),
+        "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    try:
+        with open(os.path.join(workdir, LEDGER), "a") as f:
+            f.write(json.dumps(row) + "\n")
+        return True
+    except OSError as e:
+        import sys
+        print("scout-ledger write failed (non-fatal): %s" % e, file=sys.stderr)
+        return False
+
+
+def read_ledger(workdir):
+    p = os.path.join(workdir or "", LEDGER)
+    if not os.path.exists(p):
+        return []
+    out = []
+    with open(p) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except ValueError:
+                pass
+    return out
+
+
+def classify(workdir, gap_ids):
+    """Split unhandled gap-ids into unscouted / escalated / validated buckets.
+    Mirrors scout_gate.rb#classify exactly (same JSONL ledger contract)."""
+    by = {}
+    for e in read_ledger(workdir):
+        by.setdefault(str(e.get("gap_id")), []).append(e)
+    unscouted = [g for g in gap_ids if str(g) not in by]
+    rest = [g for g in gap_ids if str(g) in by]
+    validated = [g for g in rest if any(x.get("status") == "validated" for x in by[str(g)])]
+    escalated = [g for g in rest if g not in validated]
+    return {"unscouted": unscouted, "escalated": escalated, "validated": validated}

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -36,7 +36,8 @@ Env:
 """
 import argparse, json, os, re, ssl, subprocess, sys, time, urllib.request, urllib.error
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import yaml, ts_common, apply_layouts
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import yaml, ts_common, apply_layouts, scout_gate
 yaml.SafeLoader.add_constructor("tag:yaml.org,2002:value", lambda l, n: l.construct_scalar(n))
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -193,6 +194,40 @@ def post_workbook(spec, wd):
         f.write(json.dumps({"id": wb, "name": spec.get("name")}) + "\n")
     return wb
 
+def error_column_gate(wb, wd, display):
+    """RUN-EACH-TIME GAP-SCOUT GATE (bead beads-sigma-5l5e). The ThoughtSpot
+    converter passes TML calc expressions through optimistically (no convert-time
+    degrade signal — same as Looker); a TML function with no Sigma equivalent
+    surfaces HERE as a type=error column at workbook readback. Each such column is
+    scout-eligible: the gap-scout must ATTEMPT a Sigma translation (scripts/
+    gap-scout.md → scout-validate.py, which records to <wd>/scout-ledger.jsonl via
+    lib/scout_gate.py) before a broken column ships. An UNSCOUTED error column
+    always STOPS (exit 11) — there is no --yes/--force escape; once scouted
+    (validated or escalated) the column is accounted for and the build proceeds."""
+    cols = json.loads(sigma("GET", f"/v2/workbooks/{wb}/columns"))
+    entries = cols.get("entries") or []
+    errs = [c for c in entries if (c.get("type") or {}).get("type") == "error"]
+    if not errs:
+        return
+    print(f"   workbook '{display}': {len(errs)} ERROR-typed column(s) at readback")
+    for c in errs[:6]:
+        print(f"     [{c.get('elementId')}] {c.get('label')}: {c.get('formula')}")
+    gid = lambda c: "errcol:%s/%s" % (c.get("elementId"), c.get("label"))
+    gap_ids = list(dict.fromkeys(gid(c) for c in errs))
+    bk = scout_gate.classify(wd, gap_ids)
+    if bk["unscouted"]:
+        print("\n==================== GAP-SCOUT REQUIRED ====================")
+        print("%d of %d ERROR-typed column(s) have NOT been scouted — the gap-scout must"
+              % (len(bk["unscouted"]), len(gap_ids)))
+        print("attempt a Sigma translation before a broken column ships:")
+        for i in bk["unscouted"]:
+            print("  --gap-id '%s'" % i)
+        print("\nSpawn one gap-scout per column (scripts/gap-scout.md) with the exact --gap-id")
+        print("above plus --workdir %s, then re-run. --yes does NOT skip this gate." % wd)
+        print("===========================================================")
+        sys.exit(11)
+    print("   gap-scout: all %d error column(s) accounted for (validated or escalated)" % len(gap_ids))
+
 def render_page_png(wb, page_id, out, w=1800, h=1000):
     """Render one workbook PAGE to a PNG via the REST export API (token explicit
     via the same SIGMA_API_TOKEN the rest of the run uses). Returns True on a
@@ -280,6 +315,7 @@ def migrate_liveboard(lb_doc, dm, denorm_id, denorm_name, resolver, prefix, fall
             "pages": [{"id": "p-data", "name": "Data", "elements": data_elems},
                       {"id": "p-main", "name": display[:40], "elements": controls + elements}]}
     wb = post_workbook(spec, wd)
+    error_column_gate(wb, wd, display)             # run-each-time gap-scout gate (bead beads-sigma-5l5e)
     tiles = lb_tiles(lb, viz_specs, elements)
     control_ids = [c["id"] for c in controls]
     apply_layouts.apply(wb, tiles=tiles, controls=control_ids)
@@ -347,6 +383,7 @@ def migrate_answer(ans_id, dm, denorm_id, denorm_name, resolver, prefix, folder,
             "pages": [{"id": "p-data", "name": "Data", "elements": data_elems},
                       {"id": "p-main", "name": display[:40], "elements": [main_el]}]}
     wb = post_workbook(spec, wd)
+    error_column_gate(wb, wd, display)             # run-each-time gap-scout gate (bead beads-sigma-5l5e)
     apply_layouts.apply(wb)
     visual_qa(wb, spec, wd, display)               # Phase-5b: render full-page PNG (non-fatal)
     return wb, display

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/scout-validate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/scout-validate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""scout-validate — gap-scout validation primitive (Qlik & Power BI).
+"""scout-validate — gap-scout validation primitive (ThoughtSpot → Sigma).
 
 Validates a candidate Sigma formula against a real data-model element by building a
 throwaway test workbook, checking the column resolves (type != "error"), and — on
@@ -7,16 +7,25 @@ success — persisting the rule to the customer-local learned-rules.yaml. Generi
 skills via --home.
 
     python3 scout-validate.py \
-      --formula 'Avg([Master/Days To Ship])' \
+      --formula 'DateAdd("day", 7, [Order Fact/Order Date])' \
       --data-model-id <dm> --element-id <denorm-elem-id> --folder-id <folder> \
-      --feature 'RangeAvg' --pattern '\\bRangeAvg\\s*\\(\\s*(.+?)\\s*\\)' \
-      --template 'Avg([Master/\\1])' --hint 'aggregate context only' \
-      --description 'Qlik RangeAvg -> Sigma Avg' --home ~/.qlik-to-sigma
+      --feature 'add_days' --pattern '\\badd_days\\s*\\(\\s*(.+?)\\s*,\\s*(.+?)\\s*\\)' \
+      --template 'DateAdd("day", \\2, [\\1])' --hint 'date arithmetic' \
+      --description 'TML add_days -> Sigma DateAdd' --home ~/.thoughtspot-to-sigma
+
+To feed the run-each-time gap-scout gate (bead beads-sigma-5l5e), also pass the
+error column's gate id and the conversion working dir — the result is appended to
+<workdir>/scout-ledger.jsonl so migrate.py's type=error readback gate sees the gap
+as scouted (validated → ok; error → escalated):
+
+      --gap-id 'errcol:<elementId>/<label>' --workdir <wd>
 
 Env: SIGMA_BASE_URL, SIGMA_API_TOKEN (eval get-token.sh first).
 Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the test workbook.
 """
 import json, os, sys, ssl, urllib.request, argparse, datetime, re
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import scout_gate
 _SSL = ssl._create_unverified_context()
 
 BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
@@ -88,8 +97,10 @@ def main():
     ap.add_argument("--hint", default=""); ap.add_argument("--description", default="")
     ap.add_argument("--example-from", default="")
     ap.add_argument("--kind", default="kpi-chart", choices=["kpi-chart","table"])
-    ap.add_argument("--home", default=os.path.expanduser("~/.qlik-to-sigma"))
+    ap.add_argument("--home", default=os.path.expanduser("~/.thoughtspot-to-sigma"))
     ap.add_argument("--skill", default="", help="skill name for issue routing (default: derived from --home)")
+    ap.add_argument("--gap-id", default="", help="gap-report row this scout addressed (gate ledger; e.g. errcol:<elementId>/<label>)")
+    ap.add_argument("--workdir", default="", help="conversion working dir; ledger written here")
     a = ap.parse_args()
 
     elem_name, cols = dm_element_master_columns(a.data_model_id, a.element_id)
@@ -147,6 +158,9 @@ def main():
         result["escalation"] = build_escalation(a, err)
     # cleanup test workbook
     api("DELETE", f"/v2/files/{wb}")
+    # record to the run-each-time gap-scout ledger (bead beads-sigma-5l5e) so the
+    # migrate.py type=error readback gate sees this gap as scouted.
+    scout_gate.record(a.workdir, a.gap_id, a.feature, "validated" if status == "validated" else "escalated")
     print(json.dumps({**result,"status":status}, indent=2))
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

Makes the gap-scout a **mechanical guarantee**, not an agent-goodwill step, across all 8 migration plugins. Before this, a blanket `--force`/`--yes` let an agent skip the scout entirely and ship a degraded workbook. Now every conversion gate STOPS until each unhandled gap has been scouted (validated → translated locally, or escalated → genuinely-hard and flagged); `--force`/`--yes` only clears gaps the scout already tried, never unscouted ones.

## Shared mechanism

A per-conversion JSONL ledger `<workdir>/scout-ledger.jsonl` (rows `{gap_id,feature,status:validated|escalated,at}`). The scout primitive appends; the orchestrator classifies unhandled gaps into unscouted / escalated / validated and gates on it. Shared module vendored into each plugin's `scripts/lib/`:
- `scout_gate.rb` (Ruby) · `scout_gate.py` (Python) · `scout_gate.mjs` (Node) — identical contract, cross-verified (a `.mjs`-written row classifies identically under the Python and Ruby modules).

## Per-plugin gate

| Plugin | Gate type | Validation |
|---|---|---|
| tableau (ref), quicksight, qlik, cognos, powerbi | convert-time (warnings → OPEN QUESTIONS, gate before the exit) | **offline-e2e-proven**: stop→scout→proceed + `--yes`/`--force` can't skip |
| looker, thoughtspot, microstrategy | type=error column readback after POST | decision logic proven (mstr via mocked readback; looker no-false-fire live); live *fire* needs a live error column |

- **cognos** — built `scout_gate.mjs` (Node mirror); gate before the OPEN-QUESTIONS exit; offline-e2e on the great-outdoors module (13 warnings): unscouted→exit 11, `--yes`+unscouted→still 11, ledger-all→proceeds.
- **powerbi** — no new offline mode needed; the existing `--converter-out` route reaches the gate fully offline. Offline-e2e proven.
- **microstrategy** — had **no scout layer at all**; built it from scratch (`scout-validate.py`, `learned-rules.py`, `escalate-gap.py`, `gap-scout.md`, `lib/scout_gate.py`, and a standalone `scout-gate-readback.py` since `convert.py` only emits specs and Phase 4 POSTs via curl). SKILL.md Phase 4 now mandates the gate.
- **thoughtspot** — readback gate in `migrate.py` (both build paths); `SystemExit(11)` propagates past the per-liveboard `except Exception`.
- **qlik** — `gap-scout.md` `--gap-id`/`--workdir` doc closed.

## Not included
- The ncwe "Not Migrated" taxonomy work (separate bead) — left uncommitted.
- Live-fire demos for the readback gates (looker/thoughtspot/mstr) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)