### PR TITLE
shared/lib: warehouse-dialect SQL transforms (BQ/SF/Databricks/Redshift/PG/Athena)

### DIFF
--- a/docs/warehouse-transforms.md
+++ b/docs/warehouse-transforms.md
@@ -1,0 +1,64 @@
+# Warehouse-Specific SQL Transforms
+
+Sigma cannot render array or nested types in table cells. Source tools (Metabase, Tableau, Qlik, etc.) often emit SQL that produces these types — the migrated workbook will show blank cells or errors until the SQL is rewritten to return a scalar string instead.
+
+## Detection
+
+Always detect the warehouse from the Sigma connection before converting:
+
+```bash
+# In any skill script (Python)
+from warehouse_transforms import detect_warehouse
+warehouse = detect_warehouse(os.environ["SIGMA_BASE_URL"], os.environ["SIGMA_API_TOKEN"], connection_id)
+
+# In any skill script (Ruby)
+require_relative '../shared/lib/warehouse_transforms'
+warehouse = WarehouseTransforms.detect(ENV["SIGMA_BASE_URL"], ENV["SIGMA_API_TOKEN"], connection_id)
+```
+
+Or via curl:
+```bash
+WAREHOUSE=$(curl -s "$SIGMA_BASE_URL/v2/connections/<id>" \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" | \
+  python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('type','unknown'))")
+```
+
+## Array Aggregation → String Aggregation
+
+| Warehouse | Source pattern | Rewritten to |
+|---|---|---|
+| BigQuery | `ARRAY_AGG(x [IGNORE NULLS])` | `array_to_string(ARRAY_AGG(x [IGNORE NULLS]), ', ')` |
+| Snowflake | `ARRAY_AGG(x)` | `LISTAGG(x, ', ')` |
+| Databricks | `collect_list(x)` | `array_join(collect_list(x), ', ')` |
+| Redshift / Postgres | `ARRAY_AGG(x)` | `STRING_AGG(CAST(x AS VARCHAR), ', ')` |
+| Athena | `ARRAY_AGG(x)` | `array_join(array_agg(x), ', ')` |
+| MySQL | `GROUP_CONCAT(x)` | already a string — no change needed |
+
+## Applying Transforms
+
+```python
+# Python
+from warehouse_transforms import apply_transforms
+sql = apply_transforms(raw_sql, warehouse)   # no-op if warehouse == 'unknown'
+```
+
+```ruby
+# Ruby
+require_relative '../shared/lib/warehouse_transforms'
+sql = WarehouseTransforms.apply(raw_sql, warehouse)
+```
+
+The metabase-to-sigma converter applies these automatically when `--warehouse` is passed (or auto-detected from the Sigma connection). For other skills, call `apply_transforms` after generating or extracting SQL, before writing it to the spec.
+
+## Other Warehouse Gotchas (not yet automated)
+
+These require case-by-case handling; document them in the skill's refs/ as they're discovered:
+
+| Issue | BigQuery | Snowflake | Databricks |
+|---|---|---|---|
+| Identifier quoting | backticks `` `table` `` | double quotes `"table"` | backticks or none |
+| Date trunc syntax | `DATE_TRUNC(date, WEEK)` | `DATE_TRUNC('week', date)` | `DATE_TRUNC('week', date)` |
+| String concat | `CONCAT(a, b)` or `a || b` (BQ std) | `a || b` or `CONCAT` | `CONCAT` or `a || b` |
+| Regex | `REGEXP_CONTAINS(x, r)` | `REGEXP_LIKE(x, p)` | `x RLIKE p` |
+| ILIKE | not supported — use `LOWER(x) LIKE LOWER(y)` | supported | not supported |
+| Struct/nested fields | `x.field` | `x:field` (semi-structured) | `x.field` |

--- a/shared/lib/warehouse_transforms.py
+++ b/shared/lib/warehouse_transforms.py
@@ -1,0 +1,106 @@
+"""
+Warehouse-specific SQL transforms for Sigma migration skills.
+
+Usage:
+    from warehouse_transforms import apply_transforms, detect_warehouse
+
+    warehouse = detect_warehouse(sigma_base, token, connection_id)
+    clean_sql  = apply_transforms(raw_sql, warehouse)
+
+Warehouses: bigquery | snowflake | databricks | redshift | postgres | mysql | athena | unknown
+"""
+
+import re
+import urllib.request
+import urllib.error
+import json
+
+# Sigma connection type string → dialect key
+_SIGMA_TYPE_MAP = {
+    "bigquery":   "bigquery",
+    "snowflake":  "snowflake",
+    "databricks": "databricks",
+    "redshift":   "redshift",
+    "postgres":   "postgres",
+    "postgresql": "postgres",
+    "mysql":      "mysql",
+    "athena":     "athena",
+}
+
+
+def detect_warehouse(sigma_base: str, token: str, connection_id: str) -> str:
+    """
+    Query the Sigma connection API to determine the warehouse dialect.
+    Returns a dialect string or 'unknown' on any failure.
+    """
+    if not all([sigma_base, token, connection_id]):
+        return "unknown"
+    try:
+        url = f"{sigma_base.rstrip('/')}/v2/connections/{connection_id}"
+        req = urllib.request.Request(url, headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        })
+        with urllib.request.urlopen(req, timeout=8) as resp:
+            data = json.loads(resp.read())
+        raw_type = str(data.get("type") or data.get("connectionType") or "").lower()
+        return _SIGMA_TYPE_MAP.get(raw_type, "unknown")
+    except Exception:
+        return "unknown"
+
+
+def apply_transforms(sql: str, warehouse: str) -> str:
+    """
+    Apply warehouse-specific SQL transforms to a SQL string.
+    Currently handles: array aggregations → string aggregations.
+
+    Sigma cannot render array/nested types in table cells. Each warehouse
+    has its own string-aggregation idiom; this rewrites the common patterns.
+    """
+    if not sql or warehouse == "unknown":
+        return sql
+
+    if warehouse == "bigquery":
+        # ARRAY_AGG(x [IGNORE NULLS]) → array_to_string(ARRAY_AGG(x [IGNORE NULLS]), ', ')
+        # Guard against double-wrapping.
+        def _bq_replace(m):
+            full = m.group(0)
+            if re.search(r'array_to_string', full, re.IGNORECASE):
+                return full
+            return f"array_to_string({full}, ', ')"
+        sql = re.sub(
+            r'\bARRAY_AGG\s*\([^)]+(?:\s+IGNORE\s+NULLS)?\)(?:\s+IGNORE\s+NULLS)?',
+            _bq_replace, sql, flags=re.IGNORECASE,
+        )
+
+    elif warehouse == "snowflake":
+        # ARRAY_AGG returns VARIANT in Snowflake — Sigma renders as "[object]".
+        sql = re.sub(
+            r'\bARRAY_AGG\s*\(([^)]+)\)',
+            lambda m: f"LISTAGG({m.group(1)}, ', ')",
+            sql, flags=re.IGNORECASE,
+        )
+
+    elif warehouse == "databricks":
+        # collect_list → array_join
+        sql = re.sub(
+            r'\bcollect_list\s*\(([^)]+)\)',
+            lambda m: f"array_join(collect_list({m.group(1)}), ', ')",
+            sql, flags=re.IGNORECASE,
+        )
+
+    elif warehouse in ("redshift", "postgres"):
+        sql = re.sub(
+            r'\bARRAY_AGG\s*\(([^)]+)\)',
+            lambda m: f"STRING_AGG(CAST({m.group(1)} AS VARCHAR), ', ')",
+            sql, flags=re.IGNORECASE,
+        )
+
+    elif warehouse == "athena":
+        sql = re.sub(
+            r'\bARRAY_AGG\s*\(([^)]+)\)',
+            lambda m: f"array_join(array_agg({m.group(1)}), ', ')",
+            sql, flags=re.IGNORECASE,
+        )
+
+    return sql

--- a/shared/lib/warehouse_transforms.rb
+++ b/shared/lib/warehouse_transforms.rb
@@ -1,0 +1,68 @@
+# Warehouse-specific SQL transforms for Sigma migration skills.
+#
+# Usage:
+#   require_relative 'warehouse_transforms'
+#
+#   warehouse = WarehouseTransforms.detect(sigma_base, token, connection_id)
+#   clean_sql  = WarehouseTransforms.apply(raw_sql, warehouse)
+#
+# Warehouses: bigquery | snowflake | databricks | redshift | postgres | mysql | athena | unknown
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module WarehouseTransforms
+  SIGMA_TYPE_MAP = {
+    "bigquery"   => "bigquery",
+    "snowflake"  => "snowflake",
+    "databricks" => "databricks",
+    "redshift"   => "redshift",
+    "postgres"   => "postgres",
+    "postgresql" => "postgres",
+    "mysql"      => "mysql",
+    "athena"     => "athena",
+  }.freeze
+
+  def self.detect(sigma_base, token, connection_id)
+    return "unknown" unless sigma_base && token && connection_id
+    uri  = URI("#{sigma_base.chomp('/')}/v2/connections/#{connection_id}")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl      = uri.scheme == "https"
+    http.open_timeout = 8
+    http.read_timeout = 8
+    req  = Net::HTTP::Get.new(uri.path, "Authorization" => "Bearer #{token}", "Accept" => "application/json")
+    resp = http.request(req)
+    data = JSON.parse(resp.body)
+    raw  = (data["type"] || data["connectionType"] || "").downcase
+    SIGMA_TYPE_MAP[raw] || "unknown"
+  rescue StandardError
+    "unknown"
+  end
+
+  def self.apply(sql, warehouse)
+    return sql if sql.nil? || sql.empty? || warehouse == "unknown"
+
+    case warehouse
+    when "bigquery"
+      # ARRAY_AGG(x [IGNORE NULLS]) → array_to_string(ARRAY_AGG(x [IGNORE NULLS]), ', ')
+      sql = sql.gsub(/\bARRAY_AGG\s*\([^)]+(?:\s+IGNORE\s+NULLS)?\)(?:\s+IGNORE\s+NULLS)?/i) do |m|
+        m =~ /array_to_string/i ? m : "array_to_string(#{m}, ', ')"
+      end
+
+    when "snowflake"
+      sql = sql.gsub(/\bARRAY_AGG\s*\(([^)]+)\)/i) { "LISTAGG(#{$1}, ', ')" }
+
+    when "databricks"
+      sql = sql.gsub(/\bcollect_list\s*\(([^)]+)\)/i) { "array_join(collect_list(#{$1}), ', ')" }
+
+    when "redshift", "postgres"
+      sql = sql.gsub(/\bARRAY_AGG\s*\(([^)]+)\)/i) { "STRING_AGG(CAST(#{$1} AS VARCHAR), ', ')" }
+
+    when "athena"
+      sql = sql.gsub(/\bARRAY_AGG\s*\(([^)]+)\)/i) { "array_join(array_agg(#{$1}), ', ')" }
+    end
+
+    sql
+  end
+end


### PR DESCRIPTION
## Summary

- **`shared/lib/warehouse_transforms.py` + `.rb`** — detect warehouse dialect from the Sigma connection API and rewrite array aggregations to string aggregations: BigQuery `ARRAY_AGG`→`array_to_string`, Snowflake→`LISTAGG`, Databricks `collect_list`→`array_join`, Redshift/PG→`STRING_AGG`, Athena→`array_join`
- **`docs/warehouse-transforms.md`** — per-warehouse reference table + integration guide for all skill authors

Fixes the Eucalyptus-discovered BigQuery `ARRAY_AGG` blank-cell failure and generalises it across all supported warehouses. The metabase-to-sigma converter already calls this via `--warehouse` flag (wired in `twells89/metabase-to-sigma@5b8e581`). Other skills can adopt via `from warehouse_transforms import apply_transforms` / `require_relative`.

## Test plan
- [ ] `detect_warehouse()` returns correct dialect for a known Sigma connection
- [ ] BigQuery: `ARRAY_AGG(x IGNORE NULLS)` → `array_to_string(ARRAY_AGG(x IGNORE NULLS), ', ')`
- [ ] Snowflake: `ARRAY_AGG(x)` → `LISTAGG(x, ', ')`
- [ ] Double-wrap guard: already-wrapped expressions are not wrapped again

🤖 Generated with [Claude Code](https://claude.ai/claude-code)