### PR TITLE
MSTR: source-visual-parity gate + shared setup.rb fan-out

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+print "Client ID: "
+cid = $stdin.noecho(&:gets).chomp
+puts
+
+print "Client Secret: "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+print "Client ID: "
+cid = $stdin.noecho(&:gets).chomp
+puts
+
+print "Client Secret: "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -64,7 +64,12 @@ logic.
   API-key concept; `scripts/mstr.py` handles it.
 - **Sigma API token** — `eval "$(scripts/get-token.sh)"` (uses
   `SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`, same neutral-cred pattern as the
-  sibling skills).
+  sibling skills). If those Sigma creds aren't set yet (fresh machine, no prior
+  migration), run `ruby scripts/setup.rb` once — it prompts for the Sigma
+  base URL / client id / secret (+ optional connection id) and writes them to
+  both `~/.claude/settings.json` and `~/.sigma-migration/env`, so `get-token.sh`
+  and every sibling skill pick them up. (Source-side MSTR creds are separate —
+  see the MicroStrategy bullet above.)
 - **The same warehouse on both sides.** Sigma reads the warehouse live; parity
   only means something when the Sigma connection reaches the database
   MicroStrategy queries.
@@ -95,6 +100,51 @@ Walks dossier definition → dataset reports (`showExpressionAs=tokens`) →
 referenced attributes / metrics (compound bases included via a second pass) /
 facts / logical tables / hierarchy relationships. The bundle is the converter
 contract — `fixtures/bundle.json` is a real, validated example.
+
+### Phase 1.1 — Capture the SOURCE visual + the values it actually shows (mandatory)
+
+The bundle gives you the data model and *which* vizzes exist; it does **not**
+tell you what the dossier *looks like* or what each viz actually *displays*.
+Both are required for a faithful migration — skip this and you will rebuild the
+right numbers in the wrong dashboard (and sometimes the wrong numbers). Two
+captures:
+
+```bash
+# (a) Pixel-faithful PDF of the live dossier — the layout/branding/arrangement reference.
+python3 scripts/export-dossier-pdf.py <dossierId> source_dossier.pdf
+```
+
+**READ `source_dossier.pdf`** before composing anything. Note, per page: the
+element arrangement (columns/rows, what sits next to what), each viz's real
+chart KIND (a "microcharts" or "kpi" type is not a bar table), branding/header
+bands, and any controls/selector panels.
+
+```bash
+# (b) Execute the dossier instance and pull each visualization's grid + DISPLAYED values.
+#     The static definition's panelStacks carry NO grid metrics — you must execute:
+#       POST /dossiers/{id}/instances            (v1; v2 404s) -> mid
+#       GET  /v2/dossiers/{id}/instances/{mid}/chapters/{chapKey}/visualizations/{vizKey}
+#     Per-viz response gives definition.grid (rows/columns/metrics) + data.metricValues.
+```
+
+Capture each viz's **actual displayed values** as the parity baseline. Two
+traps this surfaces that the bundle hides:
+
+- **KPI / stat cards are frequently a *latest-period* value, not a windowed
+  aggregate.** A "Total Sales" KPI may show the most recent day's value with a
+  prior-period delta + sparkline — NOT `Sum` over the filter window. Match the
+  number the card shows; don't assume the aggregation.
+- **Chapter-level filters drive every viz.** A chapter filter (e.g. `Date
+  Between …`) found via `…/instances/{mid}/definition` → `chapters[].filters`
+  (NOT in the static `/definition`) is the reason row counts and totals look
+  "filtered." Apply the equivalent as a page/base filter so all elements inherit
+  it (a hidden base table with the filter, sourced by every element, is the
+  cleanest propagation).
+
+Sparklines and KPI comparison/delta badges are **UI-only in the Sigma spec API**
+(see `sigma-workbooks` `kpis.md`) — reproduce the big-number value via formula,
+and flag the sparkline/badge as a one-click editor follow-up rather than
+claiming spec parity.
 
 ## Phase 2 — Convert → Sigma specs
 
@@ -246,13 +296,28 @@ It also writes the gate sentinels `parity-final.json` + `wb-ids.json` next to
 the report — the contract Phase 6 reads.
 
 ## Visual QA (mandatory gate — never skip)
-A workbook that POSTs 200 and passes parity can still be visually broken — **overlapping tiles, clipped KPI titles, dead zones, filters over charts.** Sigma's grid has no z-order; the shared layout lib de-overlaps bands, but this visual gate is the safety net (without a top-level layout the workbook renders as a single-column stack — see the existing layout gate).
+A workbook that POSTs 200 and passes row parity can still be **the wrong
+dashboard** — right numbers, wrong look. This gate has TWO parts: source
+**fidelity** (does it resemble the original?) and intrinsic **quality** (is it
+cleanly laid out?). Both must pass. Sigma's grid has no z-order; the shared
+layout lib de-overlaps bands, but this gate is the safety net (without a
+top-level layout the workbook renders as a single-column stack).
 
 1. Render every page to PNG (token first: `eval "$(scripts/get-token.sh)"`):
    `python3 scripts/sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/<page>.png --w 1600`
-2. **Read each PNG** and check it against `refs/layout-visual-qa.md` (no overlaps/stacking, no dead zones, controls in-band, no clipped titles, even heights, right chart kind/format).
-3. Fix any failure in the spec — for multi-page workbooks use `sigma-skills/sigma-workbooks/scripts/wb-rep.rb` (pull → edit → push) — then **re-render and re-read**.
-4. Declare the migration done on a **clean render**, not on HTTP 200.
+2. **Source-fidelity check — put the Sigma PNG side-by-side with the Phase 1.1
+   `source_dossier.pdf`** and compare page-for-page against the
+   `refs/layout-visual-qa.md` "Source-fidelity parity" checklist: same element
+   set, same relative arrangement (3-column stays 3-column), matching chart
+   KINDS (KPI vs bar vs table), KPI showing the same VALUE as the source card,
+   selector/control panels present, branding bands present (or explicitly
+   descoped with the user). A render that looks nothing like the PDF FAILS even
+   if parity is green.
+3. **Quality check** — also verify each PNG against the intrinsic checklist (no
+   overlaps/stacking, no dead zones, controls in-band, no clipped titles, even
+   heights, right format).
+4. Fix any failure in the spec — for multi-page workbooks use `sigma-skills/sigma-workbooks/scripts/wb-rep.rb` (pull → edit → push) — then **re-render and re-compare**.
+5. Declare the migration done on a render that **matches the source PDF**, not on HTTP 200 and not on row-parity alone. If the user explicitly scoped styling down (e.g. "layout + metrics, skip branding"), record exactly what was descoped — don't silently drop it.
 
 ## Phase 6 — Finalize (hard gate before declaring GREEN)
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/layout-visual-qa.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/layout-visual-qa.md
@@ -28,6 +28,28 @@ declaring the migration done.
 4. **Loop until the render passes inspection.** Declare the migration done on a *clean render*,
    never on an HTTP 200.
 
+## Source-fidelity parity (run BEFORE the quality rubric)
+
+Clean ≠ faithful. A workbook can be perfectly laid out and still look nothing like the
+dashboard it migrated. This check compares the render against the **source's own
+appearance**, captured in Phase 1.1 as `source_dossier.pdf` (MSTR: `export-dossier-pdf.py`;
+other plugins have an equivalent source export). Put the Sigma page PNG and the source page
+side-by-side and verify, page-for-page:
+
+- [ ] **Same element set** — every viz on the source page exists on the Sigma page (none dropped, none invented).
+- [ ] **Same arrangement** — relative position holds (a 3-column source stays 3-column; KPIs that sit under a chart stay under it). Pixel-exact isn't required; the *grouping and reading order* are.
+- [ ] **Matching chart KIND** — source KPI → Sigma `kpi-chart` (not a 1-row table); source horizontal bar → horizontal bar; microchart/indicator → the closest Sigma equivalent (conditional-formatted table / data bars), not a generic bar. The dossier's `visualizationType` (`kpi`, `microcharts`, `combo_chart`, `grid`, …) is the spec to match.
+- [ ] **KPI shows the source's VALUE** — confirm the big number equals what the source card shows (often a latest-period stat, not a windowed Sum — see SKILL.md Phase 1.1). A KPI that's structurally a KPI but shows the wrong metric FAILS.
+- [ ] **Controls / selector panels present** — source filter panels, attribute/metric selectors, and chapter filters have Sigma equivalents (controls or an inherited base filter). An interactive source page rebuilt as a static grid FAILS.
+- [ ] **Branding bands** — header strips, logos, greeting/title bands present, OR explicitly descoped *with the user* and recorded.
+
+A render that diverges on any unchecked box is a FAIL even when row parity is green — fix the
+spec and re-compare. **Known spec ceilings** (don't loop on them — note them as editor
+follow-ups): KPI sparklines and comparison/delta badges are UI-only (`sigma-workbooks`
+`kpis.md`); source-tool chrome (theme toggles, native nav) has no spec equivalent. When the
+user scopes styling down ("layout + metrics, skip branding"), record exactly what was
+descoped in the final summary — never drop it silently.
+
 ## Pass/fail rubric (read the PNG against every item)
 
 - [ ] **No overlaps / no stacking.** No two elements occupy the same cell; no filter, legend, or

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/export-dossier-pdf.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/export-dossier-pdf.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Export the SOURCE MicroStrategy dossier to PDF — the visual-parity reference.
+
+Why this exists: the dossier *definition* (panelStacks/visualizations) does NOT
+carry the rendered layout, styling, branding, or the actual metric VALUES each
+viz displays. A converter that builds only from the definition produces a
+workbook with the right data but the wrong *look*. To match the source you must
+SEE it. This pulls a pixel-faithful PDF of the live dossier so the Visual QA
+gate can put the Sigma render side-by-side with the original and check fidelity
+(arrangement, chart kinds, KPI semantics, branding), not just generic quality.
+
+Pairs with execute-instance value capture (see SKILL.md Phase 1): the PDF tells
+you the layout; executing each visualization tells you the exact displayed
+values (KPIs are often a LATEST-DATE stat, not a windowed Sum — never assume).
+
+Usage:
+  python3 scripts/export-dossier-pdf.py <dossierId> [out.pdf]
+
+Env: ~/microstrategy-migration/.mstr_env (or wherever mstr.py reads), same auth
+as the rest of the pipeline. Requires mstr.py alongside this script.
+"""
+import base64
+import sys
+import mstr
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: export-dossier-pdf.py <dossierId> [out.pdf]", file=sys.stderr)
+        sys.exit(2)
+    dossier_id = sys.argv[1]
+    out = sys.argv[2] if len(sys.argv) > 2 else "source_dossier.pdf"
+
+    s = mstr.Session()
+    # Instance must be created and exported within ONE auth session (session-bound).
+    iid = s.post(f"/dossiers/{dossier_id}/instances", {})["mid"]
+    # NOTE: the v1 path works; /v2/dossiers/.../pdf 404s on this build.
+    resp = s.post(f"/documents/{dossier_id}/instances/{iid}/pdf", {})
+    if not resp or "data" not in resp:
+        print(f"error: no PDF data returned: {str(resp)[:200]}", file=sys.stderr)
+        sys.exit(1)
+    pdf = base64.b64decode(resp["data"])
+    with open(out, "wb") as f:
+        f.write(pdf)
+    print(f"wrote {out} ({len(pdf)} bytes) — READ it, then match the Sigma build to it")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+print "Client ID: "
+cid = $stdin.noecho(&:gets).chomp
+puts
+
+print "Client Secret: "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+print "Client ID: "
+cid = $stdin.noecho(&:gets).chomp
+puts
+
+print "Client Secret: "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+print "Client ID: "
+cid = $stdin.noecho(&:gets).chomp
+puts
+
+print "Client Secret: "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+print "Client ID: "
+cid = $stdin.noecho(&:gets).chomp
+puts
+
+print "Client Secret: "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+print "Client ID: "
+cid = $stdin.noecho(&:gets).chomp
+puts
+
+print "Client Secret: "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -154,6 +154,19 @@
       ]
     },
     {
+      "canonical": "shared/scripts/setup.rb",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb"
+      ]
+    },
+    {
       "canonical": "shared/assessment/dup-dashboards.py",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-assessment/scripts/dup-dashboards.py",

--- a/shared/scripts/setup.rb
+++ b/shared/scripts/setup.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+print "Client ID: "
+cid = $stdin.noecho(&:gets).chomp
+puts
+
+print "Client Secret: "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."


### PR DESCRIPTION
## Visual/layout parity (the gap that shipped a wrong-looking dashboard)
Row parity ≠ visual parity. The converter rebuilt elements from the dossier's data inventory but never looked at the source's actual design.

- **`scripts/export-dossier-pdf.py`** — exports the SOURCE dossier to PDF (`POST /documents/{id}/instances/{iid}/pdf`) as the layout/branding reference.
- **SKILL.md Phase 1.1** — capture the source PDF *and* execute the dossier instance per viz for its real chart KIND + **displayed values**. Documents two traps: KPI cards are often a **latest-period** value (not a windowed Sum), and **chapter-level filters** drive every viz.
- **Visual QA gate** reframed as **source-fidelity** (side-by-side vs the PDF), with a "Source-fidelity parity" checklist in `refs/layout-visual-qa.md`.

## Shared `setup.rb` fan-out (fixes QS Step-8 LoadError)
`setup.rb` (tool-agnostic Sigma cred capture) shipped only in tableau-to-sigma → `LoadError` for users starting from any other plugin.
- Promoted to **`shared/scripts/setup.rb`** canonical + manifest entry, synced into **all 8** converter plugins (drift-gated).
- Added a `ruby scripts/setup.rb` pointer to MSTR Prerequisites.

Gates: `check-shared.rb` ✅ (98 copies) · `lint-skills.rb` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)