### PR TITLE
Ship sigma-authoring (sigma-workbooks + data-models) as a plugin in the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace-manifest.json",
   "name": "sigma-migration-skills",
-  "description": "Skills for migrating BI tools (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight, Looker, Cognos, MicroStrategy) to Sigma \u2014 converters + assessments, validated end-to-end with warehouse parity.",
+  "description": "Skills for migrating BI tools (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight, Looker, Cognos, MicroStrategy) to Sigma \u2014 converters + assessments, validated end-to-end with warehouse parity. Install the sigma-authoring plugin alongside any converter: it carries the canonical Sigma spec the converters defer to.",
   "version": "1.0.0",
   "owner": {
     "name": "Thomas Wells"
@@ -10,6 +10,19 @@
     "pluginRoot": "./plugins"
   },
   "plugins": [
+    {
+      "name": "sigma-authoring",
+      "source": "./plugins/sigma-authoring",
+      "description": "Canonical Sigma authoring skills every converter defers to: sigma-workbooks (workbook spec \u2014 element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models, and custom-sql-to-data-model. Install this ALONGSIDE any converter \u2014 they assume it is present for the current Sigma spec surface.",
+      "category": "authoring",
+      "keywords": [
+        "sigma",
+        "workbooks",
+        "data-models",
+        "authoring",
+        "spec"
+      ]
+    },
     {
       "name": "tableau-to-sigma",
       "source": "./plugins/tableau-to-sigma",

--- a/plugins/sigma-authoring/.claude-plugin/plugin.json
+++ b/plugins/sigma-authoring/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sigma-authoring",
+  "displayName": "Sigma Authoring (Workbooks + Data Models)",
+  "version": "1.0.0",
+  "description": "The canonical Sigma authoring skills every migration converter defers to for the current spec surface: sigma-workbooks (workbook spec — element kinds, source kinds, controls, formulas, formatting, layout), sigma-data-models (data model authoring), and custom-sql-to-data-model. Install this alongside any converter — the converters assume it is present.",
+  "author": { "name": "Thomas Wells" },
+  "license": "MIT",
+  "keywords": ["sigma", "workbooks", "data-models", "authoring", "spec", "migration"],
+  "skills": "./skills/"
+}

--- a/plugins/sigma-authoring/SYNC.md
+++ b/plugins/sigma-authoring/SYNC.md
@@ -1,0 +1,26 @@
+# sigma-authoring — vendored from `twells89/sigma-skills`
+
+The skills under `skills/` (`sigma-workbooks`, `sigma-data-models`,
+`custom-sql-to-data-model`) are **vendored copies** of the canonical
+`twells89/sigma-skills` repo. They live here so the migration converters'
+hard dependency on `sigma-workbooks` (the canonical Sigma spec reference) ships
+in the **same marketplace** — installing any converter, install this too.
+
+- **Source of truth:** https://github.com/twells89/sigma-skills (edit there)
+- **Vendored at:** sigma-skills `3d4d812`
+
+## Refresh
+
+Re-vendor when the canonical skills change:
+
+```sh
+SRC=/path/to/sigma-skills    # a fresh clone of twells89/sigma-skills
+for s in sigma-workbooks sigma-data-models custom-sql-to-data-model; do
+  rm -rf "plugins/sigma-authoring/skills/$s"
+  cp -R "$SRC/$s" "plugins/sigma-authoring/skills/$s"
+done
+# then update the "Vendored at" SHA above and commit
+```
+
+Do NOT edit these copies directly — changes belong upstream in `sigma-skills`,
+then re-vendor here.

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/SKILL.md
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/SKILL.md
@@ -1,0 +1,568 @@
+---
+name: custom-sql-to-data-model
+description: >-
+  Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build
+  or reuse Sigma data models, then repoint the workbooks via the v3alpha
+  `:swapSources` endpoint. Use when you want to find ad-hoc SQL in workbooks
+  and promote it to one reusable data model per unique query.
+user-invocable: true
+---
+
+# Custom SQL → Data Model
+
+End-to-end flow:
+
+1. Scan workbooks for `source.kind: "sql"` elements (Phase 1).
+2. Scan data models to index every existing SQL or warehouse-table source (Phase 1.5).
+3. Group manifest entries by normalized SQL; for each group, decide **reuse**
+   an existing DM element or **build** a new one (Phase 1.5 → plan).
+4. Build DMs only for the to-build groups (Phase 2 / 3 / 4).
+5. Drive `:swapSources` from the plan, one workbook at a time (Phase 5).
+6. Audit and repair residual `[Prefix/SNAKE_CASE]` formulas left behind by
+   Sigma's auto-match (Phase 6).
+
+The key win versus the legacy GET/mutate/PUT approach: one workbook with N
+SQL elements is one API call with N entries in `sourceMapping`, and the
+auto-match handles formula rewrites — except for the rough edges Phase 6
+catches.
+
+---
+
+## Prerequisites
+
+Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
+
+Always chain the token eval with `&&` so the token is live for all subsequent
+commands in the same block:
+
+```bash
+eval "$(bash scripts/get-token.sh)"
+```
+
+> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `eval "$(bash scripts/get-token.sh)"` manually.
+
+---
+
+## Phase 1 — Scan workbooks for custom SQL
+
+```bash
+eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-workbooks.rb
+```
+
+Reads every workbook spec in the org, finds all elements where
+`source.kind == "sql"`, and writes `/tmp/custom-sql-manifest.json`.
+
+Each entry:
+
+```json
+{
+  "workbook_id":   "25e21c63-...",
+  "workbook_name": "Custom Sql Test",
+  "folder_id":     "57e59735-...",
+  "element_id":    "6YSI-SjSmz",
+  "element_name":  "Customer Dim SQL",
+  "connection_id": "cb2f5180-...",
+  "sql":           "select * from CSA.TJ.CUSTOMER_DIM",
+  "column_count":  18
+}
+```
+
+`element_id` is the same value as the `customSqlId` consumed by `:swapSources`
+in Phase 5 — no extra lookup needed.
+
+Review the findings and confirm with the user which workbooks to convert.
+
+---
+
+## Phase 1.5 — Index existing DMs and plan dedup
+
+### Scan DMs
+
+```bash
+eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-data-models.rb
+```
+
+Writes `/tmp/dm-sql-index.json`. The scanner emits one entry per existing DM
+element of either kind:
+
+- `kind: "sql"` — indexed by normalized SQL text
+- `kind: "warehouse-table"` — indexed by a synthetic `select * from <path>`
+  string, so trivial `SELECT *` custom-SQL maps to the right table-backed DM
+
+Each entry also tracks `dmElementCount` (total elements in that DM) so the
+planner can prefer focused DMs over kitchen-sink ones.
+
+### Build the swap plan
+
+```bash
+ruby scripts/plan-dedup.rb
+```
+
+Writes `/tmp/swap-plan.json`. The planner:
+
+1. Groups manifest entries by normalized SQL (whitespace/case-collapsed, but
+   no semantic reformatting — copy/paste duplicates collapse, semantically-
+   equivalent rewrites do not).
+2. For each group, looks up the DM index. If a candidate exists, marks the
+   group `status: "existing"` and picks the best target (same connection,
+   fewest DM elements, stable tiebreak). Otherwise marks it `to-build`.
+3. Prints a human-readable summary:
+
+```
+[REUSE] group 1: 3 occurrence(s)
+  SQL: select * from csa.tj.customer_dim
+    - Custom Sql Test / Custom Sql Test SQL (6YSI-SjSmz)
+    - Dedup Test Alpha / Customer Source  (el-customers)
+    - Dedup Test Beta  / Customer Source  (el-customers-dup)
+  -> Customer Dim / Customer Dim  (54d1f450-... / ROZzp25zn9)
+
+[BUILD] group 2: 1 occurrence(s)
+  SQL: with monthly as ( select employee_id, date_trunc('month', date) as month, …
+    - Dedup Test Alpha / OT Summary (el-ot-summary)
+  -> needs new DM (connection cb2f5180-..., folder 57e59735-...)
+
+Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
+```
+
+Confirm with the user before continuing — a `[REUSE]` decision is only as
+good as the picked candidate. If the heuristic picked the wrong DM, edit
+`/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at
+the preferred DM before Phase 5.
+
+---
+
+## Phase 2 — Build the data models for to-build groups
+
+Build one DM per `to-build` group in the plan. Phases 1.5 → 2 → 3 → 4 — only
+the to-build groups need this; reuse groups skip straight to Phase 5.
+
+### One DM per to-build group
+
+A group is "one unique SQL across N workbook occurrences" — build a single
+DM with one element wrapping that SQL, then the same DM/element pair gets
+referenced by every occurrence in the swap call. Do not build per-workbook.
+
+### Try the converter first
+
+For each to-build group:
+
+```
+mcp__sigma-data-model__convert_sql_to_sigma
+  statements    = [{"name": "<group label>", "sql": "<representative sql>"}]
+  connection_id = "<connection_id from manifest>"
+  database      = ""
+  schema        = ""
+```
+
+`database` / `schema` are inferred from the SQL.
+
+### What the converter produces
+
+| SQL type | Converter output | Action |
+|---|---|---|
+| `SELECT *` / `SELECT cols` from one table | Single `warehouse-table` element, no columns | Fetch columns — see below |
+| `SELECT` with JOINs | Multiple `warehouse-table` elements + relationships | Use as-is |
+| `SELECT` with aggregates (GROUP BY) | Elements + `metrics` array | Check child usage — see note below |
+| CTEs (`WITH ...`) | Element with `path: ["CTE_NAME"]` — fake table | Discard — build manually |
+| Subqueries / implicit joins | `Custom SQL` element | Use as-is |
+
+> **Aggregated SQL with GROUP BY**: The warehouse-table + metrics shape only
+> exposes GROUP BY dimensions as direct columns; aggregates land in `metrics`.
+> If child workbook elements reference aggregate columns as direct columns,
+> the DM page must use a `sql` source instead — build manually with the full
+> SQL and enumerate all output columns.
+
+### Column display names — matter for Phases 5 + 6
+
+The swap auto-matches columns between source and target by **display name**,
+case- and punctuation-insensitive (`CUSTOMER_KEY` ↔ `Customer Key`). Most
+columns match cleanly. **The auto-match has known silent misses** — see
+Phase 6 — but those are post-swap-repairable, so don't over-engineer at
+build time. Just ensure the DM column `name` fields are reasonable display
+names ("Total Hours", "OT Hours", …), not SQL aliases.
+
+### Column formula rules (for the DM itself)
+
+| Source kind | Formula inside the DM element | Formula in workbook referencing the DM |
+|---|---|---|
+| `warehouse-table` | `[TABLE_NAME/Column Name]` | `[DM Element Name/Column Name]` |
+| `sql` | `[Custom SQL/SQL_ALIAS]` | `[DM Element Name/Column Display Name]` |
+
+**Key rules:**
+- Inside a `sql` DM element, the formula prefix is always the literal string `Custom SQL` —
+  never the element's own `name` field.
+- Workbook formulas reference DM columns by **display name** (the column's `name` field),
+  not by server-assigned column `id`. Display names are stable across DM PUTs;
+  column IDs are reassigned every PUT.
+
+```python
+def col(sql_alias, display=None):
+    title = display or sql_alias.replace("_", " ").title()
+    return {"id": sql_alias, "name": title, "formula": f"[Custom SQL/{sql_alias}]"}
+```
+
+### SELECT * — converter produces no columns
+
+When the converter returns a `warehouse-table` element with no columns:
+
+1. `mcp__sigma-mcp-v2__search query="<TABLE_NAME>" entityTypes=["table"]` → inodeId
+2. `mcp__sigma-mcp-v2__describe object={"type":"table","inodeId":"<inodeId>"}` → column names
+3. Build columns with `formula: [TABLE/<col>]`, `name: "<Title Case>"`.
+
+### CTEs — discard converter output, build manually
+
+When the converter returns `path: ["CTE_NAME"]`, that CTE name is being used
+as a fake warehouse table path. Discard the converter output and build a
+`sql` element by hand with the full CTE in `source.statement`. Enumerate the
+output columns from the final `SELECT`.
+
+### Set folderId
+
+Always set `folderId` from the plan's `representative.folder_id` (taken
+from the source workbook's own folder — guaranteed real).
+
+---
+
+## Phase 3 — POST the data model
+
+```bash
+eval "$(bash scripts/get-token.sh)" && \
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/<name>-datamodel-spec.json \
+  "$SIGMA_BASE_URL/v2/dataModels/spec" \
+  | ruby -r yaml -r json -r date -e "
+    d = YAML.safe_load(STDIN.read, permitted_classes: [Date, Time])
+    if d['dataModelId']
+      puts 'SUCCESS  dataModelId: ' + d['dataModelId'].to_s
+    else
+      puts 'ERROR: ' + d.inspect
+    end
+  "
+```
+
+> Response is YAML — never pipe to `jq`.
+
+After POST, fetch the spec back with `Accept: application/json` to learn the
+server-assigned element IDs:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" \
+  | jq '.pages[].elements[] | {id, name}'
+```
+
+Update the plan: fill in `target.dataModelId` / `target.elementId` on every
+`to-build` entry with the new IDs.
+
+---
+
+## Phase 4 — Validate the new DMs with MCP
+
+For each newly-built DM:
+
+```
+mcp__sigma-mcp-v2__describe
+  object = {"type": "datamodel", "dataModelId": "<dmId>"}
+```
+
+Then for each element listed:
+
+```
+mcp__sigma-mcp-v2__describe
+  object = {"type": "datamodel-element", "dataModelId": "<dmId>", "elementId": "<elId>"}
+```
+
+```
+mcp__sigma-mcp-v2__query
+  query = { "type": "datamodel", "dataModelId": "<dmId>",
+            "sql": "SELECT * FROM \"datamodel\".\"<elId>\" LIMIT 3" }
+```
+
+Column identifiers in the SQL are the server-assigned IDs from the
+`describe` DDL, not display names.
+
+If anything fails, fix and re-PUT before Phase 5.
+
+---
+
+## Phase 5 — Repoint workbooks via `:swapSources`
+
+Endpoint: `POST /v3alpha/workbooks/{workbookId}:swapSources`.
+
+The call atomically:
+
+- flips `source.kind: "sql"` → `"data-model"` on each root SQL element,
+- rewrites root column formulas from `[Custom SQL/SQL_ALIAS]` to
+  `[DM Element Name/Display Name]`,
+- rewrites child element formulas that referenced the root by name.
+
+### Step 1 — Name unnamed root SQL elements first (CRITICAL)
+
+If a root SQL element has `name: null` (or empty string), child elements
+that referenced it used the implicit prefix `"Custom SQL"`. The swap rewrites
+the root's own formulas correctly but **breaks child formulas to
+`[Missing node/...]`** — and **reversing the swap does not fix them**; the
+"Missing node" placeholder is sticky and requires a manual spec edit to
+recover.
+
+**Always set a real name on each unnamed root SQL element before swapping**,
+and update any child formulas that used the `Custom SQL` prefix to use the
+new name. Then the swap auto-rewrites cleanly.
+
+```ruby
+require 'json'
+WB = '<workbookId>'
+raw = `curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" "$SIGMA_BASE_URL/v2/workbooks/#{WB}/spec"`
+spec = JSON.parse(raw)
+
+manifest = JSON.parse(File.read('/tmp/custom-sql-manifest.json'))
+new_names = manifest
+  .select { |m| m['workbook_id'] == WB }
+  .to_h    { |m| [m['element_id'], m['element_name']] }
+
+# Children that referenced a root we're renaming
+child_parent = {}
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    parent = el.dig('source', 'elementId')
+    child_parent[el['id']] = parent if parent && new_names.key?(parent)
+  end
+end
+
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    if new_names.key?(el['id'])
+      el['name'] = new_names[el['id']] if el['name'].to_s.strip.empty?
+    elsif (parent = child_parent[el['id']])
+      new_prefix = new_names[parent]
+      (el['columns'] || []).each do |col|
+        col['formula'] = col['formula']&.gsub('[Custom SQL/', "[#{new_prefix}/")
+      end
+    end
+  end
+end
+
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion documentVersion].each { |k| spec.delete(k) }
+File.write('/tmp/wb-pre-swap.json', JSON.pretty_generate(spec))
+```
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d @/tmp/wb-pre-swap.json \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec"
+```
+
+> Skip this step only if every root SQL element already has a non-empty
+> `name` AND no child formula references `[Custom SQL/...]`.
+
+### Step 2 — Call `:swapSources` per workbook, batched
+
+For each workbook in the plan, batch all of that workbook's swaps into a
+single call. The example below assumes the plan groups Alpha's two SQL
+elements together; the planner output gives you the mapping.
+
+```bash
+WB="<workbookId>"
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "sourceMapping": [
+      { "from": { "type": "custom-sql", "customSqlId": "<element_id 1>" },
+        "to":   { "type": "data-model", "dataModelId": "<dmId 1>", "elementId": "<elId 1>" } },
+      { "from": { "type": "custom-sql", "customSqlId": "<element_id 2>" },
+        "to":   { "type": "data-model", "dataModelId": "<dmId 2>", "elementId": "<elId 2>" } }
+    ]
+  }' \
+  "${SIGMA_BASE_URL}/v3alpha/workbooks/${WB}:swapSources"
+```
+
+> **Shell gotcha**: the URL contains a `:` which collides with parameter
+> expansion in zsh/bash. Always wrap the variable in braces:
+> `${WB}:swapSources`, not `$WB:swapSources` (`bad substitution` error).
+
+A successful response is HTTP 200 with body `{}`.
+
+### Step 3 — Verify the swap had effect
+
+The endpoint has two specific behaviors to guard against:
+
+| Behavior | Symptom | Mitigation |
+|---|---|---|
+| Bogus `from.customSqlId` (typo or stale) | HTTP 200, `{}` — silent no-op | Re-list `/v2/workbooks/{id}/sources` and assert no `custom-sql` entries remain |
+| Bogus `to` (e.g. wrong DM `elementId`) | HTTP 400 `"Element X not found in data model"` | Match each plan entry's `target` against the Phase 3 readback |
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "${SIGMA_BASE_URL}/v2/workbooks/${WB}/sources" | jq '[.[] | .type] | unique'
+# expect: ["data-model"] (or empty / no custom-sql)
+```
+
+### Column name misalignment — `columnMapping` override (proactive)
+
+The swap auto-matches columns by display name, case- and punctuation-
+insensitive. If you know in advance that some DM column display names won't
+match the custom-SQL aliases (and won't auto-resolve), pass `columnMapping`
+in the same request:
+
+```json
+{
+  "sourceMapping": [
+    {
+      "from": { "type": "custom-sql", "customSqlId": "..." },
+      "to":   { "type": "data-model", "dataModelId": "...", "elementId": "..." },
+      "columnMapping": [
+        { "fromColumn": ["C_KEY"],     "toColumn": ["customer_key"] },
+        { "fromColumn": ["TOTAL_REV"], "toColumn": ["lifetime_revenue"] }
+      ]
+    }
+  ]
+}
+```
+
+For cases you didn't anticipate, Phase 6 cleans up after the fact.
+
+---
+
+## Phase 6 — Audit and repair residual SNAKE_CASE formulas
+
+The auto-match has documented silent misses: short uppercase aliases and
+some token patterns survive the swap as `[Prefix/SNAKE_CASE]` even though
+the DM element's column display name is something like `OT Hours`. The
+broken formula:
+
+- Does **not** error at PUT time.
+- Surfaces at query time as a value-cell error: `Column "[OT Summary/OT_HOURS]" does not exist`.
+- Cascades into child elements that referenced the workbook column by its
+  display name (`[OT Summary/OT Flag]`) — the child returns the same error
+  string as a data value, not a query failure.
+
+The audit script walks each workbook's elements, finds formulas of the form
+`[Prefix/UPPERCASE_TOKEN]` where the local sibling column's `id` matches
+the token but its display `name` differs, and rewrites the suffix to the
+display name. Warehouse-table prefixes are left alone.
+
+```bash
+# audit specific workbooks
+ruby scripts/audit-formulas.rb <workbookId> [<workbookId> ...]
+
+# or audit every workbook touched by the current plan
+ruby scripts/audit-formulas.rb --from-plan
+```
+
+The script reports `N formula(s) repaired` per workbook. Idempotent — safe
+to re-run.
+
+After audit, re-validate with MCP to confirm the cells now return data, not
+error strings:
+
+```
+mcp__sigma-mcp-v2__query
+  query = {"type": "workbook", "workbookId": "<wb>",
+           "sql": "SELECT <cols> FROM \"workbook\".\"<elementId>\" LIMIT 3"}
+```
+
+---
+
+## Manual fallback (legacy, no `:swapSources`)
+
+If `:swapSources` doesn't fit (e.g., a partial swap, or a column remap that's
+easier as a spec edit), the older GET/mutate/PUT approach still works. The
+cost: you keep prefix/display-name rewrite logic in sync with the DM, you
+must strip response-only fields, and layout edits may get rebuilt server-
+side. Prefer `:swapSources` whenever it works.
+
+```ruby
+require 'yaml'; require 'json'; require 'date'
+spec = YAML.safe_load(File.read('/tmp/wb-spec.yaml'), permitted_classes: [Date, Time])
+
+conversions = {
+  '<root_element_id>' => {
+    dataModelId: '<dataModelId>',
+    elementId:   '<server-assigned-element-id>',
+    elementName: '<DM element name, e.g. Customer Dim>'
+  }
+}
+
+root_ids = conversions.keys.to_set
+child_parent = {}
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    parent = el.dig('source', 'elementId')
+    child_parent[el['id']] = parent if parent && root_ids.include?(parent)
+  end
+end
+
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    if (conv = conversions[el['id']])
+      el['name']   = conv[:elementName]
+      el['source'] = { 'kind' => 'data-model', 'dataModelId' => conv[:dataModelId], 'elementId' => conv[:elementId] }
+      (el['columns'] || []).each do |col|
+        display = col['id'].split('_').map(&:capitalize).join(' ')
+        col['formula'] = "[#{conv[:elementName]}/#{display}]"
+      end
+    elsif (parent = child_parent[el['id']])
+      new_prefix = conversions[parent][:elementName]
+      (el['columns'] || []).each { |c| c['formula'] = c['formula']&.gsub('[Custom SQL/', "[#{new_prefix}/") }
+    end
+  end
+end
+
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
+File.write('/tmp/wb-updated.json', JSON.pretty_generate(spec))
+```
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/wb-updated.json \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec"
+```
+
+---
+
+## Data model swap-sources
+
+The same v3alpha shape works for DMs:
+
+```
+POST /v3alpha/dataModels/{dataModelId}:swapSources
+```
+
+Use this when a DM itself contains a custom-SQL element you want to promote.
+Same `sourceMapping[].from` / `.to` shape; same silent-no-op gotcha for
+bogus `from.customSqlId`. Not part of the standard Phase 1–6 flow — included
+for completeness.
+
+---
+
+## Troubleshooting
+
+| Error / symptom | Cause | Fix |
+|---|---|---|
+| `Token missing or malformed` | Token expired between commands | Re-run `eval "$(bash scripts/get-token.sh)"` — chain with `&&` |
+| `:swapSources` returns HTTP 200 `{}` but nothing changed | `from.customSqlId` doesn't match a real element (typo or already swapped) | Re-list `/v2/workbooks/{id}/sources`; assert no `custom-sql` entries remain |
+| `Element X not found in data model` (400) on `:swapSources` | `to.elementId` doesn't exist in the DM | Use the server-assigned ID from Phase 3, not your authoring ID |
+| `bad substitution` on the curl URL | Shell expanded `$WB:swapSources` as a parameter modifier | Wrap in braces: `${WB}:swapSources` |
+| Child element formulas show `[Missing node/...]` after swap | Root SQL element was unnamed; the implicit "Custom SQL" prefix lost its referent | **Sticky** — must be fixed manually. Pre-swap: name the root element AND rewrite child formulas to use that name |
+| Query returns an error string inside a data cell, e.g. `Column "[OT Summary/OT_HOURS]" does not exist` | Auto-match silently missed a SNAKE_CASE column alias; formula points at a column ID the DM doesn't expose | Run `scripts/audit-formulas.rb --from-plan` (Phase 6). For repeat offenders, pass `columnMapping` in the swap call proactively |
+| `service_error` 500 on a swap whose `to.definition` contains SQL with single quotes | Heredoc / shell expansion mangled the SQL string | Use a JSON file with `-d @<file>` instead of inline `-d '...'`, or escape carefully |
+| Plan picked the wrong reuse target | The DM with the lowest `dmElementCount` and matching connection was not the most appropriate | Edit `/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at the preferred DM before Phase 5 |
+| `Invalid array: ...columns, got undefined` | Converter returned no columns (SELECT * case) | Fetch columns via `mcp__sigma-mcp-v2__describe` and add them manually |
+| `formula: Invalid string: undefined` | Column missing `formula` field | Every column needs `formula` — `[Custom SQL/SQL_ALIAS]` for sql, `[TABLE/COL]` for warehouse-table |
+| `Circular column reference` | Formula used the column's own display name with no prefix | Use `[Custom SQL/SQL_ALIAS]` — bare `[Display Name]` self-references |
+| `Unknown column '[ALIAS]'` | Bare alias with no prefix | Add the `Custom SQL` prefix: `[Custom SQL/ALIAS]` |
+| `dependency not found: formula reference 'element name/col'` | Used element's own name as formula prefix inside the element | Inside a sql element, always use `[Custom SQL/...]`, never `[ElementName/...]` |
+| `document parent must be a folder` | `folderId` points to a workbook or DM, not a folder | Use `folder_id` from the manifest — taken from the workbook's own folder, always a real folder |
+| Converter returns `path: ["CTE_NAME"]` | Converter treated CTE name as a warehouse table path | Discard converter output; build a `source.kind: "sql"` element manually |
+| `Column '[Element/id]' does not exist` after DM PUT | DM PUT reassigned column IDs — old IDs are stale | Workbook formulas must use display names not IDs: `[Element Name/Column Display Name]` |
+| `dataModelId` missing from response | POST failed silently | Check the full response for a `message` field |
+| Metric columns missing on child elements referencing aggregated SQL | warehouse-table + metrics approach; child references aggregate as a direct column | Rebuild the DM page as a `sql` source with all output columns enumerated explicitly |

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/cline/custom-sql-to-data-model.md
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/cline/custom-sql-to-data-model.md
@@ -1,0 +1,565 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse Sigma data models, then repoint the workbooks via the v3alpha `:swapSources` endpoint. Use when you want to find ad-hoc SQL in workbooks and promote it to one reusable data model per unique query.
+
+# Custom SQL → Data Model
+
+End-to-end flow:
+
+1. Scan workbooks for `source.kind: "sql"` elements (Phase 1).
+2. Scan data models to index every existing SQL or warehouse-table source (Phase 1.5).
+3. Group manifest entries by normalized SQL; for each group, decide **reuse**
+   an existing DM element or **build** a new one (Phase 1.5 → plan).
+4. Build DMs only for the to-build groups (Phase 2 / 3 / 4).
+5. Drive `:swapSources` from the plan, one workbook at a time (Phase 5).
+6. Audit and repair residual `[Prefix/SNAKE_CASE]` formulas left behind by
+   Sigma's auto-match (Phase 6).
+
+The key win versus the legacy GET/mutate/PUT approach: one workbook with N
+SQL elements is one API call with N entries in `sourceMapping`, and the
+auto-match handles formula rewrites — except for the rough edges Phase 6
+catches.
+
+---
+
+## Prerequisites
+
+Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
+
+Always chain the token eval with `&&` so the token is live for all subsequent
+commands in the same block:
+
+```bash
+eval "$(bash scripts/get-token.sh)"
+```
+
+> Tokens expire after ~1 hour. Re-run if you see `Token missing or malformed`.
+
+---
+
+## Phase 1 — Scan workbooks for custom SQL
+
+```bash
+eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-workbooks.rb
+```
+
+Reads every workbook spec in the org, finds all elements where
+`source.kind == "sql"`, and writes `/tmp/custom-sql-manifest.json`.
+
+Each entry:
+
+```json
+{
+  "workbook_id":   "25e21c63-...",
+  "workbook_name": "Custom Sql Test",
+  "folder_id":     "57e59735-...",
+  "element_id":    "6YSI-SjSmz",
+  "element_name":  "Customer Dim SQL",
+  "connection_id": "cb2f5180-...",
+  "sql":           "select * from CSA.TJ.CUSTOMER_DIM",
+  "column_count":  18
+}
+```
+
+`element_id` is the same value as the `customSqlId` consumed by `:swapSources`
+in Phase 5 — no extra lookup needed.
+
+Review the findings and confirm with the user which workbooks to convert.
+
+---
+
+## Phase 1.5 — Index existing DMs and plan dedup
+
+### Scan DMs
+
+```bash
+eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-data-models.rb
+```
+
+Writes `/tmp/dm-sql-index.json`. The scanner emits one entry per existing DM
+element of either kind:
+
+- `kind: "sql"` — indexed by normalized SQL text
+- `kind: "warehouse-table"` — indexed by a synthetic `select * from <path>`
+  string, so trivial `SELECT *` custom-SQL maps to the right table-backed DM
+
+Each entry also tracks `dmElementCount` (total elements in that DM) so the
+planner can prefer focused DMs over kitchen-sink ones.
+
+### Build the swap plan
+
+```bash
+ruby scripts/plan-dedup.rb
+```
+
+Writes `/tmp/swap-plan.json`. The planner:
+
+1. Groups manifest entries by normalized SQL (whitespace/case-collapsed, but
+   no semantic reformatting — copy/paste duplicates collapse, semantically-
+   equivalent rewrites do not).
+2. For each group, looks up the DM index. If a candidate exists, marks the
+   group `status: "existing"` and picks the best target (same connection,
+   fewest DM elements, stable tiebreak). Otherwise marks it `to-build`.
+3. Prints a human-readable summary:
+
+```
+[REUSE] group 1: 3 occurrence(s)
+  SQL: select * from csa.tj.customer_dim
+    - Custom Sql Test / Custom Sql Test SQL (6YSI-SjSmz)
+    - Dedup Test Alpha / Customer Source  (el-customers)
+    - Dedup Test Beta  / Customer Source  (el-customers-dup)
+  -> Customer Dim / Customer Dim  (54d1f450-... / ROZzp25zn9)
+
+[BUILD] group 2: 1 occurrence(s)
+  SQL: with monthly as ( select employee_id, date_trunc('month', date) as month, …
+    - Dedup Test Alpha / OT Summary (el-ot-summary)
+  -> needs new DM (connection cb2f5180-..., folder 57e59735-...)
+
+Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
+```
+
+Confirm with the user before continuing — a `[REUSE]` decision is only as
+good as the picked candidate. If the heuristic picked the wrong DM, edit
+`/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at
+the preferred DM before Phase 5.
+
+---
+
+## Phase 2 — Build the data models for to-build groups
+
+Build one DM per `to-build` group in the plan. Phases 1.5 → 2 → 3 → 4 — only
+the to-build groups need this; reuse groups skip straight to Phase 5.
+
+### One DM per to-build group
+
+A group is "one unique SQL across N workbook occurrences" — build a single
+DM with one element wrapping that SQL, then the same DM/element pair gets
+referenced by every occurrence in the swap call. Do not build per-workbook.
+
+### Try the converter first
+
+For each to-build group:
+
+```
+mcp__sigma-data-model__convert_sql_to_sigma
+  statements    = [{"name": "<group label>", "sql": "<representative sql>"}]
+  connection_id = "<connection_id from manifest>"
+  database      = ""
+  schema        = ""
+```
+
+`database` / `schema` are inferred from the SQL.
+
+### What the converter produces
+
+| SQL type | Converter output | Action |
+|---|---|---|
+| `SELECT *` / `SELECT cols` from one table | Single `warehouse-table` element, no columns | Fetch columns — see below |
+| `SELECT` with JOINs | Multiple `warehouse-table` elements + relationships | Use as-is |
+| `SELECT` with aggregates (GROUP BY) | Elements + `metrics` array | Check child usage — see note below |
+| CTEs (`WITH ...`) | Element with `path: ["CTE_NAME"]` — fake table | Discard — build manually |
+| Subqueries / implicit joins | `Custom SQL` element | Use as-is |
+
+> **Aggregated SQL with GROUP BY**: The warehouse-table + metrics shape only
+> exposes GROUP BY dimensions as direct columns; aggregates land in `metrics`.
+> If child workbook elements reference aggregate columns as direct columns,
+> the DM page must use a `sql` source instead — build manually with the full
+> SQL and enumerate all output columns.
+
+### Column display names — matter for Phases 5 + 6
+
+The swap auto-matches columns between source and target by **display name**,
+case- and punctuation-insensitive (`CUSTOMER_KEY` ↔ `Customer Key`). Most
+columns match cleanly. **The auto-match has known silent misses** — see
+Phase 6 — but those are post-swap-repairable, so don't over-engineer at
+build time. Just ensure the DM column `name` fields are reasonable display
+names ("Total Hours", "OT Hours", …), not SQL aliases.
+
+### Column formula rules (for the DM itself)
+
+| Source kind | Formula inside the DM element | Formula in workbook referencing the DM |
+|---|---|---|
+| `warehouse-table` | `[TABLE_NAME/Column Name]` | `[DM Element Name/Column Name]` |
+| `sql` | `[Custom SQL/SQL_ALIAS]` | `[DM Element Name/Column Display Name]` |
+
+**Key rules:**
+- Inside a `sql` DM element, the formula prefix is always the literal string `Custom SQL` —
+  never the element's own `name` field.
+- Workbook formulas reference DM columns by **display name** (the column's `name` field),
+  not by server-assigned column `id`. Display names are stable across DM PUTs;
+  column IDs are reassigned every PUT.
+
+```python
+def col(sql_alias, display=None):
+    title = display or sql_alias.replace("_", " ").title()
+    return {"id": sql_alias, "name": title, "formula": f"[Custom SQL/{sql_alias}]"}
+```
+
+### SELECT * — converter produces no columns
+
+When the converter returns a `warehouse-table` element with no columns:
+
+1. `mcp__sigma-mcp-v2__search query="<TABLE_NAME>" entityTypes=["table"]` → inodeId
+2. `mcp__sigma-mcp-v2__describe object={"type":"table","inodeId":"<inodeId>"}` → column names
+3. Build columns with `formula: [TABLE/<col>]`, `name: "<Title Case>"`.
+
+### CTEs — discard converter output, build manually
+
+When the converter returns `path: ["CTE_NAME"]`, that CTE name is being used
+as a fake warehouse table path. Discard the converter output and build a
+`sql` element by hand with the full CTE in `source.statement`. Enumerate the
+output columns from the final `SELECT`.
+
+### Set folderId
+
+Always set `folderId` from the plan's `representative.folder_id` (taken
+from the source workbook's own folder — guaranteed real).
+
+---
+
+## Phase 3 — POST the data model
+
+```bash
+eval "$(bash scripts/get-token.sh)" && \
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/<name>-datamodel-spec.json \
+  "$SIGMA_BASE_URL/v2/dataModels/spec" \
+  | ruby -r yaml -r json -r date -e "
+    d = YAML.safe_load(STDIN.read, permitted_classes: [Date, Time])
+    if d['dataModelId']
+      puts 'SUCCESS  dataModelId: ' + d['dataModelId'].to_s
+    else
+      puts 'ERROR: ' + d.inspect
+    end
+  "
+```
+
+> Response is YAML — never pipe to `jq`.
+
+After POST, fetch the spec back with `Accept: application/json` to learn the
+server-assigned element IDs:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" \
+  | jq '.pages[].elements[] | {id, name}'
+```
+
+Update the plan: fill in `target.dataModelId` / `target.elementId` on every
+`to-build` entry with the new IDs.
+
+---
+
+## Phase 4 — Validate the new DMs with MCP
+
+For each newly-built DM:
+
+```
+mcp__sigma-mcp-v2__describe
+  object = {"type": "datamodel", "dataModelId": "<dmId>"}
+```
+
+Then for each element listed:
+
+```
+mcp__sigma-mcp-v2__describe
+  object = {"type": "datamodel-element", "dataModelId": "<dmId>", "elementId": "<elId>"}
+```
+
+```
+mcp__sigma-mcp-v2__query
+  query = { "type": "datamodel", "dataModelId": "<dmId>",
+            "sql": "SELECT * FROM \"datamodel\".\"<elId>\" LIMIT 3" }
+```
+
+Column identifiers in the SQL are the server-assigned IDs from the
+`describe` DDL, not display names.
+
+If anything fails, fix and re-PUT before Phase 5.
+
+---
+
+## Phase 5 — Repoint workbooks via `:swapSources`
+
+Endpoint: `POST /v3alpha/workbooks/{workbookId}:swapSources`.
+
+The call atomically:
+
+- flips `source.kind: "sql"` → `"data-model"` on each root SQL element,
+- rewrites root column formulas from `[Custom SQL/SQL_ALIAS]` to
+  `[DM Element Name/Display Name]`,
+- rewrites child element formulas that referenced the root by name.
+
+### Step 1 — Name unnamed root SQL elements first (CRITICAL)
+
+If a root SQL element has `name: null` (or empty string), child elements
+that referenced it used the implicit prefix `"Custom SQL"`. The swap rewrites
+the root's own formulas correctly but **breaks child formulas to
+`[Missing node/...]`** — and **reversing the swap does not fix them**; the
+"Missing node" placeholder is sticky and requires a manual spec edit to
+recover.
+
+**Always set a real name on each unnamed root SQL element before swapping**,
+and update any child formulas that used the `Custom SQL` prefix to use the
+new name. Then the swap auto-rewrites cleanly.
+
+```ruby
+require 'json'
+WB = '<workbookId>'
+raw = `curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" "$SIGMA_BASE_URL/v2/workbooks/#{WB}/spec"`
+spec = JSON.parse(raw)
+
+manifest = JSON.parse(File.read('/tmp/custom-sql-manifest.json'))
+new_names = manifest
+  .select { |m| m['workbook_id'] == WB }
+  .to_h    { |m| [m['element_id'], m['element_name']] }
+
+# Children that referenced a root we're renaming
+child_parent = {}
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    parent = el.dig('source', 'elementId')
+    child_parent[el['id']] = parent if parent && new_names.key?(parent)
+  end
+end
+
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    if new_names.key?(el['id'])
+      el['name'] = new_names[el['id']] if el['name'].to_s.strip.empty?
+    elsif (parent = child_parent[el['id']])
+      new_prefix = new_names[parent]
+      (el['columns'] || []).each do |col|
+        col['formula'] = col['formula']&.gsub('[Custom SQL/', "[#{new_prefix}/")
+      end
+    end
+  end
+end
+
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion documentVersion].each { |k| spec.delete(k) }
+File.write('/tmp/wb-pre-swap.json', JSON.pretty_generate(spec))
+```
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d @/tmp/wb-pre-swap.json \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec"
+```
+
+> Skip this step only if every root SQL element already has a non-empty
+> `name` AND no child formula references `[Custom SQL/...]`.
+
+### Step 2 — Call `:swapSources` per workbook, batched
+
+For each workbook in the plan, batch all of that workbook's swaps into a
+single call. The example below assumes the plan groups Alpha's two SQL
+elements together; the planner output gives you the mapping.
+
+```bash
+WB="<workbookId>"
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "sourceMapping": [
+      { "from": { "type": "custom-sql", "customSqlId": "<element_id 1>" },
+        "to":   { "type": "data-model", "dataModelId": "<dmId 1>", "elementId": "<elId 1>" } },
+      { "from": { "type": "custom-sql", "customSqlId": "<element_id 2>" },
+        "to":   { "type": "data-model", "dataModelId": "<dmId 2>", "elementId": "<elId 2>" } }
+    ]
+  }' \
+  "${SIGMA_BASE_URL}/v3alpha/workbooks/${WB}:swapSources"
+```
+
+> **Shell gotcha**: the URL contains a `:` which collides with parameter
+> expansion in zsh/bash. Always wrap the variable in braces:
+> `${WB}:swapSources`, not `$WB:swapSources` (`bad substitution` error).
+
+A successful response is HTTP 200 with body `{}`.
+
+### Step 3 — Verify the swap had effect
+
+The endpoint has two specific behaviors to guard against:
+
+| Behavior | Symptom | Mitigation |
+|---|---|---|
+| Bogus `from.customSqlId` (typo or stale) | HTTP 200, `{}` — silent no-op | Re-list `/v2/workbooks/{id}/sources` and assert no `custom-sql` entries remain |
+| Bogus `to` (e.g. wrong DM `elementId`) | HTTP 400 `"Element X not found in data model"` | Match each plan entry's `target` against the Phase 3 readback |
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "${SIGMA_BASE_URL}/v2/workbooks/${WB}/sources" | jq '[.[] | .type] | unique'
+# expect: ["data-model"] (or empty / no custom-sql)
+```
+
+### Column name misalignment — `columnMapping` override (proactive)
+
+The swap auto-matches columns by display name, case- and punctuation-
+insensitive. If you know in advance that some DM column display names won't
+match the custom-SQL aliases (and won't auto-resolve), pass `columnMapping`
+in the same request:
+
+```json
+{
+  "sourceMapping": [
+    {
+      "from": { "type": "custom-sql", "customSqlId": "..." },
+      "to":   { "type": "data-model", "dataModelId": "...", "elementId": "..." },
+      "columnMapping": [
+        { "fromColumn": ["C_KEY"],     "toColumn": ["customer_key"] },
+        { "fromColumn": ["TOTAL_REV"], "toColumn": ["lifetime_revenue"] }
+      ]
+    }
+  ]
+}
+```
+
+For cases you didn't anticipate, Phase 6 cleans up after the fact.
+
+---
+
+## Phase 6 — Audit and repair residual SNAKE_CASE formulas
+
+The auto-match has documented silent misses: short uppercase aliases and
+some token patterns survive the swap as `[Prefix/SNAKE_CASE]` even though
+the DM element's column display name is something like `OT Hours`. The
+broken formula:
+
+- Does **not** error at PUT time.
+- Surfaces at query time as a value-cell error: `Column "[OT Summary/OT_HOURS]" does not exist`.
+- Cascades into child elements that referenced the workbook column by its
+  display name (`[OT Summary/OT Flag]`) — the child returns the same error
+  string as a data value, not a query failure.
+
+The audit script walks each workbook's elements, finds formulas of the form
+`[Prefix/UPPERCASE_TOKEN]` where the local sibling column's `id` matches
+the token but its display `name` differs, and rewrites the suffix to the
+display name. Warehouse-table prefixes are left alone.
+
+```bash
+# audit specific workbooks
+ruby scripts/audit-formulas.rb <workbookId> [<workbookId> ...]
+
+# or audit every workbook touched by the current plan
+ruby scripts/audit-formulas.rb --from-plan
+```
+
+The script reports `N formula(s) repaired` per workbook. Idempotent — safe
+to re-run.
+
+After audit, re-validate with MCP to confirm the cells now return data, not
+error strings:
+
+```
+mcp__sigma-mcp-v2__query
+  query = {"type": "workbook", "workbookId": "<wb>",
+           "sql": "SELECT <cols> FROM \"workbook\".\"<elementId>\" LIMIT 3"}
+```
+
+---
+
+## Manual fallback (legacy, no `:swapSources`)
+
+If `:swapSources` doesn't fit (e.g., a partial swap, or a column remap that's
+easier as a spec edit), the older GET/mutate/PUT approach still works. The
+cost: you keep prefix/display-name rewrite logic in sync with the DM, you
+must strip response-only fields, and layout edits may get rebuilt server-
+side. Prefer `:swapSources` whenever it works.
+
+```ruby
+require 'yaml'; require 'json'; require 'date'
+spec = YAML.safe_load(File.read('/tmp/wb-spec.yaml'), permitted_classes: [Date, Time])
+
+conversions = {
+  '<root_element_id>' => {
+    dataModelId: '<dataModelId>',
+    elementId:   '<server-assigned-element-id>',
+    elementName: '<DM element name, e.g. Customer Dim>'
+  }
+}
+
+root_ids = conversions.keys.to_set
+child_parent = {}
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    parent = el.dig('source', 'elementId')
+    child_parent[el['id']] = parent if parent && root_ids.include?(parent)
+  end
+end
+
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    if (conv = conversions[el['id']])
+      el['name']   = conv[:elementName]
+      el['source'] = { 'kind' => 'data-model', 'dataModelId' => conv[:dataModelId], 'elementId' => conv[:elementId] }
+      (el['columns'] || []).each do |col|
+        display = col['id'].split('_').map(&:capitalize).join(' ')
+        col['formula'] = "[#{conv[:elementName]}/#{display}]"
+      end
+    elsif (parent = child_parent[el['id']])
+      new_prefix = conversions[parent][:elementName]
+      (el['columns'] || []).each { |c| c['formula'] = c['formula']&.gsub('[Custom SQL/', "[#{new_prefix}/") }
+    end
+  end
+end
+
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
+File.write('/tmp/wb-updated.json', JSON.pretty_generate(spec))
+```
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/wb-updated.json \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec"
+```
+
+---
+
+## Data model swap-sources
+
+The same v3alpha shape works for DMs:
+
+```
+POST /v3alpha/dataModels/{dataModelId}:swapSources
+```
+
+Use this when a DM itself contains a custom-SQL element you want to promote.
+Same `sourceMapping[].from` / `.to` shape; same silent-no-op gotcha for
+bogus `from.customSqlId`. Not part of the standard Phase 1–6 flow — included
+for completeness.
+
+---
+
+## Troubleshooting
+
+| Error / symptom | Cause | Fix |
+|---|---|---|
+| `Token missing or malformed` | Token expired between commands | Re-run `eval "$(bash scripts/get-token.sh)"` — chain with `&&` |
+| `:swapSources` returns HTTP 200 `{}` but nothing changed | `from.customSqlId` doesn't match a real element (typo or already swapped) | Re-list `/v2/workbooks/{id}/sources`; assert no `custom-sql` entries remain |
+| `Element X not found in data model` (400) on `:swapSources` | `to.elementId` doesn't exist in the DM | Use the server-assigned ID from Phase 3, not your authoring ID |
+| `bad substitution` on the curl URL | Shell expanded `$WB:swapSources` as a parameter modifier | Wrap in braces: `${WB}:swapSources` |
+| Child element formulas show `[Missing node/...]` after swap | Root SQL element was unnamed; the implicit "Custom SQL" prefix lost its referent | **Sticky** — must be fixed manually. Pre-swap: name the root element AND rewrite child formulas to use that name |
+| Query returns an error string inside a data cell, e.g. `Column "[OT Summary/OT_HOURS]" does not exist` | Auto-match silently missed a SNAKE_CASE column alias; formula points at a column ID the DM doesn't expose | Run `scripts/audit-formulas.rb --from-plan` (Phase 6). For repeat offenders, pass `columnMapping` in the swap call proactively |
+| `service_error` 500 on a swap whose `to.definition` contains SQL with single quotes | Heredoc / shell expansion mangled the SQL string | Use a JSON file with `-d @<file>` instead of inline `-d '...'`, or escape carefully |
+| Plan picked the wrong reuse target | The DM with the lowest `dmElementCount` and matching connection was not the most appropriate | Edit `/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at the preferred DM before Phase 5 |
+| `Invalid array: ...columns, got undefined` | Converter returned no columns (SELECT * case) | Fetch columns via `mcp__sigma-mcp-v2__describe` and add them manually |
+| `formula: Invalid string: undefined` | Column missing `formula` field | Every column needs `formula` — `[Custom SQL/SQL_ALIAS]` for sql, `[TABLE/COL]` for warehouse-table |
+| `Circular column reference` | Formula used the column's own display name with no prefix | Use `[Custom SQL/SQL_ALIAS]` — bare `[Display Name]` self-references |
+| `Unknown column '[ALIAS]'` | Bare alias with no prefix | Add the `Custom SQL` prefix: `[Custom SQL/ALIAS]` |
+| `dependency not found: formula reference 'element name/col'` | Used element's own name as formula prefix inside the element | Inside a sql element, always use `[Custom SQL/...]`, never `[ElementName/...]` |
+| `document parent must be a folder` | `folderId` points to a workbook or DM, not a folder | Use `folder_id` from the manifest — taken from the workbook's own folder, always a real folder |
+| Converter returns `path: ["CTE_NAME"]` | Converter treated CTE name as a warehouse table path | Discard converter output; build a `source.kind: "sql"` element manually |
+| `Column '[Element/id]' does not exist` after DM PUT | DM PUT reassigned column IDs — old IDs are stale | Workbook formulas must use display names not IDs: `[Element Name/Column Display Name]` |
+| `dataModelId` missing from response | POST failed silently | Check the full response for a `message` field |
+| Metric columns missing on child elements referencing aggregated SQL | warehouse-table + metrics approach; child references aggregate as a direct column | Rebuild the DM page as a `sql` source with all output columns enumerated explicitly |

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/codex/AGENTS.md
@@ -1,0 +1,565 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse Sigma data models, then repoint the workbooks via the v3alpha `:swapSources` endpoint. Use when you want to find ad-hoc SQL in workbooks and promote it to one reusable data model per unique query.
+
+# Custom SQL → Data Model
+
+End-to-end flow:
+
+1. Scan workbooks for `source.kind: "sql"` elements (Phase 1).
+2. Scan data models to index every existing SQL or warehouse-table source (Phase 1.5).
+3. Group manifest entries by normalized SQL; for each group, decide **reuse**
+   an existing DM element or **build** a new one (Phase 1.5 → plan).
+4. Build DMs only for the to-build groups (Phase 2 / 3 / 4).
+5. Drive `:swapSources` from the plan, one workbook at a time (Phase 5).
+6. Audit and repair residual `[Prefix/SNAKE_CASE]` formulas left behind by
+   Sigma's auto-match (Phase 6).
+
+The key win versus the legacy GET/mutate/PUT approach: one workbook with N
+SQL elements is one API call with N entries in `sourceMapping`, and the
+auto-match handles formula rewrites — except for the rough edges Phase 6
+catches.
+
+---
+
+## Prerequisites
+
+Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
+
+Always chain the token eval with `&&` so the token is live for all subsequent
+commands in the same block:
+
+```bash
+eval "$(bash scripts/get-token.sh)"
+```
+
+> Tokens expire after ~1 hour. Re-run if you see `Token missing or malformed`.
+
+---
+
+## Phase 1 — Scan workbooks for custom SQL
+
+```bash
+eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-workbooks.rb
+```
+
+Reads every workbook spec in the org, finds all elements where
+`source.kind == "sql"`, and writes `/tmp/custom-sql-manifest.json`.
+
+Each entry:
+
+```json
+{
+  "workbook_id":   "25e21c63-...",
+  "workbook_name": "Custom Sql Test",
+  "folder_id":     "57e59735-...",
+  "element_id":    "6YSI-SjSmz",
+  "element_name":  "Customer Dim SQL",
+  "connection_id": "cb2f5180-...",
+  "sql":           "select * from CSA.TJ.CUSTOMER_DIM",
+  "column_count":  18
+}
+```
+
+`element_id` is the same value as the `customSqlId` consumed by `:swapSources`
+in Phase 5 — no extra lookup needed.
+
+Review the findings and confirm with the user which workbooks to convert.
+
+---
+
+## Phase 1.5 — Index existing DMs and plan dedup
+
+### Scan DMs
+
+```bash
+eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-data-models.rb
+```
+
+Writes `/tmp/dm-sql-index.json`. The scanner emits one entry per existing DM
+element of either kind:
+
+- `kind: "sql"` — indexed by normalized SQL text
+- `kind: "warehouse-table"` — indexed by a synthetic `select * from <path>`
+  string, so trivial `SELECT *` custom-SQL maps to the right table-backed DM
+
+Each entry also tracks `dmElementCount` (total elements in that DM) so the
+planner can prefer focused DMs over kitchen-sink ones.
+
+### Build the swap plan
+
+```bash
+ruby scripts/plan-dedup.rb
+```
+
+Writes `/tmp/swap-plan.json`. The planner:
+
+1. Groups manifest entries by normalized SQL (whitespace/case-collapsed, but
+   no semantic reformatting — copy/paste duplicates collapse, semantically-
+   equivalent rewrites do not).
+2. For each group, looks up the DM index. If a candidate exists, marks the
+   group `status: "existing"` and picks the best target (same connection,
+   fewest DM elements, stable tiebreak). Otherwise marks it `to-build`.
+3. Prints a human-readable summary:
+
+```
+[REUSE] group 1: 3 occurrence(s)
+  SQL: select * from csa.tj.customer_dim
+    - Custom Sql Test / Custom Sql Test SQL (6YSI-SjSmz)
+    - Dedup Test Alpha / Customer Source  (el-customers)
+    - Dedup Test Beta  / Customer Source  (el-customers-dup)
+  -> Customer Dim / Customer Dim  (54d1f450-... / ROZzp25zn9)
+
+[BUILD] group 2: 1 occurrence(s)
+  SQL: with monthly as ( select employee_id, date_trunc('month', date) as month, …
+    - Dedup Test Alpha / OT Summary (el-ot-summary)
+  -> needs new DM (connection cb2f5180-..., folder 57e59735-...)
+
+Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
+```
+
+Confirm with the user before continuing — a `[REUSE]` decision is only as
+good as the picked candidate. If the heuristic picked the wrong DM, edit
+`/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at
+the preferred DM before Phase 5.
+
+---
+
+## Phase 2 — Build the data models for to-build groups
+
+Build one DM per `to-build` group in the plan. Phases 1.5 → 2 → 3 → 4 — only
+the to-build groups need this; reuse groups skip straight to Phase 5.
+
+### One DM per to-build group
+
+A group is "one unique SQL across N workbook occurrences" — build a single
+DM with one element wrapping that SQL, then the same DM/element pair gets
+referenced by every occurrence in the swap call. Do not build per-workbook.
+
+### Try the converter first
+
+For each to-build group:
+
+```
+mcp__sigma-data-model__convert_sql_to_sigma
+  statements    = [{"name": "<group label>", "sql": "<representative sql>"}]
+  connection_id = "<connection_id from manifest>"
+  database      = ""
+  schema        = ""
+```
+
+`database` / `schema` are inferred from the SQL.
+
+### What the converter produces
+
+| SQL type | Converter output | Action |
+|---|---|---|
+| `SELECT *` / `SELECT cols` from one table | Single `warehouse-table` element, no columns | Fetch columns — see below |
+| `SELECT` with JOINs | Multiple `warehouse-table` elements + relationships | Use as-is |
+| `SELECT` with aggregates (GROUP BY) | Elements + `metrics` array | Check child usage — see note below |
+| CTEs (`WITH ...`) | Element with `path: ["CTE_NAME"]` — fake table | Discard — build manually |
+| Subqueries / implicit joins | `Custom SQL` element | Use as-is |
+
+> **Aggregated SQL with GROUP BY**: The warehouse-table + metrics shape only
+> exposes GROUP BY dimensions as direct columns; aggregates land in `metrics`.
+> If child workbook elements reference aggregate columns as direct columns,
+> the DM page must use a `sql` source instead — build manually with the full
+> SQL and enumerate all output columns.
+
+### Column display names — matter for Phases 5 + 6
+
+The swap auto-matches columns between source and target by **display name**,
+case- and punctuation-insensitive (`CUSTOMER_KEY` ↔ `Customer Key`). Most
+columns match cleanly. **The auto-match has known silent misses** — see
+Phase 6 — but those are post-swap-repairable, so don't over-engineer at
+build time. Just ensure the DM column `name` fields are reasonable display
+names ("Total Hours", "OT Hours", …), not SQL aliases.
+
+### Column formula rules (for the DM itself)
+
+| Source kind | Formula inside the DM element | Formula in workbook referencing the DM |
+|---|---|---|
+| `warehouse-table` | `[TABLE_NAME/Column Name]` | `[DM Element Name/Column Name]` |
+| `sql` | `[Custom SQL/SQL_ALIAS]` | `[DM Element Name/Column Display Name]` |
+
+**Key rules:**
+- Inside a `sql` DM element, the formula prefix is always the literal string `Custom SQL` —
+  never the element's own `name` field.
+- Workbook formulas reference DM columns by **display name** (the column's `name` field),
+  not by server-assigned column `id`. Display names are stable across DM PUTs;
+  column IDs are reassigned every PUT.
+
+```python
+def col(sql_alias, display=None):
+    title = display or sql_alias.replace("_", " ").title()
+    return {"id": sql_alias, "name": title, "formula": f"[Custom SQL/{sql_alias}]"}
+```
+
+### SELECT * — converter produces no columns
+
+When the converter returns a `warehouse-table` element with no columns:
+
+1. `mcp__sigma-mcp-v2__search query="<TABLE_NAME>" entityTypes=["table"]` → inodeId
+2. `mcp__sigma-mcp-v2__describe object={"type":"table","inodeId":"<inodeId>"}` → column names
+3. Build columns with `formula: [TABLE/<col>]`, `name: "<Title Case>"`.
+
+### CTEs — discard converter output, build manually
+
+When the converter returns `path: ["CTE_NAME"]`, that CTE name is being used
+as a fake warehouse table path. Discard the converter output and build a
+`sql` element by hand with the full CTE in `source.statement`. Enumerate the
+output columns from the final `SELECT`.
+
+### Set folderId
+
+Always set `folderId` from the plan's `representative.folder_id` (taken
+from the source workbook's own folder — guaranteed real).
+
+---
+
+## Phase 3 — POST the data model
+
+```bash
+eval "$(bash scripts/get-token.sh)" && \
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/<name>-datamodel-spec.json \
+  "$SIGMA_BASE_URL/v2/dataModels/spec" \
+  | ruby -r yaml -r json -r date -e "
+    d = YAML.safe_load(STDIN.read, permitted_classes: [Date, Time])
+    if d['dataModelId']
+      puts 'SUCCESS  dataModelId: ' + d['dataModelId'].to_s
+    else
+      puts 'ERROR: ' + d.inspect
+    end
+  "
+```
+
+> Response is YAML — never pipe to `jq`.
+
+After POST, fetch the spec back with `Accept: application/json` to learn the
+server-assigned element IDs:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" \
+  | jq '.pages[].elements[] | {id, name}'
+```
+
+Update the plan: fill in `target.dataModelId` / `target.elementId` on every
+`to-build` entry with the new IDs.
+
+---
+
+## Phase 4 — Validate the new DMs with MCP
+
+For each newly-built DM:
+
+```
+mcp__sigma-mcp-v2__describe
+  object = {"type": "datamodel", "dataModelId": "<dmId>"}
+```
+
+Then for each element listed:
+
+```
+mcp__sigma-mcp-v2__describe
+  object = {"type": "datamodel-element", "dataModelId": "<dmId>", "elementId": "<elId>"}
+```
+
+```
+mcp__sigma-mcp-v2__query
+  query = { "type": "datamodel", "dataModelId": "<dmId>",
+            "sql": "SELECT * FROM \"datamodel\".\"<elId>\" LIMIT 3" }
+```
+
+Column identifiers in the SQL are the server-assigned IDs from the
+`describe` DDL, not display names.
+
+If anything fails, fix and re-PUT before Phase 5.
+
+---
+
+## Phase 5 — Repoint workbooks via `:swapSources`
+
+Endpoint: `POST /v3alpha/workbooks/{workbookId}:swapSources`.
+
+The call atomically:
+
+- flips `source.kind: "sql"` → `"data-model"` on each root SQL element,
+- rewrites root column formulas from `[Custom SQL/SQL_ALIAS]` to
+  `[DM Element Name/Display Name]`,
+- rewrites child element formulas that referenced the root by name.
+
+### Step 1 — Name unnamed root SQL elements first (CRITICAL)
+
+If a root SQL element has `name: null` (or empty string), child elements
+that referenced it used the implicit prefix `"Custom SQL"`. The swap rewrites
+the root's own formulas correctly but **breaks child formulas to
+`[Missing node/...]`** — and **reversing the swap does not fix them**; the
+"Missing node" placeholder is sticky and requires a manual spec edit to
+recover.
+
+**Always set a real name on each unnamed root SQL element before swapping**,
+and update any child formulas that used the `Custom SQL` prefix to use the
+new name. Then the swap auto-rewrites cleanly.
+
+```ruby
+require 'json'
+WB = '<workbookId>'
+raw = `curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" "$SIGMA_BASE_URL/v2/workbooks/#{WB}/spec"`
+spec = JSON.parse(raw)
+
+manifest = JSON.parse(File.read('/tmp/custom-sql-manifest.json'))
+new_names = manifest
+  .select { |m| m['workbook_id'] == WB }
+  .to_h    { |m| [m['element_id'], m['element_name']] }
+
+# Children that referenced a root we're renaming
+child_parent = {}
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    parent = el.dig('source', 'elementId')
+    child_parent[el['id']] = parent if parent && new_names.key?(parent)
+  end
+end
+
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    if new_names.key?(el['id'])
+      el['name'] = new_names[el['id']] if el['name'].to_s.strip.empty?
+    elsif (parent = child_parent[el['id']])
+      new_prefix = new_names[parent]
+      (el['columns'] || []).each do |col|
+        col['formula'] = col['formula']&.gsub('[Custom SQL/', "[#{new_prefix}/")
+      end
+    end
+  end
+end
+
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion documentVersion].each { |k| spec.delete(k) }
+File.write('/tmp/wb-pre-swap.json', JSON.pretty_generate(spec))
+```
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d @/tmp/wb-pre-swap.json \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec"
+```
+
+> Skip this step only if every root SQL element already has a non-empty
+> `name` AND no child formula references `[Custom SQL/...]`.
+
+### Step 2 — Call `:swapSources` per workbook, batched
+
+For each workbook in the plan, batch all of that workbook's swaps into a
+single call. The example below assumes the plan groups Alpha's two SQL
+elements together; the planner output gives you the mapping.
+
+```bash
+WB="<workbookId>"
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "sourceMapping": [
+      { "from": { "type": "custom-sql", "customSqlId": "<element_id 1>" },
+        "to":   { "type": "data-model", "dataModelId": "<dmId 1>", "elementId": "<elId 1>" } },
+      { "from": { "type": "custom-sql", "customSqlId": "<element_id 2>" },
+        "to":   { "type": "data-model", "dataModelId": "<dmId 2>", "elementId": "<elId 2>" } }
+    ]
+  }' \
+  "${SIGMA_BASE_URL}/v3alpha/workbooks/${WB}:swapSources"
+```
+
+> **Shell gotcha**: the URL contains a `:` which collides with parameter
+> expansion in zsh/bash. Always wrap the variable in braces:
+> `${WB}:swapSources`, not `$WB:swapSources` (`bad substitution` error).
+
+A successful response is HTTP 200 with body `{}`.
+
+### Step 3 — Verify the swap had effect
+
+The endpoint has two specific behaviors to guard against:
+
+| Behavior | Symptom | Mitigation |
+|---|---|---|
+| Bogus `from.customSqlId` (typo or stale) | HTTP 200, `{}` — silent no-op | Re-list `/v2/workbooks/{id}/sources` and assert no `custom-sql` entries remain |
+| Bogus `to` (e.g. wrong DM `elementId`) | HTTP 400 `"Element X not found in data model"` | Match each plan entry's `target` against the Phase 3 readback |
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "${SIGMA_BASE_URL}/v2/workbooks/${WB}/sources" | jq '[.[] | .type] | unique'
+# expect: ["data-model"] (or empty / no custom-sql)
+```
+
+### Column name misalignment — `columnMapping` override (proactive)
+
+The swap auto-matches columns by display name, case- and punctuation-
+insensitive. If you know in advance that some DM column display names won't
+match the custom-SQL aliases (and won't auto-resolve), pass `columnMapping`
+in the same request:
+
+```json
+{
+  "sourceMapping": [
+    {
+      "from": { "type": "custom-sql", "customSqlId": "..." },
+      "to":   { "type": "data-model", "dataModelId": "...", "elementId": "..." },
+      "columnMapping": [
+        { "fromColumn": ["C_KEY"],     "toColumn": ["customer_key"] },
+        { "fromColumn": ["TOTAL_REV"], "toColumn": ["lifetime_revenue"] }
+      ]
+    }
+  ]
+}
+```
+
+For cases you didn't anticipate, Phase 6 cleans up after the fact.
+
+---
+
+## Phase 6 — Audit and repair residual SNAKE_CASE formulas
+
+The auto-match has documented silent misses: short uppercase aliases and
+some token patterns survive the swap as `[Prefix/SNAKE_CASE]` even though
+the DM element's column display name is something like `OT Hours`. The
+broken formula:
+
+- Does **not** error at PUT time.
+- Surfaces at query time as a value-cell error: `Column "[OT Summary/OT_HOURS]" does not exist`.
+- Cascades into child elements that referenced the workbook column by its
+  display name (`[OT Summary/OT Flag]`) — the child returns the same error
+  string as a data value, not a query failure.
+
+The audit script walks each workbook's elements, finds formulas of the form
+`[Prefix/UPPERCASE_TOKEN]` where the local sibling column's `id` matches
+the token but its display `name` differs, and rewrites the suffix to the
+display name. Warehouse-table prefixes are left alone.
+
+```bash
+# audit specific workbooks
+ruby scripts/audit-formulas.rb <workbookId> [<workbookId> ...]
+
+# or audit every workbook touched by the current plan
+ruby scripts/audit-formulas.rb --from-plan
+```
+
+The script reports `N formula(s) repaired` per workbook. Idempotent — safe
+to re-run.
+
+After audit, re-validate with MCP to confirm the cells now return data, not
+error strings:
+
+```
+mcp__sigma-mcp-v2__query
+  query = {"type": "workbook", "workbookId": "<wb>",
+           "sql": "SELECT <cols> FROM \"workbook\".\"<elementId>\" LIMIT 3"}
+```
+
+---
+
+## Manual fallback (legacy, no `:swapSources`)
+
+If `:swapSources` doesn't fit (e.g., a partial swap, or a column remap that's
+easier as a spec edit), the older GET/mutate/PUT approach still works. The
+cost: you keep prefix/display-name rewrite logic in sync with the DM, you
+must strip response-only fields, and layout edits may get rebuilt server-
+side. Prefer `:swapSources` whenever it works.
+
+```ruby
+require 'yaml'; require 'json'; require 'date'
+spec = YAML.safe_load(File.read('/tmp/wb-spec.yaml'), permitted_classes: [Date, Time])
+
+conversions = {
+  '<root_element_id>' => {
+    dataModelId: '<dataModelId>',
+    elementId:   '<server-assigned-element-id>',
+    elementName: '<DM element name, e.g. Customer Dim>'
+  }
+}
+
+root_ids = conversions.keys.to_set
+child_parent = {}
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    parent = el.dig('source', 'elementId')
+    child_parent[el['id']] = parent if parent && root_ids.include?(parent)
+  end
+end
+
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    if (conv = conversions[el['id']])
+      el['name']   = conv[:elementName]
+      el['source'] = { 'kind' => 'data-model', 'dataModelId' => conv[:dataModelId], 'elementId' => conv[:elementId] }
+      (el['columns'] || []).each do |col|
+        display = col['id'].split('_').map(&:capitalize).join(' ')
+        col['formula'] = "[#{conv[:elementName]}/#{display}]"
+      end
+    elsif (parent = child_parent[el['id']])
+      new_prefix = conversions[parent][:elementName]
+      (el['columns'] || []).each { |c| c['formula'] = c['formula']&.gsub('[Custom SQL/', "[#{new_prefix}/") }
+    end
+  end
+end
+
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
+File.write('/tmp/wb-updated.json', JSON.pretty_generate(spec))
+```
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/wb-updated.json \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec"
+```
+
+---
+
+## Data model swap-sources
+
+The same v3alpha shape works for DMs:
+
+```
+POST /v3alpha/dataModels/{dataModelId}:swapSources
+```
+
+Use this when a DM itself contains a custom-SQL element you want to promote.
+Same `sourceMapping[].from` / `.to` shape; same silent-no-op gotcha for
+bogus `from.customSqlId`. Not part of the standard Phase 1–6 flow — included
+for completeness.
+
+---
+
+## Troubleshooting
+
+| Error / symptom | Cause | Fix |
+|---|---|---|
+| `Token missing or malformed` | Token expired between commands | Re-run `eval "$(bash scripts/get-token.sh)"` — chain with `&&` |
+| `:swapSources` returns HTTP 200 `{}` but nothing changed | `from.customSqlId` doesn't match a real element (typo or already swapped) | Re-list `/v2/workbooks/{id}/sources`; assert no `custom-sql` entries remain |
+| `Element X not found in data model` (400) on `:swapSources` | `to.elementId` doesn't exist in the DM | Use the server-assigned ID from Phase 3, not your authoring ID |
+| `bad substitution` on the curl URL | Shell expanded `$WB:swapSources` as a parameter modifier | Wrap in braces: `${WB}:swapSources` |
+| Child element formulas show `[Missing node/...]` after swap | Root SQL element was unnamed; the implicit "Custom SQL" prefix lost its referent | **Sticky** — must be fixed manually. Pre-swap: name the root element AND rewrite child formulas to use that name |
+| Query returns an error string inside a data cell, e.g. `Column "[OT Summary/OT_HOURS]" does not exist` | Auto-match silently missed a SNAKE_CASE column alias; formula points at a column ID the DM doesn't expose | Run `scripts/audit-formulas.rb --from-plan` (Phase 6). For repeat offenders, pass `columnMapping` in the swap call proactively |
+| `service_error` 500 on a swap whose `to.definition` contains SQL with single quotes | Heredoc / shell expansion mangled the SQL string | Use a JSON file with `-d @<file>` instead of inline `-d '...'`, or escape carefully |
+| Plan picked the wrong reuse target | The DM with the lowest `dmElementCount` and matching connection was not the most appropriate | Edit `/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at the preferred DM before Phase 5 |
+| `Invalid array: ...columns, got undefined` | Converter returned no columns (SELECT * case) | Fetch columns via `mcp__sigma-mcp-v2__describe` and add them manually |
+| `formula: Invalid string: undefined` | Column missing `formula` field | Every column needs `formula` — `[Custom SQL/SQL_ALIAS]` for sql, `[TABLE/COL]` for warehouse-table |
+| `Circular column reference` | Formula used the column's own display name with no prefix | Use `[Custom SQL/SQL_ALIAS]` — bare `[Display Name]` self-references |
+| `Unknown column '[ALIAS]'` | Bare alias with no prefix | Add the `Custom SQL` prefix: `[Custom SQL/ALIAS]` |
+| `dependency not found: formula reference 'element name/col'` | Used element's own name as formula prefix inside the element | Inside a sql element, always use `[Custom SQL/...]`, never `[ElementName/...]` |
+| `document parent must be a folder` | `folderId` points to a workbook or DM, not a folder | Use `folder_id` from the manifest — taken from the workbook's own folder, always a real folder |
+| Converter returns `path: ["CTE_NAME"]` | Converter treated CTE name as a warehouse table path | Discard converter output; build a `source.kind: "sql"` element manually |
+| `Column '[Element/id]' does not exist` after DM PUT | DM PUT reassigned column IDs — old IDs are stale | Workbook formulas must use display names not IDs: `[Element Name/Column Display Name]` |
+| `dataModelId` missing from response | POST failed silently | Check the full response for a `message` field |
+| Metric columns missing on child elements referencing aggregated SQL | warehouse-table + metrics approach; child references aggregate as a direct column | Rebuild the DM page as a `sql` source with all output columns enumerated explicitly |

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/continue/custom-sql-to-data-model.md
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/continue/custom-sql-to-data-model.md
@@ -1,0 +1,565 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse Sigma data models, then repoint the workbooks via the v3alpha `:swapSources` endpoint. Use when you want to find ad-hoc SQL in workbooks and promote it to one reusable data model per unique query.
+
+# Custom SQL → Data Model
+
+End-to-end flow:
+
+1. Scan workbooks for `source.kind: "sql"` elements (Phase 1).
+2. Scan data models to index every existing SQL or warehouse-table source (Phase 1.5).
+3. Group manifest entries by normalized SQL; for each group, decide **reuse**
+   an existing DM element or **build** a new one (Phase 1.5 → plan).
+4. Build DMs only for the to-build groups (Phase 2 / 3 / 4).
+5. Drive `:swapSources` from the plan, one workbook at a time (Phase 5).
+6. Audit and repair residual `[Prefix/SNAKE_CASE]` formulas left behind by
+   Sigma's auto-match (Phase 6).
+
+The key win versus the legacy GET/mutate/PUT approach: one workbook with N
+SQL elements is one API call with N entries in `sourceMapping`, and the
+auto-match handles formula rewrites — except for the rough edges Phase 6
+catches.
+
+---
+
+## Prerequisites
+
+Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
+
+Always chain the token eval with `&&` so the token is live for all subsequent
+commands in the same block:
+
+```bash
+eval "$(bash scripts/get-token.sh)"
+```
+
+> Tokens expire after ~1 hour. Re-run if you see `Token missing or malformed`.
+
+---
+
+## Phase 1 — Scan workbooks for custom SQL
+
+```bash
+eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-workbooks.rb
+```
+
+Reads every workbook spec in the org, finds all elements where
+`source.kind == "sql"`, and writes `/tmp/custom-sql-manifest.json`.
+
+Each entry:
+
+```json
+{
+  "workbook_id":   "25e21c63-...",
+  "workbook_name": "Custom Sql Test",
+  "folder_id":     "57e59735-...",
+  "element_id":    "6YSI-SjSmz",
+  "element_name":  "Customer Dim SQL",
+  "connection_id": "cb2f5180-...",
+  "sql":           "select * from CSA.TJ.CUSTOMER_DIM",
+  "column_count":  18
+}
+```
+
+`element_id` is the same value as the `customSqlId` consumed by `:swapSources`
+in Phase 5 — no extra lookup needed.
+
+Review the findings and confirm with the user which workbooks to convert.
+
+---
+
+## Phase 1.5 — Index existing DMs and plan dedup
+
+### Scan DMs
+
+```bash
+eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-data-models.rb
+```
+
+Writes `/tmp/dm-sql-index.json`. The scanner emits one entry per existing DM
+element of either kind:
+
+- `kind: "sql"` — indexed by normalized SQL text
+- `kind: "warehouse-table"` — indexed by a synthetic `select * from <path>`
+  string, so trivial `SELECT *` custom-SQL maps to the right table-backed DM
+
+Each entry also tracks `dmElementCount` (total elements in that DM) so the
+planner can prefer focused DMs over kitchen-sink ones.
+
+### Build the swap plan
+
+```bash
+ruby scripts/plan-dedup.rb
+```
+
+Writes `/tmp/swap-plan.json`. The planner:
+
+1. Groups manifest entries by normalized SQL (whitespace/case-collapsed, but
+   no semantic reformatting — copy/paste duplicates collapse, semantically-
+   equivalent rewrites do not).
+2. For each group, looks up the DM index. If a candidate exists, marks the
+   group `status: "existing"` and picks the best target (same connection,
+   fewest DM elements, stable tiebreak). Otherwise marks it `to-build`.
+3. Prints a human-readable summary:
+
+```
+[REUSE] group 1: 3 occurrence(s)
+  SQL: select * from csa.tj.customer_dim
+    - Custom Sql Test / Custom Sql Test SQL (6YSI-SjSmz)
+    - Dedup Test Alpha / Customer Source  (el-customers)
+    - Dedup Test Beta  / Customer Source  (el-customers-dup)
+  -> Customer Dim / Customer Dim  (54d1f450-... / ROZzp25zn9)
+
+[BUILD] group 2: 1 occurrence(s)
+  SQL: with monthly as ( select employee_id, date_trunc('month', date) as month, …
+    - Dedup Test Alpha / OT Summary (el-ot-summary)
+  -> needs new DM (connection cb2f5180-..., folder 57e59735-...)
+
+Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
+```
+
+Confirm with the user before continuing — a `[REUSE]` decision is only as
+good as the picked candidate. If the heuristic picked the wrong DM, edit
+`/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at
+the preferred DM before Phase 5.
+
+---
+
+## Phase 2 — Build the data models for to-build groups
+
+Build one DM per `to-build` group in the plan. Phases 1.5 → 2 → 3 → 4 — only
+the to-build groups need this; reuse groups skip straight to Phase 5.
+
+### One DM per to-build group
+
+A group is "one unique SQL across N workbook occurrences" — build a single
+DM with one element wrapping that SQL, then the same DM/element pair gets
+referenced by every occurrence in the swap call. Do not build per-workbook.
+
+### Try the converter first
+
+For each to-build group:
+
+```
+mcp__sigma-data-model__convert_sql_to_sigma
+  statements    = [{"name": "<group label>", "sql": "<representative sql>"}]
+  connection_id = "<connection_id from manifest>"
+  database      = ""
+  schema        = ""
+```
+
+`database` / `schema` are inferred from the SQL.
+
+### What the converter produces
+
+| SQL type | Converter output | Action |
+|---|---|---|
+| `SELECT *` / `SELECT cols` from one table | Single `warehouse-table` element, no columns | Fetch columns — see below |
+| `SELECT` with JOINs | Multiple `warehouse-table` elements + relationships | Use as-is |
+| `SELECT` with aggregates (GROUP BY) | Elements + `metrics` array | Check child usage — see note below |
+| CTEs (`WITH ...`) | Element with `path: ["CTE_NAME"]` — fake table | Discard — build manually |
+| Subqueries / implicit joins | `Custom SQL` element | Use as-is |
+
+> **Aggregated SQL with GROUP BY**: The warehouse-table + metrics shape only
+> exposes GROUP BY dimensions as direct columns; aggregates land in `metrics`.
+> If child workbook elements reference aggregate columns as direct columns,
+> the DM page must use a `sql` source instead — build manually with the full
+> SQL and enumerate all output columns.
+
+### Column display names — matter for Phases 5 + 6
+
+The swap auto-matches columns between source and target by **display name**,
+case- and punctuation-insensitive (`CUSTOMER_KEY` ↔ `Customer Key`). Most
+columns match cleanly. **The auto-match has known silent misses** — see
+Phase 6 — but those are post-swap-repairable, so don't over-engineer at
+build time. Just ensure the DM column `name` fields are reasonable display
+names ("Total Hours", "OT Hours", …), not SQL aliases.
+
+### Column formula rules (for the DM itself)
+
+| Source kind | Formula inside the DM element | Formula in workbook referencing the DM |
+|---|---|---|
+| `warehouse-table` | `[TABLE_NAME/Column Name]` | `[DM Element Name/Column Name]` |
+| `sql` | `[Custom SQL/SQL_ALIAS]` | `[DM Element Name/Column Display Name]` |
+
+**Key rules:**
+- Inside a `sql` DM element, the formula prefix is always the literal string `Custom SQL` —
+  never the element's own `name` field.
+- Workbook formulas reference DM columns by **display name** (the column's `name` field),
+  not by server-assigned column `id`. Display names are stable across DM PUTs;
+  column IDs are reassigned every PUT.
+
+```python
+def col(sql_alias, display=None):
+    title = display or sql_alias.replace("_", " ").title()
+    return {"id": sql_alias, "name": title, "formula": f"[Custom SQL/{sql_alias}]"}
+```
+
+### SELECT * — converter produces no columns
+
+When the converter returns a `warehouse-table` element with no columns:
+
+1. `mcp__sigma-mcp-v2__search query="<TABLE_NAME>" entityTypes=["table"]` → inodeId
+2. `mcp__sigma-mcp-v2__describe object={"type":"table","inodeId":"<inodeId>"}` → column names
+3. Build columns with `formula: [TABLE/<col>]`, `name: "<Title Case>"`.
+
+### CTEs — discard converter output, build manually
+
+When the converter returns `path: ["CTE_NAME"]`, that CTE name is being used
+as a fake warehouse table path. Discard the converter output and build a
+`sql` element by hand with the full CTE in `source.statement`. Enumerate the
+output columns from the final `SELECT`.
+
+### Set folderId
+
+Always set `folderId` from the plan's `representative.folder_id` (taken
+from the source workbook's own folder — guaranteed real).
+
+---
+
+## Phase 3 — POST the data model
+
+```bash
+eval "$(bash scripts/get-token.sh)" && \
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/<name>-datamodel-spec.json \
+  "$SIGMA_BASE_URL/v2/dataModels/spec" \
+  | ruby -r yaml -r json -r date -e "
+    d = YAML.safe_load(STDIN.read, permitted_classes: [Date, Time])
+    if d['dataModelId']
+      puts 'SUCCESS  dataModelId: ' + d['dataModelId'].to_s
+    else
+      puts 'ERROR: ' + d.inspect
+    end
+  "
+```
+
+> Response is YAML — never pipe to `jq`.
+
+After POST, fetch the spec back with `Accept: application/json` to learn the
+server-assigned element IDs:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" \
+  | jq '.pages[].elements[] | {id, name}'
+```
+
+Update the plan: fill in `target.dataModelId` / `target.elementId` on every
+`to-build` entry with the new IDs.
+
+---
+
+## Phase 4 — Validate the new DMs with MCP
+
+For each newly-built DM:
+
+```
+mcp__sigma-mcp-v2__describe
+  object = {"type": "datamodel", "dataModelId": "<dmId>"}
+```
+
+Then for each element listed:
+
+```
+mcp__sigma-mcp-v2__describe
+  object = {"type": "datamodel-element", "dataModelId": "<dmId>", "elementId": "<elId>"}
+```
+
+```
+mcp__sigma-mcp-v2__query
+  query = { "type": "datamodel", "dataModelId": "<dmId>",
+            "sql": "SELECT * FROM \"datamodel\".\"<elId>\" LIMIT 3" }
+```
+
+Column identifiers in the SQL are the server-assigned IDs from the
+`describe` DDL, not display names.
+
+If anything fails, fix and re-PUT before Phase 5.
+
+---
+
+## Phase 5 — Repoint workbooks via `:swapSources`
+
+Endpoint: `POST /v3alpha/workbooks/{workbookId}:swapSources`.
+
+The call atomically:
+
+- flips `source.kind: "sql"` → `"data-model"` on each root SQL element,
+- rewrites root column formulas from `[Custom SQL/SQL_ALIAS]` to
+  `[DM Element Name/Display Name]`,
+- rewrites child element formulas that referenced the root by name.
+
+### Step 1 — Name unnamed root SQL elements first (CRITICAL)
+
+If a root SQL element has `name: null` (or empty string), child elements
+that referenced it used the implicit prefix `"Custom SQL"`. The swap rewrites
+the root's own formulas correctly but **breaks child formulas to
+`[Missing node/...]`** — and **reversing the swap does not fix them**; the
+"Missing node" placeholder is sticky and requires a manual spec edit to
+recover.
+
+**Always set a real name on each unnamed root SQL element before swapping**,
+and update any child formulas that used the `Custom SQL` prefix to use the
+new name. Then the swap auto-rewrites cleanly.
+
+```ruby
+require 'json'
+WB = '<workbookId>'
+raw = `curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" "$SIGMA_BASE_URL/v2/workbooks/#{WB}/spec"`
+spec = JSON.parse(raw)
+
+manifest = JSON.parse(File.read('/tmp/custom-sql-manifest.json'))
+new_names = manifest
+  .select { |m| m['workbook_id'] == WB }
+  .to_h    { |m| [m['element_id'], m['element_name']] }
+
+# Children that referenced a root we're renaming
+child_parent = {}
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    parent = el.dig('source', 'elementId')
+    child_parent[el['id']] = parent if parent && new_names.key?(parent)
+  end
+end
+
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    if new_names.key?(el['id'])
+      el['name'] = new_names[el['id']] if el['name'].to_s.strip.empty?
+    elsif (parent = child_parent[el['id']])
+      new_prefix = new_names[parent]
+      (el['columns'] || []).each do |col|
+        col['formula'] = col['formula']&.gsub('[Custom SQL/', "[#{new_prefix}/")
+      end
+    end
+  end
+end
+
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion documentVersion].each { |k| spec.delete(k) }
+File.write('/tmp/wb-pre-swap.json', JSON.pretty_generate(spec))
+```
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d @/tmp/wb-pre-swap.json \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec"
+```
+
+> Skip this step only if every root SQL element already has a non-empty
+> `name` AND no child formula references `[Custom SQL/...]`.
+
+### Step 2 — Call `:swapSources` per workbook, batched
+
+For each workbook in the plan, batch all of that workbook's swaps into a
+single call. The example below assumes the plan groups Alpha's two SQL
+elements together; the planner output gives you the mapping.
+
+```bash
+WB="<workbookId>"
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "sourceMapping": [
+      { "from": { "type": "custom-sql", "customSqlId": "<element_id 1>" },
+        "to":   { "type": "data-model", "dataModelId": "<dmId 1>", "elementId": "<elId 1>" } },
+      { "from": { "type": "custom-sql", "customSqlId": "<element_id 2>" },
+        "to":   { "type": "data-model", "dataModelId": "<dmId 2>", "elementId": "<elId 2>" } }
+    ]
+  }' \
+  "${SIGMA_BASE_URL}/v3alpha/workbooks/${WB}:swapSources"
+```
+
+> **Shell gotcha**: the URL contains a `:` which collides with parameter
+> expansion in zsh/bash. Always wrap the variable in braces:
+> `${WB}:swapSources`, not `$WB:swapSources` (`bad substitution` error).
+
+A successful response is HTTP 200 with body `{}`.
+
+### Step 3 — Verify the swap had effect
+
+The endpoint has two specific behaviors to guard against:
+
+| Behavior | Symptom | Mitigation |
+|---|---|---|
+| Bogus `from.customSqlId` (typo or stale) | HTTP 200, `{}` — silent no-op | Re-list `/v2/workbooks/{id}/sources` and assert no `custom-sql` entries remain |
+| Bogus `to` (e.g. wrong DM `elementId`) | HTTP 400 `"Element X not found in data model"` | Match each plan entry's `target` against the Phase 3 readback |
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "${SIGMA_BASE_URL}/v2/workbooks/${WB}/sources" | jq '[.[] | .type] | unique'
+# expect: ["data-model"] (or empty / no custom-sql)
+```
+
+### Column name misalignment — `columnMapping` override (proactive)
+
+The swap auto-matches columns by display name, case- and punctuation-
+insensitive. If you know in advance that some DM column display names won't
+match the custom-SQL aliases (and won't auto-resolve), pass `columnMapping`
+in the same request:
+
+```json
+{
+  "sourceMapping": [
+    {
+      "from": { "type": "custom-sql", "customSqlId": "..." },
+      "to":   { "type": "data-model", "dataModelId": "...", "elementId": "..." },
+      "columnMapping": [
+        { "fromColumn": ["C_KEY"],     "toColumn": ["customer_key"] },
+        { "fromColumn": ["TOTAL_REV"], "toColumn": ["lifetime_revenue"] }
+      ]
+    }
+  ]
+}
+```
+
+For cases you didn't anticipate, Phase 6 cleans up after the fact.
+
+---
+
+## Phase 6 — Audit and repair residual SNAKE_CASE formulas
+
+The auto-match has documented silent misses: short uppercase aliases and
+some token patterns survive the swap as `[Prefix/SNAKE_CASE]` even though
+the DM element's column display name is something like `OT Hours`. The
+broken formula:
+
+- Does **not** error at PUT time.
+- Surfaces at query time as a value-cell error: `Column "[OT Summary/OT_HOURS]" does not exist`.
+- Cascades into child elements that referenced the workbook column by its
+  display name (`[OT Summary/OT Flag]`) — the child returns the same error
+  string as a data value, not a query failure.
+
+The audit script walks each workbook's elements, finds formulas of the form
+`[Prefix/UPPERCASE_TOKEN]` where the local sibling column's `id` matches
+the token but its display `name` differs, and rewrites the suffix to the
+display name. Warehouse-table prefixes are left alone.
+
+```bash
+# audit specific workbooks
+ruby scripts/audit-formulas.rb <workbookId> [<workbookId> ...]
+
+# or audit every workbook touched by the current plan
+ruby scripts/audit-formulas.rb --from-plan
+```
+
+The script reports `N formula(s) repaired` per workbook. Idempotent — safe
+to re-run.
+
+After audit, re-validate with MCP to confirm the cells now return data, not
+error strings:
+
+```
+mcp__sigma-mcp-v2__query
+  query = {"type": "workbook", "workbookId": "<wb>",
+           "sql": "SELECT <cols> FROM \"workbook\".\"<elementId>\" LIMIT 3"}
+```
+
+---
+
+## Manual fallback (legacy, no `:swapSources`)
+
+If `:swapSources` doesn't fit (e.g., a partial swap, or a column remap that's
+easier as a spec edit), the older GET/mutate/PUT approach still works. The
+cost: you keep prefix/display-name rewrite logic in sync with the DM, you
+must strip response-only fields, and layout edits may get rebuilt server-
+side. Prefer `:swapSources` whenever it works.
+
+```ruby
+require 'yaml'; require 'json'; require 'date'
+spec = YAML.safe_load(File.read('/tmp/wb-spec.yaml'), permitted_classes: [Date, Time])
+
+conversions = {
+  '<root_element_id>' => {
+    dataModelId: '<dataModelId>',
+    elementId:   '<server-assigned-element-id>',
+    elementName: '<DM element name, e.g. Customer Dim>'
+  }
+}
+
+root_ids = conversions.keys.to_set
+child_parent = {}
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    parent = el.dig('source', 'elementId')
+    child_parent[el['id']] = parent if parent && root_ids.include?(parent)
+  end
+end
+
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    if (conv = conversions[el['id']])
+      el['name']   = conv[:elementName]
+      el['source'] = { 'kind' => 'data-model', 'dataModelId' => conv[:dataModelId], 'elementId' => conv[:elementId] }
+      (el['columns'] || []).each do |col|
+        display = col['id'].split('_').map(&:capitalize).join(' ')
+        col['formula'] = "[#{conv[:elementName]}/#{display}]"
+      end
+    elsif (parent = child_parent[el['id']])
+      new_prefix = conversions[parent][:elementName]
+      (el['columns'] || []).each { |c| c['formula'] = c['formula']&.gsub('[Custom SQL/', "[#{new_prefix}/") }
+    end
+  end
+end
+
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
+File.write('/tmp/wb-updated.json', JSON.pretty_generate(spec))
+```
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/wb-updated.json \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec"
+```
+
+---
+
+## Data model swap-sources
+
+The same v3alpha shape works for DMs:
+
+```
+POST /v3alpha/dataModels/{dataModelId}:swapSources
+```
+
+Use this when a DM itself contains a custom-SQL element you want to promote.
+Same `sourceMapping[].from` / `.to` shape; same silent-no-op gotcha for
+bogus `from.customSqlId`. Not part of the standard Phase 1–6 flow — included
+for completeness.
+
+---
+
+## Troubleshooting
+
+| Error / symptom | Cause | Fix |
+|---|---|---|
+| `Token missing or malformed` | Token expired between commands | Re-run `eval "$(bash scripts/get-token.sh)"` — chain with `&&` |
+| `:swapSources` returns HTTP 200 `{}` but nothing changed | `from.customSqlId` doesn't match a real element (typo or already swapped) | Re-list `/v2/workbooks/{id}/sources`; assert no `custom-sql` entries remain |
+| `Element X not found in data model` (400) on `:swapSources` | `to.elementId` doesn't exist in the DM | Use the server-assigned ID from Phase 3, not your authoring ID |
+| `bad substitution` on the curl URL | Shell expanded `$WB:swapSources` as a parameter modifier | Wrap in braces: `${WB}:swapSources` |
+| Child element formulas show `[Missing node/...]` after swap | Root SQL element was unnamed; the implicit "Custom SQL" prefix lost its referent | **Sticky** — must be fixed manually. Pre-swap: name the root element AND rewrite child formulas to use that name |
+| Query returns an error string inside a data cell, e.g. `Column "[OT Summary/OT_HOURS]" does not exist` | Auto-match silently missed a SNAKE_CASE column alias; formula points at a column ID the DM doesn't expose | Run `scripts/audit-formulas.rb --from-plan` (Phase 6). For repeat offenders, pass `columnMapping` in the swap call proactively |
+| `service_error` 500 on a swap whose `to.definition` contains SQL with single quotes | Heredoc / shell expansion mangled the SQL string | Use a JSON file with `-d @<file>` instead of inline `-d '...'`, or escape carefully |
+| Plan picked the wrong reuse target | The DM with the lowest `dmElementCount` and matching connection was not the most appropriate | Edit `/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at the preferred DM before Phase 5 |
+| `Invalid array: ...columns, got undefined` | Converter returned no columns (SELECT * case) | Fetch columns via `mcp__sigma-mcp-v2__describe` and add them manually |
+| `formula: Invalid string: undefined` | Column missing `formula` field | Every column needs `formula` — `[Custom SQL/SQL_ALIAS]` for sql, `[TABLE/COL]` for warehouse-table |
+| `Circular column reference` | Formula used the column's own display name with no prefix | Use `[Custom SQL/SQL_ALIAS]` — bare `[Display Name]` self-references |
+| `Unknown column '[ALIAS]'` | Bare alias with no prefix | Add the `Custom SQL` prefix: `[Custom SQL/ALIAS]` |
+| `dependency not found: formula reference 'element name/col'` | Used element's own name as formula prefix inside the element | Inside a sql element, always use `[Custom SQL/...]`, never `[ElementName/...]` |
+| `document parent must be a folder` | `folderId` points to a workbook or DM, not a folder | Use `folder_id` from the manifest — taken from the workbook's own folder, always a real folder |
+| Converter returns `path: ["CTE_NAME"]` | Converter treated CTE name as a warehouse table path | Discard converter output; build a `source.kind: "sql"` element manually |
+| `Column '[Element/id]' does not exist` after DM PUT | DM PUT reassigned column IDs — old IDs are stale | Workbook formulas must use display names not IDs: `[Element Name/Column Display Name]` |
+| `dataModelId` missing from response | POST failed silently | Check the full response for a `message` field |
+| Metric columns missing on child elements referencing aggregated SQL | warehouse-table + metrics approach; child references aggregate as a direct column | Rebuild the DM page as a `sql` source with all output columns enumerated explicitly |

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/cursor/rules/custom-sql-to-data-model.mdc
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/cursor/rules/custom-sql-to-data-model.mdc
@@ -1,0 +1,570 @@
+---
+description: "Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse Sigma data models, then repoint the workbooks via the v3alpha `:swapSources` endpoint. Use when you want to find ad-hoc SQL in workbooks and promote it to one reusable data model per unique query."
+alwaysApply: false
+---
+
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse Sigma data models, then repoint the workbooks via the v3alpha `:swapSources` endpoint. Use when you want to find ad-hoc SQL in workbooks and promote it to one reusable data model per unique query.
+
+# Custom SQL → Data Model
+
+End-to-end flow:
+
+1. Scan workbooks for `source.kind: "sql"` elements (Phase 1).
+2. Scan data models to index every existing SQL or warehouse-table source (Phase 1.5).
+3. Group manifest entries by normalized SQL; for each group, decide **reuse**
+   an existing DM element or **build** a new one (Phase 1.5 → plan).
+4. Build DMs only for the to-build groups (Phase 2 / 3 / 4).
+5. Drive `:swapSources` from the plan, one workbook at a time (Phase 5).
+6. Audit and repair residual `[Prefix/SNAKE_CASE]` formulas left behind by
+   Sigma's auto-match (Phase 6).
+
+The key win versus the legacy GET/mutate/PUT approach: one workbook with N
+SQL elements is one API call with N entries in `sourceMapping`, and the
+auto-match handles formula rewrites — except for the rough edges Phase 6
+catches.
+
+---
+
+## Prerequisites
+
+Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
+
+Always chain the token eval with `&&` so the token is live for all subsequent
+commands in the same block:
+
+```bash
+eval "$(bash scripts/get-token.sh)"
+```
+
+> Tokens expire after ~1 hour. Re-run if you see `Token missing or malformed`.
+
+---
+
+## Phase 1 — Scan workbooks for custom SQL
+
+```bash
+eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-workbooks.rb
+```
+
+Reads every workbook spec in the org, finds all elements where
+`source.kind == "sql"`, and writes `/tmp/custom-sql-manifest.json`.
+
+Each entry:
+
+```json
+{
+  "workbook_id":   "25e21c63-...",
+  "workbook_name": "Custom Sql Test",
+  "folder_id":     "57e59735-...",
+  "element_id":    "6YSI-SjSmz",
+  "element_name":  "Customer Dim SQL",
+  "connection_id": "cb2f5180-...",
+  "sql":           "select * from CSA.TJ.CUSTOMER_DIM",
+  "column_count":  18
+}
+```
+
+`element_id` is the same value as the `customSqlId` consumed by `:swapSources`
+in Phase 5 — no extra lookup needed.
+
+Review the findings and confirm with the user which workbooks to convert.
+
+---
+
+## Phase 1.5 — Index existing DMs and plan dedup
+
+### Scan DMs
+
+```bash
+eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-data-models.rb
+```
+
+Writes `/tmp/dm-sql-index.json`. The scanner emits one entry per existing DM
+element of either kind:
+
+- `kind: "sql"` — indexed by normalized SQL text
+- `kind: "warehouse-table"` — indexed by a synthetic `select * from <path>`
+  string, so trivial `SELECT *` custom-SQL maps to the right table-backed DM
+
+Each entry also tracks `dmElementCount` (total elements in that DM) so the
+planner can prefer focused DMs over kitchen-sink ones.
+
+### Build the swap plan
+
+```bash
+ruby scripts/plan-dedup.rb
+```
+
+Writes `/tmp/swap-plan.json`. The planner:
+
+1. Groups manifest entries by normalized SQL (whitespace/case-collapsed, but
+   no semantic reformatting — copy/paste duplicates collapse, semantically-
+   equivalent rewrites do not).
+2. For each group, looks up the DM index. If a candidate exists, marks the
+   group `status: "existing"` and picks the best target (same connection,
+   fewest DM elements, stable tiebreak). Otherwise marks it `to-build`.
+3. Prints a human-readable summary:
+
+```
+[REUSE] group 1: 3 occurrence(s)
+  SQL: select * from csa.tj.customer_dim
+    - Custom Sql Test / Custom Sql Test SQL (6YSI-SjSmz)
+    - Dedup Test Alpha / Customer Source  (el-customers)
+    - Dedup Test Beta  / Customer Source  (el-customers-dup)
+  -> Customer Dim / Customer Dim  (54d1f450-... / ROZzp25zn9)
+
+[BUILD] group 2: 1 occurrence(s)
+  SQL: with monthly as ( select employee_id, date_trunc('month', date) as month, …
+    - Dedup Test Alpha / OT Summary (el-ot-summary)
+  -> needs new DM (connection cb2f5180-..., folder 57e59735-...)
+
+Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
+```
+
+Confirm with the user before continuing — a `[REUSE]` decision is only as
+good as the picked candidate. If the heuristic picked the wrong DM, edit
+`/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at
+the preferred DM before Phase 5.
+
+---
+
+## Phase 2 — Build the data models for to-build groups
+
+Build one DM per `to-build` group in the plan. Phases 1.5 → 2 → 3 → 4 — only
+the to-build groups need this; reuse groups skip straight to Phase 5.
+
+### One DM per to-build group
+
+A group is "one unique SQL across N workbook occurrences" — build a single
+DM with one element wrapping that SQL, then the same DM/element pair gets
+referenced by every occurrence in the swap call. Do not build per-workbook.
+
+### Try the converter first
+
+For each to-build group:
+
+```
+mcp__sigma-data-model__convert_sql_to_sigma
+  statements    = [{"name": "<group label>", "sql": "<representative sql>"}]
+  connection_id = "<connection_id from manifest>"
+  database      = ""
+  schema        = ""
+```
+
+`database` / `schema` are inferred from the SQL.
+
+### What the converter produces
+
+| SQL type | Converter output | Action |
+|---|---|---|
+| `SELECT *` / `SELECT cols` from one table | Single `warehouse-table` element, no columns | Fetch columns — see below |
+| `SELECT` with JOINs | Multiple `warehouse-table` elements + relationships | Use as-is |
+| `SELECT` with aggregates (GROUP BY) | Elements + `metrics` array | Check child usage — see note below |
+| CTEs (`WITH ...`) | Element with `path: ["CTE_NAME"]` — fake table | Discard — build manually |
+| Subqueries / implicit joins | `Custom SQL` element | Use as-is |
+
+> **Aggregated SQL with GROUP BY**: The warehouse-table + metrics shape only
+> exposes GROUP BY dimensions as direct columns; aggregates land in `metrics`.
+> If child workbook elements reference aggregate columns as direct columns,
+> the DM page must use a `sql` source instead — build manually with the full
+> SQL and enumerate all output columns.
+
+### Column display names — matter for Phases 5 + 6
+
+The swap auto-matches columns between source and target by **display name**,
+case- and punctuation-insensitive (`CUSTOMER_KEY` ↔ `Customer Key`). Most
+columns match cleanly. **The auto-match has known silent misses** — see
+Phase 6 — but those are post-swap-repairable, so don't over-engineer at
+build time. Just ensure the DM column `name` fields are reasonable display
+names ("Total Hours", "OT Hours", …), not SQL aliases.
+
+### Column formula rules (for the DM itself)
+
+| Source kind | Formula inside the DM element | Formula in workbook referencing the DM |
+|---|---|---|
+| `warehouse-table` | `[TABLE_NAME/Column Name]` | `[DM Element Name/Column Name]` |
+| `sql` | `[Custom SQL/SQL_ALIAS]` | `[DM Element Name/Column Display Name]` |
+
+**Key rules:**
+- Inside a `sql` DM element, the formula prefix is always the literal string `Custom SQL` —
+  never the element's own `name` field.
+- Workbook formulas reference DM columns by **display name** (the column's `name` field),
+  not by server-assigned column `id`. Display names are stable across DM PUTs;
+  column IDs are reassigned every PUT.
+
+```python
+def col(sql_alias, display=None):
+    title = display or sql_alias.replace("_", " ").title()
+    return {"id": sql_alias, "name": title, "formula": f"[Custom SQL/{sql_alias}]"}
+```
+
+### SELECT * — converter produces no columns
+
+When the converter returns a `warehouse-table` element with no columns:
+
+1. `mcp__sigma-mcp-v2__search query="<TABLE_NAME>" entityTypes=["table"]` → inodeId
+2. `mcp__sigma-mcp-v2__describe object={"type":"table","inodeId":"<inodeId>"}` → column names
+3. Build columns with `formula: [TABLE/<col>]`, `name: "<Title Case>"`.
+
+### CTEs — discard converter output, build manually
+
+When the converter returns `path: ["CTE_NAME"]`, that CTE name is being used
+as a fake warehouse table path. Discard the converter output and build a
+`sql` element by hand with the full CTE in `source.statement`. Enumerate the
+output columns from the final `SELECT`.
+
+### Set folderId
+
+Always set `folderId` from the plan's `representative.folder_id` (taken
+from the source workbook's own folder — guaranteed real).
+
+---
+
+## Phase 3 — POST the data model
+
+```bash
+eval "$(bash scripts/get-token.sh)" && \
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/<name>-datamodel-spec.json \
+  "$SIGMA_BASE_URL/v2/dataModels/spec" \
+  | ruby -r yaml -r json -r date -e "
+    d = YAML.safe_load(STDIN.read, permitted_classes: [Date, Time])
+    if d['dataModelId']
+      puts 'SUCCESS  dataModelId: ' + d['dataModelId'].to_s
+    else
+      puts 'ERROR: ' + d.inspect
+    end
+  "
+```
+
+> Response is YAML — never pipe to `jq`.
+
+After POST, fetch the spec back with `Accept: application/json` to learn the
+server-assigned element IDs:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" \
+  | jq '.pages[].elements[] | {id, name}'
+```
+
+Update the plan: fill in `target.dataModelId` / `target.elementId` on every
+`to-build` entry with the new IDs.
+
+---
+
+## Phase 4 — Validate the new DMs with MCP
+
+For each newly-built DM:
+
+```
+mcp__sigma-mcp-v2__describe
+  object = {"type": "datamodel", "dataModelId": "<dmId>"}
+```
+
+Then for each element listed:
+
+```
+mcp__sigma-mcp-v2__describe
+  object = {"type": "datamodel-element", "dataModelId": "<dmId>", "elementId": "<elId>"}
+```
+
+```
+mcp__sigma-mcp-v2__query
+  query = { "type": "datamodel", "dataModelId": "<dmId>",
+            "sql": "SELECT * FROM \"datamodel\".\"<elId>\" LIMIT 3" }
+```
+
+Column identifiers in the SQL are the server-assigned IDs from the
+`describe` DDL, not display names.
+
+If anything fails, fix and re-PUT before Phase 5.
+
+---
+
+## Phase 5 — Repoint workbooks via `:swapSources`
+
+Endpoint: `POST /v3alpha/workbooks/{workbookId}:swapSources`.
+
+The call atomically:
+
+- flips `source.kind: "sql"` → `"data-model"` on each root SQL element,
+- rewrites root column formulas from `[Custom SQL/SQL_ALIAS]` to
+  `[DM Element Name/Display Name]`,
+- rewrites child element formulas that referenced the root by name.
+
+### Step 1 — Name unnamed root SQL elements first (CRITICAL)
+
+If a root SQL element has `name: null` (or empty string), child elements
+that referenced it used the implicit prefix `"Custom SQL"`. The swap rewrites
+the root's own formulas correctly but **breaks child formulas to
+`[Missing node/...]`** — and **reversing the swap does not fix them**; the
+"Missing node" placeholder is sticky and requires a manual spec edit to
+recover.
+
+**Always set a real name on each unnamed root SQL element before swapping**,
+and update any child formulas that used the `Custom SQL` prefix to use the
+new name. Then the swap auto-rewrites cleanly.
+
+```ruby
+require 'json'
+WB = '<workbookId>'
+raw = `curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" "$SIGMA_BASE_URL/v2/workbooks/#{WB}/spec"`
+spec = JSON.parse(raw)
+
+manifest = JSON.parse(File.read('/tmp/custom-sql-manifest.json'))
+new_names = manifest
+  .select { |m| m['workbook_id'] == WB }
+  .to_h    { |m| [m['element_id'], m['element_name']] }
+
+# Children that referenced a root we're renaming
+child_parent = {}
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    parent = el.dig('source', 'elementId')
+    child_parent[el['id']] = parent if parent && new_names.key?(parent)
+  end
+end
+
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    if new_names.key?(el['id'])
+      el['name'] = new_names[el['id']] if el['name'].to_s.strip.empty?
+    elsif (parent = child_parent[el['id']])
+      new_prefix = new_names[parent]
+      (el['columns'] || []).each do |col|
+        col['formula'] = col['formula']&.gsub('[Custom SQL/', "[#{new_prefix}/")
+      end
+    end
+  end
+end
+
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion documentVersion].each { |k| spec.delete(k) }
+File.write('/tmp/wb-pre-swap.json', JSON.pretty_generate(spec))
+```
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d @/tmp/wb-pre-swap.json \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec"
+```
+
+> Skip this step only if every root SQL element already has a non-empty
+> `name` AND no child formula references `[Custom SQL/...]`.
+
+### Step 2 — Call `:swapSources` per workbook, batched
+
+For each workbook in the plan, batch all of that workbook's swaps into a
+single call. The example below assumes the plan groups Alpha's two SQL
+elements together; the planner output gives you the mapping.
+
+```bash
+WB="<workbookId>"
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "sourceMapping": [
+      { "from": { "type": "custom-sql", "customSqlId": "<element_id 1>" },
+        "to":   { "type": "data-model", "dataModelId": "<dmId 1>", "elementId": "<elId 1>" } },
+      { "from": { "type": "custom-sql", "customSqlId": "<element_id 2>" },
+        "to":   { "type": "data-model", "dataModelId": "<dmId 2>", "elementId": "<elId 2>" } }
+    ]
+  }' \
+  "${SIGMA_BASE_URL}/v3alpha/workbooks/${WB}:swapSources"
+```
+
+> **Shell gotcha**: the URL contains a `:` which collides with parameter
+> expansion in zsh/bash. Always wrap the variable in braces:
+> `${WB}:swapSources`, not `$WB:swapSources` (`bad substitution` error).
+
+A successful response is HTTP 200 with body `{}`.
+
+### Step 3 — Verify the swap had effect
+
+The endpoint has two specific behaviors to guard against:
+
+| Behavior | Symptom | Mitigation |
+|---|---|---|
+| Bogus `from.customSqlId` (typo or stale) | HTTP 200, `{}` — silent no-op | Re-list `/v2/workbooks/{id}/sources` and assert no `custom-sql` entries remain |
+| Bogus `to` (e.g. wrong DM `elementId`) | HTTP 400 `"Element X not found in data model"` | Match each plan entry's `target` against the Phase 3 readback |
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "${SIGMA_BASE_URL}/v2/workbooks/${WB}/sources" | jq '[.[] | .type] | unique'
+# expect: ["data-model"] (or empty / no custom-sql)
+```
+
+### Column name misalignment — `columnMapping` override (proactive)
+
+The swap auto-matches columns by display name, case- and punctuation-
+insensitive. If you know in advance that some DM column display names won't
+match the custom-SQL aliases (and won't auto-resolve), pass `columnMapping`
+in the same request:
+
+```json
+{
+  "sourceMapping": [
+    {
+      "from": { "type": "custom-sql", "customSqlId": "..." },
+      "to":   { "type": "data-model", "dataModelId": "...", "elementId": "..." },
+      "columnMapping": [
+        { "fromColumn": ["C_KEY"],     "toColumn": ["customer_key"] },
+        { "fromColumn": ["TOTAL_REV"], "toColumn": ["lifetime_revenue"] }
+      ]
+    }
+  ]
+}
+```
+
+For cases you didn't anticipate, Phase 6 cleans up after the fact.
+
+---
+
+## Phase 6 — Audit and repair residual SNAKE_CASE formulas
+
+The auto-match has documented silent misses: short uppercase aliases and
+some token patterns survive the swap as `[Prefix/SNAKE_CASE]` even though
+the DM element's column display name is something like `OT Hours`. The
+broken formula:
+
+- Does **not** error at PUT time.
+- Surfaces at query time as a value-cell error: `Column "[OT Summary/OT_HOURS]" does not exist`.
+- Cascades into child elements that referenced the workbook column by its
+  display name (`[OT Summary/OT Flag]`) — the child returns the same error
+  string as a data value, not a query failure.
+
+The audit script walks each workbook's elements, finds formulas of the form
+`[Prefix/UPPERCASE_TOKEN]` where the local sibling column's `id` matches
+the token but its display `name` differs, and rewrites the suffix to the
+display name. Warehouse-table prefixes are left alone.
+
+```bash
+# audit specific workbooks
+ruby scripts/audit-formulas.rb <workbookId> [<workbookId> ...]
+
+# or audit every workbook touched by the current plan
+ruby scripts/audit-formulas.rb --from-plan
+```
+
+The script reports `N formula(s) repaired` per workbook. Idempotent — safe
+to re-run.
+
+After audit, re-validate with MCP to confirm the cells now return data, not
+error strings:
+
+```
+mcp__sigma-mcp-v2__query
+  query = {"type": "workbook", "workbookId": "<wb>",
+           "sql": "SELECT <cols> FROM \"workbook\".\"<elementId>\" LIMIT 3"}
+```
+
+---
+
+## Manual fallback (legacy, no `:swapSources`)
+
+If `:swapSources` doesn't fit (e.g., a partial swap, or a column remap that's
+easier as a spec edit), the older GET/mutate/PUT approach still works. The
+cost: you keep prefix/display-name rewrite logic in sync with the DM, you
+must strip response-only fields, and layout edits may get rebuilt server-
+side. Prefer `:swapSources` whenever it works.
+
+```ruby
+require 'yaml'; require 'json'; require 'date'
+spec = YAML.safe_load(File.read('/tmp/wb-spec.yaml'), permitted_classes: [Date, Time])
+
+conversions = {
+  '<root_element_id>' => {
+    dataModelId: '<dataModelId>',
+    elementId:   '<server-assigned-element-id>',
+    elementName: '<DM element name, e.g. Customer Dim>'
+  }
+}
+
+root_ids = conversions.keys.to_set
+child_parent = {}
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    parent = el.dig('source', 'elementId')
+    child_parent[el['id']] = parent if parent && root_ids.include?(parent)
+  end
+end
+
+spec['pages'].each do |page|
+  page['elements'].each do |el|
+    if (conv = conversions[el['id']])
+      el['name']   = conv[:elementName]
+      el['source'] = { 'kind' => 'data-model', 'dataModelId' => conv[:dataModelId], 'elementId' => conv[:elementId] }
+      (el['columns'] || []).each do |col|
+        display = col['id'].split('_').map(&:capitalize).join(' ')
+        col['formula'] = "[#{conv[:elementName]}/#{display}]"
+      end
+    elsif (parent = child_parent[el['id']])
+      new_prefix = conversions[parent][:elementName]
+      (el['columns'] || []).each { |c| c['formula'] = c['formula']&.gsub('[Custom SQL/', "[#{new_prefix}/") }
+    end
+  end
+end
+
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
+File.write('/tmp/wb-updated.json', JSON.pretty_generate(spec))
+```
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/wb-updated.json \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbookId>/spec"
+```
+
+---
+
+## Data model swap-sources
+
+The same v3alpha shape works for DMs:
+
+```
+POST /v3alpha/dataModels/{dataModelId}:swapSources
+```
+
+Use this when a DM itself contains a custom-SQL element you want to promote.
+Same `sourceMapping[].from` / `.to` shape; same silent-no-op gotcha for
+bogus `from.customSqlId`. Not part of the standard Phase 1–6 flow — included
+for completeness.
+
+---
+
+## Troubleshooting
+
+| Error / symptom | Cause | Fix |
+|---|---|---|
+| `Token missing or malformed` | Token expired between commands | Re-run `eval "$(bash scripts/get-token.sh)"` — chain with `&&` |
+| `:swapSources` returns HTTP 200 `{}` but nothing changed | `from.customSqlId` doesn't match a real element (typo or already swapped) | Re-list `/v2/workbooks/{id}/sources`; assert no `custom-sql` entries remain |
+| `Element X not found in data model` (400) on `:swapSources` | `to.elementId` doesn't exist in the DM | Use the server-assigned ID from Phase 3, not your authoring ID |
+| `bad substitution` on the curl URL | Shell expanded `$WB:swapSources` as a parameter modifier | Wrap in braces: `${WB}:swapSources` |
+| Child element formulas show `[Missing node/...]` after swap | Root SQL element was unnamed; the implicit "Custom SQL" prefix lost its referent | **Sticky** — must be fixed manually. Pre-swap: name the root element AND rewrite child formulas to use that name |
+| Query returns an error string inside a data cell, e.g. `Column "[OT Summary/OT_HOURS]" does not exist` | Auto-match silently missed a SNAKE_CASE column alias; formula points at a column ID the DM doesn't expose | Run `scripts/audit-formulas.rb --from-plan` (Phase 6). For repeat offenders, pass `columnMapping` in the swap call proactively |
+| `service_error` 500 on a swap whose `to.definition` contains SQL with single quotes | Heredoc / shell expansion mangled the SQL string | Use a JSON file with `-d @<file>` instead of inline `-d '...'`, or escape carefully |
+| Plan picked the wrong reuse target | The DM with the lowest `dmElementCount` and matching connection was not the most appropriate | Edit `/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at the preferred DM before Phase 5 |
+| `Invalid array: ...columns, got undefined` | Converter returned no columns (SELECT * case) | Fetch columns via `mcp__sigma-mcp-v2__describe` and add them manually |
+| `formula: Invalid string: undefined` | Column missing `formula` field | Every column needs `formula` — `[Custom SQL/SQL_ALIAS]` for sql, `[TABLE/COL]` for warehouse-table |
+| `Circular column reference` | Formula used the column's own display name with no prefix | Use `[Custom SQL/SQL_ALIAS]` — bare `[Display Name]` self-references |
+| `Unknown column '[ALIAS]'` | Bare alias with no prefix | Add the `Custom SQL` prefix: `[Custom SQL/ALIAS]` |
+| `dependency not found: formula reference 'element name/col'` | Used element's own name as formula prefix inside the element | Inside a sql element, always use `[Custom SQL/...]`, never `[ElementName/...]` |
+| `document parent must be a folder` | `folderId` points to a workbook or DM, not a folder | Use `folder_id` from the manifest — taken from the workbook's own folder, always a real folder |
+| Converter returns `path: ["CTE_NAME"]` | Converter treated CTE name as a warehouse table path | Discard converter output; build a `source.kind: "sql"` element manually |
+| `Column '[Element/id]' does not exist` after DM PUT | DM PUT reassigned column IDs — old IDs are stale | Workbook formulas must use display names not IDs: `[Element Name/Column Display Name]` |
+| `dataModelId` missing from response | POST failed silently | Check the full response for a `message` field |
+| Metric columns missing on child elements referencing aggregated SQL | warehouse-table + metrics approach; child references aggregate as a direct column | Rebuild the DM page as a `sql` source with all output columns enumerated explicitly |

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/audit-formulas.rb
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/audit-formulas.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+# Post-swap formula audit. After :swapSources, the Sigma auto-match converts
+# most SQL aliases (e.g. `EMPLOYEE_ID`) into the matching DM column's display
+# name (`Employee Id`). It silently misses some — short uppercase tokens,
+# tokens that share a prefix with siblings, etc. — leaving broken formulas
+# like `[OT Summary/OT_HOURS]` that point at a column ID the DM doesn't expose.
+#
+# This script walks every workbook the user passes, finds residual
+# `[Prefix/SNAKE_CASE]` formulas where SNAKE_CASE matches a sibling column's
+# `id` field but not its `name`, and rewrites them to `[Prefix/<Display Name>]`.
+# It does NOT touch warehouse formulas (`[WAREHOUSE_TABLE/COL]`) — those are
+# legitimate.
+#
+# Usage:
+#   ruby scripts/audit-formulas.rb <workbookId> [<workbookId> ...]
+# Or, drive from /tmp/swap-plan.json:
+#   ruby scripts/audit-formulas.rb --from-plan
+
+require 'net/http'
+require 'uri'
+require 'json'
+
+BASE_URL = ENV.fetch('SIGMA_BASE_URL')
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+# Audit loops over every dedup candidate's workbook + PUTs corrections;
+# Sigma.request auto-refreshes on 401 mid-run.
+def http_req(method, path, body = nil)
+  res = Sigma.request(method, path, body: body, accept: '*/*')
+  res.is_a?(String) ? res : res.to_json
+end
+
+def audit_one(wb_id)
+  raw = http_req(:get, "/v2/workbooks/#{wb_id}/spec")
+  spec = JSON.parse(raw)
+
+  fixed_count = 0
+  spec['pages'].each do |page|
+    (page['elements'] || []).each do |el|
+      next unless el['columns'].is_a?(Array)
+      # Map: column id (often the SQL alias) → display name
+      alias_to_display = el['columns'].to_h { |c| [c['id'], c['name']] }
+
+      el['columns'].each do |col|
+        next unless col['formula']
+        new_formula = col['formula'].gsub(/\[([^\/\]]+)\/([A-Z0-9_]+)\]/) do
+          prefix, snake = $1, $2
+          display = alias_to_display[snake]
+          # Only rewrite when display differs (i.e. there's a real Title-Cased name available)
+          if display && display != snake
+            fixed_count += 1
+            "[#{prefix}/#{display}]"
+          else
+            $~[0]
+          end
+        end
+        col['formula'] = new_formula
+      end
+    end
+  end
+
+  return [wb_id, 0] if fixed_count.zero?
+
+  # Strip response-only top-level fields before PUT
+  %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion documentVersion].each { |k| spec.delete(k) }
+
+  resp = http_req(:put, "/v2/workbooks/#{wb_id}/spec", JSON.pretty_generate(spec))
+  ok = JSON.parse(resp)['workbookId'] rescue nil
+  abort "PUT failed for #{wb_id}: #{resp}" unless ok
+  [wb_id, fixed_count]
+end
+
+ids =
+  if ARGV.first == '--from-plan'
+    plan = JSON.parse(File.read('/tmp/swap-plan.json'))
+    plan.flat_map { |e| (e['workbooks'] || []).map { |w| w['workbook_id'] } }.uniq
+  else
+    ARGV
+  end
+
+abort 'no workbooks specified' if ids.empty?
+
+ids.each do |id|
+  wb, fixed = audit_one(id)
+  puts "  #{wb}: #{fixed} formula(s) repaired"
+end

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get-token.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get-token.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Exchange Sigma client credentials for a bearer token.
+# Usage:  eval "$(scripts/get-token.sh)"
+# Sets SIGMA_API_TOKEN in the calling shell.
+
+set -euo pipefail
+
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  "$SIGMA_BASE_URL/v2/auth/token") || {
+    echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null \
+  || echo "$RESPONSE" | ruby -r json -e "print JSON.parse(STDIN.read)['access_token']")
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Token exchange failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+echo "export SIGMA_API_TOKEN=${TOKEN}"

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/lib/sigma_rest.rb
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/lib/sigma_rest.rb
@@ -1,0 +1,115 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN'] || refresh_token!
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      @token_mutex.synchronize { @token_override = tok }
+      # Surface the refreshed token to child processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/plan-dedup.rb
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/plan-dedup.rb
@@ -1,0 +1,116 @@
+#!/usr/bin/env ruby
+# Read the workbook manifest and the DM-SQL index, group manifest entries by
+# normalized SQL, and emit a swap plan. For each unique SQL:
+#   - If a DM element already wraps it → reuse (status: "existing")
+#   - Otherwise → mark as needs-build (status: "to-build")
+#
+# Output: /tmp/swap-plan.json — an array of plan entries. Each entry has the
+# normalized SQL, the list of workbook occurrences that share it, and either
+# an existing target {dataModelId, elementId} OR a `to_build: true` flag with
+# a representative sql/connection_id/folder_id the user can pass to Phase 2.
+#
+# Usage:
+#   ruby scripts/scan-workbooks.rb
+#   ruby scripts/scan-data-models.rb
+#   ruby scripts/plan-dedup.rb
+
+require 'json'
+
+MANIFEST = '/tmp/custom-sql-manifest.json'
+DM_INDEX = '/tmp/dm-sql-index.json'
+OUT      = '/tmp/swap-plan.json'
+
+unless File.exist?(MANIFEST)
+  abort "missing #{MANIFEST} — run scan-workbooks.rb first"
+end
+unless File.exist?(DM_INDEX)
+  abort "missing #{DM_INDEX} — run scan-data-models.rb first"
+end
+
+def normalize_sql(s)
+  return nil if s.nil?
+  s.to_s.strip.gsub(/\s+/, ' ').downcase
+end
+
+manifest = JSON.parse(File.read(MANIFEST))
+dm_index = JSON.parse(File.read(DM_INDEX))
+
+# Group manifest by normalized SQL
+groups = manifest.group_by { |m| normalize_sql(m['sql']) }
+
+plan = groups.map do |norm, occurrences|
+  rep = occurrences.first  # representative for SQL/connection/folder
+
+  # Look up existing DM element
+  candidates = dm_index[norm] || []
+
+  # Pick the best candidate. Heuristic in order:
+  #   1. Same connection as the workbook's custom-SQL
+  #   2. Fewest elements in the DM (most focused — beats kitchen-sink DMs)
+  #   3. Stable tiebreak by DM name then element name
+  match = candidates
+    .sort_by { |c| [
+      c['connectionId'] == rep['connection_id'] ? 0 : 1,
+      c['dmElementCount'] || 999_999,
+      c['dataModelName'].to_s,
+      c['elementName'].to_s
+    ] }
+    .first
+
+  entry = {
+    normalized_sql_preview: norm.to_s.slice(0, 120),
+    occurrence_count:       occurrences.size,
+    workbooks:              occurrences.map { |o|
+                              { workbook_id:   o['workbook_id'],
+                                workbook_name: o['workbook_name'],
+                                element_id:    o['element_id'],
+                                element_name:  o['element_name'] }
+                            },
+    representative: {
+      sql:           rep['sql'],
+      connection_id: rep['connection_id'],
+      folder_id:     rep['folder_id']
+    }
+  }
+
+  if match
+    entry[:status]      = 'existing'
+    entry[:target]      = {
+      dataModelId:   match['dataModelId'],
+      dataModelName: match['dataModelName'],
+      elementId:     match['elementId'],
+      elementName:   match['elementName']
+    }
+  else
+    entry[:status]      = 'to-build'
+    entry[:target]      = nil
+  end
+  entry
+end
+
+# Order: to-build first (most actionable), then existing
+plan.sort_by! { |e| [e[:status] == 'to-build' ? 0 : 1, -e[:occurrence_count]] }
+
+File.write(OUT, JSON.pretty_generate(plan))
+puts "Plan written to #{OUT}\n\n"
+
+plan.each_with_index do |e, i|
+  marker = e[:status] == 'existing' ? '[REUSE]' : '[BUILD]'
+  puts "#{marker} group #{i + 1}: #{e[:occurrence_count]} occurrence(s)"
+  puts "  SQL: #{e[:normalized_sql_preview]}#{'…' if e[:normalized_sql_preview].length >= 120}"
+  e[:workbooks].each do |w|
+    puts "    - #{w[:workbook_name]} / #{w[:element_name]} (#{w[:element_id]})"
+  end
+  if e[:status] == 'existing'
+    t = e[:target]
+    puts "  -> #{t[:dataModelName]} / #{t[:elementName]} (#{t[:dataModelId]} / #{t[:elementId]})"
+  else
+    puts "  -> needs new DM (connection #{e[:representative][:connection_id]}, folder #{e[:representative][:folder_id]})"
+  end
+  puts
+end
+
+build_count = plan.count { |e| e[:status] == 'to-build' }
+reuse_count = plan.count { |e| e[:status] == 'existing' }
+total_swaps = plan.sum { |e| e[:occurrence_count] }
+puts "Summary: #{plan.size} unique SQL strings → #{reuse_count} reuse, #{build_count} build. #{total_swaps} total swap actions."

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/scan-data-models.rb
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/scan-data-models.rb
@@ -1,0 +1,122 @@
+#!/usr/bin/env ruby
+# Scan all data models for elements with source.kind == "sql".
+# Outputs a JSON index keyed by normalized SQL to /tmp/dm-sql-index.json,
+# used by plan-dedup.rb to decide whether to reuse an existing DM element
+# or build a new one for a given custom-SQL fingerprint.
+#
+# Usage:
+#   eval "$(bash scripts/get-token.sh)"
+#   ruby scripts/scan-data-models.rb
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'yaml'
+require 'date'
+
+BASE_URL = ENV.fetch('SIGMA_BASE_URL') { abort 'SIGMA_BASE_URL not set' }
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+# Full-site DM scans can outlive a single 1-hour token; Sigma.request
+# auto-refreshes on 401.
+def get(path)
+  res = Sigma.request(:get, path, accept: '*/*')
+  res.is_a?(String) ? res : res.to_json
+end
+
+# Normalize a SQL string for equivalence comparison.
+# Removes leading/trailing whitespace, collapses internal whitespace, lowercases.
+# Intentionally conservative — does not reformat or reorder clauses, so two
+# functionally-equivalent queries written differently will be treated as
+# distinct. The point is to catch true duplicates from copy/paste.
+def normalize_sql(s)
+  return nil if s.nil?
+  s.to_s.strip.gsub(/\s+/, ' ').downcase
+end
+
+# Fetch all data models (paginate)
+puts 'Fetching data model list...'
+dms = []
+next_page = nil
+loop do
+  path = '/v2/dataModels?limit=100'
+  path += "&page=#{next_page}" if next_page
+  body = JSON.parse(get(path))
+  dms.concat(body.fetch('entries', []))
+  next_page = body['nextPage']
+  break unless next_page
+end
+puts "Found #{dms.size} data models total.\n\n"
+
+# Walk each DM spec for SQL elements
+index = {}  # normalized_sql => [ { dataModelId, dataModelName, elementId, elementName, connectionId, sql } ]
+dms.each do |dm|
+  dmid = dm['dataModelId']
+  name = dm['name']
+
+  begin
+    raw  = get("/v2/dataModels/#{dmid}/spec")
+    spec = JSON.parse(raw)
+    next unless spec.is_a?(Hash) && spec['pages']
+  rescue => e
+    $stderr.puts "  [ERROR] #{name} (#{dmid}): #{e.message}"
+    next
+  end
+
+  # Total element count across all pages — used by the planner to prefer
+  # focused DMs (fewer elements) over kitchen-sink models when picking
+  # between equivalent candidates.
+  dm_element_count = spec['pages'].sum { |p| (p['elements'] || []).size }
+
+  spec['pages'].each do |page|
+    (page['elements'] || []).each do |el|
+      src = el['source']
+      next unless src.is_a?(Hash)
+
+      case src['kind']
+      when 'sql'
+        norm = normalize_sql(src['statement'])
+        entry = {
+          dataModelId:      dmid,
+          dataModelName:    name,
+          dmElementCount:   dm_element_count,
+          elementId:        el['id'],
+          elementName:      el['name'],
+          connectionId:     src['connectionId'],
+          sourceKind:    'sql',
+          sql:           src['statement']
+        }
+        (index[norm] ||= []) << entry
+        puts "  [FOUND] #{name} / #{el['name']} (sql)"
+
+      when 'warehouse-table'
+        # Surface warehouse-table elements as candidates for trivial
+        # `SELECT * FROM <path>` custom-SQL. Keyed by a synthetic
+        # equivalent so the normalizer collapses to one bucket.
+        path = (src['path'] || []).map { |p| p.to_s.downcase }.join('.')
+        next if path.empty?
+        synthetic = "select * from #{path}"
+        entry = {
+          dataModelId:      dmid,
+          dataModelName:    name,
+          dmElementCount:   dm_element_count,
+          elementId:        el['id'],
+          elementName:      el['name'],
+          connectionId:     src['connectionId'],
+          sourceKind:    'warehouse-table',
+          path:          src['path']
+        }
+        (index[synthetic] ||= []) << entry
+        puts "  [FOUND] #{name} / #{el['name']} (warehouse-table → #{synthetic})"
+      end
+    end
+  end
+end
+
+puts "\n#{'=' * 60}"
+puts "Unique SQL strings indexed across DMs: #{index.size}"
+
+out = '/tmp/dm-sql-index.json'
+File.write(out, JSON.pretty_generate(index))
+puts "Index written to #{out}"

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/scan-workbooks.rb
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/scan-workbooks.rb
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+# Scan all workbooks for elements with source.kind == "sql".
+# Outputs a JSON manifest to /tmp/custom-sql-manifest.json
+#
+# Usage:
+#   eval "$(bash scripts/get-token.sh)"
+#   ruby scripts/scan-workbooks.rb
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'yaml'
+require 'date'
+
+BASE_URL = ENV.fetch('SIGMA_BASE_URL') { abort 'SIGMA_BASE_URL not set — run: eval "$(bash scripts/get-token.sh)"' }
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+# Full-site workbook scans paginate over hundreds of items and can take >1
+# hour on large customer orgs; Sigma.request auto-refreshes on 401.
+def get(path)
+  res = Sigma.request(:get, path, accept: '*/*')
+  res.is_a?(String) ? res : res.to_json
+end
+
+# Fetch all workbooks (paginate)
+puts "Fetching workbook list..."
+workbooks = []
+next_page = nil
+loop do
+  path = '/v2/workbooks?limit=100'
+  path += "&page=#{next_page}" if next_page
+  body = JSON.parse(get(path))
+  workbooks.concat(body.fetch('entries', []))
+  next_page = body['nextPage']
+  break unless next_page
+end
+puts "Found #{workbooks.size} workbooks total.\n\n"
+
+# Scan each workbook spec for SQL elements
+findings = []
+workbooks.each do |wb|
+  wid  = wb['workbookId']
+  name = wb['name']
+
+  begin
+    raw  = get("/v2/workbooks/#{wid}/spec")
+    spec = YAML.safe_load(raw, permitted_classes: [Date, Time])
+    next unless spec.is_a?(Hash) && spec['pages']
+
+    folder_id = spec['folderId']
+
+    spec['pages'].each do |page|
+      (page['elements'] || []).each do |el|
+        src = el['source']
+        next unless src.is_a?(Hash) && src['kind'] == 'sql'
+
+        # Use element name if set, otherwise fall back to workbook name
+        el_name = (el['name'] && !el['name'].strip.empty?) ? el['name'] : "#{name} SQL"
+
+        findings << {
+          workbook_id:   wid,
+          workbook_name: name,
+          folder_id:     folder_id,
+          element_id:    el['id'],
+          element_name:  el_name,
+          connection_id: src['connectionId'],
+          sql:           src['statement'],
+          column_count:  (el['columns'] || []).size
+        }
+        puts "  [FOUND] #{name} / #{el_name}"
+        puts "          SQL: #{src['statement'][0..100]}#{'...' if src['statement'].length > 100}"
+      end
+    end
+  rescue => e
+    $stderr.puts "  [ERROR] #{name}: #{e.message}"
+  end
+end
+
+puts "\n#{'='*60}"
+puts "Custom SQL elements found: #{findings.size}"
+
+if findings.empty?
+  puts "No custom SQL elements found in any workbook."
+else
+  out = '/tmp/custom-sql-manifest.json'
+  File.write(out, JSON.pretty_generate(findings))
+  puts "Manifest written to #{out}"
+end

--- a/plugins/sigma-authoring/skills/sigma-data-models/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: sigma-data-models
+description: >-
+  Author, retrieve, or modify a Sigma data model spec (the JSON/YAML
+  semantic-layer definition with sources, columns, metrics, relationships,
+  filters, controls, folder groupings, and column-level security) by calling
+  the Sigma REST API directly. Use when the user wants to build a new data
+  model from existing warehouse tables, add metrics or relationships to an
+  existing model, change a model's source, edit columns, or round-trip a
+  data model spec through code. **Out of scope: converting from another BI
+  tool's format (dbt, LookML, Tableau, Power BI, Alteryx, etc.).** Those
+  conversions are handled by the Sigma data-model converter (browser tool +
+  MCP) — point users there when they paste source-format input.
+  Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+---
+
+# Sigma Data Models (Author / Get / Update)
+
+Build a Sigma data model spec — the JSON definition of pages, sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security — and round-trip it through the Sigma REST API.
+
+This skill is for **authoring from existing warehouse tables**: a user knows their warehouse, wants to expose specific tables as a Sigma data model with the right joins, metrics, and governance, and needs help composing the spec. Conversions from other BI-tool formats (dbt schema.yml, LookML views, Tableau TDS, Power BI PBIT, Alteryx YXMD, etc.) are **not in this skill** — direct users to the Sigma data-model converter MCP / browser tool, which already handles those mappings.
+
+**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. This skill assumes both are already exported.
+
+**Requirements:** `curl`, `jq`, `base64`. Your Sigma API credentials must have permission to create or edit data models, plus "Can edit" access on the destination folder (for create) or the existing data model (for update). If a request returns 403, ask your Sigma admin to confirm the credential's permissions.
+
+## Reference Index
+
+Feature-specific JSON patterns live in `reference/`. Load each file when you identify the corresponding feature in the user's request — don't read every file up-front.
+
+| File | When to load |
+|------|--------------|
+| `reference/columns.md` | Calculated columns, formula columns, derived columns; **renaming a column, changing a formula**, warehouse-column ID conventions, column reference rules. |
+| `reference/metrics.md` | Metrics, aggregate measures, metric timelines, time-series / trend metrics; **adding a metric to an existing table or changing aggregation**. |
+| `reference/relationships.md` | Relationships, foreign-key linking, related tables, cross-table lookups; **adding a relationship between an existing element and a new one** (mixed-ID rule — see `workflows/crud.md`). |
+| `reference/sources.md` | Custom SQL sources, join sources, union sources, transpose sources; **swapping a model's source kind** on an existing model. |
+| `reference/filters.md` | Row filters, where clauses, date range filters, top-N; **adding/removing a filter on an existing model**. |
+| `reference/folders-groupings.md` | Folders, column groupings, column ordering, sort, organize columns; **reordering existing columns**. |
+| `reference/column-level-security.md` | Column-level security (CLS), data masking, restrict columns by team / user attribute; **applying CLS to an existing column**. |
+| `reference/controls.md` | List/dropdown, text input, text area, number input, number range, date, date range, slider, range slider, segmented, switch, checkbox, top-N controls; **adding a control to an existing page**. |
+| `reference/formatting.md` | Column or metric formatting — currency, percentage, date format, decimals, datetime; **reformatting a column or metric on an existing model**. |
+| `reference/calc-columns.md` | Calculated / derived / formula columns on a DM element. Covers shape, formula references, and the **window-function silent-error gotcha** (`CountOver`/`SumOver` etc. fail in DM element calc cols → workarounds). |
+
+## Workflows Index
+
+| File | When to load |
+|------|--------------|
+| `reference/workflows/discover.md` | **Read first when starting a new model.** Find the user's connection, resolve a table path → inodeId, list columns. Without this, you'll guess column names and the spec will fail. |
+| `reference/workflows/authoring.md` | Composition judgment calls — one big model vs many small, SQL source vs warehouse-table, joins in the model vs in workbooks, naming conventions, where to put metrics, folder placement, when to materialize. |
+| `reference/workflows/crud.md` | `POST` / `GET` / `PUT` against `/v2/dataModels` endpoints. Always load before any API call. Contains the ID-semantics contrast (CREATE remap vs GET source-of-truth vs UPDATE preserve), full step-by-step recipes, and the mixed-ID rule for relationships in updates. |
+| `reference/workflows/validate.md` | Pre-submit checklist + decoding common errors (400 / 403 / 409) + the "pull a known-working model and diff" pattern when guessing isn't working. |
+
+## ID Conventions
+
+Cross-cutting rules. Per-workflow ID semantics (remap vs preserve vs mixed cross-references) live in `reference/workflows/crud.md`.
+
+- Short alphanumeric IDs for generated entities: `"page-1"`, `"table-orders"`, `"col-revenue"`.
+- Warehouse column IDs follow `"inode-<tableId>/<COLUMN_NAME>"` — use `"<YOUR_TABLE_INODE>/<COL_NAME>"` as a placeholder.
+- Control `id` is the element ID; `controlId` is the formula reference name — keep them distinct.
+
+## Unsupported Features
+
+Call out any of these before presenting the final spec:
+
+- Multiple tables with identical names in the same data model
+- Input tables, Python elements, and UI elements
+- Referencing Sigma elements in custom SQL
+- Partial updates — the create and update endpoints both require the full representation
+- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
+
+## Cross-Skill References
+
+- **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
+- **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
+
+## Out of Scope (use a different tool)
+
+- **Converting from dbt / LookML / Tableau / Power BI / Alteryx / Snowflake semantic views** → the Sigma data-model converter (browser tool at `~/sigma-skills/.../sigma-data-model-manager` and the `sigma-data-model` MCP) handles these. Don't re-implement converter logic in this skill.
+- **Tableau-to-Sigma full pipeline** (datasource + workbook + repoint) → use the `tableau-to-sigma` skill.

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/cline/sigma-data-models.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/cline/sigma-data-models.md
@@ -1,0 +1,72 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Author, retrieve, or modify a Sigma data model spec (the JSON/YAML semantic-layer definition with sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security) by calling the Sigma REST API directly. Use when the user wants to build a new data model from existing warehouse tables, add metrics or relationships to an existing model, change a model's source, edit columns, or round-trip a data model spec through code. **Out of scope: converting from another BI tool's format (dbt, LookML, Tableau, Power BI, Alteryx, etc.).** Those conversions are handled by the Sigma data-model converter (browser tool + MCP) — point users there when they paste source-format input. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Data Models (Author / Get / Update)
+
+Build a Sigma data model spec — the JSON definition of pages, sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security — and round-trip it through the Sigma REST API.
+
+This skill is for **authoring from existing warehouse tables**: a user knows their warehouse, wants to expose specific tables as a Sigma data model with the right joins, metrics, and governance, and needs help composing the spec. Conversions from other BI-tool formats (dbt schema.yml, LookML views, Tableau TDS, Power BI PBIT, Alteryx YXMD, etc.) are **not in this skill** — direct users to the Sigma data-model converter MCP / browser tool, which already handles those mappings.
+
+**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. This skill assumes both are already exported.
+
+**Requirements:** `curl`, `jq`, `base64`. Your Sigma API credentials must have permission to create or edit data models, plus "Can edit" access on the destination folder (for create) or the existing data model (for update). If a request returns 403, ask your Sigma admin to confirm the credential's permissions.
+
+## Reference Index
+
+Feature-specific JSON patterns live in `reference/`. Load each file when you identify the corresponding feature in the user's request — don't read every file up-front.
+
+| File | When to load |
+|------|--------------|
+| `reference/columns.md` | Calculated columns, formula columns, derived columns; **renaming a column, changing a formula**, warehouse-column ID conventions, column reference rules. |
+| `reference/metrics.md` | Metrics, aggregate measures, metric timelines, time-series / trend metrics; **adding a metric to an existing table or changing aggregation**. |
+| `reference/relationships.md` | Relationships, foreign-key linking, related tables, cross-table lookups; **adding a relationship between an existing element and a new one** (mixed-ID rule — see `workflows/crud.md`). |
+| `reference/sources.md` | Custom SQL sources, join sources, union sources, transpose sources; **swapping a model's source kind** on an existing model. |
+| `reference/filters.md` | Row filters, where clauses, date range filters, top-N; **adding/removing a filter on an existing model**. |
+| `reference/folders-groupings.md` | Folders, column groupings, column ordering, sort, organize columns; **reordering existing columns**. |
+| `reference/column-level-security.md` | Column-level security (CLS), data masking, restrict columns by team / user attribute; **applying CLS to an existing column**. |
+| `reference/controls.md` | List/dropdown, text input, text area, number input, number range, date, date range, slider, range slider, segmented, switch, checkbox, top-N controls; **adding a control to an existing page**. |
+| `reference/formatting.md` | Column or metric formatting — currency, percentage, date format, decimals, datetime; **reformatting a column or metric on an existing model**. |
+| `reference/calc-columns.md` | Calculated / derived / formula columns on a DM element. Covers shape, formula references, and the **window-function silent-error gotcha** (`CountOver`/`SumOver` etc. fail in DM element calc cols → workarounds). |
+
+## Workflows Index
+
+| File | When to load |
+|------|--------------|
+| `reference/workflows/discover.md` | **Read first when starting a new model.** Find the user's connection, resolve a table path → inodeId, list columns. Without this, you'll guess column names and the spec will fail. |
+| `reference/workflows/authoring.md` | Composition judgment calls — one big model vs many small, SQL source vs warehouse-table, joins in the model vs in workbooks, naming conventions, where to put metrics, folder placement, when to materialize. |
+| `reference/workflows/crud.md` | `POST` / `GET` / `PUT` against `/v2/dataModels` endpoints. Always load before any API call. Contains the ID-semantics contrast (CREATE remap vs GET source-of-truth vs UPDATE preserve), full step-by-step recipes, and the mixed-ID rule for relationships in updates. |
+| `reference/workflows/validate.md` | Pre-submit checklist + decoding common errors (400 / 403 / 409) + the "pull a known-working model and diff" pattern when guessing isn't working. |
+
+## ID Conventions
+
+Cross-cutting rules. Per-workflow ID semantics (remap vs preserve vs mixed cross-references) live in `reference/workflows/crud.md`.
+
+- Short alphanumeric IDs for generated entities: `"page-1"`, `"table-orders"`, `"col-revenue"`.
+- Warehouse column IDs follow `"inode-<tableId>/<COLUMN_NAME>"` — use `"<YOUR_TABLE_INODE>/<COL_NAME>"` as a placeholder.
+- Control `id` is the element ID; `controlId` is the formula reference name — keep them distinct.
+
+## Unsupported Features
+
+Call out any of these before presenting the final spec:
+
+- Multiple tables with identical names in the same data model
+- Input tables, Python elements, and UI elements
+- Referencing Sigma elements in custom SQL
+- Partial updates — the create and update endpoints both require the full representation
+- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
+
+## Cross-Skill References
+
+- **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
+- **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+
+## Out of Scope (use a different tool)
+
+- **Converting from dbt / LookML / Tableau / Power BI / Alteryx / Snowflake semantic views** → the Sigma data-model converter (browser tool at `~/sigma-skills/.../sigma-data-model-manager` and the `sigma-data-model` MCP) handles these. Don't re-implement converter logic in this skill.
+- **Tableau-to-Sigma full pipeline** (datasource + workbook + repoint) → use the `tableau-to-sigma` skill.

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/codex/AGENTS.md
@@ -1,0 +1,72 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Author, retrieve, or modify a Sigma data model spec (the JSON/YAML semantic-layer definition with sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security) by calling the Sigma REST API directly. Use when the user wants to build a new data model from existing warehouse tables, add metrics or relationships to an existing model, change a model's source, edit columns, or round-trip a data model spec through code. **Out of scope: converting from another BI tool's format (dbt, LookML, Tableau, Power BI, Alteryx, etc.).** Those conversions are handled by the Sigma data-model converter (browser tool + MCP) — point users there when they paste source-format input. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Data Models (Author / Get / Update)
+
+Build a Sigma data model spec — the JSON definition of pages, sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security — and round-trip it through the Sigma REST API.
+
+This skill is for **authoring from existing warehouse tables**: a user knows their warehouse, wants to expose specific tables as a Sigma data model with the right joins, metrics, and governance, and needs help composing the spec. Conversions from other BI-tool formats (dbt schema.yml, LookML views, Tableau TDS, Power BI PBIT, Alteryx YXMD, etc.) are **not in this skill** — direct users to the Sigma data-model converter MCP / browser tool, which already handles those mappings.
+
+**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. This skill assumes both are already exported.
+
+**Requirements:** `curl`, `jq`, `base64`. Your Sigma API credentials must have permission to create or edit data models, plus "Can edit" access on the destination folder (for create) or the existing data model (for update). If a request returns 403, ask your Sigma admin to confirm the credential's permissions.
+
+## Reference Index
+
+Feature-specific JSON patterns live in `reference/`. Load each file when you identify the corresponding feature in the user's request — don't read every file up-front.
+
+| File | When to load |
+|------|--------------|
+| `reference/columns.md` | Calculated columns, formula columns, derived columns; **renaming a column, changing a formula**, warehouse-column ID conventions, column reference rules. |
+| `reference/metrics.md` | Metrics, aggregate measures, metric timelines, time-series / trend metrics; **adding a metric to an existing table or changing aggregation**. |
+| `reference/relationships.md` | Relationships, foreign-key linking, related tables, cross-table lookups; **adding a relationship between an existing element and a new one** (mixed-ID rule — see `workflows/crud.md`). |
+| `reference/sources.md` | Custom SQL sources, join sources, union sources, transpose sources; **swapping a model's source kind** on an existing model. |
+| `reference/filters.md` | Row filters, where clauses, date range filters, top-N; **adding/removing a filter on an existing model**. |
+| `reference/folders-groupings.md` | Folders, column groupings, column ordering, sort, organize columns; **reordering existing columns**. |
+| `reference/column-level-security.md` | Column-level security (CLS), data masking, restrict columns by team / user attribute; **applying CLS to an existing column**. |
+| `reference/controls.md` | List/dropdown, text input, text area, number input, number range, date, date range, slider, range slider, segmented, switch, checkbox, top-N controls; **adding a control to an existing page**. |
+| `reference/formatting.md` | Column or metric formatting — currency, percentage, date format, decimals, datetime; **reformatting a column or metric on an existing model**. |
+| `reference/calc-columns.md` | Calculated / derived / formula columns on a DM element. Covers shape, formula references, and the **window-function silent-error gotcha** (`CountOver`/`SumOver` etc. fail in DM element calc cols → workarounds). |
+
+## Workflows Index
+
+| File | When to load |
+|------|--------------|
+| `reference/workflows/discover.md` | **Read first when starting a new model.** Find the user's connection, resolve a table path → inodeId, list columns. Without this, you'll guess column names and the spec will fail. |
+| `reference/workflows/authoring.md` | Composition judgment calls — one big model vs many small, SQL source vs warehouse-table, joins in the model vs in workbooks, naming conventions, where to put metrics, folder placement, when to materialize. |
+| `reference/workflows/crud.md` | `POST` / `GET` / `PUT` against `/v2/dataModels` endpoints. Always load before any API call. Contains the ID-semantics contrast (CREATE remap vs GET source-of-truth vs UPDATE preserve), full step-by-step recipes, and the mixed-ID rule for relationships in updates. |
+| `reference/workflows/validate.md` | Pre-submit checklist + decoding common errors (400 / 403 / 409) + the "pull a known-working model and diff" pattern when guessing isn't working. |
+
+## ID Conventions
+
+Cross-cutting rules. Per-workflow ID semantics (remap vs preserve vs mixed cross-references) live in `reference/workflows/crud.md`.
+
+- Short alphanumeric IDs for generated entities: `"page-1"`, `"table-orders"`, `"col-revenue"`.
+- Warehouse column IDs follow `"inode-<tableId>/<COLUMN_NAME>"` — use `"<YOUR_TABLE_INODE>/<COL_NAME>"` as a placeholder.
+- Control `id` is the element ID; `controlId` is the formula reference name — keep them distinct.
+
+## Unsupported Features
+
+Call out any of these before presenting the final spec:
+
+- Multiple tables with identical names in the same data model
+- Input tables, Python elements, and UI elements
+- Referencing Sigma elements in custom SQL
+- Partial updates — the create and update endpoints both require the full representation
+- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
+
+## Cross-Skill References
+
+- **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
+- **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+
+## Out of Scope (use a different tool)
+
+- **Converting from dbt / LookML / Tableau / Power BI / Alteryx / Snowflake semantic views** → the Sigma data-model converter (browser tool at `~/sigma-skills/.../sigma-data-model-manager` and the `sigma-data-model` MCP) handles these. Don't re-implement converter logic in this skill.
+- **Tableau-to-Sigma full pipeline** (datasource + workbook + repoint) → use the `tableau-to-sigma` skill.

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/continue/sigma-data-models.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/continue/sigma-data-models.md
@@ -1,0 +1,72 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Author, retrieve, or modify a Sigma data model spec (the JSON/YAML semantic-layer definition with sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security) by calling the Sigma REST API directly. Use when the user wants to build a new data model from existing warehouse tables, add metrics or relationships to an existing model, change a model's source, edit columns, or round-trip a data model spec through code. **Out of scope: converting from another BI tool's format (dbt, LookML, Tableau, Power BI, Alteryx, etc.).** Those conversions are handled by the Sigma data-model converter (browser tool + MCP) — point users there when they paste source-format input. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Data Models (Author / Get / Update)
+
+Build a Sigma data model spec — the JSON definition of pages, sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security — and round-trip it through the Sigma REST API.
+
+This skill is for **authoring from existing warehouse tables**: a user knows their warehouse, wants to expose specific tables as a Sigma data model with the right joins, metrics, and governance, and needs help composing the spec. Conversions from other BI-tool formats (dbt schema.yml, LookML views, Tableau TDS, Power BI PBIT, Alteryx YXMD, etc.) are **not in this skill** — direct users to the Sigma data-model converter MCP / browser tool, which already handles those mappings.
+
+**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. This skill assumes both are already exported.
+
+**Requirements:** `curl`, `jq`, `base64`. Your Sigma API credentials must have permission to create or edit data models, plus "Can edit" access on the destination folder (for create) or the existing data model (for update). If a request returns 403, ask your Sigma admin to confirm the credential's permissions.
+
+## Reference Index
+
+Feature-specific JSON patterns live in `reference/`. Load each file when you identify the corresponding feature in the user's request — don't read every file up-front.
+
+| File | When to load |
+|------|--------------|
+| `reference/columns.md` | Calculated columns, formula columns, derived columns; **renaming a column, changing a formula**, warehouse-column ID conventions, column reference rules. |
+| `reference/metrics.md` | Metrics, aggregate measures, metric timelines, time-series / trend metrics; **adding a metric to an existing table or changing aggregation**. |
+| `reference/relationships.md` | Relationships, foreign-key linking, related tables, cross-table lookups; **adding a relationship between an existing element and a new one** (mixed-ID rule — see `workflows/crud.md`). |
+| `reference/sources.md` | Custom SQL sources, join sources, union sources, transpose sources; **swapping a model's source kind** on an existing model. |
+| `reference/filters.md` | Row filters, where clauses, date range filters, top-N; **adding/removing a filter on an existing model**. |
+| `reference/folders-groupings.md` | Folders, column groupings, column ordering, sort, organize columns; **reordering existing columns**. |
+| `reference/column-level-security.md` | Column-level security (CLS), data masking, restrict columns by team / user attribute; **applying CLS to an existing column**. |
+| `reference/controls.md` | List/dropdown, text input, text area, number input, number range, date, date range, slider, range slider, segmented, switch, checkbox, top-N controls; **adding a control to an existing page**. |
+| `reference/formatting.md` | Column or metric formatting — currency, percentage, date format, decimals, datetime; **reformatting a column or metric on an existing model**. |
+| `reference/calc-columns.md` | Calculated / derived / formula columns on a DM element. Covers shape, formula references, and the **window-function silent-error gotcha** (`CountOver`/`SumOver` etc. fail in DM element calc cols → workarounds). |
+
+## Workflows Index
+
+| File | When to load |
+|------|--------------|
+| `reference/workflows/discover.md` | **Read first when starting a new model.** Find the user's connection, resolve a table path → inodeId, list columns. Without this, you'll guess column names and the spec will fail. |
+| `reference/workflows/authoring.md` | Composition judgment calls — one big model vs many small, SQL source vs warehouse-table, joins in the model vs in workbooks, naming conventions, where to put metrics, folder placement, when to materialize. |
+| `reference/workflows/crud.md` | `POST` / `GET` / `PUT` against `/v2/dataModels` endpoints. Always load before any API call. Contains the ID-semantics contrast (CREATE remap vs GET source-of-truth vs UPDATE preserve), full step-by-step recipes, and the mixed-ID rule for relationships in updates. |
+| `reference/workflows/validate.md` | Pre-submit checklist + decoding common errors (400 / 403 / 409) + the "pull a known-working model and diff" pattern when guessing isn't working. |
+
+## ID Conventions
+
+Cross-cutting rules. Per-workflow ID semantics (remap vs preserve vs mixed cross-references) live in `reference/workflows/crud.md`.
+
+- Short alphanumeric IDs for generated entities: `"page-1"`, `"table-orders"`, `"col-revenue"`.
+- Warehouse column IDs follow `"inode-<tableId>/<COLUMN_NAME>"` — use `"<YOUR_TABLE_INODE>/<COL_NAME>"` as a placeholder.
+- Control `id` is the element ID; `controlId` is the formula reference name — keep them distinct.
+
+## Unsupported Features
+
+Call out any of these before presenting the final spec:
+
+- Multiple tables with identical names in the same data model
+- Input tables, Python elements, and UI elements
+- Referencing Sigma elements in custom SQL
+- Partial updates — the create and update endpoints both require the full representation
+- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
+
+## Cross-Skill References
+
+- **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
+- **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+
+## Out of Scope (use a different tool)
+
+- **Converting from dbt / LookML / Tableau / Power BI / Alteryx / Snowflake semantic views** → the Sigma data-model converter (browser tool at `~/sigma-skills/.../sigma-data-model-manager` and the `sigma-data-model` MCP) handles these. Don't re-implement converter logic in this skill.
+- **Tableau-to-Sigma full pipeline** (datasource + workbook + repoint) → use the `tableau-to-sigma` skill.

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
@@ -1,0 +1,77 @@
+---
+description: "Author, retrieve, or modify a Sigma data model spec (the JSON/YAML semantic-layer definition with sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security) by calling the Sigma REST API directly. Use when the user wants to build a new data model from existing warehouse tables, add metrics or relationships to an existing model, change a model's source, edit columns, or round-trip a data model spec through code. **Out of scope: converting from another BI tool's format (dbt, LookML, Tableau, Power BI, Alteryx, etc.).** Those conversions are handled by the Sigma data-model converter (browser tool + MCP) — point users there when they paste source-format input. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first."
+alwaysApply: false
+---
+
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Author, retrieve, or modify a Sigma data model spec (the JSON/YAML semantic-layer definition with sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security) by calling the Sigma REST API directly. Use when the user wants to build a new data model from existing warehouse tables, add metrics or relationships to an existing model, change a model's source, edit columns, or round-trip a data model spec through code. **Out of scope: converting from another BI tool's format (dbt, LookML, Tableau, Power BI, Alteryx, etc.).** Those conversions are handled by the Sigma data-model converter (browser tool + MCP) — point users there when they paste source-format input. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Data Models (Author / Get / Update)
+
+Build a Sigma data model spec — the JSON definition of pages, sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security — and round-trip it through the Sigma REST API.
+
+This skill is for **authoring from existing warehouse tables**: a user knows their warehouse, wants to expose specific tables as a Sigma data model with the right joins, metrics, and governance, and needs help composing the spec. Conversions from other BI-tool formats (dbt schema.yml, LookML views, Tableau TDS, Power BI PBIT, Alteryx YXMD, etc.) are **not in this skill** — direct users to the Sigma data-model converter MCP / browser tool, which already handles those mappings.
+
+**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. This skill assumes both are already exported.
+
+**Requirements:** `curl`, `jq`, `base64`. Your Sigma API credentials must have permission to create or edit data models, plus "Can edit" access on the destination folder (for create) or the existing data model (for update). If a request returns 403, ask your Sigma admin to confirm the credential's permissions.
+
+## Reference Index
+
+Feature-specific JSON patterns live in `reference/`. Load each file when you identify the corresponding feature in the user's request — don't read every file up-front.
+
+| File | When to load |
+|------|--------------|
+| `reference/columns.md` | Calculated columns, formula columns, derived columns; **renaming a column, changing a formula**, warehouse-column ID conventions, column reference rules. |
+| `reference/metrics.md` | Metrics, aggregate measures, metric timelines, time-series / trend metrics; **adding a metric to an existing table or changing aggregation**. |
+| `reference/relationships.md` | Relationships, foreign-key linking, related tables, cross-table lookups; **adding a relationship between an existing element and a new one** (mixed-ID rule — see `workflows/crud.md`). |
+| `reference/sources.md` | Custom SQL sources, join sources, union sources, transpose sources; **swapping a model's source kind** on an existing model. |
+| `reference/filters.md` | Row filters, where clauses, date range filters, top-N; **adding/removing a filter on an existing model**. |
+| `reference/folders-groupings.md` | Folders, column groupings, column ordering, sort, organize columns; **reordering existing columns**. |
+| `reference/column-level-security.md` | Column-level security (CLS), data masking, restrict columns by team / user attribute; **applying CLS to an existing column**. |
+| `reference/controls.md` | List/dropdown, text input, text area, number input, number range, date, date range, slider, range slider, segmented, switch, checkbox, top-N controls; **adding a control to an existing page**. |
+| `reference/formatting.md` | Column or metric formatting — currency, percentage, date format, decimals, datetime; **reformatting a column or metric on an existing model**. |
+| `reference/calc-columns.md` | Calculated / derived / formula columns on a DM element. Covers shape, formula references, and the **window-function silent-error gotcha** (`CountOver`/`SumOver` etc. fail in DM element calc cols → workarounds). |
+
+## Workflows Index
+
+| File | When to load |
+|------|--------------|
+| `reference/workflows/discover.md` | **Read first when starting a new model.** Find the user's connection, resolve a table path → inodeId, list columns. Without this, you'll guess column names and the spec will fail. |
+| `reference/workflows/authoring.md` | Composition judgment calls — one big model vs many small, SQL source vs warehouse-table, joins in the model vs in workbooks, naming conventions, where to put metrics, folder placement, when to materialize. |
+| `reference/workflows/crud.md` | `POST` / `GET` / `PUT` against `/v2/dataModels` endpoints. Always load before any API call. Contains the ID-semantics contrast (CREATE remap vs GET source-of-truth vs UPDATE preserve), full step-by-step recipes, and the mixed-ID rule for relationships in updates. |
+| `reference/workflows/validate.md` | Pre-submit checklist + decoding common errors (400 / 403 / 409) + the "pull a known-working model and diff" pattern when guessing isn't working. |
+
+## ID Conventions
+
+Cross-cutting rules. Per-workflow ID semantics (remap vs preserve vs mixed cross-references) live in `reference/workflows/crud.md`.
+
+- Short alphanumeric IDs for generated entities: `"page-1"`, `"table-orders"`, `"col-revenue"`.
+- Warehouse column IDs follow `"inode-<tableId>/<COLUMN_NAME>"` — use `"<YOUR_TABLE_INODE>/<COL_NAME>"` as a placeholder.
+- Control `id` is the element ID; `controlId` is the formula reference name — keep them distinct.
+
+## Unsupported Features
+
+Call out any of these before presenting the final spec:
+
+- Multiple tables with identical names in the same data model
+- Input tables, Python elements, and UI elements
+- Referencing Sigma elements in custom SQL
+- Partial updates — the create and update endpoints both require the full representation
+- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
+
+## Cross-Skill References
+
+- **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
+- **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+
+## Out of Scope (use a different tool)
+
+- **Converting from dbt / LookML / Tableau / Power BI / Alteryx / Snowflake semantic views** → the Sigma data-model converter (browser tool at `~/sigma-skills/.../sigma-data-model-manager` and the `sigma-data-model` MCP) handles these. Don't re-implement converter logic in this skill.
+- **Tableau-to-Sigma full pipeline** (datasource + workbook + repoint) → use the `tableau-to-sigma` skill.

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/calc-columns.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/calc-columns.md
@@ -1,0 +1,49 @@
+# Calculated Columns
+
+Calculated columns are columns whose value is derived from a formula rather than read from the warehouse. They live in the same `columns` array as warehouse columns on an element.
+
+## Shape
+
+```json
+{
+  "id": "<short-id>",
+  "name": "Profit",
+  "formula": "[Revenue] - [Cost]"
+}
+```
+
+A calc column has no warehouse-column ID prefix — its `id` is a generated short alphanumeric, not `inode-<22>/COL`. The `formula` is what makes it a calc column.
+
+## Formula references
+
+- **Within the same element** — bare `[Column Name]` (case-sensitive, must match a column's `name` field on the same element).
+- **Cross-element** — `[Element Name/Column Name]`. The element name is the source element's `name`.
+- **From a warehouse-table source** — `[TABLE_NAME/Column Display Name]` where `TABLE_NAME` is the last segment of the source's `path` (uppercase, as it appears in the warehouse).
+
+A calc column **cannot reference itself**, even transitively — the server rejects circular references.
+
+## Window functions don't work in DM element calc columns
+
+`CountOver`, `SumOver`, `RowNumberOver`, `RankOver`, and other window-style functions silently fail when used as a formula on a calculated column **inside a data model element**. The column's `error` flag flips on without a clear UI signal, and any downstream chart that references the column blanks out.
+
+This is independent of the underlying SQL — the same formula works fine in a workbook calc column on most element types, but **not** on a workbook master table that's sourced from a data model (the workbook table inherits the DM-side restriction).
+
+### Workarounds
+
+| If you need… | Do this |
+|---|---|
+| A running total or rank by group on warehouse data | Push the calculation to a `sql` source — write the window function in SQL once, expose the result as a regular warehouse column. |
+| A row-number-by-group at view time | Move the calc to a workbook-level table that's **not** sourced from the DM (i.e., sources directly from warehouse-table). Window functions are allowed in those contexts. |
+| A simple cumulative metric | Express it as a metric on the model with `Sum / Count / etc.` — metrics aggregate across rows, which gets you most of what `SumOver` would. |
+
+### Side effect to know about
+
+When a calc column on a DM element is set to an unsupported formula and the model is saved via API, **the element's column IDs may be reassigned** on the next read. Always re-`GET` the spec after a save before composing any update — don't trust your last-known IDs.
+
+## Common errors
+
+- **"Invalid column reference"** — bare `[col]` where a prefix was needed, or a misspelling. Re-check column names against the source via `discover.md`.
+- **Column shows `error` icon, formula looks fine** — likely a window function. Try a simpler aggregation; if that works, the window function is the issue.
+- **Chart that references this column blanks out** — the calc column is in error state. Fix the formula; the chart will recover on the next render.
+
+See `formulas.md` (in the `sigma-workbooks` skill) for the full formula language reference, including the function list. The data-model side uses the same formula syntax with the constraints noted here.

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/column-level-security.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/column-level-security.md
@@ -1,0 +1,58 @@
+# Column-Level Security (CLS)
+
+CLS rules restrict which users can see specific columns. They are defined in the `columnSecurities` array of a table element.
+
+Each rule specifies a `criteria` (who is allowed to view) and a `restrictedColumns` list (which columns to protect). Users who do not meet the criteria cannot see the listed columns.
+
+## No one can view
+
+Hides the column from all users, including admins.
+
+```json
+"columnSecurities": [
+  {
+    "id": "cls-ssn",
+    "criteria": { "kind": "no-one-can-view" },
+    "restrictedColumns": ["<column-id>"]
+  }
+]
+```
+
+## Specific users and teams
+
+Only the explicitly listed users and/or teams can view the column.
+
+```json
+{
+  "id": "cls-finance",
+  "criteria": {
+    "kind": "specific-users-and-teams",
+    "assignments": [
+      { "type": "user", "userId": "<user-id>" },
+      { "type": "team", "teamId": "<team-id>" }
+    ]
+  },
+  "restrictedColumns": ["<column-id>"]
+}
+```
+
+## User attribute
+
+Only users whose attribute matches the required value can view the column. Useful for dynamic, attribute-based access control.
+
+```json
+{
+  "id": "cls-region",
+  "criteria": {
+    "kind": "user-attribute",
+    "assignments": [
+      { "userAttributeId": "<attr-id>", "value": "<required-value>" }
+    ]
+  },
+  "restrictedColumns": ["<column-id>"]
+}
+```
+
+## Enum values
+
+**`criteria.kind` values:** `"no-one-can-view"`, `"specific-users-and-teams"`, `"user-attribute"`

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/columns.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/columns.md
@@ -1,0 +1,173 @@
+# Columns
+
+Columns are defined in the `columns` array of a table element. All columns require `id` and `formula`.
+
+## Warehouse columns
+
+Warehouse columns reference source data with the `[TableName/Column Name]` formula syntax. Their IDs follow the `inode-<tableId>/<COLUMN_NAME>` pattern — use `<YOUR_TABLE_INODE>/<COL_NAME>` as a placeholder until the real inode is known.
+
+```json
+[
+  { "id": "<YOUR_TABLE_INODE>/ORDER_NUMBER", "formula": "[<YOUR_TABLE_NAME>/Order Number]", "name": "Order Number" },
+  { "id": "<YOUR_TABLE_INODE>/PRICE",        "formula": "[<YOUR_TABLE_NAME>/Price]",        "name": "Price" },
+  { "id": "<YOUR_TABLE_INODE>/DATE",         "formula": "[<YOUR_TABLE_NAME>/Date]",         "name": "Date" }
+]
+```
+
+## Calculated columns
+
+Calculated columns use any Sigma formula expression. Use a short descriptive ID.
+
+```json
+[
+  { "id": "col-profit",   "formula": "[Price] - [Cost]",                                                "name": "Profit" },
+  { "id": "col-margin",   "formula": "[Profit] / [Revenue]",                                            "name": "Margin" },
+  { "id": "col-lifetime", "formula": "DateDiff(\"day\", Date([Cust Json].CUST_SINCE), Today())",        "name": "Customer Lifetime Days" }
+]
+```
+
+## Column schema
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Short alphanumeric or `inode-<tableId>/<COL>` pattern |
+| `formula` | string | yes | Sigma formula expression |
+| `name` | string | no | Display name shown in UI |
+| `description` | string | no | Tooltip / description text |
+| `hidden` | boolean | no | Hides column from non-admin users when `true` |
+| `format` | Format object | no | See [formatting.md](formatting.md) |
+
+---
+
+## Column Reference Rules
+
+Every column formula references either a column **outside** the element or a column **inside** the same element.
+
+### Outside the element — use `[SourceName/column_name]`
+
+The prefix depends on the source type:
+
+- **Warehouse table**: `SourceName` = last segment of the `path` array.
+  - Path `["DB", "SCHEMA", "ORDERS"]` → `[ORDERS/revenue]`
+  - Path `["ANALYTICS", "PUBLIC", "USERS"]` → `[USERS/email]`
+
+- **Another workbook element**: `SourceName` = that element's `name` field.
+  - Element named "Sales Table" → `[Sales Table/Revenue]`
+
+- **Join source**: `SourceName` = the `name` field on a specific join leg, or the top-level `name` on the join object (for the `primarySource` leg).
+  - Join with `primarySource.name` implicitly tied to top-level `name: "Sales Star"` → `[Sales Star/Order Number]` for primary columns.
+  - Join leg with `name: "Sales"` → `[Sales/Cust Key]` for that joined table's columns.
+  - Warehouse path segments do **not** become the prefix inside a join — use the join leg's `name` instead.
+
+- Column names must match exactly what the describe endpoint returns. **Never invent column names.**
+
+### Inside the same element — use `[column_name]` (no prefix)
+
+References a column already defined in this element by its `name` field.
+
+```
+// Given columns: "Revenue" (formula: [ORDERS/revenue]), "Cost" (formula: [ORDERS/cost])
+// A third column can reference them:
+[Revenue] - [Cost]       // valid — references sibling columns by name
+Sum([Revenue])           // valid — aggregation over a sibling column
+```
+
+**A column cannot reference itself** — that is a circular reference error. This trips up copy-paste: if a column's `name` field matches any bracketed reference inside its own `formula`, the server treats it as circular even when you meant to reference a different column. Rename one side to break the cycle.
+
+### Common mistakes
+
+| Wrong | Correct | Why |
+|-------|---------|-----|
+| `[revenue]` | `[ORDERS/revenue]` | Missing table prefix for warehouse column |
+| `[ORDERS/Total Revenue]` | `[Total Revenue]` | "Total Revenue" is a sibling column, not a warehouse column |
+| `[Revenue]` in the "Revenue" column | N/A — circular | A column cannot reference itself |
+
+### Special characters
+
+If you retrieve column names from the `connections/tables/<id>/columns` endpoint, normalize column names by going to title case and removing special characters like `/` and `-` before using them in column references.
+
+For example, `Country/Region` should become `Country Region`, and `Sub-Category` should become `Sub Category`
+
+## Operators
+
+### Arithmetic
+`+`, `-`, `*`, `/`, `%` (modulo), `^` (power)
+
+**Do not use** `Power()` or `Mod()` — use `^` and `%` instead.
+
+### Boolean
+`and`, `or`, `not`
+
+### String concatenation
+`&` (not `+`)
+
+**Do not use** `Concat()` — use `&` instead.
+
+## Aggregation Functions
+
+| Function | Description |
+|----------|-------------|
+| `Sum([col])` | Sum of values |
+| `Avg([col])` | Average of values |
+| `Count([col])` | Count of non-null values |
+| `CountDistinct([col])` | Count of distinct values |
+| `Min([col])` | Minimum value |
+| `Max([col])` | Maximum value |
+| `Median([col])` | Median value |
+
+## Date Functions
+
+| Function | Example |
+|----------|---------|
+| `DateTrunc(<part>, <date>)` | `DateTrunc("month", [Date])` |
+| `DateDiff(<part>, <start>, <end>)` | `DateDiff("day", [Start], [End])` |
+| `DateAdd(<part>, <units>, <date>)` | `DateAdd("month", 3, [Date])` |
+| `DateFormat(<date>, <fmt>)` | `DateFormat([Date], "%Y-%m-%d")` |
+
+Date parts (must be quoted strings): `"year"`, `"quarter"`, `"month"`, `"week"`, `"day"`, `"hour"`, `"minute"`, `"second"`
+
+## Conditional
+
+```
+If(<condition>, <then>, <else>)
+```
+
+Supports multiple conditions (chained):
+```
+If([Status] = "Active", "Active", [Status] = "Pending", "Pending", "Other")
+```
+
+**Do not use** `Case` — use `If` instead.
+
+## Text Functions
+
+| Function | Description |
+|----------|-------------|
+| `Contains(<text>, <search>)` | True if text contains search |
+| `Left(<text>, <n>)` | First n characters |
+| `Right(<text>, <n>)` | Last n characters |
+| `Upper(<text>)` | Uppercase |
+| `Lower(<text>)` | Lowercase |
+| `Trim(<text>)` | Remove leading/trailing whitespace |
+| `Length(<text>)` | Character count |
+| `Replace(<text>, <old>, <new>)` | Replace occurrences |
+
+## Other Functions
+
+| Function | Description |
+|----------|-------------|
+| `Coalesce(<a>, <b>, ...)` | First non-null value |
+| `In([col], "a", "b", "c")` | True if value is in the list |
+| `IsNull([col])` | True if null |
+| `Null` | Null literal |
+
+## Window Functions
+
+| Function | Description |
+|----------|-------------|
+| `Rank()` | Rank within partition |
+| `RowNumber()` | Row number within partition |
+| `Lead(<col>)` | Next row's value |
+| `Lag(<col>)` | Previous row's value |
+| `RunningSum(<col>)` | Cumulative sum |
+| `RunningAvg(<col>)` | Cumulative average |

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/controls.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/controls.md
@@ -1,0 +1,319 @@
+# Controls
+
+Controls are interactive filter elements. They are defined as separate entries in the page's `elements` array — **not** nested inside table elements.
+
+## Common fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `kind` | yes | Always `"control"` |
+| `id` | yes | Element ID — must be unique on the page |
+| `controlId` | yes | Formula reference name (e.g., `"RegionFilter"`) — keep distinct from `id` |
+| `controlType` | yes | Determines the UI widget and filter behavior |
+| `filters` | no | Array of `{ "source": { "kind": "table", "elementId": "..." }, "columnId": "..." }` — connects the control to columns on table elements |
+
+---
+
+## List values
+
+Dropdown or multi-select picker sourced dynamically from a column.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-region",
+  "controlId": "RegionFilter",
+  "controlType": "list",
+  "mode": "include",
+  "selectionMode": "multiple",
+  "values": [],
+  "source": {
+    "kind": "source",
+    "source": { "kind": "table", "elementId": "<table-element-id>" },
+    "columnId": "<source-column-id>"
+  },
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+`mode`: `"include"` | `"exclude"` · `selectionMode`: `"multiple"` | `"single"`
+
+---
+
+## Text input
+
+Single-line text filter control.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-search",
+  "controlId": "SearchText",
+  "controlType": "text",
+  "mode": "contains",
+  "value": "",
+  "case": "insensitive",
+  "includeNulls": "when-no-value-is-selected",
+  "showOperators": false,
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+`mode` values: `"equals"`, `"does-not-equal"`, `"contains"`, `"does-not-contain"`, `"starts-with"`, `"ends-with"`, `"like"`, `"matches-regexp"`, and their negations.
+
+---
+
+## Text area
+
+Multi-line text input control.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-notes",
+  "controlId": "NotesInput",
+  "controlType": "text-area",
+  "value": "",
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+---
+
+## Number input
+
+Single numeric value filter.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-qty",
+  "controlId": "QuantityFilter",
+  "controlType": "number",
+  "mode": ">=",
+  "value": 0,
+  "includeNulls": "when-no-value-is-selected",
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+`mode` values: `"="`, `"!="`, `"<"`, `"<="`, `">"`, `">="`
+
+---
+
+## Number range
+
+Two-value numeric range filter.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-price-range",
+  "controlId": "PriceRange",
+  "controlType": "number-range",
+  "min": 0,
+  "max": 100,
+  "includeNulls": "when-no-value-is-selected",
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+---
+
+## Date control
+
+Single date filter.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-date",
+  "controlId": "DateFilter",
+  "controlType": "date",
+  "mode": ">=",
+  "value": "2024-01-01T00:00:00Z",
+  "includeNulls": "when-no-value-is-selected",
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+`mode` values: `"="`, `"<"`, `"<="`, `">"`, `">="`
+
+Dynamic value: `{ "op": "now-minus", "unit": "day", "value": 2 }` (or `"now-plus"`); `unit` values: `"year"`, `"quarter"`, `"month"`, `"week"`, `"day"`, `"hour"`, `"minute"`
+
+---
+
+## Date range
+
+Two-date range filter.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-date-range",
+  "controlId": "DateRange",
+  "controlType": "date-range",
+  "mode": "between",
+  "startDate": "2024-01-01T00:00:00Z",
+  "endDate": "2024-12-31T23:59:59Z",
+  "includeNulls": "when-no-value-is-selected",
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+---
+
+## Slider
+
+Single-handle slider with a comparison operator.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-slider",
+  "controlId": "ScoreSlider",
+  "controlType": "slider",
+  "low": 0,
+  "high": 100,
+  "mode": "<=",
+  "value": 50,
+  "includeNulls": "when-no-value-is-selected",
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+`mode` values: `"="`, `"<"`, `"<="`, `">"`, `">="` · `low`/`high` define the slider range
+
+---
+
+## Range slider
+
+Dual-handle slider selecting a min/max range.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-range",
+  "controlId": "ScoreRange",
+  "controlType": "range-slider",
+  "low": 0,
+  "high": 100,
+  "min": 20,
+  "max": 80,
+  "includeNulls": "when-no-value-is-selected",
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+`low`/`high` define the slider range; `min`/`max` are the selected values.
+
+---
+
+## Segmented control
+
+Radio-button style selector sourced from a column.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-segment",
+  "controlId": "CategoryPicker",
+  "controlType": "segmented",
+  "value": true,
+  "source": {
+    "kind": "source",
+    "source": { "kind": "table", "elementId": "<table-element-id>" },
+    "columnId": "<source-column-id>"
+  },
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+---
+
+## Switch
+
+Boolean toggle control.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-switch",
+  "controlId": "ActiveToggle",
+  "controlType": "switch",
+  "mode": "True/False",
+  "value": true,
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+`mode` values: `"True/False"`, `"True/All"`
+
+---
+
+## Checkbox
+
+Boolean checkbox control.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-check",
+  "controlId": "ActiveOnly",
+  "controlType": "checkbox",
+  "mode": "True/False",
+  "value": true,
+  "filters": [
+    { "source": { "kind": "table", "elementId": "<table-element-id>" }, "columnId": "<column-id>" }
+  ]
+}
+```
+
+`mode` values: `"True/False"`, `"True/All"`
+
+---
+
+## Top N
+
+Limits results to the top or bottom N rows by a ranking function.
+
+```json
+{
+  "kind": "control",
+  "id": "ctrl-top-n",
+  "controlId": "TopProducts",
+  "controlType": "top-n",
+  "rankingFunction": "rank",
+  "mode": "top-n",
+  "rowCount": 10,
+  "includeNulls": "when-no-value-is-selected"
+}
+```
+
+`rankingFunction` values: `"rank"`, `"rank-dense"`, `"row-number"`
+
+`mode` values: `"top-n"`, `"bottom-n"`
+
+Percentile variant: use `percentile` (number) instead of `rowCount`, with `rankingFunction`: `"rank-percentile"` or `"cume-dist"`, and `mode`: `"top-percentile"` or `"bottom-percentile"`

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/filters.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/filters.md
@@ -1,0 +1,99 @@
+# Filters
+
+Row filters restrict which rows are included in a table element's results. They are defined in the `filters` array of the table element.
+
+## Number range
+
+```json
+{
+  "id": "filter-price",
+  "columnId": "<column-id>",
+  "kind": "number-range",
+  "min": 100,
+  "max": 500,
+  "includeNulls": "when-no-value-is-selected"
+}
+```
+
+## Date range
+
+Date range filters support two modes. Use `"between"` for a start/end window and `"on"` for a single date.
+
+```json
+{
+  "id": "filter-date-window",
+  "columnId": "<column-id>",
+  "kind": "date-range",
+  "mode": "between",
+  "startDate": "2024-01-01T00:00:00Z",
+  "endDate": "2024-12-31T23:59:59Z",
+  "includeNulls": "when-no-value-is-selected"
+}
+```
+
+```json
+{
+  "id": "filter-date-on",
+  "columnId": "<column-id>",
+  "kind": "date-range",
+  "mode": "on",
+  "date": "2024-06-15T00:00:00Z",
+  "includeNulls": "when-no-value-is-selected"
+}
+```
+
+## List (include or exclude)
+
+```json
+{
+  "id": "filter-region",
+  "columnId": "<column-id>",
+  "kind": "list",
+  "mode": "include",
+  "values": ["West", "East"]
+}
+```
+
+## Text match
+
+```json
+{
+  "id": "filter-name",
+  "columnId": "<column-id>",
+  "kind": "text-match",
+  "mode": "contains",
+  "value": "search term",
+  "case": "insensitive",
+  "includeNulls": "when-no-value-is-selected"
+}
+```
+
+## Top N
+
+Returns the top (or bottom) N rows ranked by a column. `rowCount` sets the number of rows; `rankingFunction` is always `"rank"`.
+
+```json
+{
+  "id": "filter-top10",
+  "columnId": "<column-id>",
+  "kind": "top-n",
+  "mode": "top-n",
+  "rankingFunction": "rank",
+  "rowCount": 10,
+  "includeNulls": "when-no-value-is-selected"
+}
+```
+
+## Enum values
+
+**`kind` values:** `"number-range"`, `"date-range"`, `"list"`, `"text-match"`, `"top-n"`
+
+**`includeNulls` values:** `"always"`, `"never"`, `"when-no-value-is-selected"`
+
+**Date range `mode` values:** `"between"` (requires `startDate` + `endDate`), `"on"` (requires `date`)
+
+**Text match `mode` values:** `"equals"`, `"does-not-equal"`, `"contains"`, `"does-not-contain"`, `"starts-with"`, `"does-not-start-with"`, `"ends-with"`, `"does-not-end-with"`, `"like"`, `"not-like"`, `"matches-regexp"`, `"does-not-match-regexp"`
+
+**Text `case` values:** `"sensitive"`, `"insensitive"`
+
+**List `mode` values:** `"include"`, `"exclude"`

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/folders-groupings.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/folders-groupings.md
@@ -1,0 +1,82 @@
+# Folders, Groupings, Order, and Sort
+
+These properties are all set on the table element alongside `columns` and `metrics`.
+
+## Folders
+
+Group columns into visual folders using the `folders` array. Reference the folder `id` in the `order` array to position the folder in the column list.
+
+```json
+"folders": [
+  {
+    "id": "folder-dates",
+    "name": "Date Fields",
+    "items": [
+      "<col-id-order-date>",
+      "<col-id-ship-date>"
+    ]
+  },
+  {
+    "id": "folder-financials",
+    "name": "Financials",
+    "items": [
+      "<col-id-price>",
+      "<col-id-cost>",
+      "col-profit"
+    ]
+  }
+]
+```
+
+**Folder schema:** `id` (required), `name` (required), `items`? (array of column IDs and/or nested folder IDs)
+
+## Groupings
+
+Groupings define default group-by behavior on the table element.
+
+```json
+"groupings": [
+  {
+    "id": "grouping-1",
+    "groupBy": [
+      "<column-id>"
+    ],
+    "calculations": [
+      "<calculation-column-id>"
+    ]
+  }
+]
+```
+
+**Grouping schema:** `id` (required), `groupBy`? (array of column or folder IDs), `calculations`? (array of calculation column IDs)
+
+## Column order
+
+The `order` array sets the display sequence of columns and folders. Items not listed appear after the listed ones. Summary columns are excluded from `order`.
+
+```json
+"order": [
+  "folder-dates",
+  "<col-id-1>",
+  "<col-id-2>",
+  "folder-financials"
+]
+```
+
+## Sort
+
+The `sort` array sets the default sort order on the table element.
+
+```json
+"sort": [
+  {
+    "columnId": "<col-id>",
+    "direction": "descending",
+    "nulls": "last"
+  }
+]
+```
+
+**`direction` values:** `"ascending"`, `"descending"`
+
+**`nulls` values:** `"first"`, `"last"`, `"connection-default"`

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/formatting.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/formatting.md
@@ -1,0 +1,56 @@
+# Column and Metric Formatting
+
+Add a `format` property to any column or metric object to control how values are displayed in the Sigma UI.
+
+## Datetime
+
+```json
+{
+  "id": "<col-id>",
+  "formula": "[<TableName>/Order Date]",
+  "format": {
+    "kind": "datetime",
+    "formatString": "%b %d, %Y"
+  }
+}
+```
+
+Common `formatString` patterns:
+
+| Pattern | Example output |
+|---|---|
+| `"%Y-%m-%d"` | 2024-03-15 |
+| `"%b %d, %Y"` | Mar 15, 2024 |
+| `"%m/%d/%Y"` | 03/15/2024 |
+| `"%a, %b %d, %Y"` | Fri, Mar 15, 2024 |
+| `"%Y-%m-%dT%H:%M:%S"` | 2024-03-15T14:30:00 |
+
+## Number and currency
+
+```json
+{
+  "id": "<col-id>",
+  "formula": "[<TableName>/Revenue]",
+  "format": {
+    "kind": "number",
+    "formatString": "$.2f",
+    "decimalSymbol": ".",
+    "digitGroupingSymbol": ",",
+    "digitGroupingSize": [3],
+    "currencySymbol": "$"
+  }
+}
+```
+
+Common `formatString` patterns:
+
+| Pattern | Example output | Use for |
+|---|---|---|
+| `"$.2f"` | $1,234.56 | Currency (USD) |
+| `"€.2f"` | €1,234.56 | Currency (EUR) |
+| `",.0f"` | 1,235 | Integer with thousands separator |
+| `".2f"` | 1234.56 | Decimal, 2 places |
+| `".1%"` | 12.3% | Percentage |
+| `".0%"` | 12% | Percentage, no decimals |
+
+Omit `currencySymbol`, `decimalSymbol`, `digitGroupingSymbol`, and `digitGroupingSize` if they are not needed for the format.

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/metrics.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/metrics.md
@@ -1,0 +1,59 @@
+# Metrics
+
+Metrics are aggregate measures defined in the `metrics` array of a table element. They standardize common calculations so workbook authors don't need to rewrite them.
+
+## Metric
+
+```json
+"metrics": [
+  {
+    "id": "metric-revenue",
+    "formula": "Sum([Price])",
+    "name": "Total Revenue"
+  },
+  {
+    "id": "metric-unique-skus",
+    "formula": "CountDistinct([Sku Number])",
+    "name": "Unique Products"
+  }
+]
+```
+
+## Metric schema
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Short alphanumeric ID |
+| `formula` | string | yes | Sigma aggregate formula |
+| `name` | string | no | Display name |
+| `description` | string | no | |
+| `format` | Format object | no | See [formatting.md](formatting.md) |
+| `timeline` | Timeline object | no | See below |
+
+## Metric timeline
+
+> **`dateColumnId`:** Use the column's ID as defined in the same spec. The API resolves this cross-reference at submission time — if you submit with an inode column ID (e.g., `"inode-5FCsrDpnzcdw5YYJRBbY6l/DATE"`), the returned spec will show the server-assigned column ID. The timeline will be present and correct in the returned spec.
+
+Add a `timeline` object to a metric to enable time-series trend tracking.
+
+```json
+{
+  "id": "metric-revenue",
+  "formula": "Sum([Price])",
+  "name": "Revenue",
+  "timeline": {
+    "dateColumnId": "<column-id-of-date-column>",
+    "truncation": "month",
+    "comparison": {
+      "comparisonPeriod": "year",
+      "direction": "higher-is-better"
+    }
+  }
+}
+```
+
+**`truncation` values:** `"year"`, `"quarter"`, `"month"`, `"week-starting-sunday"`, `"week-starting-monday"`, `"day"`, `"hour"`, `"minute"`
+
+**`comparisonPeriod` values:** `"year"`, `"quarter"`, `"month"`, `"week"`, `"day"`
+
+**`direction` values:** `"higher-is-better"`, `"lower-is-better"`

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/relationships.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/relationships.md
@@ -1,0 +1,35 @@
+# Relationships
+
+Relationships are pre-defined joins added to the `relationships` array of a table element. They let workbook authors create cross-table analyses without defining joins themselves — the join logic is encoded in the data model.
+
+```json
+"relationships": [
+  {
+    "id": "rel-orders-customers",
+    "targetElementId": "<id-of-target-table-element>",
+    "keys": [
+      {
+        "sourceColumnId": "<column-id-in-this-table>",
+        "targetColumnId": "<column-id-in-target-table>"
+      }
+    ],
+    "name": "Orders → Customers"
+  }
+]
+```
+
+Both elements must be on the same page. Use the table element `id` values (e.g., `"table-1"`, `"table-2"`) for `targetElementId`.
+
+## Relationship schema
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | |
+| `targetElementId` | string | yes | `id` of the related table element on the same page |
+| `keys` | array | yes | One or more column pairs defining the join condition |
+| `name` | string | no | Display name for the relationship |
+| `description` | string | no | |
+
+Each key in `keys`:
+- `sourceColumnId` — column ID in this table
+- `targetColumnId` — column ID in the target table

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/sources.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/sources.md
@@ -1,0 +1,175 @@
+# Source Types
+
+The `source` property of a table element defines where the data comes from. Replace the entire `source` object with the appropriate type for your use case.
+
+## warehouse-table (default)
+
+Direct connection to a warehouse table.
+
+```json
+"source": {
+  "kind": "warehouse-table",
+  "connectionId": "<YOUR_CONNECTION_ID>",
+  "path": ["<YOUR_DATABASE>", "<YOUR_SCHEMA>", "<YOUR_TABLE_NAME>"]
+}
+```
+
+## Custom SQL
+
+Run a raw SQL query against a connection. Columns then reference `[Custom SQL/<Column Name>]` in their formulas.
+
+```json
+"source": {
+  "kind": "sql",
+  "connectionId": "<YOUR_CONNECTION_ID>",
+  "statement": "SELECT order_id, customer_id, SUM(price) AS REVENUE FROM orders GROUP BY 1, 2"
+}
+```
+
+> **Column naming:** The formula prefix `[Custom SQL/...]` must match the **exact output column name** from the SQL query. For Snowflake (the most common warehouse), unquoted column names and aliases are returned in UPPERCASE — e.g., `SUM(price) AS revenue` becomes `[Custom SQL/REVENUE]`. Use double-quoted aliases (e.g., `AS "revenue"`) if you need mixed-case or lowercase column names.
+
+## Join
+
+Combine two table elements using a join. Both source tables must be defined as separate elements on the same page and referenced by their element `id`.
+
+```json
+"source": {
+  "kind": "join",
+  "joins": [
+    {
+      "left":  { "kind": "table", "elementId": "<left-table-element-id>" },
+      "right": { "kind": "table", "elementId": "<right-table-element-id>" },
+      "columns": [
+        { "left": "[<Left Join Column>]", "right": "[<Right Join Column>]" }
+      ],
+      "joinType": "inner"
+    }
+  ],
+  "primarySource": { "kind": "table", "elementId": "<primary-table-element-id>" }
+}
+```
+
+**`joinType` values:** `"inner"`, `"left-outer"`, `"right-outer"`, `"full-outer"`, `"lookup"`
+
+**Join column `op`** (optional, defaults to `=`): `"="`, `"!="`, `"<"`, `"<="`, `">"`, `">="`, `"within"`, `"intersects"`
+
+To use a non-equality join condition, add `"op": "<value>"` alongside `"left"` and `"right"` in a join column object.
+
+**Column formulas in the join element** reference each source element by its `name` field, using `[ElementName/Column Name]`. Use the primary/left element name for columns from that table and the right element name for columns from the joined table. If a column name appears in both, qualify it to disambiguate:
+
+```json
+{
+  "id": "table-orders-with-customers",
+  "kind": "table",
+  "name": "Orders with Customers",
+  "source": { "kind": "join", "..." : "..." },
+  "columns": [
+    { "id": "col-order-id",  "formula": "[Orders/Order Id]",   "name": "Order Id" },
+    { "id": "col-revenue",   "formula": "[Orders/Revenue]",    "name": "Revenue" },
+    { "id": "col-cust-name", "formula": "[Customers/Name]",    "name": "Customer Name" },
+    { "id": "col-city",      "formula": "[Customers/City]",    "name": "City" }
+  ]
+}
+```
+
+## Union
+
+Stack rows from multiple sources. `sourceColumns` accepts `null` for columns absent in a given source.
+
+```json
+{
+  "id": "table-union",
+  "kind": "table",
+  "source": {
+    "kind": "union",
+    "sources": [
+      { "kind": "table", "elementId": "<element-id-of-source-1>" },
+      { "kind": "table", "elementId": "<element-id-of-source-2>" }
+    ],
+    "matches": [
+      { "outputColumnName": "Column A", "sourceColumns": ["[Column A]", "[Column A]"] },
+      { "outputColumnName": "Column B", "sourceColumns": ["[Column B]", null] }
+    ]
+  },
+  "columns": [
+    { "id": "col-a", "formula": "[Union of 2 Sources/Column A]", "name": "Column A" },
+    { "id": "col-b", "formula": "[Union of 2 Sources/Column B]", "name": "Column B" }
+  ]
+}
+```
+
+**Union element `columns` and naming:** The union element's `columns` array uses a self-referential formula prefix. The API auto-generates this prefix as `"Union of N Sources"` where N is the number of sources in the `sources` array (e.g. 2 sources → `"Union of 2 Sources"`, 3 sources → `"Union of 3 Sources"`).
+
+> **Do NOT set a `name` on the union element.** If an explicit `name` is provided, formula validation rejects self-referential column references because the API cannot resolve the element by name during spec creation/update. Leave `name` omitted — the element will be named "Union of N Sources" in the UI and can be renamed manually afterward. Setting `columns: []` avoids the validation error but leaves the table with zero visible columns.
+
+**Use `elementId`-based sources, not direct `warehouse-table` sources.** Direct `warehouse-table` entries in `sources` work for simple column names but fail for columns containing `/` or `-`. Always define intermediate warehouse-table elements and reference them by `elementId`.
+
+**`sourceColumns` reference format:** Each entry is a bare `[Column Name]` resolved within that source element's own column set — use the `name` field of each column in the source element's `columns` array, NOT the raw warehouse column name.
+
+> **`sourceColumns` and special characters:** `sourceColumns` entries are resolved by column name within the source element's own column set, not re-parsed as a Sigma formula expression. Always use the `name` field value of the column in the source element — not the raw warehouse name. With friendly names ON, a warehouse column `Sub-Category` will have `name: "Sub Category"` (space), so reference it as `"[Sub Category]"`. With a SQL source that aliases it as `"Sub-Category"`, the `name` is `Sub-Category` and you reference it as `"[Sub-Category]"`.
+
+- **Warehouse-table source elements:** Sigma normalizes ALL_CAPS single-word names to title case (`SALES` → `Sales`, `REGION` → `Region`), and splits ALL_CAPS underscore-delimited names on `_`, title-casing each part (`CUSTOMER_ID` → `Customer Id`, `FIRST_NAME` → `First Name`). Digits are preserved in place: `PHONE1` → `Phone1`, `STORE_2` → `Store 2`. Mixed-case quoted identifiers resolve as-is (`Order ID` → `Order ID`, `Last Updated` → `Last Updated`).
+- **SQL source elements:** The column name is exactly what the SQL outputs (your alias) — no normalization. `SELECT SEGMENT AS "Segment"` produces `[Segment]`; `SELECT "Order ID"` produces `[Order ID]`.
+
+**Example:** A warehouse-table source element on Snowflake's `CUSTOMER_ID`, `FIRST_NAME`, `SALES` columns would be referenced in `sourceColumns` as `"[Customer Id]"`, `"[First Name]"`, `"[Sales]"`.
+
+**Column name casing in `sourceColumns`:** (See normalization rules above.) When in doubt, use the name exactly as returned by `/v2/connections/tables/{tableId}/columns` but convert any fully-uppercase name to title case.
+
+**Column names containing `/`:** How `/` is handled depends on whether **friendly names** are enabled for the org.
+
+- **Friendly names ON (default for most orgs):** Sigma automatically replaces `/` **and** `-` with a space when the column is materialized into an element. `Country/Region` → `Country Region`; `Sub-Category` → `Sub Category`. Reference them with the space form in both column formulas and `sourceColumns` — no SQL workaround needed. This is the most common case.
+
+- **Friendly names OFF:** The `/` is a hard blocker — the Sigma formula engine parses it as a path separator, so there is no formula syntax that can reference such a column at runtime. The only working solution is a `sql` source that aliases the column to a slash-free name:
+
+```json
+"source": {
+  "kind": "sql",
+  "connectionId": "<YOUR_CONNECTION_ID>",
+  "statement": "SELECT *, \"Country/Region\" AS \"Country Region\" FROM <DB>.<SCHEMA>.<TABLE>"
+}
+```
+
+Then define the column using `"formula": "[Custom SQL/Country Region]"` and reference `"[Country Region]"` in `sourceColumns`.
+
+> **Prefer explicit SELECT over `SELECT *`** when using SQL to rename a slash column, to avoid both the original and aliased name appearing as columns. List every column explicitly, aliasing just the problem one.
+
+**Practical guidance:** When building a spec for an org you don't control, assume friendly names are ON unless the user tells you otherwise — use direct warehouse-table elements and reference the column with the `/` replaced by a space.
+
+**Column names containing `-`:** With **friendly names ON** (default), hyphens are automatically replaced with spaces — the same behavior as `/`. A warehouse column named `Sub-Category` materializes as `Sub Category` inside the element. Use `"formula": "[TABLE_NAME/Sub Category]"` and `"name": "Sub Category"`. Reference it as `[Sub Category]` in `sourceColumns`.
+
+With **friendly names OFF**, a hyphen is a hard blocker in formula expressions (treated as subtraction). Use a `sql` source with a double-quoted alias: `"Sub-Category" AS "Sub-Category"` preserves the hyphen cleanly. Then `"formula": "[Custom SQL/Sub-Category]"` and reference as `[Sub-Category]` in `sourceColumns`.
+
+**Other special characters (`%`, `(`, `)`, `#`, `@`):** These have no special meaning in Sigma formula syntax and can appear in column names without issues. `[Profitability (in %)]` is a valid formula reference.
+
+## Transpose — column-to-row
+
+Merge multiple columns into key/value pairs (unpivot).
+
+```json
+"source": {
+  "kind": "transpose",
+  "source": { "kind": "warehouse-table", "connectionId": "<YOUR_CONNECTION_ID>", "path": ["<DB>", "<SCHEMA>", "<TABLE>"] },
+  "direction": "column-to-row",
+  "columnsToMerge": ["Column A", "Column B", "Column C"],
+  "columnLabelForMergedColumns": "Event Type",
+  "columnLabelForValues": "Event Time"
+}
+```
+
+## Transpose — row-to-column
+
+Pivot row values into column headers.
+
+```json
+"source": {
+  "kind": "transpose",
+  "source": { "kind": "warehouse-table", "connectionId": "<YOUR_CONNECTION_ID>", "path": ["<DB>", "<SCHEMA>", "<TABLE>"] },
+  "direction": "row-to-column",
+  "columnToTranspose": "<column-id-whose-values-become-headers>",
+  "valueColumn": "<column-id-for-cell-values>",
+  "outputColumns": ["Value A", "Value B", "Value C"],
+  "aggregate": "sum"
+}
+```
+
+**Row-to-column `aggregate` values:** `"min"`, `"max"`, `"count"`, `"count-if"`, `"count-distinct"`, `"sum"`, `"avg"`, `"median"`

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/workflows/authoring.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/workflows/authoring.md
@@ -1,0 +1,85 @@
+# Authoring — Judgment Calls When Building a Data Model
+
+Mechanics live in `crud.md`. This file is the "how should I structure this?" guidance for someone composing a new data model from scratch.
+
+## One big model vs. many small ones
+
+A Sigma data model is a graph of elements (tables, derived elements, SQL sources) connected by relationships. There's no hard limit, but readability and load time degrade past ~30–40 elements.
+
+- **One model per analytic domain.** Sales, marketing, ops — each gets its own model. Don't try to fit everything in `Master Model`.
+- **Reuse via workbook-level joins** if two domains rarely overlap. A workbook can source columns from two different models on the same page; you don't have to merge them.
+- **Split a model** when more than half its elements are unused by any consumer; the unused ones add load time and visual clutter without benefit.
+
+## SQL source vs. warehouse-table source
+
+| Use a `warehouse-table` source when… | Use a `sql` (custom SQL) source when… |
+|---|---|
+| The table is already shaped the way you want it. | The shape requires a JOIN, UNION, or window function the model can't express directly. |
+| You want column-level lineage and CLS to flow naturally. | You're depending on a vendor-specific SQL feature (e.g., Snowflake `MATCH_RECOGNIZE`, BigQuery `STRUCT` flattening). |
+| The table is small enough to query live. | A pre-computed view exists in the warehouse and you want to surface it as-is. |
+| You want push-down to be obvious to the reader. | Performance demands a materialized intermediate table the model can pin to. |
+
+Default to `warehouse-table`. Reach for `sql` only when you have a concrete reason — every SQL source is one more thing for someone else to debug six months from now.
+
+## Joins in the model vs. joins in workbooks
+
+Both are valid; they have different ergonomics.
+
+**Model-level joins (`relationships`):**
+- Pros: every workbook that sources the model gets the joined columns "for free". Lineage and CLS flow consistently.
+- Cons: if a workbook only needs one side, the join still executes. Wider blast radius when a key changes.
+
+**Workbook-level joins (`source.kind: "join"`):**
+- Pros: scoped to one workbook. No effect on other consumers of the underlying model.
+- Cons: every new workbook re-defines the same join. Easy to drift apart over time.
+
+Rule of thumb: **if more than two workbooks need the join, put it in the model.** If it's a one-off (e.g., enriching a dashboard with a temporary cohort table), keep it in the workbook.
+
+## Naming conventions
+
+- **Element names** — natural language, capitalized. `Orders Fact`, `Customer Dimension`, `Daily Sales Snapshot`. The element name shows up everywhere downstream (workbook formulas, lineage views, search) — make it readable.
+- **Column display names** — Title Case (`Order Id`, not `ORDER_ID`). The MCP / converter tool handles `SNAKE_CASE → Title Case` automatically; if you're hand-authoring, do it yourself.
+- **Metric names** — start with the verb (`Sum of Revenue`, `Average Order Value`, `Active Customer Count`). Avoid bare nouns; they collide with column names.
+- **Relationship names** — `<source> to <target>` (`Orders to Customers`). The relationship name appears in formulas as the prefix when referencing the joined table.
+
+## Where to put metrics: model vs. column vs. workbook
+
+| Kind | Lives on… | Use when |
+|---|---|---|
+| Metric (model-level) | An element's `metrics` array | The aggregation is canonical for that table — `Total Revenue`, `Active Customers`. Should be the same number in every workbook that uses the model. |
+| Calculated column (model-level) | An element's `columns` array as a derived formula | Per-row derivation like `Revenue - Cost` or `If([Status]="Active", 1, 0)`. Makes sense to compute once at the model layer if multiple workbooks need it. |
+| Workbook calc | The workbook's `columns` on the chart/table | One-off calculation only that workbook cares about. Don't pollute the model with workbook-specific math. |
+
+## Folder & workspace placement
+
+- New colleagues' models default to **`My Documents`** unless told otherwise. That's fine for prototyping.
+- Once a model is consumed by a published workbook, move it to a **shared workspace** (e.g., `Marketing Workbooks`, `Operations`) so it's discoverable and grant-controlled. Don't leave production models in someone's home folder.
+- Keep "scratch / WIP" models in a separate folder (`Dev`, `Sandbox`) so they're easy to clean up later.
+- The `folderId` field on a model spec is required at create time. Use `GET /v2/files?typeFilters=folder` to find folder IDs.
+
+## When to materialize
+
+Materializing a model element pre-computes the result and stores it in the warehouse on a schedule. Consider it when:
+
+- An element's query takes more than ~10s to render in interactive use.
+- The same heavy aggregation is consumed by multiple workbooks.
+- The underlying tables don't change often (daily snapshot models, monthly metric rollups).
+
+Avoid for:
+
+- Real-time / near-real-time data (materialization adds lag).
+- Models still being authored — set up materialization once the shape stabilizes.
+- Tiny tables where the query already runs in <1s.
+
+See `crud.md` for the materialization API (`POST /v2/dataModels/{id}:materialize`).
+
+## When stuck on shape
+
+If you're guessing at how a field should look — especially after one or two failed `POST` attempts — **stop guessing and pull a known-working model's spec from the user's workspace**:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" > /tmp/reference.json
+```
+
+Diff against your draft. The canonical shape sitting in the user's workspace beats any guess. See `validate.md` for the full troubleshooting flow.

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/workflows/crud.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/workflows/crud.md
@@ -1,0 +1,244 @@
+# Data Model CRUD
+
+POST / GET / PUT against the data-model spec endpoints. Load this for any create, retrieve, or update operation.
+
+The three workflows share auth, ID conventions, and the feature reference files in `reference/`. They differ in HTTP verb, full-replacement semantics, and ID handling. Read the **ID semantics across CRUD** table first — many bugs come from mixing up which IDs the server respects vs. remaps.
+
+Every call includes `-H "Authorization: Bearer $SIGMA_API_TOKEN"`. Auth comes from the `sigma-api` skill.
+
+## ID Semantics Across CRUD
+
+| Phase | What happens to IDs |
+|-------|---------------------|
+| **CREATE (POST)** | All submitted IDs (pages, elements, columns) are remapped by the server to short alphanumeric IDs. Cross-references (`dateColumnId`, relationship keys) are resolved against the submitted IDs *before* remapping, so they end up correct. Nothing you sent comes back verbatim. |
+| **GET** | Server-assigned IDs only. This is the source of truth for any subsequent UPDATE. |
+| **UPDATE (PUT) — existing elements** | Keep the server-assigned IDs verbatim. Changing them on unchanged elements can break workbooks that depend on this data model. |
+| **UPDATE (PUT) — new elements added in the same PUT** | Server remaps them just like CREATE. Use placeholder IDs (`inode-<tableId>/<COL>` for warehouse columns, short alphanumeric otherwise) — they will not come back verbatim. |
+| **UPDATE — mixed cross-references** (e.g., a relationship between an existing column and a new one) | Existing side uses the live server ID. New side uses the placeholder. Server resolves on submit. |
+
+> **Rule of thumb:** GET is the only step that returns IDs you can rely on. Use GET as the entry point for every UPDATE.
+
+## CREATE — Author a New Model
+
+### 1. Gather required IDs
+
+You need a `folderId`, a `connectionId`, and (usually) a warehouse `path` + inode prefix.
+
+**Destination folder:**
+
+```sh
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/files" \
+  | jq '.entries[] | {inodeId, name, type}'
+```
+
+The `inodeId` of the target folder becomes `folderId`.
+
+**Connection:**
+
+```sh
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/connections" \
+  | jq '.entries[] | {connectionId, name}'
+```
+
+**Connection paths and tables:**
+
+```sh
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/connections/paths?limit=1000"
+```
+
+Search the `entries` array for depth-3 `path` values (e.g., `["EXAMPLES", "PLUGS_ELECTRONICS", "TABLE_NAME"]`). If `hasMore` is `true`, paginate with `&page=<nextPage>`.
+
+Once you have the path, look up the table for its inode prefix:
+
+```sh
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"path": ["<DATABASE>", "<SCHEMA>", "<TABLE>"]}' \
+  "$SIGMA_BASE_URL/v2/connection/<connectionId>/lookup"
+```
+
+The last segment of the `url` field (e.g., `.../t/5FCsrDpnzcdw5YYJRBbY6l`) becomes the inode prefix for warehouse column IDs: `inode-5FCsrDpnzcdw5YYJRBbY6l/<COLUMN_NAME>`.
+
+**Connection table columns** (use to discover real column names + types before composing — never invent column names):
+
+```sh
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/connections/tables/<inodeId>/columns"
+```
+
+Returns `name`, `type`, and `visibility`. Normalize special characters per the **Special characters** section in `reference/columns.md`.
+
+**Existing data-model elements / columns** (only when the user explicitly names an existing model as a relationship target or template):
+
+```sh
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/elements"
+
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/columns"
+```
+
+Use `columnId` values when referencing columns in relationship keys.
+
+> Do **not** read other data models to infer column names, discover table structure, or borrow patterns unless the user explicitly named one as a template or source.
+
+### 2. Identify features
+
+Map the user's request to feature reference files via the SKILL.md **Reference Index**. Tell the user which features you identified and why, then read the relevant files before composing.
+
+If the user explicitly names an existing model to base the new one on, retrieve its spec via the GET workflow below and use it — modified per the description — as the basis instead of the minimal structure.
+
+### 3. Compose the JSON
+
+Start from the minimal structure, then layer in patterns from the reference files.
+
+```json
+{
+  "name": "<YOUR_DATA_MODEL_NAME>",
+  "folderId": "<YOUR_FOLDER_ID>",
+  "schemaVersion": 1,
+  "pages": [
+    {
+      "id": "page-1",
+      "name": "Main",
+      "elements": [
+        {
+          "id": "table-1",
+          "kind": "table",
+          "source": {
+            "kind": "warehouse-table",
+            "connectionId": "<YOUR_CONNECTION_ID>",
+            "path": ["<YOUR_DATABASE>", "<YOUR_SCHEMA>", "<YOUR_TABLE_NAME>"]
+          },
+          "columns": [
+            {
+              "id": "<YOUR_TABLE_INODE>/<COLUMN_NAME>",
+              "formula": "[<YOUR_TABLE_NAME>/Column Name]",
+              "name": "Column Name"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+After the JSON, surface a "What you need to supply" table:
+
+| Placeholder | What it is | How to find it |
+|---|---|---|
+| `<YOUR_FOLDER_ID>` | Destination folder for the data model | `GET /v2/files` output or the folder URL in Sigma |
+| `<YOUR_CONNECTION_ID>` | Data source connection | `GET /v2/connections` output or the Connections page |
+| `<YOUR_DATABASE>` / `<YOUR_SCHEMA>` / `<YOUR_TABLE_NAME>` | Warehouse path to source table | The warehouse, or the connection browser in Sigma |
+| `<YOUR_TABLE_INODE>` | Inode prefix for warehouse column IDs | Last path segment of the `url` returned by `POST /v2/connection/<id>/lookup` (e.g., `.../t/5FCsrDpnzcdw5YYJRBbY6l` → `inode-5FCsrDpnzcdw5YYJRBbY6l`) |
+
+Reminder on IDs: anything you submit is remapped on accept (see the ID semantics table at the top). Cross-references (e.g., `dateColumnId` in metric timelines, relationship keys) are resolved correctly before remapping.
+
+### 4. Submit
+
+```sh
+cat > spec.json <<'EOF'
+{ ...the composed JSON... }
+EOF
+
+curl -s -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @spec.json \
+  "$SIGMA_BASE_URL/v2/dataModels/spec"
+```
+
+The response includes the `dataModelId` of the new model. Give the user a link in the form `https://app.sigmacomputing.com/<org_name>/data-model/<dataModelId>`.
+
+## GET — Read an Existing Model
+
+> **This is the entry point for an UPDATE — always GET first.** The retrieved spec is the only source of IDs you can safely PUT back.
+
+### 1. List models
+
+```sh
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/dataModels" \
+  | jq '.entries[] | {dataModelId, name}'
+```
+
+If the user wants to browse by folder first:
+
+```sh
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/files" \
+  | jq '.entries[] | {inodeId, name, type}'
+```
+
+### 2. Retrieve the spec
+
+```sh
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" \
+  | jq .
+```
+
+Save to a file for review or as input to the UPDATE workflow:
+
+```sh
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" \
+  > my-data-model.json
+```
+
+## UPDATE — Modify an Existing Model
+
+The update endpoint uses **PUT** and requires the **complete** representation, not a diff. Always start from the GET so existing elements are preserved.
+
+### 1. List + identify
+
+Same as the GET workflow — `GET /v2/dataModels`, optionally `GET /v2/files` to browse by folder.
+
+### 2. Retrieve the current spec
+
+```sh
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" \
+  > current-spec.json
+```
+
+### 3. Identify changes and load references
+
+For each type of change the user is asking for, read the corresponding reference file from the SKILL.md **Reference Index** to get the correct JSON pattern. Common change categories:
+
+- Add, rename, or remove a column or metric → `reference/columns.md`, `reference/metrics.md`
+- Add a calculated column or change a formula → `reference/columns.md`
+- Change or swap the data source → `reference/sources.md`
+- Add a relationship or join → `reference/relationships.md`, `reference/sources.md`
+- Add, modify, or remove filters → `reference/filters.md`
+- Add column-level security → `reference/column-level-security.md`
+- Add or modify controls → `reference/controls.md`
+- Reorder columns or change folder/grouping → `reference/folders-groupings.md`
+- Reformat a column or metric → `reference/formatting.md`
+
+Use the retrieved spec as structural context — match existing ID conventions and naming patterns.
+
+### 4. Compose the updated spec
+
+Apply the changes to `current-spec.json`. Key rules:
+
+- Include from the GET response: `name`, `folderId`, `ownerId`, `createdAt`, `updatedAt`, `schemaVersion`, and all of `pages`. Server-managed fields (`documentVersion`, `latestDocumentVersion`, `url`, `createdBy`, `updatedBy`) can be omitted — they are silently ignored if present.
+- **Preserve existing element IDs** — changing them on unchanged elements can break workbooks that depend on this data model.
+- For new elements, follow the ID conventions: short alphanumeric for generated IDs, `inode-<tableId>/<COL>` for warehouse columns. They'll be remapped on submit.
+- Controls live in the page `elements` array alongside table elements, not inside them.
+- Mixed-ID cross-references (e.g., a relationship between an existing column and a new one): see the ID semantics table at the top of this file. Existing side uses the live server ID; new side uses the placeholder; server resolves on submit.
+
+### 5. Submit
+
+```sh
+curl -s -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @current-spec.json \
+  "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec"
+```

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/workflows/discover.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/workflows/discover.md
@@ -1,0 +1,62 @@
+# Discover — Find Connections, Tables, Columns
+
+The first step before authoring any data model is figuring out **what data exists**: which connections the user has, which schemas / tables live inside them, and which columns each table exposes. **Never invent column names** — only use names you confirmed via the API or the user gave you.
+
+Auth via the `sigma-api` skill first. All commands assume `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN` are set.
+
+## 1. List connections
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/connections?limit=200" | jq '.entries[] | {connectionId, name, type}'
+```
+
+Pick the connection by `name` or `type` (Snowflake, BigQuery, Databricks, Redshift, Postgres, MySQL, etc.). Save its `connectionId` — you'll need it for every warehouse-table source in the spec.
+
+## 2. Resolve a table path → inodeId
+
+You need the table's `inodeId` (not just its dotted path) for the columns endpoint and for warehouse-table sources. Resolve it with `lookup`:
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"path": ["DATABASE", "SCHEMA", "TABLE_NAME"]}' \
+  "$SIGMA_BASE_URL/v2/connection/<connectionId>/lookup" | jq .
+```
+
+The response includes the table's `inodeId` (looks like `inode-<22-char>`). The `path` array segments depend on the warehouse — Snowflake is typically `[DATABASE, SCHEMA, TABLE]`, BigQuery is `[PROJECT, DATASET, TABLE]`, etc.
+
+## 3. List columns for a table
+
+The columns endpoint is keyed by **table inodeId**, not connectionId:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/connections/tables/<tableInodeId>/columns" | jq '.entries[] | {name, type}'
+```
+
+Capture the column `name` exactly as returned — case, special characters, and underscores all matter for downstream formula references.
+
+> **Wrong shape:** `/v2/connections/<connectionId>/tables/<inodeId>/columns` is **not** the endpoint. The connection ID does not appear in the path. Using the wrong shape returns 404.
+
+## 4. Browse schemas (optional)
+
+If the user doesn't know the table path yet, walk the connection's path tree:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/connections/paths?connectionId=<connectionId>&parentPath=DATABASE" | jq .
+```
+
+Each level (database → schema → table) is a separate call. Most authoring sessions start from a path the user already knows; this is the fallback for "what schemas can I see in this connection?"
+
+## 5. Sanity-check before drafting
+
+Before writing the model spec:
+
+- [ ] Connection `connectionId` confirmed.
+- [ ] Every table you plan to include has a real `inodeId` (lookup result, not guessed).
+- [ ] Every column you plan to reference appears in the columns response **verbatim** (or the user provided it from a warehouse query they ran themselves).
+- [ ] If joining elements, you know the join keys and whether they're 1:1, 1:many, or many:many — ask the user if uncertain.
+
+Cross-link: the `sources.md` file documents the warehouse-table source shape that consumes these IDs. The `columns.md` file covers the column ID format (`inode-<22>/COLUMN_NAME`) and the `[TABLE/Display Name]` formula reference rule.

--- a/plugins/sigma-authoring/skills/sigma-data-models/reference/workflows/validate.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/reference/workflows/validate.md
@@ -1,0 +1,63 @@
+# Validate — Pre-Submit Checklist & Troubleshooting
+
+Run through this before every `POST /v2/dataModels/spec` and `PUT /v2/dataModels/<id>/spec`. Most failures are catchable here.
+
+## Pre-submit checklist
+
+- [ ] `name` and `folderId` are set (required at create time).
+- [ ] `schemaVersion` is the value returned by `GET /v2/dataModels/<reference-id>/spec` — never hardcoded.
+- [ ] Every element has a unique `id` and a descriptive `name`.
+- [ ] Every column has a unique `id` and a `formula`.
+- [ ] Warehouse-table column IDs follow `inode-<22-char>/<COLUMN_NAME_UPPER>` format.
+- [ ] Generated short IDs (10-char alphanumeric) are unique within their scope.
+- [ ] Every formula reference matches an existing column or element name **case-sensitively** — `[ORDERS/Order Id]` ≠ `[orders/order id]`.
+- [ ] No `IsIn(...)` calls. (Sigma's formula language has no `IsIn` — see `../formulas` cross-link in the workbook skill, or use chained `or` instead.)
+- [ ] No `CountOver` / `SumOver` / `RowNumberOver` in **DM element calculated columns** — they silently fail. See `../calc-columns.md` for workarounds.
+- [ ] If `relationships[]` is set, every `targetElementId` exists in `pages[].elements[].id`.
+- [ ] If joining a new element to an existing one in an UPDATE, the existing element's ID is the **server-assigned internal ID** (from a fresh `GET`), not your external draft ID. See `crud.md` "mixed-ID rule."
+- [ ] Response-only fields (`dataModelId`, `url`, `documentVersion`, `latestDocumentVersion`, `ownerId`, `createdBy`, `updatedBy`, `createdAt`, `updatedAt`) are stripped from the request body.
+
+## Decode common errors
+
+| Error | Likely cause |
+|---|---|
+| `400 Invalid argument` / `unknown field` / `unexpected property` | Schema drift between this skill and the live API. Fetch the OpenAPI (`https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`) and diff field names. |
+| `400 Invalid column reference` | Bare `[col]` used where `[TABLE/col]` was needed, or the column name is misspelled. |
+| `400 Invalid element ID` (in relationships) | An UPDATE that mixes external and internal IDs. The existing element ID must come from `GET`. |
+| `403 Forbidden` | Credential lacks "Create, edit, and publish data models" permission, or "Can edit" on the destination folder. Ask your Sigma admin. |
+| `409 Conflict` (`inode_archived`) | The target file is archived. Restore via `PATCH /v2/files/<id>` with `{"restore": true}`, then retry. |
+
+## When stuck — pull a known-working model
+
+If a fix doesn't work after one or two attempts, **stop iterating and pull the spec of a real, working data model in the user's workspace**:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/dataModels/<workingModelId>/spec" > /tmp/reference-spec.json
+```
+
+Diff your draft against `/tmp/reference-spec.json`. Real working specs encode all the constraints the docs may omit. Match the working shape rather than guessing.
+
+To find candidate models:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/dataModels?limit=200" | jq '.entries[] | select(.path | startswith("Production")) | {dataModelId, name}'
+```
+
+Pick one that uses the same source kind / relationship style / metric pattern as your draft.
+
+## After CREATE — IDs reassign
+
+The server remaps your external IDs to internal ones on `POST`. **Before any follow-up `PUT`** that adds to or modifies the model, GET the current spec and use the IDs from the readback. See `crud.md` for the full ID-remap behavior.
+
+## Manual smoke-test in the UI
+
+After a successful CREATE or UPDATE, open the model in the Sigma UI. Check:
+
+- All expected elements appear in the model panel.
+- Relationships are drawn as expected.
+- A sample query (preview a column) returns rows, not an error icon.
+- Metrics show the right formula in the metric editor.
+
+A spec that POSTs cleanly can still render broken — the manual check catches that.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: sigma-workbooks
+description: >-
+  Build, edit, and iterate on Sigma workbook specs — the JSON definition you
+  POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs,
+  tables, formulas, and sources. The Sigma OpenAPI is the source of truth for
+  every shape and field; this skill adds navigation, style guidance, and
+  proven recipes for effective dashboards. Use when the user wants to
+  construct a dashboard from a spec, add or modify pages / elements /
+  controls / formulas, validate a spec before submission, or work through
+  the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN
+  — obtain via the sigma-api skill first.
+---
+
+# Sigma Workbooks (Spec via REST API)
+
+This skill helps you build effective Sigma workbooks by **navigating the Sigma OpenAPI** and applying **style guidance + proven recipes** beyond what the OpenAPI alone teaches.
+
+## Scope
+
+The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pages, elements, sources, formulas, and layout. Lifecycle around the workbook (embeds, grants, materialization schedules, bookmarks, sharing) is a separate API surface and out of scope here.
+
+## Sources of truth
+
+1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
+   `https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`
+2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`.
+
+Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
+
+## Consulting the OpenAPI
+
+The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
+
+```bash
+curl -sf https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+
+# The entire workbook spec request body lives under one path (it is not split into named schemas):
+jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json
+```
+
+Element, source, control, and format shapes are **inlined** under that path and identified by their `kind` value (e.g. `bar-chart`, `kpi-chart`, `join`, `warehouse-table`) — not by a top-level schema name. Navigate by the `kind` discriminator:
+
+```bash
+# List every kind the spec accepts (elements, sources, controls, formats, …):
+jq -r '[.. | objects | select(.properties.kind.enum) | .properties.kind.enum[0]] | unique[]' /tmp/sigma-api.json
+
+# Full field list (required + optional) for one kind — swap bar-chart for any kind above:
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))
+  | {required: ([.allOf[]?.required // .required] | add | unique), properties: ([(.allOf[]?.properties // .properties) | keys[]] | unique)}' /tmp/sigma-api.json
+
+# The full nested shape for that kind (to inspect sub-objects like source, yAxis, format, comparison):
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+`WebFetch` works for the JSON too. Either path is fine.
+
+**Why bother:** the API ships new fields and viz configurations regularly, and this skill covers the common surface, not every field. If you want a capability and don't see it documented here, **assume it may exist and check the spec before concluding it doesn't** — the `kind` query above answers in seconds.
+
+## Auth
+
+Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`.
+
+## Recommended Workflow
+
+These are guidelines, not mandates — but they prevent the failure modes that show up most often when drafting from scratch.
+
+> **Schema drift signal:** an error about request *shape* (`invalid argument`, `unknown field`, `missing required field`, `unexpected property`) usually means this skill is stale on that detail. Fetch the OpenAPI and compare; the canonical shape is there.
+
+### Step 0 — Authenticate, capture user identity
+
+```bash
+USER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/whoami" | jq -r '.userId')
+
+HOME_FOLDER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/members/$USER_ID" | jq -r '.homeFolderId')
+```
+
+If the user provided a **target image** (a screenshot, mockup, or PDF of a dashboard they want reproduced), pause here and load `reference/workflows/from-image.md` — it adds explicit observation, description, and validation steps that have to happen *before* normal data discovery. The standard workflow alone tends to produce workbooks with the right vibe but the wrong shape when the input is visual.
+
+### Step 1 — Find a reference workbook to study
+
+Any existing workbook on the user's org doubles as a template. List and pick one with similar content:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks?limit=50" | jq '.entries[] | {workbookId, name}'
+```
+
+If no relevant workbook exists, pick any — the goal is studying spec structure, not matching content. If the org has no workbooks at all, draft from scratch using the OpenAPI shapes + this skill's recipes.
+
+### Step 2 — Study the reference spec
+
+YAML is the canonical format for workbook specs in this skill — easier to read, diff, and review than JSON. Sigma's API accepts both (`Content-Type: application/yaml` or `application/json`); `Accept: application/yaml` is the default on `GET /v2/workbooks/<id>/spec`. Use `yq` to inspect spec YAML the same way you'd use `jq` on JSON.
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<reference-workbook-id>/spec" \
+  > /tmp/reference-spec.yaml
+```
+
+Look at source structure, column ID patterns, formula syntax, element naming, layout XML idioms. The `pages` array shape is exactly what you'll POST when creating.
+
+### Step 3 — Discover data sources
+
+Load `reference/workflows/discover.md`. Quick summary:
+
+1. `GET /v2/connections` — find the user's connection by name or type.
+2. Ask the user for the table path; verify with `POST /v2/connection/<id>/lookup`.
+3. Discover columns directly via `GET /v2/connections/tables/{inodeId}/columns` (full mechanics in `reference/workflows/discover.md`). Only fall back to asking the user when the endpoint doesn't return what's needed.
+
+**Never invent column names** — only use names returned by the API or supplied by the user.
+
+**Verify literal values before writing predicates.** If your task involves filtering on a categorical column (e.g., `CountIf([Status] = "active")`, `If([Type] = "sale", ...)`), you need to know what values that column *actually* contains — the `/v2/connections/tables/{inodeId}/columns` endpoint gives you names and types but not values. Run a `SELECT DISTINCT <col>` via any tool that reaches the warehouse — an MCP server (warehouse or [Sigma](https://help.sigmacomputing.com/docs/use-sigma-mcp-server)), a SQL CLI, or just ask the user. Don't guess literals. See `reference/workflows/discover.md`.
+
+### Step 4 — Identify features and load only what you need
+
+Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
+
+### Step 5 — Draft the spec to a local file
+
+Write the spec YAML to disk (e.g., `/tmp/workbook-spec.yaml`). YAML is preferred over JSON in this skill — easier to read, diff, and comment for human review. The API accepts either; pick YAML unless something downstream specifically needs JSON. Key rules:
+
+- Every element needs a unique `id` and a descriptive `name`.
+- Every column needs a unique `id`, a `name`, and a `formula`.
+- Follow the formula reference rules in `reference/specification/formulas.md` exactly — most spec errors happen here.
+- **Write explicit `layout` XML for multi-element workbooks.** Auto-arrange (omitting `layout`) is acceptable only for single-element pages or a uniform stack of tables. See `reference/specification/layout.md` for the rubric.
+- Start with 1–2 pages. Add more later via update.
+
+For **create**, the file must include top-level `name`, `folderId`, `schemaVersion`, and `pages`. `description` is optional. `layout` is technically optional but expected for multi-element workbooks. `schemaVersion` is usually `1` — that's the current value; it may change in the future, so if the API rejects the spec on that field, check what your reference-workbook GET in Step 2 returned and use that instead. Full CRUD mechanics are in `reference/workflows/crud.md`.
+
+### Step 6 — Validate the spec
+
+**Run the bundled validator first — do not skip.**
+
+```bash
+./scripts/validate-spec.sh /tmp/workbook-spec.yaml
+```
+
+Then do the manual formula pass and final shape checks per `reference/workflows/validate.md`. Fix everything reported before continuing.
+
+### Step 7 — Create the workbook
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/workbook-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/spec" > /tmp/create-response.yaml
+
+WORKBOOK_ID=$(yq -r '.workbookId' /tmp/create-response.yaml)
+cp /tmp/workbook-spec.yaml "/tmp/workbook-spec-${WORKBOOK_ID}.yaml"
+```
+
+Persist the spec after a successful create so subsequent `PUT` updates can start from it. Report **both** the workbook URL **and** the saved spec path.
+
+If creation fails, read the error, fix the spec, re-validate, retry. See `reference/workflows/validate.md` for decoding cryptic errors.
+
+### Step 7b — Verify the workbook actually compiles
+
+**Do not skip.** A successful POST is necessary but not sufficient — Sigma accepts specs whose formulas don't resolve, then surfaces the failures at query time by embedding the error as a string literal in the compiled SQL (`'Unknown column "[X]"'`, `'Circular column reference to [Y]'`). Affected elements render empty in the UI. Only Sigma's compiler knows whether your formula references actually resolve.
+
+```bash
+./scripts/verify-workbook.sh "$WORKBOOK_ID"
+```
+
+If any element reports `[FAIL]`, fix the column formulas in the spec (most often a missing source prefix, a self-referencing column, or a friendly-name mismatch with the warehouse — see `reference/specification/formulas.md`), `PUT` the corrected spec, and re-verify.
+
+### Step 8 — Iterate
+
+After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
+
+**For anything beyond ~1 page / ~10 elements, switch to the element rep** (`reference/workflows/element-rep.md`): `scripts/wb-rep.rb pull <id> <dir>` explodes the spec into one file per element so each edit touches a ~½KB file instead of the whole spec, `push` handles drift-check + validation + PUT, and `render` exports page PNGs you can actually look at. The raw GET/PUT flow below remains fine for small workbooks and one-off tweaks.
+
+> **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" \
+  > /tmp/current-spec.yaml
+
+# Edit /tmp/current-spec.yaml, then:
+curl -s -X PUT -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/current-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" | yq .
+
+cp /tmp/current-spec.yaml "/tmp/workbook-spec-<workbook-id>.yaml"
+./scripts/verify-workbook.sh "<workbook-id>"
+```
+
+### Step 9 — Report back
+
+Report the workbook URL and the saved spec path. **Do not tack on generic "improvement ideas" or "next steps."** Match the response to what was asked.
+
+Surface follow-up items only when they're load-bearing, and name them concretely:
+
+- **Tradeoffs you made during the build** — dropped a chart, simplified a formula, skipped a control because the shape wasn't in your reference.
+- **Obvious gaps revealed by the column list** — e.g., the user asked for "sales by region" and the table has a `region_tier` column that would make the breakdown richer. One sentence, named.
+
+If none apply, just report the URL + spec path and stop.
+
+## Reference Index
+
+The reference is feature-sliced — don't read every file up-front. The index has three sections: **elements** (the visual / interactive pieces), **sources** (where each element gets its data), and **cross-cutting** (formulas, layout, formatting, validation, CRUD).
+
+### Elements
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
+| `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
+| `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
+| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the period-over-period formula recipe, and the spec limits of the comparison / trend-sparkline blocks (UI-bound). |
+| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
+| `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
+| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+
+### Sources
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/sources-warehouse.md` | Always — load before drafting any spec. Warehouse-table source (Snowflake, BigQuery, Databricks, Redshift, Postgres/MySQL). |
+| `reference/specification/sources.md` | Reference another chart/table/element, derive from existing element, join, combine tables, data model / semantic-layer source, custom SQL, union, transpose, unpivot. |
+
+### Cross-cutting
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/schema.md` | Always — load before drafting any spec. Top-level shape, required fields, response-only fields to strip. |
+| `reference/specification/formulas.md` | Always — load before drafting any spec. Formula syntax, qualification, special characters, the #1 mistake. |
+| `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
+| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
+| `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
+
+### Workflows
+
+| File | When to load |
+|------|--------------|
+| `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
+| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
+| `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
+| `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
+
+## Quick Formula Rules
+
+The single most common spec error is bare `[column_name]` references to warehouse columns. Full rules in `reference/specification/formulas.md`. Skeleton:
+
+**Outside the element** — use `[SourceName/column_name]`:
+- Warehouse-table source: `SourceName` = last segment of the `path` array (e.g., `[ORDERS/Revenue]`)
+- Another element: `SourceName` = that element's `name`
+- Join legs: prefix by the leg's `name`, or by the join's top-level `name` for `primarySource` columns
+
+**Inside the same element** — use `[column_name]` (no prefix):
+- References a column defined in this element by its `name` field.
+- A column cannot reference itself (circular reference error).
+
+## Troubleshooting
+
+### "I don't see this field in the skill"
+
+Fetch the OpenAPI. The skill documents stable, common surface area; the API has more. See **Consulting the OpenAPI** above.
+
+### API schema mismatch (skill is stale)
+
+A 400 about request *shape* — `invalid argument`, `unknown field`, `unexpected property`, `missing required field` — usually means the API moved past the skill. Fetch the OpenAPI (see **Consulting the OpenAPI**), diff the live shape for that `kind`, and retry **once** with the correction. Tell the user it looks like the skill is out of date and worth updating through whatever channel they installed it from; don't loop on retries.
+
+### 401 Unauthorized
+
+Sigma OAuth tokens expire after ~1 hour. Long workbook-building sessions (orchestrated batch conversions, multi-step iterations, anything that runs >50 minutes) will hit this mid-flight.
+
+**Ruby callers** (any of the `tableau-to-sigma/scripts/*.rb` Sigma-touching scripts): use the `Sigma` REST wrapper at `tableau-to-sigma/scripts/lib/sigma_rest.rb` — it does automatic 401-with-refresh-and-retry. Concretely:
+
+```ruby
+require_relative 'lib/sigma_rest'
+spec = Sigma.request(:get, "/v2/workbooks/#{id}/spec")   # auto-refreshes on 401
+```
+
+**Bash / curl callers**: re-run `eval "$(scripts/get-token.sh)"` to refresh manually. For long shell loops, wrap the curl in a small helper that retries once on 401:
+
+```bash
+sigma_curl() {
+  local resp code
+  resp=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $SIGMA_API_TOKEN" "$@")
+  code=$(echo "$resp" | tail -1)
+  if [ "$code" = "401" ]; then
+    eval "$(scripts/get-token.sh)"
+    resp=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $SIGMA_API_TOKEN" "$@")
+  fi
+  echo "$resp" | sed '$d'  # strip trailing status code
+}
+```
+
+If 401 persists after refresh, re-authenticate via `sigma-api` and verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`.
+
+### 403 Forbidden on workbook create
+
+The credentials authenticated but aren't permitted to create workbooks here. Ask the user's Sigma admin to confirm the credential's permissions and folder access.
+
+### "Invalid column reference" or formula errors on creation
+
+The most common spec issue. A bare `[column_name]` was used where `[TABLE/column_name]` is needed. See `reference/specification/formulas.md` for the full rules and `reference/workflows/validate.md` for the manual checklist.
+
+### "Unknown column" errors
+
+The column name in the formula doesn't match what the warehouse actually has. Re-confirm the column names via `GET /v2/connections/tables/{inodeId}/columns` (raw warehouse names) and the readback (`GET /v2/workbooks/<id>/spec`, which shows Sigma's normalized friendly names). Use those names verbatim.
+
+### `jq` or `yq` not installed
+
+`jq` is used for OpenAPI inspection (the OpenAPI is JSON). `yq` is used for workbook-spec inspection (specs are YAML).
+
+- `jq`: `brew install jq` (macOS) or `apt install jq` (Debian/Ubuntu).
+- `yq`: **two different tools share this name** — the Go **mikefarah/yq** (`brew install yq`) and the Python **`pip install yq`** wrapper around jq. *Reading* works the same in both (`yq -r '.workbookId' f.yaml`), but *in-place editing differs*: mikefarah uses `yq -i '…' f.yaml`, while the Python wrapper needs `yq -y -i '…' f.yaml`. Run `yq --help` to see which you have and adapt.
+
+### Cryptic validation errors / silent bad data
+
+See `reference/workflows/validate.md` for the full triage table (mapping `Invalid kind: pages[0].elements[N]...` style errors to the right spec file).

--- a/plugins/sigma-authoring/skills/sigma-workbooks/docs/workbook-rep-companion.html
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/docs/workbook-rep-companion.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>The Workbook Rep — how an agent builds &amp; edits a workbook as files</title>
+<style>
+  :root {
+    --ink: #1e1b3a; --muted: #5d5a78; --soft: #8d88ad;
+    --violet: #7c3aed; --violet-deep: #4c1d95; --indigo: #1e1b4b;
+    --amber: #f59e0b; --cyan: #0891b2; --green: #059669; --red: #dc2626;
+    --page: #f2f1f6; --card: #ffffff; --card-border: #e4e2ee;
+    --code-bg: #f4f2fa; --code-ink: #3b3663; --code-dim: #8d88ad;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { background: var(--page); }
+  body { font: 14.5px/1.55 Georgia, "Iowan Old Style", "Times New Roman", serif; color: var(--ink); max-width: 920px; margin: 0 auto; padding: 26px 30px 34px; }
+  .sans { font-family: -apple-system, "Segoe UI", Inter, Roboto, sans-serif; }
+
+  /* hero band — the same idiom the tool builds */
+  .hero { background: #1e1b4b; background: linear-gradient(105deg, #17143b 0%, #2a1a66 55%, #5b21b6 100%); color: #fff; border-radius: 14px; padding: 26px 30px 22px; }
+  .hero h1 { font-family: -apple-system, "Segoe UI", Inter, Roboto, sans-serif; font-weight: 800; font-size: 26px; line-height: 1.18; letter-spacing: -0.015em; max-width: 34ch; }
+  .hero .sub { color: #b9b3e8; font-size: 14px; margin-top: 8px; max-width: 80ch; font-style: italic; }
+  .facts { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; margin-top: 20px; padding-top: 16px; border-top: 1px solid rgba(255,255,255,.14); }
+  .facts .f .lbl { font-family: -apple-system, Inter, sans-serif; font-size: 9.5px; font-weight: 800; letter-spacing: .12em; }
+  .facts .f .val { font-family: -apple-system, Inter, sans-serif; font-size: 17px; font-weight: 800; color: #fff; margin-top: 3px; }
+  .a1 { color: #c4b5fd; } .a2 { color: #fcd34d; } .a3 { color: #67e8f9; } .a4 { color: #6ee7b7; }
+
+  /* dashboard-card sections */
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-top: 14px; }
+  .card { background: var(--card); border: 1px solid var(--card-border); border-radius: 14px; padding: 18px 20px; page-break-inside: avoid; }
+  .card.wide { grid-column: 1 / 3; }
+  .eyebrow { font-family: -apple-system, Inter, sans-serif; font-size: 10px; font-weight: 800; letter-spacing: .14em; margin-bottom: 6px; }
+  .e1 { color: var(--violet); } .e2 { color: var(--amber); } .e3 { color: var(--cyan); } .e4 { color: var(--green); }
+  .card h2 { font-family: -apple-system, Inter, sans-serif; font-size: 16.5px; font-weight: 800; letter-spacing: -0.01em; margin-bottom: 8px; }
+  .card p { margin-bottom: 8px; }
+  .card p:last-child { margin-bottom: 0; }
+
+  /* light code panels — spec slices, not terminals */
+  .code { background: var(--code-bg); border: 1px solid #e2ddf2; border-radius: 10px; padding: 12px 14px; font: 11px/1.6 "SF Mono", ui-monospace, Menlo, monospace; color: var(--code-ink); white-space: pre; margin: 10px 0 8px; }
+  .code .dim { color: var(--code-dim); }
+  .code .v { color: var(--violet); font-weight: 600; }
+  .code .am { color: #b45309; }
+  .code .gr { color: var(--green); }
+
+  /* the loop as a segmented control */
+  .seg { display: flex; border: 1.5px solid var(--violet-deep); border-radius: 999px; overflow: hidden; font-family: -apple-system, Inter, sans-serif; font-size: 12px; font-weight: 700; margin: 10px 0 14px; }
+  .seg .s { flex: 1; text-align: center; padding: 7px 4px; color: var(--violet-deep); border-right: 1.5px solid var(--violet-deep); }
+  .seg .s:last-child { border-right: 0; }
+  .seg .on { background: var(--violet-deep); color: #fff; }
+
+  ol.gates, ul.catch { margin: 4px 0 0 17px; }
+  ol.gates li, ul.catch li { margin-bottom: 6px; }
+  ol.gates b, ul.catch b { font-family: -apple-system, Inter, sans-serif; font-size: 13px; }
+
+  .zoom { width: 100%; border-collapse: collapse; font-size: 13px; margin-top: 4px; }
+  .zoom td { border-top: 1px dotted var(--card-border); padding: 6px 8px 6px 0; vertical-align: top; }
+  .zoom tr:first-child td { border-top: 0; }
+  .zoom td:first-child { font: 600 11px/1.5 "SF Mono", ui-monospace, Menlo, monospace; color: var(--violet); width: 44%; padding-right: 12px; }
+
+  .buys { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+  .buys .b .t { font-family: -apple-system, Inter, sans-serif; font-weight: 800; font-size: 13px; margin-bottom: 4px; }
+  .buys .b p { font-size: 13px; color: var(--muted); }
+
+  .ok { color: var(--green); font-weight: 700; } .no { color: var(--red); font-weight: 700; }
+  .foot { font-family: -apple-system, Inter, sans-serif; color: var(--soft); font-size: 11.5px; margin-top: 14px; padding: 0 6px; }
+  .foot code { font-size: 11px; }
+  @media print {
+    html, body { background: var(--page) !important; }
+    .hero, .seg .on, .code, .card { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    body { padding: 16px 18px 20px; }
+  }
+</style>
+</head>
+<body>
+
+<div class="hero">
+  <h1>The workbook rep — an agent edits a Sigma workbook as files</h1>
+  <p class="sub">No middleware and no new interface: the spec becomes a directory of small files, the agent works with the file tools it is already best at, and a render loop means it sees what it built before calling it done.</p>
+  <div class="facts">
+    <div class="f"><div class="lbl a1">UNIT OF WORK</div><div class="val">1 file = 1 element</div></div>
+    <div class="f"><div class="lbl a2">INTERFACE</div><div class="val">Read · Edit · Glob</div></div>
+    <div class="f"><div class="lbl a3">WRITE PATH</div><div class="val">4-gate push</div></div>
+    <div class="f"><div class="lbl a4">ACCEPTANCE</div><div class="val">Pixels, not 200s</div></div>
+  </div>
+</div>
+
+<div class="grid">
+
+  <div class="card">
+    <div class="eyebrow e1">STRUCTURE</div>
+    <h2>The element is the unit of work</h2>
+    <p>Sigma's spec API moves whole workbooks — every small edit drags the full document through an agent's context, and parallel work is a merge hazard. The rep <b>explodes the spec into one file per element</b> and reassembles it on push.</p>
+    <p>Nothing is a new format: every file is a verbatim slice of the spec, so existing spec documentation applies unchanged. A 20-element workbook becomes twenty ~600-byte files; an edit touches exactly one. Add an element = add a file. Delete = delete it. Reorder = rename the prefix.</p>
+  </div>
+
+  <div class="card">
+    <div class="eyebrow e1">LAYOUT</div>
+    <h2>A workbook, as a directory</h2>
+    <div class="code">&lt;rep&gt;/
+  workbook.yaml            <span class="dim">name, folderId, …</span>
+  pages/
+    010-overview/          <span class="dim">prefix = order</span>
+      _page.yaml           <span class="dim">page identity</span>
+      _layout.xml          <span class="dim">layout XML block</span>
+      <span class="v">010-revenue-kpi.yaml</span>   <span class="dim">one element each</span>
+      <span class="v">020-sales-by-region.yaml</span>
+  renders/                 <span class="dim">agent-readable PNGs</span>
+  .sigma/                  <span class="dim">snapshot + manifest</span></div>
+    <p style="font-size:13px; color:var(--muted)">The element-level abstraction lives in the file layout, not in a process — the agent's native <code>Read / Edit / Glob / grep</code> are the API.</p>
+  </div>
+
+  <div class="card wide">
+    <div class="eyebrow e2">THE LOOP</div>
+    <div class="seg">
+      <div class="s">pull</div><div class="s">edit files</div><div class="s">status</div><div class="s">push</div><div class="s">verify</div><div class="s on">render &amp; look</div>
+    </div>
+    <div style="display:grid; grid-template-columns: 1fr 1fr; gap: 22px; align-items: start;">
+      <div>
+        <p><b class="sans" style="font-size:13.5px">push</b> reassembles the files and writes through four gates:</p>
+        <ol class="gates">
+          <li><b>Drift check</b> — if the server spec changed since pull (a UI edit), push aborts and shows exactly what would be overwritten. No silent clobbering, ever.</li>
+          <li><b>Diff preview</b> — the element-level change set about to apply.</li>
+          <li><b>Validation</b> — static formula/shape checks before any network write.</li>
+          <li><b>Readback</b> — re-GET after the PUT, refresh the snapshot, report anything the server normalized.</li>
+        </ol>
+      </div>
+      <div>
+        <div class="code"><span class="dim">$ wb-rep status my-dashboard/</span>
+  page "Pulse":
+  <span class="am">~ element "Clones per day"
+      [columns, yAxis, color]</span>
+  <span class="gr">+ element "Star events per month"</span>
+
+<span class="dim">$ wb-rep push my-dashboard/
+  # drift-check · diff · validate · readback</span>
+rendered "Pulse" -&gt; renders/pulse.png</div>
+        <p style="font-size:13px; color:var(--muted)">The API still receives a standard full-spec PUT — element semantics arrive on top of the existing endpoint, today. Reassembly is byte-exact: an untouched rep pushes back as a no-op.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="eyebrow e3">FEEDBACK</div>
+    <h2>The render loop — the agent looks at its work</h2>
+    <p>A spec that POSTs cleanly and compiles cleanly can still be wrong. <b>render</b> exports any page or element as a PNG; the agent reads the image and critiques it against the plan. Acceptance is <i>"the pixels look right"</i> — not <i>"the API returned 200."</i></p>
+    <p class="sans" style="font-size:13px"><b>Failure classes only this gate has caught:</b></p>
+    <ul class="catch" style="font-size:13.5px">
+      <li>a style the API <b>accepted and silently dropped</b> — element rendered with no background</li>
+      <li>a formula error inside <code>{{…}}</code> text templating — invisible to both POST and SQL compile</li>
+      <li>a chart numerically correct and visually useless</li>
+      <li>KPI panels clipping at real viewport widths</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <div class="eyebrow e3">READS</div>
+    <h2>Zoom reads — context only on demand</h2>
+    <p style="font-size:13.5px">The whole spec never enters context. Orientation and authoring are a zoom:</p>
+    <table class="zoom">
+      <tr><td>summarize &lt;id|dir&gt;</td><td>pages, element kinds, sources — one screen</td></tr>
+      <tr><td>ls pages/&lt;page&gt;/</td><td>one page, as a file listing</td></tr>
+      <tr><td>Read &lt;element&gt;.yaml</td><td>one element, full detail (~600 bytes)</td></tr>
+      <tr><td>capabilities --kind K [--field F]</td><td>what's authorable — distilled live from the public OpenAPI</td></tr>
+    </table>
+  </div>
+
+  <div class="card wide">
+    <div class="eyebrow e4">BEYOND THE SCHEMA</div>
+    <h2>The verified-behavior catalog</h2>
+    <p>The OpenAPI says what shapes <i>parse</i>; it can't say what the platform <i>does</i>. The rep's companion reference keeps a catalog where every entry is <b>live-verified against the API</b> and marked <span class="ok">✓</span>/<span class="no">✗</span> with the exact error and the workaround — which idioms are UI-only, which fields render although undocumented, which writes are accepted-then-dropped. When a render exposes a new behavior, it lands in the catalog the same day, and every future build inherits it.</p>
+  </div>
+
+  <div class="card wide">
+    <div class="eyebrow e1">WHAT THE STRUCTURE BUYS</div>
+    <div class="buys">
+      <div class="b"><div class="t">Parallel builds</div><p>Element files are independent — one sub-agent per element, zero merge conflicts, one atomic push.</p></div>
+      <div class="b"><div class="t">Create mode</div><p>A rep authored from scratch POSTs a new workbook through the same gates. The directory <i>is</i> the design doc.</p></div>
+      <div class="b"><div class="t">Git-native</div><p>PRs show <code>changed: revenue-kpi.yaml</code>, not a 2,000-line spec diff. Workbooks-as-code for free.</p></div>
+      <div class="b"><div class="t">Zero install</div><p>One dependency-free script (Ruby stdlib) plus the agent's own file tools. No server, no daemon.</p></div>
+    </div>
+  </div>
+
+</div>
+
+<p class="foot">Lives in <b>twells89/sigma-skills → sigma-workbooks/</b> — <code>scripts/wb-rep.rb</code> · <code>reference/workflows/element-rep.md</code> · verified-behavior catalog in <code>reference/specification/styling.md</code>. Proven on live workbooks: byte-exact round-trips, from-scratch multi-page creates, and design iterations driven entirely by the render loop.</p>
+
+</body>
+</html>

--- a/plugins/sigma-authoring/skills/sigma-workbooks/docs/workbook-rep-companion.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/docs/workbook-rep-companion.md
@@ -1,0 +1,133 @@
+# How an Agent Builds & Edits a Workbook through the Filesystem
+
+*The workbook rep: element-level editing over Sigma's whole-spec API — with no middleware,
+and a feedback loop where the agent **sees** what it built.*
+
+---
+
+## The idea
+
+Sigma's spec API moves whole workbooks: `GET` and `PUT` carry the entire document. On a
+multi-page workbook that means every small edit drags tens of thousands of tokens through an
+agent's context, and two agents can't safely work on the same workbook at once.
+
+The **rep** fixes this without introducing any new interface: the spec is *exploded into a
+directory of small files* — one file per element — and reassembled on push. The agent edits
+workbooks with the tools it is already best at: `Read`, `Edit`, `Glob`, `grep`. The element-level
+abstraction lives in the file layout, not in a process.
+
+```
+<rep>/
+  workbook.yaml              top-level fields (name, folderId, schemaVersion)
+  pages/
+    010-overview/            numeric prefix = page order (×10, insert between)
+      _page.yaml             page identity & visibility
+      _layout.xml            this page's <Page> block of the layout XML
+      010-revenue-kpi.yaml   one element per file — ~600 bytes each
+      020-sales-by-region.yaml
+  renders/                   PNGs the agent looks at (see "The render loop")
+  .sigma/                    plumbing: snapshot, manifest — never hand-edited
+```
+
+Nothing is a new format. Every file is a verbatim slice of the spec, so all existing spec
+documentation applies unchanged to a single element file. A 20-element workbook becomes twenty
+~600-byte files instead of one 20KB document; an edit touches exactly one of them.
+
+## The loop
+
+```
+pull ──▶ edit files ──▶ status ──▶ push ──▶ verify ──▶ render ──▶ look ──▶ edit …
+```
+
+**`pull <workbook-id> <dir>`** — GET the spec, explode it, store a pristine snapshot.
+Reassembly is byte-exact: an untouched rep pushes back as a no-op.
+
+**Edit** — plain file operations. Add an element = add a file (+ one line of layout XML).
+Delete = delete the file. Reorder = rename the numeric prefix.
+
+**`status`** — offline, element-level diff against the snapshot:
+
+```
+  page "Pulse":
+  ~ element "Clones per day" (line-clones) [columns, yAxis, color]
+  + element "Star events per month" (bar-star-months)
+```
+
+**`push`** — reassemble and write, through four gates:
+1. **Drift check** — if the server spec changed since pull (someone edited in the UI), push
+   aborts and shows exactly what would be overwritten. No silent clobbering, ever.
+2. **Diff preview** — prints the element-level change set it is about to apply.
+3. **Validation** — static formula/shape checks before any network write.
+4. **Readback** — re-GETs after the PUT, refreshes the snapshot, and reports anything the
+   server normalized.
+
+The API itself still receives a full-spec PUT — the rep gives element-level semantics *on top of*
+the existing endpoint, today, with no server changes.
+
+**`verify`** — compile check: Sigma accepts specs whose formulas don't resolve and only fails
+them at query time, so every element's compiled SQL is checked for embedded error literals.
+
+## The render loop — the agent looks at its work
+
+A spec that POSTs cleanly and compiles cleanly can still be wrong. **`render`** exports any page
+or element as a PNG, and the agent *reads the image* and critiques it against the plan before
+calling the work done.
+
+```
+render <dir> [--page Pulse | --element <id>]   →   renders/pulse.png
+```
+
+This loop has caught, in practice, every class of failure the other gates can't:
+
+- a CSS gradient the API **accepted and silently dropped** — element rendered with no background
+- a formula error inside `{{…}}` text templating — invisible to both POST and SQL compile,
+  rendered as `Invalid Query: …` in the banner
+- a chart whose data was technically correct and visually useless (one 153-unit bar crushing
+  a column of zeros)
+- KPI panels clipping against a gradient band at real viewport widths
+
+Acceptance criterion: *the pixels look right* — not *the API returned 200*.
+
+## Zoom reads — context only on demand
+
+For orientation and authoring, two read-only commands keep context spend near zero:
+
+```
+summarize <id|dir>      pages, element kinds, sources — one screen, no spec loaded
+capabilities                            every authorable element kind
+capabilities --kind bar-chart           the fields that kind supports
+capabilities --kind bar-chart --field color     the exact schema for one field
+```
+
+`capabilities` distils Sigma's public OpenAPI live, so it always tracks the current API. The
+read side is a zoom: summarize → list a page directory → read one element file → query one
+field's schema. At no point does the whole spec enter context.
+
+## Beyond the schema: the verified-behavior catalog
+
+The OpenAPI says what shapes parse; it can't say what the platform actually does. The rep's
+companion reference (the `sigma-workbooks` skill) keeps a catalog where every entry is
+**live-verified against the API** and marked ✓/✗ with the exact error and the workaround —
+e.g. which typography classes stand alone vs. require an alignment, that alpha-hex
+`#rrggbbaa` renders although only `#rrggbb` is documented, and which idioms are UI-only.
+When a render exposes a new behavior, it lands in the catalog the same day, and every future
+build inherits it.
+
+## What the structure buys
+
+- **Parallel builds.** Element files are independent, so a plan can fan out one sub-agent per
+  element with zero merge conflicts — the orchestrator owns only the plan, the id namespace,
+  and the layout; a single push lands everything atomically.
+- **Create mode.** A rep authored from scratch (or exploded from any spec via `import`) POSTs a
+  new workbook — same files, same gates. Plan-as-file-tree: the directory *is* the design doc.
+- **Git-native.** A rep directory commits cleanly: PRs show `changed: revenue-kpi.yaml`, not a
+  2,000-line spec diff. The snapshot is the merge base; workbooks-as-code falls out for free.
+- **No installation, no server.** One dependency-free script (`wb-rep.rb`, Ruby stdlib) plus the
+  agent's own file tools.
+
+## Where it lives
+
+`twells89/sigma-skills` → `sigma-workbooks/` — `scripts/wb-rep.rb`,
+`reference/workflows/element-rep.md` (workflow), `reference/specification/styling.md`
+(verified-behavior catalog). Built and proven on live workbooks: byte-exact round-trips,
+from-scratch multi-page creates, and design iterations driven entirely by the render loop.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -1,0 +1,312 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Workbooks (Spec via REST API)
+
+This skill helps you build effective Sigma workbooks by **navigating the Sigma OpenAPI** and applying **style guidance + proven recipes** beyond what the OpenAPI alone teaches.
+
+## Scope
+
+The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pages, elements, sources, formulas, and layout. Lifecycle around the workbook (embeds, grants, materialization schedules, bookmarks, sharing) is a separate API surface and out of scope here.
+
+## Sources of truth
+
+1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
+   `https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`
+2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`.
+
+Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
+
+## Consulting the OpenAPI
+
+The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
+
+```bash
+curl -sf https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+
+# The entire workbook spec request body lives under one path (it is not split into named schemas):
+jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json
+```
+
+Element, source, control, and format shapes are **inlined** under that path and identified by their `kind` value (e.g. `bar-chart`, `kpi-chart`, `join`, `warehouse-table`) — not by a top-level schema name. Navigate by the `kind` discriminator:
+
+```bash
+# List every kind the spec accepts (elements, sources, controls, formats, …):
+jq -r '[.. | objects | select(.properties.kind.enum) | .properties.kind.enum[0]] | unique[]' /tmp/sigma-api.json
+
+# Full field list (required + optional) for one kind — swap bar-chart for any kind above:
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))
+  | {required: ([.allOf[]?.required // .required] | add | unique), properties: ([(.allOf[]?.properties // .properties) | keys[]] | unique)}' /tmp/sigma-api.json
+
+# The full nested shape for that kind (to inspect sub-objects like source, yAxis, format, comparison):
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+`WebFetch` works for the JSON too. Either path is fine.
+
+**Why bother:** the API ships new fields and viz configurations regularly, and this skill covers the common surface, not every field. If you want a capability and don't see it documented here, **assume it may exist and check the spec before concluding it doesn't** — the `kind` query above answers in seconds.
+
+## Auth
+
+Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`.
+
+## Recommended Workflow
+
+These are guidelines, not mandates — but they prevent the failure modes that show up most often when drafting from scratch.
+
+> **Schema drift signal:** an error about request *shape* (`invalid argument`, `unknown field`, `missing required field`, `unexpected property`) usually means this skill is stale on that detail. Fetch the OpenAPI and compare; the canonical shape is there.
+
+### Step 0 — Authenticate, capture user identity
+
+```bash
+USER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/whoami" | jq -r '.userId')
+
+HOME_FOLDER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/members/$USER_ID" | jq -r '.homeFolderId')
+```
+
+If the user provided a **target image** (a screenshot, mockup, or PDF of a dashboard they want reproduced), pause here and load `reference/workflows/from-image.md` — it adds explicit observation, description, and validation steps that have to happen *before* normal data discovery. The standard workflow alone tends to produce workbooks with the right vibe but the wrong shape when the input is visual.
+
+### Step 1 — Find a reference workbook to study
+
+Any existing workbook on the user's org doubles as a template. List and pick one with similar content:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks?limit=50" | jq '.entries[] | {workbookId, name}'
+```
+
+If no relevant workbook exists, pick any — the goal is studying spec structure, not matching content. If the org has no workbooks at all, draft from scratch using the OpenAPI shapes + this skill's recipes.
+
+### Step 2 — Study the reference spec
+
+YAML is the canonical format for workbook specs in this skill — easier to read, diff, and review than JSON. Sigma's API accepts both (`Content-Type: application/yaml` or `application/json`); `Accept: application/yaml` is the default on `GET /v2/workbooks/<id>/spec`. Use `yq` to inspect spec YAML the same way you'd use `jq` on JSON.
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<reference-workbook-id>/spec" \
+  > /tmp/reference-spec.yaml
+```
+
+Look at source structure, column ID patterns, formula syntax, element naming, layout XML idioms. The `pages` array shape is exactly what you'll POST when creating.
+
+### Step 3 — Discover data sources
+
+Load `reference/workflows/discover.md`. Quick summary:
+
+1. `GET /v2/connections` — find the user's connection by name or type.
+2. Ask the user for the table path; verify with `POST /v2/connection/<id>/lookup`.
+3. Discover columns directly via `GET /v2/connections/tables/{inodeId}/columns` (full mechanics in `reference/workflows/discover.md`). Only fall back to asking the user when the endpoint doesn't return what's needed.
+
+**Never invent column names** — only use names returned by the API or supplied by the user.
+
+**Verify literal values before writing predicates.** If your task involves filtering on a categorical column (e.g., `CountIf([Status] = "active")`, `If([Type] = "sale", ...)`), you need to know what values that column *actually* contains — the `/v2/connections/tables/{inodeId}/columns` endpoint gives you names and types but not values. Run a `SELECT DISTINCT <col>` via any tool that reaches the warehouse — an MCP server (warehouse or [Sigma](https://help.sigmacomputing.com/docs/use-sigma-mcp-server)), a SQL CLI, or just ask the user. Don't guess literals. See `reference/workflows/discover.md`.
+
+### Step 4 — Identify features and load only what you need
+
+Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
+
+### Step 5 — Draft the spec to a local file
+
+Write the spec YAML to disk (e.g., `/tmp/workbook-spec.yaml`). YAML is preferred over JSON in this skill — easier to read, diff, and comment for human review. The API accepts either; pick YAML unless something downstream specifically needs JSON. Key rules:
+
+- Every element needs a unique `id` and a descriptive `name`.
+- Every column needs a unique `id`, a `name`, and a `formula`.
+- Follow the formula reference rules in `reference/specification/formulas.md` exactly — most spec errors happen here.
+- **Write explicit `layout` XML for multi-element workbooks.** Auto-arrange (omitting `layout`) is acceptable only for single-element pages or a uniform stack of tables. See `reference/specification/layout.md` for the rubric.
+- Start with 1–2 pages. Add more later via update.
+
+For **create**, the file must include top-level `name`, `folderId`, `schemaVersion`, and `pages`. `description` is optional. `layout` is technically optional but expected for multi-element workbooks. `schemaVersion` is usually `1` — that's the current value; it may change in the future, so if the API rejects the spec on that field, check what your reference-workbook GET in Step 2 returned and use that instead. Full CRUD mechanics are in `reference/workflows/crud.md`.
+
+### Step 6 — Validate the spec
+
+**Run the bundled validator first — do not skip.**
+
+```bash
+./scripts/validate-spec.sh /tmp/workbook-spec.yaml
+```
+
+Then do the manual formula pass and final shape checks per `reference/workflows/validate.md`. Fix everything reported before continuing.
+
+### Step 7 — Create the workbook
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/workbook-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/spec" > /tmp/create-response.yaml
+
+WORKBOOK_ID=$(yq -r '.workbookId' /tmp/create-response.yaml)
+cp /tmp/workbook-spec.yaml "/tmp/workbook-spec-${WORKBOOK_ID}.yaml"
+```
+
+Persist the spec after a successful create so subsequent `PUT` updates can start from it. Report **both** the workbook URL **and** the saved spec path.
+
+If creation fails, read the error, fix the spec, re-validate, retry. See `reference/workflows/validate.md` for decoding cryptic errors.
+
+### Step 7b — Verify the workbook actually compiles
+
+**Do not skip.** A successful POST is necessary but not sufficient — Sigma accepts specs whose formulas don't resolve, then surfaces the failures at query time by embedding the error as a string literal in the compiled SQL (`'Unknown column "[X]"'`, `'Circular column reference to [Y]'`). Affected elements render empty in the UI. Only Sigma's compiler knows whether your formula references actually resolve.
+
+```bash
+./scripts/verify-workbook.sh "$WORKBOOK_ID"
+```
+
+If any element reports `[FAIL]`, fix the column formulas in the spec (most often a missing source prefix, a self-referencing column, or a friendly-name mismatch with the warehouse — see `reference/specification/formulas.md`), `PUT` the corrected spec, and re-verify.
+
+### Step 8 — Iterate
+
+After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
+
+> **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" \
+  > /tmp/current-spec.yaml
+
+# Edit /tmp/current-spec.yaml, then:
+curl -s -X PUT -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/current-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" | yq .
+
+cp /tmp/current-spec.yaml "/tmp/workbook-spec-<workbook-id>.yaml"
+./scripts/verify-workbook.sh "<workbook-id>"
+```
+
+### Step 9 — Report back
+
+Report the workbook URL and the saved spec path. **Do not tack on generic "improvement ideas" or "next steps."** Match the response to what was asked.
+
+Surface follow-up items only when they're load-bearing, and name them concretely:
+
+- **Tradeoffs you made during the build** — dropped a chart, simplified a formula, skipped a control because the shape wasn't in your reference.
+- **Obvious gaps revealed by the column list** — e.g., the user asked for "sales by region" and the table has a `region_tier` column that would make the breakdown richer. One sentence, named.
+
+If none apply, just report the URL + spec path and stop.
+
+## Reference Index
+
+The reference is feature-sliced — don't read every file up-front. The index has three sections: **elements** (the visual / interactive pieces), **sources** (where each element gets its data), and **cross-cutting** (formulas, layout, formatting, validation, CRUD).
+
+### Elements
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
+| `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
+| `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
+| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the period-over-period formula recipe, and the spec limits of the comparison / trend-sparkline blocks (UI-bound). |
+| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
+| `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
+| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+
+### Sources
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/sources-warehouse.md` | Always — load before drafting any spec. Warehouse-table source (Snowflake, BigQuery, Databricks, Redshift, Postgres/MySQL). |
+| `reference/specification/sources.md` | Reference another chart/table/element, derive from existing element, join, combine tables, data model / semantic-layer source, custom SQL, union, transpose, unpivot. |
+
+### Cross-cutting
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/schema.md` | Always — load before drafting any spec. Top-level shape, required fields, response-only fields to strip. |
+| `reference/specification/formulas.md` | Always — load before drafting any spec. Formula syntax, qualification, special characters, the #1 mistake. |
+| `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
+| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
+| `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
+
+### Workflows
+
+| File | When to load |
+|------|--------------|
+| `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
+| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
+| `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
+| `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+
+## Quick Formula Rules
+
+The single most common spec error is bare `[column_name]` references to warehouse columns. Full rules in `reference/specification/formulas.md`. Skeleton:
+
+**Outside the element** — use `[SourceName/column_name]`:
+- Warehouse-table source: `SourceName` = last segment of the `path` array (e.g., `[ORDERS/Revenue]`)
+- Another element: `SourceName` = that element's `name`
+- Join legs: prefix by the leg's `name`, or by the join's top-level `name` for `primarySource` columns
+
+**Inside the same element** — use `[column_name]` (no prefix):
+- References a column defined in this element by its `name` field.
+- A column cannot reference itself (circular reference error).
+
+## Troubleshooting
+
+### "I don't see this field in the skill"
+
+Fetch the OpenAPI. The skill documents stable, common surface area; the API has more. See **Consulting the OpenAPI** above.
+
+### API schema mismatch (skill is stale)
+
+A 400 about request *shape* — `invalid argument`, `unknown field`, `unexpected property`, `missing required field` — usually means the API moved past the skill. Fetch the OpenAPI (see **Consulting the OpenAPI**), diff the live shape for that `kind`, and retry **once** with the correction. Tell the user it looks like the skill is out of date and worth updating through whatever channel they installed it from; don't loop on retries.
+
+### 401 Unauthorized
+
+Sigma OAuth tokens expire after ~1 hour. Long workbook-building sessions (orchestrated batch conversions, multi-step iterations, anything that runs >50 minutes) will hit this mid-flight.
+
+**Ruby callers** (any of the `tableau-to-sigma/scripts/*.rb` Sigma-touching scripts): use the `Sigma` REST wrapper at `tableau-to-sigma/scripts/lib/sigma_rest.rb` — it does automatic 401-with-refresh-and-retry. Concretely:
+
+```ruby
+require_relative 'lib/sigma_rest'
+spec = Sigma.request(:get, "/v2/workbooks/#{id}/spec")   # auto-refreshes on 401
+```
+
+**Bash / curl callers**: re-run `eval "$(scripts/get-token.sh)"` to refresh manually. For long shell loops, wrap the curl in a small helper that retries once on 401:
+
+```bash
+sigma_curl() {
+  local resp code
+  resp=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $SIGMA_API_TOKEN" "$@")
+  code=$(echo "$resp" | tail -1)
+  if [ "$code" = "401" ]; then
+    eval "$(scripts/get-token.sh)"
+    resp=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $SIGMA_API_TOKEN" "$@")
+  fi
+  echo "$resp" | sed '$d'  # strip trailing status code
+}
+```
+
+If 401 persists after refresh, re-authenticate via `sigma-api` and verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`.
+
+### 403 Forbidden on workbook create
+
+The credentials authenticated but aren't permitted to create workbooks here. Ask the user's Sigma admin to confirm the credential's permissions and folder access.
+
+### "Invalid column reference" or formula errors on creation
+
+The most common spec issue. A bare `[column_name]` was used where `[TABLE/column_name]` is needed. See `reference/specification/formulas.md` for the full rules and `reference/workflows/validate.md` for the manual checklist.
+
+### "Unknown column" errors
+
+The column name in the formula doesn't match what the warehouse actually has. Re-confirm the column names via `GET /v2/connections/tables/{inodeId}/columns` (raw warehouse names) and the readback (`GET /v2/workbooks/<id>/spec`, which shows Sigma's normalized friendly names). Use those names verbatim.
+
+### `jq` or `yq` not installed
+
+`jq` is used for OpenAPI inspection (the OpenAPI is JSON). `yq` is used for workbook-spec inspection (specs are YAML).
+
+- `jq`: `brew install jq` (macOS) or `apt install jq` (Debian/Ubuntu).
+- `yq`: **two different tools share this name** — the Go **mikefarah/yq** (`brew install yq`) and the Python **`pip install yq`** wrapper around jq. *Reading* works the same in both (`yq -r '.workbookId' f.yaml`), but *in-place editing differs*: mikefarah uses `yq -i '…' f.yaml`, while the Python wrapper needs `yq -y -i '…' f.yaml`. Run `yq --help` to see which you have and adapt.
+
+### Cryptic validation errors / silent bad data
+
+See `reference/workflows/validate.md` for the full triage table (mapping `Invalid kind: pages[0].elements[N]...` style errors to the right spec file).

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
@@ -1,0 +1,312 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Workbooks (Spec via REST API)
+
+This skill helps you build effective Sigma workbooks by **navigating the Sigma OpenAPI** and applying **style guidance + proven recipes** beyond what the OpenAPI alone teaches.
+
+## Scope
+
+The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pages, elements, sources, formulas, and layout. Lifecycle around the workbook (embeds, grants, materialization schedules, bookmarks, sharing) is a separate API surface and out of scope here.
+
+## Sources of truth
+
+1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
+   `https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`
+2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`.
+
+Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
+
+## Consulting the OpenAPI
+
+The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
+
+```bash
+curl -sf https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+
+# The entire workbook spec request body lives under one path (it is not split into named schemas):
+jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json
+```
+
+Element, source, control, and format shapes are **inlined** under that path and identified by their `kind` value (e.g. `bar-chart`, `kpi-chart`, `join`, `warehouse-table`) — not by a top-level schema name. Navigate by the `kind` discriminator:
+
+```bash
+# List every kind the spec accepts (elements, sources, controls, formats, …):
+jq -r '[.. | objects | select(.properties.kind.enum) | .properties.kind.enum[0]] | unique[]' /tmp/sigma-api.json
+
+# Full field list (required + optional) for one kind — swap bar-chart for any kind above:
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))
+  | {required: ([.allOf[]?.required // .required] | add | unique), properties: ([(.allOf[]?.properties // .properties) | keys[]] | unique)}' /tmp/sigma-api.json
+
+# The full nested shape for that kind (to inspect sub-objects like source, yAxis, format, comparison):
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+`WebFetch` works for the JSON too. Either path is fine.
+
+**Why bother:** the API ships new fields and viz configurations regularly, and this skill covers the common surface, not every field. If you want a capability and don't see it documented here, **assume it may exist and check the spec before concluding it doesn't** — the `kind` query above answers in seconds.
+
+## Auth
+
+Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`.
+
+## Recommended Workflow
+
+These are guidelines, not mandates — but they prevent the failure modes that show up most often when drafting from scratch.
+
+> **Schema drift signal:** an error about request *shape* (`invalid argument`, `unknown field`, `missing required field`, `unexpected property`) usually means this skill is stale on that detail. Fetch the OpenAPI and compare; the canonical shape is there.
+
+### Step 0 — Authenticate, capture user identity
+
+```bash
+USER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/whoami" | jq -r '.userId')
+
+HOME_FOLDER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/members/$USER_ID" | jq -r '.homeFolderId')
+```
+
+If the user provided a **target image** (a screenshot, mockup, or PDF of a dashboard they want reproduced), pause here and load `reference/workflows/from-image.md` — it adds explicit observation, description, and validation steps that have to happen *before* normal data discovery. The standard workflow alone tends to produce workbooks with the right vibe but the wrong shape when the input is visual.
+
+### Step 1 — Find a reference workbook to study
+
+Any existing workbook on the user's org doubles as a template. List and pick one with similar content:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks?limit=50" | jq '.entries[] | {workbookId, name}'
+```
+
+If no relevant workbook exists, pick any — the goal is studying spec structure, not matching content. If the org has no workbooks at all, draft from scratch using the OpenAPI shapes + this skill's recipes.
+
+### Step 2 — Study the reference spec
+
+YAML is the canonical format for workbook specs in this skill — easier to read, diff, and review than JSON. Sigma's API accepts both (`Content-Type: application/yaml` or `application/json`); `Accept: application/yaml` is the default on `GET /v2/workbooks/<id>/spec`. Use `yq` to inspect spec YAML the same way you'd use `jq` on JSON.
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<reference-workbook-id>/spec" \
+  > /tmp/reference-spec.yaml
+```
+
+Look at source structure, column ID patterns, formula syntax, element naming, layout XML idioms. The `pages` array shape is exactly what you'll POST when creating.
+
+### Step 3 — Discover data sources
+
+Load `reference/workflows/discover.md`. Quick summary:
+
+1. `GET /v2/connections` — find the user's connection by name or type.
+2. Ask the user for the table path; verify with `POST /v2/connection/<id>/lookup`.
+3. Discover columns directly via `GET /v2/connections/tables/{inodeId}/columns` (full mechanics in `reference/workflows/discover.md`). Only fall back to asking the user when the endpoint doesn't return what's needed.
+
+**Never invent column names** — only use names returned by the API or supplied by the user.
+
+**Verify literal values before writing predicates.** If your task involves filtering on a categorical column (e.g., `CountIf([Status] = "active")`, `If([Type] = "sale", ...)`), you need to know what values that column *actually* contains — the `/v2/connections/tables/{inodeId}/columns` endpoint gives you names and types but not values. Run a `SELECT DISTINCT <col>` via any tool that reaches the warehouse — an MCP server (warehouse or [Sigma](https://help.sigmacomputing.com/docs/use-sigma-mcp-server)), a SQL CLI, or just ask the user. Don't guess literals. See `reference/workflows/discover.md`.
+
+### Step 4 — Identify features and load only what you need
+
+Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
+
+### Step 5 — Draft the spec to a local file
+
+Write the spec YAML to disk (e.g., `/tmp/workbook-spec.yaml`). YAML is preferred over JSON in this skill — easier to read, diff, and comment for human review. The API accepts either; pick YAML unless something downstream specifically needs JSON. Key rules:
+
+- Every element needs a unique `id` and a descriptive `name`.
+- Every column needs a unique `id`, a `name`, and a `formula`.
+- Follow the formula reference rules in `reference/specification/formulas.md` exactly — most spec errors happen here.
+- **Write explicit `layout` XML for multi-element workbooks.** Auto-arrange (omitting `layout`) is acceptable only for single-element pages or a uniform stack of tables. See `reference/specification/layout.md` for the rubric.
+- Start with 1–2 pages. Add more later via update.
+
+For **create**, the file must include top-level `name`, `folderId`, `schemaVersion`, and `pages`. `description` is optional. `layout` is technically optional but expected for multi-element workbooks. `schemaVersion` is usually `1` — that's the current value; it may change in the future, so if the API rejects the spec on that field, check what your reference-workbook GET in Step 2 returned and use that instead. Full CRUD mechanics are in `reference/workflows/crud.md`.
+
+### Step 6 — Validate the spec
+
+**Run the bundled validator first — do not skip.**
+
+```bash
+./scripts/validate-spec.sh /tmp/workbook-spec.yaml
+```
+
+Then do the manual formula pass and final shape checks per `reference/workflows/validate.md`. Fix everything reported before continuing.
+
+### Step 7 — Create the workbook
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/workbook-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/spec" > /tmp/create-response.yaml
+
+WORKBOOK_ID=$(yq -r '.workbookId' /tmp/create-response.yaml)
+cp /tmp/workbook-spec.yaml "/tmp/workbook-spec-${WORKBOOK_ID}.yaml"
+```
+
+Persist the spec after a successful create so subsequent `PUT` updates can start from it. Report **both** the workbook URL **and** the saved spec path.
+
+If creation fails, read the error, fix the spec, re-validate, retry. See `reference/workflows/validate.md` for decoding cryptic errors.
+
+### Step 7b — Verify the workbook actually compiles
+
+**Do not skip.** A successful POST is necessary but not sufficient — Sigma accepts specs whose formulas don't resolve, then surfaces the failures at query time by embedding the error as a string literal in the compiled SQL (`'Unknown column "[X]"'`, `'Circular column reference to [Y]'`). Affected elements render empty in the UI. Only Sigma's compiler knows whether your formula references actually resolve.
+
+```bash
+./scripts/verify-workbook.sh "$WORKBOOK_ID"
+```
+
+If any element reports `[FAIL]`, fix the column formulas in the spec (most often a missing source prefix, a self-referencing column, or a friendly-name mismatch with the warehouse — see `reference/specification/formulas.md`), `PUT` the corrected spec, and re-verify.
+
+### Step 8 — Iterate
+
+After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
+
+> **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" \
+  > /tmp/current-spec.yaml
+
+# Edit /tmp/current-spec.yaml, then:
+curl -s -X PUT -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/current-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" | yq .
+
+cp /tmp/current-spec.yaml "/tmp/workbook-spec-<workbook-id>.yaml"
+./scripts/verify-workbook.sh "<workbook-id>"
+```
+
+### Step 9 — Report back
+
+Report the workbook URL and the saved spec path. **Do not tack on generic "improvement ideas" or "next steps."** Match the response to what was asked.
+
+Surface follow-up items only when they're load-bearing, and name them concretely:
+
+- **Tradeoffs you made during the build** — dropped a chart, simplified a formula, skipped a control because the shape wasn't in your reference.
+- **Obvious gaps revealed by the column list** — e.g., the user asked for "sales by region" and the table has a `region_tier` column that would make the breakdown richer. One sentence, named.
+
+If none apply, just report the URL + spec path and stop.
+
+## Reference Index
+
+The reference is feature-sliced — don't read every file up-front. The index has three sections: **elements** (the visual / interactive pieces), **sources** (where each element gets its data), and **cross-cutting** (formulas, layout, formatting, validation, CRUD).
+
+### Elements
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
+| `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
+| `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
+| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the period-over-period formula recipe, and the spec limits of the comparison / trend-sparkline blocks (UI-bound). |
+| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
+| `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
+| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+
+### Sources
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/sources-warehouse.md` | Always — load before drafting any spec. Warehouse-table source (Snowflake, BigQuery, Databricks, Redshift, Postgres/MySQL). |
+| `reference/specification/sources.md` | Reference another chart/table/element, derive from existing element, join, combine tables, data model / semantic-layer source, custom SQL, union, transpose, unpivot. |
+
+### Cross-cutting
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/schema.md` | Always — load before drafting any spec. Top-level shape, required fields, response-only fields to strip. |
+| `reference/specification/formulas.md` | Always — load before drafting any spec. Formula syntax, qualification, special characters, the #1 mistake. |
+| `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
+| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
+| `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
+
+### Workflows
+
+| File | When to load |
+|------|--------------|
+| `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
+| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
+| `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
+| `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+
+## Quick Formula Rules
+
+The single most common spec error is bare `[column_name]` references to warehouse columns. Full rules in `reference/specification/formulas.md`. Skeleton:
+
+**Outside the element** — use `[SourceName/column_name]`:
+- Warehouse-table source: `SourceName` = last segment of the `path` array (e.g., `[ORDERS/Revenue]`)
+- Another element: `SourceName` = that element's `name`
+- Join legs: prefix by the leg's `name`, or by the join's top-level `name` for `primarySource` columns
+
+**Inside the same element** — use `[column_name]` (no prefix):
+- References a column defined in this element by its `name` field.
+- A column cannot reference itself (circular reference error).
+
+## Troubleshooting
+
+### "I don't see this field in the skill"
+
+Fetch the OpenAPI. The skill documents stable, common surface area; the API has more. See **Consulting the OpenAPI** above.
+
+### API schema mismatch (skill is stale)
+
+A 400 about request *shape* — `invalid argument`, `unknown field`, `unexpected property`, `missing required field` — usually means the API moved past the skill. Fetch the OpenAPI (see **Consulting the OpenAPI**), diff the live shape for that `kind`, and retry **once** with the correction. Tell the user it looks like the skill is out of date and worth updating through whatever channel they installed it from; don't loop on retries.
+
+### 401 Unauthorized
+
+Sigma OAuth tokens expire after ~1 hour. Long workbook-building sessions (orchestrated batch conversions, multi-step iterations, anything that runs >50 minutes) will hit this mid-flight.
+
+**Ruby callers** (any of the `tableau-to-sigma/scripts/*.rb` Sigma-touching scripts): use the `Sigma` REST wrapper at `tableau-to-sigma/scripts/lib/sigma_rest.rb` — it does automatic 401-with-refresh-and-retry. Concretely:
+
+```ruby
+require_relative 'lib/sigma_rest'
+spec = Sigma.request(:get, "/v2/workbooks/#{id}/spec")   # auto-refreshes on 401
+```
+
+**Bash / curl callers**: re-run `eval "$(scripts/get-token.sh)"` to refresh manually. For long shell loops, wrap the curl in a small helper that retries once on 401:
+
+```bash
+sigma_curl() {
+  local resp code
+  resp=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $SIGMA_API_TOKEN" "$@")
+  code=$(echo "$resp" | tail -1)
+  if [ "$code" = "401" ]; then
+    eval "$(scripts/get-token.sh)"
+    resp=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $SIGMA_API_TOKEN" "$@")
+  fi
+  echo "$resp" | sed '$d'  # strip trailing status code
+}
+```
+
+If 401 persists after refresh, re-authenticate via `sigma-api` and verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`.
+
+### 403 Forbidden on workbook create
+
+The credentials authenticated but aren't permitted to create workbooks here. Ask the user's Sigma admin to confirm the credential's permissions and folder access.
+
+### "Invalid column reference" or formula errors on creation
+
+The most common spec issue. A bare `[column_name]` was used where `[TABLE/column_name]` is needed. See `reference/specification/formulas.md` for the full rules and `reference/workflows/validate.md` for the manual checklist.
+
+### "Unknown column" errors
+
+The column name in the formula doesn't match what the warehouse actually has. Re-confirm the column names via `GET /v2/connections/tables/{inodeId}/columns` (raw warehouse names) and the readback (`GET /v2/workbooks/<id>/spec`, which shows Sigma's normalized friendly names). Use those names verbatim.
+
+### `jq` or `yq` not installed
+
+`jq` is used for OpenAPI inspection (the OpenAPI is JSON). `yq` is used for workbook-spec inspection (specs are YAML).
+
+- `jq`: `brew install jq` (macOS) or `apt install jq` (Debian/Ubuntu).
+- `yq`: **two different tools share this name** — the Go **mikefarah/yq** (`brew install yq`) and the Python **`pip install yq`** wrapper around jq. *Reading* works the same in both (`yq -r '.workbookId' f.yaml`), but *in-place editing differs*: mikefarah uses `yq -i '…' f.yaml`, while the Python wrapper needs `yq -y -i '…' f.yaml`. Run `yq --help` to see which you have and adapt.
+
+### Cryptic validation errors / silent bad data
+
+See `reference/workflows/validate.md` for the full triage table (mapping `Invalid kind: pages[0].elements[N]...` style errors to the right spec file).

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -1,0 +1,312 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Workbooks (Spec via REST API)
+
+This skill helps you build effective Sigma workbooks by **navigating the Sigma OpenAPI** and applying **style guidance + proven recipes** beyond what the OpenAPI alone teaches.
+
+## Scope
+
+The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pages, elements, sources, formulas, and layout. Lifecycle around the workbook (embeds, grants, materialization schedules, bookmarks, sharing) is a separate API surface and out of scope here.
+
+## Sources of truth
+
+1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
+   `https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`
+2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`.
+
+Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
+
+## Consulting the OpenAPI
+
+The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
+
+```bash
+curl -sf https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+
+# The entire workbook spec request body lives under one path (it is not split into named schemas):
+jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json
+```
+
+Element, source, control, and format shapes are **inlined** under that path and identified by their `kind` value (e.g. `bar-chart`, `kpi-chart`, `join`, `warehouse-table`) — not by a top-level schema name. Navigate by the `kind` discriminator:
+
+```bash
+# List every kind the spec accepts (elements, sources, controls, formats, …):
+jq -r '[.. | objects | select(.properties.kind.enum) | .properties.kind.enum[0]] | unique[]' /tmp/sigma-api.json
+
+# Full field list (required + optional) for one kind — swap bar-chart for any kind above:
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))
+  | {required: ([.allOf[]?.required // .required] | add | unique), properties: ([(.allOf[]?.properties // .properties) | keys[]] | unique)}' /tmp/sigma-api.json
+
+# The full nested shape for that kind (to inspect sub-objects like source, yAxis, format, comparison):
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+`WebFetch` works for the JSON too. Either path is fine.
+
+**Why bother:** the API ships new fields and viz configurations regularly, and this skill covers the common surface, not every field. If you want a capability and don't see it documented here, **assume it may exist and check the spec before concluding it doesn't** — the `kind` query above answers in seconds.
+
+## Auth
+
+Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`.
+
+## Recommended Workflow
+
+These are guidelines, not mandates — but they prevent the failure modes that show up most often when drafting from scratch.
+
+> **Schema drift signal:** an error about request *shape* (`invalid argument`, `unknown field`, `missing required field`, `unexpected property`) usually means this skill is stale on that detail. Fetch the OpenAPI and compare; the canonical shape is there.
+
+### Step 0 — Authenticate, capture user identity
+
+```bash
+USER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/whoami" | jq -r '.userId')
+
+HOME_FOLDER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/members/$USER_ID" | jq -r '.homeFolderId')
+```
+
+If the user provided a **target image** (a screenshot, mockup, or PDF of a dashboard they want reproduced), pause here and load `reference/workflows/from-image.md` — it adds explicit observation, description, and validation steps that have to happen *before* normal data discovery. The standard workflow alone tends to produce workbooks with the right vibe but the wrong shape when the input is visual.
+
+### Step 1 — Find a reference workbook to study
+
+Any existing workbook on the user's org doubles as a template. List and pick one with similar content:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks?limit=50" | jq '.entries[] | {workbookId, name}'
+```
+
+If no relevant workbook exists, pick any — the goal is studying spec structure, not matching content. If the org has no workbooks at all, draft from scratch using the OpenAPI shapes + this skill's recipes.
+
+### Step 2 — Study the reference spec
+
+YAML is the canonical format for workbook specs in this skill — easier to read, diff, and review than JSON. Sigma's API accepts both (`Content-Type: application/yaml` or `application/json`); `Accept: application/yaml` is the default on `GET /v2/workbooks/<id>/spec`. Use `yq` to inspect spec YAML the same way you'd use `jq` on JSON.
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<reference-workbook-id>/spec" \
+  > /tmp/reference-spec.yaml
+```
+
+Look at source structure, column ID patterns, formula syntax, element naming, layout XML idioms. The `pages` array shape is exactly what you'll POST when creating.
+
+### Step 3 — Discover data sources
+
+Load `reference/workflows/discover.md`. Quick summary:
+
+1. `GET /v2/connections` — find the user's connection by name or type.
+2. Ask the user for the table path; verify with `POST /v2/connection/<id>/lookup`.
+3. Discover columns directly via `GET /v2/connections/tables/{inodeId}/columns` (full mechanics in `reference/workflows/discover.md`). Only fall back to asking the user when the endpoint doesn't return what's needed.
+
+**Never invent column names** — only use names returned by the API or supplied by the user.
+
+**Verify literal values before writing predicates.** If your task involves filtering on a categorical column (e.g., `CountIf([Status] = "active")`, `If([Type] = "sale", ...)`), you need to know what values that column *actually* contains — the `/v2/connections/tables/{inodeId}/columns` endpoint gives you names and types but not values. Run a `SELECT DISTINCT <col>` via any tool that reaches the warehouse — an MCP server (warehouse or [Sigma](https://help.sigmacomputing.com/docs/use-sigma-mcp-server)), a SQL CLI, or just ask the user. Don't guess literals. See `reference/workflows/discover.md`.
+
+### Step 4 — Identify features and load only what you need
+
+Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
+
+### Step 5 — Draft the spec to a local file
+
+Write the spec YAML to disk (e.g., `/tmp/workbook-spec.yaml`). YAML is preferred over JSON in this skill — easier to read, diff, and comment for human review. The API accepts either; pick YAML unless something downstream specifically needs JSON. Key rules:
+
+- Every element needs a unique `id` and a descriptive `name`.
+- Every column needs a unique `id`, a `name`, and a `formula`.
+- Follow the formula reference rules in `reference/specification/formulas.md` exactly — most spec errors happen here.
+- **Write explicit `layout` XML for multi-element workbooks.** Auto-arrange (omitting `layout`) is acceptable only for single-element pages or a uniform stack of tables. See `reference/specification/layout.md` for the rubric.
+- Start with 1–2 pages. Add more later via update.
+
+For **create**, the file must include top-level `name`, `folderId`, `schemaVersion`, and `pages`. `description` is optional. `layout` is technically optional but expected for multi-element workbooks. `schemaVersion` is usually `1` — that's the current value; it may change in the future, so if the API rejects the spec on that field, check what your reference-workbook GET in Step 2 returned and use that instead. Full CRUD mechanics are in `reference/workflows/crud.md`.
+
+### Step 6 — Validate the spec
+
+**Run the bundled validator first — do not skip.**
+
+```bash
+./scripts/validate-spec.sh /tmp/workbook-spec.yaml
+```
+
+Then do the manual formula pass and final shape checks per `reference/workflows/validate.md`. Fix everything reported before continuing.
+
+### Step 7 — Create the workbook
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/workbook-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/spec" > /tmp/create-response.yaml
+
+WORKBOOK_ID=$(yq -r '.workbookId' /tmp/create-response.yaml)
+cp /tmp/workbook-spec.yaml "/tmp/workbook-spec-${WORKBOOK_ID}.yaml"
+```
+
+Persist the spec after a successful create so subsequent `PUT` updates can start from it. Report **both** the workbook URL **and** the saved spec path.
+
+If creation fails, read the error, fix the spec, re-validate, retry. See `reference/workflows/validate.md` for decoding cryptic errors.
+
+### Step 7b — Verify the workbook actually compiles
+
+**Do not skip.** A successful POST is necessary but not sufficient — Sigma accepts specs whose formulas don't resolve, then surfaces the failures at query time by embedding the error as a string literal in the compiled SQL (`'Unknown column "[X]"'`, `'Circular column reference to [Y]'`). Affected elements render empty in the UI. Only Sigma's compiler knows whether your formula references actually resolve.
+
+```bash
+./scripts/verify-workbook.sh "$WORKBOOK_ID"
+```
+
+If any element reports `[FAIL]`, fix the column formulas in the spec (most often a missing source prefix, a self-referencing column, or a friendly-name mismatch with the warehouse — see `reference/specification/formulas.md`), `PUT` the corrected spec, and re-verify.
+
+### Step 8 — Iterate
+
+After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
+
+> **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" \
+  > /tmp/current-spec.yaml
+
+# Edit /tmp/current-spec.yaml, then:
+curl -s -X PUT -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/current-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" | yq .
+
+cp /tmp/current-spec.yaml "/tmp/workbook-spec-<workbook-id>.yaml"
+./scripts/verify-workbook.sh "<workbook-id>"
+```
+
+### Step 9 — Report back
+
+Report the workbook URL and the saved spec path. **Do not tack on generic "improvement ideas" or "next steps."** Match the response to what was asked.
+
+Surface follow-up items only when they're load-bearing, and name them concretely:
+
+- **Tradeoffs you made during the build** — dropped a chart, simplified a formula, skipped a control because the shape wasn't in your reference.
+- **Obvious gaps revealed by the column list** — e.g., the user asked for "sales by region" and the table has a `region_tier` column that would make the breakdown richer. One sentence, named.
+
+If none apply, just report the URL + spec path and stop.
+
+## Reference Index
+
+The reference is feature-sliced — don't read every file up-front. The index has three sections: **elements** (the visual / interactive pieces), **sources** (where each element gets its data), and **cross-cutting** (formulas, layout, formatting, validation, CRUD).
+
+### Elements
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
+| `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
+| `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
+| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the period-over-period formula recipe, and the spec limits of the comparison / trend-sparkline blocks (UI-bound). |
+| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
+| `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
+| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+
+### Sources
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/sources-warehouse.md` | Always — load before drafting any spec. Warehouse-table source (Snowflake, BigQuery, Databricks, Redshift, Postgres/MySQL). |
+| `reference/specification/sources.md` | Reference another chart/table/element, derive from existing element, join, combine tables, data model / semantic-layer source, custom SQL, union, transpose, unpivot. |
+
+### Cross-cutting
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/schema.md` | Always — load before drafting any spec. Top-level shape, required fields, response-only fields to strip. |
+| `reference/specification/formulas.md` | Always — load before drafting any spec. Formula syntax, qualification, special characters, the #1 mistake. |
+| `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
+| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
+| `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
+
+### Workflows
+
+| File | When to load |
+|------|--------------|
+| `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
+| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
+| `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
+| `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+
+## Quick Formula Rules
+
+The single most common spec error is bare `[column_name]` references to warehouse columns. Full rules in `reference/specification/formulas.md`. Skeleton:
+
+**Outside the element** — use `[SourceName/column_name]`:
+- Warehouse-table source: `SourceName` = last segment of the `path` array (e.g., `[ORDERS/Revenue]`)
+- Another element: `SourceName` = that element's `name`
+- Join legs: prefix by the leg's `name`, or by the join's top-level `name` for `primarySource` columns
+
+**Inside the same element** — use `[column_name]` (no prefix):
+- References a column defined in this element by its `name` field.
+- A column cannot reference itself (circular reference error).
+
+## Troubleshooting
+
+### "I don't see this field in the skill"
+
+Fetch the OpenAPI. The skill documents stable, common surface area; the API has more. See **Consulting the OpenAPI** above.
+
+### API schema mismatch (skill is stale)
+
+A 400 about request *shape* — `invalid argument`, `unknown field`, `unexpected property`, `missing required field` — usually means the API moved past the skill. Fetch the OpenAPI (see **Consulting the OpenAPI**), diff the live shape for that `kind`, and retry **once** with the correction. Tell the user it looks like the skill is out of date and worth updating through whatever channel they installed it from; don't loop on retries.
+
+### 401 Unauthorized
+
+Sigma OAuth tokens expire after ~1 hour. Long workbook-building sessions (orchestrated batch conversions, multi-step iterations, anything that runs >50 minutes) will hit this mid-flight.
+
+**Ruby callers** (any of the `tableau-to-sigma/scripts/*.rb` Sigma-touching scripts): use the `Sigma` REST wrapper at `tableau-to-sigma/scripts/lib/sigma_rest.rb` — it does automatic 401-with-refresh-and-retry. Concretely:
+
+```ruby
+require_relative 'lib/sigma_rest'
+spec = Sigma.request(:get, "/v2/workbooks/#{id}/spec")   # auto-refreshes on 401
+```
+
+**Bash / curl callers**: re-run `eval "$(scripts/get-token.sh)"` to refresh manually. For long shell loops, wrap the curl in a small helper that retries once on 401:
+
+```bash
+sigma_curl() {
+  local resp code
+  resp=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $SIGMA_API_TOKEN" "$@")
+  code=$(echo "$resp" | tail -1)
+  if [ "$code" = "401" ]; then
+    eval "$(scripts/get-token.sh)"
+    resp=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $SIGMA_API_TOKEN" "$@")
+  fi
+  echo "$resp" | sed '$d'  # strip trailing status code
+}
+```
+
+If 401 persists after refresh, re-authenticate via `sigma-api` and verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`.
+
+### 403 Forbidden on workbook create
+
+The credentials authenticated but aren't permitted to create workbooks here. Ask the user's Sigma admin to confirm the credential's permissions and folder access.
+
+### "Invalid column reference" or formula errors on creation
+
+The most common spec issue. A bare `[column_name]` was used where `[TABLE/column_name]` is needed. See `reference/specification/formulas.md` for the full rules and `reference/workflows/validate.md` for the manual checklist.
+
+### "Unknown column" errors
+
+The column name in the formula doesn't match what the warehouse actually has. Re-confirm the column names via `GET /v2/connections/tables/{inodeId}/columns` (raw warehouse names) and the readback (`GET /v2/workbooks/<id>/spec`, which shows Sigma's normalized friendly names). Use those names verbatim.
+
+### `jq` or `yq` not installed
+
+`jq` is used for OpenAPI inspection (the OpenAPI is JSON). `yq` is used for workbook-spec inspection (specs are YAML).
+
+- `jq`: `brew install jq` (macOS) or `apt install jq` (Debian/Ubuntu).
+- `yq`: **two different tools share this name** — the Go **mikefarah/yq** (`brew install yq`) and the Python **`pip install yq`** wrapper around jq. *Reading* works the same in both (`yq -r '.workbookId' f.yaml`), but *in-place editing differs*: mikefarah uses `yq -i '…' f.yaml`, while the Python wrapper needs `yq -y -i '…' f.yaml`. Run `yq --help` to see which you have and adapt.
+
+### Cryptic validation errors / silent bad data
+
+See `reference/workflows/validate.md` for the full triage table (mapping `Invalid kind: pages[0].elements[N]...` style errors to the right spec file).

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -1,0 +1,317 @@
+---
+description: "Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first."
+alwaysApply: false
+---
+
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Workbooks (Spec via REST API)
+
+This skill helps you build effective Sigma workbooks by **navigating the Sigma OpenAPI** and applying **style guidance + proven recipes** beyond what the OpenAPI alone teaches.
+
+## Scope
+
+The workbook **spec** — the JSON you POST to `/v2/workbooks/spec` defining pages, elements, sources, formulas, and layout. Lifecycle around the workbook (embeds, grants, materialization schedules, bookmarks, sharing) is a separate API surface and out of scope here.
+
+## Sources of truth
+
+1. **Sigma OpenAPI** — canonical schema for every request/response shape and field.
+   `https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json`
+2. **Existing workbooks on the user's org** — concrete working specs, accessible via `GET /v2/workbooks/{id}/spec`.
+
+Everything in this skill is commentary, style guidance, and recipes layered on top of those two sources. **When this skill and the OpenAPI disagree, the OpenAPI wins.** When a feature exists in the OpenAPI but isn't covered here, fetch the OpenAPI and use what it documents.
+
+## Consulting the OpenAPI
+
+The OpenAPI is the source of truth. **The field lists and examples in this skill are illustrative, not exhaustive** — when you need the complete, current shape of anything, query the spec. Fetch once per session and inspect with `jq`:
+
+```bash
+curl -sf https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json > /tmp/sigma-api.json
+
+# The entire workbook spec request body lives under one path (it is not split into named schemas):
+jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json
+```
+
+Element, source, control, and format shapes are **inlined** under that path and identified by their `kind` value (e.g. `bar-chart`, `kpi-chart`, `join`, `warehouse-table`) — not by a top-level schema name. Navigate by the `kind` discriminator:
+
+```bash
+# List every kind the spec accepts (elements, sources, controls, formats, …):
+jq -r '[.. | objects | select(.properties.kind.enum) | .properties.kind.enum[0]] | unique[]' /tmp/sigma-api.json
+
+# Full field list (required + optional) for one kind — swap bar-chart for any kind above:
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))
+  | {required: ([.allOf[]?.required // .required] | add | unique), properties: ([(.allOf[]?.properties // .properties) | keys[]] | unique)}' /tmp/sigma-api.json
+
+# The full nested shape for that kind (to inspect sub-objects like source, yAxis, format, comparison):
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+`WebFetch` works for the JSON too. Either path is fine.
+
+**Why bother:** the API ships new fields and viz configurations regularly, and this skill covers the common surface, not every field. If you want a capability and don't see it documented here, **assume it may exist and check the spec before concluding it doesn't** — the `kind` query above answers in seconds.
+
+## Auth
+
+Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`.
+
+## Recommended Workflow
+
+These are guidelines, not mandates — but they prevent the failure modes that show up most often when drafting from scratch.
+
+> **Schema drift signal:** an error about request *shape* (`invalid argument`, `unknown field`, `missing required field`, `unexpected property`) usually means this skill is stale on that detail. Fetch the OpenAPI and compare; the canonical shape is there.
+
+### Step 0 — Authenticate, capture user identity
+
+```bash
+USER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/whoami" | jq -r '.userId')
+
+HOME_FOLDER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/members/$USER_ID" | jq -r '.homeFolderId')
+```
+
+If the user provided a **target image** (a screenshot, mockup, or PDF of a dashboard they want reproduced), pause here and load `reference/workflows/from-image.md` — it adds explicit observation, description, and validation steps that have to happen *before* normal data discovery. The standard workflow alone tends to produce workbooks with the right vibe but the wrong shape when the input is visual.
+
+### Step 1 — Find a reference workbook to study
+
+Any existing workbook on the user's org doubles as a template. List and pick one with similar content:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks?limit=50" | jq '.entries[] | {workbookId, name}'
+```
+
+If no relevant workbook exists, pick any — the goal is studying spec structure, not matching content. If the org has no workbooks at all, draft from scratch using the OpenAPI shapes + this skill's recipes.
+
+### Step 2 — Study the reference spec
+
+YAML is the canonical format for workbook specs in this skill — easier to read, diff, and review than JSON. Sigma's API accepts both (`Content-Type: application/yaml` or `application/json`); `Accept: application/yaml` is the default on `GET /v2/workbooks/<id>/spec`. Use `yq` to inspect spec YAML the same way you'd use `jq` on JSON.
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<reference-workbook-id>/spec" \
+  > /tmp/reference-spec.yaml
+```
+
+Look at source structure, column ID patterns, formula syntax, element naming, layout XML idioms. The `pages` array shape is exactly what you'll POST when creating.
+
+### Step 3 — Discover data sources
+
+Load `reference/workflows/discover.md`. Quick summary:
+
+1. `GET /v2/connections` — find the user's connection by name or type.
+2. Ask the user for the table path; verify with `POST /v2/connection/<id>/lookup`.
+3. Discover columns directly via `GET /v2/connections/tables/{inodeId}/columns` (full mechanics in `reference/workflows/discover.md`). Only fall back to asking the user when the endpoint doesn't return what's needed.
+
+**Never invent column names** — only use names returned by the API or supplied by the user.
+
+**Verify literal values before writing predicates.** If your task involves filtering on a categorical column (e.g., `CountIf([Status] = "active")`, `If([Type] = "sale", ...)`), you need to know what values that column *actually* contains — the `/v2/connections/tables/{inodeId}/columns` endpoint gives you names and types but not values. Run a `SELECT DISTINCT <col>` via any tool that reaches the warehouse — an MCP server (warehouse or [Sigma](https://help.sigmacomputing.com/docs/use-sigma-mcp-server)), a SQL CLI, or just ask the user. Don't guess literals. See `reference/workflows/discover.md`.
+
+### Step 4 — Identify features and load only what you need
+
+Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
+
+### Step 5 — Draft the spec to a local file
+
+Write the spec YAML to disk (e.g., `/tmp/workbook-spec.yaml`). YAML is preferred over JSON in this skill — easier to read, diff, and comment for human review. The API accepts either; pick YAML unless something downstream specifically needs JSON. Key rules:
+
+- Every element needs a unique `id` and a descriptive `name`.
+- Every column needs a unique `id`, a `name`, and a `formula`.
+- Follow the formula reference rules in `reference/specification/formulas.md` exactly — most spec errors happen here.
+- **Write explicit `layout` XML for multi-element workbooks.** Auto-arrange (omitting `layout`) is acceptable only for single-element pages or a uniform stack of tables. See `reference/specification/layout.md` for the rubric.
+- Start with 1–2 pages. Add more later via update.
+
+For **create**, the file must include top-level `name`, `folderId`, `schemaVersion`, and `pages`. `description` is optional. `layout` is technically optional but expected for multi-element workbooks. `schemaVersion` is usually `1` — that's the current value; it may change in the future, so if the API rejects the spec on that field, check what your reference-workbook GET in Step 2 returned and use that instead. Full CRUD mechanics are in `reference/workflows/crud.md`.
+
+### Step 6 — Validate the spec
+
+**Run the bundled validator first — do not skip.**
+
+```bash
+./scripts/validate-spec.sh /tmp/workbook-spec.yaml
+```
+
+Then do the manual formula pass and final shape checks per `reference/workflows/validate.md`. Fix everything reported before continuing.
+
+### Step 7 — Create the workbook
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/workbook-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/spec" > /tmp/create-response.yaml
+
+WORKBOOK_ID=$(yq -r '.workbookId' /tmp/create-response.yaml)
+cp /tmp/workbook-spec.yaml "/tmp/workbook-spec-${WORKBOOK_ID}.yaml"
+```
+
+Persist the spec after a successful create so subsequent `PUT` updates can start from it. Report **both** the workbook URL **and** the saved spec path.
+
+If creation fails, read the error, fix the spec, re-validate, retry. See `reference/workflows/validate.md` for decoding cryptic errors.
+
+### Step 7b — Verify the workbook actually compiles
+
+**Do not skip.** A successful POST is necessary but not sufficient — Sigma accepts specs whose formulas don't resolve, then surfaces the failures at query time by embedding the error as a string literal in the compiled SQL (`'Unknown column "[X]"'`, `'Circular column reference to [Y]'`). Affected elements render empty in the UI. Only Sigma's compiler knows whether your formula references actually resolve.
+
+```bash
+./scripts/verify-workbook.sh "$WORKBOOK_ID"
+```
+
+If any element reports `[FAIL]`, fix the column formulas in the spec (most often a missing source prefix, a self-referencing column, or a friendly-name mismatch with the warehouse — see `reference/specification/formulas.md`), `PUT` the corrected spec, and re-verify.
+
+### Step 8 — Iterate
+
+After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
+
+> **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" \
+  > /tmp/current-spec.yaml
+
+# Edit /tmp/current-spec.yaml, then:
+curl -s -X PUT -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/current-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" | yq .
+
+cp /tmp/current-spec.yaml "/tmp/workbook-spec-<workbook-id>.yaml"
+./scripts/verify-workbook.sh "<workbook-id>"
+```
+
+### Step 9 — Report back
+
+Report the workbook URL and the saved spec path. **Do not tack on generic "improvement ideas" or "next steps."** Match the response to what was asked.
+
+Surface follow-up items only when they're load-bearing, and name them concretely:
+
+- **Tradeoffs you made during the build** — dropped a chart, simplified a formula, skipped a control because the shape wasn't in your reference.
+- **Obvious gaps revealed by the column list** — e.g., the user asked for "sales by region" and the table has a `region_tier` column that would make the breakdown richer. One sentence, named.
+
+If none apply, just report the URL + spec path and stop.
+
+## Reference Index
+
+The reference is feature-sliced — don't read every file up-front. The index has three sections: **elements** (the visual / interactive pieces), **sources** (where each element gets its data), and **cross-cutting** (formulas, layout, formatting, validation, CRUD).
+
+### Elements
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
+| `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
+| `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
+| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the period-over-period formula recipe, and the spec limits of the comparison / trend-sparkline blocks (UI-bound). |
+| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
+| `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
+| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+
+### Sources
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/sources-warehouse.md` | Always — load before drafting any spec. Warehouse-table source (Snowflake, BigQuery, Databricks, Redshift, Postgres/MySQL). |
+| `reference/specification/sources.md` | Reference another chart/table/element, derive from existing element, join, combine tables, data model / semantic-layer source, custom SQL, union, transpose, unpivot. |
+
+### Cross-cutting
+
+| File | When to load |
+|------|--------------|
+| `reference/specification/schema.md` | Always — load before drafting any spec. Top-level shape, required fields, response-only fields to strip. |
+| `reference/specification/formulas.md` | Always — load before drafting any spec. Formula syntax, qualification, special characters, the #1 mistake. |
+| `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
+| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
+| `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
+
+### Workflows
+
+| File | When to load |
+|------|--------------|
+| `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
+| `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
+| `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
+| `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+
+## Quick Formula Rules
+
+The single most common spec error is bare `[column_name]` references to warehouse columns. Full rules in `reference/specification/formulas.md`. Skeleton:
+
+**Outside the element** — use `[SourceName/column_name]`:
+- Warehouse-table source: `SourceName` = last segment of the `path` array (e.g., `[ORDERS/Revenue]`)
+- Another element: `SourceName` = that element's `name`
+- Join legs: prefix by the leg's `name`, or by the join's top-level `name` for `primarySource` columns
+
+**Inside the same element** — use `[column_name]` (no prefix):
+- References a column defined in this element by its `name` field.
+- A column cannot reference itself (circular reference error).
+
+## Troubleshooting
+
+### "I don't see this field in the skill"
+
+Fetch the OpenAPI. The skill documents stable, common surface area; the API has more. See **Consulting the OpenAPI** above.
+
+### API schema mismatch (skill is stale)
+
+A 400 about request *shape* — `invalid argument`, `unknown field`, `unexpected property`, `missing required field` — usually means the API moved past the skill. Fetch the OpenAPI (see **Consulting the OpenAPI**), diff the live shape for that `kind`, and retry **once** with the correction. Tell the user it looks like the skill is out of date and worth updating through whatever channel they installed it from; don't loop on retries.
+
+### 401 Unauthorized
+
+Sigma OAuth tokens expire after ~1 hour. Long workbook-building sessions (orchestrated batch conversions, multi-step iterations, anything that runs >50 minutes) will hit this mid-flight.
+
+**Ruby callers** (any of the `tableau-to-sigma/scripts/*.rb` Sigma-touching scripts): use the `Sigma` REST wrapper at `tableau-to-sigma/scripts/lib/sigma_rest.rb` — it does automatic 401-with-refresh-and-retry. Concretely:
+
+```ruby
+require_relative 'lib/sigma_rest'
+spec = Sigma.request(:get, "/v2/workbooks/#{id}/spec")   # auto-refreshes on 401
+```
+
+**Bash / curl callers**: re-run `eval "$(scripts/get-token.sh)"` to refresh manually. For long shell loops, wrap the curl in a small helper that retries once on 401:
+
+```bash
+sigma_curl() {
+  local resp code
+  resp=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $SIGMA_API_TOKEN" "$@")
+  code=$(echo "$resp" | tail -1)
+  if [ "$code" = "401" ]; then
+    eval "$(scripts/get-token.sh)"
+    resp=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $SIGMA_API_TOKEN" "$@")
+  fi
+  echo "$resp" | sed '$d'  # strip trailing status code
+}
+```
+
+If 401 persists after refresh, re-authenticate via `sigma-api` and verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`.
+
+### 403 Forbidden on workbook create
+
+The credentials authenticated but aren't permitted to create workbooks here. Ask the user's Sigma admin to confirm the credential's permissions and folder access.
+
+### "Invalid column reference" or formula errors on creation
+
+The most common spec issue. A bare `[column_name]` was used where `[TABLE/column_name]` is needed. See `reference/specification/formulas.md` for the full rules and `reference/workflows/validate.md` for the manual checklist.
+
+### "Unknown column" errors
+
+The column name in the formula doesn't match what the warehouse actually has. Re-confirm the column names via `GET /v2/connections/tables/{inodeId}/columns` (raw warehouse names) and the readback (`GET /v2/workbooks/<id>/spec`, which shows Sigma's normalized friendly names). Use those names verbatim.
+
+### `jq` or `yq` not installed
+
+`jq` is used for OpenAPI inspection (the OpenAPI is JSON). `yq` is used for workbook-spec inspection (specs are YAML).
+
+- `jq`: `brew install jq` (macOS) or `apt install jq` (Debian/Ubuntu).
+- `yq`: **two different tools share this name** — the Go **mikefarah/yq** (`brew install yq`) and the Python **`pip install yq`** wrapper around jq. *Reading* works the same in both (`yq -r '.workbookId' f.yaml`), but *in-place editing differs*: mikefarah uses `yq -i '…' f.yaml`, while the Python wrapper needs `yq -y -i '…' f.yaml`. Run `yq --help` to see which you have and adapt.
+
+### Cryptic validation errors / silent bad data
+
+See `reference/workflows/validate.md` for the full triage table (mapping `Invalid kind: pages[0].elements[N]...` style errors to the right spec file).

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/charts.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/charts.md
@@ -1,0 +1,335 @@
+# Charts
+
+Chart elements: `line-chart`, `bar-chart`, `donut-chart`. This file is a **recipe book** for chart specs and the style choices that go with each kind. The OpenAPI is the source of truth for every field — chart schemas are inlined behind their `kind` discriminator, so fetch one by its kind:
+
+```bash
+# Swap `bar-chart` for any kind: line-chart, area-chart, combo-chart, scatter-chart, donut-chart, pie-chart
+jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+The field lists below are curated, not exhaustive — use the recipe above to discover the full shape of any field.
+
+All three share the same skeleton: a `source`, a `columns` array, and axis/value pointers that reference column IDs. Formulas on a chart that sources another element must use the source's prefix (`[<SourceName>/col]`) — see `formulas.md`.
+
+---
+
+## Line chart (revenue over time)
+
+```yaml
+id: sales-over-time
+kind: line-chart
+name: Sales over time
+source:
+  kind: table
+  elementId: sales-table
+columns:
+  - id: col-month
+    name: Month
+    formula: DateTrunc("month", [Master/Date])
+    format:
+      kind: datetime
+      formatString: "%b %Y"
+  - id: col-sales
+    name: Sales
+    formula: Sum([Master/Sales Amount])
+    format:
+      kind: number
+      formatString: "$,.0f"
+xAxis:
+  columnId: col-month
+yAxis:
+  columnIds:
+    - col-sales
+```
+
+- `xAxis` — single `{ columnId, sort?, format? }`
+- `yAxis` — single `{ columnIds: [<colId>, ...], format? }`. On any cartesian chart, a `columnIds` entry may be an object `{ columnId, type }` (`type`: `bar` | `line` | `area` | `scatter`) to set that series' shape — most useful on `combo-chart`
+- `xAxis.sort` shape: `{ by: <colId>, direction: ascending | descending }`
+- Optional `format` on each axis configures title, labels, marks, and scale — it's inlined on `xAxis.format` / `yAxis.format`; inspect it via the kind recipe above rather than transcribing the whole object
+
+## Bar chart (revenue by category)
+
+Same axis shape as line-chart. Adds `stacking`.
+
+```yaml
+id: sales-by-region
+kind: bar-chart
+name: Sales by region
+source:
+  kind: table
+  elementId: sales-table
+columns:
+  - id: col-region
+    name: Region
+    formula: "[Master/Store Region]"
+  - id: col-sales
+    name: Sales
+    formula: Sum([Master/Sales Amount])
+    format:
+      kind: number
+      formatString: "$,.0f"
+xAxis:
+  columnId: col-region
+  sort:
+    by: col-sales
+    direction: descending
+yAxis:
+  columnIds:
+    - col-sales
+stacking: none
+```
+
+`stacking`: `none` | `stacked` | `normalized` (the percent-stacked variant — `"100"` is rejected by the API; live-verified 2026-06-11).
+
+## Bar chart with custom category colors
+
+`bar-chart` accepts an optional `color` channel with three variants:
+
+```yaml
+# Single fixed color
+color:
+  by: single
+  value: "#3b82f6"
+
+# One color per category (positional — see below)
+color:
+  by: category
+  column: col-region
+  scheme: ["#3b82f6", "#ef4444", "#10b981", "#f59e0b"]
+
+# Continuous scale across a measure
+color:
+  by: scale
+  column: col-sales
+  scheme: ["#fef3c7", "#fbbf24", "#dc2626"]
+  domain: { min: 0, max: 10000, mid: 5000 }   # `mid` is optional; its presence makes the gradient diverging, otherwise sequential
+```
+
+**Recipe — pin specific categories to specific colors:**
+
+`scheme` is a **positional** array: Sigma assigns colors to categories in the order they appear on the axis, not by category name. To pin Electronics → blue, Apparel → red, Home → green, control the sort order alongside the color array:
+
+```yaml
+kind: bar-chart
+name: Revenue by category
+columns:
+  - id: col-cat
+    name: Category
+    formula: "[Sales/Product Category]"
+  - id: col-sales
+    name: Revenue
+    formula: Sum([Sales/Revenue])
+    format:
+      kind: number
+      formatString: "$,.0f"
+xAxis:
+  columnId: col-cat
+  sort:
+    by: col-cat
+    direction: ascending
+yAxis:
+  columnIds:
+    - col-sales
+color:
+  by: category
+  column: col-cat
+  scheme: ["#3b82f6", "#ef4444", "#10b981"]
+```
+
+For category-by-name binding rather than position, use a derived column with an `If(...)` that emits the categories in a known order, then sort by that order.
+
+## Donut
+
+Uses `value` and `color` instead of `xAxis` / `yAxis`.
+
+```yaml
+id: sales-by-family
+kind: donut-chart
+name: Sales by product family
+source:
+  kind: table
+  elementId: sales-table
+columns:
+  - id: col-family
+    name: Family
+    formula: "[Master/Product Family]"
+  - id: col-sales
+    name: Sales
+    formula: Sum([Master/Sales Amount])
+    format:
+      kind: number
+      formatString: "$,.0f"
+value:
+  id: col-sales
+color:
+  id: col-family
+  sort:
+    by: col-sales
+    direction: descending
+```
+
+`holeValue` is optional. When set, it references one of the donut's columns by ID — that column's aggregated value drives the hole label/render — not a literal number. **It must be a different column than `value.id`** — a column can only sit on one channel at a time, and the API rejects the collision with a 400 (`Column 'X' is referenced from both 'value' and 'holeValue'`). For a center label that shows the same metric, add a second column with the same formula:
+
+```yaml
+holeValue:
+  id: col-sales-hole    # distinct column, e.g. formula: Sum([Master/Sales Amount])
+```
+
+Related donut-only fields (all round-trip): `innerRadius` (hole size as a ratio of the outer radius, default 0.6) and `hole.value` styling (`fontWeight`, `color`, `visibility`) for the center label.
+
+## Element-level filters (Top-N, etc.)
+
+Charts take the same `filters` array as tables — the top-N example in `tables.md` applies to `bar-chart`, `line-chart`, and `donut-chart` without changes.
+
+Top 10 regions by `Sales` on a bar chart:
+
+```yaml
+filters:
+  - id: top-10
+    columnId: col-sales
+    kind: top-n
+    rankingFunction: rank
+    mode: top-n
+    rowCount: 10
+    includeNulls: when-no-value-is-selected
+```
+
+`rowCount` takes a number literal — it cannot be bound to a control (see `controls.md`, "Where Control Bindings Apply").
+
+## Cartesian-only optional features
+
+These apply to `bar-chart`, `line-chart`, `area-chart`, `scatter-chart`, and `combo-chart`. Use the kind recipe at the top of this file to read the full operator and styling enums for any of them.
+
+### `refMarks` — reference lines and bands
+
+```yaml
+refMarks:
+  - type: line
+    axis: series              # axis = x-axis, series = primary y, series2 = secondary y
+    value: { type: formula, formula: "Avg([Master/Sales])" }   # see value shape below
+    line: { color: "#ef4444", width: 2 }
+    label: { visibility: shown, text: "Threshold" }            # visibility REQUIRED
+  - type: band
+    axis: series
+    value: { type: formula, formula: "800" }
+    endValue: { type: formula, formula: "1200" }               # required for bands
+```
+
+> **`value` must be the wrapped object `{ type: formula, formula: "<expr>" }`** — verified live 2026-06-15. A bare number/string (`value: 1000`) and `{ type: static, value: 1000 }` are both rejected with the opaque `refMarks[0]: Invalid value: object`. A **constant** is expressed as a formula string, e.g. a 45% target line: `value: { type: formula, formula: "0.45" }`. `label.visibility` must be `shown` (omitting it, or `hidden`, also trips `Invalid value: object`).
+
+### `trendlines` — regression overlays
+
+```yaml
+trendlines:
+  - columnId: col-sales       # which series to fit
+    model: linear             # linear | quadratic | polynomial | exponential | logarithmic | power
+    line: { color: "#336699", width: 2 }
+    label: { visibility: shown, text: "Sales trend" }
+```
+
+Trendlines are rejected when the chart has no `xAxis`, uses stacking on bar/area/combo, or has a `color` channel — discover those constraints by submitting and reading the error.
+
+### `dataLabel` — value labels on marks
+
+```yaml
+dataLabel:
+  labels: shown               # shown | hidden
+  labelDisplay: all            # auto | minimum | maximum | min-max | all
+  valueFormat: percent
+  totals: { display: shown }
+```
+
+For `combo-chart`, optional `seriesDataLabel` is a map keyed by layer shape (`bar`, `line`, `area`, `scatter`) with per-shape overrides:
+
+```yaml
+seriesDataLabel:
+  bar: { labelDisplay: maximum }
+  line: { labelDisplay: all }
+```
+
+## Combo charts (mixed series + secondary axis)
+
+A `combo-chart` mixes bar/line/area/scatter series on one plot. Set each series' shape with the `{ columnId, type }` form on `yAxis.columnIds`, and put series that need a different scale on the secondary axis `yAxis2`. **`yAxis2.columnIds` must be a subset of `yAxis.columnIds`** — list the column on both, with `yAxis2` marking which series render against the right axis (a `yAxis2` entry missing from `yAxis` is a 400: `'X' is not listed on yAxis.columnIds`):
+
+```yaml
+kind: combo-chart
+xAxis:
+  columnId: col-month
+yAxis:                          # ALL series live here, each with its shape
+  columnIds:
+    - { columnId: col-revenue, type: bar }
+    - { columnId: col-margin-pct, type: line }
+yAxis2:                         # subset of yAxis.columnIds that renders on the right axis
+  columnIds:
+    - col-margin-pct
+  format:
+    visibility: shown           # set to `hidden` to hide the axis (no other fields on that branch)
+```
+
+Per-series styling is keyed by layer shape (`bar` / `line` / `area` / `scatter`):
+
+- `seriesLineAreaStyle` — stroke/fill, curve, and area opacity for line/area layers
+- `seriesPointStyle` — marker shape/size for points
+- `seriesDataLabel` — per-shape data-label overrides (above)
+
+Chart-wide fallbacks `barStyle`, `lineAreaStyle`, `pointStyle`, and `gap` also exist. Inspect the kind recipe for the full sub-field set of any of these.
+
+### More cartesian options
+
+Each of these is a top-level key on cartesian charts; one-liner here, full sub-fields via the kind recipe at the top of this file.
+
+- `orientation: horizontal` on `bar-chart` — horizontal bars. Omit for the default vertical bars.
+- `trellis: { column, row, share?, tileSize? }` — **styles a UI-configured trellis only.** `tileSize` and the `column`/`row` guide styling (`labels`, `border`, `title`) round-trip, but the facet *column binding* cannot be set via spec — `columnId`/`id` inside `column`/`row` are silently stripped (live-verified 2026-06-11). Configure the facets in the editor; the spec can then style them.
+- `legend: { visibility, position, ... }` — legend placement and styling.
+- `tooltip: { columnNames?, multiSeries?, valueFormat? }` — hover-tooltip content. Support is config-dependent (live-verified 2026-06-11): `columnNames` round-trips broadly; `multiSeries` round-trips on line charts but is silently stripped on bar-with-color; `valueFormat` is rejected or stripped in most configurations. Verify the readback after setting anything beyond `columnNames`.
+
+(Trendlines and `refMarks` are covered above.)
+
+## Scatter
+
+A `scatter-chart` is **measure-vs-measure**, one point per dimension value — fundamentally different from `bar-chart`. The trap (verified the hard way): if you put an aggregate measure (`Sum(...)`) directly on `xAxis`/`yAxis` of a scatter sourced from a flat table, Sigma's scatter axis is a *grouping* axis, so the aggregate evaluates **per row** and every point collapses to one x. A spec like this **POSTs cleanly but renders wrong** — POST success does NOT prove a correct scatter.
+
+The correct shape binds the scatter to a **grouping**: source a table element that groups by the point dimension and pre-computes the x/y/(size) aggregates, then point the scatter at that grouping with `source.groupingId` and reference the grouped columns with raw refs. (Verified against a UI-built scatter, 2026-06-15.)
+
+```yaml
+# 1) a (hidden) grouped source table: one row per point dimension
+- id: scatter-src
+  kind: table
+  name: Rep Performance            # unique name — raw refs resolve as [Rep Performance/Col]
+  source: { kind: table, elementId: master }
+  columns:
+    - { id: g-rep, name: Sales Rep, formula: "[Data/Sales Rep Name]" }
+    - { id: g-mpct, name: Margin %, formula: "(Sum([Data/Revenue])-Sum([Data/Cost]))/Sum([Data/Revenue])" }
+    - { id: g-rev,  name: Revenue,  formula: "Sum([Data/Revenue])" }
+    - { id: g-qty,  name: Quantity, formula: "Sum([Data/Quantity])" }
+  groupings:
+    - { id: grp-rep, groupBy: [g-rep], calculations: [g-mpct, g-rev, g-qty] }
+  visibleAsSource: false
+# 2) the scatter binds to that grouping; columns are RAW refs to the grouped values
+- id: scatter
+  kind: scatter-chart
+  name: Sales vs Margin by Sales Rep
+  source: { kind: table, elementId: scatter-src, groupingId: grp-rep }
+  columns:
+    - { id: s-rep,  formula: "[Rep Performance/Sales Rep]" }
+    - { id: s-mpct, formula: "[Rep Performance/Margin %]" }
+    - { id: s-rev,  formula: "[Rep Performance/Revenue]" }
+    - { id: s-qty,  formula: "[Rep Performance/Quantity]" }
+  xAxis: { columnId: s-mpct }       # x = a measure (Margin %)
+  yAxis: { columnIds: [s-rev] }     # y = a measure (Revenue)
+  color: { by: category, column: s-rep }   # point identity — one mark per rep
+  size:  { id: s-qty }              # optional bubble size; note `size.id`, NOT size.columnId
+```
+
+`color` always takes the `{ by: single|category|scale, column, ... }` form (see "Bar chart with custom category colors") — a bare `{ id }` / `{ columnId }` is rejected. **Validate a scatter by querying it for >1 distinct x**, not by POST status alone.
+
+## Other chart kinds
+
+Per the OpenAPI, these are all valid `kind` values; documented examples for the most common are above. The shape mirrors the `bar-chart`/`line-chart` pattern (`source`, `columns`, `xAxis`, `yAxis`). Inspect any of them with the kind recipe at the top of this file:
+
+- `area-chart`, `combo-chart` — same shape as `bar-chart`/`line-chart`, just a different `kind` (and `combo-chart` adds the series configs above).
+- `scatter-chart` — **NOT the same as bar-chart.** It is measure-vs-measure with the dimension as the point identity, and it must bind to a **grouping** or every point collapses to one x. See the Scatter section below.
+- `pie-chart` — like `donut-chart` (`value` + `color`), but without the donut-only `hole` / `holeValue` / `innerRadius` / `trellis` keys.
+- `pivot-table` — uses `values` instead of `yAxis`; useful for cross-tab analysis. See `tables.md`.
+
+For element-level reference of `kind: "text"` (free-form Markdown blocks), see `content-elements.md`.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/content-elements.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/content-elements.md
@@ -1,0 +1,97 @@
+# Content Elements (text, image, divider, embed)
+
+The non-data-bound elements — prose, images, rules, and embedded URLs. None take a `source`. Pull any kind's exact shape from the spec:
+
+```bash
+jq --arg k text 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+# swap k for image / divider / embed
+```
+
+These position in the page grid via `<LayoutElement>` like any other element — see `layout.md`.
+
+## text
+
+A Markdown block — titles, descriptions, section headers, callouts. Required `id`, `kind`, `body`; optional `verticalAlign` (`start` / `middle` / `end`) and `overflow` (`clip` / `scroll`). No `name`, no `source`.
+
+```yaml
+id: text-header
+kind: text
+body: |
+  # Sales Overview
+
+  A weekly view of revenue, with the regions driving the most growth.
+```
+
+(YAML's `|` block scalar keeps the body readable.)
+
+### `body`: Markdown + inline styling
+
+`body` is Markdown plus a small set of inline HTML for styling. Standard Markdown: paragraphs, `**bold**`, `*italic*`, headings (`#`, `##`, `###`), bullet / ordered lists, `[links](https://example.com)`, and `{{formula}}` / `{{ast | fmt}}` segments (same syntax as element titles, e.g. `{{Count() | ,.0f}}`).
+
+Inline styling via HTML — all round-trip through the spec and render:
+
+- **Color / background:** `<span style="color: #8B0000">` and/or `background-color` — **hex values** (`#rgb` / `#rrggbb`).
+- **Font size:** `<span style="font-size: 24px">`.
+- **Font family:** `<span style="font-family: Georgia">` — a single family name that starts with a letter and contains only letters, numbers, spaces, underscores, or dashes. **No comma-separated fallback lists** — `"Georgia, serif"` is rejected.
+- **Paragraph block styles:** `<p class="p-large">…</p>` and `<p class="p-small">…</p>`.
+- **Alignment:** `<p style="text-align: center">…</p>` (also `left` / `right`).
+
+A single `<span>` can combine properties (e.g. color + font-size). If a value violates its rule, the API rejects the whole `body` with a specific message naming the field — read it and fix the value.
+
+Common pattern — bold + color (both supported):
+
+```markdown
+# **<span style="color: #8B0000">Deployments Dashboard</span>**
+```
+
+## image
+
+Embeds an external image by URL (hosted only — no uploads). Required `id`, `kind`, `url`; `url` supports `{{formula}}` references for dynamic selection. `alt`, `link`, and a `style` block exist too — pull the shape from the recipe. Sizing comes from the layout grid, not the element.
+
+```yaml
+id: logo
+kind: image
+url: https://cdn.example.com/logo.png
+```
+
+## divider
+
+A rule for separating sections. Required `id`, `kind`; optional `direction` (`horizontal` / `vertical`), `align`, and `style` (`color` / `width` / `strokeStyle`).
+
+```yaml
+id: section-rule
+kind: divider
+```
+
+## embed
+
+Renders an external URL inline — a hosted report, form, video, etc. Required `id`, `kind`, `url`; `url` supports `{{formula}}` references.
+
+```yaml
+id: embed-report
+kind: embed
+url: https://example.com/report
+```
+
+## plugin (2026-06-18 release)
+
+Embeds a **custom Sigma plugin** as a page element. Required `id`, `kind`, `pluginId`; optional `displayName`, `style`, and a plugin-defined `config`.
+
+```yaml
+id: my-histogram
+kind: plugin
+pluginId: 6cdf51c1-dda0-4f99-aa08-5c72804020bb   # the plugin's registered UUID
+displayName: Histogram                            # optional label
+style: { backgroundColor: "#101826" }             # optional element background (see notes)
+config:                                            # plugin-defined bindings + settings
+  source: { kind: element, elementId: master }     # bind an element as the data source
+  valueColumn: { kind: column, columnId: m-netprof, source: source }
+  chartType: Frequency
+  binMethod: "Auto (Sturges)"
+  binCount: "10"
+```
+
+- **Data bindings** inside `config`: `{ kind: element, elementId }` selects a source element; `{ kind: column, columnId, source }` selects one of its columns (`{ kind: column, columnIds: [...], source }` for several); `source: source` points at the `config.source` element. A plugin can also read a control's value — bind the control the same way the plugin's input expects.
+- **`config` is half-opaque** — bare **literals** (strings/booleans/string-arrays) pass through unvalidated and are handed to the plugin at render time (a literal round-tripping does **not** mean Sigma supports it). But **`kind`-tagged references are resolved and validated**: a `{kind: element, ...}` / `{kind: column, ...}` / `{kind: control, ...}` pointing at something that doesn't exist is a hard 400 (`Dependency not found`). The literal keys are per-plugin — harvest them from a working spec.
+- **Element background:** use element-level `style.backgroundColor` (same shape as a container `style`) — a plugin renders on its own white canvas otherwise, which looks wrong inside a dark theme. A bare top-level `background` key is stripped.
+- **Discover available plugins with `GET /v2/plugins`** ("List custom plugins", paginated `pageSize`/`pageToken`; needs `Accept: application/json`). Each entry is `{ pluginId, name, description, url, devUrl, type }` — list them to pick the right `pluginId` instead of guessing. A **bogus `pluginId` is not validated at POST** (200, then renders as a broken "missing plugin"), so always source it from `/v2/plugins`. The endpoint returns id + name only — the per-plugin **`config` shape** still has to come from a workbook spec that uses the plugin (or the plugin's source). See `twells89/sigma-workbook-spec-findings` finding #27 + Plugin-ID catalog.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
@@ -1,0 +1,312 @@
+# Controls
+
+Recipe book for the control element family and the patterns that wire them up. The OpenAPI is the source of truth for every field; this file adds the wiring patterns it doesn't teach.
+
+Controls are interactive filter elements — lists, date pickers, text inputs, sliders, etc. They live in the page's `elements` array alongside tables and charts, **not** nested inside them. The wiring (which column a control filters, which downstream elements respond) is the part the OpenAPI doesn't teach — that's what this file is for.
+
+**Every `controlType` wires up the same way** (`controlId` + `filters`, below); they differ only in the widget and its (flat top-level) value fields. So treat the per-type sections below as illustrations of the *wiring*, **not a catalog of what's supported** — a `controlType` you don't see here works the same way. The set also grows over time, so get the current list from the spec rather than hardcoding it:
+
+```bash
+jq -r '[.. | objects | select(.properties?.controlType?.enum) | .properties.controlType.enum[0]] | unique[]' /tmp/sigma-api.json
+```
+
+## Control Element Fields
+
+A `control` element has exactly these fields:
+
+| Field | Required | Notes |
+|---|---|---|
+| `kind` | yes | Always `control` |
+| `id` | yes | Element ID — must be unique on the page |
+| `controlId` | yes | Formula reference name (e.g., `RegionFilter`) — keep distinct from `id`. This is the human-meaningful handle used when referring to the control's value from formulas. |
+| `controlType` | yes | Any value the recipe above returns. Determines the widget and filter behavior. |
+| `filters` | — | Array of `{ source, columnId }` — connects the control to the column(s) it filters. `source` is `{ kind: table, elementId: ... }`. |
+| `source` | list/segmented | Where the widget's VALUE LIST comes from. Double-nested: `{ kind: source, source: { kind: table, elementId: ... }, columnId: ... }`. |
+| `mode` | list | `include` \| `exclude`. **Flat top-level field.** |
+| `selectionMode` | list | `single` \| `multiple`. **Flat top-level field.** |
+| `values` | list | Default selection (`[]` = all). **Flat top-level field.** |
+| `parameters` | — | Array, for binding the control to a data-model control (parameter). |
+| `name` | — | Display label. |
+| `style` | — | Presentation options for the widget. |
+
+The value/widget fields (`mode`, `selectionMode`, `values`, range bounds, etc.) are **flat top-level siblings of `controlType`**, NOT nested in a separate "value object" — verified against a live workbook 2026-06-15. Different `controlType`s carry different value fields (the per-type recipes below show which), but they are always flat. Omitting them — or nesting them — yields the opaque `Invalid kind: control` rejection.
+
+`filters[]` items are `{ source: { kind: table, elementId: ... }, columnId: ... }`. The `columnId` is the column on the target element to filter.
+
+---
+
+## List
+
+A single- or multi-select list control over a column's values.
+
+```yaml
+kind: control
+id: ctrl-region          # element id — distinct from controlId
+controlId: region        # formula handle
+name: Store region
+controlType: list
+mode: include            # include | exclude   (TOP-LEVEL, not nested)
+selectionMode: multiple  # single | multiple   (TOP-LEVEL)
+values: []               # default selection, [] = all   (TOP-LEVEL)
+source:                  # where the control's VALUE LIST comes from (note the double nesting)
+  kind: source
+  source:
+    kind: table
+    elementId: sales-master
+  columnId: col-region
+filters:                 # the TARGETS it filters — one entry per element+column it controls
+  - source:
+      kind: table
+      elementId: sales-by-region
+    columnId: scoped-col-region
+```
+
+> **Verified working shape** (pulled from a live, successfully-POSTed workbook 2026-06-15). A list control carries `source` / `mode` / `selectionMode` / `values` as **flat top-level siblings** — NOT inside a nested "value object." The single most common mistake is omitting `source`/`mode`/`selectionMode`/`values` (or nesting them); Sigma then rejects the element with the opaque catch-all `Invalid kind: control`, which means **the inner fields are wrong, NOT that controls are unsupported** (see `reference/workflows/validate.md`). `segmented` and `hierarchy` are the other list-style widgets — same wiring (value-list `source` + `filters` targets).
+
+## Date Range
+
+A date-range control filters one or more date columns. The widget shape is determined by `mode`, and each mode takes different additional fields — all of them **flat top-level siblings of `controlType`** (verified against a live workbook 2026-06-15; a nested `value:{mode,unit}` object is rejected with `Invalid kind: control`). No `source` is needed — the column is defined by the `filters` binding.
+
+```yaml
+kind: control
+id: ctrl-date
+controlId: DateFilter
+name: Date range
+controlType: date-range
+filters:
+  - source:
+      kind: table
+      elementId: sales-table
+    columnId: col-date
+```
+
+`mode` and its parameters are flat top-level fields. `includeNulls`: `always` | `never` | `when-no-value-is-selected`.
+
+### Modes
+
+| Mode | Extra fields | Use for |
+|---|---|---|
+| `between` | `startDate?`, `endDate?` (ISO 8601) | Inclusive range. Both fields optional — omitting them shows the picker with no preset. |
+| `last` | `value` (number), `unit`, `includeToday` (bool) | "Last N days/weeks/months." |
+| `next` | `value`, `unit`, `includeToday` | "Next N days/weeks/months." |
+| `current` | `unit` | "This year/quarter/month/week/day." |
+| `on` | `date` (ISO 8601) | Exact date match. |
+| `before` | `date` | Strictly before a fixed date. |
+| `after` | `date` | Strictly after a fixed date. |
+| `custom` | `startDate`, `endDate` (each: ISO string OR `{ op, unit, value }` for relative) | Mixed fixed/relative bounds. |
+
+`unit` values: `year`, `quarter`, `month`, `week-starting-sunday`, `week-starting-monday`, `day`, `hour`, `minute`.
+
+For relative `startDate` / `endDate` shapes (used in `custom` mode):
+
+```yaml
+op: now-minus
+unit: day
+value: 30
+```
+
+`op`: `now-minus` or `now-plus`.
+
+### Mode Examples
+
+These show the flat fields each `mode` carries — all top-level siblings of `controlType` (shown without the wrapping control element for brevity).
+
+**Last 70 days:**
+
+```yaml
+mode: last
+value: 70
+unit: day
+includeToday: true
+```
+
+**This quarter:**
+
+```yaml
+mode: current
+unit: quarter
+```
+
+**Fixed range:**
+
+```yaml
+mode: between
+startDate: "2026-01-01"
+endDate: "2026-03-31"
+```
+
+**Last 90 days through today (custom mode with relative bounds):**
+
+```yaml
+mode: custom
+startDate:
+  op: now-minus
+  unit: day
+  value: 90
+endDate:
+  op: now-minus
+  unit: day
+  value: 0
+```
+
+## Text
+
+Single-line text filter. (`text-area` is the multi-line variant — same wiring, different widget.)
+
+```yaml
+kind: control
+id: ctrl-search
+controlId: SearchText
+name: Search
+controlType: text
+filters:
+  - source:
+      kind: table
+      elementId: sales-table
+    columnId: col-product-name
+```
+
+The text control carries the match `mode` and the search string as flat top-level fields. `mode` values include `equals`, `does-not-equal`, `contains`, `does-not-contain`, `starts-with`, `ends-with`, `like`, `matches-regexp`, and their negations.
+
+## Number Range
+
+```yaml
+kind: control
+id: ctrl-amount
+controlId: AmountFilter
+name: Amount
+controlType: number-range
+filters:
+  - source:
+      kind: table
+      elementId: sales-table
+    columnId: col-amount
+```
+
+The number-range control expresses the bounds with flat top-level `low`, `high`, and an optional `step` — **not** a positional `values: [min, max]` array and **not** a nested value object.
+
+## Sliders
+
+`slider` and `range-slider` are both first-class `controlType` values — distinct from `number` and `number-range`. A `slider` is a single-handle widget; `range-slider` has two handles for a low/high band. The bounds and value are **flat top-level fields** (verified against a live, UI-built workbook and a successful POST, 2026-06-15) — there is no value object.
+
+A **single-handle `slider`** carries the track bounds (`low`/`high`), a `mode` comparator describing which rows the handle keeps, and a **scalar** `value` for the handle position:
+
+```yaml
+kind: control
+id: ctrl-deal-size
+controlId: DealSize
+name: Deal size
+controlType: slider
+low: 0
+high: 100000
+mode: "<="          # comparator: <= | >= | = | < | > — rows kept relative to the handle
+value: 33755        # scalar handle position (FLAT — not a value object)
+includeNulls: when-no-value-is-selected
+filters:
+  - source:
+      kind: table
+      elementId: sales-table
+    columnId: col-amount
+```
+
+A **`range-slider`** drops the scalar `value`/`mode` and uses the two-handle `low`/`high` band:
+
+```yaml
+controlType: range-slider
+low: 0
+high: 100000        # flat low/high band; no scalar value
+filters:
+  - source:
+      kind: table
+      elementId: sales-table
+    columnId: col-amount
+```
+
+> A nested `value:{low,high}` object is rejected with `Invalid kind: control`. The most common slider mistake is omitting `mode` — without the comparator the element is rejected even though `low`/`high`/`value` are present.
+
+## Single-value types
+
+`number`, `date`, `checkbox`, and `switch` are single-value controls. `checkbox` and `switch` are the boolean widgets — same value (a boolean), different presentation:
+
+```yaml
+kind: control
+id: ctrl-active-only
+controlId: ActiveOnly
+name: Active only
+controlType: switch
+filters:
+  - source:
+      kind: table
+      elementId: users-table
+    columnId: col-is-active
+```
+
+## Top-N
+
+`top-n` is a dedicated control type for "show the top N" interactions. Wire it like any other control via `filters`; the cap is a flat top-level field.
+
+---
+
+## One Control, Multiple Elements
+
+A control's `filters` array can hold **multiple bindings** — one per element/column the control should filter. This is the right tool for a page-level filter that applies to several tables or charts at once. Don't make a separate control per element.
+
+```yaml
+kind: control
+id: ctrl-region
+controlId: RegionFilter
+name: Store region
+controlType: list
+filters:
+  - source: { kind: table, elementId: sales-table }
+    columnId: col-region
+  - source: { kind: table, elementId: returns-table }
+    columnId: col-region
+  - source: { kind: table, elementId: sales-by-region }
+    columnId: col-region
+```
+
+Each binding names the target element by `elementId` and the column on that element to filter by `columnId`. The column IDs do **not** need to match across elements; they just need to exist on each target element.
+
+## One Element, Multiple Controls
+
+The dual pattern, and a common Sigma layout: a parent table that several controls filter, with downstream elements (KPIs, charts, secondary tables) sourcing from the parent. Filter once at the parent — every element that sources it inherits the filter automatically.
+
+```yaml
+# Parent: "sales-table". Downstream KPIs/charts source from it.
+# Three controls each filter the parent on a different column.
+
+- kind: control
+  id: ctrl-region
+  controlId: RegionFilter
+  controlType: list
+  filters:
+    - source: { kind: table, elementId: sales-table }
+      columnId: col-region
+
+- kind: control
+  id: ctrl-date
+  controlId: DateFilter
+  controlType: date-range
+  filters:
+    - source: { kind: table, elementId: sales-table }
+      columnId: col-date
+
+- kind: control
+  id: ctrl-amount
+  controlId: AmountFilter
+  controlType: number-range
+  filters:
+    - source: { kind: table, elementId: sales-table }
+      columnId: col-amount
+```
+
+Multiple controls on the same target compose with **AND** — selecting region "West" + date "Q1" narrows to the intersection. Prefer this over binding each control to every downstream element; it's less repetitive and keeps the filter chain in one place.
+
+## Tip: `controlId` vs `id`
+
+They are not the same and both are required:
+- `id` is the element ID used internally and in `layout.md`.
+- `controlId` is a human-facing handle used when referring to this control's value from formulas or downstream logic. Pick it to be meaningful (e.g., `RegionFilter`, `DateRange`).
+</content>
+</invoke>

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/example-full.yaml
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/example-full.yaml
@@ -1,0 +1,891 @@
+# Full real-world workbook spec — a "layout-driven workbook" with KPIs, charts,
+# join sources, controls, and a custom grid layout. Use this as a concrete
+# reference when composing new specs: copy the shapes here, don't invent them.
+#
+# Fields above `pages` marked (response-only) are returned by GET requests but
+# should NOT be included in a POST create body. The required top-level fields
+# for POST /v2/workbooks/spec are: name, folderId, schemaVersion, pages.
+# `description` and `layout` are optional. All others below are response-only.
+
+workbookId: c3a2a50f-65d3-4bdc-bb4a-d54b5eb712e5            # response-only
+name: layout driven workbook
+url: https://app.sigmacomputing.com/<your-org>/workbook/layout-driven-workbook-<workbook-slug>  # response-only
+documentVersion: 58                                          # response-only
+latestDocumentVersion: 58                                    # response-only
+ownerId: FVksufTcpblsOOTZ4pYPgc8XKJE28                       # response-only
+folderId: 04723db6-5dc0-4853-b2b6-71cb65ea0ea5
+createdBy: FVksufTcpblsOOTZ4pYPgc8XKJE28                     # response-only
+updatedBy: FVksufTcpblsOOTZ4pYPgc8XKJE28                     # response-only
+createdAt: '2026-04-06T21:44:37.813Z'                        # response-only
+updatedAt: '2026-04-17T23:46:13.136Z'                        # response-only
+schemaVersion: 1
+pages:
+  - id: zTWZZ-jV0-
+    name: PLUGS Dashboard
+    elements:
+      - id: VDmtIbjIiM
+        kind: container
+      - kind: control
+        controlId: dashRegion
+        id: ctrl-dash-region
+        name: Store region
+        filters:
+          - source:
+              kind: table
+              elementId: XnyLSupesM
+            columnId: gwtkFeVXOX
+        controlType: list
+        mode: include
+        selectionMode: multiple
+        values: []
+        source:
+          kind: source
+          source:
+            kind: table
+            elementId: XnyLSupesM
+          columnId: gwtkFeVXOX
+      - kind: control
+        controlId: dashDate
+        id: ctrl-dash-date
+        name: Date range
+        filters:
+          - source:
+              kind: table
+              elementId: XnyLSupesM
+            columnId: tyvRcRPZjQ
+        controlType: date-range
+        mode: between
+        includeNulls: when-no-value-is-selected
+      - id: GlZTnW60cY
+        kind: container
+      - id: _vo5wivHIk
+        kind: kpi-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: gBXB7mNDp6
+            formula: Sum([Master/Sales Amount])
+            format:
+              kind: number
+              formatString: $,.0f
+        value:
+          columnId: gBXB7mNDp6
+        name: Total sales
+      - id: YBiGG5m5kY
+        kind: kpi-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: dJaWh_79UB
+            formula: Sum([Master/Sales Amount]) - Sum([Master/Cost Amount])
+            format:
+              kind: number
+              formatString: $,.0f
+        value:
+          columnId: dJaWh_79UB
+        name: Total profit
+      - id: XSzhu5CtLf
+        kind: line-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: uHU1J_MXtl
+            formula: DateTrunc("month", [Master/Date])
+            name: Month
+            format:
+              kind: datetime
+              formatString: '%b %Y'
+          - id: nUll5YMT5j
+            formula: Sum([Master/Sales Amount])
+            name: Sales
+            format:
+              kind: number
+              formatString: $,.0f
+          - id: 7Xt23jjvu-
+            formula: (Sum([Master/Sales Amount]) - Sum([Master/Cost Amount])) / Sum([Master/Sales Amount])
+            name: Profit margin
+            format:
+              kind: number
+              formatString: ',.2%'
+        yAxis:
+          columnIds:
+            - nUll5YMT5j
+            - 7Xt23jjvu-
+        xAxis:
+          columnId: uHU1J_MXtl
+        name: Sales over time
+      - id: 17QGJ7ZJxQ
+        kind: kpi-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: wB0OB8xetX
+            formula: CountDistinct([Master/Order Number])
+            format:
+              kind: number
+              formatString: ',.0f'
+        value:
+          columnId: wB0OB8xetX
+        name: Total orders
+      - id: wQ5ezUY81K
+        kind: kpi-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: VKZCXc5o6g
+            formula: Sum([Master/Sales Amount]) / CountDistinct([Master/Order Number])
+            format:
+              kind: number
+              formatString: $,.2f
+        value:
+          columnId: VKZCXc5o6g
+        name: Avg order value
+      - id: HWYC72b6av
+        kind: container
+      - id: blo8c1FIpf
+        kind: bar-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: mVC9Hnp2zq
+            formula: '[Master/Store Region]'
+            name: Store Region
+          - id: F2Oz_P4Kyt
+            formula: Sum([Master/Sales Amount])
+            name: Sales
+            format:
+              kind: number
+              formatString: $,.0f
+        yAxis:
+          columnIds:
+            - F2Oz_P4Kyt
+        xAxis:
+          columnId: mVC9Hnp2zq
+        stacking: none
+        name: Sales by region
+      - id: z9QWSXomyE
+        kind: donut-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: oJ4m0bMl34
+            formula: '[Master/Product Family]'
+            name: Product Family
+          - id: rMc1XEsnWx
+            formula: Sum([Master/Sales Amount])
+            name: Sales
+            format:
+              kind: number
+              formatString: $,.0f
+        color:
+          id: oJ4m0bMl34
+          sort:
+            by: rMc1XEsnWx
+            direction: descending
+        value:
+          id: rMc1XEsnWx
+        name: Sales by product family
+  - id: 3Ht0vQc7hD
+    name: Data
+    elements:
+      - id: XnyLSupesM
+        kind: table
+        source:
+          kind: join
+          joins:
+            - left:
+                connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+                kind: warehouse-table
+                path:
+                  - SE_DEMO_DB
+                  - PLUGS_ELECTRONICS
+                  - F_POINT_OF_SALE
+              right:
+                connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+                kind: warehouse-table
+                path:
+                  - SE_DEMO_DB
+                  - PLUGS_ELECTRONICS
+                  - F_SALES
+              columns:
+                - left: '[Order Number]'
+                  right: '[Order Number]'
+              name: Sales
+              joinType: left-outer
+            - left:
+                connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+                kind: warehouse-table
+                path:
+                  - SE_DEMO_DB
+                  - PLUGS_ELECTRONICS
+                  - F_POINT_OF_SALE
+              right:
+                connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+                kind: warehouse-table
+                path:
+                  - SE_DEMO_DB
+                  - PLUGS_ELECTRONICS
+                  - D_PRODUCT
+              columns:
+                - left: '[Product Key]'
+                  right: '[Product Key]'
+              name: Product
+              joinType: left-outer
+            - left:
+                connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+                kind: warehouse-table
+                path:
+                  - SE_DEMO_DB
+                  - PLUGS_ELECTRONICS
+                  - F_SALES
+              right:
+                connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+                kind: warehouse-table
+                path:
+                  - SE_DEMO_DB
+                  - PLUGS_ELECTRONICS
+                  - D_CUSTOMER
+              columns:
+                - left: '[Cust Key]'
+                  right: '[Cust Key]'
+              name: Customer
+              joinType: left-outer
+            - left:
+                connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+                kind: warehouse-table
+                path:
+                  - SE_DEMO_DB
+                  - PLUGS_ELECTRONICS
+                  - F_SALES
+              right:
+                connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+                kind: warehouse-table
+                path:
+                  - SE_DEMO_DB
+                  - PLUGS_ELECTRONICS
+                  - D_STORE
+              columns:
+                - left: '[Store Key]'
+                  right: '[Store Key]'
+              name: Store
+              joinType: left-outer
+            - left:
+                connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+                kind: warehouse-table
+                path:
+                  - SE_DEMO_DB
+                  - PLUGS_ELECTRONICS
+                  - F_SALES
+              right:
+                connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+                kind: warehouse-table
+                path:
+                  - SE_DEMO_DB
+                  - PLUGS_ELECTRONICS
+                  - D_DATE
+              columns:
+                - left: '[Date]'
+                  right: '[Date Day]'
+              name: Date
+              joinType: left-outer
+          primarySource:
+            connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+            kind: warehouse-table
+            path:
+              - SE_DEMO_DB
+              - PLUGS_ELECTRONICS
+              - F_POINT_OF_SALE
+          name: Sales Star
+        columns:
+          - id: rSjAgTWVKP
+            formula: '[Sales Star/Order Number]'
+            name: Order Number
+          - id: yG8f-dLcZn
+            formula: '[Sales Star/Product Key]'
+            name: Product Key
+          - id: nQ9mvzicNA
+            formula: '[Sales Star/Sales Quantity]'
+            name: Sales Quantity
+          - id: 7xg8A8Aft1
+            formula: '[Sales Star/Sales Amount]'
+            name: Sales Amount
+            format:
+              kind: number
+              formatString: $,.2f
+          - id: 1YbyBjlXXD
+            formula: '[Sales Star/Cost Amount]'
+            name: Cost Amount
+            format:
+              kind: number
+              formatString: $,.2f
+          - id: 1hT37aJJzs
+            formula: '[Sales/Cust Key]'
+            name: Cust Key
+          - id: FHmaJ0Y7et
+            formula: '[Sales/Store Key]'
+            name: Store Key
+          - id: tyvRcRPZjQ
+            formula: '[Sales/Date]'
+            name: Date
+            format:
+              kind: datetime
+              formatString: '%Y-%m-%d'
+          - id: yNva713xzf
+            formula: '[Sales/Transaction Type]'
+            name: Transaction Type
+          - id: h2VpfPK3if
+            formula: '[Sales/Purchase Method]'
+            name: Purchase Method
+          - id: 4cN6RZxk3N
+            formula: '[Product/Product Name]'
+            name: Product Name
+          - id: xkwdkYukRz
+            formula: '[Product/Product Family]'
+            name: Product Family
+          - id: ZTvD_JJGzX
+            formula: '[Product/Product Line]'
+            name: Product Line
+          - id: QJFGrVOg_O
+            formula: '[Product/Price]'
+            name: Price
+            format:
+              kind: number
+              formatString: $,.2f
+          - id: suDr8vb83B
+            formula: '[Customer/Cust Name]'
+            name: Cust Name
+          - id: 7RKm7VOHHM
+            formula: '[Customer/Cust Region]'
+            name: Cust Region
+          - id: ihNgb_U35t
+            formula: '[Customer/Cust State]'
+            name: Cust State
+          - id: w9nDAe3TrH
+            formula: '[Customer/Age Group]'
+            name: Age Group
+          - id: 3n8bZJO54W
+            formula: '[Customer/Loyalty Program]'
+            name: Loyalty Program
+          - id: Mij86WMbij
+            formula: '[Store/Store Name]'
+            name: Store Name
+          - id: gwtkFeVXOX
+            formula: '[Store/Store Region]'
+            name: Store Region
+          - id: PUU07Z72ba
+            formula: '[Store/Store State]'
+            name: Store State
+          - id: BhLGDsPhMI
+            formula: '[Store/Store Size]'
+            name: Store Size
+          - id: UZcLskoBdG
+            formula: '[Date/Year Num]'
+            name: Year Num
+          - id: lP8sJUgbb-
+            formula: '[Date/Month Name]'
+            name: Month Name
+          - id: LVNgCi2evt
+            formula: '[Date/Month Num]'
+            name: Month Num
+          - id: d1wWu7nvfl
+            formula: '[Date/Quarter Name]'
+            name: Quarter Name
+          - id: te1KKUfvSC
+            formula: '[Store/Number of Employees]'
+            name: Employees
+            format:
+              kind: number
+              formatString: ',.0f'
+          - id: 4gyJa1rm7I
+            formula: '[Store/Total Square Footage]'
+            name: Sq Ft
+            format:
+              kind: number
+              formatString: ',.0f'
+          - id: rA6o2zAEDv
+            formula: '[Store/Monthly Rent Cost]'
+            name: Monthly Rent
+            format:
+              kind: number
+              formatString: $,.0f
+        name: Master
+        order:
+          - rSjAgTWVKP
+          - yG8f-dLcZn
+          - nQ9mvzicNA
+          - 7xg8A8Aft1
+          - 1YbyBjlXXD
+          - 1hT37aJJzs
+          - FHmaJ0Y7et
+          - tyvRcRPZjQ
+          - yNva713xzf
+          - h2VpfPK3if
+          - 4cN6RZxk3N
+          - xkwdkYukRz
+          - ZTvD_JJGzX
+          - QJFGrVOg_O
+          - suDr8vb83B
+          - 7RKm7VOHHM
+          - ihNgb_U35t
+          - w9nDAe3TrH
+          - 3n8bZJO54W
+          - Mij86WMbij
+          - gwtkFeVXOX
+          - PUU07Z72ba
+          - BhLGDsPhMI
+          - UZcLskoBdG
+          - lP8sJUgbb-
+          - LVNgCi2evt
+          - d1wWu7nvfl
+          - te1KKUfvSC
+          - 4gyJa1rm7I
+          - rA6o2zAEDv
+  - id: MspSDgy-qY
+    name: Customers
+    elements:
+      - id: 2B07dCkvIY
+        kind: container
+      - id: CE_TB50vql
+        kind: kpi-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: 6bTPYGXwIm
+            formula: CountDistinct([Master/Cust Key])
+            name: Total customers
+            format:
+              kind: number
+              formatString: ',.0f'
+        value:
+          columnId: 6bTPYGXwIm
+        name: Total customers
+      - id: rhbytbOPeu
+        kind: kpi-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: TofUW7R0OU
+            formula: Sum([Master/Sales Amount]) / CountDistinct([Master/Cust Key])
+            name: Avg spend per customer
+            format:
+              kind: number
+              formatString: $,.2f
+        value:
+          columnId: TofUW7R0OU
+        name: Avg spend per customer
+      - id: MvuERTuXJl
+        kind: kpi-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: 3B8rMjpiTi
+            formula: CountDistinct([Master/Order Number]) / CountDistinct([Master/Cust Key])
+            name: Orders per customer
+            format:
+              kind: number
+              formatString: ',.2f'
+        value:
+          columnId: 3B8rMjpiTi
+        name: Orders per customer
+      - id: Nf1e5obnQB
+        kind: bar-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: Lg2lRXBlW4
+            formula: '[Master/Loyalty Program]'
+            name: Loyalty Program
+          - id: xUCkExm5o7
+            formula: Sum([Master/Sales Amount])
+            name: Sales
+            format:
+              kind: number
+              formatString: $,.0f
+        yAxis:
+          columnIds:
+            - xUCkExm5o7
+        xAxis:
+          columnId: Lg2lRXBlW4
+        stacking: none
+        name: Sales by loyalty program
+      - id: 21okb8vVQR
+        kind: bar-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: difSb6YU9U
+            formula: '[Master/Age Group]'
+            name: Age Group
+          - id: vPxRKXY6SW
+            formula: Sum([Master/Sales Amount])
+            name: Sales
+            format:
+              kind: number
+              formatString: $,.0f
+        yAxis:
+          columnIds:
+            - vPxRKXY6SW
+        xAxis:
+          columnId: difSb6YU9U
+        stacking: none
+        name: Sales by age group
+      - id: D4QPEbu1Qi
+        kind: bar-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: yexydlDqUp
+            formula: '[Master/Cust Region]'
+            name: Cust Region
+          - id: sudjQ9sGtv
+            formula: CountDistinct([Master/Cust Key])
+            name: Customers
+            format:
+              kind: number
+              formatString: ',.0f'
+        yAxis:
+          columnIds:
+            - sudjQ9sGtv
+        xAxis:
+          columnId: yexydlDqUp
+        stacking: none
+        name: Customers by region
+  - id: 57aivWea2T
+    name: Stores
+    elements:
+      - id: JjDopAGmOK
+        kind: container
+      - kind: control
+        controlId: storesRegion
+        id: ctrl-stores-region
+        name: Store region
+        filters:
+          - source:
+              kind: table
+              elementId: XnyLSupesM
+            columnId: gwtkFeVXOX
+        controlType: list
+        mode: include
+        selectionMode: multiple
+        values: []
+        source:
+          kind: source
+          source:
+            kind: table
+            elementId: XnyLSupesM
+          columnId: gwtkFeVXOX
+      - id: NyXYOVYRa7
+        kind: bar-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: aZp_IttHn8
+            formula: '[Master/Store Name]'
+            name: Store
+          - id: bvo3DHs6PI
+            formula: Sum([Master/Sales Amount])
+            name: Sales
+            format:
+              kind: number
+              formatString: $,.0f
+        yAxis:
+          columnIds:
+            - bvo3DHs6PI
+        xAxis:
+          columnId: aZp_IttHn8
+        stacking: none
+        name: Sales per store
+      - id: UxHffLbrEj
+        kind: bar-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: RB_fvo4SFj
+            formula: '[Master/Store Name]'
+            name: Store
+          - id: 9nsFcsTpSL
+            formula: Sum([Master/Sales Amount]) / First([Master/Sq Ft])
+            name: Sales per Sq Ft
+            format:
+              kind: number
+              formatString: $,.2f
+        yAxis:
+          columnIds:
+            - 9nsFcsTpSL
+        xAxis:
+          columnId: RB_fvo4SFj
+          sort:
+            by: 9nsFcsTpSL
+            direction: descending
+        stacking: none
+        name: Sales per sq ft
+      - id: iH7JsxANEw
+        kind: bar-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: D_N24yHn5p
+            formula: '[Master/Store Name]'
+            name: Store
+          - id: Ez57X-jegL
+            formula: Sum([Master/Sales Amount]) / First([Master/Employees])
+            name: Sales per Employee
+            format:
+              kind: number
+              formatString: $,.0f
+        yAxis:
+          columnIds:
+            - Ez57X-jegL
+        xAxis:
+          columnId: D_N24yHn5p
+          sort:
+            by: Ez57X-jegL
+            direction: descending
+        stacking: none
+        name: Sales per employee
+      - id: yP2VVWFRkl
+        kind: table
+        source:
+          connectionId: c8808f57-574d-4bb9-9244-5a630e615065
+          kind: warehouse-table
+          path:
+            - SE_DEMO_DB
+            - PLUGS_ELECTRONICS
+            - D_STORE
+        columns:
+          - id: jHSXIoUh9U
+            formula: '[Store Name]'
+          - id: 0EfLLN2Rta
+            formula: '[Store Region]'
+          - id: wOPhsdAz_o
+            formula: '[Store State]'
+          - id: IMExPfjk1C
+            formula: '[Store City]'
+          - id: 8aPhd-MzUX
+            formula: '[Store Size]'
+          - id: LZMgfoofAa
+            formula: '[Number of Employees]'
+            format:
+              kind: number
+              formatString: ',.0f'
+          - id: v4lQ9mWC_A
+            formula: '[Total Square Footage]'
+            format:
+              kind: number
+              formatString: ',.0f'
+          - id: zRNAZnRlct
+            formula: '[Monthly Rent Cost]'
+            format:
+              kind: number
+              formatString: $,.0f
+          - id: LZIYA0Cwh0
+            formula: '[Online Ordering]'
+        name: Store detail
+        order:
+          - jHSXIoUh9U
+          - 0EfLLN2Rta
+          - wOPhsdAz_o
+          - IMExPfjk1C
+          - 8aPhd-MzUX
+          - LZMgfoofAa
+          - v4lQ9mWC_A
+          - zRNAZnRlct
+          - LZIYA0Cwh0
+  - id: 1YXIx34u1n
+    name: Products
+    elements:
+      - id: SzU4VtebPV
+        kind: container
+      - kind: control
+        controlId: productsRegion
+        id: ctrl-prod-region
+        name: Store region
+        filters:
+          - source:
+              kind: table
+              elementId: XnyLSupesM
+            columnId: gwtkFeVXOX
+        controlType: list
+        mode: include
+        selectionMode: multiple
+        values: []
+        source:
+          kind: source
+          source:
+            kind: table
+            elementId: XnyLSupesM
+          columnId: gwtkFeVXOX
+      - kind: control
+        controlId: productsDate
+        id: ctrl-prod-date
+        name: Date range
+        filters:
+          - source:
+              kind: table
+              elementId: XnyLSupesM
+            columnId: tyvRcRPZjQ
+        controlType: date-range
+        mode: between
+        includeNulls: when-no-value-is-selected
+      - id: yvc_ZvHZai
+        kind: bar-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: r78AKmsdTc
+            formula: '[Master/Product Name]'
+            name: Product
+          - id: NDS13WYaA8
+            formula: Sum([Master/Sales Amount])
+            name: Sales
+            format:
+              kind: number
+              formatString: $,.0f
+        yAxis:
+          columnIds:
+            - NDS13WYaA8
+        xAxis:
+          columnId: r78AKmsdTc
+          sort:
+            by: NDS13WYaA8
+            direction: descending
+        stacking: none
+        filters:
+          - id: Ff80twGxRg
+            columnId: NDS13WYaA8
+            kind: top-n
+            rankingFunction: rank
+            mode: top-n
+            rowCount: 20
+            includeNulls: when-no-value-is-selected
+        name: Sales by product
+      - id: q06x2JTGb3
+        kind: bar-chart
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: 2ge_p25EIO
+            formula: '[Master/Product Family]'
+            name: Product Family
+          - id: gCPyCfh3sd
+            formula: (Sum([Master/Sales Amount]) - Sum([Master/Cost Amount])) / Sum([Master/Sales Amount])
+            name: Margin
+            format:
+              kind: number
+              formatString: ',.2%'
+        yAxis:
+          columnIds:
+            - gCPyCfh3sd
+        xAxis:
+          columnId: 2ge_p25EIO
+          sort:
+            by: gCPyCfh3sd
+            direction: descending
+        stacking: none
+        name: Profit margin by product family
+      - id: cPJXbQdtxN
+        kind: table
+        source:
+          elementId: XnyLSupesM
+          kind: table
+        columns:
+          - id: oRuXQtfQKV
+            formula: '[Master/Product Name]'
+          - id: FwZYD7oJQs
+            formula: '[Master/Product Family]'
+          - id: YrpxiI8jY4
+            formula: '[Master/Price]'
+            format:
+              kind: number
+              formatString: $,.2f
+          - id: i4X_Hhj7h2
+            formula: Sum([Master/Sales Quantity])
+            format:
+              kind: number
+              formatString: ',.0f'
+          - id: _8kRBbrCfk
+            formula: Sum([Master/Sales Amount])
+            format:
+              kind: number
+              formatString: $,.0f
+          - id: kc-dlu1PC_
+            formula: Sum([Master/Sales Amount]) - Sum([Master/Cost Amount])
+            format:
+              kind: number
+              formatString: $,.0f
+          - id: fQYX1-lMz1
+            formula: (Sum([Master/Sales Amount]) - Sum([Master/Cost Amount])) / Sum([Master/Sales Amount])
+            format:
+              kind: number
+              formatString: ',.2%'
+        name: Product performance
+        groupings:
+          - id: jc9EdrwLk4
+            groupBy:
+              - oRuXQtfQKV
+              - FwZYD7oJQs
+              - YrpxiI8jY4
+            calculations:
+              - i4X_Hhj7h2
+              - _8kRBbrCfk
+              - kc-dlu1PC_
+              - fQYX1-lMz1
+layout: |
+  <?xml version="1.0" encoding="utf-8"?>
+  <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="zTWZZ-jV0-">
+    <GridContainer elementId="VDmtIbjIiM" type="grid" gridColumn="1 / 25" gridRow="1 / 4" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+      <LayoutElement elementId="ctrl-dash-region" gridColumn="1 / 13" gridRow="1 / 4"/>
+      <LayoutElement elementId="ctrl-dash-date" gridColumn="13 / 25" gridRow="1 / 4"/>
+    </GridContainer>
+    <GridContainer elementId="GlZTnW60cY" type="grid" gridColumn="1 / 25" gridRow="4 / 16" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+      <LayoutElement elementId="_vo5wivHIk" gridColumn="1 / 7" gridRow="1 / 7"/>
+      <LayoutElement elementId="YBiGG5m5kY" gridColumn="7 / 13" gridRow="1 / 7"/>
+      <LayoutElement elementId="XSzhu5CtLf" gridColumn="13 / 25" gridRow="1 / 13"/>
+      <LayoutElement elementId="17QGJ7ZJxQ" gridColumn="1 / 7" gridRow="7 / 13"/>
+      <LayoutElement elementId="wQ5ezUY81K" gridColumn="7 / 13" gridRow="7 / 13"/>
+    </GridContainer>
+    <GridContainer elementId="HWYC72b6av" type="grid" gridColumn="1 / 25" gridRow="16 / 28" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+      <LayoutElement elementId="blo8c1FIpf" gridColumn="1 / 13" gridRow="1 / 13"/>
+      <LayoutElement elementId="z9QWSXomyE" gridColumn="13 / 25" gridRow="1 / 13"/>
+    </GridContainer>
+  </Page>
+  <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="3Ht0vQc7hD">
+    <LayoutElement elementId="XnyLSupesM" gridColumn="1 / 25" gridRow="1 / 21"/>
+  </Page>
+  <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="MspSDgy-qY">
+    <GridContainer elementId="2B07dCkvIY" type="grid" gridColumn="1 / 25" gridRow="1 / 7" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+      <LayoutElement elementId="CE_TB50vql" gridColumn="1 / 9" gridRow="1 / 7"/>
+      <LayoutElement elementId="rhbytbOPeu" gridColumn="9 / 17" gridRow="1 / 7"/>
+      <LayoutElement elementId="MvuERTuXJl" gridColumn="17 / 25" gridRow="1 / 7"/>
+    </GridContainer>
+    <LayoutElement elementId="Nf1e5obnQB" gridColumn="1 / 13" gridRow="7 / 19"/>
+    <LayoutElement elementId="21okb8vVQR" gridColumn="13 / 25" gridRow="7 / 19"/>
+    <LayoutElement elementId="D4QPEbu1Qi" gridColumn="1 / 25" gridRow="19 / 31"/>
+  </Page>
+  <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="57aivWea2T">
+    <GridContainer elementId="JjDopAGmOK" type="grid" gridColumn="1 / 25" gridRow="1 / 4" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+      <LayoutElement elementId="ctrl-stores-region" gridColumn="1 / 13" gridRow="1 / 4"/>
+    </GridContainer>
+    <LayoutElement elementId="NyXYOVYRa7" gridColumn="1 / 25" gridRow="4 / 16"/>
+    <LayoutElement elementId="UxHffLbrEj" gridColumn="1 / 13" gridRow="16 / 28"/>
+    <LayoutElement elementId="iH7JsxANEw" gridColumn="13 / 25" gridRow="16 / 28"/>
+    <LayoutElement elementId="yP2VVWFRkl" gridColumn="1 / 25" gridRow="28 / 48"/>
+  </Page>

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/formatting.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/formatting.md
@@ -1,0 +1,74 @@
+# Column Formats
+
+Recipe for column-level `format` objects + the d3-format / strftime conventions Sigma uses. A `format` object is either `kind: number` or `kind: datetime`. For the canonical schema of each:
+
+```bash
+jq --arg k number   'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+jq --arg k datetime 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+`format` is optional on every column — omit it for raw values. This file is mainly the cheat sheet of common format strings (currency, percentages, dates) since the OpenAPI doesn't enumerate them.
+
+## Number Formats
+
+```yaml
+kind: number
+formatString: "$,.0f"
+```
+
+Common format strings (d3-format conventions):
+
+| String | Example output | Description |
+|--------|----------------|-------------|
+| `"$,.0f"` | `$1,234` | Currency, no decimals |
+| `"$,.2f"` | `$1,234.56` | Currency, 2 decimals |
+| `",.0f"` | `1,234` | Integer with thousands separator |
+| `",.2f"` | `1,234.56` | Number, 2 decimals |
+| `",.2%"` | `12.34%` | Percentage, 2 decimals |
+| `".3~e"` | `1.23e+3` | Scientific, 3 significant digits |
+
+Format-string cheat sheet:
+- `$` — currency prefix
+- `,` — thousands separator
+- `.<n>f` — fixed decimal places
+- `.<n>%` — percent with decimals (value × 100)
+- `.<n>~e` — scientific with trimmed trailing zeros
+
+Alternatively, build a number format from **structured fields** instead of (or alongside) a raw `formatString` — e.g. `prefix`, `suffix`, `displayNullAs`, `currencySymbol`, `decimalSymbol`, `digitGroupingSymbol`. See the `kind: number` recipe above for the full set.
+
+## Datetime Formats
+
+```yaml
+kind: datetime
+formatString: "%b %Y"
+```
+
+Common format strings (strftime conventions):
+
+| String | Example output | Description |
+|--------|----------------|-------------|
+| `"%Y-%m-%d"` | `2026-04-21` | ISO date |
+| `"%b %Y"` | `Apr 2026` | Short month + year |
+| `"%B %Y"` | `April 2026` | Full month + year |
+| `"%Y-%m-%d %H:%M"` | `2026-04-21 14:30` | ISO datetime |
+| `"%a, %b %-d"` | `Tue, Apr 21` | Short day + month + day (no zero pad) |
+
+Tokens:
+- `%Y` — 4-digit year · `%y` — 2-digit year
+- `%m` — month number (01–12) · `%-m` — unpadded · `%b` — short name · `%B` — full name
+- `%d` — day of month · `%-d` — unpadded
+- `%H` / `%I` — 24h / 12h hour · `%M` — minutes · `%S` — seconds
+- `%a` / `%A` — short / full weekday
+
+## Where Format Goes
+
+Inline on any column:
+
+```yaml
+id: col-sales
+name: Sales
+formula: Sum([Master/Sales Amount])
+format:
+  kind: number
+  formatString: "$,.0f"
+```

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/formulas.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/formulas.md
@@ -1,0 +1,231 @@
+# Sigma Formula Reference
+
+This is the highest-traffic reference file — Sigma's formula DSL is the largest source of spec errors and the OpenAPI doesn't fully describe its semantics. Treat this as the source of truth for the **formula language itself** (syntax, qualification, operator behavior). Field-level shape (where formulas appear in the spec) is in the OpenAPI per-element schemas.
+
+## ⚠️ READ FIRST: The #1 Formula Mistake
+
+When an element sources another element (e.g., a KPI or chart sourcing a table), **every column reference inside aggregations must include the source element's name as a prefix.** Forgetting the prefix is the single most common Sigma spec error.
+
+**Wrong:**
+```yaml
+kind: kpi-chart
+source: { kind: table, elementId: usage-table }
+columns:
+  - name: Total
+    formula: Count([Question ID])
+```
+
+**Right:**
+```yaml
+kind: kpi-chart
+source: { kind: table, elementId: usage-table }
+columns:
+  - name: Total
+    formula: Count([AI Usage Data/Question ID])
+```
+
+**Why:** a bare `[column_name]` means *defined in THIS element's own `columns[]` array* — not *visible through the source*. SQL intuition leaks here: `Count([col])` feels local because the source "is" the table, but Sigma's formula language requires you to name the source explicitly.
+
+**Rule of thumb:** if your element's `source` points at another element (or a warehouse table, or a join), 90%+ of your formulas will start with `[<SourceName>/...]`. Bare refs are only for columns you literally defined a line or two above in the same `columns[]` array.
+
+Before publishing, run `./scripts/validate-spec.sh <spec.yaml>` — it catches exactly this mistake.
+
+---
+
+## ⚠️ READ SECOND: Raw vs. Friendly Column Names
+
+Sigma's formula DSL references columns by their **friendly name**, not their raw warehouse name. The two diverge in two ways:
+
+1. **Special characters** — `/`, `-`, `.`, `[`, `]`, and leading/trailing whitespace are stripped or replaced.
+2. **Casing and word boundaries** — `ALL_CAPS_WITH_UNDERSCORES` is title-cased and underscores become spaces; `camelCase` is split on case boundaries.
+
+Examples observed on real Sigma instances:
+
+| Raw warehouse name | Friendly name used in formulas |
+|---|---|
+| `DATE` | `Date` |
+| `UNIT PRICE` | `Unit Price` |
+| `ORDER_ID` | `Order ID` |
+| `V userId` | `V User Id` |
+| `Net/Gross` | `Net Gross` |
+
+The trap: `GET /v2/connections/tables/{inodeId}/columns` returns **raw warehouse names** (`DATE`, `V userId`). Formulas written against those raw names will silently fail to resolve — Sigma is permissive at POST time and even auto-normalizes some simple cases (`[ORDERS/DATE]` → `[ORDERS/Date]`), but the auto-fix does **not** cover everything. The reliable workflow:
+
+1. POST your spec using your best guess (often the raw name works for ALL_CAPS columns).
+2. Run `./scripts/verify-workbook.sh <workbookId>` — if any element compiles to `'Unknown column "[X]"'` SQL, the friendly name doesn't match.
+3. Fix the affected formulas in your spec. To learn the canonical friendly name, GET the workbook spec back (`GET /v2/workbooks/<id>/spec`) — Sigma's readback shows the names it actually resolved against. Use those for the PUT.
+
+**Don't guess the normalization rules** — Sigma's are more aggressive than they look. When verify fails, ask the readback.
+
+Wrong: `[ORDERS/Net/Gross Revenue]` (slash inside a column name; unparseable)
+Wrong: `[ORDERS/Order-ID]` (raw warehouse name with a dash)
+Wrong: `[ORDERS/ORDER_ID]` (raw underscore form; usually needs `Order ID`)
+Right: `[ORDERS/Net Gross Revenue]` (friendly name)
+Right: `[ORDERS/Order ID]` (friendly name)
+
+---
+
+## Column Reference Rules
+
+Every column formula references either a column **outside** the element or a column **inside** the same element.
+
+### Outside the element — use `[SourceName/column_name]`
+
+The prefix depends on the source type:
+
+- **Warehouse table**: `SourceName` = last segment of the `path` array.
+  - Path `["DB", "SCHEMA", "ORDERS"]` → `[ORDERS/revenue]`
+  - Path `["ANALYTICS", "PUBLIC", "USERS"]` → `[USERS/email]`
+
+- **Another workbook element**: `SourceName` = that element's `name` field.
+  - Element named "Sales Table" → `[Sales Table/Revenue]`
+
+- **Join source**: `SourceName` = the `name` field on a specific join leg, or the top-level `name` on the join object (for the `primarySource` leg).
+  - Join with `primarySource` implicitly tied to top-level `name: "Sales Star"` → `[Sales Star/Order Number]` for primary columns.
+  - Join leg with `name: "Sales"` → `[Sales/Cust Key]` for that joined table's columns.
+  - Warehouse path segments do **not** become the prefix inside a join — use the join leg's `name` instead.
+
+- **Union source**: `SourceName` = the union's `name` field. References resolve against the union's `matches[].outputColumnName` values, not the underlying tables' columns.
+  - Union with `name: "All Sales"` → `[All Sales/Order Number]`.
+  - If you omit `name`, Sigma assigns `"Union of N Sources"`; **a bare reference like `[Order Number]` to a column the consuming element also defines named `Order Number` is a circular reference and the SQL won't compile.** Set the `name` explicitly to avoid this.
+
+- Column names must match exactly what the describe endpoint returns. **Never invent column names.**
+
+### Inside the same element — use `[column_name]` (no prefix)
+
+References a column already defined in this element by its `name` field.
+
+```
+// Given columns: "Revenue" (formula: [ORDERS/revenue]), "Cost" (formula: [ORDERS/cost])
+// A third column can reference them:
+[Revenue] - [Cost]       // valid — references sibling columns by name
+Sum([Revenue])           // valid — aggregation over a sibling column
+```
+
+**A column cannot reference itself** — that is a circular reference error. This trips up copy-paste: if a column's `name` field matches any bracketed reference inside its own `formula`, the server treats it as circular even when you meant to reference a different column. Rename one side to break the cycle.
+
+### Common mistakes
+
+| Wrong | Correct | Why |
+|-------|---------|-----|
+| `[revenue]` | `[ORDERS/revenue]` | Missing table prefix for warehouse column |
+| `[ORDERS/Total Revenue]` | `[Total Revenue]` | "Total Revenue" is a sibling column, not a warehouse column |
+| `[Revenue]` in the "Revenue" column | Rename one side | A column cannot reference itself |
+| `Count([Question ID])` on a sourced element | `Count([AI Usage Data/Question ID])` | Aggregation argument needs the source prefix |
+
+## Operators
+
+### Arithmetic
+`+`, `-`, `*`, `/`, `%` (modulo), `^` (power)
+
+**Do not use** `Power()` or `Mod()` — use `^` and `%` instead.
+
+### Boolean
+`and`, `or`, `not` are **prefix/infix operators, not function calls** — always put a space before the operand.
+
+```
+Wrong: Not(Contains([Deployment], "staging"))       // parses, but every row is null
+Right: Not (Contains([Deployment], "staging"))      // space after Not
+
+Wrong: And([Active], [Paid])                         // not a function
+Right: [Active] And [Paid]                           // infix
+
+Wrong: Or([Trial], [Free])                           // not a function
+Right: [Trial] Or [Free]                             // infix
+
+Right: Not [Active]
+Right: [A] And Not [B]
+Right: ([Status] = "Active") And ([Plan] = "Pro")
+```
+
+The trap: `Not(...)` parses successfully (the parens become grouping), so the failure is silent — null rows, no error. Easy to get wrong by analogy with `Sum([X])` / `If(...)`.
+
+### String concatenation
+`&` (not `+`)
+
+**Do not use** `Concat()` — use `&` instead.
+
+## Aggregation Functions
+
+| Function | Description |
+|----------|-------------|
+| `Sum([col])` | Sum of values |
+| `Avg([col])` | Average of values |
+| `Count([col])` | Count of non-null values |
+| `CountDistinct([col])` | Count of distinct values |
+| `Min([col])` | Minimum value |
+| `Max([col])` | Maximum value |
+| `Median([col])` | Median value |
+
+## Date Functions
+
+| Function | Example |
+|----------|---------|
+| `DateTrunc(<part>, <date>)` | `DateTrunc("month", [Date])` |
+| `DateDiff(<part>, <start>, <end>)` | `DateDiff("day", [Start], [End])` |
+| `DateAdd(<part>, <units>, <date>)` | `DateAdd("month", 3, [Date])` |
+| `DateFormat(<date>, <fmt>)` | `DateFormat([Date], "%Y-%m-%d")` |
+
+Date parts (must be quoted strings): `"year"`, `"quarter"`, `"month"`, `"week"`, `"day"`, `"hour"`, `"minute"`, `"second"`
+
+## Conditional
+
+```
+If(<condition>, <then>, <else>)
+```
+
+Supports multiple conditions (chained):
+```
+If([Status] = "Active", "Active", [Status] = "Pending", "Pending", "Other")
+```
+
+**Do not use** `Case` — use `If` instead.
+
+## Text Functions
+
+| Function | Description |
+|----------|-------------|
+| `Contains(<text>, <search>)` | True if text contains search |
+| `Left(<text>, <n>)` | First n characters |
+| `Right(<text>, <n>)` | Last n characters |
+| `Upper(<text>)` | Uppercase |
+| `Lower(<text>)` | Lowercase |
+| `Trim(<text>)` | Remove leading/trailing whitespace |
+| `Length(<text>)` | Character count |
+| `Replace(<text>, <old>, <new>)` | Replace occurrences |
+
+## JSON / Struct Field Access
+
+Columns containing JSON or struct data (common for event payload / metadata columns) support **field access via dot notation** on the bracketed column reference. The extracted value is untyped — wrap it in the appropriate type constructor (`Text`, `Number`, `Date`) to coerce before passing it to downstream functions.
+
+```
+Text([Langfuse Metadata].agentId)           // extracts agentId as text
+Text([Event Payload].user.id)               // nested access
+Number([Event Payload].latency_ms)          // numeric cast
+Text([Organizations].users[0])              // array index — first element
+Text([Organizations].users[0].email)        // index + nested field
+```
+
+Without the wrapping cast, comparisons (`=`, `<`), aggregations (`Count`, `CountDistinct`), and text ops (`Contains`, concatenation with `&`) will often behave unexpectedly or fail silently — the extracted value keeps its variant/untyped flavor. If a JSON-derived formula appears to return `null` or mismatched values for every row, check that it's wrapped in `Text()` / `Number()` first.
+
+Dot notation goes directly on the `]` — no space: `[Col].field`, not `[Col] .field`.
+
+## Other Functions
+
+| Function | Description |
+|----------|-------------|
+| `Coalesce(<a>, <b>, ...)` | First non-null value |
+| `In([col], "a", "b", "c")` | True if value is in the list |
+| `IsNull([col])` | True if null |
+| `Null` | Null literal |
+
+## Window Functions
+
+| Function | Description |
+|----------|-------------|
+| `Rank()` | Rank within partition |
+| `RowNumber()` | Row number within partition |
+| `Lead(<col>)` | Next row's value |
+| `Lag(<col>)` | Previous row's value |
+| `RunningSum(<col>)` | Cumulative sum |
+| `RunningAvg(<col>)` | Cumulative average |

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/input-tables.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/input-tables.md
@@ -1,0 +1,90 @@
+# Input tables — operational guide
+
+> **Spec shape lives in `tables.md`** (the "Input tables" section there covers
+> `inputMode`, `source` kinds, and the four column shapes). This file is the
+> operational supplement: what has to be true *around* the spec for an input
+> table to actually work, and how to read the data back.
+
+Input tables are workbook elements that support **structured data entry** —
+forecasting, what-if, manual augmentation — and write the entered values back to
+the warehouse. Use them when the user wants to *type or upload data*, not just
+read it. Other elements (tables, charts, KPIs) can then source from the input
+table, and a data model can read it through a warehouse view.
+
+## Requirements & lifecycle
+
+1. **Write-enabled connection required.** `source: { kind: empty, connectionId }`
+   must point at a connection with `writeAccess: true` (`GET /v2/connections`).
+   A non-write connection fails at POST. Linked tables (`kind: linked`) inherit
+   the parent's connection.
+2. **Data lands in `SIGDS_`-prefixed tables** in the connection's write schema.
+   Don't query or modify those directly — see "Reading the data" below.
+3. **Data is invisible until Publish.** A query of an input table before the
+   workbook is published returns **0 rows** — the query layer reads the
+   published version. Publish, then re-query.
+4. **System columns take no `type`** (`ID`, `CREATED_AT`, `CREATED_BY`,
+   `UPDATED_AT`, `UPDATED_BY`) — adding one breaks the column.
+
+## Three types
+
+| Type | What it is | Source shape |
+|---|---|---|
+| **Empty** | Blank table; rows added/typed/pasted from scratch | `source: { kind: empty, connectionId }` |
+| **CSV** | Pre-populated from a CSV upload, then editable | created from an upload (UI); element is otherwise an empty-style input table |
+| **Linked** | Child of a parent element; key columns bind rows to the parent, entry/formula columns sit alongside | `source: { kind: linked, from: <parentElementId> }` + `{ id, key }` columns |
+
+**Linked tables are spec-authorable as of the 2026-06-11 release** —
+`source.kind: linked` + `from` + `{ id, key }` columns POST and round-trip
+cleanly (verified 2026-06-11, including a cross-element formula column).
+One caveat until proven otherwise: that verification was **structural** (POST +
+readback). The pre-release API accepted the same shapes but broke the key
+correlation at the *data* level — inherited columns showed "multiple values" —
+so after the first real rows land, **query the table** (don't just inspect
+`/elements`) to confirm inherited columns resolve per-row. On older orgs/API
+versions linked tables were also dropped from `/spec` entirely; if inherited
+columns misbehave, suspect an older org/API first.
+
+**Column validation is now spec-authorable (2026-06-18 release)** — see the
+"Editable data column" shapes in `tables.md`. Confirmed round-tripping live:
+- **Single-select** dropdown — a scalar column (`type: text|number|datetime`) plus
+  a fixed **`values: [ ... ]`** option list. (There is no `single-select` type
+  token — `type: single-select` 400s; the `values` list is what makes it a
+  dropdown.)
+- **Multi-select** — `type: multi-select` + `values: [ ... ]`. Variant-backed:
+  requires a connection whose warehouse supports variant columns (e.g. Snowflake).
+- **Range bounds** — `range: { min, max }` on a `number` or `datetime` column.
+- **Options from a sibling element** — `valuesFrom: { element: <elementId>, column: <columnId> }`
+  (single- or multi-select). Note the keys are `element` / `column`, not
+  `elementId` / `columnId`.
+- **Pills** — render a select column as pills: `pills: single-color` or
+  `pills: color-by-option` (an enum *string*; omit for plain text).
+- **File-upload columns** — `type: file` + optional `maxFileNum`, `maxFileSizeMb`,
+  `acceptedFileTypes: [ ... ]`. Variant-backed.
+
+`values`, `valuesFrom`, and `range` share **one** validation slot — they're
+mutually exclusive on a column (combining them 400s). Still UI-only: **column
+protection** and **data-entry permissions**.
+
+## Reading an input table's data & structure
+
+`SIGDS_` write-back tables aren't directly queryable. To read the data, create a
+**warehouse view** for the input table (UI: input-table element → *Warehouse
+views → Create new*), then `SELECT … FROM <db>.<schema>.<view>`.
+
+To inspect an input table's **structure regardless of `/spec`** (handy on older
+orgs where linked tables are hidden from `/spec`, or for a quick column dump),
+use the element endpoints (linked columns label as `Col (ParentName)`):
+
+```bash
+# list every element (incl. input tables hidden from /spec on older orgs)
+GET /v2/workbooks/{workbookId}/elements
+GET /v2/workbooks/{workbookId}/pages/{pageId}/elements
+# column-level detail: labels, formulas (linked refs show as [Parent/Col]), types
+GET /v2/workbooks/{workbookId}/elements/{elementId}/columns
+```
+
+## Migration pattern
+
+For data-entry migrations (Excel/planning models) the end-to-end pattern is
+input table → publish → warehouse view → data model `FROM` that view. The
+`excel-to-sigma` skill covers it in depth.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/kpis.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/kpis.md
@@ -1,0 +1,67 @@
+# KPIs
+
+Recipe for `kpi-chart` — the single-value stat card. For the canonical schema:
+
+```bash
+jq --arg k kpi-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+Typically a KPI points at a table as its source and computes one aggregated value.
+
+## Shape
+
+```yaml
+id: total-sales
+kind: kpi-chart
+name: Total sales
+source:
+  kind: table
+  elementId: sales-table
+columns:
+  - id: kpi-val
+    formula: Sum([Master/Sales Amount])
+    format:
+      kind: number
+      formatString: "$,.0f"
+value:
+  columnId: kpi-val
+```
+
+- `columns` — define exactly one column (the value you want displayed). More columns are allowed but only the bound `value.columnId` is rendered.
+- `value.columnId` — REQUIRED. The column ID to show in the card.
+- `format` on the column controls the displayed format. See `formatting.md`.
+- **Hiding the title (avoid the duplicate-title trap):** a KPI derives its visible title from the element `name` **and, when that is absent, from the bound value column's `name`.** So *omitting the element `name` is not enough* — the value column's name still renders as a title. This is the #1 KPI mistake: pairing a colored Markdown category label above the KPI (see `styling.md` KPI-card recipe) with a KPI whose value column has a real name like `Net Revenue` → you get **two** stacked titles ("NET REVENUE" label + "Net Revenue" title + the number). To show only the label + number, set the **value column's** `name: ' '` (a single space). `name: ''` (empty) or omitting it gets stripped and the title re-derives — only a single space persists. (If you instead want the KPI's own title and no separate label, skip the Markdown label and give the value column a real `name`.)
+
+For a period-over-period delta (e.g. "vs. prior quarter"), compute it as a **formula column** — `[This Quarter] / [Last Quarter] - 1` against the source — and show it in its own column or a second KPI.
+
+## Value styling
+
+`value` also accepts presentation fields — `fontSize` (number or `"auto"`) and `color` (a hex string or a theme reference `{ kind: "theme", ref: "colors-xxx" }`).
+
+## Formula qualification
+
+Every KPI sources another element, so the column's formula must use the source's prefix (`[<SourceName>/col]`). A bare `[col]` is only valid for referencing another column defined in this KPI's own `columns[]` array. This is the single most common mistake — see `formulas.md`.
+
+Run `./scripts/validate-spec.sh <spec.yaml>` before publishing to catch it.
+
+## `layout`, `comparison`, and `trend` blocks
+
+The OpenAPI exposes three more kpi-chart objects; their spec-authoring support differs (live-verified 2026-06-11, re-verified 2026-06-24):
+
+- `layout` — **round-trips.** `{ anchor: start|middle|end, titleOrient: top|bottom, ... }` positions the card contents. Default values are omitted on readback.
+- `value` styling — **round-trips.** `fontSize` (number or `"auto"`), `color`; `fontWeight: bold` reads back omitted (it appears to be the default).
+- `comparison` and `trend` (sparkline) — **did not render from spec in this org / the current public API (verified 2026-06-24); treat as UI-bound here, possibly org/version-dependent.** The public OpenAPI exposes only their *formatting* fields (shape, colors, interpolation, label) — **neither block carries the date/series binding** that drives the sparkline or the period delta, and `kpi-chart` has no `groupings` or dimension field to supply one. In this org that binding is **UI-only state, and `GET /v2/workbooks/{id}/spec` does not surface it.** Safe path: build the KPI via spec, then bind the trend (date) and comparison in the editor; the spec carries formatting overrides on top. For a guaranteed spec-only period-over-period *figure*, use the formula-column recipe above.
+
+  Behavior on POST/readback differs by block (verified 2026-06-24):
+  - `trend` — **accepted and persists** on readback, but **inert without a UI binding** — it renders nothing on its own here.
+  - `comparison` and a column-level `columns[].sparkline` — **stripped** on readback. (A second team independently reports `comparison` is "best-effort — survives on some KPIs, stripped on others; finish in the UI if it drops" — i.e. don't rely on it round-tripping.)
+
+  > ⚠️ **The widely-shared sparkline recipe did not reproduce here.** `trend: {shape: line}` + a `DateTrunc("month")` column + a date-range filter on it rendered **no** sparkline — tested ~8 ways on 2026-06-24, including the full documented recipe (a pre-grouped month time-series source, the month column in the KPI, **and both `mode: between` and the relative `mode: last … unit: month`**), column-level `sparkline`, and an exact copy of a *working* UI-bound KPI's columns. Every one rendered the value alone (the **grand total** — no date column ever created the series). Notably, the documented shape that filters a KPI on a `DateTrunc` month column **living on the source** (not in the KPI's own `columns`) is **rejected outright** by this API (`Dependency not found`). A KPI render that shows a live spark in the UI returns **no** `trend`/`sparkline` in its spec — only leftover `DateTrunc`/raw-date columns the editor added.
+  >
+  > **Open question — likely an org/version difference.** Another environment reports these *do* build from spec and render a stable sparkline. I could not reproduce that on this org/public API across the configs above, and the schema exposes no series binding — so until a workbook **built purely from spec and never opened in the editor** is shown to render a sparkline, treat spec sparklines as unsupported here and finish them in the UI. (Our own Looker converter agrees — `build_workbook.py` warns "Sigma KPI spec has no comparison/delta slot … set it in the UI".)
+
+### Give a trend/comparison KPI enough height (or you won't *see* the sparkline)
+
+A KPI stacks **title → value → comparison line → sparkline**, and Sigma **drops the lower items first** when the tile is too short — the sparkline goes before the comparison, which goes before the value. A plain value KPI is fine at ~5 grid rows (below that the title hides — see `styling.md`), but **a KPI carrying a sparkline + comparison needs noticeably more — budget ~8+ grid rows (~240px+)**, taller for long titles.
+
+This is a **render-loop trap**: if you bind a sparkline but lay the tile out short, the export PNG shows only the number, and it's easy to wrongly conclude "the spark didn't build." When a sparkline you configured doesn't appear in the render, **first grow the element's `gridRow` span and re-export** before assuming it failed. (Exporting a single element with `pixelHeight` only scales the output canvas — it does **not** reproduce this layout-height clipping; you have to actually give the element more rows in the page layout.)

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/layout.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/layout.md
@@ -1,0 +1,135 @@
+# Layout
+
+Recipe book for the top-level `layout` XML — when to write it, the two-tag grammar, and the silent-failure traps to watch for. **Default to writing explicit `layout` XML for multi-element workbooks.**
+
+> ⚠️ **`layout` is a TOP-LEVEL spec field — a sibling of `name`, `folderId`, `pages` — NOT a property nested under a page.** Its value is one XML string containing one `<Page id="…">` block per page (the `id` ties each block to a `pages[].id`). Putting `layout:` *inside* a `pages[]` entry is **silently ignored**: POST/PUT still returns `success: true`, but Sigma discards it and auto-arranges every page into a single stacked column. Verified 2026-06-16 — when correctly placed at top level it applies on both `POST` (create) and `PUT`; when nested under a page it's dropped on both. The failure is invisible until you render the page or GET the spec back: a readback that shows self-closing `<GridContainer .../>` tags with the children hoisted out as stacked siblings (and every element spanning `1 / 13`) means your authored layout was discarded. See `schema.md` for the top-level object shape.
+
+Container *elements* (the `kind: "container"` JSON placeholders that pair with `<GridContainer>` in this XML) are covered in **Container elements** below.
+
+## When to write layout vs. let Sigma auto-arrange
+
+Write explicit `layout` when **any** of these apply:
+
+- The page has **mixed element kinds** (charts + KPIs, controls + charts, text/image/divider polish). Auto-arrange treats them as a vertical stack and gives every element the same height — KPIs end up the size of charts, dividers get huge gutters around them.
+- The user asked for specific positioning ("logo on left, title on right", "KPIs across the top", side-by-side charts).
+- There's a `kind: "container"` element on the page. Containers without a matching `<GridContainer>` are functionally no-ops.
+- The workbook has more than ~4 elements on a page. Auto-arrange becomes a long scroll.
+
+Auto-arrange (omit `layout`) is fine when:
+
+- The page has a single element.
+- The page is a uniform stack of tables — auto-arrange produces a reasonable list view.
+- The user explicitly says default layout is fine.
+
+If unsure, write the layout. Writing one is cheap (the patterns below are copy-paste); a visually broken dashboard is expensive.
+
+## Two-tag grammar
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="<pageId>">
+  <GridContainer elementId="<containerId>" type="grid" gridColumn="1 / 25" gridRow="1 / 4"
+                 gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+    <LayoutElement elementId="<childId>" gridColumn="1 / 13" gridRow="1 / 4"/>
+  </GridContainer>
+  <LayoutElement elementId="<elementId>" gridColumn="1 / 25" gridRow="4 / 16"/>
+</Page>
+```
+
+Each `<Page id>` matches a `pages[].id`. Each `elementId` matches an element on that page. `gridColumn` / `gridRow` use standard CSS grid line syntax (`start / end`); the default grid is 24 columns wide. One `<Page>` block per workbook page.
+
+## `<GridContainer>` vs `<LayoutElement>`
+
+- `<LayoutElement elementId="X" .../>` — **leaf**. Positions a single element; no children.
+- `<GridContainer elementId="X" ...>...</GridContainer>` — **container**. Wraps child `<LayoutElement>`s in its own inner grid.
+
+Use `<GridContainer>` for any tag with nested children — a `<LayoutElement>` only renders as a leaf.
+
+## Container elements
+
+A `kind: "container"` element in `pages[].elements[]` is a grouping placeholder — a labeled section, a branded header strip, a KPI row treated as a unit. It renders **only** when a matching `<GridContainer elementId="…">` positions it; declared without one, it's a no-op. Containers carry optional `style` (background color, border, corner radius, padding) and `backgroundImage` — pull the current shape from the spec rather than hardcoding it (the set of container/layout options is growing):
+
+```bash
+jq --arg k container 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+```yaml
+- id: header
+  kind: container
+  style: { backgroundColor: "#0B3D91" }
+```
+
+- **Element on a background image:** to place an element *on top of* a container's `backgroundImage`, make it a **child** of that container in the layout XML — the background spans the container and the child sits on top.
+- **When to skip:** with no shared background or logical grouping, position elements directly with `<LayoutElement>`. A container around a single element is usually overkill.
+
+## `gridTemplateRows`: always `"auto"`
+
+Row tracks are always `"auto"` — write `gridTemplateRows="auto"`. Height comes from the children, not from the row track.
+
+### Stacking children inside a container
+
+Because row tracks collapse to `"auto"`, height comes from children, not from the container's `gridTemplateRows`. Two patterns work:
+
+**Side-by-side** — children share the container's row range, differ by `gridColumn`:
+
+```xml
+<GridContainer elementId="kpi-row" type="grid"
+               gridColumn="1 / 25" gridRow="1 / 4"
+               gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+  <LayoutElement elementId="kpi-1" gridColumn="1 / 9"  gridRow="1 / 4"/>
+  <LayoutElement elementId="kpi-2" gridColumn="9 / 17" gridRow="1 / 4"/>
+  <LayoutElement elementId="kpi-3" gridColumn="17 / 25" gridRow="1 / 4"/>
+</GridContainer>
+```
+
+**Stacked rows** — children have disjoint `gridRow` spans within the container's row range:
+
+```xml
+<GridContainer elementId="header-row" type="grid"
+               gridColumn="1 / 25" gridRow="1 / 12"
+               gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+  <LayoutElement elementId="title"  gridColumn="1 / 25" gridRow="1 / 4"/>
+  <LayoutElement elementId="kpi-1"  gridColumn="1 / 9"  gridRow="4 / 12"/>
+  <LayoutElement elementId="kpi-2"  gridColumn="9 / 17" gridRow="4 / 12"/>
+  <LayoutElement elementId="kpi-3"  gridColumn="17 / 25" gridRow="4 / 12"/>
+</GridContainer>
+```
+
+Use stacked rows when you want a section header above a row of charts inside the same container, instead of moving those elements out to the page level.
+
+## Element height heuristics — give tables room to breathe
+
+A table element's `gridRow` span controls how many data rows are visible before it scrolls. The recurring mistake is **under-sizing tables** — a detail/raw-row table given a 5–8 row span shows only ~2 data rows, which defeats the point of a "see the underlying data" table. Size by role:
+
+- **Detail / raw-row tables** (the bottom-of-page "drill into the data" table): give a **tall** span — **~14–20 grid rows** (e.g. `gridRow="32 / 50"`). The user should see 6–10+ rows without scrolling. When a detail table is the last element on the page, err on the side of *too tall* — trailing whitespace below it is cheaper than a cramped 2-row table.
+- **Summary / aggregated tables** (a handful of grouped rows): size to roughly the row count + header, ~6–10 grid rows.
+- **KPIs**: short — ~5–6 rows; they're a single number.
+- **Charts**: ~8–12 rows so axes and labels aren't crushed.
+
+Heights are relative grid units (tracks are `auto`), so these are rules of thumb, not pixels — but the asymmetry holds: **tables are the element most often made too short.** If you're unsure, render the page (PNG export) and count visible rows.
+
+## Page-level fields: `visibility` and `backgroundImage`
+
+Besides `id`, `name`, `elements`, and `layout`, a page supports two optional fields:
+
+- **`visibility`** — set to `hidden` to hide the page from end users. Omit for a visible page.
+- **`backgroundImage`** — a page-wide background image, same shape as a container's `backgroundImage`: a required `url` plus an optional `style` block (`fit`, `horizontalAlign`, `verticalAlign`, `tiling`). `url` supports `{{formula}}` references.
+
+```yaml
+pages:
+  - id: overview
+    name: Overview
+    visibility: hidden
+    backgroundImage:
+      url: https://cdn.example.com/bg.jpg
+      style:
+        fit: cover
+        tiling: none
+    elements: [ ... ]
+```
+
+## Layout `elementId` references
+
+Each layout `elementId` must match an element `id` on that page exactly (case-sensitive). IDs are preserved verbatim on create, so the IDs in your saved spec stay valid for follow-up `PUT`s.
+
+To study real grid-container idioms, fetch an existing multi-page workbook's spec (`GET /v2/workbooks/{id}/spec`, see SKILL.md Steps 1–2). The OpenAPI doesn't model the `layout` XML string, so a live spec is the way to see production layout.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/maps.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/maps.md
@@ -1,0 +1,30 @@
+# Map Elements (geography-map, point-map, region-map)
+
+Three map visualizations. They share the standard element envelope — `source` and `columns` (each `{ id, formula }`), plus the same `color` channel as charts (`by: single | category | scale`) — and differ only in how the geography is bound. Pull the full shape (including `mapStyle`, `legend`, `tooltip` sub-objects) from the spec:
+
+```bash
+jq --arg k region-map 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+# swap k for geography-map / point-map
+```
+
+The distinctive binding per kind (the part worth knowing up front):
+
+- **geography-map** — `geography: { id: <columnId> }`, a single column of GeoJSON geometries.
+- **point-map** — `latitude: { id }` + `longitude: { id }`; optional `size: { id }` makes it a bubble map.
+- **region-map** — `region: { id, regionType }`. `regionType` ∈ `country`, `us-state`, `us-county`, `us-zipcode`, `us-cbsa`, `us-postal-place`, `ca-province`; the region column's values must match it.
+
+**Shape gotcha:** `geography` / `latitude` / `longitude` / `size` / `region` are **single `{ id }` objects**, but `label` and `tooltip` are **arrays** of `{ id }`.
+
+```yaml
+id: sales-by-state
+kind: region-map
+source:
+  kind: warehouse-table
+  connectionId: <YOUR_CONNECTION_ID>
+  path: [DB, SCHEMA, SALES]
+columns:
+  - { id: col-state, formula: "[STATE]" }
+  - { id: col-rev,   formula: "Sum([REVENUE])" }
+region: { id: col-state, regionType: us-state }
+color:  { by: scale, column: col-rev }
+```

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/schema.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/schema.md
@@ -1,0 +1,113 @@
+# Workbook Spec — Top-Level Schema
+
+Recipe + reference for the overall shape of the top-level workbook spec object and the `pages` array skeleton. The full schema lives in the OpenAPI:
+
+```bash
+jq '.paths."/v2/workbooks/spec".post.requestBody.content."application/json".schema' /tmp/sigma-api.json
+```
+
+This file covers what the OpenAPI alone won't tell you: which fields are response-only (ignored on write), the page and ID rules, and a minimal working example. See the per-element and per-source reference files for the pieces that go inside `pages[].elements[]`.
+
+## Top-Level Object
+
+The object passed to `POST /v2/workbooks/spec`:
+
+```yaml
+name: My Workbook
+folderId: <folder-uuid>
+description: Optional description
+schemaVersion: 1
+pages: [...]
+layout: |
+  <?xml ...?>...
+```
+
+**Required:** `name`, `folderId`, `schemaVersion`, `pages`.
+**Optional:** `description`, `layout`.
+
+Use the `schemaVersion` returned by `GET /v2/workbooks/<reference-workbook-id>/spec` in Step 2 of the workflow — don't hardcode it. The server will reject a spec whose `schemaVersion` doesn't match what the API expects.
+
+## Response-Only Fields
+
+`GET /v2/workbooks/<id>/spec` also returns these server-managed fields. They're **ignored** on write (POST/PUT), so you don't have to strip them before re-submitting a GET response — though it's cleaner to:
+
+- `workbookId`
+- `url`
+- `documentVersion`
+- `latestDocumentVersion`
+- `ownerId`
+- `createdBy`
+- `updatedBy`
+- `createdAt`
+- `updatedAt`
+
+## Pages
+
+`pages` is the core of the spec. Each page:
+
+```yaml
+id: page-1
+name: Overview
+elements: [...]
+visibility: shown   # optional: "shown" (default) | "hidden"
+```
+
+The `elements` array holds table elements, charts, KPIs, controls, and containers. See the per-element reference files.
+
+`visibility: hidden` keeps the page in the workbook (so other elements can `source` from its tables via `elementId`) but excludes it from the viewer. See `reference/workflows/composition.md` for when to reach for this.
+
+## ID Rules
+
+- Element IDs and column IDs must be unique within their scope.
+- Use descriptive kebab-case or short random-looking IDs — both are fine. IDs are internal identifiers, not displayed to users.
+- IDs you submit are **preserved verbatim** on `POST` — pages, elements, and columns keep the `id` values you sent, and layout `elementId` references stay valid. You can edit your saved spec and `PUT` it back directly. Layout `elementId` references must match an element `id` on that page exactly (case-sensitive).
+
+## Minimal Working Example
+
+The smallest spec that creates a workable workbook:
+
+```yaml
+name: Sales Dashboard
+folderId: <folder-uuid>
+schemaVersion: 1
+pages:
+  - id: page-1
+    name: Overview
+    elements:
+      - id: sales-table
+        kind: table
+        name: Sales Data
+        source:
+          kind: warehouse-table
+          connectionId: <conn-uuid>
+          path: [SALES_DB, PUBLIC, ORDERS]
+        columns:
+          - id: col-order-id
+            name: Order ID
+            formula: "[ORDERS/order_id]"
+          - id: col-amount
+            name: Amount
+            formula: "[ORDERS/amount]"
+          - id: col-revenue
+            name: Revenue
+            formula: "[ORDERS/revenue]"
+          - id: col-cost
+            name: Cost
+            formula: "[ORDERS/cost]"
+          - id: col-date
+            name: Date
+            formula: "[ORDERS/order_date]"
+          - id: col-total
+            name: Total Amount
+            formula: Sum([Amount])
+          - id: col-profit
+            name: Profit
+            formula: "[Revenue] - [Cost]"
+```
+
+Note how:
+- `[ORDERS/order_id]` references a warehouse column (table prefix required).
+- `Sum([Amount])` references the "Amount" column defined in the same element (no prefix).
+- `[Revenue] - [Cost]` references two other columns in the same element by their `name` field.
+
+For a realistic multi-page, multi-element spec, fetch an existing workbook's spec (`GET /v2/workbooks/{id}/spec`, see SKILL.md Steps 1–2) — a live spec is current and reflects real usage. For how much to build for a given request, see `reference/workflows/composition.md`.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/sources-warehouse.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/sources-warehouse.md
@@ -1,0 +1,46 @@
+# Warehouse Table Source
+
+The `warehouse-table` source is the most common source kind — raw data from a warehouse connection. Virtually every workbook starts with at least one element sourced from a warehouse table (or from an element that is, via `kind: "table"` / `kind: "join"`).
+
+For the canonical schema:
+
+```bash
+jq --arg k warehouse-table 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+This file covers: path formats per warehouse (which the OpenAPI describes loosely), formula-prefix conventions (which it doesn't describe at all), and the special-character / friendly-name pitfalls.
+
+See `reference/workflows/discover.md` for how to find the `connectionId` and `path` via the REST API.
+
+## Shape
+
+```yaml
+kind: warehouse-table
+connectionId: <conn-uuid>
+path: [DATABASE, SCHEMA, TABLE]
+```
+
+## Formula References
+
+Column formulas reference warehouse columns via the **last segment of the path array**:
+
+- Path `["SALES_DB", "PUBLIC", "ORDERS"]` → `[ORDERS/revenue]`, `[ORDERS/order_date]`
+- Path `["ANALYTICS", "CORE", "USERS"]` → `[USERS/email]`
+
+Inside a `join` source, warehouse path segments are **not** used as prefixes — use the join leg's `name` instead. See `sources.md` > join section.
+
+## Path Formats by Warehouse
+
+| Warehouse | Path format |
+|---|---|
+| Snowflake | `["DATABASE", "SCHEMA", "TABLE"]` |
+| BigQuery | `["PROJECT", "DATASET", "TABLE"]` |
+| Databricks | `["CATALOG", "SCHEMA", "TABLE"]` |
+| Redshift | `["SCHEMA", "TABLE"]` |
+| PostgreSQL / MySQL | `["SCHEMA", "TABLE"]` |
+
+## Common Pitfalls
+
+- **Column names with special characters** — `/`, `-`, `.`, brackets, leading/trailing whitespace all get normalized by Sigma. Never hand-transform a raw warehouse name; ask the user for the exact name Sigma uses. See `formulas.md` > Special Characters.
+- **Inventing column names** — don't. Only reference columns the user has supplied or confirmed.
+- **Wrong path depth** — a warehouse table's path must be exactly the depth its warehouse uses (e.g., Snowflake is always 3; Postgres is always 2). Use `/v2/connection/<id>/lookup` to resolve ambiguity.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/sources.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/sources.md
@@ -1,0 +1,116 @@
+# Sources (non-warehouse)
+
+Recipe book for source kinds other than `warehouse-table`. For the canonical schema of any source kind, pull it by its `kind` value (`warehouse-table`, `sql`, `table`, `data-model`, `join`, `union`, `transpose`):
+
+```bash
+jq --arg k join 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+Every element with columns has a `source` that defines where its data comes from. This file focuses on the **patterns** and **formula-prefix conventions** for each non-warehouse source kind — the parts the OpenAPI alone won't teach.
+
+**For warehouse-table** — the most common source — see the dedicated `sources-warehouse.md`. It's loaded by default because nearly every workbook uses it.
+
+**For discovery** (finding connection IDs, paths, data model IDs, element IDs) see `reference/workflows/discover.md`.
+
+---
+
+## table (cross-element reference)
+
+Sources another element in the same workbook. This is the most common source kind for charts, KPIs, and derived tables.
+
+```yaml
+kind: table
+elementId: <id of another element on some page>
+```
+
+Column formulas reference that element's columns using its `name`:
+- Element named "Sales Table" → `[Sales Table/Revenue]`
+
+## data-model
+
+References an element from an existing data model. **Prefer this source kind when the user's org has relevant data models** — it inherits the data model's joins, filters, and column-level security, which is usually closer to what the user wants than re-deriving from raw warehouse tables. Discover available models with `GET /v2/dataModels`; if none are relevant, fall back to `warehouse-table` rather than trying to manufacture a model.
+
+```yaml
+kind: data-model
+dataModelId: <data-model-uuid>
+elementId: <element-uuid within that model>
+```
+
+Optionally add `groupingId` to apply one of the model element's groupings.
+
+## join
+
+Joins multiple sources into one logical source via an array of `joins`. Each leg (`primarySource`, `left`, `right`) can be any source kind, so warehouse tables, other elements, and data-model elements can be joined interchangeably.
+
+Only `joins` (with each entry's `left`, `right`, `columns`) is required. `primarySource` is optional — if omitted, Sigma infers it as the source that appears on the left of some join but never on the right. Each join's `name` (used as the formula prefix — `[<name>/column]`; defaults to the right source's name) and `joinType` (defaults to inner) are also optional.
+
+```yaml
+kind: join
+name: Sales Star
+primarySource:
+  kind: warehouse-table
+  connectionId: <conn-uuid>
+  path: [DB, SCHEMA, F_POS]
+joins:
+  - name: Sales
+    joinType: left-outer
+    left:
+      kind: warehouse-table
+      connectionId: <conn-uuid>
+      path: [DB, SCHEMA, F_POS]
+    right:
+      kind: warehouse-table
+      connectionId: <conn-uuid>
+      path: [DB, SCHEMA, F_SALES]
+    columns:
+      - left: "[Order Number]"
+        right: "[Order Number]"
+```
+
+Each entry in a join's top-level `columns[]` is a join-key pair (`left`/`right`, with an optional `op` for non-equi joins) — a different shape from an element's `columns[]` (see below). Pull `joinType` values and the column-pair shape from the spec via the recipe at the top.
+
+**Column formula prefixes with joins** — see `formulas.md` for the full rules:
+- Primary-source columns use the **join's top-level `name`**: `[Sales Star/Order Number]`
+- Joined-table columns use the **join leg's `name`**: `[Sales/Cust Key]`
+- Warehouse path segments are **not** used as prefixes inside a join.
+
+## sql
+
+A custom SQL query against a connection — `kind: sql` with `connectionId` + `statement`. Pull the shape from the spec via the recipe.
+
+## transpose
+
+Pivots a source's rows and columns. Needs a `source` (any source kind) plus a direction config — `row-to-column` (pivot wider) or `column-to-row` (unpivot longer), each with its own fields. Pull the per-direction shape from the spec via the recipe.
+
+## Element `columns[]` vs. join `columns[]`
+
+Two unrelated things share the name. An element's `columns[]` is its **output columns** (each a `formula`); a join source's top-level `columns[]` is its **join keys** (`left`/`right` pairs). Don't conflate them.
+
+## union
+
+Combines two or more sources (`warehouse-table`, `table`, or `data-model`) into a single source whose columns are explicitly mapped via `matches[]`.
+
+```yaml
+kind: union
+name: All Sales
+sources:
+  - kind: warehouse-table
+    connectionId: <conn-uuid>
+    path: [DB, SCHEMA, JULY_SALES]
+  - kind: warehouse-table
+    connectionId: <conn-uuid>
+    path: [DB, SCHEMA, AUGUST_SALES]
+matches:
+  - outputColumnName: Order ID
+    sourceColumns:
+      - '[Order ID]'   # column from the first source
+      - '[Order ID]'   # column from the second source
+  - outputColumnName: Sales
+    sourceColumns:
+      - '[Sales]'
+      - '[Sales]'
+```
+
+`sourceColumns` is an array aligned to `sources` — one entry per source, in order. `outputColumnName` becomes the column users see and the name your element formulas reference.
+
+**Set `name` explicitly.** Formula prefixes for the consuming element use the union's `name`, e.g. `[All Sales/Order ID]`. If you omit `name`, Sigma assigns `"Union of N Sources"`; if your element also defines a column whose `name` matches an `outputColumnName`, a bare `[Order ID]` formula becomes a circular self-reference and the SQL fails to compile. See `formulas.md` > Union source.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/styling.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/styling.md
@@ -1,0 +1,503 @@
+# Styling — designed-looking dashboards from spec alone
+
+> **These are options to draw from, not a house style.** Reach for them when the user asks for
+> design polish or you're composing from scratch with no brand direction. Never impose them on
+> a migration (fidelity to the source dashboard wins) or over a user's stated branding.
+
+Recipe library for moving a workbook from "default auto-arrange" to "looks designed." Every pattern below is built from fields that already exist in the workbook spec — no external CSS, no theme JSON, no UI editing required.
+
+The recipes were extracted from a 2026-05-29 design experiment that built 6 versions of the same dashboard (default → polished) and compared screenshots via the `/v2/workbooks/{id}/export` PNG endpoint. The findings caught two silent-failure bugs (see `charts.md` donut section) and 4 undocumented container `style` knobs (see `layout.md`).
+
+---
+
+## Anti-patterns — the generic-AI tells (and the recipe that fixes each)
+
+The recipes below are the *positive* moves. This is the *negative* checklist: the visual tropes that
+mark a dashboard as generic AI output. They're easiest to catch on a render — after you POST, export
+each page to PNG (`/v2/workbooks/{id}/export`) and read it against this list. Each tell links to the
+fix already in this file. **Same caveat as the recipes: these are defaults for a from-scratch build,
+never an override of a user's stated branding or a migration's source fidelity.**
+
+- [ ] **No focal point** — every tile the same size and weight; the page reads as a uniform grid with
+      no "most important thing." Fix: give the signature element a **wider `gridColumn` span** (e.g.
+      a hero trend at `1 / 17` with a supporting chart at `17 / 25`), not an automatic 50/50. Proportion
+      should follow priority — see *Putting it together* and *Balance density top vs bottom*.
+- [ ] **Automatic equal-width rows** — two elements split a row 50/50 regardless of priority. Equal
+      spans are right for a **KPI strip** (true peers) and genuine comparisons; for a primary-vs-supporting
+      pair, weight the primary. See Recipe 2 (equal KPI cards = correct) vs the hero proportion above.
+- [ ] **Every page opens the same way** — each page of a multi-page workbook leads with an identical
+      KPI band. Lead each page with the thing it's *for*; vary the opening. (Launcher/landing pattern and
+      `visibility: hidden` data pages help — see *Interaction patterns*.)
+- [ ] **No grid breaks** — the same 2–3-column chart row repeats down the whole page ("spreadsheet of
+      cards"). Change the layout when the section's purpose changes: hero row → section header → paired
+      charts → full-width detail. See Recipe 3 (section headers) and the composition pattern.
+- [ ] **Decorative accent overuse** — the accent color is sprayed onto every card, tint, and surface, so
+      nothing stands out. Reserve it: tint the hero band and the primary KPI label, default the rest to the
+      neutral card surface (`#FBFBFB`/`#FAFBFC`, not pure white). **Carry *one* accent system through the
+      page** — repeat the KPI label colors in the charts below, in order. See *Composition principles*.
+- [ ] **Oversaturated status colors** — raw default red/green badges. Use the vetted palette
+      (`#10B981` growth, `#F59E0B`/`#EF4444` warning/negative only) and reserve red/amber for genuinely
+      negative values. See *Vetted color palette* and Recipe 5.
+- [ ] **Flat typography** — every heading, KPI, and label at the same size/weight; "feels like a form."
+      Build a scale: hero `#`/`##` title → quiet uppercase `p-small` section labels → KPI `value.fontSize`
+      (28–32) → table cells. See *Typography* and *Quiet section labels*.
+- [ ] **Centered text everywhere** — every block centered, so every section reads like a landing page.
+      Default to left for text and titles (note: left-aligned `h-*` heading classes are rejected — use
+      markdown `#` + a `<span>`); reserve centering for a single hero moment. See *Typography*.
+- [ ] **Nested cards** — a card inside a card inside a card (e.g. a chart wrapped in its own styled
+      container that already sits in a band container). Flattens hierarchy and adds noise. Use containers
+      for **bands and KPI cards**, not to re-wrap every element; separate with spacing, type, and
+      dividers (Recipe 4) before adding another container.
+
+---
+
+## Workbook theme (2026-06-18 release)
+
+A workbook now carries a **top-level theme**, alongside `pages` and `layout`:
+
+```yaml
+name: My Workbook
+schemaVersion: 1
+pages: [ ... ]
+layout: ...
+themeName: Dark          # built-in: Light | Dark | Surface  — OR an org theme UUID
+themeOverrides:          # optional — colors / fonts / layout style / table defaults
+  colors:
+    text: "#FFFFFF"
+    highlight: "#1E88E5"
+    surface: "#101826"
+```
+
+- `themeName` accepts a **built-in** name (`Light` / `Dark` / `Surface`) or an **org theme id** (a UUID). All four round-trip. Only the **format** is checked, not existence: a malformed value 400s, but a well-formed but nonexistent UUID is accepted as-is and renders broken (like a bad `pluginId`) — so a clean POST is not proof the theme exists.
+- **There is no API to discover theme names.** Built-ins are the three above; an org theme id can only be learned by reading a workbook spec that already uses it (admin Branding Settings shows names, not ids). So the theme id has to come from somewhere external — an agent cannot enumerate them from a single call.
+- **Use the per-org theme registry instead of asking blind.** `harvest-theme-registry.py` (in `sigma-migration-skills/shared/scripts/`) scans an org's workbook specs once and writes `~/.sigma-migration/theme-registry.yaml`, keyed by API host, with each `themeName` and how many workbooks use it. Read it to suggest the org's themes ranked by frequency — **the most-used org-UUID is almost always the org default.** If the registry is missing or stale, run the harvester (a full scan is ~20–40s and persists), then fall back to asking the user only if no org themes are found. Singletons are often test/transient junk — prefer the high-count entries.
+- `themeOverrides` round-trips (colors confirmed). Use it for one-off tweaks on top of a base theme.
+- Theme vs. the recipes below: a theme is the global skin (selected, org-managed). The recipes here style individual elements from spec fields and **stack on top of** whatever theme is set. For a migration, prefer the source dashboard's look; reach for a theme only when the user asks to apply one.
+
+---
+
+## What "designed" looks like via spec
+
+You can ship a dashboard that looks legitimately professional from the spec by stacking five patterns:
+
+1. **Branded hero header strip** — full-width container with a dark background and a colored Markdown title sitting inside.
+2. **KPI cards** — each KPI inside its own white container with rounded corners + a thin border + a colored Markdown category label.
+3. **Section headers** — Markdown `##` text elements between groups of elements.
+4. **Categorical chart colors** — `color.scheme` on bar/line/area/combo (not donut/pie — those use the workbook theme).
+5. **Number formatting on everything** — `$,.2s` for KPI values (yields `$103k`), `$,.0f` for table cells, never raw numbers.
+
+If you do all five, the dashboard reads as designed. Skip any one and it reads as "the LLM didn't try."
+
+---
+
+## Vetted color palette
+
+Use this Tailwind-derived modern palette unless the customer has specified branding:
+
+```
+Primary blue:   #3B82F6
+Green:          #10B981
+Amber:          #F59E0B
+Red:            #EF4444
+Purple:         #8B5CF6
+Cyan:           #06B6D4
+
+Dark surface:   #0F172A   (slate-900 — hero header bg)
+Muted text:     #94A3B8   (slate-400 — subtitle text on dark bg)
+Card border:    #E2E8F0   (slate-200 — subtle 1px on white cards)
+Card bg:        #FFFFFF
+Page bg:        (Sigma default — don't override)
+```
+
+Apply consistently: the same blue (`#3B82F6`) for the "primary metric" KPI label and the primary bar chart; green for "growth" metrics; amber/red for "warning" / "negative" only.
+
+---
+
+## Recipe 1 — Hero header strip
+
+A dark, full-width strip at the top with a bold white title and a muted subtitle.
+
+```yaml
+elements:
+  - id: hero
+    kind: container
+    style:
+      backgroundColor: "#0F172A"
+      borderRadius: round
+  - id: title
+    kind: text
+    body: |
+      # <span style="color: #FFFFFF">Orders Overview</span>
+      <span style="color: #94A3B8">Net revenue, order mix, and channel performance — last full period</span>
+```
+
+```xml
+<GridContainer elementId="hero" type="grid"
+               gridColumn="1 / 25" gridRow="1 / 5"
+               gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+  <LayoutElement elementId="title" gridColumn="1 / 25" gridRow="1 / 5"/>
+</GridContainer>
+```
+
+Notes:
+- Title color via Markdown `<span style="color: #...">`. For size control beyond `#`/`##`, use Sigma's typography classes (`<p class="h-med">` etc.) and `font-family` spans — see **Field-observed idioms** below.
+- For an edge-to-edge image background instead of a solid color, swap `backgroundColor` for `backgroundImage` and add `padding: none` (`backgroundColor` + `padding: none` is also valid — it just blocks `border*`).
+
+---
+
+## Recipe 2 — KPI card row
+
+Three (or four) KPIs in styled white cards, each with a colored category label above the value.
+
+```yaml
+elements:
+  - id: kpi-net-box
+    kind: container
+    style:
+      backgroundColor: "#FFFFFF"
+      borderRadius: round
+      borderColor: "#E2E8F0"
+      borderWidth: 1
+  - id: kpi-net-label
+    kind: text
+    body: |
+      <span style="color: #3B82F6">**NET REVENUE**</span>
+  - id: kpi-net
+    kind: kpi-chart
+    name: ' '   # single space — suppresses the KPI's own title (see note below)
+    source:
+      elementId: master
+      kind: table
+    columns:
+      - id: kpi-nr-val
+        formula: Sum([Master/Net Revenue])
+        format:
+          kind: number
+          formatString: "$,.2s"    # renders as "$103k"
+    value:
+      columnId: kpi-nr-val
+```
+
+```xml
+<GridContainer elementId="kpi-net-box" type="grid"
+               gridColumn="1 / 9" gridRow="5 / 12"
+               gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+  <LayoutElement elementId="kpi-net-label" gridColumn="1 / 25" gridRow="1 / 3"/>
+  <LayoutElement elementId="kpi-net"       gridColumn="1 / 25" gridRow="3 / 8"/>
+</GridContainer>
+```
+
+Repeat the container + label + KPI triple for each metric, switching the label color (green for growth, purple for averages, amber for trailing-indicator metrics). Three across at columns `1/9`, `9/17`, `17/25` is the standard layout.
+
+> **Set the value column's `name: ' '` (a single space)** when a colored Markdown label sits above the KPI — otherwise you get a **duplicate title**: the card label (`NET REVENUE`) *and* the KPI's own title (`Net Revenue`) stacked in the same card. The title comes from the element `name` **and, when that's absent, the bound value column's `name`** — so with no element name (the usual case here) the *column* name is what leaks through. There's no `showTitle: false` field, and **omitting the name does NOT work** — an empty/absent name is stripped and the title re-derives. Only a single space persists. (Verified live + rendered; this is the #1 KPI-card mistake.)
+
+---
+
+## Recipe 3 — Section header
+
+A heading row between groups of elements. Tighter than a hero, looser than a chart.
+
+```yaml
+- id: section-charts
+  kind: text
+  body: |
+    ## Revenue breakdown
+```
+
+```xml
+<LayoutElement elementId="section-charts" gridColumn="1 / 25" gridRow="12 / 14"/>
+```
+
+Use these between (a) KPI row and chart row, (b) chart row and detail table, (c) any two thematically distinct chunks. Two per dashboard is usually enough — more than that and the page reads as fragmented.
+
+---
+
+## Recipe 4 — Divider before the detail table
+
+Between the high-level charts and the "drill down to raw rows" table, a horizontal rule sets the visual separation cleanly.
+
+```yaml
+- id: divider-1
+  kind: divider
+```
+
+```xml
+<LayoutElement elementId="divider-1" gridColumn="1 / 25" gridRow="26 / 27"/>
+```
+
+A 1-row span. The `divider` element is a first-class kind, not a hack — see `content-elements.md`.
+
+---
+
+## Recipe 5 — Categorical chart colors
+
+For bar / line / area / combo charts, pin slice colors to the vetted palette:
+
+```yaml
+- id: chart-by-status
+  kind: bar-chart
+  source:
+    elementId: master
+    kind: table
+  columns:
+    - id: bs-status
+      formula: '[Master/Order Status]'
+    - id: bs-rev
+      formula: Sum([Master/Net Revenue])
+      format:
+        kind: number
+        formatString: "$,.0f"
+  xAxis:
+    columnId: bs-status
+    sort:
+      by: bs-rev
+      direction: descending
+  yAxis:
+    columnIds: [bs-rev]
+  color:
+    by: category
+    column: bs-status
+    scheme: ["#3B82F6", "#F59E0B", "#EF4444"]
+```
+
+`scheme` is positional — pin colors to category sort order, not to category names. Sort by the value descending to get "biggest bar = primary blue, smaller = warning amber/red."
+
+> **Donut and pie do NOT accept `scheme`.** The field is silently stripped on those chart kinds; they always use Sigma's default palette. To customize donut/pie slice colors, set the workbook theme in the UI. See `charts.md` donut section for the verified gotchas.
+
+---
+
+## Recipe 6 — Number formatting
+
+Every value gets a `format` block. The four most useful:
+
+| Format string | Output |
+|---|---|
+| `"$,.2s"` | `$103k` — compact, perfect for KPI tiles |
+| `"$,.0f"` | `$103,247` — full precision, table cells |
+| `",.0f"` | `1,234` — count with thousands separator |
+| `",.2%"` | `12.34%` — percentage |
+
+```yaml
+columns:
+  - id: kpi-val
+    formula: Sum([Master/Revenue])
+    format:
+      kind: number
+      formatString: "$,.2s"
+```
+
+See `formatting.md` for the full d3-format / strftime reference.
+
+---
+
+## Putting it together — page composition pattern
+
+The 24-column grid layout that pulls all six recipes into one dashboard:
+
+```
+Row 1-5      Hero header (full width)
+Row 5-12     KPI tile 1 | KPI tile 2 | KPI tile 3   (each 8 cols wide)
+Row 12-14    Section header — "Revenue breakdown"
+Row 14-26    Donut / pie  | Bar chart                (each 12 cols wide)
+Row 26-27    Divider
+Row 27-29    Section header — "Order details"
+Row 29-37    Detail table (full width)
+```
+
+XML:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="page-1">
+
+  <GridContainer elementId="hero" type="grid"
+                 gridColumn="1 / 25" gridRow="1 / 5"
+                 gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+    <LayoutElement elementId="title" gridColumn="1 / 25" gridRow="1 / 5"/>
+  </GridContainer>
+
+  <GridContainer elementId="kpi-net-box" type="grid"
+                 gridColumn="1 / 9" gridRow="5 / 12"
+                 gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+    <LayoutElement elementId="kpi-net-label" gridColumn="1 / 25" gridRow="1 / 3"/>
+    <LayoutElement elementId="kpi-net"       gridColumn="1 / 25" gridRow="3 / 8"/>
+  </GridContainer>
+  <!-- two more KPI containers at 9/17 and 17/25 -->
+
+  <LayoutElement elementId="section-charts"   gridColumn="1 / 25"  gridRow="12 / 14"/>
+  <LayoutElement elementId="chart-by-channel" gridColumn="1 / 13"  gridRow="14 / 26"/>
+  <LayoutElement elementId="chart-by-status"  gridColumn="13 / 25" gridRow="14 / 26"/>
+
+  <LayoutElement elementId="divider-1"      gridColumn="1 / 25" gridRow="26 / 27"/>
+  <LayoutElement elementId="section-detail" gridColumn="1 / 25" gridRow="27 / 29"/>
+  <LayoutElement elementId="master"         gridColumn="1 / 25" gridRow="29 / 37"/>
+</Page>
+```
+
+---
+
+## Field-observed idioms (Sigma SE demo org, 2026-06-12)
+
+Mined from the specs of Sigma's flagship demo workbooks (Cold Provisions, Marketing
+Control Center, Actuarial Insights Portal, Power Grid Operations, Trade Surveillance,
+Headcount Forecasting — ~1.6MB of designed spec), then **live-verified by POST/PUT on a
+standard production org on 2026-06-12** (a redesigned 4-page workbook). Items marked
+✓ round-tripped through the spec API; items marked ✗ exist in demo specs (UI-authored)
+but were REJECTED when pushed via the API — with the workaround noted. The API
+validates HTML bodies strictly; the verified rules are below.
+
+**The headline lesson:** in the polished demos, *text (285), container (221), image (56)
+and control (161) elements outnumber charts ~10:1*. The designed look is composition —
+typography, cards, icons, density — not chart configuration.
+
+### Typography — far beyond bare Markdown
+
+Text bodies accept HTML `<p>` with **Sigma typography classes** and inline style — but
+the spec API validates them. Verified rules (the UI is more permissive than the API):
+
+```yaml
+body: '# <span style="color: #FFFFFF">Repo Health</span>'                                              # ✓ markdown heading + span color
+body: '<p class="p-small"><span style="color: #94A3B8">subtitle text</span></p>'                       # ✓ p-small / p-large stand alone
+body: '<p class="h-med" style="text-align: center"><span style="color: #0e2e52">Title</span></p>'     # ✓ h-* classes need a non-default alignment
+body: '<p class="h-med"><span style="color: #FFF">Title</span></p>'                                    # ✗ 400: "<p> carries no non-default block style or alignment"
+body: '<p class="h-med" style="text-align: left">…'                                                    # ✗ left = default, same 400
+body: '<span style="color: var(--colors-textNeutral)">…</span>'                                        # ✗ 400: "color value must be hex" — theme CSS vars are UI-only; use hex
+```
+
+- Classes: `h-med`, `h-small` (only with `text-align: center|right`), `p-large`, `p-small` (standalone OK). For **left-aligned headings use markdown `#`/`##` + a `<span>`** for color.
+- Markdown (`**bold**`, `*italic*`) works inside spans; `font-family` spans work (observed `font-family: Inter`).
+- Colors in spans must be **hex** via the API (`var(--colors-*)` appears in UI-authored demo specs but the API rejects it).
+- Text elements take a top-level `verticalAlign: middle` ✓ (sibling of `body`, not in `style`).
+
+### Dynamic text — `{{…}}` formula templating ✓
+
+Text bodies interpolate live formulas, including cross-element aggregates — verified:
+
+```yaml
+body: '<p class="p-small"><span style="color: #E2E8F0">**{{Sum([Clones/Clones])}}** clones · **{{CountDistinct([Clones/Repo Name])}}** repos</span></p>'
+```
+
+- The server normalizes markdown that crosses `{{…}}` boundaries into per-segment spans (harmless).
+- `Text()` is **single-argument** — `Text(Sum(...), "#,##0")` renders as `Invalid Query: Text expected 1 argument` *in the rendered text only*: the spec POSTs fine and the SQL compile check passes, so **only a visual render catches templating errors**.
+- Demo orgs also use `{{CallText("ai_query", …)}}` for AI narrative summaries and template image `url` fields (`url: '{{[Stores/Store Image Url]}}'`) — not yet round-tripped here.
+
+### Cards and chips ✓
+
+- `borderRadius` has a third value: **`pill`** ✓ (heavily used — softer than `round`).
+- **Tinted chip cards** ✓: pastel fill + same-hue border, verified set — blue `#f0f7ff`/`#bad9f8`, cyan `#e6f6fa`/`#a5dded`, green `#e4f7ec`/`#a4dfc0`, purple `#f0ebfa`/`#cfc0ee`. Soft neutrals `#FBFBFB`/`#FAFBFC` with `#e6e6e6` borders are the default card surface (not pure white).
+- `style.borderColor` accepts **theme refs** in demo specs: `borderColor: {kind: theme, ref: colors-border}` — not yet round-tripped via API (hex always works).
+- `padding: none` ✓ for dense, app-like layouts.
+- `backgroundColor: "auto"` lets a container adapt to the theme.
+
+### KPIs — style them directly, no wrapper needed ✓
+
+`kpi-chart` takes its own `style` (so a KPI can be its own card), `value.fontSize`, `value.color`, and a `layout` block — all verified:
+
+```yaml
+style: { backgroundColor: "#f0f7ff", padding: none }      # match the chip tint so the KPI blends in
+value: { columnId: k1-v, fontSize: 28 }
+layout: { anchor: middle }            # also: verticalAnchor: start|middle, titleOrient: bottom, comparisonValueOrient: right
+```
+
+**KPI strip inside a dark hero** ✓ — the strongest "designed" move observed (KPIs live in the
+hero band, not below it): one dark container spans the full band; the title text, accent-colored
+labels, and the KPIs all lay out inside its `GridContainer`; each KPI pops with
+`value: {columnId: …, fontSize: 32, color: "#FFFFFF"}`. Use light accent tints for the labels on
+dark (`#93C5FD` blue, `#67E8F9` cyan, `#6EE7B7` green, `#C4B5FD` purple).
+
+Make the KPI background **transparent** with 8-digit alpha hex —
+`style: {backgroundColor: "#00000000", padding: none}` ✓ — so the numbers sit directly on the
+band. Matching the band's solid color instead breaks the moment the band is a gradient: each KPI
+renders as an opaque panel hugging its numeral, which reads as "cut off" at real viewport widths.
+Alpha hex `#rrggbbaa` is accepted and rendered (the OpenAPI only documents `#rrggbb`).
+
+### Single-color chart marks ✓
+
+The top-level `color` channel on bar/line/area charts takes a discriminated object — `by: single`
+for one hue, `by: category` for the positional `scheme` (Recipe 5):
+
+```yaml
+color: { by: single, value: "#3B82F6" }     # ✓ one hue for all marks
+color: "#3B82F6"                            # ✗ 400 "Invalid value: string"
+color: { value: "#3B82F6" }                 # ✗ 400 "Invalid value: object" (missing by)
+```
+
+`name` can also be an object `{text: "Revenue for {{[Store/Name]}}", fontSize: 16}` (templated titles — observed, not yet round-tripped).
+41 of 109 demo KPIs carry a `comparison`, 21 a `trend` sparkline — but per `kpis.md`
+the comparison/trend *column binding* is UI-only; the spec styles what the UI bound.
+For spec-only PoP figures use the formula-column recipe in `kpis.md`.
+
+### Gradient hero bands — hosted image only
+
+Neil-style gradient banners are NOT directly authorable:
+
+- `style.backgroundColor` with a CSS `linear-gradient(...)` string is **accepted by POST/PUT but
+  silently dropped** — the container renders with *no* background at all (worse than a 400; only
+  a render catches it). Hex only.
+- Container `backgroundImage` is `{url}` only — the schema says "**must be an external URL
+  (uploads are not supported)**", and data-URIs are additionally WAF-blocked (below).
+- ✓ The working recipe (live-verified): generate a small gradient PNG (256×64 is plenty — it
+  stretches), host it at any https URL, and set `backgroundImage: {url: "https://…/gradient.png"}`
+  on the hero container, keeping a solid `style.backgroundColor` as the load/fallback color.
+  `url` supports `{{formula}}` templating for data-driven backgrounds. A pure-Ruby/zlib PNG
+  encoder is ~20 lines if no image tooling is available; GitHub Pages works as the host (mind
+  build pipelines — a Vite/Actions site only ships what its build emits, so static assets go in
+  `public/`, not the repo root).
+
+### Icons — inline SVG data-URIs ✗ (WAF-blocked via API)
+
+Demo workbooks are full of `image` elements with base64 [Lucide](https://lucide.dev) SVG data-URIs
+(`url: "data:image/svg+xml;base64,…"`) — those specs were authored in the UI. **Pushing the same
+shape through the public API gets the request 403'd by Cloudflare's WAF** (an HTML "Just a moment…"
+challenge page, not a Sigma error — the base64-SVG payload trips an XSS signature). Workarounds:
+host icons at an https URL, or skip icons (tinted chips + typography carry the design). Data-driven
+`url: '{{[El/Image Url]}}'` templating and circular photos
+(`style: {fit: cover, borderRadius: pill, borderColor: "#ffffff", borderWidth: 3}`) are unaffected shapes.
+
+### Composition principles for a "sleek" page ✓
+
+Options, not a template — these are the moves that fixed a page that read as two
+disconnected halves (a dark hero floating over a sparse light body):
+
+- **Compact the hero band.** Size the container to its content: if the inner grid ends at
+  row N, end the band at N+1. Dead dark rows under the KPI values are the #1 "looks off" signal.
+- **Quiet section labels.** Between a strong hero and the content, a small uppercase
+  `<p class="p-small"><span style="color: #64748B">**LABEL**</span></p>` reads sleeker than a big
+  `##` heading — the heading competes with the hero, the label connects to it.
+- **Carry one accent system through the page.** Whatever colors the KPI labels use, repeat them
+  in the charts below (`color: {by: single, value: …}`) in the same order. The eye links each
+  trend to its KPI.
+- **Prefer single-series trend charts.** Multi-measure lines get default series colors you cannot
+  set via spec (no per-series scheme); one measure per chart, hue-matched, is cleaner and authorable.
+- **Balance density top vs bottom.** A 4-KPI strip over 2 charts reads bottom-light; match the
+  rhythm (4-over-3 or 3-over-3) or add a detail row.
+
+### Interaction patterns
+
+- **Segmented control as date-grain switcher** — the single most common interactive idiom:
+
+```yaml
+kind: control
+controlType: segmented
+controlId: cDateGrain
+source: { kind: manual, valueType: text, values: [Quarter, Month, Week, Day], labels: [Quarter, Month, Week, Day] }
+value: Week
+```
+
+- **Launcher/landing pages**: a Homepage of nav cards (container + `**BOLD TITLE**` text + one-line description per card) makes a workbook feel like an app. Pair with `visibility: hidden` data pages.
+
+---
+
+## Things that are NOT designable via spec (as of 2026-05-29)
+
+Don't waste a round-trip trying to set these — the spec API silently drops them.
+
+- **Chart tooltip customization** (spec-findings #10)
+- **Trellis / small-multiples layout** (spec-findings #11)
+- **Donut / pie slice colors** (spec-findings #22)
+- **KPI title color or "hide title" toggle** — `name` always renders as a black title
+- **Element title font size / font family** — the `name` field has no `style` sibling. (Text *elements* CAN set fonts via `<span style="font-family: …">` — see field-observed idioms above; it's only the title `name` that can't.)
+- **Workbook-level palette / theme** via spec (open question in spec-findings)
+- **Chart `tooltip` / `trellis*` fields** (UI-only)
+
+If a customer needs slice color branding on donut/pie, set the workbook theme in the UI after the spec is posted.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/tables.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/tables.md
@@ -1,0 +1,228 @@
+# Tables
+
+Recipe book for `table`, `pivot-table`, and `input-table` elements + style and trap guidance. The full schemas live in the OpenAPI — fetch any element kind by its `kind` value:
+
+```bash
+jq --arg k pivot-table 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
+```
+
+Swap `pivot-table` for `table` or `input-table` to inspect the others.
+
+The `table` element is the most common element kind and the primary way data enters a workbook — charts, KPIs, and other elements usually point their `source` at a table.
+
+## Basic shape
+
+```yaml
+id: sales-table
+kind: table
+name: Sales Data
+source:
+  kind: warehouse-table
+  connectionId: <conn-uuid>
+  path: [DATABASE, SCHEMA, TABLE]
+columns:
+  - id: col-1
+    name: Column Name
+    formula: "[TABLE/column_name]"
+  - id: col-2
+    name: Total
+    formula: Sum([Column Name])
+order: [col-1, col-2]
+```
+
+See `sources.md` for all source kinds and `formulas.md` for the column-reference rules. Every column needs `id`, `name`, `formula`; optional `format` (see `formatting.md`).
+
+For the `table` kind, `name` is a plain string. The styled title-section object (with `text`, styling, and `noDataText`) applies to `pivot-table` and `input-table` — see those sections below.
+
+## Common optional fields
+
+### `order`
+
+Array of column IDs controlling left-to-right display order. Defaults to declaration order.
+
+### `groupings`
+
+Pivot / aggregation views without changing element kind:
+
+```yaml
+groupings:
+  - id: by-region
+    groupBy: [col-region]
+    calculations: [col-total, col-profit]   # MUST be aggregate columns (Sum/Count/…)
+    sort: [{ columnId: col-total, direction: descending }]   # optional
+```
+
+> **A `table` with no `groupings` shows raw DETAIL rows.** This is the #1 migration bug for aggregated source vizzes: a Tableau worksheet with a dimension on Rows + `SUM(...)` is an *aggregated* query, so its Sigma `table` MUST carry a `groupings` entry. Without it the table renders every warehouse row (e.g. "9,676,896 rows"), the dimension repeats, and `Sum(If(...))` columns read `$0` per row. If a "summary" table renders the base row count, it's missing `groupings`. (Charts don't need this — they aggregate by their axis/`value` binding; only `table` does.)
+>
+> **`calculations` columns must be AGGREGATE expressions** (`Sum([Amt])`, `CountDistinct([Id])`, …). A conditional aggregate is a **row-level** column `If(cond, [val], 0)` wrapped in `Sum(...)` at the grouping — i.e. `Sum([Cur Amt])` where `Cur Amt = If(flag = "Cur", [Tcv], 0)`. Do **not** put a *passthrough of an already-aggregated* column in `calculations`; it re-aggregates to **"multiple values"** in every group cell. (Verified 2026-06-15.)
+>
+> **Multiple `groupings` on one element NEST hierarchically** (array order = levels: `[by-region, by-flag]` ⇒ region→flag, not two independent rollups). For two *independent* group-bys (e.g. one table by Region and another by Flag) give each its **own source element**, or let a chart aggregate the second one by axis. (Verified 2026-06-15.)
+>
+> **Exclude a NULL/unwanted bucket** with an element list filter on the dimension — this is how a Tableau view filter maps: `filters: [{ id: f, columnId: col-flag, kind: list, mode: include, values: ["Cur FYTD", "Prior FYTD"] }]`. (A grouped bar that includes the NULL bucket is the classic "giant first bar" artifact.)
+
+### `filters` (top-N, element-level row filters)
+
+```yaml
+filters:
+  - id: top-20
+    columnId: col-revenue
+    kind: top-n
+    rankingFunction: rank
+    mode: top-n
+    rowCount: 20
+    includeNulls: when-no-value-is-selected
+```
+
+> **`rowCount` takes a number literal only** — it cannot be parametrized by a control. `rowCount: "[TopN]"` is rejected. Control bindings apply to filter **values**, not to structural fields like `rowCount`, `rankingFunction`, `mode`, or `kind`. To vary the cap interactively, duplicate the element per cap.
+
+### `conditionalFormats` — cell coloring, gradients, and **data bars**
+
+`conditionalFormats` works on `kind: table` (verified live 2026-06-24 — POST accepted, round-trips, and renders), not just `pivot-table` / `input-table`. The most-requested variant is **`dataBars`** — in-cell horizontal bars scaled to the column's value — which migrations frequently *drop* even though it's fully spec-authorable:
+
+```yaml
+conditionalFormats:
+  - type: dataBars
+    columnIds: [t-rev]                 # one or more aggregate/calculation columns
+    scheme: ["#a4dfc0", "#4caf7d"]     # 2+ hex stops (low→high gradient); optional
+    # optional: domain (value range), order, valueLabels
+```
+
+Place it at the element level (sibling of `columns` / `groupings`), targeting the grouping's calculation column(s) by id. Other variants (`single` threshold rules, `backgroundScale`, `fontScale`) are below. Pull the full per-type field set with the `conditionalFormats` property via the `kind`-form recipe at the top.
+
+> **Round-trip caveat:** data bars **authored via spec** persist on `GET`. Data bars **added in the Sigma editor** may *not* appear in `GET /spec` (observed on a converted workbook) — so don't infer "the source had no data bars" from a readback. When migrating, author them explicitly.
+
+### `tableStyle` — presentation preset, spacing, grid lines, banding
+
+`tableStyle` is an element-level object on `table` / `pivot-table`. The default is the dense **spreadsheet** grid; `preset: presentation` switches to the roomier, lighter "presentation" look (taller rows, softer borders) that source BI tools often use for dashboard tables. **Spec-authorable, round-trips, and renders** (verified live 2026-06-24) — but, like data bars, an editor-set value may be absent from `GET /spec`, so author it explicitly when migrating.
+
+```yaml
+kind: table
+tableStyle:
+  preset: presentation          # 'spreadsheet' (default) | 'presentation'
+  cellSpacing: medium           # extra-small | small | medium | large
+  gridLines: horizontal         # none | vertical | horizontal | all
+  banding: shown                # row banding: shown | hidden
+  # also: bandingColor, outerBorder, headerDividerColor, autofitColumns,
+  #       heavyVerticalDividers / heavyHorizontalDividers (pivot only), textStyles
+```
+
+All fields are optional; omit `preset` for the spreadsheet default. Pull the full enum set via the `kind`-form recipe at the top.
+
+---
+
+# Pivot tables
+
+The `pivot-table` element is a sibling of `table` for cross-tab analysis — measure cells aggregated across one or more row/column dimensions.
+
+## Shape
+
+```yaml
+id: deployments-pivot
+kind: pivot-table
+name: Deployments by cloud and env
+source:
+  kind: table
+  elementId: deployments-source
+columns:
+  - id: piv-cloud
+    name: Cloud
+    formula: "[Deployments/Cloud]"
+  - id: piv-env
+    name: Environment
+    formula: "[Deployments/Environment]"
+  - id: piv-count
+    name: Deployments
+    formula: CountDistinct([Deployments/Deployment UUID])
+    format:
+      kind: number
+      formatString: ",.0f"
+values: [piv-count]
+rowsBy:
+  - id: piv-cloud
+columnsBy:
+  - id: piv-env
+    sort:
+      direction: descending
+```
+
+`values` (required) is the measure column array — the cells of the pivot. `rowsBy` and `columnsBy` place dimension columns explicitly on the row and column shelves; each item is `{ id, sort? }`, where `sort` is `{ direction: ascending | descending, by?, aggregation? }` (`by` can be a column ID or `"row-count"`). Columns not listed on either shelf still render as available dimensions.
+
+## `conditionalFormats` — threshold coloring on cells
+
+Available on `table`, `pivot-table`, and `input-table` (the `table` support is verified live — see the table `conditionalFormats` note above). Apply background/text styling per cell based on column values. Variants include `single`, `backgroundScale`, `fontScale`, and `dataBars` — covering threshold rules, gradient scales, font-color scales, and inline data bars. Inspect the OpenAPI for the full operator + style enums (use the `conditionalFormats` property on the element schema).
+
+**Recipe — red/green threshold coloring on a revenue column:**
+
+```yaml
+conditionalFormats:
+  - type: single
+    columnIds: [col-revenue]
+    condition: ">"
+    value: 1000
+    style:
+      backgroundColor: "#22c55e"
+  - type: single
+    columnIds: [col-revenue]
+    condition: "<"
+    value: 100
+    style:
+      backgroundColor: "#ef4444"
+```
+
+Condition operators include `=`, `!=`, `>`, `>=`, `<`, `<=`, `IsNull`, `IsNotNull`, `Contains`, `NotContains`, `StartsWith`, `EndsWith`, `Between`, `NotBetween`, and `formula` (arbitrary boolean). Style block supports `backgroundColor`, `color`, `bold`, `italic`, `underline`, and column-level `format` override.
+
+---
+
+# Input tables
+
+The `input-table` element is an editable table — users type values directly into cells, backed by a provisioned warehouse table. Required fields: `id`, `kind`, `source`, `inputMode`.
+
+`inputMode` controls who can edit and where:
+
+- `edit` — workbook editors only, in draft mode
+- `explore` — users with explore permission or greater, in published view
+- `view` — all users, in published view
+
+`source` is one of:
+
+- `{ kind: empty, connectionId: <YOUR_CONNECTION_ID> }` — provisions a fresh, blank warehouse table.
+- `{ kind: linked, from: <elementId> }` — rows are linked to another element; the connection is inherited, and editable rows are matched to source rows by the `key` columns.
+
+`columns[]` items come in four shapes (each also accepts optional `name`, `description`, `hidden`, `format`):
+
+- **System column** — `{ id }` where `id` ∈ `ID`, `CREATED_AT`, `CREATED_BY`, `UPDATED_AT`, `UPDATED_BY`. Protocol-managed; type is fixed.
+- **Key column** — `{ id, key }` binding to a source column on `source.from` (linked tables; `key` is immutable once created).
+- **Editable data column** — `{ id, type }` where `type` ∈ `text`, `number`, `datetime`, `checkbox`, `multi-select`, `file`.
+- **Formula column** — `{ id, formula }` for a computed column.
+
+**Column validation (2026-06-18 release; all verified round-tripping):**
+
+- **Single-select dropdown** — a scalar column + a fixed option list: `{ id, type: text, values: ["A", "B", "C"] }` (also `number`/`datetime`). There is **no** `single-select` type token — the `values` list is what makes it a dropdown.
+- **Multi-select** — `{ id, type: multi-select, values: [...] }`. **Variant-backed** — needs a variant-capable warehouse (e.g. Snowflake).
+- **Range bounds** — `{ id, type: number, range: { min, max } }` (also `datetime`, which normalizes to `…T00:00:00Z`).
+- **Options from a sibling element** — `{ id, type: text, valuesFrom: { element: <elementId>, column: <columnId> } }` (single- or multi-select). Keys are `element`/`column`, **not** `elementId`/`columnId`.
+- **Pills** — render a select column as pills: `{ ..., pills: single-color }` or `{ ..., pills: color-by-option }` (enum string).
+- **File upload** — `{ id, type: file, maxFileNum: 3, maxFileSizeMb: 10, acceptedFileTypes: ["image/png", "application/pdf"] }`. **Variant-backed.**
+- **One validation slot:** `values` / `valuesFrom` / `range` are mutually exclusive on a column — combining them is a 400.
+
+```yaml
+id: feedback-input
+kind: input-table
+name: Manual feedback
+inputMode: edit
+source:
+  kind: empty
+  connectionId: <YOUR_CONNECTION_ID>
+columns:
+  - id: ID
+  - id: customer
+    type: text
+  - id: score
+    type: number
+  - id: flagged
+    type: checkbox
+  - id: score-bucket
+    formula: If([score] >= 8, "Promoter", "Other")
+```
+
+`input-table` also supports `filters`, `conditionalFormats` (see above), `sort`, `summary`, and the styled title-section `name`/`noDataText`. Fetch the full schema with the `kind`-form recipe at the top of this doc.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/composition.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/composition.md
@@ -1,0 +1,48 @@
+# Composition: making the design choice
+
+A workbook spec that compiles cleanly and has correct data can still be unusable. Layout, element choice, label clarity, whether to add a comparison vs current state — these are design decisions, not API ones. **This skill has no opinions about what makes a good dashboard.** It asks you to ask.
+
+## Calibrate scope to the request
+
+Build the simplest workbook that fully answers the request. Let the ask set the complexity — not a template, and not a sense of what a dashboard "should" have. Both directions fail: a bare table dumped on a page when the user wanted a dashboard, and an unrequested multi-page layout with joins and a KPI row when the user asked for one number.
+
+A rough sizing ladder (starting points, not rules):
+
+- **A single thing** — "show total revenue", "a table of orders", "one KPI" → one element. Skip explicit layout XML; auto-arrange is fine for a single element or a uniform stack of tables.
+- **A focused view** — "revenue over time with a region filter" → a few elements plus a control; light layout.
+- **A dashboard** — "a sales dashboard", "an exec overview" → the fuller pattern is appropriate: a KPI row up top, one or two charts, a supporting table, controls, explicit layout XML, and the base/source table on a hidden page (see Defaults below). This is the tier where polish is the point.
+
+For concrete shapes at any tier, don't assemble from memory. Fetch a real workbook's spec (`GET /v2/workbooks/{id}/spec`, Steps 1–2) and read the relevant feature docs — a live spec shows current, valid, org-idiomatic structure, including the layout XML the OpenAPI doesn't model. Size up only when the request asks for it.
+
+## When to stop and ask the user
+
+Defer to the user any time the prompt admits more than one reasonable interpretation. Signals:
+
+- **Open-ended request.** "Build me a sales dashboard" leaves dozens of decisions unmade — audience, time scope, level of detail, what decision the dashboard should support.
+- **The data could be sliced multiple ways.** If revenue can be broken out by region OR product OR month OR channel and the prompt doesn't specify, pick the most-obvious one *and* surface that choice (see below) — but for a real ambiguity, just ask.
+- **Page-shape ambiguity.** Single page or multi-page? Executive summary vs. operator detail? Don't guess if the answer changes the entire workbook.
+- **You're about to make a structural decision the user can't easily revert.** Reordering elements is easy; deciding "this needs three pages" and threading sources across them is harder to undo.
+
+When you do ask, keep it specific. "What would you like the dashboard to look like?" is useless. Better:
+
+- *"Is this for an executive briefing or operator detail? Affects whether I use KPIs at top or a ranked detail table."*
+- *"Should this support a weekly meeting (current-state snapshot) or an investigation (drillable detail)?"*
+- *"What decision should the viewer be able to make after looking at this?"*
+
+## Surface your decisions in the final summary
+
+Agents quietly choose: how many KPIs, which chart kinds, multi-page vs single, what to group on, what to sort by. The user can't see those choices from the rendered workbook alone. Always include a one-paragraph summary at the end of the run listing the structural choices you made and inviting redirection.
+
+Example: *"Built a single-page dashboard with 4 KPIs across the top, a revenue-by-region bar chart, and a ranked store table sorted descending by revenue. Used Sales Amount over Net Orders for the headline metric. Tell me if you want any of these changed — different KPI mix, multi-page split, a different sort, etc."*
+
+## Defaults to fall back on when not asking
+
+These are *defaults, not rules.* The skill doesn't claim they're right for every dashboard; they're starting points when the user's preference isn't known and stopping to ask isn't appropriate.
+
+- **Source/base tables go on a hidden page.** When a workbook needs a base table (warehouse-table or join source) to feed charts, KPIs, and grouped views, that base table doesn't belong in the dashboard view. Put it on a separate page with `visibility: hidden` (see `reference/specification/schema.md`) and source dashboard elements from it via `elementId`. The base table stays available to the workbook without dropping a million-row dump on the viewer.
+- **Sort ranked tables by the metric the user is ranking on.** "Bottom 10 stores by revenue" implies ascending by revenue; "top products" implies descending. Sorting alphabetically by name is rarely what a meeting attendee wants.
+- **Don't expose intermediate joins as visible elements.** Same rationale as the base-table rule — they're plumbing, not deliverables.
+
+## Image-driven cases have their own composition guide
+
+When the user provides a target screenshot or mockup, the design space is much narrower — the goal is structural fidelity to the image. See `reference/workflows/from-image.md` for the observation-first workflow that applies in that case.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/crud.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/crud.md
@@ -1,0 +1,129 @@
+# Workbook Spec CRUD
+
+Recipe + traps for POST / GET / PUT against `/v2/workbooks/spec`. Load this when creating, retrieving, or updating a workbook.
+
+```bash
+jq '.paths."/v2/workbooks/spec".post, .paths."/v2/workbooks/{workbookId}/spec".get, .paths."/v2/workbooks/{workbookId}/spec".put' /tmp/sigma-api.json
+```
+
+The endpoints are straightforward; the spec value is in calling out the **non-obvious behaviors**: YAML is the default content type (this skill prefers it for human readability), PUT being full-replacement (anything you omit is dropped), and server-managed fields being ignored rather than rejected on write.
+
+Every call includes `-H "Authorization: Bearer $SIGMA_API_TOKEN"`. Auth comes from the `sigma-api` skill.
+
+## Endpoints
+
+```bash
+# CREATE — POST the spec, response includes workbookId.
+# YAML by default on both directions. `--data-binary` preserves the
+# multiline body byte-for-byte (`-d` strips newlines, breaking YAML).
+curl -s -X POST -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/workbook-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/spec"
+
+# GET — retrieve current spec (YAML by default)
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec"
+
+# UPDATE — PUT replaces the entire spec.
+curl -s -X PUT -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/workbook-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec"
+```
+
+If you'd rather work in JSON, swap `application/yaml` → `application/json` and `--data-binary @file.yaml` → `-d @file.json` on each call. Sigma accepts both. YAML is the recommended default for this skill because workbook specs are human-reviewable artifacts and YAML diffs cleanly in PRs.
+
+## Required Fields on CREATE
+
+The POST body must include:
+
+- `name` (string)
+- `folderId` (string — usually the user's `homeFolderId`)
+- `schemaVersion` (number — use the value returned by `GET /v2/workbooks/<reference-workbook-id>/spec`, do NOT hardcode it)
+- `pages` (array — at least one page with at least one element)
+
+Optional: `description`, `layout` (top-level layout XML).
+
+```yaml
+name: Sales Dashboard
+folderId: <homeFolderId>
+description: Sales overview dashboard
+schemaVersion: 1
+pages: [...]
+```
+
+The server rejects a spec whose `schemaVersion` doesn't match what the current API expects, hence the rule against hardcoding it — always read it back from a recent reference GET.
+
+The CREATE response shape (in YAML, the default):
+
+```yaml
+success: true
+workbookId: <uuid>
+```
+
+Extract `workbookId` with `yq -r '.workbookId' /tmp/create-response.yaml` (or `jq` if you switched to JSON content types).
+
+## Persisting the Spec
+
+After a successful CREATE, copy the spec to a workbook-keyed path so it survives the next build, the user can diff or re-POST it, and subsequent PUTs can start from it:
+
+```bash
+WORKBOOK_ID=$(yq -r '.workbookId' /tmp/create-response.yaml)
+cp /tmp/workbook-spec.yaml "/tmp/workbook-spec-${WORKBOOK_ID}.yaml"
+```
+
+After a successful PUT, refresh the saved copy from the file you just submitted so it tracks server state:
+
+```bash
+cp /tmp/current-spec.yaml "/tmp/workbook-spec-<workbook-id>.yaml"
+```
+
+Report **both** the workbook URL **and** the saved spec path.
+
+## UPDATE Is Full Replacement (No Diffs)
+
+The PUT endpoint replaces the entire spec — partial updates are not supported. Always:
+
+1. GET the current spec first.
+2. Edit the file on disk.
+3. PUT the **full** payload back.
+
+If you skip the GET and submit a partial spec, anything you didn't include is gone.
+
+## IDs Are Preserved on CREATE
+
+The `id` values you send in `POST /v2/workbooks/spec` — for pages, elements, and columns — are **preserved verbatim**. Layout `elementId` attributes, control bindings, and cross-element `source` references that name your IDs all stay valid after create. You can edit your saved spec and `PUT` it back directly; `GET` the current spec first only when you don't have your latest copy on hand.
+
+## Response-Only Fields to Strip
+
+`GET /v2/workbooks/<id>/spec` returns extra server-managed fields. When you take a GET response and PUT it back (the standard update flow), the server **ignores** them — you don't have to strip them, though it's cleaner to. See `reference/specification/schema.md` for the canonical list.
+
+## Iteration Pattern
+
+```bash
+# Get current spec (YAML by default)
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" \
+  > /tmp/current-spec.yaml
+
+# If you also want the HTTP status (e.g. for trace logging), keep streams
+# separate: write the body via -o, send the status to stdout via -w.
+# NEVER combine `-w "...%{http_code}..."` with `> body.yaml` — that mixes
+# status text into the body file and corrupts the YAML.
+curl -s -o /tmp/current-spec.yaml -w "%{http_code}\n" \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec"
+
+# Edit /tmp/current-spec.yaml on disk, then:
+curl -s -X PUT -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/yaml" \
+  -H "Accept: application/yaml" \
+  --data-binary @/tmp/current-spec.yaml \
+  "$SIGMA_BASE_URL/v2/workbooks/<workbook-id>/spec" | yq .
+
+# Refresh the saved copy so the next edit starts from the latest spec
+cp /tmp/current-spec.yaml "/tmp/workbook-spec-<workbook-id>.yaml"
+```

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/discover.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/discover.md
@@ -1,0 +1,127 @@
+# Source Discovery
+
+Recipe for finding connections, tables, and column names — *and probing actual column values before writing predicates against them*.
+
+```bash
+jq '.paths."/v2/connections", .paths."/v2/connection/{connectionId}/lookup", .paths."/v2/connections/tables/{tableId}/columns"' /tmp/sigma-api.json
+```
+
+Assumes `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN` are set in the shell. Use the `sigma-api` skill's `scripts/get-token.sh` to populate `$SIGMA_API_TOKEN` — see SKILL.md for details.
+
+## Verify values before writing predicates
+
+If your task involves a predicate that filters on a categorical column — `CountIf([Transaction Type] = "sale")`, `If([Status] = "active", ...)`, `If([Tier] = "Gold", ...)` — you need to verify the actual distinct values *before* writing the formula. Guessing literals leads to predicates that match zero rows, dashboards that render all zeros, and `verify-workbook.sh` reporting success because the SQL compiled fine.
+
+A column named `TRANSACTION_TYPE` rarely contains exactly `"sale"` and `"return"` — it might be `"Purchase"` and `"Return"`, or `1`/`0`, or something else entirely. A single `SELECT DISTINCT` resolves the question. Verify by whatever means you have at hand:
+
+- An MCP server connected to the warehouse (Snowflake, BigQuery, Databricks, Sigma, etc.) — call its query tool with `SELECT DISTINCT "<col>" FROM <table>` and read the values back.
+- A SQL CLI or warehouse client the user can run — paste the results into the conversation.
+- Just ask the user. *"Before I write the formula, what values does the `Transaction Type` column contain?"* costs nothing and often saves a broken dashboard.
+
+The principle is verification, not any specific tool. Pick the cheapest path your environment supports.
+
+**Raw warehouse column names work directly in Sigma spec formulas.** `[F_SALES/TRANSACTION_TYPE]` is accepted by the spec API and compiles to the same column reference as `[F_SALES/Transaction Type]`. Use whatever form your verification source returns — no transformation step required.
+
+### If you're using the Sigma MCP server
+
+The Sigma MCP server adds workspace-level discovery on top of plain value probing: `search` across workbooks / data models / tables by topic, `describe` of existing Sigma elements, awareness of pre-built metrics on data models. See [Use the Sigma MCP server](https://help.sigmacomputing.com/docs/use-sigma-mcp-server) for setup.
+
+One footgun specific to the Sigma MCP's `query` tool: the SQL `FROM` clause uses a fixed identifier pattern based on `query.type`:
+
+| `query.type` | FROM clause shape |
+|---|---|
+| `"connection"` | `FROM "connection"."<inodeId>"` |
+| `"datamodel"` | `FROM "datamodel"."<elementId>"` |
+| `"workbook"` | `FROM "workbook"."<elementId>"` |
+
+The first identifier is a **literal string** — `"connection"`, `"datamodel"`, or `"workbook"` — not the human-readable connection name. Don't write `FROM "Sigma Sample Database"."<inode>"`; the server rejects it. The DDL that `describe` returns shows the correct shape verbatim.
+
+## Warehouse Table Sources
+
+For elements with `source.kind: "warehouse-table"`, you need three things:
+1. **connectionId** — the UUID of the warehouse connection
+2. **path** — the fully-qualified path as an array (e.g., `["DATABASE", "SCHEMA", "TABLE"]`)
+3. **Column names** — exact names from the warehouse, used in formulas
+
+**Prefer a pre-existing MCP tool when you have one.** If an MCP is connected, discover through it: the **Sigma MCP** (`search` / `describe` across connections, tables, and data models) or a **warehouse-native MCP** (Snowflake, BigQuery, Databricks, …) querying `INFORMATION_SCHEMA`. The REST endpoints below are the universal fallback when no MCP is available — they cover all three and need no extra setup.
+
+### Step 1: Find the Connection
+
+List available connections:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/connections"
+```
+
+This returns connections with their `connectionId`, `name`, and `type`.
+
+### Step 2: Resolve the Table Path and Capture the `inodeId`
+
+Ask the user for the fully-qualified table path, **or browse the connection tree yourself** (below). Path depth varies by database:
+
+- **Snowflake**: `["DATABASE", "SCHEMA", "TABLE"]`
+- **BigQuery**: `["PROJECT", "DATASET", "TABLE"]`
+- **Databricks**: `["CATALOG", "SCHEMA", "TABLE"]`
+- **Redshift**: `["SCHEMA", "TABLE"]`
+- **PostgreSQL / MySQL**: `["SCHEMA", "TABLE"]`
+
+**Browse instead of guessing.** If an MCP is connected, browse through it first — the **Sigma MCP** (`search`) or a **warehouse-native MCP** (Snowflake, BigQuery, …) is the easiest way to find a table. As a no-MCP fallback, `GET /v2/connections/paths` lists every database / schema / table across the org's connections. Each entry is `{ connectionId, path, urlId }` — the endpoint takes only `page`/`limit` (no connection filter), so filter by `connectionId` client-side:
+
+```bash
+curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/connections/paths?limit=1000" \
+  | jq -r --arg c "<connection-id>" \
+      '.entries[] | select(.connectionId == $c) | select(.path | length == 3) | .path | join(".")'
+```
+
+(Adjust the `length` filter to your path depth — `3` for Snowflake/BigQuery/Databricks, `2` for Redshift/Postgres/MySQL. Paginate via `page`/`limit` on large connections. The response carries no `inodeId` — capture that from `lookup` next.)
+
+Verify the path resolves and capture the `inodeId` — Step 3 needs it:
+
+```bash
+INODE_ID=$(curl -sf -X POST -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"path": ["SALES_DB", "PUBLIC", "ORDERS"]}' \
+  "$SIGMA_BASE_URL/v2/connection/<connection-id>/lookup" \
+  | jq -r '.inodeId')
+```
+
+Use the verified path in the source definition.
+
+### Step 3: Discover Column Names via the API
+
+Use the `inodeId` from Step 2 to list the table's columns directly — no need to ask the user or have them query the warehouse:
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/connections/tables/$INODE_ID/columns" \
+  | jq '.entries[] | {name, type}'
+```
+
+Each entry has `name`, `type`, `description`, and `visibility`. Use the `name` value verbatim in formulas — do not invent or transform it.
+
+Public docs: <https://help.sigmacomputing.com/reference/listconnectiontablecolumns>.
+
+If the call fails (rare — connector quirks, permissions), fall back to asking the user for column names or having them run `DESCRIBE TABLE` / `INFORMATION_SCHEMA.COLUMNS` against the warehouse.
+
+For a warehouse-table source with path `["SALES_DB", "PUBLIC", "ORDERS"]`, the formula for a column is `[ORDERS/order_id]` (last path segment + column name).
+
+## Data Model Sources
+
+For elements with `source.kind: "data-model"`, you need:
+- **dataModelId** — the UUID of the data model
+- **elementId** — the UUID of the specific element within the data model
+
+Ask the user to supply the `dataModelId` (visible in the Sigma UI URL when viewing a data model). To find elements within the data model, fetch the data model spec and examine the `pages[].elements[]` array.
+
+## Cross-Element Sources
+
+For elements sourced from another element in the same workbook:
+
+```yaml
+kind: table
+elementId: other-element-id
+```
+
+Use the `id` of the source element. Column references use the source element's `name` field: `[Source Element Name/column_name]`.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/element-rep.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/element-rep.md
@@ -1,0 +1,128 @@
+# Element-Level Workbook Rep (`scripts/wb-rep.rb`)
+
+The Sigma spec API is whole-workbook only: GET and PUT move the entire spec. On a
+5-page, 40-element workbook that means every small edit drags the full document
+through your context, and parallel work on two elements is a merge hazard. The
+**rep** fixes this by making the *element* the unit of work: the spec is exploded
+into a directory of small YAML files, edited with ordinary file tools, and
+reassembled on push.
+
+Load this file when: a workbook has grown past ~1 page / ~10 elements, multiple
+elements need editing in one session, you want to parallelize element work across
+sub-agents, or the user wants workbook changes reviewable as diffs.
+
+## Layout
+
+```
+<rep>/
+  workbook.yaml              top-level fields (name, folderId, schemaVersion, description)
+  pages/
+    010-overview/            numeric prefix = page order (×10 so you can insert between)
+      _page.yaml             page id / name / visibility — everything except elements
+      _layout.xml            this page's <Page> block of the layout XML (omit = auto-arrange)
+      010-revenue-kpi.yaml   one element per file; prefix = element order, rest is a slug
+      020-sales-by-region.yaml
+  renders/                   PNGs written by `render`
+  .sigma/                    plumbing — never hand-edit
+    manifest.yaml            workbookId, url, pulledAt/pushedAt
+    snapshot.yaml            the full spec as last synced with the server
+    layout-preamble.xml      XML prolog preserved for byte-exact reassembly
+```
+
+Nothing is a new format: every file is a verbatim slice of the spec, so all the
+per-element reference files in this skill (charts.md, kpis.md, tables.md, …)
+apply unchanged to a single element file.
+
+## Commands
+
+All commands need `SIGMA_BASE_URL` / `SIGMA_API_TOKEN` (sigma-api skill) except
+`status` and `assemble`, which are offline.
+
+```bash
+# Tip: with admin credentials, GET /v2/workbooks?skipPermissionCheck=true lists workbooks
+# beyond your grants (same flag as /v2/dataModels) — useful for finding a workbook id to pull.
+scripts/wb-rep.rb summarize <id|dir>           # zoom level 0: pages, element kinds, sources — no spec in context
+scripts/wb-rep.rb pull <workbook-id> <dir>     # GET + explode (refuses to clobber local edits; --force to discard)
+scripts/wb-rep.rb status <dir>                 # element-level diff: files vs last-synced snapshot
+scripts/wb-rep.rb push <dir>                   # reassemble → remote-drift check → validate-spec.sh → PUT → readback
+scripts/wb-rep.rb render <dir>                 # export every page as PNG into <dir>/renders/ — then LOOK at them
+scripts/wb-rep.rb render <dir> --page Overview # one page (id, name, or slug); --element <id> for one element
+scripts/wb-rep.rb import <spec.yaml> <dir>     # explode a local spec; push will POST a new workbook (create mode)
+scripts/wb-rep.rb assemble <dir> -o out.yaml   # reassembled spec without pushing (debugging)
+scripts/wb-rep.rb capabilities                 # every authorable kind, distilled live from the OpenAPI
+scripts/wb-rep.rb capabilities --kind bar-chart [--field color]   # fields of a kind / schema of one field
+```
+
+The read side is a zoom: `summarize` (whole workbook, one screen) → `ls pages/<page>/`
+(one page, file listing) → `Read <element>.yaml` (one element, full detail) →
+`capabilities --kind <kind> [--field <f>]` (what's authorable there). No step loads the
+whole spec into context.
+
+Safety built into `push`:
+
+1. **Drift check** — if the server spec changed since your pull (someone edited in
+   the UI), push aborts and shows exactly what you'd overwrite. Re-pull and
+   re-apply, or `--force`.
+2. **Diff preview** — prints the added/removed/changed elements it is about to push.
+3. **Validation** — runs `validate-spec.sh` on the assembled spec; aborts on issues
+   (`--no-validate` to override a false positive).
+4. **Layout lint** — warns about elements not referenced in their page's `_layout.xml`.
+5. **Readback** — refreshes the snapshot from the server and reports any fields the
+   server normalized.
+
+`push` is still a full-spec PUT under the hood (the API has no element PATCH), but
+you never see that: the rep gives you element-level GET/POST/PATCH semantics at
+the file layer.
+
+## The build loop: Plan → Build → See
+
+**Plan.** Decide pages and elements first (use `workflows/composition.md`). Express
+the plan as the file tree itself: create page dirs and *stub* element files (id,
+kind, name, source — no styling). The tree is the plan document.
+
+**Build — fan out sub-agents, one per element file.** Element files are
+independent, so parallel sub-agents cannot conflict: give each agent one file
+path, the relevant reference file (e.g. `charts.md` for a bar chart), the source
+element/column list it may reference, and the formula rules. No agent ever needs
+the whole workbook in context. The orchestrator keeps only the plan and the
+shared facts (source names, column lists, palette).
+
+Things that span elements stay with the orchestrator: `_layout.xml`, control
+targets, cross-element `[Element Name/Column]` refs, and the id namespace
+(hand out unique element/column ids in the plan so agents never collide).
+
+**Push, verify, see.**
+
+```bash
+scripts/wb-rep.rb push <dir>
+scripts/verify-workbook.sh <workbook-id>    # compile check — formulas resolve?
+scripts/wb-rep.rb render <dir>              # then Read the PNGs
+```
+
+Look at every render. Compare against the plan (or the user's target image —
+see `workflows/from-image.md`): wrong chart type, unreadable axis, dead space,
+truncated labels, default-blue-everything. Fix the specific element files and
+repeat. Stop when a render passes inspection, not when the API returns 200 —
+a clean POST proves the spec parsed, only the pixels prove the dashboard is good.
+
+## Editing rules
+
+- **Order = filename prefix.** Reorder elements/pages by renaming. New element
+  between `010-` and `020-` → name it `015-`. Slugs after the prefix are cosmetic.
+- **Add an element** = add a file (unique `id` inside) + reference it in
+  `_layout.xml`. **Delete** = delete the file + its layout reference.
+- **IDs are stable.** The server preserves element/column ids on PUT and CREATE,
+  so file identity survives round-trips. Never reuse a deleted element's id.
+- Cross-element formula refs use the *element name*: renaming an element breaks
+  `[Old Name/Column]` refs in other files — grep the rep before renaming.
+- `_layout.xml` holds exactly one `<Page …>…</Page>` block whose `id` matches
+  `_page.yaml`. A page with no `_layout.xml` auto-arranges (fine for single-element
+  pages only — see `specification/layout.md`).
+- `.sigma/` is plumbing. To resync files from the server: `pull <id> <dir> --force`.
+
+## Git
+
+A rep directory is designed to be committed: one element per file means PRs show
+"changed: revenue-kpi.yaml" instead of a 2,000-line spec diff. Commit the rep
+including `.sigma/snapshot.yaml` (it's the merge base); add `renders/` to
+`.gitignore` if PNG churn is unwanted.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/from-image.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/from-image.md
@@ -1,0 +1,99 @@
+# Building from a target image
+
+Use this workflow when the user has provided a screenshot, mockup, or PDF of a dashboard they want reproduced in Sigma — including migrations from Tableau, Looker, PowerBI, or any other BI tool.
+
+The general spec workflow ([the rest of SKILL.md](../../SKILL.md)) still applies. This document covers **only the additional steps** that come *before* and *alongside* normal data discovery and spec drafting.
+
+## Why this workflow exists
+
+When the user supplies an image, the agent's first job isn't to call the API — it's to *interpret*. A workbook spec is a precise object; an image is not. Going straight from "I see a picture" to "POST this YAML" almost always produces a workbook that has the right vibe but wrong shape, wrong axes, or wrong groupings — because the agent never committed to an interpretation explicit enough to debug.
+
+The workflow below makes the interpretation step explicit and auditable.
+
+## Workflow
+
+### Step 0a — Read the target image first
+
+Before any API calls, before any data discovery, **read the image with the Read tool**. Don't read it as a confirmation step at the end; read it as the first thing you do.
+
+If the user provided a target image, treat the workbook-creation task as a two-input problem: the prose request *and* the image. The image usually carries more information than the prose, but ambiguities in the image are why the prose is also there.
+
+### Step 0b — Describe what you see, in Sigma terms
+
+After reading the image, **write out an inventory** of what you saw. Do this as part of your reply / planning, before drafting any spec. The inventory has three sections:
+
+1. **Element count and kinds.** For each visible element, name the Sigma `kind` it most closely maps to (`kpi-chart`, `bar-chart`, `line-chart`, `donut-chart`, `table`, `text`, `image`, `geography-map`, etc.). If you're not sure, describe the visual marks (bars of equal width? a line? a sector?) and state your best guess.
+2. **Per-element details.** For each element: what's on the x-axis, y-axis, color/series channel? Is it grouped or stacked? Are there filters or controls visible?
+3. **Layout.** Grid density (how many elements per row, how many rows), any container groupings (logos / headers / sections), any visible whitespace.
+
+The goal is to produce an explicit, debuggable interpretation. If you build a workbook and the visual judge says "this looks different," you can point at the inventory and see exactly where you went wrong.
+
+### Step 0c — Validate the interpretation
+
+Before drafting, read your own inventory and check it against the image again. Two questions:
+
+- **Are there elements you didn't list?** Look at the corners and edges; small KPIs and titles get missed.
+- **Is anything ambiguous?** "I see a bar chart with bars of different colors — that could be `color.by: category` on a single grouping, or it could be a stacked bar with one stack." When in doubt, prefer the simpler interpretation and note that you're guessing — don't quietly commit.
+
+### Step 0d — Now proceed with normal discovery
+
+Once you have a validated inventory, run the normal data-discovery flow (see Step 3 of the main workflow). For each element in the inventory, decide which available column maps to the axis or grouping field. If the source data doesn't have a column that matches the image's exactly, **substitute the closest equivalent and note the substitution** — structural fidelity matters more than data fidelity for image-driven cases.
+
+Example: image shows "Gross Margin by Customer Value Tier (Bronze / Silver / Gold / Platinum)" but the available data has no customer tiers. Substitute by a comparable categorical dimension that does exist (e.g., a `customer_segment` column with whatever buckets it has, or a derived bucket from order count). Document this in your final summary.
+
+### Step 0d.1 — Verify each dimension picked is the *right shape*
+
+A common failure: the agent sees "Ship Speed Category" in the target image (four bars labeled Economy / Express / Slow / Standard), grabs the first categorical-looking column in the available data (e.g. `product_brand` with hundreds of values), and ends up with a bar chart that has 200 unreadable rotated labels.
+
+Before drafting, for each dimension you picked, sanity-check two things:
+
+1. **Cardinality.** Count distinct values in the column. If the target image shows 4 bars and your column has 200 distinct values, that's the wrong column — keep looking, or derive a coarser bucketing.
+2. **Semantics.** The column's contents should make sense for what the target's label implies. "Ship speed" should be values like Express/Standard/Slow, not product names or SKUs.
+
+A two-line probe in your data-discovery step:
+
+```sql
+-- check cardinality
+SELECT COUNT(DISTINCT <candidate_column>) FROM <table>;
+-- check semantics (sample values)
+SELECT DISTINCT <candidate_column> FROM <table> LIMIT 10;
+```
+
+If the candidate fails either check, document the gap in your final summary and either (a) substitute a different column that fits better, (b) derive a coarser bucketing via a formula like `If([order_count] >= 10, "Frequent", [order_count] >= 3, "Regular", "Occasional")`, or (c) drop that element from your reproduction if no good substitute exists.
+
+### Step 0d.2 — Verify each metric is the *right calculation*
+
+The other common failure: agent sees "Return Rate by Ship Speed" in the target and builds a bar chart showing 0-100% values for every category because they used `Sum([is_return])` instead of a rate calculation.
+
+Before drafting, for each measure (the y-axis aggregate) you picked:
+
+- **If the target label says "rate" or "%":** the measure is a *ratio*, not a sum. Use `Sum([numerator])/Count(*)` or `Sum([numerator])/Sum([denominator])` — not a raw sum.
+- **If the target label says "average":** use `Avg(...)`, not `Sum(...)`.
+- **If the target label is a money amount:** confirm the column is the right kind (revenue / margin / cost / price), and format the column with a currency format string.
+
+After creation, the produced chart's y-axis range should look approximately like the target's. A "0-100%" axis when the target shows "0-4%" is a calculation error, not a formatting one.
+
+### Step 0e — Draft and verify
+
+From here, follow the standard workflow (Steps 5–8). One additional verification step before declaring done:
+
+- **Export the workbook to PDF** via `POST /v2/workbooks/{id}/export` with `{"format": {"type": "pdf", "layout": "landscape"}}`, download via `GET /v2/query/{queryId}/download`, then compare the result side-by-side with the target image.
+- Diff at the inventory level: do the chart kinds match? Are the axes assigned correctly? Does the layout density match? If not, iterate via PUT before declaring done.
+
+## Things to watch out for
+
+- **The toolbar text in BI tool screenshots is misleading.** A Tableau "marks card" labeled "automatic" or a Looker "visualization type: bar" can ship as anything visually — read the actual visual, not the metadata text.
+- **Don't carry source-tool concepts directly.** Tableau "sheets," Looker "looks," PowerBI "visuals" all map onto Sigma's flat `elements[]` list, but they don't translate 1:1. A Tableau dashboard tab is a Sigma `page`; a Tableau sheet is one or more Sigma elements.
+- **Title text isn't the data.** A chart titled "Gross Revenue by Ship Speed" tells you what the user wants the chart *labeled*; the data fields are inferred from the visual marks, axes, and the user's other instructions — not from the title.
+- **When the data is empty.** If your produced workbook renders "No data" for a panel, the structural interpretation may be right but the data substitution wrong. Re-check: did you pick a column that actually has rows in the selected time range? Did the default filter exclude everything? Fix and re-verify rather than calling it done.
+
+## What this workflow does NOT cover
+
+This page is about *interpreting* an image into spec intent. It does not redefine:
+
+- How to discover data (see `reference/workflows/discover.md`)
+- How to write formulas, layouts, or spec shapes (see `reference/specification/*.md`)
+- How to validate a spec before submitting (see `reference/workflows/validate.md`)
+- How to verify after creating (see `scripts/verify-workbook.sh`)
+
+You still need those — this workflow just sits in front of them.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/validate.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/workflows/validate.md
@@ -1,0 +1,75 @@
+# Workbook Spec Validation
+
+Validation runs in two phases: **pre-submit** (this file's sections 1–3) catches what's visible in the spec text; **post-create** (section 4) catches what Sigma's compiler discovers but the spec parser tolerates. Both matter — silent compilation failures are the largest hidden failure mode.
+
+Load this file before any POST or PUT.
+
+## 1. Run the bundled validator
+
+```bash
+./scripts/validate-spec.sh /tmp/workbook-spec.yaml
+```
+
+The validator catches the most common failure: bare bracketed refs (`[column]` without a `/`) that don't match any column defined in the same element's `columns[]` array. Fix everything it reports before continuing. If it exits 0, proceed to the manual pass.
+
+## 2. Manual formula pass
+
+After the validator passes, do a final mechanical pass on every formula in the spec. **Do not skip to submission until every formula has been checked.**
+
+For each column's `formula`:
+
+1. **List every bracketed reference** in the formula. E.g., `Sum([Master/Sales]) - [Cost]` → refs are `Master/Sales` and `Cost`.
+2. **For each reference, it must resolve to exactly one of:**
+   - A **sibling** — the portion inside the brackets (no `/`) exactly matches a `name` in THIS element's `columns[]` array.
+   - A **qualified ref** — contains `/`, and the prefix matches one of:
+     - The last segment of the `path` array (if source is `warehouse-table`)
+     - Another element's `name` (if source is `table` referencing that element)
+     - A join leg's `name`, or the join's top-level `name` for `primarySource` columns (if source is `join`)
+3. **If a reference doesn't match either, the formula is wrong.** The most common fix is adding the source prefix — see the wrong/right example at the top of `reference/specification/formulas.md`.
+
+## 3. Final shape checks
+
+Also check for these rarer issues:
+
+- A column's `formula` references a name matching its own `name` field → circular reference.
+- A formula references a column name that doesn't exist on the source (re-confirm column names with the user).
+- Donut charts require `value.id` (the measure) and `color.id` (the slice dimension) — **not** `value.columnId`. `holeValue` is **optional**; if set it must reference a *different* column than `value.id` (see `reference/specification/charts.md`).
+- Layout XML: no `<LayoutElement type="grid">` with children — use `<GridContainer>` for nesting.
+
+## 4. Post-create verification (do not skip)
+
+`POST /v2/workbooks/spec` is generous. It accepts specs whose column formulas don't actually resolve, and Sigma surfaces the failures *at query time* by embedding the error as a string literal in the compiled SQL:
+
+```sql
+select V_44 "Total Revenue" from (select 'Unknown column "[ORDER_TOTAL]"' V_44) Q1
+select V_11 "Quarter" from (select distinct 'Circular column reference to [Quarter]' V_11 ...) Q1
+```
+
+The UI renders these elements as empty. There is no way to catch this from the spec text alone — only Sigma's compiler knows whether `[ORDERS/Date]` resolves to a real column.
+
+After every CREATE and after every PUT that touches columns or formulas, run:
+
+```bash
+./scripts/verify-workbook.sh <workbookId>
+```
+
+It hits `GET /v2/workbooks/<id>/elements/<eid>/query` for each element and reports any whose SQL contains the error markers above. Treat a non-zero exit the same as a failed POST — fix the spec and re-PUT.
+
+The most common causes of post-create failure:
+
+- **Bare warehouse refs.** `Sum([ORDER_TOTAL])` instead of `Sum([ORDERS/ORDER_TOTAL])`. The single biggest trap; see `reference/specification/formulas.md`.
+- **Friendly-name mismatch.** The columns endpoint returns raw warehouse names (`V userId`, `UNIT PRICE`); formulas need Sigma's normalized friendly names (`V User Id`, `Unit Price`). Sigma is permissive at POST and normalizes casing for many simple cases, but won't rescue all of them. When in doubt, GET the spec back after a successful create — Sigma's readback shows the canonical names — and use those for any subsequent PUT.
+- **Circular reference.** A column named `Quarter` with formula `[Quarter]` — easy to write when copying warehouse column names verbatim into a sibling-reference position. Rename one side.
+
+## Decoding Cryptic Validation Errors
+
+Server-side validation errors point at a JSON path but don't say what shape was expected. Use the path as the root-cause hint, then check the spec reference file for that feature to compare shapes.
+
+| Error pattern | Most likely cause | Where to look |
+|---------------|-------------------|---------------|
+| `Invalid kind: pages[0].elements[N], got "..."` | Almost always the element's **inner shape** is wrong for the `controlType`/`kind` it claims, **not** that the kind is unsupported. Sigma's parser picks a schema by `kind` + `controlType` and reports the parent path when the inner match fails. | `reference/specification/controls.md` (slider is the most common trap), or the relevant element file (`charts.md`, `kpis.md`, `tables.md`). |
+| `Invalid value: pages[0].elements[N].filters[M], got object` | The field is typed as an array of a specific shape and you sent something that doesn't match. | A working reference workbook (`GET` an existing workbook) for that exact field. |
+| `Invalid kind: pages[0].elements[N].columns[M]` | Usually missing `id`, `name`, or `formula`, or `format.kind` mismatched. | `reference/specification/formatting.md`. |
+| **Silent bad data** — no error, but the value/element is missing or `null` on readback | (a) A boolean-operator formula written as a function call (`Not(...)` instead of `Not ...`) — parses successfully but evaluates to `null` per row; (b) layout XML naming an `elementId` that doesn't exist on the page (typo or wrong id). | `formulas.md` for (a), `layout.md` for (b). All under `reference/specification/`. |
+
+**General strategy:** the error path names the offending field; the spec reference file for that feature shows the shape. If after checking both you still can't see the mismatch, fetch a known-good reference workbook via `GET /v2/workbooks/<id>/spec` (with `Accept: application/json`) and diff your shape against it.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/validate-spec.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/validate-spec.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# validate-spec.sh — scan a workbook spec for likely formula-qualification errors.
+#
+# Catches the #1 Sigma spec mistake: a bare bracketed reference (e.g. [Question ID])
+# inside a formula when the referenced column actually lives on the source element,
+# not the current one, and therefore needs a prefix (e.g. [AI Usage Data/Question ID]).
+#
+# Accepts YAML (recommended) or JSON input. YAML is detected by the
+# .yaml/.yml extension and converted to JSON internally before the jq pass.
+#
+# Usage: ./validate-spec.sh <path-to-spec.yaml|.json>
+# Exit codes:
+#   0  — no obvious issues
+#   1  — issues found
+#   2  — setup / input error
+#
+# Limitations: regex-based, so it does not parse formulas semantically. It can
+# produce false positives on bracketed text inside string literals (e.g.
+# DateFormat(..., "[MM] %Y") ) — inspect flagged cases before blindly fixing.
+# It does NOT verify that qualified refs ([Source/col]) point to real sources;
+# the server reports those.
+
+set -euo pipefail
+
+FILE="${1:-}"
+if [ -z "$FILE" ]; then
+  echo "Usage: $0 <path-to-spec.yaml|.json>" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required. Install with: brew install jq (macOS) or apt install jq (Debian/Ubuntu)." >&2
+  exit 2
+fi
+
+if [ ! -f "$FILE" ]; then
+  echo "Error: file not found: $FILE" >&2
+  exit 2
+fi
+
+# Convert YAML → JSON in memory if the file looks like YAML.
+#
+# Earlier versions trusted yq's exit code as proof of JSON output, which broke
+# against Go yq (mikefarah, Homebrew default on macOS): `yq . file.yaml` exits 0
+# but emits YAML, not JSON, so the downstream jq call failed with
+# "Invalid literal at line 1, column 5". Fix: try Go yq's explicit -o=json first,
+# fall back to Python yq's bare `.`, and validate each candidate with `jq empty`
+# before accepting it — the success criterion is now "output parses as JSON",
+# not "yq exited 0".
+to_json() {
+  case "$FILE" in
+    *.yaml|*.yml)
+      if command -v yq >/dev/null 2>&1; then
+        # Go yq (mikefarah) — explicit JSON output flag, unambiguous.
+        out=$(yq -o=json . "$FILE" 2>/dev/null) \
+          && printf '%s' "$out" | jq empty >/dev/null 2>&1 \
+          && { printf '%s' "$out"; return 0; }
+        # Python yq (kislyuk) — bare `.` already emits JSON.
+        out=$(yq . "$FILE" 2>/dev/null) \
+          && printf '%s' "$out" | jq empty >/dev/null 2>&1 \
+          && { printf '%s' "$out"; return 0; }
+      fi
+      if command -v python3 >/dev/null 2>&1; then
+        python3 - "$FILE" <<'PY' 2>/dev/null && return 0
+import sys, json
+try:
+    import yaml
+except ImportError:
+    sys.exit(2)
+with open(sys.argv[1]) as f:
+    print(json.dumps(yaml.safe_load(f)))
+PY
+      fi
+      echo "Error: cannot convert YAML to JSON. Install one of:" >&2
+      echo "  - Go yq:        brew install yq                (recommended on macOS)" >&2
+      echo "  - Python yq:    pip install yq" >&2
+      echo "  - PyYAML:       pip install PyYAML            (python3 + import yaml)" >&2
+      exit 2
+      ;;
+    *)
+      cat "$FILE"
+      ;;
+  esac
+}
+
+SPEC_JSON="$(to_json)"
+
+ISSUES=$(printf '%s' "$SPEC_JSON" | jq -r '
+  .pages[]? | .elements[]? |
+    . as $element |
+    (.columns // []) as $cols |
+    ($cols | map(.name // "")) as $siblings |
+    $cols[]? |
+    . as $col |
+    ($col.formula // "") as $formula |
+    ( [ $formula | scan("\\[[^/\\]]+\\]") | .[1:-1] ] ) as $bare_refs |
+    ( $bare_refs | map(select(. as $ref | $siblings | index($ref) | not)) ) as $unresolved |
+    select($unresolved | length > 0) |
+    "Element: \($element.name // $element.id // "(unnamed)")\n  Column: \($col.name // $col.id // "(unnamed)")\n  Formula: \($formula)\n  Unresolved bare refs: \($unresolved | join(", "))\n"
+')
+
+if [ -z "$ISSUES" ]; then
+  echo "OK: no obvious formula qualification errors."
+  echo ""
+  echo "Note: this validator only catches bare bracketed refs ([col] without a '/') that"
+  echo "don't match a sibling column in the same element. Qualified refs ([Source/col])"
+  echo "are not verified here — the server checks those on publish."
+  exit 0
+fi
+
+echo "Likely formula qualification errors:"
+echo ""
+echo "$ISSUES"
+echo "Fix: a bare bracketed ref ([col] with no '/') must match a column 'name' defined"
+echo "in the SAME element's columns[] array. Otherwise add the source prefix."
+echo ""
+echo "  Wrong:  Count([Question ID])"
+echo "  Right:  Count([AI Usage Data/Question ID])       (source element name as prefix)"
+exit 1

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/verify-workbook.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/verify-workbook.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# verify-workbook.sh — confirm a created workbook's elements compile to valid SQL.
+#
+# Why this exists: POST /v2/workbooks/spec is generous. It accepts specs whose
+# column formulas don't actually resolve, then surfaces the failures at query
+# time as string literals embedded in the compiled SQL — e.g.
+#   select 'Unknown column "[ORDER_TOTAL]"' V_44 from ...
+#   select 'Circular column reference to [Quarter]' V_11 ...
+# The UI renders these elements as empty. Catching this is impossible from the
+# spec alone; only Sigma's compiler knows. This script asks the server.
+#
+# For each element on the workbook, it fetches the compiled SQL via
+#   GET /v2/workbooks/{id}/elements/{eid}/query
+# and greps the markers. Any hit means a formula doesn't resolve.
+#
+# Usage: ./verify-workbook.sh <workbook-id>
+# Requires env: SIGMA_BASE_URL, SIGMA_API_TOKEN.
+# Exit codes:
+#   0  — every element compiled clean
+#   1  — one or more elements have unresolved/circular references
+#   2  — setup / input error
+
+set -euo pipefail
+
+WB_ID="${1:-}"
+if [ -z "$WB_ID" ]; then
+  echo "Usage: $0 <workbook-id>" >&2
+  exit 2
+fi
+
+if [ -z "${SIGMA_BASE_URL:-}" ] || [ -z "${SIGMA_API_TOKEN:-}" ]; then
+  echo "Error: SIGMA_BASE_URL and SIGMA_API_TOKEN must be set in the environment." >&2
+  echo "Authenticate via the sigma-api skill first." >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required." >&2
+  exit 2
+fi
+
+ELEMENTS_JSON=$(curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/workbooks/$WB_ID/elements") || {
+  echo "Error: could not fetch elements for workbook $WB_ID." >&2
+  exit 2
+}
+
+ERRORS=0
+TOTAL=0
+while IFS=$'\t' read -r EID NAME; do
+  TOTAL=$((TOTAL + 1))
+  # /elements/{id}/query 4xx's on controls and similar non-queryable elements —
+  # don't let -f kill the loop. Just skip them.
+  RAW=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+    "$SIGMA_BASE_URL/v2/workbooks/$WB_ID/elements/$EID/query")
+  SQL=$(printf '%s' "$RAW" | jq -r '.sql // ""' 2>/dev/null || true)
+
+  if [ -z "$SQL" ]; then
+    printf '  [skip] %-30s (%s) — no SQL (control or non-queryable element)\n' "$NAME" "$EID"
+    continue
+  fi
+
+  # grep exits 1 when no matches, which would trip `set -o pipefail` — swallow that
+  # case explicitly so a clean element doesn't kill the loop.
+  BAD=$(printf '%s' "$SQL" \
+    | grep -oE "(Unknown column \"[^\"]+\"|Circular column reference to \[[^]]+\])" \
+    | sort -u | paste -sd '; ' - || true)
+  if [ -n "$BAD" ]; then
+    printf '  [FAIL] %-30s (%s) — %s\n' "$NAME" "$EID" "$BAD"
+    ERRORS=$((ERRORS + 1))
+  else
+    printf '  [ok]   %-30s (%s)\n' "$NAME" "$EID"
+  fi
+done < <(echo "$ELEMENTS_JSON" | jq -r '.entries[]? | [.elementId, .name] | @tsv')
+
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "$ERRORS of $TOTAL element(s) have unresolved formula references."
+  echo "Fix the offending columns in the spec (see reference/specification/formulas.md)"
+  echo "and re-PUT the spec, then re-verify."
+  exit 1
+fi
+echo "All $TOTAL element(s) compile cleanly."
+exit 0

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb
@@ -1,0 +1,487 @@
+#!/usr/bin/env ruby
+# wb-rep.rb — element-level file representation ("rep") of a Sigma workbook spec.
+#
+# The Sigma spec API is whole-workbook only (GET/PUT the entire spec). Large
+# multi-page workbooks blow up an agent's context when edited as one document.
+# This tool makes the ELEMENT the unit of work by exploding the spec into a
+# directory of small files, and reassembling them on push:
+#
+#   <rep>/
+#     workbook.yaml              top-level fields (name, folderId, schemaVersion, ...)
+#     pages/
+#       010-overview/
+#         _page.yaml             page fields minus elements (id, name, visibility)
+#         _layout.xml            this page's <Page> block from the top-level layout XML
+#         010-revenue-kpi.yaml   one element per file (filename prefix = order)
+#         020-sales-by-region.yaml
+#     .sigma/                    plumbing — do not hand-edit
+#       manifest.yaml            workbookId, url, baseUrl, pulledAt
+#       snapshot.yaml            full spec as last synced with the server
+#       layout-preamble.xml      anything before the first <Page> in the layout
+#
+# Edit element files with normal file tools; nothing here is a new format —
+# each file is a verbatim slice of the spec. push reassembles, diffs against
+# the snapshot, refuses to clobber remote edits, validates, and PUTs.
+#
+# Commands:
+#   pull <workbook-id> [dir]     GET spec and explode (refuses to overwrite a dirty rep)
+#   status [dir]                 element-level diff: working files vs last-synced snapshot
+#   push [dir]                   reassemble -> drift-check -> validate -> PUT (or POST create)
+#   assemble [dir] [-o file]     print/write the reassembled spec without pushing
+#   import <spec.yaml> [dir]     explode an existing local spec file (create mode: push POSTs)
+#   render [dir] [--page X]      export page(s) (or --element <id>) as PNG into <dir>/renders/
+#                                — LOOK at what you built and iterate; renders server state
+#
+# Flags: --force (pull: overwrite dirty rep; push: ignore remote drift)
+#        --no-validate (push: skip validate-spec.sh)
+#        -o FILE (assemble: write instead of stdout)
+#
+# Env: SIGMA_BASE_URL, SIGMA_API_TOKEN (obtain via the sigma-api skill / get-token.sh).
+# Exit codes: 0 ok / clean, 1 differences or push aborted, 2 usage or API error.
+
+require 'yaml'
+require 'json'
+require 'net/http'
+require 'uri'
+require 'fileutils'
+require 'time'
+
+RESPONSE_ONLY = %w[workbookId url documentVersion latestDocumentVersion ownerId
+                   createdBy updatedBy createdAt updatedAt].freeze
+XML_PROLOG = %(<?xml version="1.0" encoding="utf-8"?>\n).freeze
+
+def die(msg, code = 2)
+  warn "wb-rep: #{msg}"
+  exit code
+end
+
+def api_raw(method, path, body = nil, content_type: 'application/yaml', accept: 'application/yaml')
+  base = ENV['SIGMA_BASE_URL'] or die 'SIGMA_BASE_URL not set — run the sigma-api skill / eval "$(get-token.sh)" first'
+  token = ENV['SIGMA_API_TOKEN'] or die 'SIGMA_API_TOKEN not set — run the sigma-api skill / eval "$(get-token.sh)" first'
+  uri = URI("#{base.sub(%r{/$}, '')}#{path}")
+  req = { get: Net::HTTP::Get, put: Net::HTTP::Put, post: Net::HTTP::Post }.fetch(method).new(uri)
+  req['Authorization'] = "Bearer #{token}"
+  req['Accept'] = accept
+  if body
+    req['Content-Type'] = content_type
+    req.body = body
+  end
+  Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 120) { |h| h.request(req) }
+end
+
+def api(method, path, body = nil, **opts)
+  res = api_raw(method, path, body, **opts)
+  unless res.code.to_i.between?(200, 299)
+    die "#{method.to_s.upcase} #{path} -> HTTP #{res.code}\n#{res.body}", 2
+  end
+  res.body
+end
+
+def slug(s)
+  out = s.to_s.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/^-+|-+$/, '')
+  out.empty? ? nil : out[0, 60]
+end
+
+def strip_response_only(spec)
+  spec.reject { |k, _| RESPONSE_ONLY.include?(k) }
+end
+
+# Split the top-level layout XML into [preamble, { page_id => chunk }].
+# Chunks are verbatim byte slices so an untouched rep reassembles identically.
+def split_layout(layout)
+  return [XML_PROLOG, {}] if layout.nil? || layout.empty?
+  starts = []
+  layout.scan(/<Page[\s>]/) { starts << Regexp.last_match.begin(0) }
+  return [layout, {}] if starts.empty?
+  preamble = layout[0...starts.first]
+  chunks = {}
+  starts.each_with_index do |s, i|
+    chunk = layout[s...(starts[i + 1] || layout.length)]
+    id = chunk[/\A<Page[^>]*\bid="([^"]*)"/, 1]
+    warn "wb-rep: warning — layout <Page> block without an id attribute; it will be appended last" unless id
+    chunks[id || "_orphan#{i}"] = chunk
+  end
+  [preamble, chunks]
+end
+
+def explode(spec, dir, raw_yaml:, manifest_extra: {})
+  spec = spec.dup
+  pages = spec.delete('pages') || []
+  layout = spec.delete('layout')
+  preamble, layout_chunks = split_layout(layout)
+  top = strip_response_only(spec)
+
+  FileUtils.rm_rf(File.join(dir, 'pages'))
+  FileUtils.mkdir_p(File.join(dir, 'pages'))
+  FileUtils.mkdir_p(File.join(dir, '.sigma'))
+  File.write(File.join(dir, 'workbook.yaml'), YAML.dump(top))
+  File.write(File.join(dir, '.sigma', 'layout-preamble.xml'), preamble)
+
+  used_page_dirs = {}
+  pages.each_with_index do |page, pi|
+    page = page.dup
+    elements = page.delete('elements') || []
+    base = slug(page['name']) || slug(page['id']) || "page-#{pi + 1}"
+    base += "-#{page['id']}"[0, 20] if used_page_dirs[base]
+    used_page_dirs[base] = true
+    pdir = File.join(dir, 'pages', format('%03d-%s', (pi + 1) * 10, base))
+    FileUtils.mkdir_p(pdir)
+    File.write(File.join(pdir, '_page.yaml'), YAML.dump(page))
+    if (chunk = layout_chunks.delete(page['id']))
+      File.write(File.join(pdir, '_layout.xml'), chunk)
+    end
+    used = {}
+    elements.each_with_index do |el, ei|
+      ebase = slug(el['name']) || slug(el['kind']) || 'element'
+      ebase += "-#{slug(el['id']) || ei}" if used[ebase]
+      used[ebase] = true
+      File.write(File.join(pdir, format('%03d-%s.yaml', (ei + 1) * 10, ebase)), YAML.dump(el))
+    end
+  end
+  layout_chunks.each_key do |k|
+    warn "wb-rep: warning — layout <Page id=\"#{k}\"> matches no page in the spec; chunk dropped"
+  end
+
+  File.write(File.join(dir, '.sigma', 'snapshot.yaml'), raw_yaml)
+  File.write(File.join(dir, '.sigma', 'manifest.yaml'),
+             YAML.dump({ 'baseUrl' => ENV['SIGMA_BASE_URL'], 'pulledAt' => Time.now.utc.iso8601 }.merge(manifest_extra)))
+end
+
+def load_yaml_file(path)
+  YAML.load(File.read(path)) || {}
+rescue Psych::SyntaxError => e
+  die "YAML parse error in #{path}: #{e.message}"
+end
+
+def assemble(dir)
+  wb_path = File.join(dir, 'workbook.yaml')
+  die "no workbook.yaml in #{dir} — not a rep directory (run pull/import first)" unless File.exist?(wb_path)
+  spec = load_yaml_file(wb_path)
+  preamble_path = File.join(dir, '.sigma', 'layout-preamble.xml')
+  preamble = File.exist?(preamble_path) ? File.read(preamble_path) : XML_PROLOG
+
+  pages = []
+  layout_parts = []
+  Dir[File.join(dir, 'pages', '*/')].sort.each do |pdir|
+    ppath = File.join(pdir, '_page.yaml')
+    die "missing _page.yaml in #{pdir}" unless File.exist?(ppath)
+    page = load_yaml_file(ppath)
+    elements = Dir[File.join(pdir, '*.yaml')].sort
+                                             .reject { |f| File.basename(f) == '_page.yaml' }
+                                             .map { |f| load_yaml_file(f) }
+    page['elements'] = elements
+    pages << page
+    lpath = File.join(pdir, '_layout.xml')
+    layout_parts << File.read(lpath) if File.exist?(lpath)
+  end
+  spec['pages'] = pages
+  spec['layout'] = preamble + layout_parts.join unless layout_parts.empty?
+  spec
+end
+
+# ---- diffing -------------------------------------------------------------
+
+def index_by_id(arr)
+  (arr || []).each_with_index.map { |x, i| [x['id'] || "@#{i}", x] }.to_h
+end
+
+def changed_keys(a, b)
+  (a.keys | b.keys).reject { |k| a[k] == b[k] }
+end
+
+def diff_specs(old_spec, new_spec)
+  lines = []
+  ot = strip_response_only(old_spec).reject { |k, _| %w[pages layout].include?(k) }
+  nt = strip_response_only(new_spec).reject { |k, _| %w[pages layout].include?(k) }
+  changed_keys(ot, nt).each { |k| lines << "~ workbook.#{k}" }
+
+  old_pages = index_by_id(old_spec['pages'])
+  new_pages = index_by_id(new_spec['pages'])
+  _, old_layout = split_layout(old_spec['layout'])
+  _, new_layout = split_layout(new_spec['layout'])
+
+  (old_pages.keys | new_pages.keys).each do |pid|
+    op = old_pages[pid]
+    np = new_pages[pid]
+    pname = (np || op)['name'] || pid
+    if op.nil? then lines << "+ page \"#{pname}\" (#{(np['elements'] || []).size} elements)"; next end
+    if np.nil? then lines << "- page \"#{pname}\""; next end
+    meta = changed_keys(op.reject { |k, _| k == 'elements' }, np.reject { |k, _| k == 'elements' })
+    lines << "~ page \"#{pname}\" [#{meta.join(', ')}]" unless meta.empty?
+    lines << "~ page \"#{pname}\" layout" if old_layout[pid] != new_layout[pid]
+    oe = index_by_id(op['elements'])
+    ne = index_by_id(np['elements'])
+    el_lines = []
+    (oe.keys | ne.keys).each do |eid|
+      o = oe[eid]
+      n = ne[eid]
+      ename = (n || o)['name'] || (n || o)['kind'] || eid
+      if o.nil? then el_lines << "  + element \"#{ename}\" (#{eid})"
+      elsif n.nil? then el_lines << "  - element \"#{ename}\" (#{eid})"
+      elsif o != n then el_lines << "  ~ element \"#{ename}\" (#{eid}) [#{changed_keys(o, n).join(', ')}]"
+      end
+    end
+    lines << "  page \"#{pname}\":" unless el_lines.empty?
+    lines.concat(el_lines)
+  end
+  lines
+end
+
+def snapshot_spec(dir)
+  path = File.join(dir, '.sigma', 'snapshot.yaml')
+  File.exist?(path) ? YAML.load(File.read(path)) : nil
+end
+
+def manifest(dir)
+  path = File.join(dir, '.sigma', 'manifest.yaml')
+  File.exist?(path) ? YAML.load(File.read(path)) : {}
+end
+
+def rep_dirty?(dir)
+  snap = snapshot_spec(dir)
+  return false unless snap && File.exist?(File.join(dir, 'workbook.yaml'))
+  !diff_specs(snap, assemble(dir)).empty?
+end
+
+def lint_layout_coverage(spec)
+  _, chunks = split_layout(spec['layout'])
+  (spec['pages'] || []).each do |page|
+    chunk = chunks[page['id']] or next # no layout block = auto-arrange, nothing to check
+    (page['elements'] || []).each do |el|
+      next if chunk.include?(%(elementId="#{el['id']}"))
+      warn "wb-rep: warning — element \"#{el['name'] || el['id']}\" (page \"#{page['name']}\") is not referenced in the page's _layout.xml"
+    end
+  end
+end
+
+# ---- commands ------------------------------------------------------------
+
+def cmd_pull(args, force:)
+  wb_id = args.shift or die 'usage: wb-rep.rb pull <workbook-id> [dir]'
+  dir = args.shift || '.'
+  if File.exist?(File.join(dir, 'workbook.yaml')) && rep_dirty?(dir) && !force
+    die "rep at #{dir} has local changes (see `status`) — pull would overwrite them; use --force to discard", 1
+  end
+  raw = api(:get, "/v2/workbooks/#{wb_id}/spec")
+  spec = YAML.load(raw)
+  explode(spec, dir, raw_yaml: raw,
+                     manifest_extra: { 'workbookId' => wb_id, 'url' => spec['url'] })
+  n_el = (spec['pages'] || []).sum { |p| (p['elements'] || []).size }
+  puts "pulled \"#{spec['name']}\" -> #{dir} (#{(spec['pages'] || []).size} pages, #{n_el} elements)"
+end
+
+def cmd_import(args)
+  src = args.shift or die 'usage: wb-rep.rb import <spec.yaml> [dir]'
+  dir = args.shift || '.'
+  raw = File.read(src)
+  explode(YAML.load(raw), dir, raw_yaml: raw)
+  puts "imported #{src} -> #{dir} (create mode: push will POST a new workbook)"
+end
+
+def cmd_status(args)
+  dir = args.shift || '.'
+  snap = snapshot_spec(dir)
+  unless snap
+    spec = assemble(dir)
+    n_el = (spec['pages'] || []).sum { |p| (p['elements'] || []).size }
+    puts "create mode — never pushed (#{(spec['pages'] || []).size} pages, #{n_el} elements staged)"
+    return
+  end
+  lines = diff_specs(snap, assemble(dir))
+  if lines.empty?
+    puts 'clean — working files match the last-synced snapshot'
+  else
+    puts lines
+    exit 1
+  end
+end
+
+def cmd_assemble(args)
+  out = nil
+  if (i = args.index('-o'))
+    out = args[i + 1] or die 'assemble: -o needs a file argument'
+    args.slice!(i, 2)
+  end
+  dir = args.shift || '.'
+  yaml = YAML.dump(assemble(dir))
+  out ? (File.write(out, yaml); puts "wrote #{out}") : puts(yaml)
+end
+
+def cmd_push(args, force:, validate: true)
+  dir = args.shift || '.'
+  spec = assemble(dir)
+  snap = snapshot_spec(dir)
+  mf = manifest(dir)
+  wb_id = mf['workbookId']
+  die "rep has a workbookId but no snapshot in #{dir}/.sigma — re-run pull first" if wb_id && snap.nil?
+
+  lines = snap ? diff_specs(snap, spec) : []
+  if wb_id && lines.empty?
+    puts 'nothing to push — working files match the last-synced snapshot'
+    return
+  end
+  puts 'changes to push:'
+  puts(lines.empty? ? '  (initial create)' : lines.map { |l| "  #{l}" })
+
+  if wb_id && !force
+    remote = YAML.load(api(:get, "/v2/workbooks/#{wb_id}/spec"))
+    drift = diff_specs(snap, remote)
+    unless drift.empty?
+      warn 'wb-rep: remote workbook changed since last pull — pushing would overwrite:'
+      drift.each { |l| warn "  #{l}" }
+      die 'resolve by re-running pull (re-apply your edits) or push --force to overwrite', 1
+    end
+  end
+
+  lint_layout_coverage(spec)
+
+  body = YAML.dump(strip_response_only(spec))
+  if validate
+    require 'tempfile'
+    Tempfile.create(['wb-rep-spec', '.yaml']) do |f|
+      f.write(body)
+      f.flush
+      validator = File.expand_path('validate-spec.sh', __dir__)
+      if File.exist?(validator)
+        ok = system(validator, f.path)
+        die 'validator found issues (above) — fix them or push --no-validate to override', 1 unless ok
+      end
+    end
+  end
+
+  if wb_id
+    api(:put, "/v2/workbooks/#{wb_id}/spec", body)
+  else
+    die 'create mode: workbook.yaml must include folderId' unless spec['folderId']
+    res = YAML.load(api(:post, '/v2/workbooks/spec', body))
+    wb_id = res['workbookId'] or die "create response had no workbookId:\n#{res.inspect}"
+    mf['workbookId'] = wb_id
+  end
+
+  raw = api(:get, "/v2/workbooks/#{wb_id}/spec")
+  readback = YAML.load(raw)
+  FileUtils.mkdir_p(File.join(dir, '.sigma'))
+  File.write(File.join(dir, '.sigma', 'snapshot.yaml'), raw)
+  mf['url'] = readback['url']
+  mf['pushedAt'] = Time.now.utc.iso8601
+  File.write(File.join(dir, '.sigma', 'manifest.yaml'), YAML.dump(mf))
+
+  norm = diff_specs(spec, readback)
+  unless norm.empty?
+    puts 'server normalized some fields on save (working files now differ from snapshot):'
+    puts norm.map { |l| "  #{l}" }
+    puts "run `pull #{wb_id} #{dir} --force` to resync files, or leave as-is and `status` will show this delta"
+  end
+  puts "pushed -> #{readback['url'] || wb_id}"
+  puts "verify compile next: scripts/verify-workbook.sh #{wb_id}"
+end
+
+# Zoom-style reads (no full-spec load): summarize a workbook or rep cheaply,
+# and distil authorable capabilities live from the public OpenAPI.
+def cmd_summarize(args)
+  target = args.shift || '.'
+  spec = if File.directory?(target)
+           snapshot_spec(target) || assemble(target)
+         else
+           YAML.load(api(:get, "/v2/workbooks/#{target}/spec"))
+         end
+  puts "#{spec['name']}  (schemaVersion #{spec['schemaVersion']})"
+  sources = []
+  (spec['pages'] || []).each do |p|
+    els = p['elements'] || []
+    kinds = els.group_by { |e| e['kind'] }.map { |k, v| "#{k}×#{v.size}" }.join(', ')
+    vis = p['visibility'] == 'hidden' ? ' [hidden]' : ''
+    puts "  page \"#{p['name']}\"#{vis}: #{els.size} elements (#{kinds})"
+    els.each do |e|
+      s = e['source'] or next
+      sources << (s['path'] ? s['path'].join('.') : s['kind'] == 'data-model' ? "data-model #{s['dataModelId']}" : nil)
+    end
+  end
+  puts "  sources: #{sources.compact.uniq.join(', ')}" unless sources.compact.empty?
+end
+
+OPENAPI_CACHE = '/tmp/sigma-api.json'.freeze
+def cmd_capabilities(args)
+  kind = field = nil
+  if (i = args.index('--kind')) then kind = args[i + 1]; args.slice!(i, 2); end
+  if (i = args.index('--field')) then field = args[i + 1]; args.slice!(i, 2); end
+  unless File.exist?(OPENAPI_CACHE)
+    system('curl', '-sf', 'https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json', '-o', OPENAPI_CACHE) or die 'failed to fetch OpenAPI'
+  end
+  sel = %q{first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))}
+  if kind.nil?
+    system('jq', '-r', '[.. | objects | select(.properties.kind.enum) | .properties.kind.enum[0]] | unique[]', OPENAPI_CACHE)
+  elsif field.nil?
+    system('jq', '-r', '--arg', 'k', kind, "#{sel} | [.allOf[]?.properties // .properties | keys[]] | unique[]", OPENAPI_CACHE)
+  else
+    system('jq', '--arg', 'k', kind, "[#{sel} | .. | objects | select(.properties[\"#{field}\"]) | .properties[\"#{field}\"]] | .[0]", OPENAPI_CACHE)
+  end
+end
+
+def export_png(wb_id, body, out_path, label)
+  res = JSON.parse(api(:post, "/v2/workbooks/#{wb_id}/export", JSON.dump(body),
+                       content_type: 'application/json', accept: 'application/json'))
+  query_id = res['queryId'] or die "export response had no queryId:\n#{res.inspect}"
+  deadline = Time.now + 180
+  loop do
+    r = api_raw(:get, "/v2/query/#{query_id}/download", accept: '*/*')
+    code = r.code.to_i
+    if code == 200 && r.body && !r.body.empty?
+      File.binwrite(out_path, r.body)
+      puts "rendered #{label} -> #{out_path} (#{r.body.bytesize / 1024}KB)"
+      return
+    elsif [202, 204].include?(code) || code == 200
+      die "render of #{label} timed out after 180s", 2 if Time.now > deadline
+      sleep 3
+    else
+      die "download for #{label} -> HTTP #{r.code}\n#{r.body}", 2
+    end
+  end
+end
+
+def cmd_render(args)
+  page_sel = element_sel = nil
+  if (i = args.index('--page')) then page_sel = args[i + 1]; args.slice!(i, 2); end
+  if (i = args.index('--element')) then element_sel = args[i + 1]; args.slice!(i, 2); end
+  dir = args.shift || '.'
+  wb_id = manifest(dir)['workbookId'] or die 'render shows SERVER state — pull or push a real workbook first (no workbookId in manifest)'
+  warn 'wb-rep: warning — rep has unpushed local changes; render shows the last-pushed state' if rep_dirty?(dir)
+  out_dir = File.join(dir, 'renders')
+  FileUtils.mkdir_p(out_dir)
+
+  if element_sel
+    export_png(wb_id, { 'elementId' => element_sel, 'format' => { 'type' => 'png' } },
+               File.join(out_dir, "element-#{slug(element_sel)}.png"), "element #{element_sel}")
+    return
+  end
+
+  spec = snapshot_spec(dir) or die "no snapshot in #{dir}/.sigma — run pull or import first"
+  pages = spec['pages'] || []
+  pages = pages.select { |p| [p['id'], p['name'], slug(p['name'])].compact.include?(page_sel) } if page_sel
+  die "no page matches #{page_sel.inspect}" if pages.empty?
+  pages.each do |p|
+    name = slug(p['name']) || p['id']
+    export_png(wb_id, { 'pageId' => p['id'], 'format' => { 'type' => 'png' } },
+               File.join(out_dir, "#{name}.png"), "page \"#{p['name'] || p['id']}\"")
+  end
+end
+
+# ---- main ----------------------------------------------------------------
+
+argv = ARGV.dup
+force = !!argv.delete('--force')
+no_validate = !!argv.delete('--no-validate')
+cmd = argv.shift
+
+case cmd
+when 'pull'     then cmd_pull(argv, force: force)
+when 'import'   then cmd_import(argv)
+when 'status'   then cmd_status(argv)
+when 'assemble' then cmd_assemble(argv)
+when 'push'         then cmd_push(argv, force: force, validate: !no_validate)
+when 'render'       then cmd_render(argv)
+when 'summarize'    then cmd_summarize(argv)
+when 'capabilities' then cmd_capabilities(argv)
+else
+  die "usage: wb-rep.rb {pull <workbook-id> [dir] | import <spec.yaml> [dir] | status [dir] | assemble [dir] [-o file] | push [dir] | render [dir] [--page <id|name>] [--element <id>] | summarize [dir|workbook-id] | capabilities [--kind K [--field F]]} [--force] [--no-validate]"
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -23,7 +23,7 @@ that mirrors the Tableau dashboard layout as closely as possible.
 - `refs/window-functions.md` — Tableau window/table calcs → Sigma-native window math (WINPROBE-validated mapping table, two-level helper shape, sort/partition/week-anchor rules, manual residues)
 - `refs/coverage-matrix.md` — converter-wide Tableau→Sigma coverage matrix (every construct → Sigma output + status: ✅ spec / 🧩 workbook pattern / 🔐 reported / 🟡 verify / ❌ flagged / ⛔ silent gap). Static companion to the per-workbook `scan-workbook-gaps.rb` readout.
 
-**For canonical workbook spec shape** (element kinds, source kinds, controls, formulas, formatting), defer to the companion **`sigma-workbooks`** skill (install it if you haven't — it's the canonical Sigma workbook spec reference). This skill restates only the Tableau-conversion-specific patterns; everything else (KPI fields, color channel, pivot-table shape, manual sources, container styling, YAML default, etc.) lives there. Read its `reference/specification/` whenever you need the current spec surface.
+**For canonical workbook spec shape** (element kinds, source kinds, controls, formulas, formatting), defer to the companion **`sigma-workbooks`** skill, which ships as the **`sigma-authoring`** plugin in this same marketplace — install it alongside this converter (it's the canonical Sigma workbook spec reference, and this converter assumes it is present). This skill restates only the Tableau-conversion-specific patterns; everything else (KPI fields, color channel, pivot-table shape, manual sources, container styling, YAML default, etc.) lives there. Read its `reference/specification/` whenever you need the current spec surface.
 
 ---
 


### PR DESCRIPTION
## Why

The migration converters defer to the **`sigma-workbooks`** skill for the canonical Sigma workbook spec ("install it if you haven't"). But that skill lived in a separate `twells89/sigma-skills` repo with **no `.claude-plugin` manifest and no marketplace** — i.e. no install path at all. So people install this marketplace but never get the spec reference the converters assume, and the companion's unique-cloner count is a fraction of the marketplace's.

## What

Package the companion authoring skills as a first-class **`sigma-authoring`** plugin inside this marketplace (listed first), so one marketplace ships both the converters and the spec they depend on.

- **`plugins/sigma-authoring/`** — vendored `sigma-workbooks` + `sigma-data-models` + `custom-sql-to-data-model` (from `twells89/sigma-skills` @ `3d4d812`), with a `plugin.json` (`skills: ./skills/`) and a `SYNC.md` documenting source-of-truth + refresh (edit upstream, re-vendor here). ~672K.
- **`marketplace.json`** — new `sigma-authoring` entry (first); the marketplace description now tells users to install it alongside any converter.
- **`tableau-to-sigma` SKILL.md** — the "install it if you haven't (separate repo)" prose now points at the in-marketplace `sigma-authoring` plugin.

## Effect

A single marketplace install path now surfaces the spec reference right next to the converters (one-click install), and a repo clone includes it on disk — closing the gap where converters ran without the spec they defer to.

## Notes

- Source of truth stays `twells89/sigma-skills`; these are vendored copies (refresh per `SYNC.md`).
- Other converters reference `sigma-workbooks` by name but had no clone/install prose; the tableau SKILL.md was the only one with an explicit "go install the separate repo" instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
