### PR TITLE
qlik-to-sigma: correct on-prem validation wording (verified vs Cloud, not on-prem)

### DIFF
--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/QUICKSTART.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/QUICKSTART.md
@@ -53,7 +53,9 @@ Duration: 2
     quickstart). Don't create a qlik-cli context — follow
     **[On-prem setup](#on-prem-setup-client-managed-qlik-sense)** below in place of
     Installation steps 4–5. A shim-driven discovery is verified output-identical to a
-    qlik-cli run on the same app. QlikView ≠ Qlik Sense: not covered.
+    qlik-cli run on the same app — though that verification was against Qlik *Cloud*
+    (identical QIX protocol); the on-prem auth/QRS path is unproven live (see the
+    note in the On-prem setup section). QlikView ≠ Qlik Sense: not covered.
 - **Qlik Cloud access** — an API key *or* an OAuth client (Admin → OAuth). For creating/round-tripping content, an **M2M impersonation** client is ideal (acts as a real user so content is visible).
 - **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`).
 - A **Sigma connection to the same warehouse** the Qlik app loads from (for true parity).
@@ -138,7 +140,7 @@ ls scripts/qlik-onprem-shim.py refs/connection-onprem.md   # both should exist
    This should list your on-prem apps. From here **every step below runs unchanged** — wherever the guide says a `qlik ...` command or `--context <ctx>`, the shim handles it via `QLIK_BIN` (no context flag needed).
 
 positive
-: The shim's Engine/QIX layer is **live-verified** (output-identical to qlik-cli on the same app). The QRS layer + on-prem auth bootstrap are code-complete but newer — if a first connection misbehaves, expect to debug auth/ports here, not in discovery or conversion. Without QRS only `appName`/`lastReloadTime` metadata degrade; discovery still completes.
+: The shim's command/output layer is verified **output-identical to qlik-cli — against a live Qlik *Cloud* tenant** (the QIX protocol is identical on-prem, so the command-parsing and output-shaping logic carries over). The **on-prem-specific path has not yet been run live**: certificate/JWT auth, the QRS layer (Cloud has no QRS), and the Engine transport against an on-prem server are code-complete but unproven end-to-end — **your engagement is the first live test.** If a first connection misbehaves, expect to debug auth/ports/proxy here, not in discovery or conversion. Failure is bounded: without QRS, only `appName`/`lastReloadTime`/Section-Access metadata degrade — discovery still completes off the Engine layer.
 
 ## Prepare demo data (optional)
 Duration: 3

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/connection-onprem.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/connection-onprem.md
@@ -16,14 +16,22 @@ python3 scripts/qlik-discover.py --app <appId> --out extract/
 
 Everything downstream (converter, DM/workbook build, parity) is identical to Cloud.
 
-> **Validation status:** the shim's Engine/QIX layer is **live-verified** — a full
-> discovery run through the shim produced output **identical (order-insensitive)**
-> to a qlik-cli run on the same app (script, charts, master items, layout, KPI/
-> bucket snapshot values). The QIX protocol is the same on-prem and Cloud. The
-> **QRS layer and on-prem auth bootstrap are code-complete but not yet live-run**
-> (Cloud has no QRS) — on your first on-prem engagement, expect to debug there
-> first, not in discovery/conversion. Without QRS, only `appName`/`lastReloadTime`
-> metadata degrade — discovery still completes.
+> **Validation status — read before promising on-prem.** The shim's command/output
+> layer is verified **output-identical to qlik-cli** — a full discovery run through
+> the shim produced output **identical (order-insensitive)** to a qlik-cli run on the
+> same app (script, charts, master items, layout, KPI/bucket snapshot values).
+> **Important: that run was against a live Qlik _Cloud_ tenant, not an on-prem
+> server.** The QIX protocol is identical on-prem and Cloud, so the command-parsing
+> and output-shaping logic carries over — but the **on-prem-specific path has not yet
+> been run live anywhere:** certificate/JWT auth, the QRS layer (Cloud has no QRS),
+> and the Engine transport *against an on-prem server* (WebSocket to :4747 with
+> `X-Qlik-User`, or through a virtual proxy) are all **code-complete but unproven
+> end-to-end**. Your first on-prem engagement is the first live test — expect to
+> debug there (auth / ports / proxy), not in discovery or conversion. Failure is
+> bounded, though: a QRS failure is non-fatal (the shim warns and continues), so only
+> `appName`/`lastReloadTime`/Section-Access metadata degrade — discovery still
+> completes off the Engine layer. Only an empty load script (an Engine-layer read)
+> hard-fails.
 
 > **QlikView is NOT covered.** It's a different product (.qvw + the old QMS API,
 > no QIX engine surface in this form). If the customer says "Qlik on-prem",


### PR DESCRIPTION
## Why
Follow-up to #168. The on-prem validation language claimed the shim's "Engine/QIX layer is **live-verified**" without saying *against what*. Per #70's own validation notes, the output-identical-to-qlik-cli run was **against a live Qlik Cloud tenant** (justified by the QIX protocol being identical on-prem/Cloud) — **not** against a real on-prem Qlik Sense Enterprise server. No part of the on-prem-specific path — certificate/JWT auth, the QRS layer, or the Engine transport against an on-prem server — has ever been run live.

With this heading to a high-scrutiny customer (first real on-prem engagement), that's a material distinction worth stating honestly.

## What changed (wording only)
- **QUICKSTART.md** — prereq bullet + On-prem setup `positive` note: attribute the verification to Cloud, explain why it carries over (identical QIX protocol), and state that the on-prem auth/QRS/transport path is unproven end-to-end ("your engagement is the first live test").
- **refs/connection-onprem.md** — same correction in the Validation status block.
- Kept (and tightened) the graceful-degradation note, which I confirmed in code: `qlik()` warns-and-continues on a QRS failure, so only `appName`/`lastReloadTime`/Section-Access metadata degrade; only an empty load script (an Engine-layer read) hard-fails.

No code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)