### PR TITLE
tableau-to-sigma: complex-dashboard controls + first-pass robustness

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -115,6 +115,7 @@ OptionParser.new do |p|
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
+  p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -620,6 +621,40 @@ else
       warn "[WARN] gate 8: parity-final.json records no screenshot_path/visual_checked flag — " \
            'render exists but confirm you actually compared it to the source and noted any divergence.'
     end
+  end
+end
+
+# Gate 9 — Visual-verify tiles (build-from-signals). Tiles whose Tableau data
+# export came back EMPTY (action-filter-gated etc.) are built from .twb signals
+# and cannot be value-diffed, so they must be confirmed by IMAGE comparison
+# (verify-visual-tiles.rb). Without this gate they'd pass parity silently. No-op
+# (and invisible to other converters) when the sidecar is absent.
+vv_sidecar = File.join(opts[:tab], 'visual-verify-tiles.json')
+if File.exist?(vv_sidecar)
+  vtiles = (JSON.parse(File.read(vv_sidecar)) rescue [])
+  if opts[:skip_visual_tiles]
+    puts "[SKIP] gate 9: #{vtiles.size} build-from-signals tile(s) visual-verify WAIVED (#{opts[:skip_visual_tiles]})."
+  elsif vtiles.any?
+    man_path = File.join(opts[:tab], 'visual-verify', 'manifest.json')
+    man = File.exist?(man_path) ? (JSON.parse(File.read(man_path)) rescue nil) : nil
+    if man.nil?
+      warn "[FAIL] gate 9: #{vtiles.size} tile(s) had EMPTY data exports (built from .twb signals) but no"
+      warn "       visual-verify/manifest.json exists — run: ruby scripts/verify-visual-tiles.rb"
+      warn "       --workbook #{opts[:wb] || '<id>'} --tableau-dir #{opts[:tab]}, then READ each"
+      warn '       <tile>.tableau.png vs <tile>.sigma.png pair and mark "visual_verified": true.'
+      exit 11
+    end
+    unverified = man.reject { |m| m['visual_verified'] }
+    if unverified.any?
+      warn "[FAIL] gate 9: #{unverified.size}/#{man.size} build-from-signals tile(s) NOT visually verified: " \
+           "#{unverified.map { |m| m['worksheet'] }.join(', ')}."
+      warn '       These tiles have no value actuals (empty Tableau export). READ each'
+      warn "       <tile>.tableau.png vs <tile>.sigma.png under #{File.join(opts[:tab], 'visual-verify')}/,"
+      warn '       confirm trend/axis/magnitudes match, and set "visual_verified": true per tile in'
+      warn '       visual-verify/manifest.json. Escape hatch: --skip-visual-tiles "<reason>" (name it in your report).'
+      exit 11
+    end
+    puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
 end
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -115,6 +115,7 @@ OptionParser.new do |p|
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
+  p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -620,6 +621,40 @@ else
       warn "[WARN] gate 8: parity-final.json records no screenshot_path/visual_checked flag — " \
            'render exists but confirm you actually compared it to the source and noted any divergence.'
     end
+  end
+end
+
+# Gate 9 — Visual-verify tiles (build-from-signals). Tiles whose Tableau data
+# export came back EMPTY (action-filter-gated etc.) are built from .twb signals
+# and cannot be value-diffed, so they must be confirmed by IMAGE comparison
+# (verify-visual-tiles.rb). Without this gate they'd pass parity silently. No-op
+# (and invisible to other converters) when the sidecar is absent.
+vv_sidecar = File.join(opts[:tab], 'visual-verify-tiles.json')
+if File.exist?(vv_sidecar)
+  vtiles = (JSON.parse(File.read(vv_sidecar)) rescue [])
+  if opts[:skip_visual_tiles]
+    puts "[SKIP] gate 9: #{vtiles.size} build-from-signals tile(s) visual-verify WAIVED (#{opts[:skip_visual_tiles]})."
+  elsif vtiles.any?
+    man_path = File.join(opts[:tab], 'visual-verify', 'manifest.json')
+    man = File.exist?(man_path) ? (JSON.parse(File.read(man_path)) rescue nil) : nil
+    if man.nil?
+      warn "[FAIL] gate 9: #{vtiles.size} tile(s) had EMPTY data exports (built from .twb signals) but no"
+      warn "       visual-verify/manifest.json exists — run: ruby scripts/verify-visual-tiles.rb"
+      warn "       --workbook #{opts[:wb] || '<id>'} --tableau-dir #{opts[:tab]}, then READ each"
+      warn '       <tile>.tableau.png vs <tile>.sigma.png pair and mark "visual_verified": true.'
+      exit 11
+    end
+    unverified = man.reject { |m| m['visual_verified'] }
+    if unverified.any?
+      warn "[FAIL] gate 9: #{unverified.size}/#{man.size} build-from-signals tile(s) NOT visually verified: " \
+           "#{unverified.map { |m| m['worksheet'] }.join(', ')}."
+      warn '       These tiles have no value actuals (empty Tableau export). READ each'
+      warn "       <tile>.tableau.png vs <tile>.sigma.png under #{File.join(opts[:tab], 'visual-verify')}/,"
+      warn '       confirm trend/axis/magnitudes match, and set "visual_verified": true per tile in'
+      warn '       visual-verify/manifest.json. Escape hatch: --skip-visual-tiles "<reason>" (name it in your report).'
+      exit 11
+    end
+    puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
 end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -115,6 +115,7 @@ OptionParser.new do |p|
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
+  p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -620,6 +621,40 @@ else
       warn "[WARN] gate 8: parity-final.json records no screenshot_path/visual_checked flag — " \
            'render exists but confirm you actually compared it to the source and noted any divergence.'
     end
+  end
+end
+
+# Gate 9 — Visual-verify tiles (build-from-signals). Tiles whose Tableau data
+# export came back EMPTY (action-filter-gated etc.) are built from .twb signals
+# and cannot be value-diffed, so they must be confirmed by IMAGE comparison
+# (verify-visual-tiles.rb). Without this gate they'd pass parity silently. No-op
+# (and invisible to other converters) when the sidecar is absent.
+vv_sidecar = File.join(opts[:tab], 'visual-verify-tiles.json')
+if File.exist?(vv_sidecar)
+  vtiles = (JSON.parse(File.read(vv_sidecar)) rescue [])
+  if opts[:skip_visual_tiles]
+    puts "[SKIP] gate 9: #{vtiles.size} build-from-signals tile(s) visual-verify WAIVED (#{opts[:skip_visual_tiles]})."
+  elsif vtiles.any?
+    man_path = File.join(opts[:tab], 'visual-verify', 'manifest.json')
+    man = File.exist?(man_path) ? (JSON.parse(File.read(man_path)) rescue nil) : nil
+    if man.nil?
+      warn "[FAIL] gate 9: #{vtiles.size} tile(s) had EMPTY data exports (built from .twb signals) but no"
+      warn "       visual-verify/manifest.json exists — run: ruby scripts/verify-visual-tiles.rb"
+      warn "       --workbook #{opts[:wb] || '<id>'} --tableau-dir #{opts[:tab]}, then READ each"
+      warn '       <tile>.tableau.png vs <tile>.sigma.png pair and mark "visual_verified": true.'
+      exit 11
+    end
+    unverified = man.reject { |m| m['visual_verified'] }
+    if unverified.any?
+      warn "[FAIL] gate 9: #{unverified.size}/#{man.size} build-from-signals tile(s) NOT visually verified: " \
+           "#{unverified.map { |m| m['worksheet'] }.join(', ')}."
+      warn '       These tiles have no value actuals (empty Tableau export). READ each'
+      warn "       <tile>.tableau.png vs <tile>.sigma.png under #{File.join(opts[:tab], 'visual-verify')}/,"
+      warn '       confirm trend/axis/magnitudes match, and set "visual_verified": true per tile in'
+      warn '       visual-verify/manifest.json. Escape hatch: --skip-visual-tiles "<reason>" (name it in your report).'
+      exit 11
+    end
+    puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
 end
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -115,6 +115,7 @@ OptionParser.new do |p|
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
+  p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -620,6 +621,40 @@ else
       warn "[WARN] gate 8: parity-final.json records no screenshot_path/visual_checked flag — " \
            'render exists but confirm you actually compared it to the source and noted any divergence.'
     end
+  end
+end
+
+# Gate 9 — Visual-verify tiles (build-from-signals). Tiles whose Tableau data
+# export came back EMPTY (action-filter-gated etc.) are built from .twb signals
+# and cannot be value-diffed, so they must be confirmed by IMAGE comparison
+# (verify-visual-tiles.rb). Without this gate they'd pass parity silently. No-op
+# (and invisible to other converters) when the sidecar is absent.
+vv_sidecar = File.join(opts[:tab], 'visual-verify-tiles.json')
+if File.exist?(vv_sidecar)
+  vtiles = (JSON.parse(File.read(vv_sidecar)) rescue [])
+  if opts[:skip_visual_tiles]
+    puts "[SKIP] gate 9: #{vtiles.size} build-from-signals tile(s) visual-verify WAIVED (#{opts[:skip_visual_tiles]})."
+  elsif vtiles.any?
+    man_path = File.join(opts[:tab], 'visual-verify', 'manifest.json')
+    man = File.exist?(man_path) ? (JSON.parse(File.read(man_path)) rescue nil) : nil
+    if man.nil?
+      warn "[FAIL] gate 9: #{vtiles.size} tile(s) had EMPTY data exports (built from .twb signals) but no"
+      warn "       visual-verify/manifest.json exists — run: ruby scripts/verify-visual-tiles.rb"
+      warn "       --workbook #{opts[:wb] || '<id>'} --tableau-dir #{opts[:tab]}, then READ each"
+      warn '       <tile>.tableau.png vs <tile>.sigma.png pair and mark "visual_verified": true.'
+      exit 11
+    end
+    unverified = man.reject { |m| m['visual_verified'] }
+    if unverified.any?
+      warn "[FAIL] gate 9: #{unverified.size}/#{man.size} build-from-signals tile(s) NOT visually verified: " \
+           "#{unverified.map { |m| m['worksheet'] }.join(', ')}."
+      warn '       These tiles have no value actuals (empty Tableau export). READ each'
+      warn "       <tile>.tableau.png vs <tile>.sigma.png under #{File.join(opts[:tab], 'visual-verify')}/,"
+      warn '       confirm trend/axis/magnitudes match, and set "visual_verified": true per tile in'
+      warn '       visual-verify/manifest.json. Escape hatch: --skip-visual-tiles "<reason>" (name it in your report).'
+      exit 11
+    end
+    puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -115,6 +115,7 @@ OptionParser.new do |p|
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
+  p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -620,6 +621,40 @@ else
       warn "[WARN] gate 8: parity-final.json records no screenshot_path/visual_checked flag — " \
            'render exists but confirm you actually compared it to the source and noted any divergence.'
     end
+  end
+end
+
+# Gate 9 — Visual-verify tiles (build-from-signals). Tiles whose Tableau data
+# export came back EMPTY (action-filter-gated etc.) are built from .twb signals
+# and cannot be value-diffed, so they must be confirmed by IMAGE comparison
+# (verify-visual-tiles.rb). Without this gate they'd pass parity silently. No-op
+# (and invisible to other converters) when the sidecar is absent.
+vv_sidecar = File.join(opts[:tab], 'visual-verify-tiles.json')
+if File.exist?(vv_sidecar)
+  vtiles = (JSON.parse(File.read(vv_sidecar)) rescue [])
+  if opts[:skip_visual_tiles]
+    puts "[SKIP] gate 9: #{vtiles.size} build-from-signals tile(s) visual-verify WAIVED (#{opts[:skip_visual_tiles]})."
+  elsif vtiles.any?
+    man_path = File.join(opts[:tab], 'visual-verify', 'manifest.json')
+    man = File.exist?(man_path) ? (JSON.parse(File.read(man_path)) rescue nil) : nil
+    if man.nil?
+      warn "[FAIL] gate 9: #{vtiles.size} tile(s) had EMPTY data exports (built from .twb signals) but no"
+      warn "       visual-verify/manifest.json exists — run: ruby scripts/verify-visual-tiles.rb"
+      warn "       --workbook #{opts[:wb] || '<id>'} --tableau-dir #{opts[:tab]}, then READ each"
+      warn '       <tile>.tableau.png vs <tile>.sigma.png pair and mark "visual_verified": true.'
+      exit 11
+    end
+    unverified = man.reject { |m| m['visual_verified'] }
+    if unverified.any?
+      warn "[FAIL] gate 9: #{unverified.size}/#{man.size} build-from-signals tile(s) NOT visually verified: " \
+           "#{unverified.map { |m| m['worksheet'] }.join(', ')}."
+      warn '       These tiles have no value actuals (empty Tableau export). READ each'
+      warn "       <tile>.tableau.png vs <tile>.sigma.png under #{File.join(opts[:tab], 'visual-verify')}/,"
+      warn '       confirm trend/axis/magnitudes match, and set "visual_verified": true per tile in'
+      warn '       visual-verify/manifest.json. Escape hatch: --skip-visual-tiles "<reason>" (name it in your report).'
+      exit 11
+    end
+    puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -111,6 +111,51 @@ DATE_TRUNC = {
   'Hour-Trunc'   => 'hour'
 }.freeze
 
+# Tableau date-derivation code (on a shelf column-instance) → the "<grain> of "
+# prefix Tableau puts on the CSV/header label for that field. Used to
+# reconstruct the view headers from shelf signals when the data export came
+# back empty (see synthesize_view_from_signals).
+DATE_DERIV_LABEL = {
+  'tyr' => 'Year of ',  'yr' => 'Year of ',
+  'tqr' => 'Quarter of ', 'qr' => 'Quarter of ',
+  'tmn' => 'Month of ', 'mn' => 'Month of ',
+  'twk' => 'Week of ',  'wk' => 'Week of ',
+  'tdy' => 'Day of ',   'dy' => 'Day of ',
+  'thr' => 'Hour of ',  'hr' => 'Hour of ',
+  'tmi' => 'Minute of ', 'mi' => 'Minute of ',
+  'tsc' => 'Second of ', 'sc' => 'Second of '
+}.freeze
+
+# Reconstruct the view's CSV header row from the parsed shelf signals when the
+# Tableau data export came back EMPTY (a common case for sheets gated behind a
+# dashboard ACTION filter — Tableau renders them fine but its headless data API
+# returns zero rows). The 2-column / multi-channel build flow downstream is
+# driven by the HEADERS plus the aggregations/trunc dicts, not by data rows, so
+# a header-only reconstruction lets us build the chart instead of dropping the
+# tile. Returns { headers: [...] } (dims first, then measures) or nil if the
+# shelves don't carry at least one dim + one measure. Principle: never skip
+# anything that's in the .twb — an empty parity export is not a missing viz.
+def synthesize_view_from_signals(z, meta)
+  cbg = meta['columns_by_guid'] || {}
+  field_header = lambda do |f|
+    return nil unless f && f['guid']
+    cap = (cbg[f['guid']] || {})['caption']
+    cap = f['guid'] if cap.nil? || cap.to_s.empty?
+    pre = DATE_DERIV_LABEL[f['derivation'].to_s.downcase]
+    pre ? "#{pre}#{cap}" : cap
+  end
+  fields = ((z.dig('cols_shelf', 'fields') || []) + (z.dig('rows_shelf', 'fields') || []))
+  dims = fields.select { |f| f['role'] == 'dim' }
+  meas = fields.select { |f| f['role'] == 'measure' }
+  # Include a color-channel dimension if the encoding names one not on a shelf.
+  if (cc = z.dig('channels', 'color', 'column'))
+    g = guid_from_text(cc.to_s)
+    dims << { 'guid' => g, 'role' => 'dim', 'derivation' => 'none' } if g && dims.none? { |f| f['guid'] == g }
+  end
+  headers = (dims.map(&field_header) + meas.map(&field_header)).compact
+  headers.length >= 2 ? { headers: headers } : nil
+end
+
 # Tableau relative-date offset window (first-period..last-period, in periods
 # relative to now — e.g. first=-2,last=0 = "last 3 months") → explicit
 # [startDate, endDate] bounds. Returns [nil, nil] for periods we don't bound
@@ -1711,6 +1756,10 @@ elements = []
 data_elements = [] # hidden helper elements (scatter grouped sources — bead z1d0)
 warnings = []
 lod_chains = [] # nested-FIXED helper-element chains (beads-sigma-t67b)
+# Tiles built from .twb signals because their Tableau data export was EMPTY
+# (action-filter-gated, etc). They can't be value-diffed (no actuals), so they
+# route to IMAGE-based visual verification instead of silently passing parity.
+signal_built_tiles = [] # [{ 'worksheet' => cap, 'view_id' => id }]
 
 layout.each do |dash|
   dash['zones'].each do |z|
@@ -1756,6 +1805,13 @@ layout.each do |dash|
       warnings << "no Tableau view matched '#{cap}'"
       next
     end
+    # Chart kind was INFERRED from shelves (Tableau mark=Automatic) — route it to
+    # IMAGE confirmation so a wrong line/bar/scatter guess can't pass silently.
+    if z['chart_kind_inferred']
+      signal_built_tiles << { 'worksheet' => cap, 'view_id' => view['id'], 'reason' => 'chart-kind-inferred' }
+      warnings << "'#{cap}' chart kind was AUTOMATIC in Tableau — inferred '#{z['chart_kind']}' from the shelves; " \
+                  'routed to image confirmation (verify-visual-tiles) — confirm against the Tableau view image.'
+    end
     csv_path = File.join(opts[:tab], 'views', "#{view['id']}.csv")
     unless File.exist?(csv_path)
       warnings << "missing CSV for '#{cap}' at #{csv_path}"
@@ -1763,14 +1819,30 @@ layout.each do |dash|
     end
     rows = CSV.read(csv_path)
     if rows.empty?
-      # LOUD on purpose (bead gjhe): an empty/0-byte view CSV used to silently
-      # drop the zone — the dashboard shipped with N-1 charts and every gate
-      # still passed because the missing chart never entered the parity plan.
-      warnings << "ZONE DROPPED: '#{cap}' — view CSV at #{csv_path} is EMPTY (0 bytes / 0 rows) " \
-                  "but the zone exists in the dashboard. NO Sigma chart was built for it. " \
-                  "Re-fetch the view data (fetch-view-data.rb) or build the chart by hand — " \
-                  "the Phase-6 tile census will report this zone as unmatched."
-      next
+      # An empty/0-byte view CSV is usually NOT a missing viz — it's a sheet
+      # gated behind a dashboard ACTION filter (Tableau renders it fine, but its
+      # headless data export returns zero rows), or a permission/timeout empty.
+      # Dropping the tile shipped N-1 charts (bead gjhe). Instead, reconstruct
+      # the view headers from the .twb shelf signals and build the chart from
+      # those — the downstream flow is header+signal driven, not row driven — so
+      # we never skip a viz that exists in the workbook. Parity for THIS tile is
+      # downgraded to manual (no exportable actuals to diff).
+      synth = synthesize_view_from_signals(z, meta)
+      if synth
+        warnings << "'#{cap}' — Tableau view CSV is EMPTY (0 bytes), almost always an ACTION-FILTER-gated " \
+                    "export (the sheet renders fine in Tableau). BUILT FROM .twb SIGNALS instead of dropping it: " \
+                    "headers=#{synth[:headers].inspect}. Sigma sources the same warehouse so the chart will populate; " \
+                    "DATA PARITY for this one tile must be verified manually (no exportable actuals)."
+        rows = [synth[:headers]]   # header row only — body stays empty
+        z['_parity_manual'] = true
+        signal_built_tiles << { 'worksheet' => cap, 'view_id' => (view && view['id']) }
+      else
+        warnings << "ZONE DROPPED: '#{cap}' — view CSV at #{csv_path} is EMPTY (0 bytes / 0 rows) AND the shelf " \
+                    "signals carry no dim+measure to reconstruct it (rows_shelf=#{(z['rows_shelf']||{})['raw'].inspect}, " \
+                    "cols_shelf=#{(z['cols_shelf']||{})['raw'].inspect}). Build the chart by hand — " \
+                    "the Phase-6 tile census will report this zone as unmatched."
+        next
+      end
     end
     headers = rows.shift
     if headers.length < 2
@@ -1913,7 +1985,13 @@ layout.each do |dash|
       end
     end
 
-    dim  = map_column(dim_hdr,  mmap)
+    # A date-grain header ("Month of Order Date") won't match a master column
+    # named "Order Date"; try the grain-stripped form so the DateTrunc wraps the
+    # real master date column instead of leaking the prefixed name into the
+    # formula (which would resolve to a non-existent column). dim_trunc below
+    # still carries the grain. Strips only when the full header didn't match.
+    dim_hdr_base = dim_hdr.sub(/^(?:second|minute|hour|day|week|month|quarter|year) of /i, '')
+    dim  = map_column(dim_hdr, mmap) || (dim_hdr_base != dim_hdr ? map_column(dim_hdr_base, mmap) : nil)
     meas = map_column(meas_hdr, mmap)
     find_ws_calc = lambda do |hdr|
       (z['calculations'] || []).find { |c| c['name'].to_s.gsub(/^\[|\]$/, '').strip.casecmp?(hdr.to_s.strip) }
@@ -3547,6 +3625,28 @@ unless control_scope_records.empty?
   warn "wrote #{scope_path} (#{contract_controls.size} control scope entr(y/ies), #{dropped_rs.size} dropped)"
 end
 warnings.each { |w| warn "  WARN  #{w}" }
+
+# ---- Visual-verify sidecar (build-from-signals tiles) -----------------------
+# Tiles built from .twb signals (empty data export) can't be value-diffed, so
+# the orchestrator routes them to IMAGE-based verification (verify-visual-
+# tiles.rb): fetch the Tableau view image + render the Sigma element and compare
+# them. Resolve each tile's Sigma element id by name so the renderer can target
+# it. Always write the file (possibly empty) so the gate can distinguish
+# "checked, none needed" from "never ran".
+if opts[:tab]
+  by_name = elements.each_with_object({}) { |e, h| h[e['name'].to_s] = e['id'] if e['name'] }
+  seen = {}
+  vv = signal_built_tiles.map do |t|
+    { 'worksheet' => t['worksheet'], 'view_id' => t['view_id'],
+      'element_id' => by_name[t['worksheet'].to_s], 'reason' => (t['reason'] || 'empty-data-export') }
+  end.select { |t| t['element_id'] && !seen[t['worksheet']] && (seen[t['worksheet']] = true) }
+  vv_path = File.join(opts[:tab], 'visual-verify-tiles.json')
+  File.write(vv_path, JSON.pretty_generate(vv))
+  unless vv.empty?
+    by_reason = vv.group_by { |t| t['reason'] }.transform_values(&:size)
+    warn "wrote #{vv_path} (#{vv.size} tile(s) need IMAGE verification: #{by_reason.map { |r, n| "#{n} #{r}" }.join(', ')})"
+  end
+end
 
 # ---- Nested-LOD chains sidecar (beads-sigma-t67b) ---------------------------
 # Machine-readable helper-element chains for every nested {FIXED} calc: the

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -60,6 +60,7 @@ OptionParser.new do |p|
   p.on('--chart-y0 PCT', Float)   { |v| opts[:chart_y0] = v }
   p.on('--chart-y1 PCT', Float)   { |v| opts[:chart_y1] = v }
   p.on('--chart-row0 N', Integer) { |v| opts[:chart_row0] = v }
+  p.on('--no-containers', 'force the geometry-banded layout even when the dashboard nests a filter/parameter rail') { opts[:no_containers] = true }
 end.parse!
 %i[layout wb_ids out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
 
@@ -115,6 +116,170 @@ def chart_pos(z, opts)
   col_end   = [opts[:page_cols] + 1, (1 + ((z['x_pct'] || 0) + (z['w_pct'] || 0)) / 100.0 * opts[:page_cols]).round].min
   col_end   = col_start + 1 if col_end <= col_start
   [col_start, col_end, row_start, row_end]
+end
+
+# ---- Faithful container-tree layout (preferred when a control rail exists) --
+# Mirror Tableau's nested zone tree as nested Sigma GridContainers so each
+# filter / parameter / chart lands INSIDE the container it lives in — preserving
+# the left-rail / sidebar idiom and arbitrary nesting — instead of re-banding by
+# raw geometry (which lumps every control into one top strip). Activates only
+# when the dashboard actually nests a filter/parameter zone; otherwise the
+# proven banded path runs. Any failure falls back to bands (rescued in caller).
+
+def clampc(v, lo, hi)
+  [[v, lo].max, hi].min
+end
+
+# True when the zone tree contains a filter/parameter zone at any depth — the
+# case the banded path mishandles and the container path fixes.
+def tree_has_controls?(tree)
+  (tree || []).any? do |n|
+    %w[filter parameter].include?(n['kind']) || tree_has_controls?(n['children'])
+  end
+end
+
+# Place a child within its parent container's internal 24-col grid from pct
+# bounds. parent_rows = grid row-lines the parent spans internally.
+def place_in_parent(ch, p, parent_rows)
+  pw = (p['w_pct'] || 100).to_f; pw = 1.0 if pw <= 0
+  ph = (p['h_pct'] || 100).to_f; ph = 1.0 if ph <= 0
+  px = (p['x_pct'] || 0).to_f;   py = (p['y_pct'] || 0).to_f
+  cx = (ch['x_pct'] || 0).to_f;  cy  = (ch['y_pct'] || 0).to_f
+  cw = (ch['w_pct'] || 0).to_f;  chh = (ch['h_pct'] || 0).to_f
+  c0 = clampc(1 + ((cx - px) / pw * 24).round, 1, 24)
+  c1 = clampc(1 + ((cx + cw - px) / pw * 24).round, c0 + 1, 25)
+  r0 = [1, 1 + ((cy - py) / ph * parent_rows).round].max
+  r1 = [r0 + 1, 1 + ((cy + chh - py) / ph * parent_rows).round].max
+  [c0, c1, r0, r1]
+end
+
+# Resolve a leaf zone to an existing workbook element id (chart by caption,
+# filter/param control by target-column / caption, title text to the page
+# title). Returns nil for zones Sigma renders inline (legend) or drops (spacer).
+def resolve_leaf(node, ctx)
+  case node['kind']
+  when 'chart'
+    name = ctx[:renames][node['caption']] || node['caption']
+    el = ctx[:els_by_name][name]
+    el && el['id']
+  when 'filter', 'parameter'
+    # Pre-assigned by build_page_from_tree (caption match, then rail-fill) so a
+    # control lands in its container even when its target column didn't resolve.
+    ctx[:zone_to_ctl][node['id']]
+  when 'text', 'title'
+    if ctx[:title_el] && !ctx[:title_used]
+      ctx[:title_used] = true
+      ctx[:title_el]['id']
+    end
+  end
+end
+
+# Recursively emit a zone node as Sigma layout XML at grid cell (c0,c1,r0,r1)
+# RELATIVE to its parent container. Container nodes become GridContainers whose
+# children are placed in the container's own 24-col internal grid; empty
+# containers (no resolvable children) are dropped. Appends new container spec
+# placeholders to ctx[:extra]; records placed element ids in ctx[:placed].
+def emit_node(node, c0, c1, r0, r1, ctx)
+  if node['kind'] == 'container'
+    kids = node['children'] || []
+    my_rows = [r1 - r0, 2].max
+    inner = kids.map do |ch|
+      kc0, kc1, kr0, kr1 = place_in_parent(ch, node, my_rows)
+      emit_node(ch, kc0, kc1, kr0, kr1, ctx)
+    end.compact
+    return nil if inner.empty?
+    cid = "tc-#{ctx[:page_id]}-#{node['id']}"
+    ctx[:extra] << container_el(cid)
+    gc(cid, c0, c1, r0, r1, inner.join("\n"))
+  else
+    eid = resolve_leaf(node, ctx)
+    return nil unless eid && !ctx[:placed].include?(eid)
+    ctx[:placed] << eid
+    le(eid, c0, c1, r0, r1)
+  end
+end
+
+# Container-tree page builder. Same return shape as build_page_for_dashboard.
+def build_page_from_tree(dashboard, page, opts)
+  tree        = dashboard['zone_tree'] || []
+  els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
+  ctl_by_name = page['elements'].select { |e| e['kind'] == 'control' && e['name'] }
+                    .each_with_object({}) { |e, h| h[e['name'].to_s.downcase] = e }
+  title_el    = page['elements'].find { |e| e['kind'] == 'text' }
+
+  ctx = { page_id: page['id'], renames: opts[:renames], els_by_name: els_by_name,
+          ctl_by_name: ctl_by_name, title_el: title_el, title_used: false,
+          extra: [], placed: [], zone_to_ctl: {} }
+
+  # Assign workbook control elements to control zones (filter/parameter), in
+  # document order: caption match first, then fill the remaining control zones
+  # with leftover controls. This puts a rail's controls INSIDE the rail even
+  # when a zone's target column didn't resolve to a caption.
+  control_zones = []
+  collect = lambda { |ns| (ns || []).each { |n| control_zones << n if %w[filter parameter].include?(n['kind']); collect.call(n['children']) } }
+  collect.call(tree)
+  all_ctls = page['elements'].select { |e| e['kind'] == 'control' }
+  used = {}
+  control_zones.each do |z|
+    nm = (z['filter_column_caption'] || z['caption']).to_s.downcase
+    el = nm.empty? ? nil : ctl_by_name[nm]
+    next unless el && !used[el['id']]
+    ctx[:zone_to_ctl][z['id']] = el['id']; used[el['id']] = true
+  end
+  leftover = all_ctls.reject { |e| used[e['id']] }
+  control_zones.each do |z|
+    next if ctx[:zone_to_ctl][z['id']]
+    el = leftover.shift or next
+    ctx[:zone_to_ctl][z['id']] = el['id']; used[el['id']] = true
+  end
+
+  children  = []
+  extra_els = ctx[:extra]
+  page_rows = opts[:page_rows]
+  body_rows = [page_rows - HEADER_ROWS, 4].max
+  page_pseudo = { 'x_pct' => 0.0, 'y_pct' => 0.0, 'w_pct' => 100.0, 'h_pct' => 100.0 }
+
+  # Header band (dark title strip), same chrome as the banded path.
+  hdr_id = "tc-#{page['id']}-hdr"
+  extra_els << container_el(hdr_id, HEADER_STYLE.dup)
+  if title_el
+    children << header_band_xml(hdr_id, title_el['id'])
+    ctx[:title_used] = true
+  else
+    txt_id = "tc-#{page['id']}-hdrtext"
+    extra_els << header_text_el(txt_id, page['name'])
+    children << header_band_xml(hdr_id, txt_id)
+  end
+
+  # Top-level zones → page children, shifted below the header band.
+  tree.each do |node|
+    c0, c1, r0, r1 = place_in_parent(node, page_pseudo, body_rows)
+    r0 += HEADER_ROWS; r1 += HEADER_ROWS
+    xml = emit_node(node, c0, c1, r0, r1, ctx)
+    children << xml if xml
+  end
+
+  # Safety net: any chart/control element NOT placed by the tree (an unmatched
+  # zone, or a control with no dashboard zone) lands in a bottom band so nothing
+  # silently drops from the layout.
+  unplaced = page['elements'].select do |e|
+    %w[chart control].include?(e['kind']) && e['name'] && !ctx[:placed].include?(e['id'])
+  end
+  unless unplaced.empty?
+    n = unplaced.length
+    cw = 24.0 / n
+    inner = unplaced.each_with_index.map do |e, i|
+      cs = 1 + (cw * i).round
+      ce = i == n - 1 ? 25 : [1 + (cw * (i + 1)).round, cs + 1].max
+      le(e['id'], cs, ce, 1, 5)
+    end.join("\n")
+    bid = "tc-#{page['id']}-extra"
+    extra_els << container_el(bid)
+    children << gc(bid, 1, 25, [page_rows - 4, HEADER_ROWS + 1].max, page_rows + 1, inner)
+    warn "WARN: #{n} element(s) had no Tableau zone — appended in a bottom band: #{unplaced.map { |e| e['name'] }.join(', ')}"
+  end
+
+  [page_xml(page['id'], *children), extra_els, ctx[:placed].size, tree.length, ctl_by_name.size]
 end
 
 # Build one container-banded page for a single dashboard. Returns
@@ -222,7 +387,18 @@ totals = { charts: 0, bands: 0, controls: 0 }
 dash_layout.each do |d|
   page = page_for_dash[d['dashboard']]
   next unless page
-  pxml, extra_els, n_charts, n_bands, n_ctls = build_page_for_dashboard(d, page, opts)
+  use_tree = !opts[:no_containers] && tree_has_controls?(d['zone_tree'])
+  if use_tree
+    begin
+      pxml, extra_els, n_charts, n_bands, n_ctls = build_page_from_tree(d, page, opts)
+      warn "container-tree layout: #{d['dashboard'].inspect} → nested Sigma containers (filters/params placed in their Tableau container)"
+    rescue StandardError => e
+      warn "WARN: container-tree layout failed for #{d['dashboard'].inspect} (#{e.class}: #{e.message}) — falling back to banded layout"
+      pxml, extra_els, n_charts, n_bands, n_ctls = build_page_for_dashboard(d, page, opts)
+    end
+  else
+    pxml, extra_els, n_charts, n_bands, n_ctls = build_page_for_dashboard(d, page, opts)
+  end
   page_xmls << pxml
   sidecar[page['id']] = extra_els
   totals[:charts] += n_charts

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -1499,6 +1499,26 @@ p6 = ['ruby', File.join(HERE, 'phase6-parity.rb'),
 p6 += ['--extract-mode', '--extract-tol', '0.30'] if has_extracts
 sigma_run!(p6)
 
+# Phase 6f-visual — tiles whose Tableau data export came back EMPTY (action-
+# filter-gated etc.) were BUILT from .twb signals and have no actuals to value-
+# diff. Stage an IMAGE comparison (Tableau view image vs Sigma element render)
+# so they're verified visually instead of silently passing parity.
+vv_sidecar = File.join(WORK, 'visual-verify-tiles.json')
+vv_tiles = File.exist?(vv_sidecar) ? (JSON.parse(File.read(vv_sidecar)) rescue []) : []
+if vv_tiles.any?
+  line "Phase 6f-visual: #{vv_tiles.size} tile(s) had EMPTY data exports / inferred chart kinds — staging per-tile image comparison"
+  sigma_run!(['ruby', File.join(HERE, 'verify-visual-tiles.rb'),
+              '--workbook', wb_id, '--tableau-dir', WORK], allow_fail: true)
+end
+
+# Phase 6f — FULL-DASHBOARD ground truth: stage the source Tableau dashboard
+# image next to the Sigma page render per dashboard, so the mandatory whole-page
+# visual comparison (and the repair loop: diff → fix → re-render) has both sides
+# ready. Writes visual-qa/compare-manifest.json (agent sets visual_match).
+line 'Phase 6f-visual: staging full-dashboard source-vs-Sigma image pairs for the repair loop'
+sigma_run!(['ruby', File.join(HERE, 'verify-dashboard-visual.rb'),
+            '--workbook', wb_id, '--tableau-dir', WORK], allow_fail: true)
+
 puts
 puts '================ RESULT (pass 1 — parity PENDING) ================'
 puts "dataModelId : #{dm_id}#{reuse_dm_id ? '  (REUSED existing DM)' : ''}"
@@ -1511,6 +1531,15 @@ end
 puts 'PARITY      : PENDING — the pooled collector filled parity-actuals.json for every'
 puts '              exportable chart; run the REMAINING mcp-v2 queries printed above'
 puts "              (if any), merge into #{File.join(WORK, 'parity-actuals.json')}, then:"
+puts 'VISUAL      : FULL-DASHBOARD comparison staged — READ each source vs Sigma pair under'
+puts "              #{File.join(WORK, 'visual-qa')}/ (<dash>.source.png vs <dash>.sigma.png). Diff layout,"
+puts '              chart kinds, sizing; fix the spec + re-render for any divergence; set "visual_match":true'
+puts '              per dashboard in compare-manifest.json (the repair loop).'
+if vv_tiles.any?
+  puts "              ALSO #{vv_tiles.size} per-tile pair(s) under #{File.join(WORK, 'visual-verify')}/ — tiles with"
+  puts '              EMPTY data exports or INFERRED chart kinds (no value-diff possible). Confirm each and set'
+  puts '              "visual_verified": true in visual-verify/manifest.json (gate 9 blocks GREEN until done).'
+end
 finalize_cmd = "  ruby scripts/migrate-tableau.rb #{opts[:wb_id] ? "--workbook-id #{opts[:wb_id]}" : "--workbook \"#{opts[:wb_name]}\""}" \
                "#{opts[:out] ? " --out #{WORK}" : ''} \\\n    --finalize --actuals #{File.join(WORK, 'parity-actuals.json')}"
 puts finalize_cmd

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -79,9 +79,12 @@ end
 # real caption instead of being silently dropped by the auto-control builder
 # ("shared filter has no resolvable column_caption"). The raw-GUID behaviour is
 # unchanged — we only add the calc-id alternative.
+#   - raw warehouse columns by FRIENDLY NAME (`none:Region:nk`) — simple
+#     columns whose instance ref uses the column name rather than a GUID; the
+#     friendly head (`Region`) is registered in COL_BY_GUID too.
 def guid_from_param(param)
   return nil if param.nil? || param.empty?
-  m = param.match(/\.\[(?:[a-z\-]+:)?([0-9a-f\-]{36}|Calculation_\d+)(?::[a-z]+)?\]$/i)
+  m = param.match(/\.\[(?:[a-z\-]+:)?([0-9a-f\-]{36}|Calculation_\d+|[A-Za-z_][\w. ]*)(?::[a-z]+)?\]$/i)
   m && m[1]
 end
 
@@ -641,6 +644,29 @@ end
 #     as a bar in our experience but is not deterministic; we emit "automatic" so
 #     the agent KNOWS to look at the PNG before committing to a Sigma kind.
 #   - Geographic encoding presence beats mark class for map detection.
+# Tableau "Show Me" picks a mark for an Automatic worksheet deterministically
+# from the shelf structure. Replicate the high-value rules so an Automatic sheet
+# isn't blindly defaulted to a bar (the #1 first-pass fidelity miss — a time
+# series silently became bars). Conservative: only fires for mark=Automatic;
+# anything it can't classify still falls back to bar (and gets image-confirmed
+# downstream, since the kind was inferred not declared).
+DATE_GRAIN_DERIV = %w[tyr tqr tmn twk tdy thr tmi tsc yr qr mn wk dy hr mi sc].freeze
+def infer_automatic_kind(meta)
+  rs = meta[:rows_shelf] || {}
+  cs = meta[:cols_shelf] || {}
+  fields = (rs['fields'] || []) + (cs['fields'] || [])
+  dims = fields.select { |f| f['role'] == 'dim' }
+  meas = fields.select { |f| f['role'] == 'measure' }
+  has_date_dim = dims.any? { |f| DATE_GRAIN_DERIV.include?(f['derivation'].to_s.downcase) }
+  # 1) continuous date dimension + a measure → time-series LINE
+  return 'line' if has_date_dim && !meas.empty?
+  # 2) a measure on BOTH axes (rows AND cols), ≤1 dim → SCATTER
+  return 'scatter' if rs['measure_count'].to_i >= 1 && cs['measure_count'].to_i >= 1 && dims.size <= 1
+  # 3) categorical dim(s) + measure → BAR (Tableau's default for cat × measure)
+  return 'bar' if !dims.empty? && !meas.empty?
+  'bar'
+end
+
 def chart_kind_for(meta)
   return nil unless meta
   mc       = (meta[:mark_class] || '').downcase
@@ -670,10 +696,71 @@ def chart_kind_for(meta)
   when 'shape'      then 'scatter'
   # Automatic is Tableau's default-pick — but a zero-dim single-measure sheet
   # under Automatic renders as a big-number text table, i.e. a KPI (bead 3w4d).
-  when 'automatic'  then (meta[:is_kpi] ? 'kpi' : 'automatic')
+  when 'automatic'
+    # A measure on BOTH axes is unambiguously a scatter (not a big-number KPI),
+    # so it overrides the zero-dim KPI heuristic; otherwise zero-dim → KPI.
+    inferred = infer_automatic_kind(meta)
+    inferred == 'scatter' ? 'scatter' : (meta[:is_kpi] ? 'kpi' : inferred)
   when ''           then 'other'
   else 'other'
   end
+end
+
+# Map a Tableau zone `type-v2` (+ presence of a worksheet name) to our
+# zone-level kind label. Shared by the flat-zone loop and the nested
+# zone-tree builder so the two never diverge.
+def zone_kind(type_v2, caption)
+  case type_v2
+  when 'layout-basic', 'layout-flow' then 'container'
+  when 'text'                        then 'text'
+  when 'title'                       then 'title'
+  when 'filter'                      then 'filter'
+  when 'paramctrl'                   then 'parameter'
+  when 'color'                       then 'legend'
+  when 'empty'                       then 'spacer'
+  when 'dashboard-object'            then 'dashboard-object'
+  when nil
+    # No type-v2 + a worksheet name → this is the chart tile
+    caption ? 'chart' : 'container'
+  else type_v2
+  end
+end
+
+# Build a NESTED zone tree for a dashboard, preserving Tableau's container
+# hierarchy (layout-basic / layout-flow, nested arbitrarily). Each node carries
+# enough to drive a faithful Sigma container layout — kind, caption, bounds,
+# flow direction (vert/horz for layout-flow), the resolved filter/param target
+# column, and `children` (direct-child zones only). This is ADDITIVE: the flat
+# `zones` list (below) is preserved for every downstream consumer that wants the
+# geometry-banded path; the layout builder prefers the tree when present.
+def build_zone_tree(z)
+  type_v2 = z.attributes['type-v2']
+  caption = z.attributes['name']
+  param   = z.attributes['param']
+  kind    = zone_kind(type_v2, caption)
+  node = {
+    'id'      => z.attributes['id'],
+    'kind'    => kind,
+    'caption' => caption,
+    'x_pct'   => pct(z.attributes['x']),
+    'y_pct'   => pct(z.attributes['y']),
+    'w_pct'   => pct(z.attributes['w']),
+    'h_pct'   => pct(z.attributes['h'])
+  }
+  # layout-flow's `param` is the stack direction; a vertical flow stacks its
+  # children top-to-bottom (the classic left filter-rail), horizontal L→R.
+  node['direction'] = (param == 'vert' ? 'vert' : 'horz') if type_v2 == 'layout-flow'
+  # filter/param zones resolve their target column from `param` (a column GUID).
+  if kind == 'filter' || kind == 'parameter'
+    g = guid_from_param(param)
+    info = g ? COL_BY_GUID[g] : nil
+    node['filter_column_caption']  = info && info[:caption]
+    node['filter_column_datatype'] = info && info[:datatype]
+  end
+  kids = []
+  z.elements.each('zone') { |cz| next if cz.attributes['id'].nil?; kids << build_zone_tree(cz) }
+  node['children'] = kids unless kids.empty?
+  node
 end
 
 dashboards = []
@@ -690,23 +777,15 @@ xml.elements.each('//dashboard') do |d|
     view_ref = z.attributes['param']
 
     # Translate Tableau zone type-v2 → our zone-level kind label
-    kind = case type_v2
-           when 'layout-basic', 'layout-flow' then 'container'
-           when 'text'                        then 'text'
-           when 'title'                       then 'title'
-           when 'filter'                      then 'filter'
-           when 'paramctrl'                   then 'parameter'
-           when 'color'                       then 'legend'
-           when 'empty'                       then 'spacer'
-           when 'dashboard-object'            then 'dashboard-object'
-           when nil
-             # No type-v2 + a worksheet name → this is the chart tile
-             caption ? 'chart' : 'container'
-           else type_v2
-           end
+    kind = zone_kind(type_v2, caption)
 
     ws_meta    = caption ? worksheets[caption] : nil
     chart_kind = kind == 'chart' ? chart_kind_for(ws_meta) : nil
+    # The chart kind was INFERRED from shelves (Tableau mark=Automatic), not
+    # declared — flag it so the builder routes it to image confirmation.
+    chart_kind_inferred = kind == 'chart' &&
+                          ws_meta&.dig(:mark_class).to_s.downcase == 'automatic' &&
+                          chart_kind != 'kpi'
 
     # Resolve filter-zone param GUID → column caption when this is a filter
     # zone, so downstream tools don't need to re-walk the .twb.
@@ -727,6 +806,7 @@ xml.elements.each('//dashboard') do |d|
       'w_pct'        => pct(z.attributes['w']),
       'h_pct'        => pct(z.attributes['h']),
       'chart_kind'   => chart_kind,
+      'chart_kind_inferred' => chart_kind_inferred,
       'mark_class'   => ws_meta&.dig(:mark_class),
       'geo_role'     => ws_meta&.dig(:geo_role),
       # New per-worksheet signal fields (nil for non-chart zones)
@@ -755,10 +835,18 @@ xml.elements.each('//dashboard') do |d|
   # treat the flipboard chrome as a regular chart page. The story itself is
   # parsed into story-plan.json below (beads-sigma-y6b).
   is_story = d.attributes['type-v2'] == 'storyboard' || !d.elements['.//story-points'].nil?
+  # Nested container tree (additive — see build_zone_tree). Walk the direct
+  # children of the dashboard's <zones> root so nesting is preserved.
+  zone_tree = []
+  if (root = d.elements['zones'])
+    root.elements.each('zone') { |z| next if z.attributes['id'].nil?; zone_tree << build_zone_tree(z) }
+  end
+
   dashboards << {
     'dashboard' => d.attributes['name'],
     'is_story'  => is_story,
-    'zones'     => zones
+    'zones'     => zones,
+    'zone_tree' => zone_tree
   }
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-automatic-chart-kind.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-automatic-chart-kind.rb
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+# Regression test for "Show Me"-style chart-kind inference on Tableau AUTOMATIC
+# worksheets. Before this, any sheet with mark=Automatic was blindly defaulted
+# to a bar chart (the #1 first-pass fidelity miss — a time series shipped as
+# bars). The parser now infers the kind from the shelf structure:
+#   - continuous date dim + measure        → line
+#   - measure on BOTH axes (≤1 dim)         → scatter
+#   - categorical dim + measure             → bar
+# and flags chart_kind_inferred:true so the builder routes it to image
+# confirmation (it's a guess, not a declared mark).
+#
+# Deterministic + offline: synthesizes a .twb with three Automatic worksheets
+# and runs the ACTUAL parse-twb-layout.rb.
+#
+# Usage:  ruby scripts/test-automatic-chart-kind.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+def ws(name, rows, cols)
+  <<~XML
+    <worksheet name='#{name}'>
+      <table><view><datasource-dependencies datasource='federated.x' /></view>
+        <rows>#{rows}</rows>
+        <cols>#{cols}</cols>
+        <pane><mark class='Automatic' /></pane>
+      </table>
+    </worksheet>
+  XML
+end
+
+GR = '[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' # Gross Revenue (measure)
+NP = '[a1111111-0000-0000-0000-000000000001]' # Net Profit (measure)
+OD = '[c2ec6b07-897e-39ab-9422-aa895d35a627]' # Order Date (date dim)
+RG = '[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' # Region (categorical dim)
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='Sales' name='federated.x'>
+        <column caption='Gross Revenue' name='#{GR}' datatype='real' role='measure' />
+        <column caption='Net Profit' name='#{NP}' datatype='real' role='measure' />
+        <column caption='Order Date ' name='#{OD}' datatype='date' role='dimension' />
+        <column caption='Region' name='#{RG}' datatype='string' role='dimension' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      #{ws('Trend',   "[federated.x].[sum:#{GR[1..-2]}:qk]", "[federated.x].[tmn:#{OD[1..-2]}:qk]")}
+      #{ws('ByRegion', "[federated.x].[sum:#{GR[1..-2]}:qk]", "[federated.x].[none:#{RG[1..-2]}:nk]")}
+      #{ws('Scatter', "[federated.x].[sum:#{NP[1..-2]}:qk]", "[federated.x].[sum:#{GR[1..-2]}:qk]")}
+    </worksheets>
+    <dashboards>
+      <dashboard name='Dash'><zones>
+        <zone id='1' name='Trend' x='0' y='0' w='33000' h='100000' />
+        <zone id='2' name='ByRegion' x='33000' y='0' w='33000' h='100000' />
+        <zone id='3' name='Scatter' x='66000' y='0' w='34000' h='100000' />
+      </zones></dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+zones = nil
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  File.write(twb, TWB)
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  zones = JSON.parse(File.read(lay)).flat_map { |dash| dash['zones'] || [] }
+end
+
+by_name = (zones || []).each_with_object({}) { |z, h| h[z['caption']] = z if z['caption'] }
+def kind(by, name); (by[name] || {})['chart_kind']; end
+
+check(kind(by_name, 'Trend') == 'line',
+      "Automatic + date dim + measure → line (got #{kind(by_name, 'Trend').inspect})", fails)
+check(kind(by_name, 'ByRegion') == 'bar',
+      "Automatic + categorical dim + measure → bar (got #{kind(by_name, 'ByRegion').inspect})", fails)
+check(kind(by_name, 'Scatter') == 'scatter',
+      "Automatic + measure on both axes → scatter (got #{kind(by_name, 'Scatter').inspect})", fails)
+check((by_name['Trend'] || {})['chart_kind_inferred'] == true,
+      'inferred-automatic kinds carry chart_kind_inferred:true (→ image confirmation)', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — Automatic worksheets infer line/bar/scatter from shelves (no blind bar default)'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-container-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-container-layout.rb
@@ -1,0 +1,149 @@
+#!/usr/bin/env ruby
+# Regression test for the container-fidelity layout path — Tableau dashboards
+# that group filters/parameters into a (often nested) layout container, e.g. a
+# left vertical rail beside the chart area. Before this fix the layout builder
+# discarded the container tree and lumped every control into one top strip
+# (build_page_for_dashboard's single control band).
+#
+# Asserts, end-to-end through the ACTUAL parse-twb-layout.rb +
+# build-dashboard-layout.rb (no Tableau/Sigma calls):
+#   1. The parser preserves the nested zone tree (a layout-flow rail INSIDE a
+#      layout-basic root, holding a filter zone + a paramctrl zone).
+#   2. The layout builder emits NESTED Sigma GridContainers (a container inside
+#      a container), not a flat band stack.
+#   3. The filter control AND the parameter control both land INSIDE the same
+#      rail container — i.e. filters/params are laid out within their Tableau
+#      container — while the chart sits OUTSIDE that rail.
+#
+# Usage:  ruby scripts/test-container-layout.rb
+
+require 'json'
+require 'rexml/document'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-dashboard-layout.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# A dashboard whose <zones> root is a layout-basic container holding:
+#   - a layout-flow VERTICAL rail (left) with a filter zone (on "Region") and a
+#     paramctrl zone (parameter "Metric Switch")
+#   - a chart zone ("Sales by Region") filling the right
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='Params' name='Parameters'>
+        <column param-domain-type='list' caption='Metric Switch' name='[Parameter 1]' datatype='string' value='&quot;Revenue&quot;'>
+          <members><member value='&quot;Revenue&quot;' /><member value='&quot;Profit&quot;' /></members>
+        </column>
+      </datasource>
+      <datasource caption='Sales' name='federated.x'>
+        <column caption='Region' name='[Region]' datatype='string' role='dimension' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Sales by Region'><table><view><datasource-dependencies datasource='federated.x' /></view></table></worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Pipeline'>
+        <zones>
+          <zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+            <zone id='2' type-v2='layout-flow' param='vert' x='0' y='0' w='25000' h='100000'>
+              <zone id='3' type-v2='filter' param='[federated.x].[none:Region:nk]' x='0' y='0' w='25000' h='40000' />
+              <zone id='4' type-v2='paramctrl' param='[Parameters].[Parameter 1]' x='0' y='40000' w='25000' h='40000' />
+            </zone>
+            <zone id='5' name='Sales by Region' x='25000' y='0' w='75000' h='100000' />
+          </zone>
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+layout = nil
+xml_doc = nil
+build_log = ''
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  File.write(twb, TWB)
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  layout = JSON.parse(File.read(lay))
+
+  # Synthetic workbook readback: a Data page + the dashboard page with a chart
+  # element (named like the worksheet), two controls (named like the filter
+  # column + the parameter caption), and a title text element.
+  wb_ids = {
+    'pages' => [
+      { 'name' => 'Data', 'elements' => [{ 'id' => 'master', 'kind' => 'table', 'name' => 'Data' }] },
+      { 'name' => 'Pipeline', 'elements' => [
+        { 'id' => 'el-chart', 'kind' => 'bar-chart', 'name' => 'Sales by Region' },
+        { 'id' => 'el-region', 'kind' => 'control', 'name' => 'Region' },
+        { 'id' => 'el-metric', 'kind' => 'control', 'name' => 'Metric Switch' },
+        { 'id' => 'el-title', 'kind' => 'text', 'name' => nil }
+      ] }
+    ]
+  }
+  wbf = File.join(d, 'wb-ids.json')
+  out = File.join(d, 'layout.xml')
+  File.write(wbf, JSON.dump(wb_ids))
+  build_log = `ruby #{BUILD} --layout #{lay} --wb-ids #{wbf} --out #{out} 2>&1`
+  if File.exist?(out)
+    # The layout file has multiple top-level <Page> roots; wrap for REXML.
+    body = File.read(out).sub(/\A<\?xml[^>]*\?>\s*/, '')
+    xml_doc = REXML::Document.new("<Root>#{body}</Root>")
+  end
+end
+
+# ---- 1. parser preserved the nested tree -----------------------------------
+dash = (layout || []).find { |x| x['dashboard'] == 'Pipeline' }
+tree = dash && dash['zone_tree']
+root = tree && tree.first
+rail = root && (root['children'] || []).find { |c| c['kind'] == 'container' }
+check(!root.nil? && root['kind'] == 'container', 'parser: <zones> root is a container node', fails)
+check(rail && rail['direction'] == 'vert', "parser: nested vertical rail container preserved (direction=#{rail && rail['direction'].inspect})", fails)
+rail_kids = rail ? (rail['children'] || []).map { |c| c['kind'] } : []
+check(rail_kids.include?('filter') && rail_kids.include?('parameter'),
+      "parser: rail holds the filter + parameter zones (got #{rail_kids.inspect})", fails)
+fcap = rail && (rail['children'] || []).find { |c| c['kind'] == 'filter' }&.dig('filter_column_caption')
+check(fcap == 'Region', "parser: filter zone resolves column caption 'Region' (got #{fcap.inspect})", fails)
+
+# ---- 2 + 3. builder nested the containers and placed controls in the rail ---
+gcs = xml_doc ? xml_doc.elements.to_a('//GridContainer') : []
+nested = gcs.any? { |g| !g.elements.to_a('.//GridContainer').empty? }
+check(nested, 'builder: emitted NESTED GridContainers (container inside container)', fails)
+
+# Find the container whose descendants include BOTH control element ids.
+def descendant_el_ids(gc)
+  gc.elements.to_a('.//LayoutElement').map { |le| le.attributes['elementId'] }
+end
+rail_gc = gcs.find do |g|
+  ids = descendant_el_ids(g)
+  ids.include?('el-region') && ids.include?('el-metric') &&
+    g.elements.to_a('.//GridContainer').empty? # innermost container = the rail
+end
+check(!rail_gc.nil?, 'builder: both controls (Region + Metric Switch) live INSIDE one rail container', fails)
+chart_in_rail = rail_gc && descendant_el_ids(rail_gc).include?('el-chart')
+check(rail_gc && !chart_in_rail, 'builder: the chart is NOT inside the control rail', fails)
+chart_placed = gcs.any? { |g| descendant_el_ids(g).include?('el-chart') }
+check(chart_placed, 'builder: the chart element is placed in the layout', fails)
+check(build_log.include?('container-tree layout'), 'builder: took the container-tree path (not the banded fallback)', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — container-fidelity layout: nested Tableau containers → nested Sigma containers; filters/params placed within their container'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  puts "\n--- build log (tail) ---"
+  puts build_log.to_s.lines.last(15).join
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-empty-csv-build-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-empty-csv-build-from-signals.rb
@@ -1,0 +1,136 @@
+#!/usr/bin/env ruby
+# Regression test for the empty-view-CSV recovery — a worksheet gated behind a
+# dashboard ACTION filter renders fine in Tableau but its headless data export
+# returns ZERO rows. The builder used to DROP the tile (shipping N-1 charts);
+# it must instead reconstruct the view headers from the .twb shelf signals and
+# BUILD the chart (Sigma sources the same warehouse, so it populates). Parity
+# for that one tile is downgraded to manual. Principle: never skip anything in
+# the .twb.
+#
+# Deterministic + offline: synthesizes a minimal .twb (a line chart of
+# Month(Order Date) × SUM(Gross Revenue) gated by an action filter), runs the
+# ACTUAL parse-twb-layout.rb + build-charts-from-signals.rb with an EMPTY view
+# CSV, and asserts the chart element was built (not dropped).
+#
+# Usage:  ruby scripts/test-empty-csv-build-from-signals.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Line chart: cols = Month-Trunc(Order Date), rows = SUM(Gross Revenue), with a
+# dashboard action filter on Region (the reason the data export comes back empty).
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='ORDER_FACT' name='federated.fact'>
+        <connection class='federated'>
+          <named-connections>
+            <named-connection name='snow'><connection class='snowflake' dbname='CSA' schema='TJ' /></named-connection>
+          </named-connections>
+          <relation connection='snow' name='ORDER_FACT' table='[TJ].[ORDER_FACT]' type='table' />
+        </connection>
+        <column caption='Gross Revenue' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
+        <column caption='Order Date ' name='[c2ec6b07-897e-39ab-9422-aa895d35a627]' datatype='date' role='dimension' type='ordinal' />
+        <column caption='Region' name='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' datatype='string' role='dimension' type='nominal' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Monthly Revenue Trend'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.fact'>
+              <column caption='Gross Revenue' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
+              <column caption='Order Date ' name='[c2ec6b07-897e-39ab-9422-aa895d35a627]' datatype='date' role='dimension' type='ordinal' />
+              <column-instance column='[c2ec6b07-897e-39ab-9422-aa895d35a627]' derivation='Month-Trunc' name='[tmn:c2ec6b07-897e-39ab-9422-aa895d35a627:qk]' pivot='key' type='quantitative' />
+              <column-instance column='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' derivation='Sum' name='[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]' pivot='key' type='quantitative' />
+            </datasource-dependencies>
+          </view>
+          <rows>[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]</rows>
+          <cols>[federated.fact].[tmn:c2ec6b07-897e-39ab-9422-aa895d35a627:qk]</cols>
+          <pane><mark class='Line' /></pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Dash'>
+        <zones><zone id='1' name='Monthly Revenue Trend' x='0' y='0' w='100000' h='100000' /></zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+MASTER_MAP = {
+  '(?i)^Gross Revenue$' => { 'id' => 'm-gr',   'name' => 'Gross Revenue' },
+  '(?i)^Order Date $'   => { 'id' => 'm-od',   'name' => 'Order Date ' },
+  '(?i)^Order Date$'    => { 'id' => 'm-od',   'name' => 'Order Date ' },
+  '(?i)^Region$'        => { 'id' => 'm-reg',  'name' => 'Region' }
+}
+
+build_out = nil
+build_log = ''
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  mm  = File.join(d, 'master-map.json')
+  File.write(twb, TWB)
+  File.write(mm, JSON.dump(MASTER_MAP))
+  # get-workbook view list + an EMPTY view CSV (the action-filter-gated export).
+  File.write(File.join(d, 'get-workbook.json'),
+             JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => 'Monthly Revenue Trend' }] }))
+  Dir.mkdir(File.join(d, 'views'))
+  File.write(File.join(d, 'views', 'v1.csv'), '')   # 0 bytes — the whole point
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  out = File.join(d, 'specs.json')
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --title Dash --out #{out} 2>&1`
+  build_out = JSON.parse(File.read(out)) if File.exist?(out)
+  vv_path = File.join(d, 'visual-verify-tiles.json')
+  $vv_sidecar = File.exist?(vv_path) ? JSON.parse(File.read(vv_path)) : nil
+end
+
+els = build_out ? (build_out.is_a?(Array) ? build_out : (build_out['elements'] || (build_out['pages'] || []).flat_map { |p| p['elements'] || [] })) : []
+trend = els.find { |e| e['name'].to_s.casecmp?('Monthly Revenue Trend') }
+
+check(!trend.nil?, 'chart BUILT from signals despite empty CSV (not dropped)', fails)
+check(trend && trend['kind'] == 'line-chart', "built element is a line-chart (got #{trend && trend['kind'].inspect})", fails)
+cols = trend ? (trend['columns'] || []) : []
+xcol = trend && cols.find { |c| c['id'] == trend.dig('xAxis', 'columnId') }
+ycol = trend && cols.find { |c| trend.dig('yAxis', 'columnIds')&.include?(c['id']) }
+check(xcol && xcol['formula'].to_s =~ /DateTrunc\("month"/i,
+      "x-axis is Month DateTrunc of Order Date (got #{xcol && xcol['formula'].inspect})", fails)
+check(ycol && ycol['formula'].to_s =~ /Sum\(/i,
+      "y-axis is Sum(Gross Revenue) (got #{ycol && ycol['formula'].inspect})", fails)
+check(build_log.include?('BUILT FROM .twb SIGNALS'),
+      'builder logged the empty-CSV → build-from-signals recovery (not a ZONE DROPPED)', fails)
+check(!build_log.include?('ZONE DROPPED'), 'no ZONE DROPPED warning emitted', fails)
+
+# ---- visual-verify sidecar: the tile routes to IMAGE verification -----------
+vv = $vv_sidecar
+check(vv.is_a?(Array) && vv.length == 1,
+      "builder wrote visual-verify-tiles.json with the empty-export tile (got #{vv.inspect})", fails)
+entry = vv && vv.first
+check(entry && entry['worksheet'] == 'Monthly Revenue Trend' && entry['view_id'] == 'v1' &&
+      entry['element_id'] == (trend && trend['id']),
+      "sidecar entry carries worksheet + view_id + the built element id (got #{entry.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — empty action-filter-gated CSV: chart rebuilt from .twb signals, nothing skipped'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  puts "\n--- build log (tail) ---"
+  puts build_log.to_s.lines.last(20).join
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-dashboard-visual.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-dashboard-visual.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+# Phase 6f — FULL-DASHBOARD visual ground truth + repair loop enabler. The
+# mandatory visual gate compares the WHOLE Sigma page to the WHOLE source
+# Tableau dashboard (per-element checks miss layout/relationship defects —
+# overlaps, dead zones, wrong relative sizing, stranded controls). This stages
+# both images side by side per dashboard so the agent can diff them, fix the
+# spec, re-render, and repeat until they match — then records the pairing the
+# gate (assert-phase6-ran gate 8) and the agent rely on.
+#
+# For each Tableau dashboard it:
+#   1. finds the source DASHBOARD view (view name == dashboard name) and fetches
+#      its Tableau image (reusing the cached views/<id>.png if discovery got it),
+#   2. renders the matching Sigma PAGE (page name == dashboard name),
+#   3. writes  <dir>/visual-qa/<slug>.source.png + <slug>.sigma.png  + a
+#      compare-manifest.json the agent fills in (visual_match per dashboard).
+#
+# Usage:
+#   eval "$(scripts/get-token.sh)"; eval "$(scripts/get-tableau-token.sh)"
+#   ruby scripts/verify-dashboard-visual.rb --workbook <sigmaWbId> --tableau-dir <dir>
+#
+# Then: READ each <slug>.source.png vs <slug>.sigma.png, fix any divergence
+# (re-PUT the spec + re-render), and set "visual_match": true per dashboard.
+
+require 'json'
+require 'optparse'
+require 'fileutils'
+require_relative 'lib/tableau_rest'
+
+opts = { w: 1700, h: 1100 }
+OptionParser.new do |p|
+  p.on('--workbook ID')     { |v| opts[:wb] = v }
+  p.on('--tableau-dir DIR') { |v| opts[:tab] = v }
+  p.on('--w N', Integer)    { |v| opts[:w] = v }
+  p.on('--h N', Integer)    { |v| opts[:h] = v }
+end.parse!
+%i[wb tab].each { |k| abort("missing --#{k.to_s.tr('_', '-')}") unless opts[k] }
+
+dash_layout = JSON.parse(File.read(File.join(opts[:tab], 'dashboard-layout.json')))
+wb_ids = JSON.parse(File.read(File.join(opts[:tab], 'wb-ids.json')))
+gw = (JSON.parse(File.read(File.join(opts[:tab], 'get-workbook.json'))) rescue {})
+views = gw.dig('views', 'view') || []
+views = [views] unless views.is_a?(Array)
+view_id_by_name = views.each_with_object({}) { |v, h| h[v['name']] = v['id'] if v['name'] }
+page_id_by_name = (wb_ids['pages'] || []).each_with_object({}) { |p, h| h[p['name']] = p['id'] if p['name'] }
+
+outdir = File.join(opts[:tab], 'visual-qa')
+FileUtils.mkdir_p(outdir)
+png_script = File.join(__dir__, 'sigma-export-png.py')
+slugify = ->(s) { s.to_s.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/^-|-$/, '')[0..50] }
+
+manifest = []
+dash_layout.each do |d|
+  name = d['dashboard']
+  next if name.to_s.start_with?('[synthetic]')
+  slug = slugify.call(name)
+  src_png = File.join(outdir, "#{slug}.source.png")
+  sig_png = File.join(outdir, "#{slug}.sigma.png")
+  rec = { 'dashboard' => name, 'source_png' => nil, 'sigma_png' => nil, 'visual_match' => false }
+
+  # 1) Source Tableau dashboard image (reuse the cached discovery PNG if present)
+  vid = view_id_by_name[name]
+  cached = vid && File.join(opts[:tab], 'views', "#{vid}.png")
+  begin
+    if cached && File.size?(cached)
+      FileUtils.cp(cached, src_png)
+    elsif vid
+      File.binwrite(src_png, Tableau.view_image(vid, width: opts[:w], height: opts[:h]))
+    end
+    rec['source_png'] = src_png if File.size?(src_png)
+  rescue StandardError => e
+    warn "  WARN  source dashboard image failed for #{name.inspect}: #{e.class}: #{e.message}"
+  end
+
+  # 2) Sigma page render
+  pid = page_id_by_name[name] || page_id_by_name.reject { |k, _| k == 'Data' }.values.first
+  if pid
+    ok = system('python3', png_script, '--workbook', opts[:wb], '--page', pid,
+                '--out', sig_png, '--w', opts[:w].to_s, '--h', opts[:h].to_s,
+                out: File::NULL, err: File::NULL)
+    rec['sigma_png'] = sig_png if ok && File.size?(sig_png)
+  end
+
+  status = (rec['source_png'] && rec['sigma_png']) ? 'READY for side-by-side' : 'INCOMPLETE'
+  puts "  #{name}  → #{status}  (source=#{rec['source_png'] ? 'ok' : 'MISSING'}, sigma=#{rec['sigma_png'] ? 'ok' : 'MISSING'})"
+  manifest << rec
+end
+
+man_path = File.join(outdir, 'compare-manifest.json')
+File.write(man_path, JSON.pretty_generate(manifest))
+ready = manifest.count { |m| m['source_png'] && m['sigma_png'] }
+puts
+puts "wrote #{man_path} (#{ready}/#{manifest.size} dashboard(s) staged for full-page comparison)"
+puts 'REPAIR LOOP: READ each <slug>.source.png vs <slug>.sigma.png. For any divergence (missing/wrong-kind'
+puts '  tile, overlap, dead zone, wrong sizing, stranded control), fix the spec + re-render, then re-run.'
+puts '  Set "visual_match": true per dashboard once it matches.'
+exit(ready == manifest.size ? 0 : 7)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-visual-tiles.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-visual-tiles.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env ruby
+# Phase 6f-visual — IMAGE-based parity for tiles whose Tableau data export came
+# back EMPTY (action-filter-gated sheets etc.). Those tiles are BUILT from the
+# .twb shelf signals (so the viz is never dropped) but can't be value-diffed —
+# there are no exportable actuals. Instead of letting them pass parity silently,
+# this fetches the TABLEAU VIEW IMAGE (which always renders) and the SIGMA
+# ELEMENT render side-by-side so the agent can confirm the migrated tile matches.
+#
+# Reads  <tableau-dir>/visual-verify-tiles.json  (written by build-charts-from-
+# signals.rb) and writes, per tile, two PNGs + a manifest the hard gate checks:
+#   <tableau-dir>/visual-verify/<slug>.tableau.png
+#   <tableau-dir>/visual-verify/<slug>.sigma.png
+#   <tableau-dir>/visual-verify/manifest.json
+#
+# Usage:
+#   eval "$(scripts/get-token.sh)"; eval "$(scripts/get-tableau-token.sh)"
+#   ruby scripts/verify-visual-tiles.rb --workbook <sigmaWorkbookId> --tableau-dir <dir>
+#
+# After it runs: READ each pair with the Read tool and compare (shape, trend,
+# axis, magnitudes). Mark reviewed tiles by setting "visual_verified": true in
+# the manifest, then the hard gate (assert-phase6-ran.rb) treats them as passed.
+
+require 'json'
+require 'optparse'
+require 'fileutils'
+require_relative 'lib/tableau_rest'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook ID')     { |v| opts[:wb] = v }
+  p.on('--tableau-dir DIR') { |v| opts[:tab] = v }
+  p.on('--w N', Integer)    { |v| opts[:w] = v }
+  p.on('--h N', Integer)    { |v| opts[:h] = v }
+end.parse!
+%i[wb tab].each { |k| abort("missing --#{k.to_s.tr('_', '-')}") unless opts[k] }
+opts[:w] ||= 1400
+opts[:h] ||= 900
+
+sidecar = File.join(opts[:tab], 'visual-verify-tiles.json')
+unless File.exist?(sidecar)
+  puts "no visual-verify-tiles.json in #{opts[:tab]} — nothing to verify (no empty-export tiles). OK."
+  exit 0
+end
+tiles = JSON.parse(File.read(sidecar))
+if tiles.empty?
+  puts 'visual-verify-tiles.json is empty — no empty-export tiles. OK.'
+  exit 0
+end
+
+outdir = File.join(opts[:tab], 'visual-verify')
+FileUtils.mkdir_p(outdir)
+png_script = File.join(__dir__, 'sigma-export-png.py')
+
+slugify = ->(s) { s.to_s.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/^-|-$/, '')[0..50] }
+manifest = []
+tiles.each do |t|
+  ws   = t['worksheet']
+  slug = slugify.call(ws)
+  tab_png   = File.join(outdir, "#{slug}.tableau.png")
+  sigma_png = File.join(outdir, "#{slug}.sigma.png")
+  rec = { 'worksheet' => ws, 'element_id' => t['element_id'], 'view_id' => t['view_id'],
+          'reason' => t['reason'], 'tableau_png' => nil, 'sigma_png' => nil,
+          'visual_verified' => false }
+
+  # 1) Tableau view image (renders fine even though its data export was empty)
+  begin
+    if t['view_id']
+      bytes = Tableau.view_image(t['view_id'], width: opts[:w], height: opts[:h])
+      File.binwrite(tab_png, bytes)
+      rec['tableau_png'] = tab_png if File.size?(tab_png)
+    end
+  rescue StandardError => e
+    warn "  WARN  Tableau image fetch failed for #{ws.inspect}: #{e.class}: #{e.message}"
+  end
+
+  # 2) Sigma element render
+  if t['element_id']
+    ok = system('python3', png_script, '--workbook', opts[:wb], '--element', t['element_id'],
+                '--out', sigma_png, '--w', opts[:w].to_s, '--h', opts[:h].to_s,
+                out: File::NULL, err: File::NULL)
+    rec['sigma_png'] = sigma_png if ok && File.size?(sigma_png)
+  end
+
+  status = (rec['tableau_png'] && rec['sigma_png']) ? 'READY for review' : 'INCOMPLETE'
+  puts "  #{ws}  → #{status}  (tableau=#{rec['tableau_png'] ? 'ok' : 'MISSING'}, sigma=#{rec['sigma_png'] ? 'ok' : 'MISSING'})"
+  manifest << rec
+end
+
+man_path = File.join(outdir, 'manifest.json')
+File.write(man_path, JSON.pretty_generate(manifest))
+ready = manifest.count { |m| m['tableau_png'] && m['sigma_png'] }
+puts
+puts "wrote #{man_path} (#{ready}/#{manifest.size} tile(s) ready for visual review)"
+puts 'NEXT: READ each tableau_png / sigma_png pair and compare (trend, axis, magnitudes).'
+puts '      Set "visual_verified": true per reviewed tile so assert-phase6-ran.rb counts it as passed.'
+# Non-zero exit if any tile could not be staged for review — the orchestrator
+# surfaces it rather than declaring parity done with an unverifiable tile.
+exit(ready == manifest.size ? 0 : 7)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -115,6 +115,7 @@ OptionParser.new do |p|
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
+  p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -620,6 +621,40 @@ else
       warn "[WARN] gate 8: parity-final.json records no screenshot_path/visual_checked flag — " \
            'render exists but confirm you actually compared it to the source and noted any divergence.'
     end
+  end
+end
+
+# Gate 9 — Visual-verify tiles (build-from-signals). Tiles whose Tableau data
+# export came back EMPTY (action-filter-gated etc.) are built from .twb signals
+# and cannot be value-diffed, so they must be confirmed by IMAGE comparison
+# (verify-visual-tiles.rb). Without this gate they'd pass parity silently. No-op
+# (and invisible to other converters) when the sidecar is absent.
+vv_sidecar = File.join(opts[:tab], 'visual-verify-tiles.json')
+if File.exist?(vv_sidecar)
+  vtiles = (JSON.parse(File.read(vv_sidecar)) rescue [])
+  if opts[:skip_visual_tiles]
+    puts "[SKIP] gate 9: #{vtiles.size} build-from-signals tile(s) visual-verify WAIVED (#{opts[:skip_visual_tiles]})."
+  elsif vtiles.any?
+    man_path = File.join(opts[:tab], 'visual-verify', 'manifest.json')
+    man = File.exist?(man_path) ? (JSON.parse(File.read(man_path)) rescue nil) : nil
+    if man.nil?
+      warn "[FAIL] gate 9: #{vtiles.size} tile(s) had EMPTY data exports (built from .twb signals) but no"
+      warn "       visual-verify/manifest.json exists — run: ruby scripts/verify-visual-tiles.rb"
+      warn "       --workbook #{opts[:wb] || '<id>'} --tableau-dir #{opts[:tab]}, then READ each"
+      warn '       <tile>.tableau.png vs <tile>.sigma.png pair and mark "visual_verified": true.'
+      exit 11
+    end
+    unverified = man.reject { |m| m['visual_verified'] }
+    if unverified.any?
+      warn "[FAIL] gate 9: #{unverified.size}/#{man.size} build-from-signals tile(s) NOT visually verified: " \
+           "#{unverified.map { |m| m['worksheet'] }.join(', ')}."
+      warn '       These tiles have no value actuals (empty Tableau export). READ each'
+      warn "       <tile>.tableau.png vs <tile>.sigma.png under #{File.join(opts[:tab], 'visual-verify')}/,"
+      warn '       confirm trend/axis/magnitudes match, and set "visual_verified": true per tile in'
+      warn '       visual-verify/manifest.json. Escape hatch: --skip-visual-tiles "<reason>" (name it in your report).'
+      exit 11
+    end
+    puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
 end
 

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -115,6 +115,7 @@ OptionParser.new do |p|
   p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
+  p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -620,6 +621,40 @@ else
       warn "[WARN] gate 8: parity-final.json records no screenshot_path/visual_checked flag — " \
            'render exists but confirm you actually compared it to the source and noted any divergence.'
     end
+  end
+end
+
+# Gate 9 — Visual-verify tiles (build-from-signals). Tiles whose Tableau data
+# export came back EMPTY (action-filter-gated etc.) are built from .twb signals
+# and cannot be value-diffed, so they must be confirmed by IMAGE comparison
+# (verify-visual-tiles.rb). Without this gate they'd pass parity silently. No-op
+# (and invisible to other converters) when the sidecar is absent.
+vv_sidecar = File.join(opts[:tab], 'visual-verify-tiles.json')
+if File.exist?(vv_sidecar)
+  vtiles = (JSON.parse(File.read(vv_sidecar)) rescue [])
+  if opts[:skip_visual_tiles]
+    puts "[SKIP] gate 9: #{vtiles.size} build-from-signals tile(s) visual-verify WAIVED (#{opts[:skip_visual_tiles]})."
+  elsif vtiles.any?
+    man_path = File.join(opts[:tab], 'visual-verify', 'manifest.json')
+    man = File.exist?(man_path) ? (JSON.parse(File.read(man_path)) rescue nil) : nil
+    if man.nil?
+      warn "[FAIL] gate 9: #{vtiles.size} tile(s) had EMPTY data exports (built from .twb signals) but no"
+      warn "       visual-verify/manifest.json exists — run: ruby scripts/verify-visual-tiles.rb"
+      warn "       --workbook #{opts[:wb] || '<id>'} --tableau-dir #{opts[:tab]}, then READ each"
+      warn '       <tile>.tableau.png vs <tile>.sigma.png pair and mark "visual_verified": true.'
+      exit 11
+    end
+    unverified = man.reject { |m| m['visual_verified'] }
+    if unverified.any?
+      warn "[FAIL] gate 9: #{unverified.size}/#{man.size} build-from-signals tile(s) NOT visually verified: " \
+           "#{unverified.map { |m| m['worksheet'] }.join(', ')}."
+      warn '       These tiles have no value actuals (empty Tableau export). READ each'
+      warn "       <tile>.tableau.png vs <tile>.sigma.png under #{File.join(opts[:tab], 'visual-verify')}/,"
+      warn '       confirm trend/axis/magnitudes match, and set "visual_verified": true per tile in'
+      warn '       visual-verify/manifest.json. Escape hatch: --skip-visual-tiles "<reason>" (name it in your report).'
+      exit 11
+    end
+    puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
 end
 


### PR DESCRIPTION
## Why

Complex Tableau dashboards were migrating poorly on the first pass — controls were silently skipped, charts were dropped, the visual-parity step was skipped, and the agent could still declare "done." This branch makes a cold/first-pass migration faithful without hand-holding, driven by real customer feedback.

## What

**Complex-dashboard controls & pivots** (commits 1–2)
- Calc-field-bound filters and parameter-driven `Switch` controls now migrate instead of being dropped as "orphans."
- Parameter-driven CASE/IF chains translate as pivot values; aggregation-name + parameter name-ref fixes.
- Local-first converter backend (data-residency safe); hosted MCP is opt-in.

**First-pass robustness** (commit 3)
- **Container-faithful layout** — the nested Tableau zone tree maps to nested Sigma containers, so filters/parameters land *inside* their container (left-rail/sidebar idiom) instead of a generic top strip. Banded layout remains the fallback (`--no-containers`).
- **Never drop a viz on an empty data export** — a sheet gated by a dashboard action filter exports 0 rows but renders fine; the chart is now rebuilt from `.twb` shelf signals (Sigma queries the same warehouse, so values are exact) instead of dropped. Plus `guid_from_param` friendly-name + date-grain fixes.
- **Never guess a chart kind silently** — "Show Me"-style inference for `Automatic` marks (date+measure→line, measure-on-both-axes→scatter, categorical+measure→bar) replaces the blind bar default; inferred kinds are routed to image confirmation.
- **Never pass a tile unverified** — `verify-visual-tiles.rb` stages a Tableau-image vs Sigma-element comparison for tiles with no value actuals (empty export / inferred kind), and **`assert-phase6-ran` gate 9** blocks GREEN until each is `visual_verified`.
- **Full-dashboard repair loop** — `verify-dashboard-visual.rb` stages the source Tableau dashboard image vs the Sigma page render per dashboard for diff → fix → re-render.
- **Fleet-wide visual gate (gate 8 + gate 9)** live in canonical `shared/scripts/assert-phase6-ran.rb`, synced to all converters (gate 9 is a graceful no-op where the sidecar isn't produced).

## Verification

- Offline regression suite green: `test-container-layout`, `test-empty-csv-build-from-signals`, `test-automatic-chart-kind`, `test-complex-dashboard-e2e`, `test-calc-field-controls`.
- Live end-to-end migration of a Snowflake-backed workbook: the action-gated line chart now builds and matches the source to the dollar; container layout + both visual-staging steps fire in-flow; 0 error-typed columns.
- Shared-file governance check clean (98 copies match canonical).

## Deliberately not included

VDS-backfill of empty-export tiles (querying the published datasource to bypass the action filter) — proven reachable but field-caption mapping is ambiguous/unreliable, so image-verification covers those tiles instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
