### PR TITLE
telemetry: explicit opt-out conversation notice before ping fires

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -313,13 +313,15 @@ it returns an opt-in `scripts/escalate-gap.py` command to file a tracking issue 
 
 ---
 
-## Telemetry (call after the final gate passes)
+## Telemetry (after the final gate passes)
 
-Report anonymous usage telemetry — no customer data is sent.
-See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+**Tell the user this in the conversation before running anything:**
+
+> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md) for the exact payload. Just say 'skip' if you'd prefer not to send it."
+
+If the user does not object, run:
 
 ```bash
 python3 scripts/report-telemetry.py --tool cognos-to-sigma --duration <elapsed_seconds>
-# on failure:
-python3 scripts/report-telemetry.py --tool cognos-to-sigma --duration <elapsed_seconds> --failed
+# on failure: python3 scripts/report-telemetry.py --tool cognos-to-sigma --duration <elapsed_seconds> --failed
 ```

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -796,13 +796,15 @@ declaring Phase 4 green.
 
 ---
 
-## Telemetry (call after the final gate passes)
+## Telemetry (after the final gate passes)
 
-Report anonymous usage telemetry — no customer data is sent.
-See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+**Tell the user this in the conversation before running anything:**
+
+> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md) for the exact payload. Just say 'skip' if you'd prefer not to send it."
+
+If the user does not object, run:
 
 ```bash
 python3 scripts/report-telemetry.py --tool looker-to-sigma --duration <elapsed_seconds>
-# on failure:
-python3 scripts/report-telemetry.py --tool looker-to-sigma --duration <elapsed_seconds> --failed
+# on failure: python3 scripts/report-telemetry.py --tool looker-to-sigma --duration <elapsed_seconds> --failed
 ```

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -409,13 +409,15 @@ doesn't carry them).
 
 ---
 
-## Telemetry (call after the final gate passes)
+## Telemetry (after the final gate passes)
 
-Report anonymous usage telemetry — no customer data is sent.
-See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+**Tell the user this in the conversation before running anything:**
+
+> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md) for the exact payload. Just say 'skip' if you'd prefer not to send it."
+
+If the user does not object, run:
 
 ```bash
 python3 scripts/report-telemetry.py --tool microstrategy-to-sigma --duration <elapsed_seconds>
-# on failure:
-python3 scripts/report-telemetry.py --tool microstrategy-to-sigma --duration <elapsed_seconds> --failed
+# on failure: python3 scripts/report-telemetry.py --tool microstrategy-to-sigma --duration <elapsed_seconds> --failed
 ```

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -333,13 +333,15 @@ Row/column security is **never silently dropped and never silently ported** — 
 
 ---
 
-## Telemetry (call after the final gate passes)
+## Telemetry (after the final gate passes)
 
-Report anonymous usage telemetry — no customer data is sent.
-See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+**Tell the user this in the conversation before running anything:**
+
+> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md) for the exact payload. Just say 'skip' if you'd prefer not to send it."
+
+If the user does not object, run:
 
 ```bash
 python3 scripts/report-telemetry.py --tool powerbi-to-sigma --duration <elapsed_seconds>
-# on failure:
-python3 scripts/report-telemetry.py --tool powerbi-to-sigma --duration <elapsed_seconds> --failed
+# on failure: python3 scripts/report-telemetry.py --tool powerbi-to-sigma --duration <elapsed_seconds> --failed
 ```

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -362,13 +362,15 @@ Row/column security is **never silently dropped and never silently ported** — 
 
 ---
 
-## Telemetry (call after the final gate passes)
+## Telemetry (after the final gate passes)
 
-Report anonymous usage telemetry — no customer data is sent.
-See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+**Tell the user this in the conversation before running anything:**
+
+> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md) for the exact payload. Just say 'skip' if you'd prefer not to send it."
+
+If the user does not object, run:
 
 ```bash
 python3 scripts/report-telemetry.py --tool qlik-to-sigma --duration <elapsed_seconds>
-# on failure:
-python3 scripts/report-telemetry.py --tool qlik-to-sigma --duration <elapsed_seconds> --failed
+# on failure: python3 scripts/report-telemetry.py --tool qlik-to-sigma --duration <elapsed_seconds> --failed
 ```

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -255,13 +255,15 @@ Row/column security is **never silently dropped and never silently ported** — 
 
 ---
 
-## Telemetry (call after the final gate passes)
+## Telemetry (after the final gate passes)
 
-Report anonymous usage telemetry — no customer data is sent.
-See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+**Tell the user this in the conversation before running anything:**
+
+> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md) for the exact payload. Just say 'skip' if you'd prefer not to send it."
+
+If the user does not object, run:
 
 ```bash
 python3 scripts/report-telemetry.py --tool quicksight-to-sigma --duration <elapsed_seconds>
-# on failure:
-python3 scripts/report-telemetry.py --tool quicksight-to-sigma --duration <elapsed_seconds> --failed
+# on failure: python3 scripts/report-telemetry.py --tool quicksight-to-sigma --duration <elapsed_seconds> --failed
 ```

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -1800,13 +1800,15 @@ Row/column security is **never silently dropped and never silently ported** — 
 
 ---
 
-## Telemetry (call after the final gate passes)
+## Telemetry (after the final gate passes)
 
-Report anonymous usage telemetry — no customer data is sent.
-See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+**Tell the user this in the conversation before running anything:**
+
+> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md) for the exact payload. Just say 'skip' if you'd prefer not to send it."
+
+If the user does not object, run:
 
 ```bash
 python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration <elapsed_seconds>
-# on failure:
-python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration <elapsed_seconds> --failed
+# on failure: python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration <elapsed_seconds> --failed
 ```

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -318,13 +318,15 @@ Row/column security is **never silently dropped and never silently ported** — 
 
 ---
 
-## Telemetry (call after the final gate passes)
+## Telemetry (after the final gate passes)
 
-Report anonymous usage telemetry — no customer data is sent.
-See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md).
+**Tell the user this in the conversation before running anything:**
+
+> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md) for the exact payload. Just say 'skip' if you'd prefer not to send it."
+
+If the user does not object, run:
 
 ```bash
 python3 scripts/report-telemetry.py --tool thoughtspot-to-sigma --duration <elapsed_seconds>
-# on failure:
-python3 scripts/report-telemetry.py --tool thoughtspot-to-sigma --duration <elapsed_seconds> --failed
+# on failure: python3 scripts/report-telemetry.py --tool thoughtspot-to-sigma --duration <elapsed_seconds> --failed
 ```


### PR DESCRIPTION
## Summary

Updates all 8 plugin `SKILL.md` files so Claude tells the user what's being sent **in the conversation** and waits for an objection before calling `report-telemetry.py`.

Previously the only disclosure was the terminal output of the script itself — invisible to users who'd pre-authorized bash commands or run with `--dangerously-skip-permissions`.

## What Claude now says

> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See TELEMETRY.md for the exact payload. Just say 'skip' if you'd prefer not to send it."

User says skip → Claude doesn't run the script. No prompt required.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)