### PR TITLE
setup.rb: align UX to the Looker variant, keep multi-agent + conn-id, govern via manifest

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb
@@ -39,13 +39,19 @@ print "Base URL [https://aws-api.sigmacomputing.com]: "
 base = $stdin.gets.chomp
 base = "https://aws-api.sigmacomputing.com" if base.empty?
 
-print "Client ID: "
-cid = $stdin.noecho(&:gets).chomp
-puts
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
 
-print "Client Secret: "
+print "Client Secret (hidden): "
 sec = $stdin.noecho(&:gets).chomp
 puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
 # the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
@@ -60,6 +66,7 @@ settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
 settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
 pairs = {
@@ -70,11 +77,19 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
 puts
 puts "Credentials saved to:"
 puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
 puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
 puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
 puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
 puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
 puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb
@@ -39,13 +39,19 @@ print "Base URL [https://aws-api.sigmacomputing.com]: "
 base = $stdin.gets.chomp
 base = "https://aws-api.sigmacomputing.com" if base.empty?
 
-print "Client ID: "
-cid = $stdin.noecho(&:gets).chomp
-puts
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
 
-print "Client Secret: "
+print "Client Secret (hidden): "
 sec = $stdin.noecho(&:gets).chomp
 puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
 # the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
@@ -60,6 +66,7 @@ settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
 settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
 pairs = {
@@ -70,11 +77,19 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
 puts
 puts "Credentials saved to:"
 puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
 puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
 puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
 puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
 puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
 puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb
@@ -39,13 +39,19 @@ print "Base URL [https://aws-api.sigmacomputing.com]: "
 base = $stdin.gets.chomp
 base = "https://aws-api.sigmacomputing.com" if base.empty?
 
-print "Client ID: "
-cid = $stdin.noecho(&:gets).chomp
-puts
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
 
-print "Client Secret: "
+print "Client Secret (hidden): "
 sec = $stdin.noecho(&:gets).chomp
 puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
 # the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
@@ -60,6 +66,7 @@ settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
 settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
 pairs = {
@@ -70,11 +77,19 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
 puts
 puts "Credentials saved to:"
 puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
 puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
 puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
 puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
 puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
 puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb
@@ -39,13 +39,19 @@ print "Base URL [https://aws-api.sigmacomputing.com]: "
 base = $stdin.gets.chomp
 base = "https://aws-api.sigmacomputing.com" if base.empty?
 
-print "Client ID: "
-cid = $stdin.noecho(&:gets).chomp
-puts
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
 
-print "Client Secret: "
+print "Client Secret (hidden): "
 sec = $stdin.noecho(&:gets).chomp
 puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
 # the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
@@ -60,6 +66,7 @@ settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
 settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
 pairs = {
@@ -70,11 +77,19 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
 puts
 puts "Credentials saved to:"
 puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
 puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
 puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
 puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
 puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
 puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb
@@ -39,13 +39,19 @@ print "Base URL [https://aws-api.sigmacomputing.com]: "
 base = $stdin.gets.chomp
 base = "https://aws-api.sigmacomputing.com" if base.empty?
 
-print "Client ID: "
-cid = $stdin.noecho(&:gets).chomp
-puts
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
 
-print "Client Secret: "
+print "Client Secret (hidden): "
 sec = $stdin.noecho(&:gets).chomp
 puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
 # the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
@@ -60,6 +66,7 @@ settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
 settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
 pairs = {
@@ -70,11 +77,19 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
 puts
 puts "Credentials saved to:"
 puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
 puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
 puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
 puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
 puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
 puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb
@@ -39,13 +39,19 @@ print "Base URL [https://aws-api.sigmacomputing.com]: "
 base = $stdin.gets.chomp
 base = "https://aws-api.sigmacomputing.com" if base.empty?
 
-print "Client ID: "
-cid = $stdin.noecho(&:gets).chomp
-puts
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
 
-print "Client Secret: "
+print "Client Secret (hidden): "
 sec = $stdin.noecho(&:gets).chomp
 puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
 # the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
@@ -60,6 +66,7 @@ settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
 settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
 pairs = {
@@ -70,11 +77,19 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
 puts
 puts "Credentials saved to:"
 puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
 puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
 puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
 puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
 puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
 puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb
@@ -39,13 +39,19 @@ print "Base URL [https://aws-api.sigmacomputing.com]: "
 base = $stdin.gets.chomp
 base = "https://aws-api.sigmacomputing.com" if base.empty?
 
-print "Client ID: "
-cid = $stdin.noecho(&:gets).chomp
-puts
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
 
-print "Client Secret: "
+print "Client Secret (hidden): "
 sec = $stdin.noecho(&:gets).chomp
 puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
 # the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
@@ -60,6 +66,7 @@ settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
 settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
 pairs = {
@@ -70,11 +77,19 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
 puts
 puts "Credentials saved to:"
 puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
 puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
 puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
 puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
 puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
 puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb
@@ -39,13 +39,19 @@ print "Base URL [https://aws-api.sigmacomputing.com]: "
 base = $stdin.gets.chomp
 base = "https://aws-api.sigmacomputing.com" if base.empty?
 
-print "Client ID: "
-cid = $stdin.noecho(&:gets).chomp
-puts
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
 
-print "Client Secret: "
+print "Client Secret (hidden): "
 sec = $stdin.noecho(&:gets).chomp
 puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
 # the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
@@ -60,6 +66,7 @@ settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
 settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
 pairs = {
@@ -70,11 +77,19 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
 puts
 puts "Credentials saved to:"
 puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
 puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
 puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
 puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
 puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
 puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -191,6 +191,19 @@
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/layout-visual-qa.md",
         "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/layout-visual-qa.md"
       ]
+    },
+    {
+      "canonical": "shared/scripts/setup.rb",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/setup.rb",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb"
+      ]
     }
   ]
 }

--- a/shared/scripts/setup.rb
+++ b/shared/scripts/setup.rb
@@ -39,13 +39,19 @@ print "Base URL [https://aws-api.sigmacomputing.com]: "
 base = $stdin.gets.chomp
 base = "https://aws-api.sigmacomputing.com" if base.empty?
 
-print "Client ID: "
-cid = $stdin.noecho(&:gets).chomp
-puts
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
 
-print "Client Secret: "
+print "Client Secret (hidden): "
 sec = $stdin.noecho(&:gets).chomp
 puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
 
 # The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
 # the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
@@ -60,6 +66,7 @@ settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
 settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
 pairs = {
@@ -70,11 +77,19 @@ pairs = {
 pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 upsert_neutral_env(pairs)
 
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
 puts
 puts "Credentials saved to:"
 puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
 puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
 puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
 puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
 puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
 puts "though get-token.sh and the Ruby scripts auto-source it for you."


### PR DESCRIPTION
## Context (from Phil / QS)

The quickstarts-public QSes hand-fixed their `setup.rb` (PR #108/#112 over there) to the **Looker variant** — echo the Client ID, validate, confirm. But **upstream still ships the older Tableau-shaped `setup.rb`** (Client ID hidden via `noecho`) **byte-identical across every plugin**. If a QS re-vendors from upstream, the reader gets the bad experience back — defeating those QS fixes. On top of that, `setup.rb` was **not in `shared/manifest.json`**, so its byte-identical state was manual coincidence, free to drift (which is exactly how it diverged).

This is the "align upstream" option, done so it can't regress or drift again.

## What this does

Folds the Looker variant's UX wins into the canonical `shared/scripts/setup.rb` **without dropping the two upstream-only features the QS variant had shed**:

**Adopted from the Looker variant**
- Echo the **Client ID** (it's not a secret — the hidden prompt made readers paste the wrong value blind); label the secret `(hidden)`.
- **Validate**: abort if Base URL / Client ID / Secret is empty — no half-written settings.
- **Confirm**: echo back saved values with a redacted secret + a "re-run if the Client ID looks like a URL" hint.

**Kept from upstream (the variant dropped these — they're load-bearing)**
- The neutral **`~/.sigma-migration/env`** write — `get-token.sh` and `lib/sigma_rest.rb` fall back to it so non-Claude agents (Cursor, Cortex, plain shell) work.
- The optional **Connection ID** capture — the `migrate-*` orchestrators use it to skip a manual export each run.

**Hardening**
- `mkdir -p` the settings dir before writing (avoids `ENOENT` in fresh environments; surfaced in testing).

**Governance (the part that makes it stick)**
- Adds `shared/scripts/setup.rb` to `shared/manifest.json` and runs `tools/sync-shared.rb`, so all 8 plugin copies regenerate from the canonical and **`check-shared.rb` fails on future drift**. One canonical → every current and future plugin.

Re-vendor QS from this and the good experience is the default everywhere, permanently.

## Verification

`ruby -c` clean; `tools/check-shared.rb` → 115 copies match canonical (was 107; +8 now governed). Logic tested under a throwaway `HOME` (with `noecho` stubbed so input can be piped — the only line not exercised, an unchanged idiom):
- **happy path** → all 4 keys in `settings.json` **and** the neutral env (mode `0600`); secret redacted in the confirmation, raw secret never echoed;
- **skip Connection ID** → omitted from both files;
- **empty Client ID** → aborts, writes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)