### PR TITLE
Telemetry rollout: anonymous usage ping to all 9 migration skills

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -310,3 +310,16 @@ against the customer's live Sigma via `scripts/scout-validate-and-persist.mjs`, 
 success persists the rule to `~/.cognos-to-sigma/learned-rules.json` — which the converter
 CLI auto-applies *before* the built-in translator on the next run. If no formula validates,
 it returns an opt-in `scripts/escalate-gap.py` command to file a tracking issue (ask first).
+
+---
+
+## Telemetry (call after the final gate passes)
+
+Report anonymous usage telemetry — no customer data is sent.
+See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+
+```bash
+python3 scripts/report-telemetry.py --tool cognos-to-sigma --duration <elapsed_seconds>
+# on failure:
+python3 scripts/report-telemetry.py --tool cognos-to-sigma --duration <elapsed_seconds> --failed
+```

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,101 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import re
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    """Extract region slug from Sigma API base URL."""
+    if ".au." in sigma_base:  return "au"
+    if ".eu." in sigma_base:  return "eu"
+    if ".uk." in sigma_base:  return "uk"
+    if ".ca." in sigma_base:  return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """Anonymous org fingerprint: first 8 hex chars of SHA256(client_id)."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
+    must never block or fail a migration.
+
+    What is sent:
+      - tool name (e.g. "metabase-to-sigma")
+      - Sigma region (derived from API base URL, e.g. "au")
+      - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
+          → unique per org, not reversible to your credentials
+      - migration duration in seconds
+      - success flag
+      - skill version
+
+    What is NOT sent:
+      - workbook names, IDs, or URLs
+      - SQL queries or column names
+      - dashboard or card titles
+      - user email or name
+      - any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        # Never surface telemetry errors to the user
+        print("  → telemetry unavailable (skipped)\n")

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared telemetry reporter for sigma-migration-skills.
+Call at the end of a successful (or failed) migration after all gates pass.
+
+Usage:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+
+Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
+Prints what it sends; never raises; skips silently if endpoint unreachable.
+See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+from sigma_telemetry import report_migration
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+args = parser.parse_args()
+
+report_migration(
+    tool=args.tool,
+    sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
+    client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
+    duration_seconds=args.duration,
+    success=not args.failed,
+)

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,101 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import re
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    """Extract region slug from Sigma API base URL."""
+    if ".au." in sigma_base:  return "au"
+    if ".eu." in sigma_base:  return "eu"
+    if ".uk." in sigma_base:  return "uk"
+    if ".ca." in sigma_base:  return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """Anonymous org fingerprint: first 8 hex chars of SHA256(client_id)."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
+    must never block or fail a migration.
+
+    What is sent:
+      - tool name (e.g. "metabase-to-sigma")
+      - Sigma region (derived from API base URL, e.g. "au")
+      - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
+          → unique per org, not reversible to your credentials
+      - migration duration in seconds
+      - success flag
+      - skill version
+
+    What is NOT sent:
+      - workbook names, IDs, or URLs
+      - SQL queries or column names
+      - dashboard or card titles
+      - user email or name
+      - any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        # Never surface telemetry errors to the user
+        print("  → telemetry unavailable (skipped)\n")

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared telemetry reporter for sigma-migration-skills.
+Call at the end of a successful (or failed) migration after all gates pass.
+
+Usage:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+
+Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
+Prints what it sends; never raises; skips silently if endpoint unreachable.
+See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+from sigma_telemetry import report_migration
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+args = parser.parse_args()
+
+report_migration(
+    tool=args.tool,
+    sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
+    client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
+    duration_seconds=args.duration,
+    success=not args.failed,
+)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -793,3 +793,16 @@ declaring Phase 4 green.
 | LookML model 404s on query right after deploy | Model not registered | `POST /lookml_models {name, project_name, allowed_db_connection_names}` |
 | `PUT /projects/{id}` 404 when setting git remote | Wrong verb | Use `PATCH /projects/{id}` |
 | Looker dev-workspace mutation has no effect | The calls ran in separate processes/sessions (the bearer cache is per-process; a 401 re-login also starts a NEW session that resets the workspace to production) | Do the whole dev flow in ONE process — `looker_api.py`'s cached token keeps one session, so `PATCH /session {workspace_id: dev}` sticks for subsequent `call()`s; re-PATCH after any forced re-login |
+
+---
+
+## Telemetry (call after the final gate passes)
+
+Report anonymous usage telemetry — no customer data is sent.
+See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+
+```bash
+python3 scripts/report-telemetry.py --tool looker-to-sigma --duration <elapsed_seconds>
+# on failure:
+python3 scripts/report-telemetry.py --tool looker-to-sigma --duration <elapsed_seconds> --failed
+```

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,101 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import re
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    """Extract region slug from Sigma API base URL."""
+    if ".au." in sigma_base:  return "au"
+    if ".eu." in sigma_base:  return "eu"
+    if ".uk." in sigma_base:  return "uk"
+    if ".ca." in sigma_base:  return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """Anonymous org fingerprint: first 8 hex chars of SHA256(client_id)."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
+    must never block or fail a migration.
+
+    What is sent:
+      - tool name (e.g. "metabase-to-sigma")
+      - Sigma region (derived from API base URL, e.g. "au")
+      - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
+          → unique per org, not reversible to your credentials
+      - migration duration in seconds
+      - success flag
+      - skill version
+
+    What is NOT sent:
+      - workbook names, IDs, or URLs
+      - SQL queries or column names
+      - dashboard or card titles
+      - user email or name
+      - any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        # Never surface telemetry errors to the user
+        print("  → telemetry unavailable (skipped)\n")

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared telemetry reporter for sigma-migration-skills.
+Call at the end of a successful (or failed) migration after all gates pass.
+
+Usage:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+
+Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
+Prints what it sends; never raises; skips silently if endpoint unreachable.
+See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+from sigma_telemetry import report_migration
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+args = parser.parse_args()
+
+report_migration(
+    tool=args.tool,
+    sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
+    client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
+    duration_seconds=args.duration,
+    success=not args.failed,
+)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -406,3 +406,16 @@ doesn't carry them).
   gate 7 catches escapes).
 - Python 3.13+ rejects some MSTR cloud CA certs (`VERIFY_X509_STRICT`) —
   `mstr.py` handles it.
+
+---
+
+## Telemetry (call after the final gate passes)
+
+Report anonymous usage telemetry — no customer data is sent.
+See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+
+```bash
+python3 scripts/report-telemetry.py --tool microstrategy-to-sigma --duration <elapsed_seconds>
+# on failure:
+python3 scripts/report-telemetry.py --tool microstrategy-to-sigma --duration <elapsed_seconds> --failed
+```

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,101 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import re
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    """Extract region slug from Sigma API base URL."""
+    if ".au." in sigma_base:  return "au"
+    if ".eu." in sigma_base:  return "eu"
+    if ".uk." in sigma_base:  return "uk"
+    if ".ca." in sigma_base:  return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """Anonymous org fingerprint: first 8 hex chars of SHA256(client_id)."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
+    must never block or fail a migration.
+
+    What is sent:
+      - tool name (e.g. "metabase-to-sigma")
+      - Sigma region (derived from API base URL, e.g. "au")
+      - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
+          → unique per org, not reversible to your credentials
+      - migration duration in seconds
+      - success flag
+      - skill version
+
+    What is NOT sent:
+      - workbook names, IDs, or URLs
+      - SQL queries or column names
+      - dashboard or card titles
+      - user email or name
+      - any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        # Never surface telemetry errors to the user
+        print("  → telemetry unavailable (skipped)\n")

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared telemetry reporter for sigma-migration-skills.
+Call at the end of a successful (or failed) migration after all gates pass.
+
+Usage:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+
+Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
+Prints what it sends; never raises; skips silently if endpoint unreachable.
+See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+from sigma_telemetry import report_migration
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+args = parser.parse_args()
+
+report_migration(
+    tool=args.tool,
+    sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
+    client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
+    duration_seconds=args.duration,
+    success=not args.failed,
+)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -330,3 +330,16 @@ Row/column security is **never silently dropped and never silently ported** — 
 
 **Skip is loud:** opting out leaves the migrated model with NO RLS — all rows visible to everyone. Confirm before skipping.
 
+
+---
+
+## Telemetry (call after the final gate passes)
+
+Report anonymous usage telemetry — no customer data is sent.
+See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+
+```bash
+python3 scripts/report-telemetry.py --tool powerbi-to-sigma --duration <elapsed_seconds>
+# on failure:
+python3 scripts/report-telemetry.py --tool powerbi-to-sigma --duration <elapsed_seconds> --failed
+```

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,101 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import re
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    """Extract region slug from Sigma API base URL."""
+    if ".au." in sigma_base:  return "au"
+    if ".eu." in sigma_base:  return "eu"
+    if ".uk." in sigma_base:  return "uk"
+    if ".ca." in sigma_base:  return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """Anonymous org fingerprint: first 8 hex chars of SHA256(client_id)."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
+    must never block or fail a migration.
+
+    What is sent:
+      - tool name (e.g. "metabase-to-sigma")
+      - Sigma region (derived from API base URL, e.g. "au")
+      - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
+          → unique per org, not reversible to your credentials
+      - migration duration in seconds
+      - success flag
+      - skill version
+
+    What is NOT sent:
+      - workbook names, IDs, or URLs
+      - SQL queries or column names
+      - dashboard or card titles
+      - user email or name
+      - any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        # Never surface telemetry errors to the user
+        print("  → telemetry unavailable (skipped)\n")

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared telemetry reporter for sigma-migration-skills.
+Call at the end of a successful (or failed) migration after all gates pass.
+
+Usage:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+
+Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
+Prints what it sends; never raises; skips silently if endpoint unreachable.
+See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+from sigma_telemetry import report_migration
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+args = parser.parse_args()
+
+report_migration(
+    tool=args.tool,
+    sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
+    client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
+    duration_seconds=args.duration,
+    success=not args.failed,
+)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -359,3 +359,16 @@ Row/column security is **never silently dropped and never silently ported** — 
 
 **Skip is loud:** opting out leaves the migrated model with NO RLS — all rows visible to everyone. Confirm before skipping.
 
+
+---
+
+## Telemetry (call after the final gate passes)
+
+Report anonymous usage telemetry — no customer data is sent.
+See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+
+```bash
+python3 scripts/report-telemetry.py --tool qlik-to-sigma --duration <elapsed_seconds>
+# on failure:
+python3 scripts/report-telemetry.py --tool qlik-to-sigma --duration <elapsed_seconds> --failed
+```

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,101 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import re
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    """Extract region slug from Sigma API base URL."""
+    if ".au." in sigma_base:  return "au"
+    if ".eu." in sigma_base:  return "eu"
+    if ".uk." in sigma_base:  return "uk"
+    if ".ca." in sigma_base:  return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """Anonymous org fingerprint: first 8 hex chars of SHA256(client_id)."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
+    must never block or fail a migration.
+
+    What is sent:
+      - tool name (e.g. "metabase-to-sigma")
+      - Sigma region (derived from API base URL, e.g. "au")
+      - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
+          → unique per org, not reversible to your credentials
+      - migration duration in seconds
+      - success flag
+      - skill version
+
+    What is NOT sent:
+      - workbook names, IDs, or URLs
+      - SQL queries or column names
+      - dashboard or card titles
+      - user email or name
+      - any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        # Never surface telemetry errors to the user
+        print("  → telemetry unavailable (skipped)\n")

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared telemetry reporter for sigma-migration-skills.
+Call at the end of a successful (or failed) migration after all gates pass.
+
+Usage:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+
+Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
+Prints what it sends; never raises; skips silently if endpoint unreachable.
+See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+from sigma_telemetry import report_migration
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+args = parser.parse_args()
+
+report_migration(
+    tool=args.tool,
+    sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
+    client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
+    duration_seconds=args.duration,
+    success=not args.failed,
+)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -252,3 +252,16 @@ Row/column security is **never silently dropped and never silently ported** — 
 
 **Skip is loud:** opting out leaves the migrated model with NO RLS — all rows visible to everyone. Confirm before skipping.
 
+
+---
+
+## Telemetry (call after the final gate passes)
+
+Report anonymous usage telemetry — no customer data is sent.
+See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+
+```bash
+python3 scripts/report-telemetry.py --tool quicksight-to-sigma --duration <elapsed_seconds>
+# on failure:
+python3 scripts/report-telemetry.py --tool quicksight-to-sigma --duration <elapsed_seconds> --failed
+```

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,101 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import re
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    """Extract region slug from Sigma API base URL."""
+    if ".au." in sigma_base:  return "au"
+    if ".eu." in sigma_base:  return "eu"
+    if ".uk." in sigma_base:  return "uk"
+    if ".ca." in sigma_base:  return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """Anonymous org fingerprint: first 8 hex chars of SHA256(client_id)."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
+    must never block or fail a migration.
+
+    What is sent:
+      - tool name (e.g. "metabase-to-sigma")
+      - Sigma region (derived from API base URL, e.g. "au")
+      - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
+          → unique per org, not reversible to your credentials
+      - migration duration in seconds
+      - success flag
+      - skill version
+
+    What is NOT sent:
+      - workbook names, IDs, or URLs
+      - SQL queries or column names
+      - dashboard or card titles
+      - user email or name
+      - any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        # Never surface telemetry errors to the user
+        print("  → telemetry unavailable (skipped)\n")

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared telemetry reporter for sigma-migration-skills.
+Call at the end of a successful (or failed) migration after all gates pass.
+
+Usage:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+
+Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
+Prints what it sends; never raises; skips silently if endpoint unreachable.
+See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+from sigma_telemetry import report_migration
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+args = parser.parse_args()
+
+report_migration(
+    tool=args.tool,
+    sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
+    client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
+    duration_seconds=args.duration,
+    success=not args.failed,
+)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -1797,3 +1797,16 @@ Row/column security is **never silently dropped and never silently ported** — 
 
 **Skip is loud:** opting out leaves the migrated model with NO RLS — all rows visible to everyone. Confirm before skipping.
 
+
+---
+
+## Telemetry (call after the final gate passes)
+
+Report anonymous usage telemetry — no customer data is sent.
+See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+
+```bash
+python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration <elapsed_seconds>
+# on failure:
+python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration <elapsed_seconds> --failed
+```

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,101 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import re
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    """Extract region slug from Sigma API base URL."""
+    if ".au." in sigma_base:  return "au"
+    if ".eu." in sigma_base:  return "eu"
+    if ".uk." in sigma_base:  return "uk"
+    if ".ca." in sigma_base:  return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """Anonymous org fingerprint: first 8 hex chars of SHA256(client_id)."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
+    must never block or fail a migration.
+
+    What is sent:
+      - tool name (e.g. "metabase-to-sigma")
+      - Sigma region (derived from API base URL, e.g. "au")
+      - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
+          → unique per org, not reversible to your credentials
+      - migration duration in seconds
+      - success flag
+      - skill version
+
+    What is NOT sent:
+      - workbook names, IDs, or URLs
+      - SQL queries or column names
+      - dashboard or card titles
+      - user email or name
+      - any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        # Never surface telemetry errors to the user
+        print("  → telemetry unavailable (skipped)\n")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared telemetry reporter for sigma-migration-skills.
+Call at the end of a successful (or failed) migration after all gates pass.
+
+Usage:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+
+Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
+Prints what it sends; never raises; skips silently if endpoint unreachable.
+See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+from sigma_telemetry import report_migration
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+args = parser.parse_args()
+
+report_migration(
+    tool=args.tool,
+    sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
+    client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
+    duration_seconds=args.duration,
+    success=not args.failed,
+)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -315,3 +315,16 @@ Row/column security is **never silently dropped and never silently ported** — 
 
 **Skip is loud:** opting out leaves the migrated model with NO RLS — all rows visible to everyone. Confirm before skipping.
 
+
+---
+
+## Telemetry (call after the final gate passes)
+
+Report anonymous usage telemetry — no customer data is sent.
+See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+
+```bash
+python3 scripts/report-telemetry.py --tool thoughtspot-to-sigma --duration <elapsed_seconds>
+# on failure:
+python3 scripts/report-telemetry.py --tool thoughtspot-to-sigma --duration <elapsed_seconds> --failed
+```

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,101 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import re
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    """Extract region slug from Sigma API base URL."""
+    if ".au." in sigma_base:  return "au"
+    if ".eu." in sigma_base:  return "eu"
+    if ".uk." in sigma_base:  return "uk"
+    if ".ca." in sigma_base:  return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """Anonymous org fingerprint: first 8 hex chars of SHA256(client_id)."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
+    must never block or fail a migration.
+
+    What is sent:
+      - tool name (e.g. "metabase-to-sigma")
+      - Sigma region (derived from API base URL, e.g. "au")
+      - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
+          → unique per org, not reversible to your credentials
+      - migration duration in seconds
+      - success flag
+      - skill version
+
+    What is NOT sent:
+      - workbook names, IDs, or URLs
+      - SQL queries or column names
+      - dashboard or card titles
+      - user email or name
+      - any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        # Never surface telemetry errors to the user
+        print("  → telemetry unavailable (skipped)\n")

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared telemetry reporter for sigma-migration-skills.
+Call at the end of a successful (or failed) migration after all gates pass.
+
+Usage:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+
+Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
+Prints what it sends; never raises; skips silently if endpoint unreachable.
+See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+from sigma_telemetry import report_migration
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+args = parser.parse_args()
+
+report_migration(
+    tool=args.tool,
+    sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
+    client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
+    duration_seconds=args.duration,
+    success=not args.failed,
+)

--- a/shared/lib/sigma_telemetry.py
+++ b/shared/lib/sigma_telemetry.py
@@ -1,0 +1,101 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import re
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    """Extract region slug from Sigma API base URL."""
+    if ".au." in sigma_base:  return "au"
+    if ".eu." in sigma_base:  return "eu"
+    if ".uk." in sigma_base:  return "uk"
+    if ".ca." in sigma_base:  return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """Anonymous org fingerprint: first 8 hex chars of SHA256(client_id)."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
+    must never block or fail a migration.
+
+    What is sent:
+      - tool name (e.g. "metabase-to-sigma")
+      - Sigma region (derived from API base URL, e.g. "au")
+      - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
+          → unique per org, not reversible to your credentials
+      - migration duration in seconds
+      - success flag
+      - skill version
+
+    What is NOT sent:
+      - workbook names, IDs, or URLs
+      - SQL queries or column names
+      - dashboard or card titles
+      - user email or name
+      - any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        # Never surface telemetry errors to the user
+        print("  → telemetry unavailable (skipped)\n")

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -63,6 +63,34 @@
       ]
     },
     {
+      "canonical": "shared/lib/sigma_telemetry.py",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py"
+      ]
+    },
+    {
+      "canonical": "shared/scripts/report-telemetry.py",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py"
+      ]
+    },
+    {
       "canonical": "shared/scripts/escalate-gap.py",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/escalate-gap.py",

--- a/shared/scripts/report-telemetry.py
+++ b/shared/scripts/report-telemetry.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Shared telemetry reporter for sigma-migration-skills.
+Call at the end of a successful (or failed) migration after all gates pass.
+
+Usage:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+
+Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
+Prints what it sends; never raises; skips silently if endpoint unreachable.
+See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+from sigma_telemetry import report_migration
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+args = parser.parse_args()
+
+report_migration(
+    tool=args.tool,
+    sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
+    client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
+    duration_seconds=args.duration,
+    success=not args.failed,
+)


### PR DESCRIPTION
## Summary

- **`shared/lib/sigma_telemetry.py`** — fire-and-forget ping client (org_id_hash, tool, region, duration, success)
- **`shared/scripts/report-telemetry.py`** — CLI wrapper synced to all plugins
- **`shared/manifest.json`** — two new entries; `sync-shared.rb` propagated both to all 9 plugins
- **8 × SKILL.md** — `## Telemetry` section appended, instructs Claude to call `report-telemetry.py` after the final gate passes

No customer data sent — only tool name, Sigma region, anonymized org fingerprint (SHA256 of `SIGMA_CLIENT_ID` first 8 chars), duration, success flag. Script prints the full payload before firing and swallows errors silently. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).

GoodData SKILL.md not yet patched — no SKILL.md on main yet for that plugin.

## Test plan
- [ ] `python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 300` prints disclosure and fires
- [ ] CI shared-file check passes (133 copies match canonical)
- [ ] Endpoint returns 200

🤖 Generated with [Claude Code](https://claude.ai/claude-code)