### PR TITLE
ci: run the looker offline Python regression (test_grid_fidelity.py)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -109,3 +109,21 @@ jobs:
             echo "::endgroup::"
           done
           exit $fail
+      - name: Run offline test_*.py suites
+        # EXPLICIT allow-list — creds-free, network-free Python tests only.
+        # PyYAML is needed by the looker offline dashboard parser
+        # (parse_lookml_dashboard.py); the runner does not ship it by default.
+        # New offline test_*.py → add its path here.
+        run: |
+          set -uo pipefail
+          python3 -m pip install --quiet pyyaml
+          tests=(
+            plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grid_fidelity.py
+          )
+          fail=0
+          for t in "${tests[@]}"; do
+            echo "::group::$t"
+            if python3 "$t"; then echo "OK $t"; else echo "::error file=$t::test failed"; fail=1; fi
+            echo "::endgroup::"
+          done
+          exit $fail


### PR DESCRIPTION
## Why

The `offline unit/regression tests (creds-free)` CI job only runs an allow-list of **tableau/powerbi** `test-*.rb`. The looker `build_workbook.py` regression added in #166 (`test_grid_fidelity.py` — covers bar orientation + grid cell-viz → data-bars/color-scale mapping) is **never exercised in CI**, so a future edit could silently break it.

## What

Adds a second step to the same offline job, mirroring the Ruby allow-list, that:
- `pip install pyyaml` — `parse_lookml_dashboard.py` requires PyYAML and the `ubuntu-24.04` runner doesn't ship it by default (the workflow header already notes PyYAML is "optional");
- runs `plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grid_fidelity.py`.

New offline `test_*.py` go in the same allow-list. Creds-free and network-free, consistent with the job's contract.

## Verified

Workflow YAML parses; the test passes from a clean checkout with the exact command the step runs (`ALL PASS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)