### PR TITLE
powerbi-to-sigma: surface a migration coverage report instead of silently dropping components

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -111,6 +111,23 @@ Then: `tableau-to-sigma/scripts/post-and-readback.rb --type datamodel`. See `ref
   - measure formula wraps the master col: `CountDistinct([Master/Col])`, `Sum([Master/Col])`, date dim `DateTrunc("month",[Master/Col])`.
 - `POST /v2/workbooks/spec` (post-and-readback `--type workbook`). Chart-element shapes mirror `tableau-to-sigma/scripts/build-charts-from-signals.rb`.
 
+## Phase 5c — Coverage report (NEVER silently drop a component)
+The build **never silently drops** what it can't resolve — every drop, downgrade,
+and approximation is recorded to `$WORK/coverage.json` and surfaced as ONE
+consolidated **MIGRATION COVERAGE** readout (the doctrine the RLS section already
+states, extended to visuals). `migrate-powerbi.rb` prints it automatically after
+the workbook POST; for a standalone `build-workbook-from-pbir.rb` run pass
+`--coverage-out` and read the file. The report **leads with what carried over**
+(an approximated treemap→bar or a degraded missing-field visual still lands with
+its data; only a `dropped` visual is truly absent) so the common "it drops a lot"
+perception — usually just gaps that were never surfaced in one place — is
+answered with the real number.
+
+- `severity`: `dropped` (no element built) · `degraded` (built, lost a role/field/sort) · `approximated` (built as a substituted Sigma kind, e.g. treemap/funnel/gauge/waterfall → bar/kpi).
+- `recoverable: true` items carry a concrete **action** (supply `--image-map`, add a joined master, re-point a drill level, supply a geo column). In an interactive run they print as an **ASSISTANCE AVAILABLE** block — present them to the user (one `AskUserQuestion` checklist: *recover* vs *accept*). Under `--yes`/`--answers` they take the accept default and are recorded as accepted degradations.
+- `recoverable: false` items are genuine Sigma spec limitations (no native gauge; region maps have no categorical legend) — reported, never asked about.
+- The recoverable items are **hard-gated** at Phase 5e: `assert-visual-compare.rb --coverage` will not go GREEN until each is recovered or explicitly acknowledged.
+
 ## Phase 5d — Layout (do NOT skip — stacked ≠ done)
 Map each visual's `x,y,w,h` → 24-col grid (`COL_UNIT = page_w/24`, `ROW_UNIT ≈ 30`) → single top-level `layout` XML (one `<Page>` per page, server page IDs) → `tableau-to-sigma/scripts/put-layout.rb`. Math + snap rules in `research/powerbi-visual-layout.md §4`.
 
@@ -130,8 +147,11 @@ pages next to the Power BI renders. Do this BEFORE Phase 6, every run:
 4. Write `$WORK/visual-qa/visual-compare.json`: `[{page, verdict: PASS|ACCEPTED|FAIL, deltas: ["…"]}]`
    — ACCEPTED means the user explicitly OK'd a listed delta (e.g. zip
    choropleth instead of PBI's bubble map; theme colors). FAIL = fix and re-export.
-5. Gate: `ruby scripts/assert-visual-compare.rb --dir $WORK/visual-qa --signals $WORK/signals.json`
-   must print GREEN before Phase 6 may be declared.
+5. Gate: `ruby scripts/assert-visual-compare.rb --dir $WORK/visual-qa --signals $WORK/signals.json --coverage $WORK/coverage.json`
+   must print GREEN before Phase 6 may be declared. `--coverage` cross-checks the
+   Phase 5c ledger: every **recoverable** gap must be acknowledged — its visual
+   named in a page's `deltas[]` (or an explicit `acceptedGaps` list) — so a
+   recoverable drop can never ship unnoticed.
 
 Layout escalation if the compare fails on arrangement: the builder's default
 `--layout clean` preserves the source positions inside a normalized grid; use
@@ -295,7 +315,7 @@ The conversion is script-driven (mirrors `tableau-to-sigma/scripts/`). `scripts/
 | `sigma-export-png.py` | 5e/5f compare | Renders a built Sigma page to PNG (`--workbook <id> --page <pageId> --out … --w 1600`) for the source-vs-target compare AND the Phase 5f Visual QA read (checked against `refs/layout-visual-qa.md`). |
 | `assert-visual-compare.rb` | 5e gate | HARD GATE: blocks Phase 6 unless visual-compare.json has a PASS/ACCEPTED verdict (with explained deltas) for every content page. |
 | `convert-model.rb` | 2–3 convert/post | MODE A prints the exact `convert_powerbi_to_sigma` MCP call for a `model.bim`; MODE B takes the converter output and applies the 3 fixups (schemaVersion + folderId/ownerId via a ref-DM harvest + base-element names) → postable DM spec. |
-| `build-workbook-from-pbir.rb` | 4 build | `signals.json` + a `master-map.json` → full workbook spec + 24-col layout XML. Applies the measure-translation patterns in `refs/measure-patterns.md`; **line charts default to a single series** (`beads-sigma-c07`) unless PBI bound a Series/Legend role. **Carries the PBI visual sort** (`f972` — PBIR `query.sortDefinition` / classic `prototypeQuery.OrderBy` → chart `xAxis.sort`/`color.sort`; grouped table → `groupings[0].sort` — element-level sort is rejected on grouped tables). Analog of `build-charts-from-signals.rb`. |
+| `build-workbook-from-pbir.rb` | 4 build | `signals.json` + a `master-map.json` → full workbook spec + 24-col layout XML. Applies the measure-translation patterns in `refs/measure-patterns.md`; **line charts default to a single series** (`beads-sigma-c07`) unless PBI bound a Series/Legend role. **Carries the PBI visual sort** (`f972` — PBIR `query.sortDefinition` / classic `prototypeQuery.OrderBy` → chart `xAxis.sort`/`color.sort`; grouped table → `groupings[0].sort` — element-level sort is rejected on grouped tables). Analog of `build-charts-from-signals.rb`. **Writes `coverage.json`** (`--coverage-out`): every dropped/degraded/approximated component aggregated (Phase 5c) — nothing silently dropped. |
 | `phase6-parity-pbi.rb` | 7 parity | executeQueries(DAX) adapter: `--emit-dax` runs the PBI side and writes the parity plan's `expected` rows; `--finalize` injects Sigma actuals and runs the shared `verify-parity.rb`. The PBI analog of Tableau's view-CSV parity adapter. |
 | `enhance-scan.rb` | E scan (opt-in) | **Phase E part 1 — SCAN (read-only).** Source signals + built spec + live element exports → `enhancements.json` candidates `{id, category, evidence, proposed, risk, verdict_hint, patch}` + descoped propose-in-UI notes. Shared Phase-E engine, vendored byte-identical across plugins (md5 discipline). |
 | `enhance-apply.rb` | E apply (opt-in) | **Phase E part 2 — APPLY (accept-only, clone-first).** Clones the parity workbook as `"<name> — Enhanced"` (1:1 artifact never written), applies ONLY `--accept`-ed candidates one at a time, each gated by an untouched-element clone-vs-original spot-check (auto-revert on shift). Writes `enhance-report.json`. Byte-identical twin of the tableau copy. |

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-visual-compare.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-visual-compare.rb
@@ -13,6 +13,11 @@ opts = {}
 OptionParser.new do |p|
   p.on('--dir D') { |v| opts[:dir] = v }
   p.on('--signals S') { |v| opts[:sig] = v }
+  # Optional: the build's coverage.json. When supplied, every RECOVERABLE gap it
+  # records must be acknowledged — its visual name must appear in some page's
+  # deltas[] (proof the human saw it during the eyeball compare) or in an
+  # explicit `acceptedGaps` list — so recoverable drops can't ship unnoticed.
+  p.on('--coverage C') { |v| opts[:cov] = v }
 end.parse!
 abort('need --dir and --signals') unless opts[:dir] && opts[:sig]
 path = File.join(opts[:dir], 'visual-compare.json')
@@ -31,4 +36,25 @@ bad = entries.reject { |e| %w[PASS ACCEPTED].include?(e['verdict'].to_s.upcase) 
 abort("BLOCKED: non-passing verdict(s): #{bad.map { |e| "#{e['page']}=#{e['verdict']}" }.join(', ')}") unless bad.empty?
 unexplained = entries.select { |e| e['verdict'].to_s.upcase == 'ACCEPTED' && Array(e['deltas']).empty? }
 abort("BLOCKED: ACCEPTED verdict without deltas[] explaining what differs: #{unexplained.map { |e| e['page'] }.join(', ')}") unless unexplained.empty?
+
+# Coverage cross-check: every RECOVERABLE gap the build flagged must be
+# acknowledged (recovered or explicitly accepted), never silently shipped.
+if opts[:cov] && File.exist?(opts[:cov])
+  cov = JSON.parse(File.read(opts[:cov])) rescue {}
+  recoverable = (cov['unresolved'] || []).select { |u| u['recoverable'] }
+  if recoverable.any?
+    acknowledged = entries.flat_map { |e| Array(e['deltas']) + Array(e['acceptedGaps']) }
+                          .map { |d| d.to_s.downcase }
+    unaccounted = recoverable.reject do |u|
+      v = u['visual'].to_s.downcase
+      acknowledged.any? { |d| !v.empty? && d.include?(v) }
+    end
+    unless unaccounted.empty?
+      msg = unaccounted.map { |u| "#{u['visual']} (#{u['detail']})" }.join('; ')
+      abort("BLOCKED: #{unaccounted.size} recoverable coverage gap(s) not acknowledged in any page's " \
+            "deltas[]/acceptedGaps — recover them or list each as an accepted delta: #{msg}")
+    end
+    puts "coverage cross-check GREEN: all #{recoverable.size} recoverable gap(s) acknowledged."
+  end
+end
 puts "visual-compare GREEN: #{entries.length} page(s) verified against the source render."

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -76,6 +76,10 @@ OptionParser.new do |p|
   # Where the intended-scope contract lands (consumed by workstream A's lint).
   # Default: control-scope.json next to --out.
   p.on('--control-scope-out PATH') { |v| opts[:scope_out] = v }
+  # Where the migration COVERAGE report lands (the aggregated drop/approx ledger
+  # migrate-powerbi.rb surfaces + assert-visual-compare.rb gates on). Default:
+  # coverage.json next to --out.
+  p.on('--coverage-out PATH') { |v| opts[:coverage_out] = v }
 end.parse!
 %i[sig mmap out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
 
@@ -182,6 +186,27 @@ $control_scope = []
 $control_unbound = []
 $used_control_ids = Hash.new(0)
 
+# coverage.json accumulator (bead beads-sigma-cov). Every visual/field the build
+# could NOT carry over faithfully is recorded here so migrate-powerbi.rb can show
+# ONE consolidated coverage report + an assistance gate instead of leaving these
+# as scattered STDERR warnings the user has to reconstruct by hand (customer
+# feedback, 2026-06-25: "silently drops components it cannot resolve"). The build
+# ALREADY warns loudly at each site — this just AGGREGATES the same facts.
+# Entry schema: {visual, pbi_type, sigma_kind, severity, detail, recoverable, action}.
+#   severity: 'dropped'      — nothing built for this visual/field
+#             'degraded'     — element built, but a role/field/sort was lost
+#             'approximated' — built as a different (best-effort) Sigma kind
+# recoverable: true  -> a concrete user/agent action recovers it (surfaced as a
+#                       decision in migrate-powerbi.rb + a hard visual-compare gate)
+#              false -> a genuine Sigma spec limitation (informational only)
+$unresolved = []
+def record_unresolved(visual:, severity:, detail:, pbi_type: nil, sigma_kind: nil,
+                      recoverable: false, action: nil)
+  $unresolved << { 'visual' => visual.to_s, 'pbi_type' => pbi_type, 'sigma_kind' => sigma_kind,
+                   'severity' => severity, 'detail' => detail.to_s,
+                   'recoverable' => recoverable, 'action' => action }
+end
+
 # TMSL column type for ENTITY.LEAF — date-typed slicers must become date-range
 # controls: a `list` control bound to a datetime column posts fine but Sigma
 # SILENTLY STRIPS its filter targets (known estate-repair gotcha).
@@ -192,6 +217,17 @@ def tmsl_date_column?(ent, leaf)
   c = t && (t['columns'] || []).find { |col| col['name'].to_s.casecmp(leaf.to_s).zero? }
   !!(c && c['dataType'].to_s =~ /date/i)
 end
+
+# PBI visualTypes that map 1:1 to a native Sigma element kind (no approximation).
+# Anything NOT in this set is rendered as a best-effort Sigma kind and recorded
+# in coverage.json as 'approximated' so the user sees the substitution (e.g.
+# treemap/funnel/gauge/ribbon/waterfall → bar). Mirrors migrate-powerbi.rb NATIVE.
+NATIVE_VISUAL_TYPES = %w[card multiRowCard kpi textbox actionButton lineChart areaChart
+                         stackedAreaChart barChart clusteredBarChart stackedBarChart columnChart
+                         clusteredColumnChart stackedColumnChart hundredPercentStackedColumnChart
+                         hundredPercentStackedBarChart lineClusteredColumnComboChart
+                         lineStackedColumnComboChart pieChart donutChart scatterChart tableEx
+                         pivotTable matrix slicer map filledMap shapeMap azureMap image].freeze
 
 SIGMA_KIND = {
   'kpi' => 'kpi-chart', 'bar' => 'bar-chart', 'line' => 'line-chart',
@@ -526,12 +562,18 @@ def apply_sort(el, kind, rec, qr_cids, name)
     end
   when 'pivot-table'
     warn "[build-workbook] WARN visual '#{name}': pivot-table sort is not spec-expressible in Sigma — set it in the UI."
+    record_unresolved(visual: name, severity: 'degraded', recoverable: false,
+                      detail: 'pivot-table sort is not spec-expressible in Sigma',
+                      action: 'Set the sort on the pivot in the Sigma UI after migration.')
   end
 end
 
 def warn_sort_miss(name, srt)
   warn "[build-workbook] WARN visual '#{name}': sort field '#{srt['queryRef']}' is not among " \
        'the built columns — sort skipped.'
+  record_unresolved(visual: name, severity: 'degraded', recoverable: true,
+                    detail: "sort field '#{srt['queryRef']}' is not among the built columns — sort skipped",
+                    action: "Add '#{srt['queryRef']}' to the visual's fields in master-map.json so the sort can resolve.")
 end
 
 # Build chart element from a normalized visual record. `extra_data` is an
@@ -568,6 +610,11 @@ def resolve_map_kind(rec, name)
   end
   why = loc.nil? ? 'no location binding' : ($geo_categories.empty? ? 'no --bim geo metadata supplied' : "'#{loc}' has no geocodable dataCategory")
   warn "[build-workbook] WARN visual '#{name}': PBI map downgraded to bar chart — #{why}. "        'Sigma maps need a region-typed column (country/state/county/zip/place) or lat+long; '        'PBI relied on Bing geocoding which Sigma does not do.'
+  record_unresolved(visual: name, pbi_type: 'map', sigma_kind: 'bar-chart',
+                    severity: 'approximated', recoverable: true,
+                    detail: "PBI map downgraded to bar chart — #{why}",
+                    action: 'Supply a region-typed column (country/state/county/zip/place) via --bim dataCategory, ' \
+                            'or lat+long bindings, to render a real Sigma map — or accept the bar approximation.')
   series = (b['Series'] || b['Legend'] || []).first
   b['Category'] = [series] if series  # old downgrade kept the legend as the bar category
   'bar-chart'
@@ -604,6 +651,10 @@ def build_element(rec, fields, masters, extra_data = [])
     unless url
       warn "[build-workbook] visual '#{rec['visual_id']}': image asset '#{rec['resource']}' " \
            'skipped — supply --image-map {resource: hostedUrl} to embed it (Sigma images are URL-only).'
+      record_unresolved(visual: (rec['title'].to_s.strip.empty? ? rec['visual_id'] : rec['title']),
+                        pbi_type: 'image', severity: 'dropped', recoverable: true,
+                        detail: "image asset '#{rec['resource']}' skipped (Sigma images are URL-only)",
+                        action: "Supply --image-map '{\"#{rec['resource']}\": \"<hostedUrl>\"}' and re-run to embed it.")
       return nil
     end
     return { 'id' => eid, 'kind' => 'image', 'url' => url }
@@ -625,6 +676,11 @@ def build_element(rec, fields, masters, extra_data = [])
       why = all_qrs.empty? ? 'no field bindings' : 'no resolvable master element'
       warn "[build-workbook] WARN visual '#{rec['title'] || rec['visual_id']}' (#{kind}) has " \
            "#{why} — element SKIPPED (would emit a source-less \"[]\" column the API rejects)."
+      record_unresolved(visual: (rec['title'] || rec['visual_id']), pbi_type: rec['visual_type'],
+                        sigma_kind: kind, severity: 'dropped', recoverable: !all_qrs.empty?,
+                        detail: "#{kind} has #{why} — element skipped",
+                        action: (all_qrs.empty? ? 'Source visual carries no field bindings; nothing to recover.' \
+                                                : 'Add a resolvable master element for this visual in master-map.json and re-run.'))
       return nil
     end
   end
@@ -641,7 +697,23 @@ def build_element(rec, fields, masters, extra_data = [])
       warn "[build-workbook] WARN visual '#{(rec['title'] || rec['visual_id'])}' has field(s) " \
            "#{unreachable.join(', ')} not reachable on the chosen master '#{master}'; a Sigma element " \
            "sources only one master, so they will be DROPPED — point them at a single joined master element."
+      record_unresolved(visual: (rec['title'] || rec['visual_id']), pbi_type: rec['visual_type'],
+                        sigma_kind: kind, severity: 'degraded', recoverable: true,
+                        detail: "field(s) #{unreachable.join(', ')} not reachable on master '#{master}' — dropped",
+                        action: "Add a single joined master element covering #{unreachable.join(', ')} " \
+                                'in master-map.json (a Sigma element sources exactly one master).')
     end
+  end
+  # Record a non-native APPROXIMATION (e.g. treemap/funnel/gauge/ribbon/waterfall
+  # → bar/kpi). map/image carry their own, more specific coverage entries above,
+  # so they're excluded from NATIVE_VISUAL_TYPES handling here. This is what makes
+  # the coverage report honest about "looks like the source" vs "same numbers".
+  vt = rec['visual_type'].to_s
+  unless vt.empty? || NATIVE_VISUAL_TYPES.include?(vt)
+    record_unresolved(visual: name, pbi_type: vt, sigma_kind: kind,
+                      severity: 'approximated', recoverable: false,
+                      detail: "#{vt} has no native Sigma element kind — approximated as #{kind}",
+                      action: "Sigma has no native #{vt}; the data is preserved as a #{kind}. Accept or pick a different Sigma chart.")
   end
   master_id = master && masters[master] ? masters[master]['id'] : nil
   el = { 'id' => eid, 'kind' => kind, 'name' => name }
@@ -683,6 +755,10 @@ def build_element(rec, fields, masters, extra_data = [])
                             'reason' => "column '#{qr}' resolves to no master column " \
                                         "(master=#{pmaster.inspect}); dropped loudly rather than " \
                                         'wired to a wrong column or shipped dead' }
+      record_unresolved(visual: name, pbi_type: 'slicer', sigma_kind: 'control',
+                        severity: 'dropped', recoverable: true,
+                        detail: "slicer column '#{qr}' resolves to no master column — control skipped",
+                        action: "Add column '#{qr}' to a master (or fix master-map.json) so the slicer can wire, then re-run.")
       return nil
     end
     reach = MODEL_RELATIONSHIPS.any? || MODEL_TABLES.any? ? reachable_entities(ent) : [ent]
@@ -795,6 +871,10 @@ def build_element(rec, fields, masters, extra_data = [])
     end
     if (srs = (b['Series'] || b['Legend'] || []).first)
       warn "[build-workbook] WARN visual '#{name}': region-map colors by the measure scale — "            "PBI legend '#{srs}' dropped (no categorical legend on a Sigma region map)."
+      record_unresolved(visual: name, pbi_type: 'map', sigma_kind: 'region-map',
+                        severity: 'degraded', recoverable: false,
+                        detail: "categorical legend '#{srs}' dropped — Sigma region maps color by a measure scale only",
+                        action: 'Sigma region maps have no categorical legend; the map colors by the measure scale instead.')
     end
   when 'point-map'
     latq = (b['Latitude'] || []).first
@@ -827,6 +907,11 @@ def build_element(rec, fields, masters, extra_data = [])
        dim_role.all? { |q| q.to_s =~ /hierarchy/i || q.to_s =~ /\.(Year|Quarter|Month|Week|Day|Date)\s*\z/i }
       warn "[build-workbook] WARN visual '#{name}': date hierarchy with #{dim_role.length} levels " \
            "reduced to '#{dim}' — deeper drill levels (#{dim_role[1..].join(', ')}) dropped."
+      record_unresolved(visual: name, pbi_type: rec['visual_type'], sigma_kind: kind,
+                        severity: 'degraded', recoverable: true,
+                        detail: "date hierarchy reduced to '#{dim}' — deeper levels (#{dim_role[1..].join(', ')}) dropped",
+                        action: "Re-point the axis dim at the intended drill level in master-map.json; " \
+                                'deeper PBI drill-down levels map to Sigma UI drill, not a single chart.')
     end
     meas = (b['Y'] || b['Values'] || [])
     series = (b['Series'] || b['Legend'] || []).first
@@ -977,6 +1062,10 @@ def build_element(rec, fields, masters, extra_data = [])
           calc_ids << gsz
         else
           warn "[build-workbook] WARN scatter '#{name}': Size role '#{sizeqr}' is not a measure — size DROPPED."
+          record_unresolved(visual: name, pbi_type: rec['visual_type'], sigma_kind: 'scatter-chart',
+                            severity: 'degraded', recoverable: false,
+                            detail: "scatter Size role '#{sizeqr}' is not a measure — bubble size dropped",
+                            action: 'A Sigma scatter size dimension must be a measure; bind an aggregatable field to Size.')
         end
       end
       extra_data << { 'id' => src_id, 'kind' => 'table', 'name' => src_name,
@@ -1013,8 +1102,14 @@ def build_element(rec, fields, masters, extra_data = [])
         cols << { 'id' => dcid, 'formula' => dfs['ref'], 'name' => qr_leaf(detail, 'Detail') }
         el['color'] = { 'by' => 'category', 'column' => dcid }
       end
-      warn "[build-workbook] WARN scatter '#{name}': Size role '#{(b['Size'] || []).first}' DROPPED " \
-           '(ungrouped scatter path).' if (b['Size'] || []).first
+      if (b['Size'] || []).first
+        warn "[build-workbook] WARN scatter '#{name}': Size role '#{(b['Size'] || []).first}' DROPPED " \
+             '(ungrouped scatter path).'
+        record_unresolved(visual: name, pbi_type: rec['visual_type'], sigma_kind: 'scatter-chart',
+                          severity: 'degraded', recoverable: true,
+                          detail: "scatter Size role '#{(b['Size'] || []).first}' dropped (ungrouped scatter path)",
+                          action: 'Add a Details/Category dimension in master-map.json so the scatter groups and the Size measure can bind.')
+      end
     end
     # PBI legend.show=false -> hide the Sigma legend (the detail-on-color split
     # otherwise surfaces a legend PBI did not show).
@@ -1533,6 +1628,36 @@ spec['folderId'] = opts[:folder] if opts[:folder]
 File.write(opts[:out], JSON.pretty_generate(spec))
 warn "[build-workbook] wrote #{opts[:out]} (#{data_elements.size} master(s), " \
      "#{content_pages.sum { |p| p['elements'].size }} chart element(s); layout embedded)"
+
+# coverage.json — the aggregated migration-coverage ledger (bead beads-sigma-cov).
+# Written AFTER the final spec so builtElements equals the shipped element count.
+# Headline framing on PURPOSE: report how MANY source visuals converted cleanly,
+# not just the handful that didn't — the "drops a lot" perception is really
+# "the few gaps weren't surfaced in one place". `unresolved` is every
+# DROPPED/DEGRADED/APPROXIMATED item (already warned at its site, now aggregated).
+total_visuals = signals['pages'].sum { |pg| (pg['visuals'] || []).size }
+# Count CONTENT elements only — exclude layout chrome (header band containers)
+# that 'clean' layout adds, so the stat reflects converted visuals, not scaffolding.
+built_elements = content_pages.sum { |p| (p['elements'] || []).count { |e| e['kind'] != 'container' } }
+by_sev = $unresolved.group_by { |u| u['severity'] }.transform_values(&:size)
+coverage_path = opts[:coverage_out] ||
+                File.join(File.dirname(File.expand_path(opts[:out])), 'coverage.json')
+File.write(coverage_path, JSON.pretty_generate(
+             { 'version' => 1, 'source' => 'powerbi',
+               'summary' => {
+                 'sourceVisuals' => total_visuals,
+                 'builtElements' => built_elements,
+                 'dropped' => by_sev['dropped'] || 0,
+                 'degraded' => by_sev['degraded'] || 0,
+                 'approximated' => by_sev['approximated'] || 0,
+                 'recoverable' => $unresolved.count { |u| u['recoverable'] }
+               },
+               'unresolved' => $unresolved }
+           ))
+warn "[build-workbook] wrote coverage -> #{coverage_path} " \
+     "(#{total_visuals} source visual(s) -> #{built_elements} element(s); " \
+     "#{by_sev['dropped'] || 0} dropped, #{by_sev['degraded'] || 0} degraded, " \
+     "#{by_sev['approximated'] || 0} approximated)"
 
 if opts[:layout_out]
   File.write(opts[:layout_out], layout_xml)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_gate.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+#
+# CoverageGate — turns build-workbook-from-pbir.rb's coverage.json into (a) a
+# human-readable migration-coverage REPORT and (b) the decision questions for the
+# RECOVERABLE drops, so migrate-powerbi.rb can surface ONE consolidated readout +
+# an assistance prompt instead of leaving the facts in scattered STDERR warnings
+# (customer feedback, 2026-06-25: "silently drops components it cannot resolve,
+# rather than prompting the user for assistance").
+#
+# Pure + unit-tested (test-coverage-gate.rb), exactly like DaxGate. The builder
+# already warns loudly at each drop site; this module only aggregates + classifies.
+#
+# coverage.json schema (written by build-workbook-from-pbir.rb):
+#   { version, source, summary:{sourceVisuals, builtElements, dropped, degraded,
+#     approximated, recoverable}, unresolved:[{visual, pbi_type, sigma_kind,
+#     severity, detail, recoverable, action}] }
+#   severity: 'dropped' | 'degraded' | 'approximated'
+require 'json'
+
+module CoverageGate
+  module_function
+
+  # Read coverage.json defensively; returns nil when absent/garbage so callers
+  # can no-op (an offline / agent-path build may not have written one).
+  def load(path)
+    return nil unless path && File.exist?(path)
+    JSON.parse(File.read(path))
+  rescue JSON::ParserError
+    nil
+  end
+
+  # The headline coverage line. Leads with what CARRIED OVER, not the gaps — an
+  # APPROXIMATED visual (treemap→bar) and a DEGRADED one (lost a field) both still
+  # land in Sigma with their data; only a DROPPED visual is truly absent. Counting
+  # approximations as "not converted" is what fuels the "drops a lot" perception.
+  # e.g. "12/12 source visuals carried over (5 approximated, 1 degraded); 0 dropped."
+  def headline(coverage)
+    s = (coverage && coverage['summary']) || {}
+    sv = s['sourceVisuals'].to_i
+    dropped_v = distinct_dropped_visuals(coverage)
+    carried = [sv - dropped_v, 0].max
+    extras = []
+    extras << "#{s['approximated'].to_i} approximated" if s['approximated'].to_i.positive?
+    extras << "#{s['degraded'].to_i} degraded" if s['degraded'].to_i.positive?
+    qual = extras.empty? ? '' : " (#{extras.join(', ')})"
+    "#{carried}/#{sv} source visual(s) carried over#{qual}; #{dropped_v} dropped."
+  end
+
+  # DISTINCT source visuals that produced NO Sigma element (a 'dropped' entry).
+  # Approximated/degraded visuals DID build, so they are NOT counted as dropped.
+  def distinct_dropped_visuals(coverage)
+    ((coverage && coverage['unresolved']) || [])
+      .select { |u| u['severity'] == 'dropped' }.map { |u| u['visual'] }.uniq.size
+  end
+
+  # Count of DISTINCT source visuals with at least one gap entry of ANY severity.
+  def distinct_visuals_with_gaps(coverage)
+    ((coverage && coverage['unresolved']) || []).map { |u| u['visual'] }.uniq.size
+  end
+
+  # Full report lines (printed under the headline). Stable ordering: dropped
+  # first (most severe), then degraded, then approximated.
+  ORDER = { 'dropped' => 0, 'degraded' => 1, 'approximated' => 2 }.freeze
+  def report_lines(coverage)
+    items = (coverage && coverage['unresolved']) || []
+    items.sort_by { |u| [ORDER[u['severity']] || 9, u['visual'].to_s] }.map do |u|
+      tag = u['severity'].to_s.upcase
+      rec = u['recoverable'] ? ' [recoverable]' : ''
+      "  • [#{tag}]#{rec} #{u['visual']}: #{u['detail']}" +
+        (u['action'] ? "\n      ↳ #{u['action']}" : '')
+    end
+  end
+
+  # Decision questions for the RECOVERABLE items only — same shape migrate-powerbi.rb
+  # pushes onto `questions` (id/severity/detail/options/default). Non-recoverable
+  # items (genuine Sigma limitations) are reported but never asked about.
+  def questions(coverage)
+    ((coverage && coverage['unresolved']) || []).select { |u| u['recoverable'] }.map do |u|
+      { 'id' => "coverage_#{u['severity']}", 'severity' => 'review',
+        'visual' => u['visual'], 'pbi_type' => u['pbi_type'],
+        'detail' => u['detail'],
+        'options' => [u['action'] || 'recover per the action note (re-run after fixing master-map.json)',
+                      'accept the gap (ship without this component)'],
+        'default' => 'accept the gap (ship without this component)' }
+    end
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -65,8 +65,9 @@ require 'set'
 
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
-require 'scout_gate' # run-each-time gap-scout gate (bead beads-sigma-5l5e)
-require 'dax_gate'   # DAX warning → decision-question classifier (regression-tested)
+require 'scout_gate'    # run-each-time gap-scout gate (bead beads-sigma-5l5e)
+require 'dax_gate'      # DAX warning → decision-question classifier (regression-tested)
+require 'coverage_gate' # workbook-build coverage.json → consolidated report + assistance prompt
 
 opts = { db: '', schema: '' }
 OptionParser.new do |o|
@@ -1082,6 +1083,7 @@ build = ['ruby', File.join(HERE, 'build-workbook-from-pbir.rb'),
          # contract for the control lint) lands in WORK.
          '--model', opts[:tmsl],
          '--control-scope-out', File.join(WORK, 'control-scope.json'),
+         '--coverage-out', File.join(WORK, 'coverage.json'),
          '--out', wb_spec, '--layout-out', layout]
 # The workbook POST requires a folderId. Use --folder if given, else inherit the
 # DM's folderId (harvested from the ref-dm at Phase 3) so both land together.
@@ -1130,6 +1132,43 @@ end
 wb_rb = JSON.parse(File.read(wb_readback))
 wb_id = wb_rb['workbookId']
 puts "   workbookId = #{wb_id}"
+
+# ---------------------------------------------------------------------------
+# MIGRATION COVERAGE REPORT — what carried over, and what didn't (bead beads-sigma-cov).
+# The build warns loudly at each drop site, but on a complex report those warnings
+# scatter through the log; this aggregates coverage.json into ONE readout and, for
+# RECOVERABLE gaps, an explicit assistance prompt so nothing is "silently dropped".
+# It leads with what DID convert — the perception that a lot is lost is usually
+# "the few gaps weren't surfaced in one place". Non-blocking (the workbook is
+# posted + usable); the recoverable items are HARD-gated later by
+# assert-visual-compare.rb (must be ACCEPTED or fixed before Phase 6 sign-off).
+# ---------------------------------------------------------------------------
+coverage = CoverageGate.load(File.join(WORK, 'coverage.json'))
+if coverage
+  puts
+  puts '==================== MIGRATION COVERAGE ===================='
+  puts "   #{CoverageGate.headline(coverage)}"
+  rlines = CoverageGate.report_lines(coverage)
+  unless rlines.empty?
+    puts
+    puts rlines.join("\n")
+  end
+  cov_qs = CoverageGate.questions(coverage)
+  unless cov_qs.empty?
+    puts
+    if opts[:yes] || opts[:answers]
+      puts "   #{cov_qs.size} recoverable gap(s) — proceeding (unattended); recorded as accepted degradations."
+      puts '   (re-run after the action note on each to recover; they are also gated by assert-visual-compare.rb)'
+    else
+      puts '-------------------- ASSISTANCE AVAILABLE --------------------'
+      puts "   #{cov_qs.size} gap(s) below are RECOVERABLE — ask the user whether to recover or accept each."
+      puts '   These are NOT silent: each has a concrete action. assert-visual-compare.rb (Phase 5e)'
+      puts '   will not go GREEN until every recoverable gap is recovered or explicitly ACCEPTED.'
+      puts JSON.pretty_generate('recoverable_gaps' => cov_qs)
+    end
+  end
+  puts '==========================================================='
+end
 
 # ---------------------------------------------------------------------------
 # Phase 5 — Layout (authoritative final spec write — bead 16i)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-coverage-gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-coverage-gate.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+# test-coverage-gate.rb — unit test for CoverageGate (the migration-coverage
+# surfacing added for customer feedback 2026-06-25). Pure, no network.
+# Run: ruby scripts/test-coverage-gate.rb
+require 'json'
+require_relative 'lib/coverage_gate'
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+# A realistic coverage.json: 12 source visuals, 5 approximations (exotic chart
+# types — informational), 1 degraded field-drop (recoverable). Mirrors the
+# Chart-Zoo end-to-end run.
+COVERAGE = {
+  'version' => 1, 'source' => 'powerbi',
+  'summary' => { 'sourceVisuals' => 12, 'builtElements' => 19,
+                 'dropped' => 0, 'degraded' => 1, 'approximated' => 5, 'recoverable' => 1 },
+  'unresolved' => [
+    { 'visual' => 'Profit Margin (gauge)', 'pbi_type' => 'gauge', 'sigma_kind' => 'kpi-chart',
+      'severity' => 'approximated', 'recoverable' => false,
+      'detail' => 'gauge has no native Sigma element kind — approximated as kpi-chart',
+      'action' => 'Sigma has no native gauge; accept or pick a different chart.' },
+    { 'visual' => 'Sub-Cat table', 'pbi_type' => 'tableEx', 'sigma_kind' => 'table',
+      'severity' => 'degraded', 'recoverable' => true,
+      'detail' => "field(s) Sales Rank not reachable on master 'SAMPLE_SUPERSTORE' — dropped",
+      'action' => 'Add a single joined master element covering Sales Rank in master-map.json.' }
+  ]
+}
+
+# headline leads with what CARRIED OVER: nothing dropped here (5 approx + 1 degraded
+# all still build), so all 12 carried over.
+hl = CoverageGate.headline(COVERAGE)
+ok('headline reports 12/12 carried (approx/degraded still build)', hl.include?('12/12'))
+ok('headline counts approximated', hl.include?('5 approximated'))
+ok('headline reports 0 dropped', hl.include?('0 dropped'))
+
+# only DROPPED visuals reduce the carried count; approximated does NOT.
+multi = { 'summary' => { 'sourceVisuals' => 3, 'approximated' => 1, 'degraded' => 1, 'dropped' => 1 },
+          'unresolved' => [
+            { 'visual' => 'A', 'severity' => 'degraded', 'recoverable' => true },
+            { 'visual' => 'A', 'severity' => 'approximated', 'recoverable' => false },
+            { 'visual' => 'B', 'severity' => 'dropped', 'recoverable' => true }
+          ] }
+ok('distinct_visuals_with_gaps de-dupes (A counted once)',
+   CoverageGate.distinct_visuals_with_gaps(multi) == 2)
+ok('distinct_dropped_visuals counts only dropped (B)',
+   CoverageGate.distinct_dropped_visuals(multi) == 1)
+ok('headline subtracts only DROPPED visuals (2/3 carried)',
+   CoverageGate.headline(multi).include?('2/3'))
+
+# questions: ONLY recoverable items become decisions.
+qs = CoverageGate.questions(COVERAGE)
+ok('exactly 1 recoverable question', qs.size == 1)
+ok('question is the degraded field-drop', qs.first['visual'] == 'Sub-Cat table')
+ok('question id namespaced by severity', qs.first['id'] == 'coverage_degraded')
+ok('recover option carries the action note',
+   qs.first['options'].first.include?('joined master'))
+ok('non-recoverable approximation is NOT asked',
+   qs.none? { |q| q['visual'].include?('gauge') })
+
+# report ordering: dropped < degraded < approximated; every recoverable item tagged.
+lines = CoverageGate.report_lines(COVERAGE)
+ok('report has a line per unresolved entry', lines.size == 2)
+ok('degraded line marked [recoverable]', lines.any? { |l| l.include?('[recoverable]') && l.include?('Sub-Cat') })
+ok('approximation line NOT marked recoverable', lines.none? { |l| l.include?('[recoverable]') && l.include?('gauge') })
+deg_i = lines.index { |l| l.include?('DEGRADED') }
+app_i = lines.index { |l| l.include?('APPROXIMATED') }
+ok('DEGRADED sorts before APPROXIMATED', deg_i && app_i && deg_i < app_i)
+
+# defensive load: missing file / garbage -> nil (caller no-ops, never crashes).
+ok('load(nil) -> nil', CoverageGate.load(nil).nil?)
+ok('load(missing) -> nil', CoverageGate.load('/no/such/coverage.json').nil?)
+ok('questions(nil) -> []', CoverageGate.questions(nil) == [])
+
+puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
## Why

A customer testing the Power BI skill on a complex dashboard reported that the migration *"silently drops components it cannot resolve, rather than prompting the user for assistance, leading to significant manual effort to identify and re-add missing elements."*

The root cause is **not coverage** — the builder already refuses to wire wrong columns and warns loudly at every drop site. It's **surfacing**: those `warn` lines scatter through a 7-phase pipeline log, are never aggregated, and the run exits 0 looking done. On a complex report the few gaps get buried, so the user reconstructs them by hand.

The model side already solved this (`DaxGate` → decision questions). This brings the same discipline to the **workbook builder**, and extends the doctrine the RLS section already states (*"never silently dropped"*) to visual components.

## What

- **`build-workbook-from-pbir.rb`** — every drop/downgrade/approximation is now recorded to a new **`coverage.json`** (`--coverage-out`) alongside the existing loud warning. Severities:
  - `dropped` — no element built (image w/o `--image-map`, unresolvable slicer)
  - `degraded` — built but lost a role/field/sort (unreachable field, dropped drill level, scatter size)
  - `approximated` — built as a substituted Sigma kind (treemap/funnel/gauge/waterfall → bar/kpi)
  - each **recoverable** item carries a concrete `action`.
- **`lib/coverage_gate.rb`** (+ `test-coverage-gate.rb`, 16 assertions) — pure classifier → consolidated report + decision questions for the recoverable gaps only. **Headline leads with what carried over** (approximated/degraded visuals still land with their data; only `dropped` is truly absent) so the "drops a lot" perception is answered with the real number.
- **`migrate-powerbi.rb`** — prints one **MIGRATION COVERAGE** readout after the workbook POST; recoverable gaps print as an **ASSISTANCE AVAILABLE** block (interactive) or are recorded as accepted degradations (`--yes`).
- **`assert-visual-compare.rb --coverage`** — hard-gates recoverable gaps: won't go GREEN until each is acknowledged in a page's `deltas[]`/`acceptedGaps`. Backward-compatible when `--coverage` is omitted.

## Testing (end-to-end)

| Fixture | Result |
|---|---|
| Chart Zoo (gauge/ribbon/treemap/funnel/waterfall) | `12/12 carried over (5 approximated, 1 degraded); 0 dropped` |
| Torture (map / image / scatter-size / unbound slicer) | all 4 drop sites captured; `2/4 carried over … 2 dropped` |
| Superstore Overview (all-native) | `9/9 carried over; 0 dropped` — **zero false-positive noise** |

Gate verified three ways: unacknowledged recoverable gap → **BLOCK**; acknowledged in deltas → **GREEN**; no `--coverage` → backward-compatible GREEN. Unit tests + the existing `test-dax-gate.rb` pass; shared-file consistency hook passes.

## Note

This pattern is worth porting to the other converters (they share the builder lineage) as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)