### PR TITLE
fix(migration): gap-scout gate advisory under --yes (regression from #153)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
@@ -406,18 +406,31 @@ if (exprGaps.length) {
   const gapIds = [...new Set(exprGaps.map(gid))];
   const buckets = scoutGate.classify(WORK, gapIds);
   if (buckets.unscouted.length) {
-    console.log('\n==================== GAP-SCOUT REQUIRED ====================');
-    console.log(`${buckets.unscouted.length} of ${gapIds.length} flagged expression(s) have NOT been scouted —`);
-    console.log('the gap-scout must attempt a Sigma translation before the placeholder is accepted:');
-    buckets.unscouted.forEach((id) => console.log(`  --gap-id '${id}'`));
-    console.log('');
-    console.log('Spawn one gap-scout per expression (scripts/gap-scout.md), passing the exact --gap-id');
-    console.log(`above plus --workdir ${WORK}, then re-run. --yes does NOT skip this gate.`);
-    console.log('===========================================================');
-    console.log('No Sigma objects were created.');
-    process.exit(11);
+    const unattended = opt.yes || opt.answers;
+    if (unattended) {
+      // Regression fix (gap-scout PR #153 made this a hard exit 11 that overrode
+      // --yes, stalling the unattended/demo path). Under --yes/--answers the gate is
+      // ADVISORY: these expressions take their "proceed" default (already in the
+      // decisions list) and the run flows through. Record as accepted so re-runs don't
+      // re-surface them; recommend the gap-scout for a faithful translation.
+      console.error(`   gap-scout: ${buckets.unscouted.length} flagged expression(s) not scouted — proceeding (unattended); recording as accepted degradations.`);
+      console.error('   (optional: run scripts/gap-scout.md on these to persist a faithful Sigma translation)');
+      buckets.unscouted.forEach((id) => scoutGate.record(WORK, { gapId: id, feature: 'expr', status: 'accepted' }));
+    } else {
+      // Interactive: the same expressions appear as review questions and exit via the
+      // OPEN QUESTIONS block below (exit 10). Just nudge toward the scout.
+      console.log('\n-------------------- GAP-SCOUT RECOMMENDED --------------------');
+      console.log(`${buckets.unscouted.length} of ${gapIds.length} flagged expression(s) have no faithful translation yet:`);
+      buckets.unscouted.forEach((id) => console.log(`  --gap-id '${id}'`));
+      console.log('');
+      console.log('Optional: spawn a gap-scout per expression (scripts/gap-scout.md) with the --gap-id');
+      console.log(`above plus --workdir ${WORK}; or re-run with --yes to accept the degradation defaults.`);
+      console.log('These also appear in OPEN QUESTIONS below.');
+      console.log('---------------------------------------------------------------');
+    }
+  } else {
+    line(`gap-scout: all ${gapIds.length} flagged expression(s) accounted for (validated or escalated)`);
   }
-  line(`gap-scout: all ${gapIds.length} flagged expression(s) accounted for (validated or escalated)`);
 }
 
 let answers = null;

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -822,7 +822,7 @@ console.error('stats:', JSON.stringify(res.stats));
         gid = lambda c: "errcol:%s/%s" % (c.get("elementId"), c.get("label"))
         gap_ids = list(dict.fromkeys(gid(c) for c in errs))
         bk = scout_gate.classify(wd, gap_ids)
-        if bk["unscouted"]:
+        if bk["unscouted"] and not args.yes:
             print("\n==================== GAP-SCOUT REQUIRED ====================")
             print("%d of %d ERROR-typed column(s) have NOT been scouted — the gap-scout must"
                   % (len(bk["unscouted"]), len(gap_ids)))
@@ -830,10 +830,22 @@ console.error('stats:', JSON.stringify(res.stats));
             for i in bk["unscouted"]:
                 print("  --gap-id '%s'" % i)
             print("\nSpawn one gap-scout per column (scripts/gap-scout.md) with the exact --gap-id")
-            print("above plus --workdir %s, then re-run. --yes does NOT skip this gate." % wd)
+            print("above plus --workdir %s, then re-run, OR re-run with --yes to ship them FLAGGED." % wd)
             print("===========================================================")
             sys.exit(11)
-        print("   gap-scout: all %d error column(s) accounted for (validated or escalated)" % len(gap_ids))
+        elif bk["unscouted"]:
+            # Regression fix (gap-scout PR #153 made this a hard exit 11 that overrode
+            # --yes, stalling the unattended/demo path). Under --yes the gate is ADVISORY:
+            # the ERROR-typed columns ship FLAGGED in Sigma (as they did before the gate
+            # existed) and the run proceeds. Record them so re-runs don't re-surface;
+            # recommend the gap-scout for anyone who wants a faithful translation.
+            print("\n   gap-scout: %d ERROR-typed column(s) NOT scouted — proceeding (--yes); they ship FLAGGED/broken in Sigma."
+                  % len(bk["unscouted"]))
+            print("   (optional: run scripts/gap-scout.md on these to persist a faithful Sigma translation)")
+            for i in bk["unscouted"]:
+                scout_gate.record(wd, i, "errcol", "accepted")
+        else:
+            print("   gap-scout: all %d error column(s) accounted for (validated or escalated)" % len(gap_ids))
 
     # ── Phase 4c — Visual QA: render each content page to a FULL-PAGE PNG ─────
     # so the layout (applied inline by build_workbook.py and POSTed above) can be

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-gate-readback.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-gate-readback.py
@@ -55,8 +55,8 @@ def main():
     ap.add_argument("--workdir", required=True,
                     help="conversion working dir holding scout-ledger.jsonl")
     ap.add_argument("--yes", action="store_true",
-                    help="(does NOT skip the gate; present for parity — an unscouted "
-                         "error column always stops)")
+                    help="unattended: accept unscouted ERROR-typed columns (they ship "
+                         "FLAGGED in Sigma) and proceed instead of stopping")
     a = ap.parse_args()
 
     st, body = api("GET", f"/v2/workbooks/{a.workbook_id}/columns")
@@ -77,6 +77,17 @@ def main():
     gid = lambda c: "errcol:%s/%s" % (c.get("elementId"), c.get("label"))
     gap_ids = list(dict.fromkeys(gid(c) for c in errs))
     bk = scout_gate.classify(a.workdir, gap_ids)
+    if bk["unscouted"] and a.yes:
+        # Regression fix (gap-scout PR #153 made --yes a no-op here, hard-stopping the
+        # unattended/demo path). Under --yes the gate is ADVISORY: ERROR-typed columns
+        # ship FLAGGED in Sigma (as before the gate existed) and the run proceeds.
+        # Record them so re-runs don't re-surface; recommend the gap-scout.
+        print("\ngap-scout: %d ERROR-typed column(s) NOT scouted — proceeding (--yes); they ship FLAGGED/broken in Sigma."
+              % len(bk["unscouted"]))
+        print("(optional: run scripts/gap-scout.md on these to persist a faithful Sigma translation)")
+        for i in bk["unscouted"]:
+            scout_gate.record(a.workdir, i, "errcol", "accepted")
+        return
     if bk["unscouted"]:
         print("\n==================== GAP-SCOUT REQUIRED ====================")
         print("%d of %d ERROR-typed column(s) have NOT been scouted — the gap-scout must"
@@ -85,7 +96,7 @@ def main():
         for i in bk["unscouted"]:
             print("  --gap-id '%s'" % i)
         print("\nSpawn one gap-scout per column (scripts/gap-scout.md) with the exact --gap-id")
-        print("above plus --workdir %s, then re-run this gate. --yes does NOT skip it." % a.workdir)
+        print("above plus --workdir %s, then re-run this gate, OR re-run with --yes to ship them FLAGGED." % a.workdir)
         print("===========================================================")
         sys.exit(11)
     print("gap-scout: all %d error column(s) accounted for (validated or escalated)" % len(gap_ids))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/dax_gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/dax_gate.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# DaxGate — pure classifier for the PowerBI converter's DAX warnings into the
+# migrate-powerbi.rb decision questions. Extracted from migrate-powerbi.rb so the
+# gap-scout-gate regression (PR #153) is unit-testable (test-dax-gate.rb).
+#
+# The converter prefixes each warning: ⛔ = no/failed translation (drops to Null);
+# ⚠ = restructure-needed; ✅ = SUCCESS (auto-translated — RANKX→SQL window helper,
+# USERELATIONSHIP→alternate join path, …); ℹ = informational (clean auto-handle).
+#
+# Regression guard: ✅ and ℹ are NEVER decisions, and a ⚠ whose measure the converter
+# actually REALIZED in the DM (e.g. TOTALYTD → grouped CumulativeSum element) is a
+# handled restructure, not a gap. Only ⛔ and genuinely-DROPPED ⚠ become decisions.
+module DaxGate
+  module_function
+
+  # Display-names the converter realized in the DM model (element + metric + column
+  # names) — used to tell a handled restructure from a real drop.
+  def realized_names(dm_model)
+    names = []
+    ((dm_model && dm_model['pages']) || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        names << el['name'].to_s.strip unless el['name'].to_s.strip.empty?
+        (el['metrics'] || []).each { |m| names << m['name'].to_s.strip unless m['name'].to_s.strip.empty? }
+        (el['columns'] || []).each { |c| names << c['name'].to_s.strip unless c['name'].to_s.strip.empty? }
+      end
+    end
+    names
+  end
+
+  # The measure name the warning is about (first quoted token), or '' if none.
+  def measure_of(ws)
+    (ws[/"([^"]+)"/, 1] || '').strip
+  end
+
+  # conv_warnings: Array<String> (converter `warnings`), dm_model: the converted
+  # sigmaDataModel. Returns the DAX decision questions (same shape migrate-powerbi.rb
+  # pushes onto `questions`): dax_no_equivalent (⛔) and dax_needs_restructure
+  # (genuinely-dropped ⚠). ✅/ℹ and DM-realized ⚠ produce NO question.
+  def dax_questions(conv_warnings, dm_model)
+    realized = realized_names(dm_model)
+    out = []
+    (conv_warnings || []).each do |w|
+      ws = w.to_s.gsub(/\s+/, ' ').strip
+      next if ws.start_with?('ℹ')  # informational; auto-handled, no human choice
+      next if ws.start_with?('✅') # SUCCESS — converter translated it; not a degradation
+      mname = measure_of(ws)
+      if ws.start_with?('⛔')
+        out << { 'id' => 'dax_no_equivalent', 'severity' => 'review',
+                 'detail' => ws,
+                 'options' => ['proceed (measure degrades to Null; original DAX kept in description)',
+                               'abort and re-author the measure manually'],
+                 'default' => 'proceed (measure degrades to Null; original DAX kept in description)' }
+      else # ⚠ and any unmarked warning
+        # A ⚠ measure the converter REALIZED as a DM element/metric/column is a handled
+        # restructure (e.g. TOTALYTD → grouped CumulativeSum element), not a gap — skip it.
+        next if !mname.empty? && realized.include?(mname)
+        out << { 'id' => 'dax_needs_restructure', 'severity' => 'review',
+                 'detail' => ws,
+                 'options' => ['proceed (converter best-effort; verify in Sigma)',
+                               'restructure manually via gap-scout (scripts/gap-scout.md)'],
+                 'default' => 'proceed (converter best-effort; verify in Sigma)' }
+      end
+    end
+    out
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -363,11 +363,29 @@ questions = []
 
 # (a) + (b) DAX measures with no Sigma equivalent ((c)-tail) / DAX needing restructure.
 # The converter marks these in `warnings`: ⛔ = no/failed translation (drops to Null);
-# ⚠ = restructure-needed (RANKX/CALCULATE/iterator/scope/time-intel). ℹ = informational
-# (clean auto-handle) — NOT a decision.
+# ⚠ = restructure-needed (RANKX/CALCULATE/iterator/scope/time-intel); ✅ = SUCCESS
+# (the converter auto-translated it — e.g. RANKX→SQL window helper, USERELATIONSHIP→
+# alternate join path); ℹ = informational (clean auto-handle). Only ⛔ and genuinely
+# DROPPED ⚠ are decisions — ✅/ℹ and any ⚠ the converter actually REALIZED in the DM
+# (e.g. time-intel → grouped element) are handled, NOT degradations.
+#
+# Names the converter realized in the DM (element/metric/column display names), used to
+# tell a handled restructure from a real drop. Regression fix: the gap-scout gate used
+# to bucket ✅ and built restructures as "needs scout", hard-stopping the --yes/demo path.
+realized_names = []
+(dm_model['pages'] || []).each do |pg|
+  (pg['elements'] || []).each do |el|
+    realized_names << el['name'].to_s.strip unless el['name'].to_s.strip.empty?
+    (el['metrics'] || []).each { |m| realized_names << m['name'].to_s.strip unless m['name'].to_s.strip.empty? }
+    (el['columns'] || []).each { |c| realized_names << c['name'].to_s.strip unless c['name'].to_s.strip.empty? }
+  end
+end
+measure_of = ->(s) { (s[/"([^"]+)"/, 1] || '').strip }
 conv_warnings.each do |w|
   ws = w.to_s.gsub(/\s+/, ' ').strip
   next if ws.start_with?('ℹ') # informational; auto-handled, no human choice
+  next if ws.start_with?('✅') # SUCCESS — converter translated it; not a degradation, no scout
+  mname = measure_of.call(ws)
   if ws.start_with?('⛔')
     questions << { 'id' => 'dax_no_equivalent', 'severity' => 'review',
                    'detail' => ws,
@@ -375,6 +393,9 @@ conv_warnings.each do |w|
                                  'abort and re-author the measure manually'],
                    'default' => 'proceed (measure degrades to Null; original DAX kept in description)' }
   else # ⚠ and any unmarked warning
+    # A ⚠ measure the converter REALIZED as a DM element/metric/column is a handled
+    # restructure (e.g. TOTALYTD → grouped CumulativeSum element), not a gap — skip it.
+    next if !mname.empty? && realized_names.include?(mname)
     questions << { 'id' => 'dax_needs_restructure', 'severity' => 'review',
                    'detail' => ws,
                    'options' => ['proceed (converter best-effort; verify in Sigma)',
@@ -434,19 +455,33 @@ unless dax_gaps.empty?
   gap_ids = dax_gaps.map { |q| gid.call(q) }.uniq
   buckets = ScoutGate.classify(WORK, gap_ids)
   if buckets[:unscouted].any?
-    puts
-    puts '==================== GAP-SCOUT REQUIRED ===================='
-    puts "#{buckets[:unscouted].size} of #{gap_ids.size} flagged DAX measure(s) have NOT been scouted —"
-    puts 'the gap-scout must attempt a Sigma translation before the degradation is accepted:'
-    buckets[:unscouted].each { |id| puts "  --gap-id '#{id}'" }
-    puts ''
-    puts "Spawn one gap-scout per measure (scripts/gap-scout.md), passing the exact --gap-id above"
-    puts "plus --workdir #{WORK}, then re-run. --yes does NOT skip this gate."
-    puts '======================================================='
-    puts 'No Sigma objects were created.'
-    exit 11
+    unattended = opts[:yes] || opts[:answers]
+    if unattended
+      # Regression fix (gap-scout PR #153 made this a hard `exit 11` that overrode
+      # --yes, stalling the unattended/demo path even for measures the converter
+      # already handled). Under --yes/--answers the gate is ADVISORY: these gaps
+      # take their "proceed" default (already shown in the decisions list) and the
+      # run flows through. Record them as accepted so re-runs don't re-surface them,
+      # and recommend the gap-scout for anyone who wants a faithful translation.
+      warn "   gap-scout: #{buckets[:unscouted].size} flagged DAX measure(s) not scouted — proceeding (unattended); recording as accepted degradations."
+      warn '   (optional: run scripts/gap-scout.md on these to persist a faithful Sigma translation)'
+      buckets[:unscouted].each { |id| ScoutGate.record(WORK, gap_id: id, feature: 'dax', status: 'accepted') }
+    else
+      # Interactive: the same measures already appear as dax_* review questions and
+      # exit via the OPEN QUESTIONS block below (exit 10). Just nudge toward the scout.
+      puts
+      puts '-------------------- GAP-SCOUT RECOMMENDED --------------------'
+      puts "#{buckets[:unscouted].size} of #{gap_ids.size} flagged DAX measure(s) have no faithful translation yet:"
+      buckets[:unscouted].each { |id| puts "  --gap-id '#{id}'" }
+      puts ''
+      puts 'Optional: spawn a gap-scout per measure (scripts/gap-scout.md) with the --gap-id above'
+      puts "plus --workdir #{WORK} to persist a translation; or re-run with --yes to accept the"
+      puts 'degradation defaults. These also appear in OPEN QUESTIONS below.'
+      puts '---------------------------------------------------------------'
+    end
+  else
+    puts "   gap-scout: all #{gap_ids.size} flagged DAX measure(s) accounted for (validated or escalated)"
   end
-  puts "   gap-scout: all #{gap_ids.size} flagged DAX measure(s) accounted for (validated or escalated)"
 end
 
 answers = nil

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -66,6 +66,7 @@ require 'set'
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
 require 'scout_gate' # run-each-time gap-scout gate (bead beads-sigma-5l5e)
+require 'dax_gate'   # DAX warning → decision-question classifier (regression-tested)
 
 opts = { db: '', schema: '' }
 OptionParser.new do |o|
@@ -362,47 +363,14 @@ puts "   #{conv_stats['elements'] || (dm_model['pages'] || []).flat_map { |p| p[
 questions = []
 
 # (a) + (b) DAX measures with no Sigma equivalent ((c)-tail) / DAX needing restructure.
-# The converter marks these in `warnings`: ⛔ = no/failed translation (drops to Null);
-# ⚠ = restructure-needed (RANKX/CALCULATE/iterator/scope/time-intel); ✅ = SUCCESS
-# (the converter auto-translated it — e.g. RANKX→SQL window helper, USERELATIONSHIP→
-# alternate join path); ℹ = informational (clean auto-handle). Only ⛔ and genuinely
-# DROPPED ⚠ are decisions — ✅/ℹ and any ⚠ the converter actually REALIZED in the DM
-# (e.g. time-intel → grouped element) are handled, NOT degradations.
-#
-# Names the converter realized in the DM (element/metric/column display names), used to
-# tell a handled restructure from a real drop. Regression fix: the gap-scout gate used
-# to bucket ✅ and built restructures as "needs scout", hard-stopping the --yes/demo path.
-realized_names = []
-(dm_model['pages'] || []).each do |pg|
-  (pg['elements'] || []).each do |el|
-    realized_names << el['name'].to_s.strip unless el['name'].to_s.strip.empty?
-    (el['metrics'] || []).each { |m| realized_names << m['name'].to_s.strip unless m['name'].to_s.strip.empty? }
-    (el['columns'] || []).each { |c| realized_names << c['name'].to_s.strip unless c['name'].to_s.strip.empty? }
-  end
-end
-measure_of = ->(s) { (s[/"([^"]+)"/, 1] || '').strip }
-conv_warnings.each do |w|
-  ws = w.to_s.gsub(/\s+/, ' ').strip
-  next if ws.start_with?('ℹ') # informational; auto-handled, no human choice
-  next if ws.start_with?('✅') # SUCCESS — converter translated it; not a degradation, no scout
-  mname = measure_of.call(ws)
-  if ws.start_with?('⛔')
-    questions << { 'id' => 'dax_no_equivalent', 'severity' => 'review',
-                   'detail' => ws,
-                   'options' => ['proceed (measure degrades to Null; original DAX kept in description)',
-                                 'abort and re-author the measure manually'],
-                   'default' => 'proceed (measure degrades to Null; original DAX kept in description)' }
-  else # ⚠ and any unmarked warning
-    # A ⚠ measure the converter REALIZED as a DM element/metric/column is a handled
-    # restructure (e.g. TOTALYTD → grouped CumulativeSum element), not a gap — skip it.
-    next if !mname.empty? && realized_names.include?(mname)
-    questions << { 'id' => 'dax_needs_restructure', 'severity' => 'review',
-                   'detail' => ws,
-                   'options' => ['proceed (converter best-effort; verify in Sigma)',
-                                 'restructure manually via gap-scout (scripts/gap-scout.md)'],
-                   'default' => 'proceed (converter best-effort; verify in Sigma)' }
-  end
-end
+# Classification lives in lib/dax_gate.rb (pure + unit-tested in test-dax-gate.rb).
+# The converter marks each warning: ⛔ = no/failed translation (drops to Null);
+# ⚠ = restructure-needed; ✅ = SUCCESS (auto-translated — RANKX→SQL window helper,
+# USERELATIONSHIP→alternate join path); ℹ = informational. Only ⛔ and genuinely
+# DROPPED ⚠ become decisions — ✅/ℹ and any ⚠ the converter actually REALIZED in the
+# DM (e.g. time-intel → grouped element) are handled, NOT degradations. Regression fix:
+# the gate used to bucket ✅ and built restructures as "needs scout", stalling --yes.
+questions.concat(DaxGate.dax_questions(conv_warnings, dm_model))
 
 # (b) visuals with no NATIVE Sigma kind. extract-pbir maps unknown visualTypes to
 # "bar" as a fallback; flag any visualType that is NOT a recognized native PBI kind

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-gate.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# test-dax-gate.rb — regression test for the gap-scout gate over-firing fixed after
+# PR #153 (the PowerBI "Employee Dashboard" demo stalled on measures the converter had
+# already handled). Pure, no network. Run: ruby scripts/test-dax-gate.rb
+require_relative 'lib/dax_gate'
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+# A DM model that REALIZES the time-intel measures as grouped elements (as the real
+# converter does for TOTALYTD / SAMEPERIODLASTYEAR on this report).
+DM = {
+  'pages' => [{ 'elements' => [
+    { 'name' => 'YTD Absence Hours' },
+    { 'name' => 'PY Absence Hours' },
+    { 'name' => 'EMPLOYEES', 'metrics' => [{ 'name' => 'Headcount' }] }
+  ] }]
+}
+
+# The exact Employee Dashboard converter warnings (verbatim prefixes).
+WARNINGS = [
+  'ℹ "Full Name" → calculated column. Review: ...',
+  'ℹ "Tenure Days" → calculated column. Review: ...',
+  '⚠ "Total Absence Hours (CC)": uses DAX iterator (SUMX). Use groupings ...',
+  '⚠ "Salary Pct of Dept": CALCULATE filter ALLEXCEPT(EMPLOYEES, EMPLOYEES[DEPARTMENT]) ...',
+  '✅ "Dept Salary Rank" (DENSE_RANK) → SQL window helper "Dense Rank DEPARTMENT" ...',
+  '✅ "Hires In Period": CALCULATE over INACTIVE relationship ... alternate join path ...',
+  '⚠ "YTD Absence Hours": uses DAX time intelligence (TOTALYTD). Use Period over ...',
+  '⚠ "PY Absence Hours": uses DAX time intelligence (SAMEPERIODLASTYEAR). Use Period ...',
+  '⚠ "Absence Hours Per Head": references "[Headcount]" ... cross-table measure ... dropped',
+  'ℹ "Severity Score" → calculated column. Review: ...',
+  '⚠ "PY Incident Count": uses DAX time intelligence (SAMEPERIODLASTYEAR). Use Period ...',
+  '✅ "Dept Incident Rank" (DENSE_RANK) → SQL window helper ...',
+  'ℹ Calculated table "DimDate": DAX CALENDAR/ADDCOLUMNS → SQL date-spine.',
+  'ℹ Inactive relationship SAFETY_INCIDENTS[DATE] → DimDate[Date] skipped.'
+]
+
+qs    = DaxGate.dax_questions(WARNINGS, DM)
+ids   = qs.map { |q| q['id'] }
+mnames = qs.map { |q| DaxGate.measure_of(q['detail']) }
+
+# Regression: the demo used to flag 9 (all non-ℹ incl. ✅ + handled time-intel).
+# After the fix exactly 4 genuinely-dropped measures remain.
+ok 'exactly 4 decisions (was 9 pre-fix)',           qs.size == 4
+ok '✅ successes excluded (DENSE_RANK/USERELATIONSHIP)',
+   mnames.none? { |m| ['Dept Salary Rank', 'Hires In Period', 'Dept Incident Rank'].include?(m) }
+ok 'ℹ informational excluded (calc cols, DimDate)',  mnames.none? { |m| ['Full Name', 'Tenure Days', 'Severity Score'].include?(m) }
+ok '⚠ realized-in-DM excluded (YTD/PY Absence Hours)',
+   mnames.none? { |m| ['YTD Absence Hours', 'PY Absence Hours'].include?(m) }
+ok 'genuinely-dropped ⚠ kept (SUMX CC)',             mnames.include?('Total Absence Hours (CC)')
+ok 'genuinely-dropped ⚠ kept (ALLEXCEPT)',           mnames.include?('Salary Pct of Dept')
+ok 'genuinely-dropped ⚠ kept (cross-table)',         mnames.include?('Absence Hours Per Head')
+ok 'unrealized time-intel kept (PY Incident Count)', mnames.include?('PY Incident Count')
+ok 'all kept are dax_needs_restructure',             ids.all? { |i| i == 'dax_needs_restructure' }
+
+# ⛔ (true no-equivalent) is always a decision, even with no DM.
+ho = DaxGate.dax_questions(['⛔ "Hierarchy Path": PATHITEM has no Sigma equivalent'], {})
+ok '⛔ no-equivalent surfaces as dax_no_equivalent',  ho.size == 1 && ho[0]['id'] == 'dax_no_equivalent'
+
+# A handled measure must not be flagged just because an unrelated DM is empty.
+ok 'empty DM → realized set empty (⚠ all kept)',
+   DaxGate.dax_questions(['⚠ "X": something'], {}).size == 1
+
+puts(($fail.zero? ? "\nPASS" : "\n#{$fail} FAILED"))
+exit($fail.zero? ? 0 : 1)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -479,20 +479,32 @@ unless scout_gaps.empty?
   gap_ids = scout_gaps.map { |q| gid.call(q) }.uniq
   buckets = ScoutGate.classify(WORK, gap_ids)
   if buckets[:unscouted].any?
-    puts
-    puts '==================== GAP-SCOUT REQUIRED ===================='
-    puts "#{buckets[:unscouted].size} of #{gap_ids.size} untranslated measure(s) have NOT been scouted —"
-    puts 'the gap-scout must attempt a Sigma translation before the degradation is accepted:'
-    buckets[:unscouted].each { |id| puts "  --gap-id '#{id}'" }
-    puts ''
-    puts "Spawn one gap-scout per measure (scripts/gap-scout.md), passing the exact --gap-id above"
-    puts "plus --workdir #{WORK}, then re-run. --yes does NOT skip this gate."
-    puts '======================================================='
-    puts 'No Sigma objects were created.'
-    phase_summary
-    exit 11
+    unattended = opts[:yes] || opts[:answers]
+    if unattended
+      # Regression fix (gap-scout PR #153 made this a hard `exit 11` that overrode
+      # --yes, stalling the unattended/demo path). Under --yes/--answers the gate is
+      # ADVISORY: these measures take their "proceed" default (already in the decisions
+      # list) and the run flows through. Record as accepted so re-runs don't re-surface
+      # them; recommend the gap-scout for anyone who wants a faithful translation.
+      warn "   gap-scout: #{buckets[:unscouted].size} untranslated measure(s) not scouted — proceeding (unattended); recording as accepted degradations."
+      warn '   (optional: run scripts/gap-scout.md on these to persist a faithful Sigma translation)'
+      buckets[:unscouted].each { |id| ScoutGate.record(WORK, gap_id: id, feature: 'measure', status: 'accepted') }
+    else
+      # Interactive: the same measures already appear as review questions and exit via
+      # the OPEN QUESTIONS block below (exit 10). Just nudge toward the scout.
+      puts
+      puts '-------------------- GAP-SCOUT RECOMMENDED --------------------'
+      puts "#{buckets[:unscouted].size} of #{gap_ids.size} untranslated measure(s) have no faithful translation yet:"
+      buckets[:unscouted].each { |id| puts "  --gap-id '#{id}'" }
+      puts ''
+      puts 'Optional: spawn a gap-scout per measure (scripts/gap-scout.md) with the --gap-id above'
+      puts "plus --workdir #{WORK} to persist a translation; or re-run with --yes to accept the"
+      puts 'degradation defaults. These also appear in OPEN QUESTIONS below.'
+      puts '---------------------------------------------------------------'
+    end
+  else
+    puts "   gap-scout: all #{gap_ids.size} untranslated measure(s) accounted for (validated or escalated)"
   end
-  puts "   gap-scout: all #{gap_ids.size} untranslated measure(s) accounted for (validated or escalated)"
 end
 
 if questions.any? && !opts[:yes] && answers.nil?

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
@@ -303,19 +303,32 @@ unless calc_gaps.empty?
   gap_ids = calc_gaps.map { |q| gid.call(q) }.uniq
   buckets = ScoutGate.classify(WORK, gap_ids)
   if buckets[:unscouted].any?
-    puts
-    puts '==================== GAP-SCOUT REQUIRED ===================='
-    puts "#{buckets[:unscouted].size} of #{gap_ids.size} degraded calc(s) have NOT been scouted —"
-    puts 'the gap-scout must attempt a Sigma translation before the degradation is accepted:'
-    buckets[:unscouted].each { |id| puts "  --gap-id '#{id}'" }
-    puts ''
-    puts "Spawn one gap-scout per calc (scripts/gap-scout.md), passing the exact --gap-id above"
-    puts "plus --workdir #{WORK}, then re-run. --yes does NOT skip this gate."
-    puts '======================================================='
-    puts 'No Sigma objects were created.'
-    exit 11
+    unattended = opts[:yes] || opts[:answers]
+    if unattended
+      # Regression fix (gap-scout PR #153 made this a hard `exit 11` that overrode
+      # --yes, stalling the unattended/demo path). Under --yes/--answers the gate is
+      # ADVISORY: these calcs take their "proceed" default (already in the decisions
+      # list) and the run flows through. Record as accepted so re-runs don't re-surface
+      # them; recommend the gap-scout for anyone who wants a faithful translation.
+      warn "   gap-scout: #{buckets[:unscouted].size} degraded calc(s) not scouted — proceeding (unattended); recording as accepted degradations."
+      warn '   (optional: run scripts/gap-scout.md on these to persist a faithful Sigma translation)'
+      buckets[:unscouted].each { |id| ScoutGate.record(WORK, gap_id: id, feature: 'calc', status: 'accepted') }
+    else
+      # Interactive: the same calcs already appear as review questions and exit via
+      # the OPEN QUESTIONS block below (exit 10). Just nudge toward the scout.
+      puts
+      puts '-------------------- GAP-SCOUT RECOMMENDED --------------------'
+      puts "#{buckets[:unscouted].size} of #{gap_ids.size} degraded calc(s) have no faithful translation yet:"
+      buckets[:unscouted].each { |id| puts "  --gap-id '#{id}'" }
+      puts ''
+      puts 'Optional: spawn a gap-scout per calc (scripts/gap-scout.md) with the --gap-id above'
+      puts "plus --workdir #{WORK} to persist a translation; or re-run with --yes to accept the"
+      puts 'degradation defaults. These also appear in OPEN QUESTIONS below.'
+      puts '---------------------------------------------------------------'
+    end
+  else
+    puts "   gap-scout: all #{gap_ids.size} degraded calc(s) accounted for (validated or escalated)"
   end
-  puts "   gap-scout: all #{gap_ids.size} degraded calc(s) accounted for (validated or escalated)"
 end
 
 answers = nil

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -775,7 +775,13 @@ if unhandled_gaps.any?
   unscouted = buckets[:unscouted].map { |id| by_name[id] }
   escalated = buckets[:escalated].map { |id| by_name[id] }
 
-  if unscouted.any?
+  # Regression fix (gap-scout PR #153): the unscouted branch hard-`exit 11`'d even
+  # under --yes/--force, stalling the unattended/demo path. Under unattended mode
+  # (--yes/--answers/--force) the gate is ADVISORY — record the gaps as accepted and
+  # proceed (the features are MISSING/flagged in Sigma, as before the gate existed).
+  # Interactive runs still hard-stop so a human sees the gap and can scout it.
+  unattended = opts[:yes] || opts[:answers] || opts[:force]
+  if unscouted.any? && !unattended
     puts
     puts '==================== GAP-SCAN STOP (scout required) ===================='
     puts "#{unscouted.size} of #{unhandled_gaps.size} ❌-unhandled feature(s) have NOT been scouted:"
@@ -784,32 +790,34 @@ if unhandled_gaps.any?
     puts "Full report: #{gap_report_md || '(see workdir *gaps-report.md)'}"
     puts 'Spawn ONE gap-scout subagent per row (scripts/gap-scout.md), passing'
     puts "  --gap-id '<the row name above>' --workdir #{WORK}"
-    puts 'so each scout records its result to the ledger. Then re-run this command.'
-    puts '--force does NOT skip this gate — it only accepts gaps the scout tried'
-    puts 'and could not auto-translate (escalated).'
+    puts 'so each scout records its result to the ledger. Then re-run this command,'
+    puts 'or re-run with --yes/--force to accept the degradation (features MISSING/flagged).'
     puts '======================================================='
     puts 'No Sigma objects were created.'
     mark('phase1-join')
     phase_summary
     exit 11
-  elsif escalated.any? && !opts[:force]
+  elsif escalated.any? && !unattended
     puts
     puts '==================== GAP-SCAN STOP (escalated gaps) ===================='
     puts "All #{unhandled_gaps.size} unhandled feature(s) were scouted; #{escalated.size} could NOT be"
     puts 'auto-translated and were escalated (recorded locally; file an issue via escalate-gap.py):'
     escalated.each { |g| puts "  - #{g['name']} (×#{g['count']})" }
     puts ''
-    puts 'Re-run with --force to accept these as manual — they will be MISSING/flagged'
+    puts 'Re-run with --force/--yes to accept these as manual — they will be MISSING/flagged'
     puts 'in the Sigma workbook. (The validated ones still migrate.)'
     puts '======================================================='
     puts 'No Sigma objects were created.'
     mark('phase1-join')
     phase_summary
     exit 11
-  elsif escalated.any?
-    line "--force: proceeding past #{escalated.size} scouted-but-escalated feature(s) — they will NOT migrate"
   else
-    line "gap-scout: all #{unhandled_gaps.size} ❌-unhandled feature(s) resolved via validated rules"
+    if unscouted.any?
+      line "gap-scout: #{unscouted.size} ❌-unhandled feature(s) NOT scouted — proceeding (unattended); they will be MISSING/flagged in Sigma. (optional: scripts/gap-scout.md to translate)"
+      unscouted.each { |g| ScoutGate.record(WORK, gap_id: g['name'].to_s, feature: 'feature', status: 'accepted') }
+    end
+    line "--force/--yes: proceeding past #{escalated.size} scouted-but-escalated feature(s) — they will NOT migrate" if escalated.any?
+    line "gap-scout: all #{unhandled_gaps.size} ❌-unhandled feature(s) resolved via validated rules" if unscouted.empty? && escalated.empty?
   end
 end
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -44,6 +44,11 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 _SSL = ssl._create_unverified_context()
 MCP_TOOL = "mcp__sigma-data-model__convert_thoughtspot_to_sigma"
 
+# Unattended mode (set from --yes in main). Regression fix (gap-scout PR #153):
+# under --yes the error-column gate is ADVISORY (ships FLAGGED columns + proceeds)
+# instead of a hard exit 11, restoring the unattended/demo path.
+UNATTENDED = False
+
 def need_env(*names):
     missing = [n for n in names if not os.environ.get(n)]
     if missing:
@@ -215,6 +220,16 @@ def error_column_gate(wb, wd, display):
     gid = lambda c: "errcol:%s/%s" % (c.get("elementId"), c.get("label"))
     gap_ids = list(dict.fromkeys(gid(c) for c in errs))
     bk = scout_gate.classify(wd, gap_ids)
+    if bk["unscouted"] and UNATTENDED:
+        # Regression fix (gap-scout PR #153): under --yes the gate is ADVISORY — the
+        # ERROR-typed columns ship FLAGGED in Sigma (as before the gate existed) and
+        # the run proceeds. Record them so re-runs don't re-surface; recommend the scout.
+        print("\n   gap-scout: %d ERROR-typed column(s) NOT scouted — proceeding (--yes); they ship FLAGGED/broken in Sigma."
+              % len(bk["unscouted"]))
+        print("   (optional: run scripts/gap-scout.md on these to persist a faithful Sigma translation)")
+        for i in bk["unscouted"]:
+            scout_gate.record(wd, i, "errcol", "accepted")
+        return
     if bk["unscouted"]:
         print("\n==================== GAP-SCOUT REQUIRED ====================")
         print("%d of %d ERROR-typed column(s) have NOT been scouted — the gap-scout must"
@@ -223,7 +238,7 @@ def error_column_gate(wb, wd, display):
         for i in bk["unscouted"]:
             print("  --gap-id '%s'" % i)
         print("\nSpawn one gap-scout per column (scripts/gap-scout.md) with the exact --gap-id")
-        print("above plus --workdir %s, then re-run. --yes does NOT skip this gate." % wd)
+        print("above plus --workdir %s, then re-run, OR re-run with --yes to ship them FLAGGED." % wd)
         print("===========================================================")
         sys.exit(11)
     print("   gap-scout: all %d error column(s) accounted for (validated or escalated)" % len(gap_ids))
@@ -402,7 +417,11 @@ def main():
                     "(decided via ts-dm-signature.py + find-or-pick-dm.rb; see SKILL.md step 2.5)")
     ap.add_argument("--no-reuse", action="store_true", help="skip the automatic DM-reuse scan and always build a "
                     "new data model (the scan runs by default and auto-reuses a same-table column-superset DM)")
+    ap.add_argument("--yes", action="store_true", help="unattended: accept unscouted ERROR-typed columns at the "
+                    "gap-scout gate (they ship FLAGGED in Sigma) and proceed instead of stopping")
     a = ap.parse_args()
+    global UNATTENDED
+    UNATTENDED = a.yes
     wd = resolve_workdir(a.workdir)
     offline = bool(a.model_tml)
     if not a.model and not a.model_tml:


### PR DESCRIPTION
## Problem
PR #153 (gap-scout-gate-rollout) made the run-each-time gap-scout gate `exit 11` even under `--yes`/`--answers`, overriding the unattended path that previously took the "proceed" defaults and ran through. This broke smooth/demo migrations — surfaced on the PowerBI **Employee Dashboard**, which stalled on measures the converter had already handled.

## Fix
**1. Advisory under unattended mode** (all 8 plugins). With `--yes`/`--answers` (or `--force`, tableau), unscouted gaps are recorded to the ledger as `accepted` and the run proceeds with a loud warning + scout recommendation, instead of exiting 11. Interactive runs still surface them (OPEN QUESTIONS / hard stop).

**2. PowerBI over-firing** (extra). Its classifier bucketed ✅ (successfully auto-translated: RANKX→SQL window helper, USERELATIONSHIP→alternate join) and ⚠ restructures the converter actually **realized in the DM** (time-intel → grouped CumulativeSum/DateLookback elements) as un-scouted gaps. Now ✅ is excluded and a ⚠ whose measure resolves to a DM element/metric/column is treated as handled. Employee Dashboard: **9 → 4** flagged.

## Gates touched
- degradation-choice: powerbi, qlik, quicksight, tableau, cognos
- error-column (readback): looker, thoughtspot (added `--yes`), microstrategy

## Tests
- New `lib/dax_gate.rb` (pure classifier, extracted from migrate-powerbi.rb) + `test-dax-gate.rb` pinning the 9→4 regression. Passes.
- All ruby/python/mjs scripts syntax-checked; shared-file drift + mandatory-gate governance hooks green.
- Live-validated: PowerBI Employee Dashboard migrated end-to-end (DM + 5-visual workbook, 4/4 chart parity) under `--yes` with no hard stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)