### PR TITLE
Graduate sisense-to-sigma into the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,66 +1,125 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace-manifest.json",
   "name": "sigma-migration-skills",
-  "description": "Skills for migrating BI tools (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight, Looker, Cognos, MicroStrategy) to Sigma — converters + assessments, validated end-to-end with warehouse parity.",
+  "description": "Skills for migrating BI tools (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight, Looker, Cognos, MicroStrategy) to Sigma \u2014 converters + assessments, validated end-to-end with warehouse parity.",
   "version": "1.0.0",
-  "owner": { "name": "Thomas Wells" },
-  "metadata": { "pluginRoot": "./plugins" },
+  "owner": {
+    "name": "Thomas Wells"
+  },
+  "metadata": {
+    "pluginRoot": "./plugins"
+  },
   "plugins": [
     {
       "name": "tableau-to-sigma",
       "source": "./plugins/tableau-to-sigma",
-      "description": "Tableau workbooks/datasources → Sigma data model + workbook, with parity verification. Bundles tableau-to-sigma + tableau-assessment + tableau-vds-to-cdw (lands published-datasource/extract data in Snowflake or Databricks when it isn't already in the warehouse).",
+      "description": "Tableau workbooks/datasources \u2192 Sigma data model + workbook, with parity verification. Bundles tableau-to-sigma + tableau-assessment + tableau-vds-to-cdw (lands published-datasource/extract data in Snowflake or Databricks when it isn't already in the warehouse).",
       "category": "migration",
-      "keywords": ["tableau", "migration", "bi"]
+      "keywords": [
+        "tableau",
+        "migration",
+        "bi"
+      ]
     },
     {
       "name": "powerbi-to-sigma",
       "source": "./plugins/powerbi-to-sigma",
-      "description": "Power BI models/reports → Sigma, DAX translation + gap-scout, with parity verification. Bundles powerbi-to-sigma + powerbi-assessment.",
+      "description": "Power BI models/reports \u2192 Sigma, DAX translation + gap-scout, with parity verification. Bundles powerbi-to-sigma + powerbi-assessment.",
       "category": "migration",
-      "keywords": ["powerbi", "dax", "migration", "bi"]
+      "keywords": [
+        "powerbi",
+        "dax",
+        "migration",
+        "bi"
+      ]
     },
     {
       "name": "qlik-to-sigma",
       "source": "./plugins/qlik-to-sigma",
-      "description": "Qlik Sense / Qlik Cloud apps → Sigma, expression + Set Analysis translation, with parity verification. Bundles qlik-to-sigma + qlik-assessment.",
+      "description": "Qlik Sense / Qlik Cloud apps \u2192 Sigma, expression + Set Analysis translation, with parity verification. Bundles qlik-to-sigma + qlik-assessment.",
       "category": "migration",
-      "keywords": ["qlik", "migration", "bi"]
+      "keywords": [
+        "qlik",
+        "migration",
+        "bi"
+      ]
     },
     {
       "name": "thoughtspot-to-sigma",
       "source": "./plugins/thoughtspot-to-sigma",
-      "description": "ThoughtSpot models/worksheets + Liveboards → Sigma, TML conversion + Liveboard rebuild (KPI/bar/line/pie/pivot/table, search-query filters) + layout, with parity verification. Bundles thoughtspot-to-sigma + thoughtspot-assessment.",
+      "description": "ThoughtSpot models/worksheets + Liveboards \u2192 Sigma, TML conversion + Liveboard rebuild (KPI/bar/line/pie/pivot/table, search-query filters) + layout, with parity verification. Bundles thoughtspot-to-sigma + thoughtspot-assessment.",
       "category": "migration",
-      "keywords": ["thoughtspot", "tml", "migration", "bi"]
+      "keywords": [
+        "thoughtspot",
+        "tml",
+        "migration",
+        "bi"
+      ]
     },
     {
       "name": "quicksight-to-sigma",
       "source": "./plugins/quicksight-to-sigma",
-      "description": "Amazon QuickSight analyses/dashboards → Sigma data model + workbook (KPI/bar/line/pie/donut/combo/scatter/table/pivot), with parity verification. Bundles quicksight-to-sigma + quicksight-assessment.",
+      "description": "Amazon QuickSight analyses/dashboards \u2192 Sigma data model + workbook (KPI/bar/line/pie/donut/combo/scatter/table/pivot), with parity verification. Bundles quicksight-to-sigma + quicksight-assessment.",
       "category": "migration",
-      "keywords": ["quicksight", "amazon", "aws", "migration", "bi"]
+      "keywords": [
+        "quicksight",
+        "amazon",
+        "aws",
+        "migration",
+        "bi"
+      ]
     },
     {
       "name": "looker-to-sigma",
       "source": "./plugins/looker-to-sigma",
-      "description": "Looker (LookML semantic model + LookML/user-defined dashboards) → Sigma data model + workbook (KPI/bar/line/area/pie/donut/scatter/table/pivot, table calcs), with 3-way warehouse parity. Bundles looker-to-sigma + looker-assessment.",
+      "description": "Looker (LookML semantic model + LookML/user-defined dashboards) \u2192 Sigma data model + workbook (KPI/bar/line/area/pie/donut/scatter/table/pivot, table calcs), with 3-way warehouse parity. Bundles looker-to-sigma + looker-assessment.",
       "category": "migration",
-      "keywords": ["looker", "lookml", "migration", "bi"]
+      "keywords": [
+        "looker",
+        "lookml",
+        "migration",
+        "bi"
+      ]
     },
     {
       "name": "cognos-to-sigma",
       "source": "./plugins/cognos-to-sigma",
-      "description": "IBM Cognos Analytics → Sigma — Data Module JSON → Sigma data model, report-spec XML → Sigma workbook (crosstab→pivot, RAVE2 charts, maps), Cognos expression DSL translation, with parity verification. Bundles cognos-to-sigma + cognos-assessment.",
+      "description": "IBM Cognos Analytics \u2192 Sigma \u2014 Data Module JSON \u2192 Sigma data model, report-spec XML \u2192 Sigma workbook (crosstab\u2192pivot, RAVE2 charts, maps), Cognos expression DSL translation, with parity verification. Bundles cognos-to-sigma + cognos-assessment.",
       "category": "migration",
-      "keywords": ["cognos", "ibm-cognos", "data-module", "report-studio", "migration", "bi"]
+      "keywords": [
+        "cognos",
+        "ibm-cognos",
+        "data-module",
+        "report-studio",
+        "migration",
+        "bi"
+      ]
     },
     {
       "name": "microstrategy-to-sigma",
       "source": "./plugins/microstrategy-to-sigma",
-      "description": "MicroStrategy (Strategy One) → Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Bundles microstrategy-to-sigma + microstrategy-assessment.",
+      "description": "MicroStrategy (Strategy One) \u2192 Sigma \u2014 dossier + classic semantic model (attributes/facts/metrics over a star schema) \u2192 Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Bundles microstrategy-to-sigma + microstrategy-assessment.",
       "category": "migration",
-      "keywords": ["microstrategy", "strategy-one", "dossier", "migration", "bi"]
+      "keywords": [
+        "microstrategy",
+        "strategy-one",
+        "dossier",
+        "migration",
+        "bi"
+      ]
+    },
+    {
+      "name": "sisense-to-sigma",
+      "source": "./plugins/sisense-to-sigma",
+      "description": "Sisense (ElastiCube / Live data model + dashboards) \u2192 Sigma data model + workbook (indicator\u2192KPI, chart/*\u2192chart, pivot2\u2192pivot, table; JAQL\u2192Sigma formulas; filters\u2192controls; columnar layout\u219224-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
+      "category": "migration",
+      "keywords": [
+        "sisense",
+        "elasticube",
+        "jaql",
+        "migration",
+        "bi"
+      ]
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ reading the relevant `SKILL.md` and executing its scripts.
 | Scope/assess a Cognos Analytics instance | `cognos-assessment` | `plugins/cognos-to-sigma/skills/cognos-assessment/` |
 | Convert a MicroStrategy dossier + semantic model → Sigma | `microstrategy-to-sigma` | `plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/` |
 | Scope/assess a MicroStrategy (Strategy One) instance | `microstrategy-assessment` | `plugins/microstrategy-to-sigma/skills/microstrategy-assessment/` |
+| Convert a Sisense (ElastiCube / Live model + dashboards) → Sigma | `sisense-to-sigma` | `plugins/sisense-to-sigma/skills/sisense-to-sigma/` |
+| Scope/assess a Sisense instance | `sisense-assessment` | `plugins/sisense-to-sigma/skills/sisense-assessment/` |
 | Land a Tableau published-datasource/extract in Snowflake or Databricks | `tableau-vds-to-cdw` | `plugins/tableau-to-sigma/skills/tableau-vds-to-cdw/` |
 
 Assessments are read-only (never write to the source or post to Sigma); run one

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ shared `~/.sigma-migration/env` under any agent.
 /plugin install cognos-to-sigma@sigma-migration-skills
 /plugin install looker-to-sigma@sigma-migration-skills
 /plugin install microstrategy-to-sigma@sigma-migration-skills
+/plugin install sisense-to-sigma@sigma-migration-skills
 ```
 
 **Other agents (Cursor, Cortex Code, …)** — clone the repo and point your agent at the
@@ -50,6 +51,7 @@ and the skill drives discovery → translation → build → parity.
 | [`cognos-to-sigma`](plugins/cognos-to-sigma/) | IBM Cognos Analytics | `cognos-to-sigma`, `cognos-assessment` |
 | [`looker-to-sigma`](plugins/looker-to-sigma/) | Looker | `looker-to-sigma`, `looker-assessment` |
 | [`microstrategy-to-sigma`](plugins/microstrategy-to-sigma/) | MicroStrategy (Strategy One) | `microstrategy-to-sigma`, `microstrategy-assessment` |
+| [`sisense-to-sigma`](plugins/sisense-to-sigma/) | Sisense (ElastiCube / Live) | `sisense-to-sigma`, `sisense-assessment` |
 
 In Claude Code, installed skills are namespaced — e.g. `/powerbi-to-sigma:powerbi-assessment`.
 

--- a/docs/phase-schema.md
+++ b/docs/phase-schema.md
@@ -58,6 +58,24 @@ MicroStrategy uses "Phase" numbering and is documented here rather than as an
 | C9 Security/RLS | "Security: RLS/CLS" section |
 | C10 Enhance | — |
 
+### sisense-to-sigma
+
+Sisense uses "Phase" numbering (it joined after the table was set). Its local
+mapping:
+
+| Canonical | sisense-to-sigma |
+|---|---|
+| C1 Assess | sisense-assessment skill + `scan_gaps.py` (gap scout) |
+| C2 Discover | Phase 1 — Discover (`discover.py`) |
+| C3 Reuse-check | Phase 2 — reuse an existing DM on the same warehouse tables before POST |
+| C4 Convert | Phase 2/3 — Convert model + dashboards → Sigma specs |
+| C5 Post-DM gate | Phase 2 — POST + read back real ids |
+| C6 Build workbook | Phase 3 — emit workbook with read-back ids, POST |
+| C7 Layout | within Phase 3 (`build_layout` → `layout` XML, LAST write) |
+| C8 Parity hard gate | Phase 4 — Verify parity (`verify_parity.py` data + `verify_layout.py` layout) |
+| C9 Security/RLS | Phase 1.5 — RLS scan (opt-in: `detect_rls.py` + `apply_sigma_rls.py`) |
+| C10 Enhance | — (defer to `sigma-workbooks`) |
+
 Notes:
 
 - **Looker runs the RLS gate early** (before building, C9 ahead of C4) by

--- a/plugins/sisense-to-sigma/README.md
+++ b/plugins/sisense-to-sigma/README.md
@@ -1,0 +1,38 @@
+# sisense-to-sigma
+
+Migrate **Sisense** (ElastiCube / Live data models + dashboards) to **Sigma**,
+in the same phase structure as the other converters in this marketplace.
+
+Sisense exposes a full REST API, so this plugin pulls the source content **live**
+(no customer-side export needed) and recreates it in Sigma — data model,
+workbook, layout, and parity.
+
+## Skills
+
+| Skill | What it does |
+|---|---|
+| `sisense-to-sigma` | Discover → convert model + dashboards → build Sigma DM + workbook → verify parity. |
+| `sisense-assessment` | Read-only estate inventory + converter-coverage scoring. |
+
+## Flow (mirrors the sibling converters — see `docs/phase-schema.md`)
+
+1. **Discover** — `discover.py`: ElastiCubes, full model schema export, dashboards + widgets.
+2. **(opt-in) RLS scan** — `detect_rls.py`: Sisense data-security → Sigma row-level security (zero-overhead when none).
+3. **Convert model** — `convert.py model`: warehouse-table elements + relationships (cardinality-resolved), ElastiCube custom-SQL → Sigma SQL (verbatim + flagged). POST + read back real ids.
+4. **Convert dashboards** — `convert.py dashboard`: indicator→KPI, chart/*→chart, pivot2→pivot, table; JAQL→Sigma formulas; filters→controls; Sisense columnar layout → Sigma 24-col grid.
+5. **Verify parity** — `verify_parity.py` (data: Sisense JAQL == warehouse) + `verify_layout.py` (structural layout) + render visual-QA (`sigma-export-png.py` + `refs/layout-visual-qa.md`).
+6. **Gap scout** — `scan_gaps.py` measures coverage, records gaps to a `learned-rules.json` ledger; `escalate-gap.py` files a tracking issue (opt-in).
+
+## Status
+
+Live-validated end-to-end against a Sisense trial → Sigma at **exact data
+parity**, with the source layout reproduced (faithful for structured layouts;
+clean auto-arrange for degenerate stacks) and opt-in RLS verified to exact
+restricted parity on both text and numeric columns. **Don't claim parity until
+`verify_parity.py` is GREEN.** See `skills/sisense-to-sigma/refs/design-notes.md`.
+
+## Credentials
+
+Sisense creds in `~/.sigma-migration/sisense.env`
+(`SISENSE_BASE_URL` + a bearer `SISENSE_API_TOKEN`); Sigma side reuses the shared
+`~/.sigma-migration/env` via `scripts/get-token.sh`, like the sibling converters.

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/PRIVACY.md
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/PRIVACY.md
@@ -1,0 +1,21 @@
+# Privacy — sisense-assessment
+
+This skill is **read-only** and operates on **metadata**, not row data.
+
+**What it reads** (over the Sisense REST API, with the credentials you provide):
+- Data model inventory: titles, dataset/table/column names and types, relations.
+- Dashboard inventory: titles, datasource names, widget types, and the JAQL
+  panel definitions (dimension/measure field references and formulas).
+
+**What it does NOT do:**
+- It does **not** run warehouse queries or read row-level/customer data.
+- It does **not** write to, modify, or delete anything in Sisense.
+- It does **not** send anything to Sigma.
+- It does **not** transmit your data to third parties. All output stays in the
+  local `--out` directory.
+
+**Credentials.** The bearer token / login is used only to call the read
+endpoints listed above and is stored locally in `~/.sigma-migration/sisense.env`
+(mode 600). Revoke it in Sisense at any time.
+
+Surface this document to the customer before running the assessment.

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/SKILL.md
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: sisense-assessment
+description: >-
+  Take inventory of a Sisense estate and produce a migration-readiness readout —
+  ElastiCube/Live model counts, dashboard counts, a widget-type histogram, JAQL
+  complexity, dataset/connection mix, and per-dashboard AUTO / HINT / MANUAL /
+  UNHANDLED tags scored against the sisense-to-sigma converter's actual
+  coverage. Use when a user wants to scope a Sisense→Sigma migration, audit BI
+  sprawl, or pick which dashboards to convert first. Read-only, all-free
+  pre-scoping over the Sisense REST API.
+user-invocable: true
+---
+
+# Sisense Assessment
+
+Surveys a Sisense estate over REST and produces a JSON inventory + markdown
+readout. The differentiator versus a generic BI audit is **converter-coverage
+classification**: every dashboard is scored against the *same* coverage the
+`sisense-to-sigma` converter actually applies
+(`../sisense-to-sigma/refs/widget-type-mapping.md`), so the readout reflects
+what the tool will really do.
+
+> **Read-only.** Lists models, dashboards, and widget metadata. It never writes
+> to Sisense and never touches Sigma. See `PRIVACY.md` and surface it to the
+> customer before running.
+
+> **All free.** Inventory, scoring, readout — part of the open migration
+> tooling. For a deeper engagement (security audit, live parity testing), point
+> the customer at a Sigma SE.
+
+> **Status:** scaffold. Discovery (shared with the converter) is live; the
+> scoring/readout in `scripts/assess.py` is not built yet.
+
+## Phase 0 — Connect
+`eval "$(../sisense-to-sigma/scripts/sisense-auth.sh)"` — bearer token or
+email+password (see `../sisense-to-sigma/refs/sisense-rest-api.md`).
+
+## Phase 1 — Inventory + score
+```sh
+python3 scripts/assess.py --out ~/sisense-migration
+```
+Reuses the converter's `discover.py` bundle, then emits:
+- `assessment.json` — counts, widget-type histogram, JAQL-complexity buckets,
+  per-dashboard coverage tag (AUTO / HINT / MANUAL / UNHANDLED).
+- `assessment.md` — ranked migration shortlist (value vs. effort).

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/assess.py
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/assess.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Sisense estate assessment — read-only inventory + converter-coverage scoring.
+
+Reuses the converter's discovery bundle (run ../sisense-to-sigma/scripts/
+discover.py first) and scores every dashboard/widget against the SAME coverage
+the sisense-to-sigma converter actually applies (WIDGET_MAP + jaql_expr), so the
+readout reflects what the tool will really do.
+
+Emits <out>/assessment.json + <out>/assessment.md:
+  - model + dashboard counts, datasets/tables/relations per model
+  - widget-type histogram
+  - JAQL complexity buckets (simple agg / formula / flagged)
+  - per-dashboard AUTO / HINT / MANUAL / UNHANDLED tally + a migration shortlist
+
+Usage: python3 assess.py [--out ~/sisense-migration]
+"""
+import argparse, json, os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "sisense-to-sigma", "scripts"))
+import convert as C
+import jaql_expr as J
+
+def jaql_complexity(w):
+    simple = formula = flagged = 0
+    for p in w.get("metadata", {}).get("panels", []):
+        for it in p.get("items", []):
+            jq = it.get("jaql", {})
+            if not jq:
+                continue
+            try:
+                J.classify(jq)
+                formula += 1 if "formula" in jq else 0
+                simple += 0 if "formula" in jq else 1
+            except J.Unsupported:
+                flagged += 1
+    return simple, formula, flagged
+
+def tag_for(wt):
+    _, tag = C.WIDGET_MAP.get(wt, (None, "UNHANDLED"))
+    if C.SIGMA_KIND.get(wt) is None and tag != "UNHANDLED":
+        tag = "MANUAL"
+    return tag
+
+def assess(out_dir):
+    disc = os.path.join(out_dir, "discovery")
+    cubes = json.load(open(os.path.join(disc, "elasticubes.json")))
+    dashboards = json.load(open(os.path.join(disc, "dashboards.json")))
+
+    models = []
+    for c in cubes:
+        safe = c["title"].replace("/", "_").replace(" ", "_")
+        mp = os.path.join(disc, f"model_{safe}.json")
+        if os.path.exists(mp):
+            m = json.load(open(mp))
+            tbls = [t for ds in m["datasets"] for t in ds["schema"]["tables"]]
+            models.append({"title": c["title"], "datasets": len(m["datasets"]),
+                           "tables": len(tbls), "relations": len(m.get("relations", [])),
+                           "custom_sql_tables": sum(1 for t in tbls if t.get("expression"))})
+
+    hist, dash_rows = {}, []
+    for d in dashboards:
+        tags = {"AUTO": 0, "HINT": 0, "MANUAL": 0, "UNHANDLED": 0}
+        cx = {"simple": 0, "formula": 0, "flagged": 0}
+        for w in d.get("widgets", []):
+            wt = w.get("type")
+            hist[wt] = hist.get(wt, 0) + 1
+            tags[tag_for(wt)] = tags.get(tag_for(wt), 0) + 1
+            s, f, fl = jaql_complexity(w)
+            cx["simple"] += s; cx["formula"] += f; cx["flagged"] += fl
+        n = max(1, len(d.get("widgets", [])))
+        score = round(100 * (tags["AUTO"] + 0.6 * tags["HINT"]) / n - 5 * cx["flagged"], 1)
+        dash_rows.append({"title": d.get("title"), "widgets": len(d.get("widgets", [])),
+                          "tags": tags, "jaql": cx, "readiness": score})
+
+    out = {"models": models, "widget_histogram": hist,
+           "dashboards": sorted(dash_rows, key=lambda r: -r["readiness"])}
+    json.dump(out, open(os.path.join(out_dir, "assessment.json"), "w"), indent=2)
+    _write_md(out, os.path.join(out_dir, "assessment.md"))
+    print(f"wrote assessment.json + assessment.md  ({len(models)} models, "
+          f"{len(dash_rows)} dashboards, {sum(hist.values())} widgets)")
+
+def _write_md(o, path):
+    L = ["# Sisense → Sigma — Migration Assessment\n", "## Data models\n",
+         "| Model | Datasets | Tables | Relations | Custom-SQL tables |", "|---|---|---|---|---|"]
+    for m in o["models"]:
+        L.append(f'| {m["title"]} | {m["datasets"]} | {m["tables"]} | {m["relations"]} | {m["custom_sql_tables"]} |')
+    L += ["\n## Widget-type histogram\n", "| Sisense widget | Count | Converter coverage |", "|---|---|---|"]
+    for wt, n in sorted(o["widget_histogram"].items(), key=lambda x: -x[1]):
+        L.append(f"| `{wt}` | {n} | {tag_for(wt)} |")
+    L += ["\n## Dashboards — migration shortlist (most ready first)\n",
+          "| Dashboard | Widgets | AUTO | HINT | MANUAL | UNHANDLED | Flagged JAQL | Readiness |",
+          "|---|---|---|---|---|---|---|---|"]
+    for r in o["dashboards"]:
+        t = r["tags"]
+        L.append(f'| {r["title"]} | {r["widgets"]} | {t["AUTO"]} | {t["HINT"]} | '
+                 f'{t["MANUAL"]} | {t["UNHANDLED"]} | {r["jaql"]["flagged"]} | {r["readiness"]} |')
+    L += ["\n_AUTO = converts cleanly · HINT = converts, verify · MANUAL = needs a human "
+          "decision (no native Sigma viz) · UNHANDLED = flagged, not converted. Read-only, all-free pre-scoping._\n"]
+    open(path, "w").write("\n".join(L))
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=os.path.expanduser("~/sisense-migration"))
+    assess(ap.parse_args().out)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: sisense-to-sigma
+description: >-
+  Migrate Sisense to Sigma. Use when the user has a Sisense instance —
+  ElastiCube or Live data models and dashboards — and wants to recreate them in
+  Sigma. Pulls the source live over the Sisense REST API (data model schema
+  export + dashboards/widgets), converts the model to a Sigma data model and the
+  dashboards to a Sigma workbook (pivot2→pivot-table, indicator→KPI,
+  chart/*→chart, filters→controls), translates JAQL formulas to Sigma formulas,
+  and verifies data parity by running JAQL against Sisense and comparing to the
+  Sigma query. For a full migration it lands the source data in Snowflake so
+  both tools read the same warehouse. Translates what maps cleanly and flags
+  what doesn't (custom JAQL, BloX/plugin widgets, scripted dashboards) instead
+  of emitting wrong logic.
+user-invocable: true
+---
+
+# Sisense → Sigma migration
+
+Convert a **Sisense** data model + dashboards into a Sigma **data model** +
+**workbook**. Pull the model schema export and the widget definitions over REST,
+translate JAQL / widget types / filters, emit the specs, then **verify parity**
+against numbers from Sisense's own JAQL engine. Translate what maps cleanly;
+**flag what doesn't** (custom JAQL functions, BloX/plugin widgets, scripted
+widgets) — never emit confidently-wrong logic.
+
+> **Status — LIVE-VALIDATED (2026-06-17).** A full end-to-end migration of the
+> Sisense *Sample ECommerce* model + dashboard was run and **verified at exact
+> data parity**: Sisense ElastiCube → Sisense Live-on-Snowflake → Snowflake
+> (`CSA.SISENSE_ECOMMERCE`) → Sigma data model (`de8a93d3`/`fee42fdc`) → Sigma
+> workbook (`d9312472`). Total Revenue **$39,759,625.515**, Total Quantity
+> **91,206**, and the joined Revenue-by-Category breakdown all match Sisense
+> JAQL exactly. The converter (`jaql_expr.py` + `convert.py`) was exercised
+> against an 18-widget coverage corpus (every chart type + JAQL formula/level/
+> top-N/break-by). Known refinements: pie-chart `color` spec + bar `topN`
+> display-limit (values correct; display cap not yet enforced). Still flag —
+> never fake — treemap/sunburst (no native Sigma equivalent) and unsupported
+> JAQL functions. See `refs/design-notes.md`.
+
+> Read `refs/` before relying on shapes: `sisense-rest-api.md` (validated
+> endpoint map + auth + the access-key-vs-token gotcha), `jaql-mapping.md`
+> (JAQL → Sigma formula + what's flagged), `widget-type-mapping.md` (widget →
+> Sigma element coverage), `design-notes.md` (architecture, the Snowflake-parity
+> requirement, hard problems, the Layout translator), `layout-visual-qa.md` (the
+> render-and-inspect gate). For canonical Sigma spec shapes, defer to the
+> `sigma-data-models` / `sigma-workbooks` skills.
+
+---
+
+## Prerequisites
+
+- **Sisense access.** Email + password or a bearer API token. Run
+  `eval "$(scripts/sisense-auth.sh)"` — reads `SISENSE_BASE_URL` +
+  `SISENSE_EMAIL`/`SISENSE_PASSWORD` (or a stored `SISENSE_API_TOKEN`) from the
+  env or `~/.sigma-migration/sisense.env`. **Use a bearer token, not an
+  access-key public key** (that's for SSO/embed — see `refs/sisense-rest-api.md`).
+- **Sigma API token** — `eval "$(scripts/get-token.sh)"` (uses
+  `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`/`SIGMA_BASE_URL` or
+  `~/.sigma-migration/env`).
+- **A Sigma connection to the warehouse holding the source data.** Parity only
+  means something when Sigma reads the same data Sisense did. For ElastiCube
+  (ECCloud) sources this means **landing the data in Snowflake first** and
+  pointing both tools at it — see `refs/design-notes.md` ("Snowflake-parity").
+- **Python 3** (stdlib only).
+
+## Phase 0 — Assess (optional)
+Run the `sisense-assessment` skill for an estate inventory + converter-coverage
+scoring before committing to conversions.
+
+**Gap scout (run each time).** `scan_gaps.py <dashboards.json>` measures
+converter coverage (AUTO/HINT/MANUAL/UNHANDLED + flagged JAQL) and appends every
+gap to a `learned-rules.json` ledger. It is the **flag-never-fake gate**: run it
+at convert time and again at the done-gate (`--strict` exits non-zero while any
+MANUAL/UNHANDLED/flagged gap is unresolved). For a gap with no clean Sigma
+translation, `escalate-gap.py` (opt-in, dry-run by default) drafts a tracking
+issue — file it only on `--yes`.
+
+## Phase 1 — Discover  ✅ working
+```sh
+eval "$(scripts/sisense-auth.sh)"
+python3 scripts/discover.py --out ~/sisense-migration        # all cubes + dashboards
+python3 scripts/discover.py --out ~/sisense-migration --cube "Sample ECommerce"
+```
+Writes `~/sisense-migration/discovery/`: `elasticubes.json`,
+`model_<title>.json` (full schema export), `dashboards.json` (widgets inlined).
+
+## Phase 1.5 — RLS scan (optional, opt-in)
+`detect_rls.py "<cube>"` checks the cube's Sisense **data-security** rules and
+maps them to Sigma row-level security. **Zero-overhead + never silent:** with no
+rules it prints nothing and exits 0; with rules it prints the recommended
+mapping (a per-column **user attribute** + a `CurrentUserAttributeText("<col>")
+= [<Col>]` row filter) and, with `--out security.json`, writes a converter-style
+`security[]`. Porting is **opt-in** — `apply_sigma_rls.py --from-security
+security.json --dm-id <id>` is reuse-first and **plan-only by default**, mutating
+only on explicit `--provision`/`--apply` (then assign per-user values via
+`POST /v2/user-attributes/{id}/users` — member values are flagged, never faked).
+This is the same tool-agnostic apply path every sibling RLS port uses.
+
+## Phase 2 — Convert the model  ✅ live-validated
+`convert.py model` → Sigma DM spec from `model_<title>.json`: each
+`schema.tables[]` → DM element (plain table → warehouse source; table with
+`expression` → Custom-SQL element, SQL verbatim + flagged), `relations[]` → DM
+relationships, column `type` codes → Sigma types. Targets the Snowflake
+connection holding the landed data. **Reuse-first:** before POSTing, check for an
+existing Sigma data model on the same warehouse tables and reuse it rather than
+creating DM sprawl.
+
+**POST + read back real ids.** POST the DM spec, then GET
+`/v2/dataModels/{id}/spec` and **read back** the server-assigned element + column
+ids — the workbook's Master element sources the fact element by its read-back
+id, never the client-side one (DM POST reassigns ids; workbook CREATE preserves
+them).
+
+## Phase 3 — Convert dashboards  ✅ live-validated
+`convert.py dashboard` → workbook spec: widget `type` → element
+(`pivot2`→pivot-table, `indicator`→KPI, `chart/*`→chart, `tablewidget`→table),
+panel JAQL → formulas via `jaql_expr.py`, filters → controls.
+
+**Layout comes over too.** Sisense's `layout.columns[]` (vertical strips →
+`cells[]` stacked → `subcells[]` side-by-side → `elements[]` by `widgetid`+px
+height) is translated into Sigma's top-level `layout` XML (24-col grid,
+`<LayoutElement gridColumn gridRow/>`). A real multi-column/subcell layout is
+ported **faithfully** — column %widths → proportional grid spans, side-by-side
+stays side-by-side. A degenerate single full-width stack (Sisense's default) is
+**auto-arranged** into something clean: leading KPIs flow into rows of up to 4
+cards, charts go 2-up, and trends/tables/pivots span full width. Controls
+(from dashboard filters) are placed as a flat row at the top — **not** a
+`<GridContainer>`, which Sigma rejects unless its `elementId` points to a real
+container element in the spec. Element IDs are preserved on workbook CREATE, so
+the layout refs resolve. The `layout` XML is the **last write** in the workbook
+spec — emitted after every element is positioned, so it reflects the final
+arrangement (no separate post-hoc layout PUT needed; CREATE preserves the ids
+the layout references). See `refs/design-notes.md` ("Layout").
+
+## Phase 4 — Verify parity  ✅ live-validated
+Two gates, both must be **GREEN** before claiming done:
+- **Data** — `verify_parity.py` runs each widget's JAQL (`POST
+  /api/datasources/{ds}/jaql`) and compares to the warehouse SQL Sigma compiles
+  to (+ a Sigma `query` spot-check). Proves the numbers match.
+- **Layout** — `verify_layout.py <dashboards.json> <sigma_workbook_spec.json>`
+  proves the arrangement came over: every mapped widget placed exactly once, no
+  orphan refs, inside the 24-col grid, no overlaps, reading order preserved,
+  side-by-side widgets stay on one row, relative widths preserved. Data parity
+  alone does **not** check any of this.
+- **Visual QA** — structural-green is not visually-correct. Render each page with
+  `sigma-export-png.py` and read it against `refs/layout-visual-qa.md` (compare
+  to the Sisense source PNG). Declare done on a clean render, not an HTTP 200.
+- **Gap scout** — re-run `scan_gaps.py --strict`; no unresolved MANUAL/UNHANDLED/
+  flagged gap may remain unaccounted-for.
+
+## Phase 5 — Repoint + enhance
+Wire workbook → DM. Layout is already ported by `convert.py dashboard` (Phase 3)
+— review it in Sigma and nudge spans if a chart needs more room; defer deeper
+polish (themes, conditional formatting) to `sigma-workbooks`.
+
+## Flag, never fake
+Custom JAQL functions, BloX/plugin/scripted widgets, import-time
+`modelingTransformations`, and any unmapped viz are surfaced as loud flags in
+the conversion report — not silently approximated.

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/fixtures/dashboards.json
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/fixtures/dashboards.json
@@ -1,0 +1,1961 @@
+[
+  {
+    "_id": "6a33404e17884480503a9e36",
+    "title": "ECommerce Overview (Live)",
+    "desc": "",
+    "source": null,
+    "type": "dashboard",
+    "shares": [
+      {
+        "shareId": "6a32fb475397399ec0a31c8f",
+        "type": "user"
+      }
+    ],
+    "style": {},
+    "owner": "6a32fb475397399ec0a31c8f",
+    "userId": "6a32fb475397399ec0a31c8f",
+    "tenantId": "6a32fb475397399ec0a31c9c",
+    "created": "2026-06-18T00:48:14.234Z",
+    "lastUpdated": "2026-06-18T13:20:07.788Z",
+    "layout": {
+      "type": "columnar",
+      "columns": [
+        {
+          "width": 100,
+          "cells": [
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a33406e17884480503a9e37"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a33406e17884480503a9e39"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a33406e17884480503a9e3b"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a33406f17884480503a9e3d"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a33406f17884480503a9e3f"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a33406f17884480503a9e41"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "instanceType": "owner",
+    "dataExploration": true,
+    "lastOpened": "2026-06-18T13:01:51.313Z",
+    "previewLayout": [],
+    "datasource": {
+      "address": "LocalHost",
+      "title": "Sample ECommerce (Snowflake Live)",
+      "database": "Sample ECommerce (Snowflake Live)",
+      "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+      "live": true
+    },
+    "oid": "6a33404e17884480503a9e35",
+    "settings": {
+      "autoUpdateOnFiltersChange": true
+    },
+    "filters": [
+      {
+        "jaql": {
+          "dim": "[Commerce.Gender]",
+          "table": "Commerce",
+          "column": "Gender",
+          "datatype": "text",
+          "title": "Gender",
+          "filter": {
+            "members": [
+              "Male",
+              "Female"
+            ]
+          }
+        }
+      },
+      {
+        "jaql": {
+          "dim": "[Country.Country]",
+          "table": "Country",
+          "column": "Country",
+          "datatype": "text",
+          "title": "Country",
+          "filter": {
+            "members": [
+              "United States",
+              "Canada"
+            ]
+          }
+        }
+      }
+    ],
+    "widgets": [
+      {
+        "_id": "6a33406e17884480503a9e38",
+        "title": "Total Revenue",
+        "type": "indicator",
+        "subtype": "indicator/numeric",
+        "oid": "6a33406e17884480503a9e37",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:48:46.198Z",
+        "lastUpdated": "2026-06-18T00:48:46.198Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "value",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "title": "Total Revenue",
+                    "agg": "sum"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "instanceid": null,
+        "options": {
+          "dashboardFiltersMode": "filter",
+          "selector": true
+        },
+        "dashboardid": "6a33404e17884480503a9e35",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a33406e17884480503a9e3a",
+        "title": "Total Quantity",
+        "type": "indicator",
+        "subtype": "indicator/numeric",
+        "oid": "6a33406e17884480503a9e39",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:48:46.522Z",
+        "lastUpdated": "2026-06-18T00:48:46.522Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "value",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Quantity]",
+                    "title": "Total Quantity",
+                    "agg": "sum"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "instanceid": null,
+        "options": {
+          "dashboardFiltersMode": "filter",
+          "selector": true
+        },
+        "dashboardid": "6a33404e17884480503a9e35",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a33406e17884480503a9e3c",
+        "title": "Revenue by Category",
+        "type": "chart/column",
+        "subtype": "column/classic",
+        "oid": "6a33406e17884480503a9e3b",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:48:46.821Z",
+        "lastUpdated": "2026-06-18T00:48:46.821Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "categories",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Category.Category]",
+                    "title": "Category",
+                    "sort": "desc"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "title": "Revenue",
+                    "agg": "sum"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "break by",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "instanceid": null,
+        "options": {
+          "dashboardFiltersMode": "filter",
+          "selector": true
+        },
+        "dashboardid": "6a33404e17884480503a9e35",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a33406f17884480503a9e3e",
+        "title": "Revenue by Country (Top 10)",
+        "type": "chart/bar",
+        "subtype": "bar/classic",
+        "oid": "6a33406f17884480503a9e3d",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:48:47.135Z",
+        "lastUpdated": "2026-06-18T00:48:47.135Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "categories",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Country.Country]",
+                    "title": "Country",
+                    "filter": {
+                      "top": {
+                        "count": 10,
+                        "by": {
+                          "dim": "[Commerce.Revenue]",
+                          "agg": "sum"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "title": "Revenue",
+                    "agg": "sum"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "break by",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "instanceid": null,
+        "options": {
+          "dashboardFiltersMode": "filter",
+          "selector": true
+        },
+        "dashboardid": "6a33404e17884480503a9e35",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a33406f17884480503a9e40",
+        "title": "Revenue Trend (Monthly)",
+        "type": "chart/line",
+        "subtype": "line/classic",
+        "oid": "6a33406f17884480503a9e3f",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:48:47.519Z",
+        "lastUpdated": "2026-06-18T00:48:47.519Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "x-axis",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Date]",
+                    "title": "Months in Date",
+                    "level": "months"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "title": "Revenue",
+                    "agg": "sum"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "break by",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "instanceid": null,
+        "options": {
+          "dashboardFiltersMode": "filter",
+          "selector": true
+        },
+        "dashboardid": "6a33404e17884480503a9e35",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a33406f17884480503a9e42",
+        "title": "Quantity by Category",
+        "type": "chart/pie",
+        "subtype": "pie/classic",
+        "oid": "6a33406f17884480503a9e41",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:48:47.839Z",
+        "lastUpdated": "2026-06-18T00:48:47.839Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "categories",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Category.Category]",
+                    "title": "Category"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Quantity]",
+                    "title": "Quantity",
+                    "agg": "sum"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "instanceid": null,
+        "options": {
+          "dashboardFiltersMode": "filter",
+          "selector": true
+        },
+        "dashboardid": "6a33404e17884480503a9e35",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      }
+    ]
+  },
+  {
+    "_id": "6a3341b417884480503a9e44",
+    "title": "ECommerce \u2014 Full Coverage",
+    "desc": "",
+    "source": null,
+    "type": "dashboard",
+    "shares": [
+      {
+        "shareId": "6a32fb475397399ec0a31c8f",
+        "type": "user"
+      }
+    ],
+    "style": {},
+    "owner": "6a32fb475397399ec0a31c8f",
+    "userId": "6a32fb475397399ec0a31c8f",
+    "tenantId": "6a32fb475397399ec0a31c9c",
+    "created": "2026-06-18T00:54:12.513Z",
+    "lastUpdated": "2026-06-18T01:02:51.317Z",
+    "layout": {
+      "type": "columnar",
+      "columns": [
+        {
+          "width": 100,
+          "cells": [
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b417884480503a9e45"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b517884480503a9e47"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b517884480503a9e49"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b517884480503a9e4b"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b617884480503a9e4d"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b617884480503a9e4f"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b617884480503a9e51"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b717884480503a9e53"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b717884480503a9e55"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b717884480503a9e57"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b817884480503a9e59"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b817884480503a9e5b"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b817884480503a9e5d"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b917884480503a9e5f"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b917884480503a9e61"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341b917884480503a9e63"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341ba17884480503a9e65"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            },
+            {
+              "subcells": [
+                {
+                  "elements": [
+                    {
+                      "minHeight": 102,
+                      "maxHeight": 1024,
+                      "minWidth": 128,
+                      "maxWidth": 2048,
+                      "height": 512,
+                      "defaultWidth": 512,
+                      "widgetid": "6a3341ba17884480503a9e67"
+                    }
+                  ],
+                  "index": 0,
+                  "stretchable": false,
+                  "width": 100
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "instanceType": "owner",
+    "dataExploration": true,
+    "lastOpened": "2026-06-18T01:02:50.914Z",
+    "previewLayout": [],
+    "datasource": {
+      "address": "LocalHost",
+      "title": "Sample ECommerce (Snowflake Live)",
+      "database": "Sample ECommerce (Snowflake Live)",
+      "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+      "live": true
+    },
+    "oid": "6a3341b417884480503a9e43",
+    "settings": {
+      "autoUpdateOnFiltersChange": true
+    },
+    "widgets": [
+      {
+        "_id": "6a3341b417884480503a9e46",
+        "title": "KPI: Total Revenue",
+        "type": "indicator",
+        "subtype": "indicator/numeric",
+        "oid": "6a3341b417884480503a9e45",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:12.839Z",
+        "lastUpdated": "2026-06-18T00:54:12.839Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "value",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Total Revenue"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b517884480503a9e48",
+        "title": "KPI: Gauge AOV",
+        "type": "indicator",
+        "subtype": "indicator/gauge",
+        "oid": "6a3341b517884480503a9e47",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:13.158Z",
+        "lastUpdated": "2026-06-18T00:54:13.158Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "value",
+              "items": [
+                {
+                  "jaql": {
+                    "formula": "SUM([r])/COUNT([v])",
+                    "context": {
+                      "[r]": {
+                        "dim": "[Commerce.Revenue]"
+                      },
+                      "[v]": {
+                        "dim": "[Commerce.Visit ID]"
+                      }
+                    },
+                    "title": "Avg Order Value"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "min",
+              "items": []
+            },
+            {
+              "name": "max",
+              "items": []
+            },
+            {
+              "name": "secondary",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b517884480503a9e4a",
+        "title": "KPI: Distinct Brands",
+        "type": "indicator",
+        "subtype": "indicator/numeric",
+        "oid": "6a3341b517884480503a9e49",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:13.471Z",
+        "lastUpdated": "2026-06-18T00:54:13.471Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "value",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Brand.Brand]",
+                    "agg": "countDistinct",
+                    "title": "Distinct Brands"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b517884480503a9e4c",
+        "title": "KPI: Revenue per Unit",
+        "type": "indicator",
+        "subtype": "indicator/numeric",
+        "oid": "6a3341b517884480503a9e4b",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:13.778Z",
+        "lastUpdated": "2026-06-18T00:54:13.778Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "value",
+              "items": [
+                {
+                  "jaql": {
+                    "formula": "SUM([r])/SUM([q])",
+                    "context": {
+                      "[r]": {
+                        "dim": "[Commerce.Revenue]"
+                      },
+                      "[q]": {
+                        "dim": "[Commerce.Quantity]"
+                      }
+                    },
+                    "title": "Revenue per Unit"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b617884480503a9e4e",
+        "title": "Revenue by Category",
+        "type": "chart/column",
+        "subtype": "column/classic",
+        "oid": "6a3341b617884480503a9e4d",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:14.098Z",
+        "lastUpdated": "2026-06-18T00:54:14.098Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "categories",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Category.Category]",
+                    "sort": "desc",
+                    "title": "Category"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "break by",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b617884480503a9e50",
+        "title": "Revenue by Country (Top 10)",
+        "type": "chart/bar",
+        "subtype": "bar/classic",
+        "oid": "6a3341b617884480503a9e4f",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:14.468Z",
+        "lastUpdated": "2026-06-18T00:54:14.468Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "categories",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Country.Country]",
+                    "filter": {
+                      "top": {
+                        "count": 10,
+                        "by": {
+                          "dim": "[Commerce.Revenue]",
+                          "agg": "sum"
+                        }
+                      }
+                    },
+                    "title": "Country"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "break by",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b617884480503a9e52",
+        "title": "Revenue Trend (Monthly)",
+        "type": "chart/line",
+        "subtype": "line/classic",
+        "oid": "6a3341b617884480503a9e51",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:14.793Z",
+        "lastUpdated": "2026-06-18T00:54:14.793Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "x-axis",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Date]",
+                    "level": "months",
+                    "title": "Months"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "break by",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b717884480503a9e54",
+        "title": "Quantity Trend (Area)",
+        "type": "chart/area",
+        "subtype": "area/classic",
+        "oid": "6a3341b717884480503a9e53",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:15.098Z",
+        "lastUpdated": "2026-06-18T00:54:15.098Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "x-axis",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Date]",
+                    "level": "months",
+                    "title": "Months"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Quantity]",
+                    "agg": "sum",
+                    "title": "Quantity"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "break by",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b717884480503a9e56",
+        "title": "Revenue by Month x Gender",
+        "type": "chart/line",
+        "subtype": "line/classic",
+        "oid": "6a3341b717884480503a9e55",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:15.415Z",
+        "lastUpdated": "2026-06-18T00:54:15.415Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "x-axis",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Date]",
+                    "level": "months",
+                    "title": "Months"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "break by",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Gender]",
+                    "title": "Gender"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b717884480503a9e58",
+        "title": "Quantity by Category (Pie)",
+        "type": "chart/pie",
+        "subtype": "pie/classic",
+        "oid": "6a3341b717884480503a9e57",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:15.730Z",
+        "lastUpdated": "2026-06-18T00:54:15.730Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "categories",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Category.Category]",
+                    "title": "Category"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Quantity]",
+                    "agg": "sum",
+                    "title": "Quantity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b817884480503a9e5a",
+        "title": "Revenue by Category (Polar)",
+        "type": "chart/polar",
+        "subtype": "polar/column",
+        "oid": "6a3341b817884480503a9e59",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:16.039Z",
+        "lastUpdated": "2026-06-18T00:54:16.039Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "categories",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Category.Category]",
+                    "title": "Category"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "break by",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b817884480503a9e5c",
+        "title": "Revenue by Condition (Funnel)",
+        "type": "chart/funnel",
+        "subtype": "funnel/classic",
+        "oid": "6a3341b817884480503a9e5b",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:16.411Z",
+        "lastUpdated": "2026-06-18T00:54:16.411Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "categories",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Condition]",
+                    "title": "Condition"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b817884480503a9e5e",
+        "title": "Revenue vs Qty by Brand (Scatter)",
+        "type": "chart/scatter",
+        "subtype": "scatter/classic",
+        "oid": "6a3341b817884480503a9e5d",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:16.734Z",
+        "lastUpdated": "2026-06-18T00:54:16.734Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "x-axis",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "y-axis",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Quantity]",
+                    "agg": "sum",
+                    "title": "Quantity"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "point",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Brand.Brand]",
+                    "filter": {
+                      "top": {
+                        "count": 50,
+                        "by": {
+                          "dim": "[Commerce.Revenue]",
+                          "agg": "sum"
+                        }
+                      }
+                    },
+                    "title": "Brand"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "break by / color",
+              "items": []
+            },
+            {
+              "name": "size",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b917884480503a9e60",
+        "title": "Pivot: Category x Gender",
+        "type": "pivot2",
+        "subtype": "",
+        "oid": "6a3341b917884480503a9e5f",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:17.114Z",
+        "lastUpdated": "2026-06-18T00:54:17.114Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "rows",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Category.Category]",
+                    "title": "Category"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "columns",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Gender]",
+                    "title": "Gender"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "values",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                },
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Quantity]",
+                    "agg": "sum",
+                    "title": "Quantity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b917884480503a9e62",
+        "title": "Detail Table",
+        "type": "tablewidget",
+        "subtype": "",
+        "oid": "6a3341b917884480503a9e61",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:17.430Z",
+        "lastUpdated": "2026-06-18T00:54:17.430Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "columns",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Brand.Brand]",
+                    "title": "Brand"
+                  }
+                },
+                {
+                  "jaql": {
+                    "dim": "[Category.Category]",
+                    "title": "Category"
+                  }
+                },
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                },
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Quantity]",
+                    "agg": "sum",
+                    "title": "Quantity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341b917884480503a9e64",
+        "title": "Revenue by Brand (Treemap)",
+        "type": "treemap",
+        "subtype": "",
+        "oid": "6a3341b917884480503a9e63",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:17.739Z",
+        "lastUpdated": "2026-06-18T00:54:17.739Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "categories",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Brand.Brand]",
+                    "filter": {
+                      "top": {
+                        "count": 20,
+                        "by": {
+                          "dim": "[Commerce.Revenue]",
+                          "agg": "sum"
+                        }
+                      }
+                    },
+                    "title": "Brand"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "size",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "color",
+              "items": []
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341ba17884480503a9e66",
+        "title": "Category>Gender (Sunburst)",
+        "type": "sunburst",
+        "subtype": "",
+        "oid": "6a3341ba17884480503a9e65",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:18.058Z",
+        "lastUpdated": "2026-06-18T00:54:18.058Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "categories",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Category.Category]",
+                    "title": "Category"
+                  }
+                },
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Gender]",
+                    "title": "Gender"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "size",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      },
+      {
+        "_id": "6a3341ba17884480503a9e68",
+        "title": "Revenue by Country (Map)",
+        "type": "map/area",
+        "subtype": "",
+        "oid": "6a3341ba17884480503a9e67",
+        "desc": null,
+        "source": null,
+        "owner": "6a32fb475397399ec0a31c8f",
+        "created": "2026-06-18T00:54:18.373Z",
+        "lastUpdated": "2026-06-18T00:54:18.373Z",
+        "datasource": {
+          "address": "LocalHost",
+          "title": "Sample ECommerce (Snowflake Live)",
+          "database": "Sample ECommerce (Snowflake Live)",
+          "fullname": "LocalHost/Sample ECommerce (Snowflake Live)",
+          "live": true
+        },
+        "selection": null,
+        "metadata": {
+          "panels": [
+            {
+              "name": "geo",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Country.Country]",
+                    "title": "Country"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "color",
+              "items": [
+                {
+                  "jaql": {
+                    "dim": "[Commerce.Revenue]",
+                    "agg": "sum",
+                    "title": "Revenue"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "style": {},
+        "dashboardid": "6a3341b417884480503a9e43",
+        "userId": "6a32fb475397399ec0a31c8f",
+        "instanceType": "owner"
+      }
+    ]
+  }
+]

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/fixtures/model_ecommerce.json
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/fixtures/model_ecommerce.json
@@ -1,0 +1,839 @@
+{
+  "oid": "5f0cb527-50f2-482b-aece-33e2ece6fe81",
+  "title": "Sample ECommerce",
+  "server": "LocalHost",
+  "serverId": "7c3f73dd-0b38-48dc-9347-c78811bd80c4",
+  "shares": [
+    {
+      "partyId": "6a32fb475397399ec0a31c8f",
+      "type": "user",
+      "permission": "w"
+    }
+  ],
+  "revision": null,
+  "lastBuildTime": "2026-06-17T22:09:33.330Z",
+  "lastSuccessfulBuildTime": null,
+  "lastBuildTimeFromNextECM": null,
+  "lastPublishTime": null,
+  "lastUpdated": "2026-06-17T19:56:32.358Z",
+  "datasets": [
+    {
+      "oid": "bf915bf9-5242-42b7-a64d-ec9d0632afe7",
+      "type": "extract",
+      "connection": {
+        "id": null,
+        "oid": "bac472bd-4d2c-4e10-b444-c478199fe5ab",
+        "provider": "CSV",
+        "parameters": {
+          "culture": "en-US",
+          "Database": "null",
+          "delimiter": ",",
+          "files": [
+            "/opt/sisense/storage/samples/Sample ECommerce/Country/Country.csv"
+          ],
+          "folder": "",
+          "hasHeader": "true",
+          "ignoreFirstRows": "0",
+          "ignoreLastRows": "0",
+          "IsUsingDirectConnection": "false",
+          "Password": "",
+          "Port": "-1",
+          "Schema": "null",
+          "Server": "/opt/sisense/storage/samples/Sample ECommerce/Country/Country.csv",
+          "stringQuote": "\"",
+          "UserName": "null"
+        },
+        "schema": null,
+        "owner": null,
+        "fileName": null,
+        "protectedParameters": null,
+        "uiParams": null,
+        "globalTableConfigOptions": null,
+        "enabled": true,
+        "created": null,
+        "lastModified": "2026-06-17T19:56:32.173+00:00",
+        "supportedModelTypes": [
+          "EXTRACT"
+        ],
+        "ownerId": "6a32fb475397399ec0a31c8f",
+        "createdByUser": false,
+        "name": "Sample Country",
+        "description": "",
+        "connectionPermissions": null
+      },
+      "lastUpdated": "2026-06-18T06:03:04.644Z",
+      "database": "null",
+      "schemaName": "null",
+      "name": "1d533975-e625-4668-bce5-881961ac7c33",
+      "fullname": "CSV:1d533975-e625-4668-bce5-881961ac7c33",
+      "modelingTransformations": [],
+      "schema": {
+        "tables": [
+          {
+            "oid": "a1f938ef-8654-4dcb-86e0-1baeba1a971d",
+            "id": "Country.csv",
+            "name": "Country",
+            "displayName": null,
+            "type": "base",
+            "expression": null,
+            "columns": [
+              {
+                "id": "Country",
+                "name": "Country",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "0920b26d-91ce-4e22-8817-b646a7a9c6c4",
+                "type": 18,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": true,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Country ID",
+                "name": "Country ID",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "1e238e3a-2408-4681-8fa6-f81286b28da5",
+                "type": 8,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              }
+            ],
+            "buildBehavior": {
+              "type": "sync",
+              "accumulativeConfig": null
+            },
+            "lastUpdated": "2026-06-17T19:56:32.076Z",
+            "hidden": false,
+            "vTag": "1429af56-9813-4706-8ad8-74d76a44065b",
+            "configOptions": {
+              "Table": "Country.csv"
+            },
+            "createdAt": "2026-06-17T19:56:32.000Z",
+            "description": null,
+            "tags": null,
+            "aiGeneratedDescription": null,
+            "isMaterialized": false,
+            "schemaName": null
+          }
+        ]
+      },
+      "schedule": {
+        "type": null,
+        "lastExecution": null,
+        "day": null,
+        "days": null,
+        "hour": null,
+        "minute": null,
+        "second": null
+      },
+      "shares": [],
+      "liveQuerySettings": null
+    },
+    {
+      "oid": "b01a091e-fa02-4ba1-988c-584de06d3de9",
+      "type": "extract",
+      "connection": {
+        "id": null,
+        "oid": "6846d970-605d-4b14-8512-24d1db30d8e3",
+        "provider": "CSV",
+        "parameters": {
+          "culture": "en-US",
+          "Database": "null",
+          "delimiter": ",",
+          "files": [
+            "/opt/sisense/storage/samples/Sample ECommerce/Commerce/Commerce.csv"
+          ],
+          "folder": "",
+          "hasHeader": "true",
+          "ignoreFirstRows": "0",
+          "ignoreLastRows": "0",
+          "IsUsingDirectConnection": "false",
+          "Password": "",
+          "Port": "-1",
+          "Schema": "null",
+          "Server": "/opt/sisense/storage/samples/Sample ECommerce/Commerce/Commerce.csv",
+          "stringQuote": "\"",
+          "UserName": "null"
+        },
+        "schema": null,
+        "owner": null,
+        "fileName": null,
+        "protectedParameters": null,
+        "uiParams": null,
+        "globalTableConfigOptions": null,
+        "enabled": true,
+        "created": null,
+        "lastModified": "2026-06-17T19:56:32.113+00:00",
+        "supportedModelTypes": [
+          "EXTRACT"
+        ],
+        "ownerId": "6a32fb475397399ec0a31c8f",
+        "createdByUser": false,
+        "name": "Sample Commerce",
+        "description": "",
+        "connectionPermissions": null
+      },
+      "lastUpdated": "2026-06-18T06:03:04.644Z",
+      "database": "null",
+      "schemaName": "null",
+      "name": "c5b6aa2d-e010-4255-ad1c-ed7ca9fcb559",
+      "fullname": "CSV:c5b6aa2d-e010-4255-ad1c-ed7ca9fcb559",
+      "modelingTransformations": [],
+      "schema": {
+        "tables": [
+          {
+            "oid": "66885815-f865-413f-949b-d91606539bf3",
+            "id": "Commerce.csv",
+            "name": "Commerce",
+            "displayName": null,
+            "type": "base",
+            "expression": null,
+            "columns": [
+              {
+                "id": "Age Range",
+                "name": "Age Range",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "e03c6792-c418-496d-911a-be01b41d0ee5",
+                "type": 18,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": true,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Cost",
+                "name": "Cost",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "97732adc-fd11-43d8-b007-db20d9e055a6",
+                "type": 5,
+                "size": 50,
+                "precision": 16,
+                "scale": 16,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Brand ID",
+                "name": "Brand ID",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "ec2c0ae8-5e3c-45e1-87f8-f319fe560580",
+                "type": 8,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Category ID",
+                "name": "Category ID",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "8190ab95-4723-40e1-a90b-d79443e0cf01",
+                "type": 8,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Condition",
+                "name": "Condition",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "74a75b92-6747-4290-810f-bbf0bbd78759",
+                "type": 18,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": true,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Country ID",
+                "name": "Country ID",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "f6125e69-8839-4bf8-8cbb-d1ab31198489",
+                "type": 8,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Date",
+                "name": "Date",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "59527454-1bb1-4189-920f-b9d5835bba0d",
+                "type": 4,
+                "size": 8,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Gender",
+                "name": "Gender",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "2375029f-b6d0-4de1-a6b5-bcdb4758ee15",
+                "type": 18,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": true,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Quantity",
+                "name": "Quantity",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "1ad27274-0b7f-43c2-96fe-48c95af8c771",
+                "type": 8,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Revenue",
+                "name": "Revenue",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "098260b9-0608-4673-a6d7-756496815fbf",
+                "type": 5,
+                "size": 50,
+                "precision": 16,
+                "scale": 16,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Visit ID",
+                "name": "Visit ID",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "f7f6da64-1a5f-45f1-995f-95be6668e978",
+                "type": 8,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              }
+            ],
+            "buildBehavior": {
+              "type": "sync",
+              "accumulativeConfig": null
+            },
+            "lastUpdated": "2026-06-17T19:56:32.076Z",
+            "hidden": false,
+            "vTag": "d50bbb17-f7d8-4bf4-b6e0-0bdf956de323",
+            "configOptions": {
+              "Table": "Commerce.csv"
+            },
+            "createdAt": "2026-06-17T19:56:32.000Z",
+            "description": null,
+            "tags": null,
+            "aiGeneratedDescription": null,
+            "isMaterialized": false,
+            "schemaName": null
+          }
+        ]
+      },
+      "schedule": {
+        "type": null,
+        "lastExecution": null,
+        "day": null,
+        "days": null,
+        "hour": null,
+        "minute": null,
+        "second": null
+      },
+      "shares": [],
+      "liveQuerySettings": null
+    },
+    {
+      "oid": "e9c5bdad-b4d1-43c0-bee7-c8b18b747857",
+      "type": "extract",
+      "connection": {
+        "id": null,
+        "oid": "559fb41d-d8b9-44e6-949d-f32260025b5f",
+        "provider": "CSV",
+        "parameters": {
+          "culture": "en-US",
+          "Database": "null",
+          "delimiter": ",",
+          "files": [
+            "/opt/sisense/storage/samples/Sample ECommerce/Category/Category.csv"
+          ],
+          "folder": "",
+          "hasHeader": "true",
+          "ignoreFirstRows": "0",
+          "ignoreLastRows": "0",
+          "IsUsingDirectConnection": "false",
+          "Password": "",
+          "Port": "-1",
+          "Schema": "null",
+          "Server": "/opt/sisense/storage/samples/Sample ECommerce/Category/Category.csv",
+          "stringQuote": "\"",
+          "UserName": "null"
+        },
+        "schema": null,
+        "owner": null,
+        "fileName": null,
+        "protectedParameters": null,
+        "uiParams": null,
+        "globalTableConfigOptions": null,
+        "enabled": true,
+        "created": null,
+        "lastModified": "2026-06-17T19:56:32.228+00:00",
+        "supportedModelTypes": [
+          "EXTRACT"
+        ],
+        "ownerId": "6a32fb475397399ec0a31c8f",
+        "createdByUser": false,
+        "name": "Sample Category",
+        "description": "",
+        "connectionPermissions": null
+      },
+      "lastUpdated": "2026-06-18T06:03:04.644Z",
+      "database": "null",
+      "schemaName": "null",
+      "name": "a03f00ab-9022-40a5-babf-dcd668daa5af",
+      "fullname": "CSV:a03f00ab-9022-40a5-babf-dcd668daa5af",
+      "modelingTransformations": [],
+      "schema": {
+        "tables": [
+          {
+            "oid": "1c9c1ee0-cc9f-4585-af87-f217f8f98e21",
+            "id": "Category.csv",
+            "name": "Category",
+            "displayName": null,
+            "type": "base",
+            "expression": null,
+            "columns": [
+              {
+                "id": "Category",
+                "name": "Category",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "53175968-694f-4c59-ad18-aaa7ce8e40db",
+                "type": 18,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": true,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Category ID",
+                "name": "Category ID",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "a0753f57-fd77-4a19-85fe-29d1f1d8509a",
+                "type": 8,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              }
+            ],
+            "buildBehavior": {
+              "type": "sync",
+              "accumulativeConfig": null
+            },
+            "lastUpdated": "2026-06-17T19:56:32.076Z",
+            "hidden": false,
+            "vTag": "631232aa-df76-483a-83c1-88d8830fd863",
+            "configOptions": {
+              "Table": "Category.csv"
+            },
+            "createdAt": "2026-06-17T19:56:32.000Z",
+            "description": null,
+            "tags": null,
+            "aiGeneratedDescription": null,
+            "isMaterialized": false,
+            "schemaName": null
+          }
+        ]
+      },
+      "schedule": {
+        "type": null,
+        "lastExecution": null,
+        "day": null,
+        "days": null,
+        "hour": null,
+        "minute": null,
+        "second": null
+      },
+      "shares": [],
+      "liveQuerySettings": null
+    },
+    {
+      "oid": "ebc6eebd-fc08-479e-a845-dfc774c5929e",
+      "type": "extract",
+      "connection": {
+        "id": null,
+        "oid": "f3a2ca12-c1a3-4d57-a576-12e4961c4700",
+        "provider": "CSV",
+        "parameters": {
+          "culture": "en-US",
+          "Database": "null",
+          "delimiter": ",",
+          "files": [
+            "/opt/sisense/storage/samples/Sample ECommerce/Brand/Brand.csv"
+          ],
+          "folder": "",
+          "hasHeader": "true",
+          "ignoreFirstRows": "0",
+          "ignoreLastRows": "0",
+          "IsUsingDirectConnection": "false",
+          "Password": "",
+          "Port": "-1",
+          "Schema": "null",
+          "Server": "/opt/sisense/storage/samples/Sample ECommerce/Brand/Brand.csv",
+          "stringQuote": "\"",
+          "UserName": "null"
+        },
+        "schema": null,
+        "owner": null,
+        "fileName": null,
+        "protectedParameters": null,
+        "uiParams": null,
+        "globalTableConfigOptions": null,
+        "enabled": true,
+        "created": null,
+        "lastModified": "2026-06-17T19:56:32.280+00:00",
+        "supportedModelTypes": [
+          "EXTRACT"
+        ],
+        "ownerId": "6a32fb475397399ec0a31c8f",
+        "createdByUser": false,
+        "name": "Sample Brand",
+        "description": "",
+        "connectionPermissions": null
+      },
+      "lastUpdated": "2026-06-18T06:03:04.644Z",
+      "database": "null",
+      "schemaName": "null",
+      "name": "95c0d7fe-3eaf-494f-be22-7e6c66889ef6",
+      "fullname": "CSV:95c0d7fe-3eaf-494f-be22-7e6c66889ef6",
+      "modelingTransformations": [],
+      "schema": {
+        "tables": [
+          {
+            "oid": "c447fc2e-51d1-47fd-bb2d-947975b1bbcf",
+            "id": "Brand.csv",
+            "name": "Brand",
+            "displayName": null,
+            "type": "base",
+            "expression": null,
+            "columns": [
+              {
+                "id": "Brand",
+                "name": "Brand",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "21861c02-df83-4302-b8ff-88dc3b28d1c1",
+                "type": 18,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": true,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              },
+              {
+                "id": "Brand ID",
+                "name": "Brand ID",
+                "displayName": null,
+                "semanticIndex": null,
+                "aiGeneratedDescription": null,
+                "oid": "8fb5272d-dd61-4780-b62f-fbc4e7baa9dc",
+                "type": 8,
+                "size": 50,
+                "precision": 0,
+                "scale": 0,
+                "hidden": false,
+                "indexed": false,
+                "isUpsertBy": false,
+                "lastUpdated": "2026-06-17T19:56:32.076Z",
+                "description": null,
+                "expression": null,
+                "import": null,
+                "isCustom": null
+              }
+            ],
+            "buildBehavior": {
+              "type": "sync",
+              "accumulativeConfig": null
+            },
+            "lastUpdated": "2026-06-17T19:56:32.076Z",
+            "hidden": false,
+            "vTag": "20b098f2-90fa-4f8d-a031-fe4e633963e4",
+            "configOptions": {
+              "Table": "Brand.csv"
+            },
+            "createdAt": "2026-06-17T19:56:32.000Z",
+            "description": null,
+            "tags": null,
+            "aiGeneratedDescription": null,
+            "isMaterialized": false,
+            "schemaName": null
+          }
+        ]
+      },
+      "schedule": {
+        "type": null,
+        "lastExecution": null,
+        "day": null,
+        "days": null,
+        "hour": null,
+        "minute": null,
+        "second": null
+      },
+      "shares": [],
+      "liveQuerySettings": null
+    }
+  ],
+  "modelingTransformations": [],
+  "relations": [
+    {
+      "oid": "52c3587b-efbd-4c5d-98c0-ca32f9cfd77c",
+      "columns": [
+        {
+          "dataset": "e9c5bdad-b4d1-43c0-bee7-c8b18b747857",
+          "table": "1c9c1ee0-cc9f-4585-af87-f217f8f98e21",
+          "column": "a0753f57-fd77-4a19-85fe-29d1f1d8509a",
+          "isDropped": null
+        },
+        {
+          "dataset": "b01a091e-fa02-4ba1-988c-584de06d3de9",
+          "table": "66885815-f865-413f-949b-d91606539bf3",
+          "column": "8190ab95-4723-40e1-a90b-d79443e0cf01",
+          "isDropped": null
+        }
+      ],
+      "type": null
+    },
+    {
+      "oid": "0e30a09c-6003-4941-8770-bd6b13e63838",
+      "columns": [
+        {
+          "dataset": "bf915bf9-5242-42b7-a64d-ec9d0632afe7",
+          "table": "a1f938ef-8654-4dcb-86e0-1baeba1a971d",
+          "column": "1e238e3a-2408-4681-8fa6-f81286b28da5",
+          "isDropped": null
+        },
+        {
+          "dataset": "b01a091e-fa02-4ba1-988c-584de06d3de9",
+          "table": "66885815-f865-413f-949b-d91606539bf3",
+          "column": "f6125e69-8839-4bf8-8cbb-d1ab31198489",
+          "isDropped": null
+        }
+      ],
+      "type": null
+    },
+    {
+      "oid": "5b080d72-5075-4723-b81f-087905f3b54a",
+      "columns": [
+        {
+          "dataset": "ebc6eebd-fc08-479e-a845-dfc774c5929e",
+          "table": "c447fc2e-51d1-47fd-bb2d-947975b1bbcf",
+          "column": "8fb5272d-dd61-4780-b62f-fbc4e7baa9dc",
+          "isDropped": null
+        },
+        {
+          "dataset": "b01a091e-fa02-4ba1-988c-584de06d3de9",
+          "table": "66885815-f865-413f-949b-d91606539bf3",
+          "column": "ec2c0ae8-5e3c-45e1-87f8-f319fe560580",
+          "isDropped": null
+        }
+      ],
+      "type": null
+    }
+  ],
+  "schedule": null,
+  "creator": {
+    "id": "6a32fb475397399ec0a31c8f",
+    "userName": "tj@pivotanalyticsllc.net",
+    "active": true,
+    "created": "2026-06-17T19:53:43.397Z",
+    "email": "tj@pivotanalyticsllc.net",
+    "encryptionSHA": null,
+    "firstName": "Thomas",
+    "lastName": "Wells",
+    "lastLogin": "2026-06-18T01:02:57.206Z",
+    "lastUpdated": "2026-06-18T01:02:49.401Z",
+    "prefrences": null,
+    "roleId": "6a32fb470faf9fa6a92192f8"
+  },
+  "type": "extract",
+  "relationType": "direct",
+  "tenant": {
+    "_id": "6a32fb475397399ec0a31c9c",
+    "name": "system",
+    "default": true,
+    "systemManagement": true
+  },
+  "aiAccessController": {
+    "availableForAnalyticsAssistant": true,
+    "availableForStudioAssistant": true,
+    "availableForSemanticEnrichment": true
+  },
+  "relationsTables": [
+    {
+      "firstTable": "1c9c1ee0-cc9f-4585-af87-f217f8f98e21",
+      "secondTable": "66885815-f865-413f-949b-d91606539bf3",
+      "directionType": null,
+      "joinType": "default"
+    },
+    {
+      "firstTable": "a1f938ef-8654-4dcb-86e0-1baeba1a971d",
+      "secondTable": "66885815-f865-413f-949b-d91606539bf3",
+      "directionType": null,
+      "joinType": "default"
+    },
+    {
+      "firstTable": "c447fc2e-51d1-47fd-bb2d-947975b1bbcf",
+      "secondTable": "66885815-f865-413f-949b-d91606539bf3",
+      "directionType": null,
+      "joinType": "default"
+    }
+  ],
+  "analyticalEngine": {
+    "queryAeMode": "AE_ONLY",
+    "customTranslationMode": null,
+    "generateDependenciesMode": null
+  }
+}

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/design-notes.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/design-notes.md
@@ -1,0 +1,191 @@
+# Design notes — sisense-to-sigma
+
+## Status (2026-06-17) — production-hardened, live-validated
+End-to-end **live-validated at exact parity** on Sample ECommerce (DM + 7-element
+workbook; Total Revenue $39,759,625.515, monthly trend, joined category
+breakdown all match Sisense JAQL). Built and tested:
+- `discover.py` — live pull (auth, model schema export, dashboards). ✅
+- `convert.py model` — DM spec; warehouse-table + **custom-SQL tables** (ElastiCube
+  SQL → warehouse SQL, flagged); relationships; parameterized db/schema. ✅
+- `convert.py dashboard` — **generic** widget→workbook emit (Master data element +
+  kpi/bar/line/area/pie/scatter/pivot→grouped-table/table), JAQL formulas via
+  `jaql_expr`, top-N filters, money formatting. ✅
+- `jaql_expr.py` — aggs, ratio/nested formulas, date-level→DateTrunc, top-N;
+  flags filtered/scoped measures + `PREV/PAST/RSUM/...`. 19 unit tests. ✅
+- `verify_parity.py` — automated gate (Sisense JAQL vs warehouse), GREEN/RED. ✅
+- `sisense-assessment/assess.py` — inventory + converter-coverage scoring. ✅
+- Offline regression: `tests/test_jaql.py` (19) + `tests/test_convert.py` (17)
+  against bundled `fixtures/`. ✅
+
+### Gaps closed (2026-06-18)
+- **Two live round-trips at exact parity.** ECommerce (clean star) AND Healthcare
+  (8 tables, snowflake schema, a custom-SQL derived table) both landed in
+  Snowflake + DM-parity-verified end-to-end.
+- **Custom-SQL tables convert and run.** ElastiCube SQL → Sigma `sql` element
+  (`statement` field, `[Custom SQL/Col]` formula prefix, quoted output aliases);
+  Healthcare's "Conditions time of stay" matches Sisense exactly (still flagged
+  for human SQL verification — dialect functions may differ).
+- **Dashboard filters → Sigma controls.** Member/date/numeric filters become
+  list/date-range/number-range controls bound to the Master, with default
+  selections carried; validated (filtered total = $3,735,431.72, exact).
+- **Relationship direction is cardinality-accurate** via `--verify-card`
+  (unique-key side = dimension); snowflake schemas handled; width fallback now
+  flags each relation for verification. No fanout (Admissions stays 5000).
+- **Dashboard layout now ports** (2026-06-22). The workbook spec emits a Sigma
+  `layout` XML: faithful for structured columnar layouts, clean auto-arrange
+  (KPI card rows + 2-up charts + full-width trends/tables) for the default
+  single-column stack. Previously the converter emitted no layout and Sigma just
+  stacked everything. See "Layout" below.
+
+### Remaining limitations (smaller)
+- Widget-level filters beyond top-N, conditional formatting, drill, RLS/data
+  security: not converted.
+- `--verify-card` needs the base data already in the warehouse; derived/custom-SQL
+  tables can't be probed (their relations fall back to the flagged width heuristic).
+- pie emitted as `pie-chart` with `{id}` refs (this org's API); donut/holeValue untested.
+
+## Architecture (phases, mirroring the sibling converters)
+
+- **Phase 0 — Assess.** `sisense-assessment` inventories the estate (cubes,
+  dashboards, widget-type histogram, JAQL complexity) and scores each dashboard
+  against converter coverage. Read-only.
+- **Phase 1 — Discover.** `discover.py` pulls the model schema export + the
+  dashboards/widgets bundle over REST. ✅ working.
+- **Phase 2 — Convert model.** ElastiCube datasets → Sigma data model. Each
+  `schema.tables[]` becomes a DM element: plain tables → warehouse table
+  sources; tables with a non-null `expression` → Custom-SQL elements (SQL
+  preserved verbatim, flagged). `relations[]` → DM relationships. Column `type`
+  codes → Sigma column types.
+- **Phase 3 — Convert dashboards.** Each widget → a workbook element
+  (`pivot2`→pivot-table, `indicator`→KPI, `chart/*`→chart, `tablewidget`→table).
+  Panel JAQL → workbook formulas via `jaql_expr.py`; dashboard + widget filters →
+  controls. Translate what maps; **flag** custom JAQL functions, BloX/plugin
+  widgets, scripted widgets. **Layout is ported here too** — see "Layout" below.
+- **Phase 4 — Parity.** Run each widget's JAQL via `POST /api/datasources/{ds}/jaql`
+  and compare to the Sigma element's query. GREEN gate before claiming done.
+- **Phase 5 — Repoint + enhance.** Wire the workbook to the DM. Layout is
+  already emitted in Phase 3; review and nudge in Sigma, defer deeper polish to
+  `sigma-workbooks`.
+
+## Layout
+
+Sisense and Sigma model layout very differently, and porting it is what made the
+output stop looking like a flat dump of charts.
+
+**Sisense** (`dashboard.layout`, `type: "columnar"`): `columns[]` are vertical
+strips with a `%` `width`; each column has `cells[]` stacked top-to-bottom; each
+cell has `subcells[]` placed left-to-right (each a `%` of the column); each
+subcell holds `elements[]` keyed by `widgetid` with a px `height`.
+
+**Sigma** (top-level `layout`, a single XML string): one `<Page type="grid"
+gridTemplateColumns="repeat(24, 1fr)">` per page; elements positioned by
+`<LayoutElement elementId gridColumn="start / end" gridRow="start / end"/>` where
+**`end` is exclusive** (full width = `1 / 25`). A `<GridContainer>` can group a
+sub-grid, but its `elementId` MUST reference a real container element in the
+spec — Sigma rejects a synthetic id ("not a valid container"), so we don't emit
+one; controls go flat instead (see below). Element IDs we choose are
+**preserved on workbook CREATE**, so the layout's `elementId` refs resolve
+without a readback.
+
+`build_layout()` in `convert.py` does the translation:
+- **Faithful** (`_faithful`) when the Sisense layout has real structure (>1
+  column, or any cell with >1 subcell): column `%`widths → proportional grid
+  spans via `_alloc` (largest-remainder split summing to exactly 24); each
+  top-level column is an independent vertical stack placed side-by-side;
+  subcells split a column horizontally; cells stack. The author's arrangement
+  is reproduced.
+- **Auto-arrange** (`_auto_arrange`) when the layout is Sisense's degenerate
+  default — one full-width column of stacked full-width widgets (porting that
+  verbatim is an ugly tall stack). Leading KPIs flow into rows of up to 4 cards,
+  remaining charts go 2-up, and `WIDE_KINDS` (line/area trends, tables, pivots)
+  span full width.
+- Dashboard-filter **controls** are placed as a flat row of `<LayoutElement>`s
+  at the top (one equal column-slice each) — never a `<GridContainer>`, which
+  Sigma rejects without a backing container element (live-found 2026-06-22).
+- px height → grid rows via `PX_PER_ROW` (≈42px/row, so Sisense's 512 default ≈
+  12 rows); KPIs are pinned to a short `KPI_ROWS` card regardless of px.
+- Tunables at the top of the layout section: `GRID_COLS`, `PX_PER_ROW`,
+  `KPI_ROWS`, `CTRL_ROWS`, `MIN_VIZ_ROWS`, `WIDE_KINDS`.
+
+Note: the bundled fixtures are single-column stacks, so they exercise the
+auto-arrange path; `tests/test_convert.py` includes an inline 2-column dashboard
+to cover the faithful path.
+
+**Layout has its own parity gate** — `verify_layout.py <dashboards.json>
+<sigma_workbook_spec.json>`. Data parity (`verify_parity.py`) checks the numbers
+only; this checks the arrangement: every mapped widget placed exactly once, no
+orphan refs (`master` + controls excepted), inside the 24-col grid, no overlaps,
+reading order preserved, side-by-side widgets share a Sigma row, relative widths
+preserved. GREEN on both bundled fixtures (auto-arrange) and a **live-built**
+multi-subcell dashboard (faithful) — validated 2026-06-22 against trial
+`signup-jnzavd0c` (dashboard "ECommerce — Executive Layout (built)": a KPI card
+row + 2-up charts + full-width trend + full-width bar ported exactly).
+
+## RLS (optional, opt-in)
+
+Sisense **data security** rules (per-cube, per-column member restrictions, via
+`GET /api/elasticubes/{server}/{cube}/datasecurity`) port to Sigma row-level
+security. `detect_rls.py` is zero-overhead and silent when a cube has none;
+when it finds rules it emits a converter-style `security[]`
+(`CurrentUserAttributeText("<col>") = Text([<col>])` + a per-column user
+attribute). **The `Text(...)` wrap is load-bearing:** without it a *numeric*
+restricted column (e.g. an ID) compares text-to-number and silently matches
+nothing. Porting is opt-in via the tool-agnostic `apply_sigma_rls.py`
+(reuse-first, plan-only by default; mutates only on `--provision`/`--apply`;
+per-user member values are flagged for assignment, never faked).
+
+**Live-validated 2026-06-22** (exact restricted parity, querying as a member
+with the attribute assigned):
+- text column — `gender = Male` → $6,158,653.81 / 142,599 rows (1 gender visible)
+- numeric column — `Country ID = 1` → $6,880,013.42 / 104,803 rows (1 country)
+both exactly matching the Snowflake ground truth, vs the unrestricted $39.76M.
+
+## Visual QA — render-and-inspect gate
+
+`verify_layout.py` proves the grid is structurally sound (no overlaps, all
+placed, reading order, no width inversions). It does NOT prove the page *looks*
+right. After POST, render each page with `sigma-export-png.py` and read it
+against `refs/layout-visual-qa.md` (compare to the Sisense source PNG). Validated
+2026-06-22: the migrated Executive-Layout workbook rendered with the exact
+Sisense arrangement (KPI card row → 2-up charts → full-width trend → full-width
+bar) and live data. (Sisense's own dashboard UI showed "No Results" for the
+same source — a Sisense REST-widget rendering quirk, NOT a migration issue; the
+Sigma render is the source of truth for "did the layout come over".)
+
+## The Snowflake-parity requirement (full migrations)
+
+Sisense sample cubes live in Sisense's **ECCloud** storage — Sigma can't read
+that. A *full* migration with real parity needs **both tools reading the same
+warehouse**. Plan:
+
+1. **Land the source data in Snowflake.** Load the Sisense sample dataset(s)
+   into the shared demo warehouse (Snowflake `CSA.TJ`, the connection the other
+   migration skills use). One schema per cube, e.g. `CSA.TJ.SISENSE_ECOMMERCE_*`.
+2. **Make Sisense read Snowflake (Live).** Add a Snowflake connection in Sisense
+   and build the source dashboard on a **Live** model over those same tables —
+   so the Sisense side and the Sigma side query byte-identical data. (Reuses the
+   existing sample-schema table structure from the model export.)
+3. **Sigma DM targets the same Snowflake connection.** Phase-2 emits a DM whose
+   sources are the `CSA.TJ.SISENSE_*` tables. Parity is then exact, not
+   approximate.
+
+Decision pending with the user: which sample cube to use as the first
+end-to-end fixture (ECommerce is smallest: 4 datasets / 3 relations), and
+whether to load via the Snowflake MCP / connector creds already on this machine.
+
+## Hard problems / flags (don't fake)
+- **JAQL custom formulas** with rich `context` (nested measures, `PREV`, `PAST`,
+  `RSUM`, `RANK`, filtered measures) — translate the common ones, flag the rest.
+- **BloX / plugin / scripted widgets** — no Sigma equivalent; flag.
+- **ElastiCube import-time transforms** (`modelingTransformations`) — may encode
+  ETL that belongs upstream in the warehouse; surface, don't silently inline.
+- **Column type code map** — only `18`=text confirmed; complete the map from a
+  populated cube before trusting numeric/date conversions.
+
+## Graduation target
+`sigma-migration-skills/plugins/sisense-to-sigma/`. Feature parity with the
+sibling converters is met and live-validated (model + dashboard + JAQL +
+filters→controls + layout + data/layout/visual-QA gates + gap-scout + opt-in
+RLS). Remaining to physically graduate: move under `plugins/`, wire shared
+governance (manifest, ref-index uses the `refs/`-prefixed link form CI checks),
+and open the PR.

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/jaql-mapping.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/jaql-mapping.md
@@ -1,0 +1,45 @@
+# JAQL → Sigma formula mapping
+
+JAQL (JSON Analytical Query Language) is how Sisense encodes dimensions,
+measures, and filters inside widget panels. This is the workbook-side
+translation surface (`scripts/jaql_expr.py`). **Verify against real widget JAQL**
+once a sample dashboard exists — the trial has 0 dashboards.
+
+## Item shapes
+```jsonc
+// simple aggregated measure
+{ "jaql": { "dim": "[Commerce.Revenue]", "agg": "sum", "title": "Total Revenue" } }
+
+// formula measure with context (each [tokenN] resolves to a sub-item)
+{ "jaql": { "formula": "SUM([Rev]) / SUM([Cost])",
+            "context": { "[Rev]": { "dim": "[Commerce.Revenue]" },
+                         "[Cost]": { "dim": "[Commerce.Cost]" } } } }
+
+// dimension with level (date)
+{ "jaql": { "dim": "[Commerce.Date]", "level": "months" } }
+```
+
+## Aggregation map
+| JAQL `agg`     | Sigma     |
+|----------------|-----------|
+| `sum`          | `Sum`     |
+| `count`        | `Count`   |
+| `countdistinct`| `CountDistinct` |
+| `avg`          | `Avg`     |
+| `min` / `max`  | `Min`/`Max` |
+
+## Function map (starter — extend + verify)
+| JAQL function          | Sigma |
+|------------------------|-------|
+| arithmetic `+ - * /`   | same |
+| `RANK(...)`            | `Rank(...)` (grouped) — verify partition semantics |
+| `RSUM(...)`            | `CumulativeSum(...)` over an ordered grouping |
+| `PREV(...)` / `PAST`   | `Lag(...)` / DateLookback in a date-grouped element |
+| `GROWTH`, `GROWTHPAST` | derived (current−prev)/prev — verify |
+| filtered measure (`context` w/ a filter member) | `SumIf`/`CountIf` style |
+
+## Flag (don't fake)
+- Custom plugin JAQL functions, deeply nested `context` measures, statistical
+  functions without a clean Sigma equivalent → surface in the conversion report.
+- Lean on the shared `convert_sql_to_sigma_formula` MCP translator for the
+  math/agg core where the JAQL formula is SQL-like.

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/layout-visual-qa.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/layout-visual-qa.md
@@ -1,0 +1,52 @@
+# Layout Visual QA — render-and-inspect gate
+
+Shared discipline across all `*-to-sigma` migration plugins. A workbook that
+POSTs cleanly (HTTP 200) and passes numeric parity can still be visually broken
+— **overlapping tiles, clipped titles, dead zones, orphaned filters**. The
+export API renders exactly what a user sees, so the reliable final check is to
+**render each page to PNG and actually read the image** before declaring done.
+
+Two layers, run in order:
+
+## 1. Structural pre-check (automated, cheap) — `verify_layout.py`
+
+```sh
+python3 scripts/verify_layout.py <dashboards.json> <sigma_workbook_spec.json>
+```
+This is the fast gate: every mapped widget placed exactly once, no orphan refs,
+inside the 24-col grid, **no overlaps**, reading order preserved, side-by-side
+widgets share a row, relative widths not inverted. It catches the mechanical
+failures (collisions, dropped/duplicated elements, inverted columns) without a
+render. **Must be GREEN before you spend a render.** It does NOT judge whether
+the result *looks* like the Sisense dashboard — that's layer 2.
+
+## 2. Visual gate (render + read) — `sigma-export-png.py`
+
+```sh
+python3 scripts/sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/<page>.png --w 1600
+```
+Contract (identical to every sibling): `POST /v2/workbooks/{id}/export` → poll
+`/v2/query/{q}/download`. Render every page, read each PNG, fix the spec, loop
+until clean. Declare done on a *clean render*, never on an HTTP 200.
+
+### Source-fidelity parity (clean ≠ faithful)
+Capture the Sisense source for side-by-side comparison — the dashboard's own PNG
+via `GET /api/v1/dashboards/{id}/export/png` (or a screenshot). Verify page-for-page:
+
+- [ ] **Same element set** — every widget on the Sisense page exists on the Sigma page (none dropped except knowingly-flagged treemap/sunburst/map; none invented).
+- [ ] **Same arrangement** — Sisense's columnar grouping + reading order holds (a row of KPI cards stays a row; a 2-up chart row stays 2-up). The faithful path reproduces this; auto-arrange re-flows a degenerate stack — confirm the re-flow reads well.
+- [ ] **Matching chart KIND** — indicator → `kpi-chart` (not a 1-row table); column/bar → bar; line/area → line/area; pivot2 → grouped pivot. HINT substitutions (polar→bar, funnel→bar, map→geo) are visible and acceptable, or re-flagged.
+- [ ] **KPI shows the right VALUE** — the big number equals the Sisense indicator.
+- [ ] **Controls present** — Sisense dashboard filters became Sigma controls in the top band (flat row), bound to the Master so they propagate.
+
+### Pass/fail rubric (read the PNG)
+- [ ] **No overlaps / no stacking** — no two elements share a cell; no control on top of a chart.
+- [ ] **No dead zones** — title never shares a band with a chart; no giant empty tile (size tables to content).
+- [ ] **Controls placed correctly** — global filters in the top control band.
+- [ ] **Titles legible** — widget titles not clipped.
+
+**Known spec ceilings** (don't loop on them — note as editor follow-ups): KPI
+sparklines/delta badges are UI-only; Sisense BloX/scripted widgets and
+treemap/sunburst have no spec equivalent (flagged, never faked). When styling is
+scoped down ("layout + metrics, skip branding"), record exactly what was
+descoped in the final summary — never drop it silently.

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/sisense-rest-api.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/sisense-rest-api.md
@@ -1,0 +1,95 @@
+# Sisense REST API — extraction map
+
+Validated live against a Sisense Cloud trial (`signup-jnzavd0c.sisense.com`),
+2026-06-17. Sisense Linux/Cloud. Paths differ on older Windows builds — note
+the version when something 404s.
+
+## Auth
+
+```
+POST /api/v1/authentication/login
+  Content-Type: application/x-www-form-urlencoded
+  username=<email>&password=<pw>
+  -> { success, access_token (JWT), profile, tenantId, roleName, userId }
+```
+
+Send `Authorization: Bearer <access_token>` on every subsequent call. Tokens are
+long-lived per user. `scripts/sisense-auth.sh` wraps this; it also accepts a
+pre-minted `SISENSE_API_TOKEN` and skips login.
+
+> **Access keys ≠ API tokens.** The "Access Keys" / "Web Access Token" feature
+> on `/app/settings/rest` produces a **Key ID + public key** for **JWT SSO /
+> embedding** — you sign requests with the *private* half. That is the wrong
+> mechanism for REST content extraction. Use the bearer token above.
+
+> **TLS.** Trial/self-signed instances can present a cert chain Python's
+> verifier rejects (`CA cert does not include key usage extension`) even though
+> curl accepts it. `discover.py` retries with an unverified context and warns.
+
+## Data models (ElastiCube / Live)
+
+```
+GET /api/v1/elasticubes/getElasticubes
+  -> [ { _id, title, datasets[ids], buildDestination.destination, server, type } ]
+
+GET /api/v2/datamodels/schema?title=<title>      # the full export — USE THIS
+  -> {
+       oid, title, server, relationType,
+       datasets: [ {
+         oid, type ("extract"|"live"), connection, database, schemaName,
+         name, fullname, modelingTransformations[],
+         schema: { tables: [ {
+           oid, id, name, displayName, type, hidden,
+           expression,            # table-level custom SQL (null for plain tables)
+           columns: [ {
+             id, name, displayName, oid,
+             type,                # Sisense numeric type code (see below)
+             size, precision, scale, hidden, indexed
+           } ]
+         } ] }
+       } ],
+       relations: [ {              # joins — each links two {dataset,table,column}
+         oid,
+         columns: [ {dataset, table, column, isDropped}, {…} ]
+       } ],
+       relationsTables: [...]
+     }
+```
+
+`/api/v2/datamodels` (list, no `?title`) and the legacy
+`/api/datasources/{ds}/jaql/metadata` were **not** available on this build
+(`Cannot GET` / 404). The `schema?title=` export is the reliable path.
+
+### Column type codes (Sisense `type` int → Sigma)
+Observed: `18` = text/string. Full map is TODO — confirm against a numeric and a
+date column when populating the converter (see `design-notes.md`).
+
+## Dashboards + widgets
+
+```
+GET /api/v1/dashboards                 -> [ { oid, title, datasource, ... } ]
+GET /api/v1/dashboards/{oid}           -> dashboard (may inline widgets)
+GET /api/v1/dashboards/{oid}/widgets   -> [ widget ]
+```
+
+A **widget** carries `type` (e.g. `pivot2`, `indicator`, `chart/column`,
+`chart/line`, `chart/pie`, `tablewidget`), `datasource`, and
+`metadata.panels[]`. Each panel (`rows`/`columns`/`values`/`filters`) holds
+**JAQL** items — `{ jaql: { dim, agg, formula, context, title }, format }`.
+JAQL `formula` + `context` is where Sisense measure logic lives → this is the
+workbook-side translation surface (see `jaql-mapping.md`).
+
+> The trial currently has **0 dashboards**. Build a sample dashboard on
+> `Sample ECommerce` before exercising the widget→workbook path or any parity
+> gate.
+
+## Parity (run later)
+
+```
+POST /api/datasources/{datasource}/jaql
+  body: a JAQL query (the same metadata a widget runs)
+  -> aggregated result rows  ->  compare to the Sigma element's query
+```
+
+`POST /api/datasources/{ds}/fields/search {offset,count}` lists fields but
+returned 400/empty here — prefer the model schema export for field metadata.

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/widget-type-mapping.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/widget-type-mapping.md
@@ -1,0 +1,24 @@
+# Sisense widget → Sigma element mapping
+
+Coverage table. Drives both the converter (Phase 3) and the assessment
+coverage scoring. **Confirm enum strings against live widget `type` values** —
+the trial has 0 dashboards, so these are from Sisense docs/field knowledge and
+must be verified when a sample dashboard exists.
+
+| Sisense widget `type`        | Sigma element            | Tag      | Notes |
+|------------------------------|--------------------------|----------|-------|
+| `indicator`                  | KPI chart                | AUTO     | single value; gauge variants → KPI + flag |
+| `pivot2` / `pivot`           | pivot-table              | AUTO     | rows/columns/values panels → pivot axes |
+| `tablewidget` / `table`      | table                    | AUTO     | |
+| `chart/column`, `chart/bar`  | bar chart                | AUTO     | orientation from sub-type |
+| `chart/line`                 | line chart               | AUTO     | |
+| `chart/area`                 | area chart               | AUTO     | |
+| `chart/pie`                  | pie chart                | AUTO     | |
+| `chart/scatter`              | scatter                  | HINT     | verify axis/size mapping |
+| `chart/polar`, `chart/funnel`| closest chart            | HINT     | |
+| `map/*` (scatter/area maps)  | region/point map         | HINT     | geo level mapping |
+| `treemap`, `sunburst`        | table (+flag)            | MANUAL   | no native equivalent |
+| BloX / `plugin/*` / scripted | flag                     | UNHANDLED| no Sigma equivalent — surface, don't fake |
+
+Tags: **AUTO** converts cleanly · **HINT** converts, verify · **MANUAL** needs a
+human decision · **UNHANDLED** flagged, not converted.

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/apply_sigma_rls.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/apply_sigma_rls.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Phase 1.5 (RLS decision gate) — apply a Looker RLS finding to Sigma, scripted.
+
+Sigma user attributes are FULLY API-supported (confirmed live 2026-06-10):
+  - GET  /v2/user-attributes            list (reuse-first)
+  - POST /v2/user-attributes            create
+  - POST /v2/user-attributes/{id}/users assign a value to a member
+And the Sigma RLS row-filter is fully spec-expressible (NOT UI-only): a boolean
+calc column `CurrentUserAttributeText("<attr>") = [<Field>]` on the base element
+plus an element `filters` entry `{kind:list, mode:include, values:[true]}`.
+
+This script does the whole flow, REUSE-FIRST and SAFE-BY-DEFAULT:
+  1. attribute   GET /v2/user-attributes → print a match if one already exists
+                 (by name, case-insensitive) before creating anything.
+  2. provision   --create  → POST /v2/user-attributes when nothing reusable exists.
+                 --assign   → POST /v2/user-attributes/{id}/users (needs --member-id
+                 + --value) to assign the attribute value to a member.
+  3. apply       --field <DisplayName> (+ --element-id/--dm-id) → print the RLS
+                 calc-column + element-filter spec snippet; with --apply, PATCH it
+                 into the DM element's spec (GET/PUT /v2/dataModels/{id}/spec).
+
+By default this only READS and PRINTS a plan — it mutates ONLY when you pass an
+explicit --create / --assign / --apply flag. Mirrors post_dm.py: reads
+$SIGMA_BASE_URL / $SIGMA_API_TOKEN from env (eval "$(scripts/get-token.sh)").
+Dependency-free (stdlib only).
+
+Live-validated: this exact flow produced exact 3-way parity (Looker-restricted ==
+Sigma-restricted == warehouse: $38,906.82 / 220 rows, region=West).
+
+Usage:
+  eval "$(scripts/get-token.sh)"
+  # reuse-first lookup only (default, read-only):
+  python3 apply_sigma_rls.py --attr region
+  # create the attribute if missing:
+  python3 apply_sigma_rls.py --attr region --value West --create
+  # assign a value to the querying member:
+  python3 apply_sigma_rls.py --attr region --value West --member-id <id> --assign
+  # print the RLS spec snippet for a DM element (plan only):
+  python3 apply_sigma_rls.py --attr region --field Region --element-id <eid>
+  # ...and PATCH it into the DM element spec:
+  python3 apply_sigma_rls.py --attr region --field Region --element-id <eid> \
+      --dm-id <dataModelId> --apply
+
+BATCH MODE (tool-agnostic) — ingest a converter's result.security[] (architecture B:
+the converter REPORTS RLS/CLS; this script provisions + applies). Handles RLS via
+user attribute / team (CurrentUserInTeam) / email, and CLS (columnSecurities):
+  # 1) convert + POST the model (converter injects NO RLS), capture dataModelId
+  # 2) write result.security to a JSON file, then:
+  python3 apply_sigma_rls.py --from-security security.json --dm-id <dmId>            # plan only
+  python3 apply_sigma_rls.py --from-security security.json --dm-id <dmId> --provision --apply
+Elements match by name (Sigma reassigns ids on POST); CLS columns match by normalized
+name. --provision creates missing attributes/teams (assign per-user values separately).
+Works for tableau/quicksight/powerbi/thoughtspot/qlik/lookml converter output alike.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+BASE = os.environ.get("SIGMA_BASE_URL")
+TOK = os.environ.get("SIGMA_API_TOKEN")
+
+
+def api(method, path, body=None):
+    if not BASE or not TOK:
+        sys.exit("SIGMA_BASE_URL / SIGMA_API_TOKEN unset — run: eval \"$(scripts/get-token.sh)\"")
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        BASE + path, data=data, method=method,
+        headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+    except urllib.error.HTTPError as e:
+        print("HTTP", e.code, method, path, "->", e.read().decode()[:1000], file=sys.stderr)
+        raise
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw  # spec endpoints return YAML
+
+
+def _short_id(prefix="rls"):
+    """A short, deterministic-enough id for a calc column / filter."""
+    import hashlib
+    return prefix + "-" + hashlib.md5(prefix.encode() + os.urandom(4)).hexdigest()[:8]
+
+
+# --- 1. reuse-first attribute lookup --------------------------------------
+def find_attribute(name):
+    """Return the existing user-attribute entry matching `name` (case-insensitive), else None."""
+    res = api("GET", "/v2/user-attributes?limit=200")
+    entries = res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+    for e in entries:
+        if (e.get("name") or "").lower() == name.lower():
+            return e
+    return None
+
+
+def list_attributes():
+    res = api("GET", "/v2/user-attributes?limit=200")
+    return res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+
+
+# --- 3. RLS spec snippet --------------------------------------------------
+def rls_spec_snippet(attr, field, element_id):
+    """The verified row-filter shape: a boolean calc column + an element list filter showing only True."""
+    col_id = _short_id("rlscol")
+    filt_id = _short_id("rlsf")
+    calc = {
+        "id": col_id,
+        "name": f"RLS {attr}",
+        "formula": f'CurrentUserAttributeText("{attr}") = [{field}]',
+    }
+    filt = {
+        "id": filt_id,
+        "columnId": col_id,
+        "kind": "list",
+        "mode": "include",
+        "values": [True],
+    }
+    return {
+        "elementId": element_id,
+        "calcColumn": calc,
+        "filter": filt,
+        "_note": (
+            f'Add calcColumn to element "{element_id}" columns, and `filter` to that '
+            f"element's filters[]. CurrentUserAttributeText(\"{attr}\") = [{field}] is the "
+            "user-attribute mode; team mode = CurrentUserInTeam([...]); email mode = "
+            "[Email] = CurrentUserEmail()."
+        ),
+    }
+
+
+def _derived_display(col):
+    """The label Sigma shows for a column: explicit `name`, else derived from a
+    lookup formula — [A/view/Field] -> 'Field (view)', [A/Field] -> 'Field'."""
+    if col.get("name"):
+        return col["name"]
+    f = (col.get("formula") or "").strip()
+    m = __import__("re").match(r"^\[([^\]]+)\]$", f)
+    if not m:
+        return None
+    parts = m.group(1).split("/")
+    if len(parts) >= 3:
+        return f"{parts[-1]} ({parts[-2]})"
+    return parts[-1]
+
+
+def _resolve_field_operand(element, field):
+    """Return the formula operand that actually RESOLVES for `field` on this
+    element. A relationship-lookup column's DERIVED display ('Region (customer_dim)')
+    is NOT a valid literal column reference — the bracket form errors. Its own
+    formula ([Order Fact/customer_dim/Region]) is the working operand, so reuse it.
+    Plain/native columns fall back to their display in brackets."""
+    target = _norm(field)
+    for c in (element.get("columns") or []):
+        if not isinstance(c, dict):
+            continue
+        if _norm(_derived_display(c)) == target:
+            f = (c.get("formula") or "").strip()
+            if f.startswith("[") and "/" in f:        # relationship lookup — reuse its ref
+                return f
+            return f"[{c.get('name') or field}]"
+    return f"[{field}]"
+
+
+def apply_to_dm(dm_id, element_id, calc, filt):
+    """PATCH the calc column + filter into the DM element's spec (GET → mutate → PUT)."""
+    spec = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    if not isinstance(spec, dict):
+        # spec endpoints can return YAML; we can't safely mutate that here.
+        sys.exit("DM spec came back non-JSON (YAML) — cannot auto-PATCH; apply the snippet by hand.")
+    # Re-resolve the RHS field ref against the live element so a relationship-lookup
+    # column (derived display 'Field (view)') compiles instead of erroring.
+    el = _resolve_element(spec, element_id, None)
+    if el:
+        m = __import__("re").search(r"=\s*(\[[^\]]+\])\s*$", calc.get("formula", ""))
+        if m:
+            operand = _resolve_field_operand(el, m.group(1)[1:-1])
+            if operand != m.group(1):
+                calc["formula"] = calc["formula"][:m.start(1)] + operand
+    # The spec shape nests elements under the model; search for the element by id.
+    found = _inject(spec, element_id, calc, filt)
+    if not found:
+        sys.exit(f"element id {element_id} not found in DM {dm_id} spec — check --element-id")
+    res = api("PUT", f"/v2/dataModels/{dm_id}/spec", spec)
+    print("PUT /v2/dataModels/%s/spec ->" % dm_id,
+          json.dumps(res)[:300] if isinstance(res, dict) else str(res)[:300])
+
+
+def _inject(node, element_id, calc, filt):
+    """Recursively find an element dict whose id == element_id; add calc col + filter. Returns True if injected."""
+    if isinstance(node, dict):
+        if node.get("id") == element_id and ("columns" in node or "kind" in node or "source" in node):
+            cols = node.setdefault("columns", [])
+            if not any(c.get("id") == calc["id"] for c in cols if isinstance(c, dict)):
+                cols.append(calc)
+            filters = node.setdefault("filters", [])
+            filters.append(filt)
+            return True
+        for v in node.values():
+            if _inject(v, element_id, calc, filt):
+                return True
+    elif isinstance(node, list):
+        for v in node:
+            if _inject(v, element_id, calc, filt):
+                return True
+    return False
+
+
+
+# --- shared engine: teams, element/column resolution, CLS, batch from result.security ---
+def find_team(name):
+    res = api("GET", "/v2/teams?limit=500")
+    entries = res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+    for e in entries:
+        if (e.get("name") or "").lower() == name.lower():
+            return e
+    return None
+
+def ensure_team(name, do_create):
+    t = find_team(name)
+    if t:
+        print(f"  REUSE team '{name}' (id={t.get('teamId') or t.get('id')}).")
+        return t.get("teamId") or t.get("id")
+    if do_create:
+        res = api("POST", "/v2/teams", {"name": name})
+        tid = res.get("teamId") or res.get("id") if isinstance(res, dict) else None
+        print(f"  CREATED team '{name}' (id={tid}). NOTE: add members via POST /v2/teams/{tid}/members.")
+        return tid
+    print(f"  (plan: team '{name}' missing — pass --provision to create it, then add members.)")
+    return None
+
+def _walk_elements(node, out):
+    if isinstance(node, dict):
+        if node.get("id") and ("columns" in node or "kind" in node):
+            out.append(node)
+        for v in node.values():
+            _walk_elements(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            _walk_elements(v, out)
+    return out
+
+def _resolve_element(spec, element_id, element_name):
+    els = _walk_elements(spec, [])
+    for e in els:
+        if element_id and e.get("id") == element_id:
+            return e
+    for e in els:                                  # Sigma reassigns ids on POST → match by name
+        if element_name and (e.get("name") == element_name):
+            return e
+    # last resort: a path-tail match (warehouse-table element named by table)
+    for e in els:
+        path = (e.get("source") or {}).get("path") or []
+        if element_name and path and str(path[-1]).upper() == str(element_name).upper():
+            return e
+    return None
+
+def _norm(x):
+    """Normalize a column name for matching across raw/display forms (NET_PROFIT == Net Profit)."""
+    return __import__("re").sub(r"[^a-z0-9]", "", (x or "").lower())
+
+def _resolve_col_ids(element, names):
+    """Map raw-or-display column names -> live column ids (formula tail or name, normalized)."""
+    out = []
+    re = __import__("re")
+    for nm in (names or []):
+        cid = None
+        for c in (element.get("columns") or []):
+            cand = c.get("name") or ""
+            f = c.get("formula") or ""
+            m = re.match(r"^\[(?:[^\]/]+/)?([^\]]+)\]$", f)
+            if m:
+                cand = cand or m.group(1)
+                if _norm(m.group(1)) == _norm(nm): cid = c.get("id"); break
+            if _norm(cand) == _norm(nm): cid = c.get("id"); break
+        if cid: out.append(cid)
+        else: print(f"  WARN: CLS column '{nm}' not found on element — skipped.")
+    return out
+
+def apply_from_security(dm_id, security, do_apply, do_provision):
+    """Provision attrs/teams + apply RLS calc/filter and CLS for each result.security entry."""
+    spec = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    if not isinstance(spec, dict):
+        sys.exit("DM spec came back non-JSON — cannot auto-apply.")
+    applied = 0
+    def _elname(e): return e.get('name') or ((e.get('source') or {}).get('path') or ['?'])[-1]
+    for rule in security:
+        el = _resolve_element(spec, rule.get("elementId"), rule.get("elementName"))
+        if not el:
+            print(f"⚠ {rule.get('kind')} on element '{rule.get('elementName')}' — not found in DM {dm_id}; skipped."); continue
+        if rule.get("kind") == "rls" and rule.get("rls"):
+            r = rule["rls"]
+            print(f"RLS → element '{_elname(el)}': {r['formula'][:80]}")
+            for attr in (r.get("userAttributes") or []):
+                ex = find_attribute(attr)
+                if ex: print(f"  REUSE attribute '{attr}'.")
+                elif do_provision:
+                    api("POST", "/v2/user-attributes", {"name": attr, "defaultValue": {"val": "", "type": "string"}})
+                    print(f"  CREATED attribute '{attr}'. NOTE: assign per-user values via POST /v2/user-attributes/{{id}}/users.")
+                else: print(f"  (plan: attribute '{attr}' — pass --provision to create; then assign per-user values.)")
+            for team in (r.get("teams") or []):
+                ensure_team(team, do_provision)
+            calc = {"id": _short_id("rlscol"), "name": r.get("name") or "RLS", "formula": r["formula"]}
+            filt = {"id": _short_id("rlsf"), "columnId": calc["id"], "kind": "list", "mode": "include", "values": [True]}
+            if do_apply:
+                el.setdefault("columns", []).append(calc)
+                el.setdefault("filters", []).append(filt); applied += 1
+        elif rule.get("kind") == "cls" and rule.get("cls"):
+            c = rule["cls"]
+            ids = _resolve_col_ids(el, c.get("restrictedColumnNames"))
+            print(f"CLS → element '{_elname(el)}': hide {c.get('restrictedColumnNames')}")
+            if do_apply and ids:
+                el.setdefault("columnSecurities", []).append({"id": _short_id("cls"), "criteria": c.get("criteria") or {"kind": "no-one-can-view"}, "restrictedColumns": ids}); applied += 1
+    if do_apply and applied:
+        res = api("PUT", f"/v2/dataModels/{dm_id}/spec", spec)
+        print(f"PUT spec -> applied {applied} rule(s):", (json.dumps(res)[:200] if isinstance(res, dict) else str(res)[:200]))
+    elif not do_apply:
+        print("\n(plan only — pass --apply --dm-id <id> to PATCH these into the DM spec; --provision to create attributes/teams.)")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Apply a Looker RLS finding to Sigma (safe-by-default).")
+    ap.add_argument("--attr", help="Sigma user-attribute name (e.g. region)")
+    ap.add_argument("--value", help="attribute value (for --create defaultValue / --assign)")
+    ap.add_argument("--description", help="description when creating the attribute")
+    ap.add_argument("--member-id", help="Sigma memberId to assign the value to (with --assign)")
+    ap.add_argument("--field", help="DM column display name to filter on (e.g. Region) — for the RLS snippet")
+    ap.add_argument("--element-id", help="DM element id the RLS calc col + filter attach to")
+    ap.add_argument("--dm-id", help="dataModelId (with --apply, to PATCH the element spec)")
+    ap.add_argument("--create", action="store_true", help="create the user attribute if no reusable match")
+    ap.add_argument("--assign", action="store_true", help="assign --value to --member-id")
+    ap.add_argument("--apply", action="store_true", help="PATCH the RLS calc col + filter into the DM element spec")
+    ap.add_argument("--from-security", help="path to a converter result.security[] JSON (batch RLS+CLS apply)")
+    ap.add_argument("--provision", action="store_true", help="create missing user attributes / teams (with --from-security)")
+    a = ap.parse_args()
+
+    # Batch mode: ingest a converter's result.security[] and provision + apply all rules.
+    if a.from_security:
+        if not a.dm_id:
+            sys.exit("--from-security requires --dm-id (the posted data model).")
+        raw = json.load(open(a.from_security))
+        security = raw.get("security", raw) if isinstance(raw, dict) else raw
+        return apply_from_security(a.dm_id, security, a.apply, a.provision)
+
+    if not a.attr:
+        sys.exit("Provide --attr (single-rule mode) or --from-security <json> (batch mode).")
+    # --- 1. reuse-first --------------------------------------------------
+    existing = find_attribute(a.attr)
+    attr_id = None
+    if existing:
+        attr_id = existing.get("userAttributeId") or existing.get("id")
+        print(f"REUSE: user attribute '{a.attr}' already exists "
+              f"(id={attr_id}, default={existing.get('defaultValue')}) — reusing, NOT creating.")
+    else:
+        print(f"No existing Sigma user attribute named '{a.attr}'.")
+        if a.create:
+            body = {"name": a.attr}
+            if a.description:
+                body["description"] = a.description
+            if a.value is not None:
+                body["defaultValue"] = {"val": a.value, "type": "string"}
+            res = api("POST", "/v2/user-attributes", body)
+            attr_id = res.get("userAttributeId") or res.get("id") if isinstance(res, dict) else None
+            print(f"CREATED user attribute '{a.attr}' (id={attr_id}).")
+        else:
+            print("  (plan only — pass --create to create it.)")
+
+    # --- 2. assign -------------------------------------------------------
+    if a.assign:
+        if not attr_id:
+            sys.exit("--assign needs an attribute id — create/reuse it first (no id resolved).")
+        if not a.member_id or a.value is None:
+            sys.exit("--assign requires --member-id and --value.")
+        body = {"assignments": [{"userId": a.member_id, "value": {"val": a.value, "type": "string"}}]}
+        res = api("POST", f"/v2/user-attributes/{attr_id}/users", body)
+        print(f"ASSIGNED '{a.attr}'={a.value} to member {a.member_id}: "
+              + (json.dumps(res)[:200] if isinstance(res, dict) else str(res)[:200]))
+    elif a.value is not None and a.member_id:
+        print(f"  (plan: would assign '{a.attr}'={a.value} to member {a.member_id} — pass --assign.)")
+
+    # --- 3. RLS spec snippet --------------------------------------------
+    if a.field:
+        if not a.element_id:
+            print("\nNOTE: --field given without --element-id; printing the formula only.")
+            print(f'  calc column formula: CurrentUserAttributeText("{a.attr}") = [{a.field}]')
+        else:
+            snip = rls_spec_snippet(a.attr, a.field, a.element_id)
+            print("\nRLS spec snippet (verified shape — boolean calc col + element list filter on True):")
+            print(json.dumps(snip, indent=2))
+            if a.apply:
+                if not a.dm_id:
+                    sys.exit("--apply requires --dm-id.")
+                apply_to_dm(a.dm_id, a.element_id, snip["calcColumn"], snip["filter"])
+            else:
+                print("  (plan only — pass --apply --dm-id <id> to PATCH it into the DM element spec.)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/convert.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/convert.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""
+Sisense -> Sigma converter.
+
+  convert.py model     <model_*.json> <inodes.json>  -> sigma_dm_spec.json
+  convert.py dashboard <dashboards.json> <dm.json>    -> sigma_workbook_spec.json
+  convert.py classify  <dashboards.json>              -> coverage report (stdout)
+
+model:     ElastiCube/Live datamodel export -> Sigma data-model spec (warehouse-table
+           elements + relationships). inodes.json maps TABLE -> {inodeId, columns}.
+dashboard: dashboard widgets -> Sigma workbook spec; widget type -> element,
+           panel JAQL -> column formulas via jaql_expr. Unmapped widgets/JAQL are
+           FLAGGED (kind:"flagged") not faked.
+"""
+import json, sys, re, os
+import jaql_expr as J
+
+# Sisense type code -> Sigma column type
+TYPE = {4: "datetime", 5: "number", 8: "number", 18: "text", 6: "datetime", 31: "datetime"}
+
+# Sisense widget type -> Sigma workbook element + coverage tag
+WIDGET_MAP = {
+    "indicator":     ("kpi",   "AUTO"),
+    "chart/column":  ("bar",   "AUTO"),
+    "chart/bar":     ("bar",   "AUTO"),
+    "chart/line":    ("line",  "AUTO"),
+    "chart/area":    ("area",  "AUTO"),
+    "chart/pie":     ("pie",   "AUTO"),
+    "pivot2":        ("pivot", "AUTO"),
+    "pivot":         ("pivot", "AUTO"),
+    "tablewidget":   ("table", "AUTO"),
+    "chart/scatter": ("scatter", "HINT"),
+    "chart/polar":   ("radar", "HINT"),
+    "chart/funnel":  ("bar",   "HINT"),   # no native funnel -> bar + flag note
+    "treemap":       (None,    "MANUAL"), # no native equivalent
+    "sunburst":      (None,    "MANUAL"),
+    "map/area":      ("geography-region", "HINT"),
+    "map/scatter":   ("geography-point",  "HINT"),
+}
+
+# ---------- model -> DM ----------
+import random, string
+def _sid(n=10):
+    return "".join(random.choices(string.ascii_letters + string.digits, k=n))
+
+def _translate_ec_sql(sql, database, schema):
+    """Best-effort port of Sisense ElastiCube SQL to warehouse SQL:
+    [Table].[Col] -> "TABLE"."Col" ; bare [Table] (FROM/JOIN) -> DB.SCHEMA."TABLE".
+    Always FLAGGED for human review — ElastiCube dialect funcs may not be warehouse-valid."""
+    # qualify FROM/JOIN table refs first (before the column rewrites touch them)
+    sql = re.sub(r"(FROM|JOIN)\s+\[([^\]]+)\]",
+                 lambda m: f'{m.group(1)} {database}.{schema}."{m.group(2).upper()}" "{m.group(2).upper()}"', sql, flags=re.I)
+    # [Table].[Col] and [Table].Col  ->  "TABLE"."Col"
+    sql = re.sub(r"\[([^\]]+)\]\.\[([^\]]+)\]",
+                 lambda m: f'"{m.group(1).upper()}"."{m.group(2)}"', sql)
+    sql = re.sub(r"\[([^\]]+)\]\.([A-Za-z_][\w]*)",
+                 lambda m: f'"{m.group(1).upper()}"."{m.group(2)}"', sql)
+    return sql
+
+def _split_top_commas(s):
+    """Split a SQL projection list on top-level commas (respecting parens)."""
+    parts, depth, cur = [], 0, ""
+    for ch in s:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        if ch == "," and depth == 0:
+            parts.append(cur); cur = ""
+        else:
+            cur += ch
+    if cur.strip():
+        parts.append(cur)
+    return parts
+
+def _ec_sql_aliased(expr, declared, database, schema):
+    """Translate ElastiCube SQL AND alias each SELECT output to the declared
+    column name (quoted) so the warehouse output columns match the element's
+    column formulas exactly (Snowflake uppercases unquoted aliases otherwise)."""
+    sql = _translate_ec_sql(expr, database, schema)
+    m = re.match(r"\s*SELECT\s+(.*?)\s+FROM\s", sql, re.S | re.I)
+    if not m:
+        return sql, False  # couldn't parse projection — leave as-is, flag harder
+    proj = _split_top_commas(m.group(1))
+    if len(proj) != len(declared):
+        return sql, False
+    aliased = []
+    for part, name in zip(proj, declared):
+        base = re.sub(r'\s+AS\s+("?[\w]+"?)\s*$', "", part.strip(), flags=re.I)
+        aliased.append(f'{base} AS "{name}"')
+    return sql[:m.start(1)] + ", ".join(aliased) + sql[m.end(1):], True
+
+def probe_directions(model, schema, database, snow_conn):
+    """Probe warehouse cardinality to resolve relationship direction accurately:
+    the one-side (dimension/target) is the side whose join column is UNIQUE.
+    Returns {frozenset({(table,col),...}): fact_table_name}. Tables not in the
+    warehouse (e.g. derived custom-SQL) are skipped → caller falls back+flags."""
+    import subprocess
+    colref = {}
+    for ds in model["datasets"]:
+        for t in ds["schema"]["tables"]:
+            for c in t["columns"]:
+                colref[(t["oid"], c["oid"])] = (t["name"], c["name"])
+    derived = {t["name"] for ds in model["datasets"] for t in ds["schema"]["tables"]
+               if (t.get("expression") or {}).get("expression")}
+    pairs = set()
+    for r in model.get("relations", []):
+        cc = r["columns"]
+        if len(cc) == 2:
+            for cell in cc:
+                ref = colref.get((cell["table"], cell["column"]))
+                if ref and ref[0] not in derived:
+                    pairs.add(ref)
+    uniq = {}
+    for table, col in pairs:
+        q = (f'SELECT COUNT(*)=COUNT(DISTINCT "{col}") FROM '
+             f'{database}.{schema}."{table.upper()}"')
+        out = subprocess.run(["snow", "sql", "-c", snow_conn, "--format", "json", "-q", q],
+                             capture_output=True, text=True,
+                             env={**os.environ, "PATH": "/opt/homebrew/bin:/usr/local/bin:" + os.environ.get("PATH", "")})
+        try:
+            uniq[(table, col)] = list(json.loads(out.stdout)[0].values())[0] in (True, "true", 1)
+        except Exception:
+            uniq[(table, col)] = None
+    directions = {}
+    for r in model.get("relations", []):
+        cc = r["columns"]
+        if len(cc) != 2:
+            continue
+        a = colref.get((cc[0]["table"], cc[0]["column"]))
+        b = colref.get((cc[1]["table"], cc[1]["column"]))
+        if not a or not b:
+            continue
+        ua, ub = uniq.get(a), uniq.get(b)
+        if ua and not ub:
+            directions[frozenset({a, b})] = b[0]   # a is unique → a=dim, b=fact
+        elif ub and not ua:
+            directions[frozenset({a, b})] = a[0]
+    return directions
+
+def convert_model(model, connection_id, schema="SISENSE_ECOMMERCE",
+                  database="CSA", name=None, directions=None):
+    """Sisense Live/ElastiCube model export -> (Sigma DM spec, flags).
+    Plain tables -> warehouse-table elements (source = connectionId + path).
+    Tables with an `expression` (ElastiCube custom SQL) -> custom-SQL ('sql')
+    elements with a best-effort dialect translation + a loud FLAG (never silently
+    treated as a physical warehouse table). Relationships go on the fact element."""
+    tables = [t for ds in model["datasets"] for t in ds["schema"]["tables"]]
+    by_lower = {t["name"].lower(): t for t in tables}
+    elements, el_id, col_id, flags = [], {}, {}, []
+    for t in tables:
+        eid = _sid()
+        el_id[t["name"]] = eid
+        expr = (t.get("expression") or {}).get("expression")
+        cols = []
+        for c in t["columns"]:
+            cid = _sid()
+            col_id[(t["name"], c["name"])] = cid
+            # warehouse-table cols prefix on the physical table; SQL-source cols
+            # use the fixed 'Custom SQL' prefix ([Custom SQL/OutputCol]) — NOT the
+            # element name (which gives "dependency not found") nor bare (circular)
+            formula = f'[Custom SQL/{c["name"]}]' if expr else f'[{t["name"].upper()}/{c["name"]}]'
+            cols.append({"id": cid, "formula": formula, "name": c["name"]})
+        if expr:
+            stmt, aliased = _ec_sql_aliased(expr, [c["name"] for c in t["columns"]],
+                                            database, schema)
+            elements.append({"id": eid, "kind": "table",
+                             "source": {"kind": "sql", "connectionId": connection_id,
+                                        "statement": stmt},
+                             "columns": cols, "name": t["name"],
+                             "order": [c["id"] for c in cols]})
+            flags.append({"table": t["name"], "reason": "ElastiCube custom-SQL table — "
+                          "emitted as a Sigma SQL element with a best-effort dialect "
+                          "translation" + ("" if aliased else " (column aliasing failed — review)") +
+                          "; VERIFY the SQL runs on the warehouse",
+                          "original_sql": expr})
+        else:
+            elements.append({"id": eid, "kind": "table",
+                             "source": {"connectionId": connection_id, "kind": "warehouse-table",
+                                        "path": [database, schema, t["name"].upper()]},
+                             "columns": cols, "name": t["name"],
+                             "order": [c["id"] for c in cols]})
+    # relationships (fact -> dim) from model.relations[]
+    colref = {}
+    for ds in model["datasets"]:
+        for t in ds["schema"]["tables"]:
+            for c in t["columns"]:
+                colref[(t["oid"], c["oid"])] = (t["name"], c["name"])
+    for r in model.get("relations", []):
+        cc = r["columns"]
+        if len(cc) != 2:
+            continue
+        a = colref.get((cc[0]["table"], cc[0]["column"]))
+        b = colref.get((cc[1]["table"], cc[1]["column"]))
+        if not a or not b:
+            continue
+        (ft, fc), (tt, tc) = (a, b)
+        fact_by_card = (directions or {}).get(frozenset({a, b}))
+        if fact_by_card:                       # cardinality-resolved (accurate)
+            if fact_by_card == b[0]:
+                (ft, fc), (tt, tc) = b, a
+        else:                                  # heuristic fallback: wider = fact
+            if len(by_lower[a[0].lower()]["columns"]) < len(by_lower[b[0].lower()]["columns"]):
+                (ft, fc), (tt, tc) = b, a
+            flags.append({"relation": f"{a[0]}.{a[1]} <-> {b[0]}.{b[1]}",
+                          "reason": f"join direction set by width heuristic (fact={ft}); "
+                          "verify many-side — run with --verify-card to resolve by cardinality"})
+        for e in elements:
+            if e["id"] == el_id[ft]:
+                e.setdefault("relationships", []).append({
+                    "id": _sid(), "targetElementId": el_id[tt],
+                    "keys": [{"sourceColumnId": col_id[(ft, fc)],
+                              "targetColumnId": col_id[(tt, tc)]}],
+                    "name": tt.upper()})  # clean workbook cross-refs: [Fact/DIM/Col]
+    elements.sort(key=lambda e: 1 if e.get("relationships") else 0)  # dims before fact
+    spec = {"name": name or f"{model.get('title', 'Model')} (from Sisense)",
+            "pages": [{"id": "p1", "name": "Model", "elements": elements}]}
+    return spec, flags
+
+# ---------- dashboard -> workbook (classify + emit) ----------
+def widget_fields(w):
+    """Return list of (panel_name, kind, sigma_formula|FLAG, title)."""
+    out = []
+    for p in w.get("metadata", {}).get("panels", []):
+        for it in p.get("items", []):
+            jaql = it.get("jaql", {})
+            if not jaql:
+                continue
+            try:
+                kind, formula = J.classify(jaql)
+            except J.Unsupported as e:
+                kind, formula = "flagged", f"FLAG: {e}"
+            out.append({"panel": p["name"], "kind": kind, "formula": formula,
+                        "title": jaql.get("title"), "topn": (J.top_n(jaql) if kind=="dimension" else None)})
+    return out
+
+def classify_dashboard(dashboards):
+    rows = []
+    for d in dashboards:
+        for w in d.get("widgets", []):
+            wt = w.get("type")
+            target, tag = WIDGET_MAP.get(wt, (None, "UNHANDLED"))
+            flags = [f for f in widget_fields(w) if f["kind"] == "flagged"]
+            if target is None:
+                tag = "MANUAL" if tag != "UNHANDLED" else "UNHANDLED"
+            rows.append({"title": w.get("title"), "sisense_type": wt,
+                         "sigma_element": target, "tag": tag,
+                         "field_flags": [f["formula"] for f in flags]})
+    return rows
+
+# ---------- dashboard -> workbook (generic emit) ----------
+# Sisense widget type -> Sigma workbook element kind
+SIGMA_KIND = {
+    "indicator": "kpi-chart", "chart/column": "bar-chart", "chart/bar": "bar-chart",
+    "chart/line": "line-chart", "chart/area": "area-chart", "chart/pie": "pie-chart",
+    "chart/polar": "bar-chart", "chart/funnel": "bar-chart", "chart/scatter": "scatter-chart",
+    "pivot2": "pivot-table", "pivot": "pivot-table", "tablewidget": "table",
+}
+MONEY = {"kind": "number", "formatString": "$,.0f", "currencySymbol": "$"}
+# Sisense panel name -> logical role
+DIM_PANELS = {"categories", "x-axis", "rows", "point", "geo", "break by"}
+MEAS_PANELS = {"value", "values", "y-axis", "size", "color"}
+
+def _masterize(formula):
+    """Rewrite bare [Col] refs to [Master/Col] (skip refs that already have '/')."""
+    return re.sub(r"\[([^/\]]+)\]", r"[Master/\1]", formula)
+
+def _money_fmt(jaql):
+    fmt = (jaql.get("format") or {})
+    return MONEY if (fmt.get("mask", {}) or {}).get("currency") or "Revenue" in (jaql.get("title") or "") or "Cost" in (jaql.get("title") or "") else None
+
+# ---------- layout: Sisense columnar grid -> Sigma 24-col grid XML ----------
+# Sisense stores layout as `layout.columns[]` (vertical strips, % width) ->
+# `cells[]` (stacked) -> `subcells[]` (side-by-side, % width) -> `elements[]`
+# ({widgetid, height px}). Sigma stores layout as ONE top-level `layout` XML
+# string: a <Page> per page (24-col grid), elements positioned by
+# <LayoutElement elementId gridColumn="start / end" gridRow="start / end"/>
+# where `end` is EXCLUSIVE (full width = "1 / 25"). On workbook CREATE the
+# server preserves our client element IDs, so layout refs resolve.
+GRID_COLS = 24
+PX_PER_ROW = 42          # Sisense px height -> grid row units (512px ~= 12 rows)
+KPI_ROWS = 4             # KPIs are short cards regardless of Sisense's px height
+CTRL_ROWS = 3
+MIN_VIZ_ROWS = 8
+WIDE_KINDS = {"line-chart", "area-chart", "table", "pivot-table"}  # span full width
+
+def _rows_for(kind, height_px):
+    if kind == "kpi-chart":
+        return KPI_ROWS
+    return max(MIN_VIZ_ROWS, round((height_px or 512) / PX_PER_ROW))
+
+def _alloc(weights, total):
+    """Split `total` grid columns across `weights` (Sisense % widths), each >=1,
+    summing EXACTLY to `total`."""
+    s = float(sum(weights)) or 1.0
+    out = [max(1, int(round(w / s * total))) for w in weights]
+    diff = total - sum(out)
+    i = 0
+    while diff and out:
+        j = i % len(out)
+        if diff > 0:
+            out[j] += 1; diff -= 1
+        elif out[j] > 1:
+            out[j] -= 1; diff += 1
+        i += 1
+        if i > 10000:
+            break
+    return out
+
+def _is_degenerate(columns):
+    """A single full-width column of stacked full-width widgets — Sisense's
+    default. Porting it verbatim = an ugly tall stack, so we auto-arrange."""
+    if len(columns) != 1:
+        return False
+    return all(len(cell.get("subcells", [])) <= 1 for cell in columns[0].get("cells", []))
+
+def _flatten(columns, wid2elem):
+    """Widgets in author order -> [(elementId, sigma_kind, height_px)]."""
+    out = []
+    for col in columns:
+        for cell in col.get("cells", []):
+            for sub in cell.get("subcells", []):
+                for el in sub.get("elements", []):
+                    info = wid2elem.get(el.get("widgetid"))
+                    if info:
+                        out.append((info[0], info[1], el.get("height")))
+    return out
+
+def _auto_arrange(columns, wid2elem, row0, place):
+    """Clean default for degenerate stacks: leading KPIs flow into rows of up to
+    4 cards; remaining charts go 2-up; trends/tables/pivots span full width."""
+    items = _flatten(columns, wid2elem)
+    row, i, n = row0, 0, len(items)
+    while i < n and items[i][1] == "kpi-chart":
+        grp = []
+        while i < n and items[i][1] == "kpi-chart" and len(grp) < 4:
+            grp.append(items[i]); i += 1
+        cs = 1
+        for (eid, _k, _h), w in zip(grp, _alloc([1] * len(grp), GRID_COLS)):
+            place(eid, cs, w, row, KPI_ROWS); cs += w
+        row += KPI_ROWS
+    pending = None
+    for eid, kind, h in items[i:]:
+        rh = _rows_for(kind, h)
+        if kind in WIDE_KINDS:
+            if pending:
+                pe, ph = pending; place(pe, 1, 12, row, ph); row += ph; pending = None
+            place(eid, 1, GRID_COLS, row, rh); row += rh
+        elif pending is None:
+            pending = (eid, rh)
+        else:
+            pe, ph = pending; rr = max(ph, rh)
+            place(pe, 1, 12, row, rr); place(eid, 13, 12, row, rr); row += rr; pending = None
+    if pending:
+        pe, ph = pending; place(pe, 1, 12, row, ph); row += ph
+    return row
+
+def _faithful(columns, wid2elem, row0, place):
+    """Port the Sisense columnar grid as-is: each top-level column is an
+    independent vertical stack placed side-by-side; subcells split a column
+    horizontally; cells stack vertically. Reproduces the author's arrangement."""
+    col_w = _alloc([c.get("width", 100) for c in columns], GRID_COLS)
+    starts, cur = [], 1
+    for w in col_w:
+        starts.append(cur); cur += w
+    maxrow = row0
+    for col, cstart, cw in zip(columns, starts, col_w):
+        row = row0
+        for cell in col.get("cells", []):
+            subs = cell.get("subcells", []) or []
+            sw = _alloc([s.get("width", 100) for s in subs], cw) if subs else []
+            sstart, cellrows = cstart, 1
+            for sub, w in zip(subs, sw):
+                subrow = row
+                for el in sub.get("elements", []):
+                    info = wid2elem.get(el.get("widgetid"))
+                    if not info:
+                        continue
+                    eid, kind = info
+                    h = _rows_for(kind, el.get("height"))
+                    place(eid, sstart, w, subrow, h); subrow += h
+                cellrows = max(cellrows, subrow - row)
+                sstart += w
+            row += cellrows
+        maxrow = max(maxrow, row)
+    return maxrow
+
+def _page(page_id, body_lines):
+    head = (f'  <Page type="grid" gridTemplateColumns="repeat({GRID_COLS}, 1fr)" '
+            f'gridTemplateRows="auto" id="{page_id}">')
+    return "\n".join([head, *body_lines, "  </Page>"])
+
+def _layout_element(eid, cstart, cw, rstart, rh):
+    return (f'    <LayoutElement elementId="{eid}" '
+            f'gridColumn="{cstart} / {cstart + cw}" gridRow="{rstart} / {rstart + rh}"/>')
+
+def build_layout(dashboards, control_ids, wid2elem):
+    """Full Sigma `layout` XML: a Data page (the Master table) + an Overview page
+    that ports every dashboard's layout (controls on top, then each dashboard's
+    grid stacked vertically)."""
+    placed = []
+    place = lambda eid, cs, cw, rs, rh: placed.append(_layout_element(eid, cs, cw, rs, rh))
+    row = 1
+    if control_ids:
+        # Controls go in a flat row at the top — one per equal column slice.
+        # NOT a <GridContainer>: a GridContainer's elementId must reference a real
+        # container element in the spec, and we don't emit one (Sigma rejects a
+        # synthetic container id with "not a valid container").
+        cw = _alloc([1] * len(control_ids), GRID_COLS)
+        cs = 1
+        for cid_, w in zip(control_ids, cw):
+            place(cid_, cs, w, row, CTRL_ROWS)
+            cs += w
+        row += CTRL_ROWS
+    for d in dashboards:
+        cols = (d.get("layout") or {}).get("columns") or []
+        if not cols:
+            continue
+        arrange = _auto_arrange if _is_degenerate(cols) else _faithful
+        row = arrange(cols, wid2elem, row, place)
+    data_page = _page("pdata", [_layout_element("master", 1, GRID_COLS, 1, 12)])
+    main_page = _page("pmain", placed)
+    return '<?xml version="1.0" encoding="utf-8"?>\n' + data_page + "\n" + main_page
+
+
+def convert_dashboard(dashboards, model, dm_info):
+    """Emit a Sigma workbook spec from Sisense dashboards.
+    dm_info = {dataModelId, factElementId, factName}. Builds a Master data
+    element on the fact DM element (own cols + cross-ref dim cols) and one viz
+    element per supported widget. Unsupported widgets are recorded in `flags`."""
+    tables = [t for ds in model["datasets"] for t in ds["schema"]["tables"]]
+    fact = max(tables, key=lambda t: len(t["columns"]))["name"]
+    fact_name = dm_info["factName"]
+    cid = lambda: _sid(8)
+
+    # collect referenced (table, col) across all widgets -> Master columns
+    master_cols, master_seen, master_idx, name_for = [], {}, {}, {}
+    def master_ref(table, col):
+        key = (table, col)
+        if key in master_seen:
+            return master_seen[key]
+        disp = col if col not in name_for or name_for[col] == table else f"{table} {col}"
+        name_for.setdefault(col, table)
+        mid = "m_" + cid()
+        formula = (f"[{fact_name}/{col}]" if table == fact
+                   else f"[{fact_name}/{table.upper()}/{col}]")
+        master_cols.append({"id": mid, "formula": formula, "name": disp})
+        master_seen[key] = disp        # viz refs use [Master/disp]
+        master_idx[key] = mid          # control bindings use the column id
+        return disp
+
+    flags, viz_elements, controls = [], [], []
+    wid2elem = {}                       # Sisense widget oid -> (sigma elementId, kind)
+    for d in dashboards:
+        # dashboard-level filters -> real Sigma controls bound to the Master
+        for fl in (d.get("filters") or []):
+            ctrl = _emit_control(fl, master_ref, master_idx, cid)
+            if ctrl:
+                controls.append(ctrl)
+            else:
+                jq = (fl.get("jaql") or {})
+                flags.append({"dashboard": d.get("title"), "filter": jq.get("title") or jq.get("dim"),
+                              "reason": "dashboard filter not auto-convertible — recreate manually"})
+        for w in d.get("widgets", []):
+            wt = w.get("type")
+            kind = SIGMA_KIND.get(wt)
+            if not kind:
+                flags.append({"widget": w.get("title"), "type": wt, "reason": "no Sigma element (treemap/sunburst/map/etc.) — flag"})
+                continue
+            dims, meas = [], []
+            ok = True
+            for p in w.get("metadata", {}).get("panels", []):
+                role = "dim" if p["name"] in DIM_PANELS else ("meas" if p["name"] in MEAS_PANELS else None)
+                for it in p.get("items", []):
+                    jaql = it.get("jaql", {})
+                    if not jaql:
+                        continue
+                    try:
+                        k, formula = J.classify(jaql)
+                    except J.Unsupported as e:
+                        flags.append({"widget": w.get("title"), "field": jaql.get("title"), "reason": str(e)})
+                        ok = False
+                        continue
+                    # register referenced columns into Master
+                    for m in re.finditer(r"\[([^.\]/]+)\.([^\]]+)\]", J.raw_dims(jaql)):
+                        master_ref(m.group(1), m.group(2))
+                    vid = "c_" + cid()
+                    spec = {"id": vid, "formula": _masterize(formula),
+                            "name": jaql.get("title") or k}
+                    fmt = _money_fmt(jaql)
+                    if fmt and k == "measure":
+                        spec["format"] = fmt
+                    (meas if (k == "measure" or role == "meas") else dims).append((vid, spec, jaql))
+            if not ok and not (dims or meas):
+                continue
+            elem = _emit_viz(kind, w.get("title"), dims, meas)
+            viz_elements.append(elem)
+            if w.get("oid"):            # link the source widget to its Sigma element for layout
+                wid2elem[w["oid"]] = (elem["id"], elem["kind"])
+
+    master = {"id": "master", "kind": "table",
+              "source": {"dataModelId": dm_info["dataModelId"],
+                         "elementId": dm_info["factElementId"], "kind": "data-model"},
+              "columns": master_cols, "name": "Master",
+              "order": [c["id"] for c in master_cols], "visibleAsSource": True}
+    spec = {"name": "ECommerce Overview (from Sisense)", "schemaVersion": 1,
+            "pages": [{"id": "pdata", "name": "Data", "elements": [master]},
+                      {"id": "pmain", "name": "Overview", "elements": controls + viz_elements}],
+            "layout": build_layout(dashboards, [c["id"] for c in controls], wid2elem)}
+    return spec, flags
+
+def _emit_control(fl, master_ref, master_idx, cid):
+    """Sisense dashboard filter -> a Sigma control bound to the Master column it
+    filters (the control propagates to every viz sourced from Master)."""
+    jq = (fl.get("jaql") or {})
+    dim = jq.get("dim")
+    m = re.match(r"\[([^.\]]+)\.([^\]]+)\]", dim or "")
+    if not m:
+        return None
+    table, col = m.group(1), m.group(2)
+    master_ref(table, col)                       # ensure the column is on Master
+    col_id = master_idx[(table, col)]
+    bind = {"source": {"kind": "table", "elementId": "master"}, "columnId": col_id}
+    name = jq.get("title") or col
+    flt = jq.get("filter") or {}
+    base = {"kind": "control", "id": "ctrl_" + cid(), "controlId": re.sub(r"\W+", "", name) or ("F" + cid()),
+            "name": name, "filters": [bind]}
+    dt = jq.get("datatype") or jq.get("dimType")
+    if "members" in flt or "explicit" in flt or jq.get("level") in (None,) and dt in ("text", None):
+        # member list filter (most common)
+        vals = flt.get("members") or (flt.get("explicit", {}) or {}).get("members") or []
+        return {**base, "controlType": "list", "mode": "exclude" if flt.get("exclude") else "include",
+                "selectionMode": "multiple", "values": vals,
+                "source": {"kind": "source", "source": {"kind": "table", "elementId": "master"}, "columnId": col_id}}
+    if jq.get("level") or dt in ("datetime", "date"):
+        return {**base, "controlType": "date-range", "mode": "between",
+                "includeNulls": "when-no-value-is-selected"}
+    if dt in ("numeric", "number"):
+        return {**base, "controlType": "number-range", "mode": "between", "values": []}
+    # default to a list control
+    return {**base, "controlType": "list", "mode": "include", "selectionMode": "multiple", "values": [],
+            "source": {"kind": "source", "source": {"kind": "table", "elementId": "master"}, "columnId": col_id}}
+
+def _emit_viz(kind, title, dims, meas):
+    cols = [s for _, s, _ in dims] + [s for _, s, _ in meas]
+    dim_ids = [i for i, _, _ in dims]
+    meas_ids = [i for i, _, _ in meas]
+    e = {"id": "v_" + _sid(8), "kind": kind,
+         "source": {"elementId": "master", "kind": "table"},
+         "columns": cols, "name": title}
+    if kind == "kpi-chart":
+        e["columns"] = [s for _, s, _ in meas][:1]
+        e["value"] = {"columnId": meas_ids[0]} if meas_ids else None
+    elif kind in ("bar-chart", "line-chart", "area-chart"):
+        e["xAxis"] = {"columnId": dim_ids[0]} if dim_ids else None
+        e["yAxis"] = {"columnIds": meas_ids}
+        if len(dims) > 1:  # break-by series
+            e["colorBy"] = {"columnId": dim_ids[1]}
+    elif kind == "pie-chart":  # this org's API uses pie-chart with {id} refs
+        e["value"] = {"id": meas_ids[0]} if meas_ids else None
+        e["color"] = {"id": dim_ids[0]} if dim_ids else None
+    elif kind == "scatter-chart":
+        e["xAxis"] = {"columnId": meas_ids[0]} if meas_ids else None
+        e["yAxis"] = {"columnIds": meas_ids[1:2]}
+    elif kind == "pivot-table":
+        # Sigma has no separate pivot element — emit a grouped table (groupBy the
+        # pivot's row+column dims, calculations = the measures). A true column
+        # cross-tab is a HINT: column-split dims become additional group levels.
+        e["kind"] = "table"
+        e["groupings"] = [{"id": "g_" + _sid(6), "groupBy": dim_ids, "calculations": meas_ids}]
+    # table: columns only
+    # element-level top-N: if any dim carried a JAQL top filter, rank by the
+    # first measure (Sigma top-n filters rank by a measure column).
+    for _, _, jq in dims:
+        tn = J.top_n(jq)
+        if tn and tn.get("count") and meas_ids:
+            e.setdefault("filters", []).append({
+                "id": "f_" + _sid(6), "columnId": meas_ids[0], "kind": "top-n",
+                "rankingFunction": "rank", "mode": "top-n", "rowCount": int(tn["count"]),
+                "includeNulls": "when-no-value-is-selected"})
+            break
+    return e
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit(__doc__)
+    cmd = sys.argv[1]
+    if cmd == "model":
+        # model <model.json> <connectionId> [schema] [database]
+        model = json.load(open(sys.argv[2])); connection_id = sys.argv[3]
+        args = [a for a in sys.argv[4:] if not a.startswith("--")]
+        schema = args[0] if len(args) > 0 else "SISENSE_ECOMMERCE"
+        database = args[1] if len(args) > 1 else "CSA"
+        directions = None
+        if "--verify-card" in sys.argv:
+            conn = sys.argv[sys.argv.index("--verify-card") + 1]
+            directions = probe_directions(model, schema, database, conn)
+            print(f"cardinality-resolved {len(directions)} relationship directions")
+        spec, flags = convert_model(model, connection_id, schema, database, directions=directions)
+        json.dump(spec, open("sigma_dm_spec.json", "w"), indent=2)
+        print(f"wrote sigma_dm_spec.json ({len(spec['pages'][0]['elements'])} elements)")
+        if flags:
+            print("FLAGS (not faked):")
+            for f in flags:
+                subj = f.get("table") or f.get("relation") or "?"
+                print(f"  - {subj}: {f['reason']}")
+    elif cmd == "classify":
+        d = json.load(open(sys.argv[2]))
+        rows = classify_dashboard(d)
+        for r in rows:
+            print(f"  [{r['tag']:8}] {r['title']:34} {r['sisense_type']:14} -> {r['sigma_element']}"
+                  + (f"  FLAGS={r['field_flags']}" if r['field_flags'] else ""))
+    elif cmd == "dashboard":
+        # dashboard <dashboards.json> <model.json> <dataModelId> <factElementId> [factName] [--only TITLE]
+        dashboards = json.load(open(sys.argv[2])); model = json.load(open(sys.argv[3]))
+        dm_info = {"dataModelId": sys.argv[4], "factElementId": sys.argv[5],
+                   "factName": sys.argv[6] if len(sys.argv) > 6 and not sys.argv[6].startswith("--") else "Commerce"}
+        only = None
+        if "--only" in sys.argv:
+            only = sys.argv[sys.argv.index("--only") + 1]
+            dashboards = [{**d, "widgets": [w for w in d.get("widgets", []) if d.get("title") == only or True]}
+                          for d in dashboards if d.get("title") == only]
+        spec, flags = convert_dashboard(dashboards, model, dm_info)
+        json.dump(spec, open("sigma_workbook_spec.json", "w"), indent=2)
+        print(f"wrote sigma_workbook_spec.json ({len(spec['pages'][1]['elements'])} viz elements, "
+              f"{len(spec['pages'][0]['elements'][0]['columns'])} master cols)")
+        if flags:
+            print("FLAGS (not faked):")
+            for f in flags:
+                print("  -", f)
+    else:
+        sys.exit(f"unknown command: {cmd}")

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/detect_rls.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/detect_rls.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Phase 1 (RLS scan) — detect Sisense data-security rules and map them to Sigma
+row-level security, so the migration makes ONE consolidated, reviewed decision
+about porting RLS — never silently drop it, never silently port a wrong mapping.
+
+OPTIONAL + NEVER SLOW: RLS porting is opt-in (like every sibling skill). This
+detector runs cheaply during discovery; if the cube has NO data-security rules
+it prints NOTHING and exits 0 — the happy path is untouched. When rules ARE
+found it prints a structured summary + the recommended Sigma mapping, and (with
+--out) writes a converter-style `security[]` JSON that the tool-agnostic
+`apply_sigma_rls.py --from-security` provisions and applies (opt-in, plan-only
+by default). Exit 0 always on a clean scan; exit 2 on a usage/IO error.
+
+Sisense data security (per ElastiCube/Live cube) restricts a table column to a
+set of member values per user/group:
+  GET /api/elasticubes/{server}/{cube}/datasecurity  -> [ rule, ... ]
+  rule ≈ {table, column, members[], allMembers, exclusionary, shares[{party,type}]}
+
+Sigma mapping (the verified recipe — see refs + apply_sigma_rls.py):
+  a per-column **user attribute** + a boolean calc column on the table element
+  `CurrentUserAttributeText("<col>") = [<Col>]` + an element list filter showing
+  only True. Per-user member values are assigned to the attribute (not faked
+  here — flagged for provisioning).
+
+Usage:
+  eval "$(scripts/sisense-auth.sh)"
+  python3 detect_rls.py "Sample ECommerce" [--server LocalHost] [--json] [--out security.json]
+"""
+import argparse, json, os, ssl, sys, urllib.parse, urllib.request, urllib.error
+
+def _get(url):
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", "Bearer " + os.environ["SISENSE_API_TOKEN"])
+    ctx = ssl._create_unverified_context()           # trial CA lacks key-usage ext
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=60) as r:
+            return json.loads(r.read() or "null")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        sys.exit(f"[detect_rls] HTTP {e.code} on {url}: {e.read().decode()[:200]}")
+
+def fetch_rules(base, server, cube):
+    path = f"/api/elasticubes/{urllib.parse.quote(server)}/{urllib.parse.quote(cube)}/datasecurity"
+    rules = _get(base.rstrip('/') + path)
+    return rules if isinstance(rules, list) else []
+
+def to_security(rules):
+    """Sisense data-security rules -> converter-style result.security[] entries
+    (the shape apply_sigma_rls.py --from-security consumes)."""
+    out = []
+    for r in rules:
+        table = r.get("table") or r.get("elasticubeTable") or "?"
+        col = r.get("column") or r.get("dim") or "?"
+        attr = col                                   # one Sigma user attribute per restricted column
+        members = r.get("members") or []
+        parties = [s.get("party") or s.get("partyId") for s in (r.get("shares") or [])]
+        out.append({
+            "kind": "rls", "elementName": table,
+            "rls": {
+                "name": f"RLS {col}",
+                # Text([col]) coerces the operand so the comparison is text=text
+                # regardless of the restricted column's type — a numeric column
+                # (e.g. an ID) compared bare to the text user-attribute value
+                # silently matches nothing. Text() is idempotent on text columns.
+                "formula": f'CurrentUserAttributeText("{attr}") = Text([{col}])',
+                "userAttributes": [attr], "teams": [],
+            },
+            "_source": {"table": table, "column": col, "members": members,
+                        "allMembers": bool(r.get("allMembers")),
+                        "exclusionary": bool(r.get("exclusionary")),
+                        "appliesTo": parties},
+        })
+    return out
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("cube", help="ElastiCube / Live cube title (datasource title)")
+    ap.add_argument("--server", default="LocalHost")
+    ap.add_argument("--json", action="store_true", help="machine output (security[] JSON to stdout)")
+    ap.add_argument("--out", help="write the security[] JSON to this file (for apply_sigma_rls.py)")
+    a = ap.parse_args()
+    if not os.environ.get("SISENSE_API_TOKEN"):
+        sys.exit('[detect_rls] need SISENSE_API_TOKEN — run: eval "$(scripts/sisense-auth.sh)"')
+
+    rules = fetch_rules(os.environ["SISENSE_BASE_URL"], a.server, a.cube)
+    security = to_security(rules)
+
+    if a.out:
+        json.dump(security, open(a.out, "w"), indent=2)
+    if a.json:
+        print(json.dumps(security, indent=2))
+        return
+
+    if not security:
+        # NEVER SLOW: nothing to decide -> silent, clean exit.
+        return
+    print(f"=== Sisense data security on '{a.cube}': {len(security)} rule(s) -> Sigma RLS ===")
+    for s in security:
+        src = s["_source"]
+        scope = "ALL members" if src["allMembers"] else (f"{len(src['members'])} member(s)")
+        excl = " (exclusionary)" if src["exclusionary"] else ""
+        print(f"  • {src['table']}.{src['column']}  restrict to {scope}{excl}; "
+              f"applies to {len(src['appliesTo'])} principal(s)")
+        print(f"      Sigma → user attribute \"{s['rls']['userAttributes'][0]}\" + row filter "
+              f"{s['rls']['formula']}")
+    print("\nRLS porting is OPT-IN. To provision + apply (reuse-first, plan-only by default):")
+    print('  python3 detect_rls.py "%s" --out security.json' % a.cube)
+    print("  python3 apply_sigma_rls.py --from-security security.json --dm-id <dataModelId>")
+    print("  # add --provision --apply once you've reviewed the plan; assign per-user")
+    print("  # values with POST /v2/user-attributes/{id}/users (members not faked here).")
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/discover.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/discover.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Sisense discovery — pull the source content a migration needs, over REST.
+
+Validated live against signense trial (signup-jnzavd0c.sisense.com) 2026-06-17.
+
+Outputs a normalized discovery bundle to <out>/discovery/:
+  - elasticubes.json        list of data models (oid, title, datasets count)
+  - model_<title>.json      full datamodel schema export per cube
+  - dashboards.json         list of dashboards (with widgets inlined)
+
+Endpoints used (see refs/sisense-rest-api.md for the full map):
+  GET  /api/v1/elasticubes/getElasticubes
+  GET  /api/v2/datamodels/schema?title=<title>     <- full datasets/relations/transforms
+  GET  /api/v1/dashboards
+  GET  /api/v1/dashboards/{oid}/widgets
+
+Auth: reads SISENSE_BASE_URL + SISENSE_API_TOKEN from the env
+      (eval "$(scripts/sisense-auth.sh)" first).
+
+Usage:
+  python3 discover.py [--out DIR] [--cube TITLE ...]
+"""
+import argparse
+import json
+import os
+import ssl
+import sys
+import urllib.parse
+import urllib.request
+
+BASE = os.environ.get("SISENSE_BASE_URL", "").rstrip("/")
+TOKEN = os.environ.get("SISENSE_API_TOKEN", "")
+
+# Some Sisense instances (notably trial/self-signed) present a cert chain that
+# Python's verifier rejects even though curl/browsers accept it. Try verified
+# first; on a cert-verification error, fall back to an unverified context (the
+# target is the customer's own instance, reached over their own creds) and warn.
+_UNVERIFIED = ssl._create_unverified_context()
+_warned_ssl = False
+
+
+def _get(path):
+    global _warned_ssl
+    url = f"{BASE}{path}"
+    req = urllib.request.Request(url, headers={
+        "Authorization": f"Bearer {TOKEN}",
+        "Content-Type": "application/json",
+    })
+    try:
+        with urllib.request.urlopen(req) as r:
+            body = r.read().decode("utf-8")
+    except urllib.error.URLError as e:
+        if not isinstance(getattr(e, "reason", None), ssl.SSLCertVerificationError):
+            raise
+        if not _warned_ssl:
+            print("  ! TLS cert not verifiable — falling back to unverified "
+                  "context (trial/self-signed cert)", file=sys.stderr)
+            _warned_ssl = True
+        with urllib.request.urlopen(req, context=_UNVERIFIED) as r:
+            body = r.read().decode("utf-8")
+    return json.loads(body)
+
+
+def discover(out_dir, only_cubes=None):
+    if not BASE or not TOKEN:
+        sys.exit("SISENSE_BASE_URL / SISENSE_API_TOKEN not set — run "
+                 'eval "$(scripts/sisense-auth.sh)" first.')
+    disc = os.path.join(out_dir, "discovery")
+    os.makedirs(disc, exist_ok=True)
+
+    # 1. Data models (ElastiCubes / Live)
+    cubes = _get("/api/v1/elasticubes/getElasticubes")
+    summary = [{
+        "oid": c.get("_id") or c.get("oid"),
+        "title": c.get("title"),
+        "datasets": len(c.get("datasets", [])),
+        "destination": (c.get("buildDestination") or {}).get("destination"),
+    } for c in cubes]
+    json.dump(summary, open(os.path.join(disc, "elasticubes.json"), "w"), indent=2)
+    print(f"elasticubes: {len(summary)}")
+
+    # 2. Full schema export per model
+    for c in summary:
+        title = c["title"]
+        if only_cubes and title not in only_cubes:
+            continue
+        q = urllib.parse.quote(title)
+        try:
+            schema = _get(f"/api/v2/datamodels/schema?title={q}")
+        except Exception as e:  # noqa: BLE001
+            print(f"  ! schema export failed for {title!r}: {e}")
+            continue
+        safe = title.replace("/", "_").replace(" ", "_")
+        json.dump(schema, open(os.path.join(disc, f"model_{safe}.json"), "w"), indent=2)
+        n_ds = len(schema.get("datasets", []))
+        n_rel = len(schema.get("relations", []))
+        print(f"  model {title!r}: {n_ds} datasets, {n_rel} relations")
+
+    # 3. Dashboards + widgets
+    dashboards = _get("/api/v1/dashboards")
+    if not isinstance(dashboards, list):
+        dashboards = dashboards.get("dashboards", [])
+    for d in dashboards:
+        oid = d.get("oid") or d.get("_id")
+        if not d.get("widgets") and oid:
+            try:
+                d["widgets"] = _get(f"/api/v1/dashboards/{oid}/widgets")
+            except Exception as e:  # noqa: BLE001
+                print(f"  ! widgets fetch failed for dashboard {oid}: {e}")
+    json.dump(dashboards, open(os.path.join(disc, "dashboards.json"), "w"), indent=2)
+    print(f"dashboards: {len(dashboards)}")
+    if not dashboards:
+        print("  (none — build a sample dashboard in Sisense before an "
+              "end-to-end parity run)")
+
+    print(f"\nwrote bundle -> {disc}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=os.path.expanduser("~/sisense-migration"))
+    ap.add_argument("--cube", action="append", dest="cubes")
+    a = ap.parse_args()
+    discover(a.out, a.cubes)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/escalate-gap.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/escalate-gap.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""escalate-gap — opt-in GitHub-issue filer for gap-scout escalations.
+
+Shared across every migration skill (vendored identically into each plugin's
+scripts/). When the gap scout can't find a working Sigma translation for a
+source feature, the main agent offers the user the *option* to open a tracking
+issue in the appropriate repo. This script is what turns that "yes" into filed
+issues — with dedupe, repo routing, converter-repo mirroring, and a cross-linked
+bead.
+
+DESIGN: opt-in, never automatic.
+  - Default (no --yes): DRY RUN. Prints the drafted issue(s), the target repo(s),
+    and any existing open issues/beads that already cover this gap. Files NOTHING.
+    This is what the agent shows the user.
+  - With --yes: actually files. Skips any repo where dedupe already found a match
+    (unless --force).
+
+ROUTING (category -> repos):
+  converter  -> twells89/sigma-data-model-manager + twells89/sigma-data-model-mcp
+               (a source expression the *converter* failed to translate — the
+                browser tool and the MCP must stay in sync, so mirror to both)
+  builder    -> twells89/sigma-migration-skills   (workbook/DM spec builder gap)
+  skill      -> twells89/sigma-migration-skills   (skill-logic / discovery gap)
+
+Usage (dry-run draft the agent shows the user):
+  python3 scout/escalate-gap.py \
+    --skill tableau-to-sigma --category converter \
+    --feature WINDOW_AVG --description 'moving average over SUM' \
+    --source-pattern 'WINDOW_AVG(SUM([...]))' \
+    --template-attempted 'MovingAvg(Sum([Master/\\1]), -10, 10)' \
+    --test-formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+    --sigma-response '<failing column type / error json>' \
+    --example-from 'Sales.twb line 412' \
+    --escalation-yaml ~/.tableau-to-sigma/escalations/window_avg.yaml
+
+Then, only if the user says yes, the agent re-runs the same command with --yes.
+
+Requires `gh` on PATH and authed for the target repos. `bd` (beads) optional.
+Exit codes: 0 = ok (drafted or filed), 3 = nothing fileable / gh missing on --yes.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+ROUTES = {
+    "converter": ["twells89/sigma-data-model-manager", "twells89/sigma-data-model-mcp"],
+    "builder":   ["twells89/sigma-migration-skills"],
+    "skill":     ["twells89/sigma-migration-skills"],
+}
+BEADS_DIR = os.path.expanduser("~/.beads-sigma")
+
+
+def have(cmd):
+    return shutil.which(cmd) is not None
+
+
+def run(args, **kw):
+    """Run a command, return (ok, stdout, stderr)."""
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, **kw)
+        return p.returncode == 0, p.stdout.strip(), p.stderr.strip()
+    except Exception as e:  # noqa: BLE001
+        return False, "", str(e)
+
+
+def build_issue(a):
+    title = f"{a.skill} gap: {a.feature}" + (f" ({a.description})" if a.description else "")
+    body = []
+    body.append(f"**Skill:** `{a.skill}`")
+    body.append(f"**Gap category:** `{a.category}`")
+    body.append(f"**Feature:** `{a.feature}`")
+    if a.description:
+        body.append(f"**Description:** {a.description}")
+    if a.source_pattern:
+        body.append(f"**Source pattern:** `{a.source_pattern}`")
+    if a.template_attempted:
+        body.append(f"**Sigma template attempted:** `{a.template_attempted}`")
+    if a.test_formula:
+        body.append(f"**Test formula POSTed:** `{a.test_formula}`")
+    if a.sigma_response:
+        body.append(f"**Sigma response:**\n```\n{a.sigma_response}\n```")
+    body.append(f"**Example source:** {a.example_from or '(not provided)'}")
+    if a.escalation_yaml:
+        body.append(f"**Local escalation record:** `{a.escalation_yaml}`")
+    body.append("\n_Filed via the gap-scout opt-in escalation flow (`escalate-gap.py`)._")
+    return title, "\n\n".join(body)
+
+
+def labels_for(a):
+    return ["gap-scout-escalation", a.skill, f"category:{a.category}"]
+
+
+def ensure_labels(repo, labels):
+    """Best-effort: create labels so `gh issue create --label` won't fail."""
+    for lab in labels:
+        run(["gh", "label", "create", lab, "--repo", repo, "--force"])
+
+
+def find_dupes(repo, feature, skill):
+    """Return list of {number,title,url} open issues that look like this gap."""
+    ok, out, _ = run([
+        "gh", "issue", "list", "--repo", repo, "--state", "open",
+        "--label", "gap-scout-escalation", "--search", feature,
+        "--json", "number,title,url",
+    ])
+    if not ok or not out:
+        return []
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return []
+    feat = feature.lower()
+    return [i for i in items if feat in (i.get("title", "").lower())]
+
+
+def find_bead_dupe(feature):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    ok, out, _ = run(["bd", "list", "--json"], cwd=BEADS_DIR)
+    if not ok or not out:
+        return None
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return None
+    rows = items if isinstance(items, list) else items.get("issues", items.get("beads", []))
+    feat = feature.lower()
+    for b in rows or []:
+        if feat in (str(b.get("title", "")) + str(b.get("summary", ""))).lower():
+            return b.get("id") or b.get("bead_id")
+    return None
+
+
+def create_bead(title, body, skill, category):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    labels = f"sigma-converter,{skill},gap-scout-escalation,category:{category}"
+    ok, out, _ = run([
+        "bd", "create", title, "--priority", "2", "--labels", labels,
+        "--description", body, "--silent",
+    ], cwd=BEADS_DIR)
+    return out.strip() if ok else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--feature", required=True)
+    ap.add_argument("--category", default="converter", choices=list(ROUTES))
+    ap.add_argument("--description", default="")
+    ap.add_argument("--source-pattern", default="")
+    ap.add_argument("--template-attempted", default="")
+    ap.add_argument("--test-formula", default="")
+    ap.add_argument("--sigma-response", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--escalation-yaml", default="")
+    ap.add_argument("--extra-repo", action="append", default=[],
+                    help="additional target repo(s), repeatable")
+    ap.add_argument("--yes", action="store_true",
+                    help="actually file. Without it: dry-run, prints the draft only.")
+    ap.add_argument("--force", action="store_true",
+                    help="file even if a matching open issue already exists")
+    ap.add_argument("--no-beads", action="store_true")
+    a = ap.parse_args()
+
+    repos = list(dict.fromkeys(ROUTES[a.category] + a.extra_repo))
+    title, body = build_issue(a)
+    labels = labels_for(a)
+
+    # Dedupe scan (read-only) up front so the agent can show it to the user.
+    gh_ok = have("gh")
+    dupes = {r: (find_dupes(r, a.feature, a.skill) if gh_ok else []) for r in repos}
+    bead_dupe = None if a.no_beads else find_bead_dupe(a.feature)
+
+    if not a.yes:
+        # DRY RUN — this is what the agent presents to the user.
+        out = {
+            "mode": "draft",
+            "would_file_in": repos,
+            "labels": labels,
+            "title": title,
+            "body": body,
+            "existing_issues": {r: d for r, d in dupes.items() if d},
+            "existing_bead": bead_dupe,
+            "gh_available": gh_ok,
+            "next_step": "re-run with --yes to file (skips repos already covered)",
+        }
+        print(json.dumps(out, indent=2))
+        return 0
+
+    # --yes: actually file.
+    if not gh_ok:
+        print(json.dumps({"status": "error", "error": "gh not on PATH; cannot file"}))
+        return 3
+
+    # Bead first (authoritative tracker), so its id can be embedded in issues.
+    bead_id = bead_dupe
+    if bead_id is None and not a.no_beads:
+        bead_id = create_bead(title, body, a.skill, a.category)
+    issue_body = body + (f"\n\n**Bead:** `{bead_id}`" if bead_id else "")
+
+    filed, skipped = [], []
+    for repo in repos:
+        if dupes.get(repo) and not a.force:
+            skipped.append({"repo": repo, "existing": dupes[repo]})
+            continue
+        ensure_labels(repo, labels)
+        ok, out, err = run([
+            "gh", "issue", "create", "--repo", repo,
+            "--title", title, "--body", issue_body,
+            "--label", ",".join(labels),
+        ])
+        if ok:
+            filed.append({"repo": repo, "url": out.strip()})
+        else:
+            # retry once without labels (in case label creation was denied)
+            ok2, out2, err2 = run([
+                "gh", "issue", "create", "--repo", repo,
+                "--title", title, "--body", issue_body,
+            ])
+            if ok2:
+                filed.append({"repo": repo, "url": out2.strip(), "note": "filed without labels"})
+            else:
+                filed.append({"repo": repo, "error": err or err2})
+
+    # Cross-link mirrored issues to each other.
+    urls = [f["url"] for f in filed if f.get("url")]
+    if len(urls) > 1:
+        for f in filed:
+            if not f.get("url"):
+                continue
+            others = [u for u in urls if u != f["url"]]
+            num = f["url"].rstrip("/").split("/")[-1]
+            link_body = issue_body + "\n\n**Mirrored to:** " + ", ".join(others)
+            run(["gh", "issue", "edit", num, "--repo", f["repo"], "--body", link_body])
+
+    # Cross-link the bead back to the filed issue urls.
+    if bead_id and urls and have("bd"):
+        run(["bd", "update", bead_id, "--description",
+             issue_body + "\n\nFiled issues: " + ", ".join(urls)], cwd=BEADS_DIR)
+
+    print(json.dumps({
+        "status": "filed",
+        "filed": filed,
+        "skipped_existing": skipped,
+        "bead_id": bead_id,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/fetch_inodes.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/fetch_inodes.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Fetch Sigma table inode IDs + warehouse paths for the SISENSE_ECOMMERCE schema.
+Writes inodes.json {TABLE_UPPER: {inodeId, path:[db,schema,table]}}."""
+import os, json, subprocess, sys
+BASE=os.environ["SIGMA_BASE_URL"].rstrip("/"); TOK=os.environ["SIGMA_API_TOKEN"]
+def files():
+    out=subprocess.run(["curl","-s",f"{BASE}/v2/files?typeFilters=table&limit=2000",
+        "-H",f"Authorization: Bearer {TOK}"],capture_output=True,text=True).stdout
+    return json.loads(out).get("entries",[])
+ents=[e for e in files() if 'SISENSE_ECOMMERCE' in (e.get('path') or '')]
+inodes={}
+for e in ents:
+    name=e.get("name")
+    inodes[name.upper()]={"inodeId":e.get("id"),"path":["CSA","SISENSE_ECOMMERCE",name]}
+json.dump(inodes,open("/Users/tjwells/sisense-migration/inodes.json","w"),indent=2)
+print(f"{len(inodes)}/4 tables:", list(inodes.keys()))
+sys.exit(0 if len(inodes)>=4 else 1)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get-token.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get-token.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Exchange Sigma client credentials for a bearer token.
+# Usage:  eval "$(scripts/get-token.sh)"
+# Sets SIGMA_API_TOKEN in the calling shell.
+
+set -euo pipefail
+
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, plain shell)
+# don't. If the creds aren't already present, source the neutral cred file.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
+: "${SIGMA_BASE_URL:?Set SIGMA_BASE_URL (e.g. https://api.sigmacomputing.com)}"
+: "${SIGMA_CLIENT_ID:?Set SIGMA_CLIENT_ID}"
+: "${SIGMA_CLIENT_SECRET:?Set SIGMA_CLIENT_SECRET}"
+
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  "$SIGMA_BASE_URL/v2/auth/token") || {
+    echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null)
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Token exchange failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+echo "export SIGMA_API_TOKEN=${TOKEN}"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/jaql_expr.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/jaql_expr.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+JAQL -> Sigma formula translation.
+
+A JAQL panel item is `{ "jaql": {...}, "format": {...} }`. The jaql is one of:
+  - dimension:        { "dim": "[Table.Column]", "level": "months"? , "sort"? , "filter"? }
+  - aggregated meas.: { "dim": "[Table.Column]", "agg": "sum" }
+  - formula measure:  { "formula": "SUM([r])/SUM([c])", "context": {"[r]":{dim..}, "[c]":{dim..}} }
+
+translate_agg()   -> a Sigma aggregate formula string e.g. "Sum([Revenue])"
+translate_dim()   -> a Sigma dimension column reference / date-trunc expression
+classify()        -> ('measure'|'dimension', sigma_formula) for any jaql item
+
+Unsupported constructs raise Unsupported so the converter FLAGS them instead of
+emitting wrong logic. Column display names are taken verbatim from the JAQL dim
+(the last [Table.Column] segment), which match the Sigma DM column names.
+"""
+import re
+
+class Unsupported(Exception):
+    pass
+
+AGG = {
+    "sum": "Sum", "count": "Count", "countdistinct": "CountDistinct",
+    "avg": "Avg", "average": "Avg", "min": "Min", "max": "Max",
+    "median": "Median", "stdev": "Stdev", "var": "Var",
+}
+
+# JAQL date level -> Sigma DateTrunc unit (None = no truncation)
+LEVEL = {
+    "years": "year", "quarters": "quarter", "months": "month", "weeks": "week",
+    "days": "day", "minutes": "minute", "hours": "hour", "seconds": "second",
+}
+
+# JAQL formula functions that need special handling or flagging
+SAFE_FUNC = {  # JAQL fn -> Sigma fn (same arg order)
+    "SUM": "Sum", "COUNT": "Count", "AVG": "Avg", "MIN": "Min", "MAX": "Max",
+    "COUNTDISTINCT": "CountDistinct", "ABS": "Abs", "ROUND": "Round",
+    "RANK": "Rank",  # verify partition semantics downstream
+}
+FLAG_FUNC = {  # JAQL fns with no clean 1:1 Sigma equivalent -> flag for human
+    "PREV", "PAST", "GROWTH", "GROWTHPAST", "RSUM", "DIFF", "DIFFPAST",
+    "QUARTILE", "PERCENTILE", "CONTRIBUTION", "ALL", "LISTAGG",
+}
+
+def col_name(dim):
+    """'[Commerce.Revenue]' -> 'Revenue' (the column display name in the DM)."""
+    m = re.match(r"\[([^.\]]+)\.([^\]]+)\]", dim.strip())
+    if not m:
+        raise Unsupported(f"unparseable JAQL dim: {dim!r}")
+    return m.group(2)
+
+def table_of(dim):
+    m = re.match(r"\[([^.\]]+)\.([^\]]+)\]", dim.strip())
+    return m.group(1) if m else None
+
+def translate_agg(jaql):
+    agg = jaql["agg"].lower()
+    if agg not in AGG:
+        raise Unsupported(f"unsupported agg: {agg}")
+    return f"{AGG[agg]}([{col_name(jaql['dim'])}])"
+
+def translate_dim(jaql):
+    name = col_name(jaql["dim"])
+    lvl = jaql.get("level")
+    if lvl:
+        if lvl not in LEVEL:
+            raise Unsupported(f"unsupported date level: {lvl}")
+        return f'DateTrunc("{LEVEL[lvl]}", [{name}])'
+    return f"[{name}]"
+
+def translate_formula(jaql):
+    """Resolve a JAQL formula's [tokens] from its context into a Sigma formula."""
+    formula = jaql["formula"]
+    ctx = jaql.get("context", {})
+    # flag JAQL functions we won't fake
+    for fn in re.findall(r"([A-Za-z_]+)\s*\(", formula):
+        if fn.upper() in FLAG_FUNC:
+            raise Unsupported(f"JAQL function {fn}() has no clean Sigma equivalent")
+    out = formula
+    for token, sub in ctx.items():
+        # a context member carrying a filter (filtered/scoped measure) has no
+        # clean 1:1 Sigma form — flag rather than silently drop the filter
+        if isinstance(sub, dict) and sub.get("filter"):
+            raise Unsupported("filtered/scoped JAQL measure — needs manual SumIf/CountIf")
+        if "formula" in sub:
+            rep = translate_formula(sub)
+        elif "agg" in sub:
+            rep = translate_agg(sub)
+        elif "dim" in sub:
+            rep = f"[{col_name(sub['dim'])}]"
+        else:
+            raise Unsupported(f"unresolvable JAQL context member: {sub!r}")
+        out = out.replace(token, rep)
+    # map JAQL scalar/agg function names to Sigma (case-insensitive)
+    def _fn(m):
+        fn = m.group(1)
+        return SAFE_FUNC.get(fn.upper(), fn) + "("
+    out = re.sub(r"([A-Za-z_]+)\s*\(", _fn, out)
+    return out
+
+def classify(jaql):
+    """Return ('measure'|'dimension', sigma_formula). Raises Unsupported to flag."""
+    if "formula" in jaql:
+        return "measure", translate_formula(jaql)
+    if jaql.get("agg"):
+        return "measure", translate_agg(jaql)
+    return "dimension", translate_dim(jaql)
+
+def raw_dims(jaql):
+    """Return a string containing every raw [Table.Column] token this JAQL item
+    references — from its dim, or from each sub-item in a formula's context.
+    Used to register the underlying columns into the workbook Master element."""
+    toks = []
+    if "dim" in jaql:
+        toks.append(jaql["dim"])
+    for sub in (jaql.get("context") or {}).values():
+        if isinstance(sub, dict):
+            toks.append(raw_dims(sub))
+    return " ".join(toks)
+
+def top_n(jaql):
+    """Extract a top-N spec from a JAQL dim filter, or None."""
+    f = jaql.get("filter") or {}
+    top = f.get("top")
+    if top:
+        return {"count": top.get("count"), "by_col": col_name(top["by"]["dim"]),
+                "by_agg": AGG.get(top["by"].get("agg", "sum").lower(), "Sum")}
+    return None

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/load_to_snowflake.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/load_to_snowflake.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Extract a Sisense ElastiCube's tables (SQL endpoint, CSV) and load them into
+Snowflake CSA.<schema> via the `snow` CLI (connection `tj`).
+
+Preserves original column names as quoted identifiers so the Sigma DM and the
+Sisense Live model line up 1:1.
+
+Usage:
+  python3 load_to_snowflake.py --cube "Sample ECommerce" \
+      --model ~/sisense-migration/discovery/model_Sample_ECommerce.json \
+      --schema SISENSE_ECOMMERCE
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.parse
+
+WORK = os.path.expanduser("~/sisense-migration/load")
+os.makedirs(WORK, exist_ok=True)
+
+BASE = os.environ["SISENSE_BASE_URL"].rstrip("/")
+TOKEN = os.environ["SISENSE_API_TOKEN"]
+
+# Sisense column type code -> Snowflake type
+TYPEMAP = {18: "VARCHAR", 8: "NUMBER(38,0)", 5: "FLOAT", 4: "DATE",
+           6: "TIMESTAMP_NTZ", 31: "DATE", 0: "VARCHAR"}
+
+
+# The SQL endpoint caps a default (no-LIMIT) response at 5000 rows, but honors a
+# large explicit LIMIT and returns the full table in one shot. Do NOT paginate
+# with OFFSET — ElastiCube SQL has no stable order across pages, so OFFSET pages
+# overlap/skip rows (same row count, corrupted aggregates). One big LIMIT is both
+# correct and faster.
+ROW_CAP = 100_000_000
+
+
+def sql_csv(cube, base_query):
+    """Fetch a full SELECT in one request via a large LIMIT; return CSV text."""
+    url = f"{BASE}/api/datasources/{urllib.parse.quote(cube)}/sql"
+    out = subprocess.run(
+        ["curl", "-sk", "--max-time", "600", "-G", url,
+         "-H", f"Authorization: Bearer {TOKEN}",
+         "--data-urlencode", f"query={base_query} LIMIT {ROW_CAP}",
+         "--data-urlencode", "format=csv"],
+        capture_output=True, text=True, check=True).stdout
+    if out.lstrip().startswith("{") and '"error"' in out[:80]:
+        raise RuntimeError(f"Sisense SQL error: {out[:200]}")
+    return out
+
+
+def snow(q):
+    subprocess.run(["snow", "sql", "-c", "tj", "-q", q],
+                   check=True, capture_output=True, text=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cube", required=True)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--schema", required=True)
+    a = ap.parse_args()
+
+    model = json.load(open(os.path.expanduser(a.model)))
+    snow(f"CREATE SCHEMA IF NOT EXISTS CSA.{a.schema};")
+    snow(f"CREATE STAGE IF NOT EXISTS CSA.{a.schema}.LOAD_STAGE;")
+
+    tables = []
+    for ds in model["datasets"]:
+        for t in ds.get("schema", {}).get("tables", []):
+            # skip custom-SQL / derived tables — the Sigma DM recomputes those as
+            # SQL elements over the base tables (don't materialize them here)
+            if (t.get("expression") or {}).get("expression"):
+                print(f"  skip (custom-SQL, computed in Sigma): {t['name']}")
+                continue
+            tables.append(t)
+
+    for t in tables:
+        name = t["name"]
+        cols = [c for c in t["columns"]]
+        # build SELECT with fully-qualified, bracketed identifiers
+        sel = ", ".join(f"[{name}].[{c['name']}]" for c in cols)
+        query = f"SELECT {sel} FROM [{name}]"
+        csv_text = sql_csv(a.cube, query)
+        path = os.path.join(WORK, f"{name}.csv")
+        open(path, "w").write(csv_text)
+        nrows = csv_text.count("\n") - 1
+        print(f"  extracted {name}: {nrows} rows -> {path}")
+
+        # DDL preserving original column names (quoted)
+        coldefs = ", ".join(
+            f'"{c["name"]}" {TYPEMAP.get(c["type"], "VARCHAR")}' for c in cols)
+        fq = f'CSA.{a.schema}."{name.upper()}"'
+        snow(f"CREATE OR REPLACE TABLE {fq} ({coldefs});")
+        snow(f"PUT 'file://{path}' @CSA.{a.schema}.LOAD_STAGE "
+             f"OVERWRITE=TRUE AUTO_COMPRESS=TRUE;")
+        snow(f"COPY INTO {fq} FROM @CSA.{a.schema}.LOAD_STAGE/{name}.csv.gz "
+             f"FILE_FORMAT=(TYPE=CSV SKIP_HEADER=1 "
+             f"FIELD_OPTIONALLY_ENCLOSED_BY='\"' EMPTY_FIELD_AS_NULL=TRUE) "
+             f"ON_ERROR=ABORT_STATEMENT;")
+        print(f"  loaded   {fq}")
+
+    print("done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/scan_gaps.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/scan_gaps.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""scan_gaps.py — gap-scout for Sisense→Sigma converter coverage.
+
+Runs the converter's own classifier over every widget in a discovery bundle and
+reports coverage by category — so coverage is *measured*, not assumed — and
+appends every unmapped widget / flagged JAQL to a learned-rules file for
+follow-up. This is the "flag, never fake" gate: a migration is not done until
+the scout has run and any UNHANDLED/MANUAL gap is either ported or knowingly
+accepted. Run each time; shared with the sisense-assessment skill.
+
+Categories (from convert.WIDGET_MAP + jaql_expr):
+  AUTO      widget type + all its JAQL map cleanly to a Sigma element
+  HINT      maps to a near-equivalent (e.g. polar→bar, map→geo) — review
+  MANUAL    no native Sigma element (treemap/sunburst) — rebuild by hand
+  UNHANDLED unknown widget type — not converted
+  plus per-widget FIELD FLAGS: JAQL the translator refused (custom funcs,
+  filtered/scoped measures, unresolvable context) — never faked.
+
+Usage:
+  python3 scan_gaps.py <dashboards.json> [--rules learned-rules.json] [--strict]
+    --strict : exit non-zero if any MANUAL/UNHANDLED/flagged gap remains
+               (use in the done-gate; default exit 0 just reports + records).
+"""
+import argparse, json, os, sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import convert as C
+
+CATEGORY_NOTE = {
+    "AUTO":      "widget + JAQL map cleanly to a Sigma element",
+    "HINT":      "near-equivalent Sigma element — review the substitution",
+    "MANUAL":    "no native Sigma element — rebuild by hand",
+    "UNHANDLED": "unknown widget type — not converted",
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dashboards")
+    ap.add_argument("--rules", default="learned-rules.json")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 if any MANUAL/UNHANDLED/flagged gap remains (done-gate)")
+    a = ap.parse_args()
+
+    dashboards = json.load(open(a.dashboards))
+    dashboards = dashboards if isinstance(dashboards, list) else [dashboards]
+    rows = C.classify_dashboard(dashboards)
+
+    by_cat, gaps = {}, []
+    for r in rows:
+        by_cat.setdefault(r["tag"], []).append(r)
+        if r["tag"] in ("MANUAL", "UNHANDLED"):
+            gaps.append({"widget": r["title"], "sisense_type": r["sisense_type"],
+                         "category": r["tag"], "reason": CATEGORY_NOTE[r["tag"]]})
+        for fl in r.get("field_flags", []):           # JAQL the translator refused
+            gaps.append({"widget": r["title"], "sisense_type": r["sisense_type"],
+                         "category": "JAQL", "reason": fl})
+
+    total = len(rows) or 1
+    auto = len(by_cat.get("AUTO", []))
+    print(f"=== Sisense->Sigma coverage: {len(rows)} widgets ===")
+    for cat in ("AUTO", "HINT", "MANUAL", "UNHANDLED"):
+        grp = by_cat.get(cat, [])
+        if grp:
+            print(f"  {cat:10} {len(grp):3}  ({CATEGORY_NOTE[cat]})")
+            for r in grp:
+                fl = f"  FLAGS={r['field_flags']}" if r.get("field_flags") else ""
+                print(f"       - {r['title']:34} {r['sisense_type']:14} -> {r['sigma_element']}{fl}")
+    flagged = sum(1 for g in gaps if g["category"] == "JAQL")
+    print(f"  ---\n  AUTO: {auto}/{len(rows)} ({100*auto//total}%); "
+          f"hint: {len(by_cat.get('HINT', []))}; "
+          f"manual/unhandled: {len(by_cat.get('MANUAL', []))+len(by_cat.get('UNHANDLED', []))}; "
+          f"flagged JAQL: {flagged}")
+
+    if gaps:
+        prev = json.load(open(a.rules)) if os.path.exists(a.rules) else []
+        seen = {(g["widget"], g["reason"]) for g in prev}
+        fresh = [g for g in gaps if (g["widget"], g["reason"]) not in seen]
+        if fresh:
+            json.dump(prev + fresh, open(a.rules, "w"), indent=2)
+            print(f"  appended {len(fresh)} new gap(s) -> {a.rules}")
+        print("  -> flag, never fake: port each gap, accept it knowingly, or "
+              "escalate-gap.py to file a tracking issue (opt-in).")
+
+    if a.strict and gaps:
+        sys.exit(f"\nRED: {len(gaps)} unresolved gap(s) — not done until ported or accepted.")
+    print("\nGREEN" if not gaps else "\n(reported — re-run with the gaps resolved for a clean scan)")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/sigma-export-png.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/sigma-export-png.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""sigma-export-png.py — render a Sigma workbook page or element to PNG via the
+REST export API, for VISUAL QA of a migrated workbook (Phase 4: side-by-side
+against the source Looker dashboard).
+
+A PNG is more reliable than an MCP SQL query for catching LAYOUT/render problems —
+hidden KPI titles, orphaned filters, overlapping tiles, wrong chart kinds — that a
+numeric parity check can't see.
+
+POST /v2/workbooks/{id}/export {pageId|elementId, format:{type:"png",pixelWidth,pixelHeight}}
+  -> {queryId, jobComplete}; then GET /v2/query/{queryId}/download until the PNG is ready.
+
+Env: SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/get-token.sh)").
+Usage:
+  python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png
+  python3 sigma-export-png.py --workbook <id> --element <elId> --out /tmp/x.png [--w 1600 --h 900]
+"""
+import argparse, os, sys, time, requests
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook", required=True)
+    ap.add_argument("--page"); ap.add_argument("--element")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--w", type=int, default=1600); ap.add_argument("--h", type=int, default=900)
+    a = ap.parse_args()
+    base = os.environ["SIGMA_BASE_URL"]; tok = os.environ["SIGMA_API_TOKEN"]
+    h = {"Authorization": f"Bearer {tok}", "Content-Type": "application/json"}
+    fmt = {"type": "png", "pixelWidth": a.w, "pixelHeight": a.h}
+    body = {"format": fmt}
+    if a.element: body["elementId"] = a.element
+    elif a.page:  body["pageId"] = a.page
+    else: sys.exit("need --page or --element")
+    r = requests.post(f"{base}/v2/workbooks/{a.workbook}/export", headers=h, json=body)
+    if r.status_code != 200: sys.exit(f"export POST {r.status_code}: {r.text[:300]}")
+    qid = r.json()["queryId"]
+    dl = f"{base}/v2/query/{qid}/download"
+    for i in range(60):
+        g = requests.get(dl, headers={"Authorization": f"Bearer {tok}"})
+        ct = g.headers.get("Content-Type", "")
+        if g.status_code == 200 and ("image" in ct or g.content[:8] == b"\x89PNG\r\n\x1a\n"):
+            open(a.out, "wb").write(g.content)
+            print(f"[png] {len(g.content)} bytes -> {a.out}"); return
+        time.sleep(3)
+    sys.exit("timed out waiting for PNG")
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/sisense-auth.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/sisense-auth.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Exchange Sisense email+password for a bearer token.
+# Usage:  eval "$(scripts/sisense-auth.sh)"
+# Sets SISENSE_API_TOKEN (and SISENSE_BASE_URL) in the calling shell.
+#
+# Credentials resolve in this order:
+#   1. SISENSE_BASE_URL / SISENSE_EMAIL / SISENSE_PASSWORD already in the env
+#   2. the neutral cred file ~/.sigma-migration/sisense.env
+# If only SISENSE_API_TOKEN is present (no email/password), it is echoed back
+# as-is — login is skipped (tokens are long-lived per user).
+
+set -euo pipefail
+
+if [ -z "${SISENSE_BASE_URL:-}" ] && [ -f "$HOME/.sigma-migration/sisense.env" ]; then
+  . "$HOME/.sigma-migration/sisense.env"
+fi
+
+: "${SISENSE_BASE_URL:?Set SISENSE_BASE_URL (e.g. https://acme.sisense.com)}"
+
+# If a token is already present and no password is supplied, reuse it.
+if [ -n "${SISENSE_API_TOKEN:-}" ] && [ -z "${SISENSE_PASSWORD:-}" ]; then
+  echo "export SISENSE_BASE_URL=${SISENSE_BASE_URL}"
+  echo "export SISENSE_API_TOKEN=${SISENSE_API_TOKEN}"
+  exit 0
+fi
+
+: "${SISENSE_EMAIL:?Set SISENSE_EMAIL}"
+: "${SISENSE_PASSWORD:?Set SISENSE_PASSWORD}"
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "username=${SISENSE_EMAIL}" \
+  --data-urlencode "password=${SISENSE_PASSWORD}" \
+  "${SISENSE_BASE_URL}/api/v1/authentication/login") || {
+    echo "Sisense login failed — check SISENSE_BASE_URL / SISENSE_EMAIL / SISENSE_PASSWORD" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null)
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Sisense login failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+echo "export SISENSE_BASE_URL=${SISENSE_BASE_URL}"
+echo "export SISENSE_API_TOKEN=${TOKEN}"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify_layout.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify_layout.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Layout-parity gate for a Sisense -> Sigma migration.
+
+`verify_parity.py` proves the DATA matches. This proves the LAYOUT came over
+correctly — a structural check that the emitted Sigma `layout` reproduces the
+Sisense dashboard's arrangement (and, for auto-arranged stacks, that the result
+is a clean, valid grid). Run it alongside the data-parity gate.
+
+For every Sisense widget that maps to a Sigma element it asserts:
+  - PLACED      every mapped widget is placed exactly once; no orphan refs
+  - GRID        nothing escapes the 24-col grid; spans are positive
+  - NO-OVERLAP  no two elements occupy the same grid cell
+  - ORDER       reading order (top->bottom, left->right) matches Sisense
+  - SIDE-BY-SIDE  widgets in the same Sisense cell stay on the same Sigma row
+  - WIDTH       relative widths are preserved (a 50% Sisense widget ~= half grid)
+
+Emits a GREEN/RED table and exits non-zero on any failure — do not claim the
+layout migrated until GREEN.
+
+Usage: python3 verify_layout.py <dashboards.json> <sigma_workbook_spec.json>
+  dashboards.json        : the discover.py bundle (widgets + layout inlined)
+  sigma_workbook_spec.json: the convert.py dashboard output
+"""
+import json, re, sys
+
+GRID_COLS = 24
+
+def parse_layout(xml):
+    """elementId -> (col_start, col_end, row_start, row_end). Skips containers."""
+    out = {}
+    for eid, gc, gr in re.findall(
+            r'<LayoutElement elementId="([^"]+)" gridColumn="([^"]+)" gridRow="([^"]+)"', xml):
+        cs, ce = (int(x) for x in gc.split(" / "))
+        rs, re_ = (int(x) for x in gr.split(" / "))
+        out[eid] = (cs, ce, rs, re_)
+    return out
+
+def sisense_order(dashboards):
+    """Sisense widgets in author reading order, with their cell index + width.
+    Returns [(widgetid, cell_key, width_pct)] where cell_key groups widgets that
+    sit side-by-side in the same Sisense cell."""
+    seq, ck = [], 0
+    for d in dashboards:
+        for col in (d.get("layout") or {}).get("columns", []):
+            for cell in col.get("cells", []):
+                subs = cell.get("subcells", [])
+                for sub in subs:
+                    for el in sub.get("elements", []):
+                        if el.get("widgetid"):
+                            seq.append((el["widgetid"], ck, sub.get("width", 100)))
+                ck += 1
+    return seq
+
+def widget_to_element(dashboards, spec):
+    """Recover widgetid -> sigma elementId by replaying convert's title match.
+    convert.py names every viz element after the widget title, so map on title
+    in author order (titles can repeat; consume left-to-right)."""
+    # build title -> [elementIds] in spec order (pmain viz only, skip controls)
+    from collections import defaultdict, deque
+    by_title = defaultdict(deque)
+    for p in spec["pages"]:
+        for e in p["elements"]:
+            if e.get("kind") == "control" or e["id"] == "master":
+                continue
+            by_title[e.get("name")].append(e["id"])
+    wid2elem = {}
+    for d in dashboards:
+        for w in d.get("widgets", []):
+            t = w.get("title")
+            if by_title.get(t):
+                wid2elem[w.get("oid")] = by_title[t].popleft()
+    return wid2elem
+
+def main():
+    dashboards = json.load(open(sys.argv[1]))
+    dashboards = dashboards if isinstance(dashboards, list) else [dashboards]
+    spec = json.load(open(sys.argv[2]))
+    P = parse_layout(spec.get("layout", ""))
+    wid2elem = widget_to_element(dashboards, spec)
+    seq = sisense_order(dashboards)
+
+    rows, failed = [], 0
+    def check(label, cond, detail=""):
+        nonlocal failed
+        rows.append((("GREEN" if cond else "RED"), label, detail))
+        if not cond:
+            failed += 1
+
+    # PLACED — every mapped, layout-present widget has exactly one placement
+    placeable = [(wid, ck, w) for (wid, ck, w) in seq if wid in wid2elem]
+    elem_ids = [wid2elem[wid] for wid, _, _ in placeable]
+    missing = [e for e in elem_ids if e not in P]
+    check("PLACED: every mapped widget placed", not missing,
+          f"unplaced={missing}" if missing else f"{len(elem_ids)} placed")
+    # non-widget placements that are legitimate: the data-page source (`master`)
+    # and dashboard-filter controls (placed in the top GridContainer)
+    legit = {"master"} | {e["id"] for p in spec["pages"] for e in p["elements"]
+                          if e.get("kind") == "control"}
+    orphans = [e for e in P if e not in set(elem_ids) and e not in legit]
+    check("PLACED: no orphan layout refs", not orphans, f"orphans={orphans}" if orphans else "")
+
+    placed = [(wid2elem[wid], ck, w) for wid, ck, w in placeable if wid2elem[wid] in P]
+
+    # GRID — within 24 cols, positive spans
+    bad = [e for e, _, _ in placed
+           if not (1 <= P[e][0] < P[e][1] <= GRID_COLS + 1 and P[e][2] < P[e][3])]
+    check("GRID: 24-col, positive spans", not bad, f"bad={bad}" if bad else "")
+
+    # NO-OVERLAP — no two elements share a grid cell
+    overlaps = []
+    for i in range(len(placed)):
+        ei = placed[i][0]; ci0, ci1, ri0, ri1 = P[ei]
+        for j in range(i + 1, len(placed)):
+            ej = placed[j][0]; cj0, cj1, rj0, rj1 = P[ej]
+            if ci0 < cj1 and cj0 < ci1 and ri0 < rj1 and rj0 < ri1:
+                overlaps.append((ei, ej))
+    check("NO-OVERLAP: elements don't collide", not overlaps,
+          f"{len(overlaps)} overlap(s): {overlaps[:3]}" if overlaps else "")
+
+    # ORDER — Sigma reading order (row then col) matches Sisense author order
+    by_reading = sorted(placed, key=lambda t: (P[t[0]][2], P[t[0]][0]))
+    check("ORDER: reading order preserved",
+          [e for e, _, _ in by_reading] == [e for e, _, _ in placed],
+          "Sigma top->bottom/left->right == Sisense author order")
+
+    # SIDE-BY-SIDE — widgets in one Sisense cell share a Sigma row start
+    sbs_ok = True; sbs_detail = ""
+    from itertools import groupby
+    for ck, grp in groupby(placed, key=lambda t: t[1]):
+        g = list(grp)
+        if len(g) > 1:
+            rstarts = {P[e][2] for e, _, _ in g}
+            if len(rstarts) != 1:
+                sbs_ok = False; sbs_detail = f"cell {ck} split across rows {rstarts}"
+    check("SIDE-BY-SIDE: same Sisense cell -> same Sigma row", sbs_ok, sbs_detail)
+
+    # WIDTH — within a multi-widget cell, Sisense width order must not be INVERTED
+    # in the grid. Near-equal widths (e.g. 34/33/33, integer thirds) legitimately
+    # map to equal grid spans, so only flag a genuine inversion: Sisense says i is
+    # meaningfully wider than j (by > one grid column's worth of %), yet the grid
+    # makes i narrower than j.
+    width_ok = True; width_detail = ""
+    TOL = 100.0 / GRID_COLS                      # one 24-col slice ~ this many %-points
+    for ck, grp in groupby(placed, key=lambda t: t[1]):
+        g = list(grp)
+        if len(g) > 1:
+            sis = [w for _, _, w in g]
+            sig = [P[e][1] - P[e][0] for e, _, _ in g]
+            for i in range(len(g)):
+                for j in range(len(g)):
+                    if sis[i] - sis[j] > TOL and sig[i] < sig[j]:
+                        width_ok = False
+                        width_detail = f"cell {ck}: sisense {sis} vs grid {sig} (#{i} should be >= #{j})"
+    check("WIDTH: relative widths preserved (no inversions)", width_ok, width_detail)
+
+    w = max(len(l) for _, l, _ in rows)
+    print(f"\nLayout parity — {len(placed)} elements placed\n" + "-" * (w + 30))
+    for status, label, detail in rows:
+        mark = "\033[92m✓\033[0m" if status == "GREEN" else "\033[91m✗\033[0m"
+        print(f"  {mark} {status:5} {label:<{w}}  {detail}")
+    print("-" * (w + 30))
+    print("RED" if failed else "GREEN", f"({failed} failure(s))" if failed else "(all checks passed)")
+    sys.exit(1 if failed else 0)
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify_parity.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify_parity.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Automated parity gate for a Sisense -> Sigma migration.
+
+For each check it runs the SAME aggregate two ways and asserts they match:
+  - Sisense:   POST /api/datasources/{ds}/jaql           (the source of truth)
+  - Warehouse: the SQL Sigma's DM/workbook compiles to   (what Sigma serves)
+Sigma reads the warehouse, so Sisense-JAQL == warehouse proves the data pipeline
+end-to-end; a thin Sigma-workbook spot-check (via the Sigma MCP `query`) confirms
+the workbook formulas compile to that same aggregate.
+
+Emits a GREEN/RED table + parity_keys.json and exits non-zero on any mismatch —
+do not claim a migration done until GREEN.
+
+Scope: this gate checks DATA only. Layout fidelity (did the dashboard's
+arrangement come over?) is a separate gate — see `verify_layout.py`. Run both.
+
+Env: SISENSE_BASE_URL/SISENSE_API_TOKEN; `snow` CLI connection (default "tj").
+Usage: python3 verify_parity.py <checks.json> [--snow-conn tj]
+checks.json: [{"label","datasource","jaql":[...],"snowflake_sql","tol":0.01}]
+"""
+import json, os, subprocess, sys
+
+def sisense_jaql(datasource, metadata):
+    ds = datasource.replace(" ", "%20").replace("(", "%28").replace(")", "%29")
+    out = subprocess.run(["curl", "-sk", "--max-time", "120", "-X", "POST",
+        f'{os.environ["SISENSE_BASE_URL"].rstrip("/")}/api/datasources/{ds}/jaql',
+        "-H", f'Authorization: Bearer {os.environ["SISENSE_API_TOKEN"]}',
+        "-H", "Content-Type: application/json",
+        "-d", json.dumps({"datasource": datasource, "metadata": metadata})],
+        capture_output=True, text=True).stdout
+    d = json.loads(out)
+    if d.get("error"):
+        return ("ERROR", d.get("details"))
+    v = d.get("values") or []
+    if not v:
+        return []
+    # single row -> flat list of cell dicts; grouped -> list of rows (lists)
+    if isinstance(v[0], dict):
+        return [c.get("data") for c in v]
+    return [(r[0].get("data"), r[-1].get("data")) for r in v]
+
+def snowflake(sql, conn):
+    out = subprocess.run(["snow", "sql", "-c", conn, "--format", "json", "-q", sql],
+                         capture_output=True, text=True,
+                         env={**os.environ, "PATH": "/opt/homebrew/bin:/usr/local/bin:" + os.environ.get("PATH", "")})
+    try:
+        rows = json.loads(out.stdout)
+    except Exception:
+        return ("ERROR", out.stdout[-200:] + out.stderr[-200:])
+    if len(rows) == 1:
+        return list(rows[0].values())
+    return [tuple(r.values()) for r in rows]
+
+def approx(a, b, tol):
+    if a is None or b is None:
+        return a == b
+    try:
+        return abs(float(a) - float(b)) <= tol * max(1.0, abs(float(b)))
+    except (TypeError, ValueError):
+        return str(a).strip() == str(b).strip()
+
+def cmp_result(sis, snow, tol):
+    if not isinstance(sis, list) or not isinstance(snow, list):
+        return False
+    if sis and isinstance(sis[0], tuple):  # grouped: compare as sorted maps
+        return sorted((str(k), round(float(v), 2)) for k, v in sis) == \
+               sorted((str(k), round(float(v), 2)) for k, v in snow)
+    return len(sis) == len(snow) and all(approx(a, b, tol) for a, b in zip(sis, snow))
+
+def run(checks, conn):
+    results, ok = [], True
+    for c in checks:
+        sis = sisense_jaql(c["datasource"], c["jaql"])
+        snow = snowflake(c["snowflake_sql"], conn)
+        match = cmp_result(sis, snow, c.get("tol", 0.01))
+        ok = ok and match
+        results.append({"label": c["label"], "sisense": sis, "warehouse": snow,
+                        "verdict": "GREEN" if match else "RED"})
+    json.dump(results, open("parity_keys.json", "w"), indent=2)
+    for r in results:
+        s = r["sisense"] if not (isinstance(r["sisense"], list) and len(r["sisense"]) > 6) else f"[{len(r['sisense'])} rows]"
+        w = r["warehouse"] if not (isinstance(r["warehouse"], list) and len(r["warehouse"]) > 6) else f"[{len(r['warehouse'])} rows]"
+        print(f"  [{r['verdict']}] {r['label']:32} sisense={s}  warehouse={w}")
+    print(f"\n{sum(1 for r in results if r['verdict']=='GREEN')}/{len(results)} GREEN")
+    return ok
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit(__doc__)
+    conn = sys.argv[sys.argv.index("--snow-conn") + 1] if "--snow-conn" in sys.argv else "tj"
+    sys.exit(0 if run(json.load(open(sys.argv[1])), conn) else 1)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_convert.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_convert.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Offline regression tests for the converter — runs against the bundled
+fixtures (no network). Run: python3 tests/test_convert.py"""
+import sys, os, json
+HERE = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+import convert as C
+
+FIX = os.path.join(HERE, "..", "fixtures")
+model = json.load(open(os.path.join(FIX, "model_ecommerce.json")))
+dashboards = json.load(open(os.path.join(FIX, "dashboards.json")))
+CONN = "00000000-0000-0000-0000-000000000000"
+
+passed = failed = 0
+def ok(label, cond):
+    global passed, failed
+    passed += 1 if cond else 0
+    failed += 0 if cond else 1
+    if not cond:
+        print(f"  FAIL {label}")
+
+# --- model -> DM ---
+spec, flags = C.convert_model(model, CONN, "SISENSE_ECOMMERCE", "CSA")
+els = spec["pages"][0]["elements"]
+ok("model: 4 elements", len(els) == 4)
+ok("model: all warehouse-table (no custom-sql in ecommerce)",
+   all(e["source"]["kind"] == "warehouse-table" for e in els))
+ok("model: 3 relationships on fact", sum(len(e.get("relationships", [])) for e in els) == 3)
+ok("model: fact element is last (after dims)", els[-1].get("relationships"))
+ok("model: clean star has only direction-heuristic flags (no custom-SQL/errors)",
+   all("join direction" in f["reason"] for f in flags))
+# with cardinality directions supplied, no flags at all
+spec2, flags2 = C.convert_model(model, CONN, "SISENSE_ECOMMERCE", "CSA",
+   directions={frozenset({("Commerce","Country ID"),("Country","Country ID")}):"Commerce",
+               frozenset({("Commerce","Category ID"),("Category","Category ID")}):"Commerce",
+               frozenset({("Commerce","Brand ID"),("Brand","Brand ID")}):"Commerce"})
+ok("model: cardinality-resolved directions -> no flags", flags2 == [])
+ok("model: warehouse path uses db+schema+TABLE",
+   els[0]["source"]["path"][:2] == ["CSA", "SISENSE_ECOMMERCE"])
+ok("model: column formula prefix is phys table",
+   els[-1]["columns"][0]["formula"].startswith("[COMMERCE/"))
+
+# --- dashboard -> workbook ---
+dm_info = {"dataModelId": "dm-x", "factElementId": "fact-x", "factName": "Commerce"}
+wb, dflags = C.convert_dashboard(
+    [d for d in dashboards if d.get("title") == "ECommerce Overview (Live)"], model, dm_info)
+page_els = wb["pages"][1]["elements"]
+controls = [e for e in page_els if e["kind"] == "control"]
+viz = [e for e in page_els if e["kind"] != "control"]
+kinds = [e["kind"] for e in viz]
+ok("wb: master data element present", wb["pages"][0]["elements"][0]["id"] == "master")
+ok("wb: 6 viz elements", len(viz) == 6)
+ok("wb: has kpi-chart", "kpi-chart" in kinds)
+ok("wb: has bar-chart", "bar-chart" in kinds)
+ok("wb: has line-chart", "line-chart" in kinds)
+ok("wb: has pie-chart", "pie-chart" in kinds)
+ok("wb: dashboard filters -> controls", len(controls) == 2 and all(c["controlType"]=="list" for c in controls))
+ok("wb: control bound to master + has default values", controls[0]["filters"][0]["source"]["elementId"]=="master" and controls[0]["values"])
+ok("wb: viz source the master", all(e["source"]["elementId"] == "master" for e in viz))
+ok("wb: master cols are cross-ref or own (no bare warehouse path)",
+   all("formula" in c for c in wb["pages"][0]["elements"][0]["columns"]))
+
+# --- layout: Sisense columnar grid -> Sigma grid XML ---
+import re, xml.dom.minidom as _M
+def parse_layout(xml):
+    """elementId -> (col_start, col_end, row_start, row_end)."""
+    out = {}
+    for eid, gc, gr in re.findall(
+            r'<LayoutElement elementId="([^"]+)" gridColumn="([^"]+)" gridRow="([^"]+)"', xml):
+        cs, ce = (int(x) for x in gc.split(" / "))
+        rs, re_ = (int(x) for x in gr.split(" / "))
+        out[eid] = (cs, ce, rs, re_)
+    return out
+
+lay = wb["layout"]
+_M.parseString("<r>" + lay.split("?>", 1)[1] + "</r>")        # raises if malformed
+ok("layout: present + well-formed XML", lay.startswith("<?xml") and "pmain" in lay and "pdata" in lay)
+P = parse_layout(lay)
+all_ids = {e["id"] for e in viz} | {e["id"] for e in controls} | {"master"}
+ok("layout: every element placed exactly once", all(i in P for i in all_ids))
+ok("layout: no orphan placement refs", all(eid in all_ids for eid in P))
+ok("layout: grid is 24-col (no element exceeds col 25)", all(ce <= 25 for _, ce, _, _ in P.values()))
+# the Live dashboard's 2 KPIs auto-arrange into one card row, side by side
+kpi_ids = [e["id"] for e in viz if e["kind"] == "kpi-chart"]
+krows = {P[i][2] for i in kpi_ids}
+ok("layout: KPIs share one row (cards, not a stack)", len(krows) == 1)
+ok("layout: KPIs sit side by side (distinct columns)", len({P[i][0] for i in kpi_ids}) == len(kpi_ids))
+
+# faithful path: a 2-column Sisense layout must port as two side-by-side stacks
+multicol = {"title": "MC", "oid": "mc", "filters": [],
+    "layout": {"type": "columnar", "columns": [
+        {"width": 60, "cells": [{"subcells": [{"width": 100, "elements": [
+            {"widgetid": "wA", "height": 512}]}]}]},
+        {"width": 40, "cells": [{"subcells": [{"width": 100, "elements": [
+            {"widgetid": "wB", "height": 512}]}]}]}]},
+    "widgets": [
+        {"oid": "wA", "type": "chart/column", "title": "A", "metadata": {"panels": [
+            {"name": "categories", "items": [{"jaql": {"dim": "[Commerce.Category ID]", "title": "Cat"}}]},
+            {"name": "values", "items": [{"jaql": {"dim": "[Commerce.Revenue]", "agg": "sum", "title": "Rev"}}]}]}},
+        {"oid": "wB", "type": "chart/line", "title": "B", "metadata": {"panels": [
+            {"name": "x-axis", "items": [{"jaql": {"dim": "[Commerce.Category ID]", "title": "Cat"}}]},
+            {"name": "values", "items": [{"jaql": {"dim": "[Commerce.Revenue]", "agg": "sum", "title": "Rev"}}]}]}}]}
+wb2, _ = C.convert_dashboard([multicol], model, dm_info)
+viz2 = [e for e in wb2["pages"][1]["elements"] if e["kind"] != "control"]
+P2 = parse_layout(wb2["layout"])
+a_id, b_id = viz2[0]["id"], viz2[1]["id"]
+ok("faithful: 2 cols -> wider col gets more grid (60/40 split)",
+   (P2[a_id][1] - P2[a_id][0]) > (P2[b_id][1] - P2[b_id][0]))
+ok("faithful: columns side by side, both start at row 1",
+   P2[a_id][2] == 1 and P2[b_id][2] == 1 and P2[a_id][0] == 1 and P2[b_id][0] == P2[a_id][1])
+
+# --- coverage classification flags the unmappable ---
+rows = C.classify_dashboard(dashboards)
+tags = {r["tag"] for r in rows}
+ok("classify: treemap/sunburst -> MANUAL present", "MANUAL" in tags)
+ok("classify: AUTO present", "AUTO" in tags)
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_gaps_rls.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_gaps_rls.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Offline tests for the gap-scout (scan_gaps.py) + RLS mapping (detect_rls.py).
+Run: python3 tests/test_gaps_rls.py"""
+import sys, os, json, subprocess, tempfile
+HERE = os.path.dirname(__file__)
+SCRIPTS = os.path.join(HERE, "..", "scripts")
+sys.path.insert(0, SCRIPTS)
+import detect_rls as R
+
+FIX = os.path.join(HERE, "..", "fixtures")
+passed = failed = 0
+def ok(label, cond, extra=""):
+    global passed, failed
+    passed += 1 if cond else 0
+    failed += 0 if cond else 1
+    print(("  ok  " if cond else "  FAIL ") + label + (f"  {extra}" if extra and not cond else ""))
+
+# --- gap scout: coverage report + learned-rules ledger + strict gate ---
+with tempfile.TemporaryDirectory() as td:
+    rules = os.path.join(td, "learned.json")
+    r = subprocess.run([sys.executable, os.path.join(SCRIPTS, "scan_gaps.py"),
+                        os.path.join(FIX, "dashboards.json"), "--rules", rules],
+                       capture_output=True, text=True)
+    ok("scan_gaps runs, reports coverage", r.returncode == 0 and "coverage" in r.stdout, r.stdout + r.stderr)
+    ok("scan_gaps flags MANUAL treemap/sunburst", "MANUAL" in r.stdout and "treemap" in r.stdout.lower())
+    ok("scan_gaps writes learned-rules ledger", os.path.exists(rules))
+    if os.path.exists(rules):
+        led = json.load(open(rules))
+        ok("ledger captured the unmapped widgets", any(g["category"] == "MANUAL" for g in led), str(led)[:200])
+    # strict mode -> non-zero while gaps remain
+    rs = subprocess.run([sys.executable, os.path.join(SCRIPTS, "scan_gaps.py"),
+                         os.path.join(FIX, "dashboards.json"), "--rules", rules, "--strict"],
+                        capture_output=True, text=True)
+    ok("scan_gaps --strict exits non-zero on unresolved gaps", rs.returncode != 0 and "RED" in rs.stdout + rs.stderr)
+
+# --- RLS: Sisense data-security rule -> Sigma security[] mapping ---
+fake = [{"table": "Commerce", "column": "Country", "members": ["USA", "Canada"],
+         "allMembers": False, "exclusionary": False, "shares": [{"party": "u1", "type": "user"}]}]
+sec = R.to_security(fake)
+ok("detect_rls maps a rule to one security entry", len(sec) == 1)
+e = sec[0]
+ok("entry kind=rls on the right element", e["kind"] == "rls" and e["elementName"] == "Commerce")
+ok("entry uses CurrentUserAttributeText row filter (Text-coerced operand)",
+   e["rls"]["formula"] == 'CurrentUserAttributeText("Country") = Text([Country])')
+ok("entry names the user attribute", e["rls"]["userAttributes"] == ["Country"])
+ok("members carried (not faked) for provisioning", e["_source"]["members"] == ["USA", "Canada"])
+ok("no rules -> empty security[] (zero-overhead path)", R.to_security([]) == [])
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_jaql.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_jaql.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Unit tests for jaql_expr — the JAQL→Sigma translation surface.
+Run: python3 tests/test_jaql.py  (stdlib only, no pytest dependency)."""
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import jaql_expr as J
+
+passed = failed = 0
+def check(label, got, want):
+    global passed, failed
+    if got == want:
+        passed += 1
+    else:
+        failed += 1
+        print(f"  FAIL {label}\n       got:  {got!r}\n       want: {want!r}")
+
+def check_flag(label, jaql):
+    global passed, failed
+    try:
+        J.classify(jaql); failed += 1; print(f"  FAIL {label}: expected Unsupported, got a translation")
+    except J.Unsupported:
+        passed += 1
+
+# --- aggregates ---
+check("sum", J.classify({"dim": "[Commerce.Revenue]", "agg": "sum"}), ("measure", "Sum([Revenue])"))
+check("countdistinct", J.classify({"dim": "[Brand.Brand]", "agg": "countDistinct".lower()}), ("measure", "CountDistinct([Brand])"))
+check("avg", J.classify({"dim": "[Commerce.Cost]", "agg": "avg"}), ("measure", "Avg([Cost])"))
+check("min", J.classify({"dim": "[Commerce.Cost]", "agg": "min"}), ("measure", "Min([Cost])"))
+# --- dimensions ---
+check("plain dim", J.classify({"dim": "[Category.Category]"}), ("dimension", "[Category]"))
+check("date month", J.classify({"dim": "[Commerce.Date]", "level": "months"}), ("dimension", 'DateTrunc("month", [Date])'))
+check("date year", J.classify({"dim": "[Commerce.Date]", "level": "years"}), ("dimension", 'DateTrunc("year", [Date])'))
+# --- formula + context (ratio) ---
+check("ratio formula",
+      J.classify({"formula": "SUM([r])/SUM([q])",
+                  "context": {"[r]": {"dim": "[Commerce.Revenue]"}, "[q]": {"dim": "[Commerce.Quantity]"}}}),
+      ("measure", "Sum([Revenue])/Sum([Quantity])"))
+# --- nested formula context ---
+check("nested formula",
+      J.classify({"formula": "[a]-[b]",
+                  "context": {"[a]": {"formula": "SUM([x])", "context": {"[x]": {"dim": "[Commerce.Revenue]"}}},
+                              "[b]": {"dim": "[Commerce.Cost]", "agg": "sum"}}}),
+      ("measure", "Sum([Revenue])-Sum([Cost])"))
+# --- top-N extraction ---
+check("top-n", J.top_n({"dim": "[Country.Country]", "filter": {"top": {"count": 10, "by": {"dim": "[Commerce.Revenue]", "agg": "sum"}}}}),
+      {"count": 10, "by_col": "Revenue", "by_agg": "Sum"})
+check("no top-n", J.top_n({"dim": "[Country.Country]"}), None)
+# --- raw_dims (Master registration) ---
+check("raw_dims formula", J.raw_dims({"formula": "[r]/[q]", "context": {"[r]": {"dim": "[Commerce.Revenue]"}, "[q]": {"dim": "[Category.X]"}}}),
+      "[Commerce.Revenue] [Category.X]")
+# --- FLAG: functions with no clean Sigma equivalent ---
+for fn in ["PREV", "PAST", "RSUM", "GROWTH", "CONTRIBUTION"]:
+    check_flag(f"flag {fn}", {"formula": f"{fn}([m])", "context": {"[m]": {"dim": "[Commerce.Revenue]", "agg": "sum"}}})
+
+# --- FLAG: filtered/scoped measures (no clean 1:1) ---
+check_flag("flag filtered measure", {"formula": "[m]", "context": {"[m]": {"dim": "[Commerce.Revenue]", "agg": "sum", "filter": {"members": ["New"]}}}})
+check_flag("flag unresolvable ctx", {"formula": "[m]", "context": {"[m]": {"foo": 1}}})
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_layout.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/tests/test_layout.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Offline test for the layout-parity gate (verify_layout.py). Converts the
+bundled fixtures + an inline 2-column dashboard, then runs the gate and asserts
+GREEN. Run: python3 tests/test_layout.py"""
+import sys, os, json, subprocess, tempfile
+HERE = os.path.dirname(__file__)
+SCRIPTS = os.path.join(HERE, "..", "scripts")
+sys.path.insert(0, SCRIPTS)
+import convert as C
+
+FIX = os.path.join(HERE, "..", "fixtures")
+model = json.load(open(os.path.join(FIX, "model_ecommerce.json")))
+dm_info = {"dataModelId": "dm-x", "factElementId": "fact-x", "factName": "Commerce"}
+
+passed = failed = 0
+def ok(label, cond, extra=""):
+    global passed, failed
+    passed += 1 if cond else 0
+    failed += 0 if cond else 1
+    print(("  ok  " if cond else "  FAIL ") + label + (f"  {extra}" if extra and not cond else ""))
+
+def run_gate(dashboards, spec):
+    with tempfile.TemporaryDirectory() as td:
+        dp = os.path.join(td, "dash.json"); sp = os.path.join(td, "spec.json")
+        json.dump(dashboards, open(dp, "w")); json.dump(spec, open(sp, "w"))
+        r = subprocess.run([sys.executable, os.path.join(SCRIPTS, "verify_layout.py"), dp, sp],
+                           capture_output=True, text=True)
+        return r.returncode, r.stdout
+
+# --- fixtures: auto-arrange path ---
+dashboards = json.load(open(os.path.join(FIX, "dashboards.json")))
+spec, _ = C.convert_dashboard(dashboards, model, dm_info)
+rc, out = run_gate(dashboards, spec)
+ok("auto-arrange fixtures -> layout gate GREEN", rc == 0 and "GREEN (all" in out, out)
+
+# --- controls must be placed FLAT, never in a <GridContainer> ---
+# (Sigma rejects a GridContainer whose elementId isn't a real container element.)
+import re as _re
+ctrl_ids = [e["id"] for e in spec["pages"][1]["elements"] if e.get("kind") == "control"]
+lay = spec.get("layout", "")
+ok("controls present in this fixture", len(ctrl_ids) >= 1, f"found {len(ctrl_ids)}")
+ok("layout emits NO <GridContainer>", "GridContainer" not in lay)
+placed_ids = set(_re.findall(r'<LayoutElement elementId="([^"]+)"', lay))
+ok("every control placed as a flat LayoutElement", all(c in placed_ids for c in ctrl_ids),
+   f"missing={[c for c in ctrl_ids if c not in placed_ids]}")
+
+# --- inline 2-column dashboard: faithful path ---
+def chart(oid, wtype, panel):
+    return {"oid": oid, "type": wtype, "title": oid, "metadata": {"panels": [
+        {"name": panel, "items": [{"jaql": {"dim": "[Commerce.Category ID]", "title": "Cat"}}]},
+        {"name": "values", "items": [{"jaql": {"dim": "[Commerce.Revenue]", "agg": "sum", "title": "Rev"}}]}]}}
+multicol = [{"title": "MC", "oid": "mc", "filters": [],
+    "layout": {"type": "columnar", "columns": [
+        {"width": 60, "cells": [{"subcells": [{"width": 100, "elements": [{"widgetid": "wA", "height": 512}]}]}]},
+        {"width": 40, "cells": [{"subcells": [{"width": 100, "elements": [{"widgetid": "wB", "height": 512}]}]}]}]},
+    "widgets": [chart("wA", "chart/column", "categories"), chart("wB", "chart/line", "x-axis")]}]
+spec2, _ = C.convert_dashboard(multicol, model, dm_info)
+rc2, out2 = run_gate(multicol, spec2)
+ok("faithful 2-col dashboard -> layout gate GREEN", rc2 == 0 and "GREEN (all" in out2, out2)
+
+# --- negative control: a corrupted layout (overlap) must go RED ---
+bad = json.loads(json.dumps(spec2))
+import re
+# collapse every element onto the same grid cell -> guaranteed overlap
+bad["layout"] = re.sub(r'gridColumn="[^"]+" gridRow="[^"]+"',
+                       'gridColumn="1 / 13" gridRow="1 / 13"', bad["layout"])
+rc3, out3 = run_gate(multicol, bad)
+ok("corrupted layout (overlap) -> gate RED", rc3 != 0 and "NO-OVERLAP" in out3 and "RED" in out3)
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)


### PR DESCRIPTION
Adds the **sisense-to-sigma** plugin (`sisense-to-sigma` + `sisense-assessment`), bringing it to feature parity with the sibling converters and live-validated end-to-end against a Sisense trial → Sigma at **exact data parity** with the source layout reproduced.

## Feature parity
- Discovery (live REST), model → Sigma DM, dashboards → Sigma workbook (KPI/chart/pivot/table)
- JAQL → Sigma formula translation; dashboard filters → controls
- **Layout porting** — Sisense columnar grid → Sigma 24-col grid (faithful for structured layouts, clean auto-arrange for degenerate stacks)
- **Gates** — `verify_parity.py` (data: Sisense JAQL == warehouse), `verify_layout.py` (structural layout), visual-QA render (`sigma-export-png.py` + `refs/layout-visual-qa.md`)
- **Gap scout** — `scan_gaps.py` + `learned-rules.json` ledger; `escalate-gap.py` (opt-in)
- **RLS (optional, opt-in)** — `detect_rls.py` → Sigma user-attribute row filters; `apply_sigma_rls.py` (reuse-first, plan-only by default)

## Live validation
- Data parity: Total Revenue **$39,759,625.52**, Quantity **91,206** — Sisense JAQL == Snowflake == Sigma.
- Layout: migrated workbook renders the exact Sisense arrangement (KPI card row → 2-up charts → full-width trend/bar).
- RLS exact restricted parity: text col `gender=Male` → $6,158,653.81; numeric col `Country ID=1` → $6,880,013.42 (both = warehouse ground truth, vs $39.76M unrestricted).

## Gates
- `tools/lint-skills.rb` OK (9/9 converters document all mandatory gates)
- `tools/check-shared.rb` OK (vendored shared scripts match canonical)
- 64 offline tests pass (convert 28, jaql 19, layout 6, gaps/rls 11)
- Registered in `marketplace.json`, `README.md`, `AGENTS.md`, `docs/phase-schema.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)