### PR TITLE
looker-to-sigma: explore-from alias, dim labels, join-key count, date controls, robust errors

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -1235,7 +1235,15 @@ def main():
     controls, control_scope, dropped_controls = [], [], []
     for flt in dash["filters"]:
         fld = flt.get("dimension") or flt.get("field") or flt.get("_resolvedField")
-        ctype = "date-range" if flt["type"] == "date_filter" else "list"
+        # A `list` control targeting a DATETIME column is silently DROPPED by
+        # Sigma on POST (its `filters` come back empty → dead control). A filter
+        # bound to a date/time dimension_group must be a date control regardless
+        # of the Looker filter `type` (a Looker field_filter on a date renders a
+        # list in LookML but must become a date control in Sigma).
+        _fld = flt.get("dimension") or flt.get("field") or flt.get("_resolvedField")
+        is_date_field = (flt["type"] == "date_filter"
+                         or (_fld is not None and dimgroup_display(_fld) is not None))
+        ctype = "date-range" if is_date_field else "list"
         cid = flt["name"].lower().replace(" ", "-")
         entry = {"controlId": cid, "name": flt["title"], "controlType": ctype,
                  "source_signal": f"looker dashboard filter '{flt['name']}' (per-tile listen: scope)",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -187,6 +187,22 @@ def parse_join_aliases(model_files):
             fm = re.search(r"\bfrom:\s*(\w+)", body)
             if fm and fm.group(1) != alias:
                 aliases[alias] = fm.group(1)
+        # explore: <alias> { from: <view> ... }  — an explore can ALIAS its BASE
+        # view via a top-level `from:` (e.g. `explore: orders_basic { from:
+        # order_fact }`). Tiles then reference the explore alias (orders_basic.x)
+        # while the converter names the DM element after the underlying VIEW
+        # (order_fact). Capture the explore's OWN base `from:` (the one before the
+        # first `join:`), brace-balanced so nested join/access_filter braces don't
+        # confuse the scan. Without this the whole base-view field set is dropped.
+        for em in re.finditer(r"explore:\s*(\w+)\s*\{", txt):
+            alias = em.group(1); start = em.end(); depth, i = 1, start
+            while i < len(txt) and depth:
+                depth += {"{": 1, "}": -1}.get(txt[i], 0); i += 1
+            body = txt[start:i]
+            head = body.split("join:", 1)[0]      # base `from:` precedes any join
+            fm = re.search(r"\bfrom:\s*(\w+)", head)
+            if fm and fm.group(1) != alias:
+                aliases[alias] = fm.group(1)
     return aliases
 
 
@@ -194,6 +210,8 @@ def build_field_index(view_files, aliases=None):
     measures = {}   # "view.field" -> (agg_type, base_display_or_None, sql, filters)
     formats = {}    # "view.field" -> Sigma format dict (or None)
     dims = set()    # "view.field"
+    labels = {}     # "view.field" -> LookML label (the converter names the column
+                    #   after the label, so a tile ref must use it, not the field name)
     view_pk = {}    # "view" -> primary-key dimension name
     yesno = set()   # "view.field" of type:yesno dims — the DM converter names
                     # their boolean calc column "<label> (T-F)"
@@ -236,6 +254,9 @@ def build_field_index(view_files, aliases=None):
                 view_pk[view] = name
             if re.search(r"type:\s*yesno\b", txt[start:i]):
                 yesno.add(f"{view}.{name}")
+            lm = re.search(r'label:\s*"([^"]*)"', txt[start:i])
+            if lm:
+                labels[f"{view}.{name}"] = lm.group(1)
         # measure blocks: measure: name { ... }
         for m in re.finditer(r"measure:\s*(\w+)\s*\{", txt):
             name = m.group(1); start = m.end()
@@ -293,9 +314,11 @@ def build_field_index(view_files, aliases=None):
             yesno.add(f"{alias}.{f.split('.', 1)[1]}")
         for g in [k for k in dim_groups if k.startswith(view + ".")]:
             dim_groups.setdefault(f"{alias}.{g.split('.', 1)[1]}", dim_groups[g])
+        for f in [k for k in labels if k.startswith(view + ".")]:
+            labels.setdefault(f"{alias}.{f.split('.', 1)[1]}", labels[f])
         if view in view_pk:
             view_pk.setdefault(alias, view_pk[view])
-    return measures, dims, view_pk, formats, yesno, dim_groups
+    return measures, dims, view_pk, formats, yesno, dim_groups, labels
 
 def main():
     ap = argparse.ArgumentParser()
@@ -325,7 +348,7 @@ def main():
     model_files = (glob.glob(os.path.join(a.views, "*.model.lkml"))
                    + glob.glob(os.path.join(a.views, "..", "*.model.lkml")))
     aliases = parse_join_aliases(model_files)
-    measures, dims, view_pk, formats, yesno_dims, dim_groups = build_field_index(
+    measures, dims, view_pk, formats, yesno_dims, dim_groups, dim_labels = build_field_index(
         sorted(glob.glob(os.path.join(a.views, "*.view.lkml"))), aliases)
     warnings = []
 
@@ -447,11 +470,23 @@ def main():
         if is_measure(f):
             if is_ratio(f): return None           # composite — components needed separately
             base = measures[f][1]                 # base column (None for plain count)
-            return (base + suf) if base else None
+            if not base: return None
+            # A count/count_distinct on a JOINED view keyed on that view's PK
+            # references the join key — which the denorm element OMITS (a
+            # cross-element passthrough of a join key compiles to type "error").
+            # The base side of the relationship carries the same value under the
+            # plain (un-suffixed) column, so reference that instead of the absent
+            # alias-suffixed one.
+            if suf and measures[f][0] in ("count", "count_distinct") and base == disp(view_pk.get(view) or ""):
+                return base
+            return base + suf
         dg = dimgroup_display(f)
         if dg is not None:
             return dg + suf
-        return disp(leaf(f)) + suf
+        # The converter names a dimension column after its LookML `label:` when one
+        # is set (e.g. dimension full_name { label: "Customer Name" } → column
+        # "Customer Name", not "Full Name"), so a tile ref must use the label.
+        return dim_labels.get(f, disp(leaf(f))) + suf
     def pk_display(view, explore):
         """Display name of a view's primary-key column in the denorm element."""
         pk = view_pk.get(view)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -503,7 +503,7 @@ def main():
         views_dir = lookml_dir
     view_files = sorted(glob.glob(os.path.join(views_dir, "*.view.lkml")))
     _aliases = parse_join_aliases(glob.glob(os.path.join(lookml_dir, "*.model.lkml")))
-    measures, _dims, view_pk, _formats, _yesno, _dim_groups = build_field_index(view_files, _aliases)
+    measures, _dims, view_pk, _formats, _yesno, _dim_groups, _labels = build_field_index(view_files, _aliases)
     print(f"   '{dash['title']}': {len(dash['elements'])} tile(s), {len(dash['filters'])} filter(s), "
           f"explore '{explore}' · {len(view_files)} view file(s), {len(measures)} measure(s) · workdir {wd}")
 
@@ -794,7 +794,20 @@ console.error('stats:', JSON.stringify(res.stats));
          f"--folder-id={folder}", f"--out={wb_spec_path}"])
     wspec = json.load(open(wb_spec_path))
     wspec["name"] = f"{prefix}{dash['title']} (from Looker)"
-    resp = sigma("POST", "/v2/workbooks/spec", wspec)       # responds in YAML
+    try:
+        resp = sigma("POST", "/v2/workbooks/spec", wspec)   # responds in YAML
+    except RuntimeError as e:
+        msg = str(e)
+        dep = re.search(r"Dependency not found: '([^']+)'", msg)
+        if dep:
+            sys.exit(
+                f"FATAL: workbook POST rejected — missing DM column '{dep.group(1)}'. "
+                f"A tile references a data-model column the converter did not emit "
+                f"(e.g. an unconverted dimension/measure, or a join column not denormalized "
+                f"onto the explore element). Inspect the spec at {wb_spec_path} and the DM "
+                f"element columns; the offending tile field should be dropped or the converter "
+                f"gap fixed — never POST past it.")
+        sys.exit(f"FATAL: workbook POST failed: {msg[:400]}")
     m = re.search(r"workbookId[\"'\s:]+([0-9a-f-]{36})", resp)
     if not m:
         sys.exit("FATAL: workbook POST: " + resp[:300])
@@ -868,7 +881,17 @@ console.error('stats:', JSON.stringify(res.stats));
 
     # ── Phase 5 — SOURCE-FRESHNESS preflight (read BEFORE any side-by-side) ───
     hdr(5, TOTAL, "Source freshness (preflight — before parity)")
-    mh, mr = parse_csv(export_csv(wb, "m-master"))
+    try:
+        mh, mr = parse_csv(export_csv(wb, "m-master"))
+    except RuntimeError as e:
+        # A CSV-export timeout here almost always means the master ended up with 0
+        # columns (every tile field was dropped/unresolved upstream). Don't crash the
+        # whole run with a raw stack trace — warn and skip the freshness readout so
+        # the parity gate still runs and reports the real coverage problem.
+        print(f"   ⚠ source-freshness export skipped: {e}")
+        print("     (the master may have no resolvable columns — check the Phase-4b "
+              "field-drop warnings above; parity will still run and surface it.)")
+        mh, mr = [], []
     print("   ── SOURCE FRESHNESS (read this before any side-by-side) ──")
     if offline:
         newest = max((os.path.getmtime(f) for f in view_files + [a.dashboard]), default=None)


### PR DESCRIPTION
Builder/orchestrator fixes from a 5-tier Looker→Sigma complexity benchmark. Result: **T1/T2/T4/T5 GREEN** (all 7 gates), T3 builds (16/23 cols; the 7 errors are a documented Sigma platform limit on cross-element refs into Custom SQL elements — see sigma-data-model-mcp#65).

## build_workbook.py
- **explore-level `from:` base alias** now resolved (`explore: orders_basic { from: order_fact }`) — was dropping 100% of tile fields (tiles ref the explore alias, the converter names the DM element after the view) → empty master → CSV-export timeout. Unblocked 4 of 5 tiers.
- **dim `label:`** used for column display (`full_name` → "Customer Name"), matching converter naming.
- **count/count_distinct on a joined view's PK** falls back to the base join-key column (the denorm omits the join key; a cross-element passthrough of it = type=error).
- **date-bound filters → `date-range` control** (not `list`). A list control on a DATETIME column is silently dropped by Sigma on POST (live `filters` come back empty → gate-7 dead control). Fixes T2/T5 RED.
- `build_field_index` returns dim labels (7-tuple); both unpack sites updated.

## migrate-looker.py
- Workbook POST 400 → clean FATAL naming the missing DM column (was an uncaught stack trace).
- Phase-5 source-freshness export failure is non-fatal (warn + skip) so the parity gate still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)