### PR TITLE
tableau-to-sigma: fix EDNA crosstab / filter / parameter coverage gaps

### DIFF
--- a/corpus/tableau/partner-crosstab-controls/MANIFEST.md
+++ b/corpus/tableau/partner-crosstab-controls/MANIFEST.md
@@ -32,7 +32,7 @@ Synthetic XML (no live tenant), modeled on real Tableau 2024.1 `.twb` shapes.
 
 | File | What it is |
 |---|---|
-| `workbook-content.twb` | Synthetic workbook: 1 Automatic-mark crosstab worksheet `Metric Partner Closed Won` (Partner Name rows × Created FYQQ + Measure Names cols), 1 dashboard, a `<shared-view>` with 3 quick filters exercising all the failure modes — caption-less multi-word (`Customer Geo`), a Tableau GROUP (`Partner Level (group)`), and a slash name (`Mkt Sourced/Influenced`) — plus an integer measure-swap parameter (`Summary $ Choose`, 1→TCV / 2→Product TCV / 3→ACV) with value aliases |
+| `workbook-content.twb` | Synthetic workbook: 1 Automatic-mark crosstab worksheet `Metric Partner Closed Won` (Partner Name rows × Created FYQQ + Measure Names cols), 1 Automatic-mark `Bookings by Quarter Bar` worksheet that is the OVER-FIRE GUARD (Measure Names on cols but the measure VALUES on rows as `[Multiple Values]` → a bar, must NOT be a crosstab), 1 dashboard, a `<shared-view>` with 3 quick filters exercising all the failure modes — caption-less multi-word (`Customer Geo`), a Tableau GROUP (`Partner Level (group)`), and a slash name (`Mkt Sourced/Influenced`) — plus an integer measure-swap parameter (`Summary $ Choose`, 1→TCV / 2→Product TCV / 3→ACV) with value aliases |
 | `get-workbook.json`, `master-columns.json` | Minimal discovery fixtures so `build-charts-from-signals.rb` runs offline |
 | `chart-specs.json` | PINNED `build-charts-from-signals.rb` output — captures all three fixes in one deterministic artifact (see assertions) |
 
@@ -59,6 +59,12 @@ copy (deterministic — element ids are name-derived, no randomness).
   (mark `Automatic`, Measure Names on cols) emits a `kind: pivot-table`
   element with `rowsBy` (Partner Name), `columnsBy` (Created FYQQ), and a
   `values` array — NOT a flat `table`.
+- **Over-fire guard (fix 1, parse-level):** `parse-twb-layout` sets
+  `is_crosstab: true` for `Metric Partner Closed Won` but `is_crosstab: false`
+  for `Bookings by Quarter Bar` — the latter carries the Measure-VALUES pill
+  (`has_measure_values: true`), so an Automatic-mark multi-measure BAR is not
+  misclassified as a crosstab. (Real-world catch from the coverage sweep: a
+  public "Barchart of accident factors" sheet was being turned into a pivot.)
 - **Quick filters resolved → controls (fix 2):** all three shared filters emit
   `kind: control`, `controlType: list` elements wired to the master — the
   caption-less multi-word `Customer Geo`, the group `Partner Level (g)`, and the

--- a/corpus/tableau/partner-crosstab-controls/MANIFEST.md
+++ b/corpus/tableau/partner-crosstab-controls/MANIFEST.md
@@ -1,0 +1,96 @@
+# tableau / partner-crosstab-controls
+
+Hand-authored minimal `.twb` reproducing the three EDNA "Partner Landscape"
+regressions a customer reported 2026-06-25 (a 10 MB, 86-worksheet partner
+bookings workbook whose data we don't have, so this fixture mirrors the SHAPES
+on the live CSA.TJ retail star instead):
+
+1. **Automatic-mark crosstabs built as flat tables.** The customer's two big
+   "Metrics by Partner" tables (Partner Name rows × quarter × Measure-Names
+   columns + Grand Total) authored with Tableau's DEFAULT `Automatic` mark —
+   `parse-twb-layout.rb` only treated `Text`/`Square` marks as crosstabs, so
+   they fell through to flat `table`/`kpi`, dropping the grouped column headers
+   and Grand Total. (Real EDNA: only 2 of 86 worksheets detected as crosstab;
+   ≥28 had dims on both shelves.)
+2. **Dashboard quick-filters dropped.** ~40 left-rail filter controls whose
+   columns carry NO `caption` attribute (`[none:Customer Geo:nk]`), are
+   multi-word, are Tableau GROUPS (`[Partner Level (group)]`), or contain a
+   slash (`[Mkt Sourced/Influenced]`). `COL_BY_GUID` registered only
+   caption-bearing columns and truncated multi-word names to the first word, and
+   `guid_from_param` choked on `(group)` / `(copy)` / `/` — so every shared
+   filter resolved to a null caption and `build-charts` skipped all of them
+   ("no resolvable column_caption"). (Real EDNA: 0 of 70 shared filters
+   resolved → fixed to 70/70.)
+3. **Measure-switcher parameter showed raw integer codes.** An integer parameter
+   (`Summary $ Choose`, 1→TCV / 2→Product TCV / 3→ACV) whose CASE swaps which
+   aggregated FIELD is displayed. The segmented control emitted `labels: []` so
+   it rendered as `1 / 2 / 3` instead of the alias labels.
+
+Synthetic XML (no live tenant), modeled on real Tableau 2024.1 `.twb` shapes.
+
+## Artifacts
+
+| File | What it is |
+|---|---|
+| `workbook-content.twb` | Synthetic workbook: 1 Automatic-mark crosstab worksheet `Metric Partner Closed Won` (Partner Name rows × Created FYQQ + Measure Names cols), 1 dashboard, a `<shared-view>` with 3 quick filters exercising all the failure modes — caption-less multi-word (`Customer Geo`), a Tableau GROUP (`Partner Level (group)`), and a slash name (`Mkt Sourced/Influenced`) — plus an integer measure-swap parameter (`Summary $ Choose`, 1→TCV / 2→Product TCV / 3→ACV) with value aliases |
+| `get-workbook.json`, `master-columns.json` | Minimal discovery fixtures so `build-charts-from-signals.rb` runs offline |
+| `chart-specs.json` | PINNED `build-charts-from-signals.rb` output — captures all three fixes in one deterministic artifact (see assertions) |
+
+## Converter
+
+No MCP converter — this case pins the SKILL-script contracts. `$S` =
+`plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts`:
+
+```
+ruby $S/parse-twb-layout.rb workbook-content.twb dashboard-layout.json
+ruby $S/build-charts-from-signals.rb --tableau-dir . --layout dashboard-layout.json \
+  --meta dashboard-layout-meta.json --master-map master-columns.json \
+  --master-element-id master --auto-controls --page-per-worksheet \
+  --title "Partner Landscape" --out chart-specs.json
+```
+
+`dashboard-layout*.json` / `control-scope.json` are regenerable intermediates
+and are not pinned; diff the regenerated `chart-specs.json` against the pinned
+copy (deterministic — element ids are name-derived, no randomness).
+
+## Assertions encoded by the pins (`chart-specs.json`)
+
+- **Crosstab → pivot-table (fix 1):** the `Metric Partner Closed Won` worksheet
+  (mark `Automatic`, Measure Names on cols) emits a `kind: pivot-table`
+  element with `rowsBy` (Partner Name), `columnsBy` (Created FYQQ), and a
+  `values` array — NOT a flat `table`.
+- **Quick filters resolved → controls (fix 2):** all three shared filters emit
+  `kind: control`, `controlType: list` elements wired to the master — the
+  caption-less multi-word `Customer Geo`, the group `Partner Level (g)`, and the
+  slash `Mkt Sourced/Influenced` — none dropped as "no resolvable
+  column_caption."
+- **Param labels (fix 3a):** the `Summary $ Choose` segmented control carries
+  `source.values: ["1","2","3"]` AND `source.labels: ["TCV","Product TCV",
+  "ACV"]` (from the parameter's value aliases) — never an empty `labels` array.
+- **Measure-swap Switch (fix 3b):** the pivot's measure value column is
+  `Switch([ctl-param-summary-choose-...], "1", Sum([TCV]), "2",
+  Sum([Product TCV]), "3", Sum([ACV]))`, and the referenced `controlId` matches
+  the emitted segmented control (no dead control).
+
+## Live validation (CSA.TJ, 2026-06-25)
+
+The same four shapes were built on the live `CSA.TJ.ORDER_FACT` warehouse
+(org `tj-wells-1989`, conn `bc0319f8`), POSTed as a DM + workbook, and rendered:
+the pivot rendered as a grouped crosstab with a **Grand-total row + column**;
+the segmented control rendered with the alias labels; flipping it from
+"Net Revenue" → "Quantity" changed the measure column (grand total
+119,038 → 1,593) while the static Net Revenue column held — proving the
+parameter switches the calculation. Throwaway workbook + DM were deleted after.
+
+## Expectations
+
+```json
+{
+  "artifacts": [
+    {"path": "workbook-content.twb", "format": "xml"},
+    {"path": "get-workbook.json", "format": "json"},
+    {"path": "master-columns.json", "format": "json"},
+    {"path": "chart-specs.json", "format": "json"}
+  ]
+}
+```

--- a/corpus/tableau/partner-crosstab-controls/chart-specs.json
+++ b/corpus/tableau/partner-crosstab-controls/chart-specs.json
@@ -1,0 +1,190 @@
+{
+  "pages": [
+    {
+      "name": "Metric Partner Closed Won",
+      "elements": [
+        {
+          "id": "title-text-metric-partner-closed-won",
+          "kind": "text",
+          "body": "## Metric Partner Closed Won"
+        },
+        {
+          "id": "el-param-summary-choose-metric-partner-closed",
+          "kind": "control",
+          "controlId": "ctl-param-summary-choose-metric-partner-closed",
+          "name": "Summary $ Choose",
+          "includeNulls": "when-no-value-is-selected",
+          "controlType": "segmented",
+          "source": {
+            "kind": "manual",
+            "valueType": "text",
+            "values": [
+              "1",
+              "2",
+              "3"
+            ],
+            "labels": [
+              "TCV",
+              "Product TCV",
+              "ACV"
+            ]
+          },
+          "value": "1"
+        },
+        {
+          "id": "el-ctl-customer-geo-metric-partner-closed",
+          "kind": "control",
+          "controlId": "ctl-customer-geo-metric-partner-closed",
+          "name": "Customer Geo",
+          "includeNulls": "when-no-value-is-selected",
+          "controlType": "list",
+          "mode": "include",
+          "selectionMode": "multiple",
+          "values": [
+
+          ],
+          "source": {
+            "kind": "source",
+            "source": {
+              "kind": "table",
+              "elementId": "master"
+            },
+            "columnId": "m-geo"
+          },
+          "filters": [
+            {
+              "source": {
+                "kind": "table",
+                "elementId": "master"
+              },
+              "columnId": "m-geo"
+            }
+          ]
+        },
+        {
+          "id": "el-ctl-partner-level-g-metric-partner-closed",
+          "kind": "control",
+          "controlId": "ctl-partner-level-g-metric-partner-closed",
+          "name": "Partner Level (g)",
+          "includeNulls": "when-no-value-is-selected",
+          "controlType": "list",
+          "mode": "include",
+          "selectionMode": "multiple",
+          "values": [
+
+          ],
+          "source": {
+            "kind": "source",
+            "source": {
+              "kind": "table",
+              "elementId": "master"
+            },
+            "columnId": "m-plevel"
+          },
+          "filters": [
+            {
+              "source": {
+                "kind": "table",
+                "elementId": "master"
+              },
+              "columnId": "m-plevel"
+            }
+          ]
+        },
+        {
+          "id": "el-ctl-mkt-sourced-influenced-metric-partner-closed",
+          "kind": "control",
+          "controlId": "ctl-mkt-sourced-influenced-metric-partner-closed",
+          "name": "Mkt Sourced/Influenced",
+          "includeNulls": "when-no-value-is-selected",
+          "controlType": "list",
+          "mode": "include",
+          "selectionMode": "multiple",
+          "values": [
+
+          ],
+          "source": {
+            "kind": "source",
+            "source": {
+              "kind": "table",
+              "elementId": "master"
+            },
+            "columnId": "m-mkt"
+          },
+          "filters": [
+            {
+              "source": {
+                "kind": "table",
+                "elementId": "master"
+              },
+              "columnId": "m-mkt"
+            }
+          ]
+        },
+        {
+          "id": "el-metric-partner-closed-won",
+          "kind": "pivot-table",
+          "name": "Summary $ Choose",
+          "source": {
+            "kind": "table",
+            "elementId": "master"
+          },
+          "columns": [
+            {
+              "id": "p-el-metric-partner-closed-won-row-partner-name",
+              "name": "Partner Name",
+              "formula": "[Master/Partner Name]"
+            },
+            {
+              "id": "p-el-metric-partner-closed-won-col-created-fyqq",
+              "name": "Created FYQQ",
+              "formula": "[Master/Created FYQQ]"
+            },
+            {
+              "id": "p-el-metric-partner-closed-won-value-calculation_summary",
+              "name": "Calculation_summary",
+              "formula": "Switch([ctl-param-summary-choose-metric-partner-closed], \"1\", Sum([TCV]), \"2\", Sum([Product TCV]), \"3\", Sum([ACV]))",
+              "format": {
+                "kind": "number",
+                "formatString": ",.0f"
+              }
+            },
+            {
+              "id": "p-el-metric-partner-closed-won-value-acv",
+              "name": "ACV",
+              "formula": "Sum([Master/ACV])",
+              "format": {
+                "kind": "number",
+                "formatString": ",.0f"
+              }
+            },
+            {
+              "id": "pvsw-tcv",
+              "name": "TCV",
+              "formula": "[Master/TCV]"
+            },
+            {
+              "id": "pvsw-product-tcv",
+              "name": "Product TCV",
+              "formula": "[Master/Product TCV]"
+            }
+          ],
+          "values": [
+            "p-el-metric-partner-closed-won-value-calculation_summary",
+            "p-el-metric-partner-closed-won-value-acv"
+          ],
+          "rowsBy": [
+            {
+              "id": "p-el-metric-partner-closed-won-row-partner-name"
+            }
+          ],
+          "columnsBy": [
+            {
+              "id": "p-el-metric-partner-closed-won-col-created-fyqq"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/corpus/tableau/partner-crosstab-controls/chart-specs.json
+++ b/corpus/tableau/partner-crosstab-controls/chart-specs.json
@@ -142,7 +142,7 @@
             },
             {
               "id": "p-el-metric-partner-closed-won-value-calculation_summary",
-              "name": "Calculation_summary",
+              "name": "Summary $",
               "formula": "Switch([ctl-param-summary-choose-metric-partner-closed], \"1\", Sum([TCV]), \"2\", Sum([Product TCV]), \"3\", Sum([ACV]))",
               "format": {
                 "kind": "number",

--- a/corpus/tableau/partner-crosstab-controls/get-workbook.json
+++ b/corpus/tableau/partner-crosstab-controls/get-workbook.json
@@ -1,0 +1,1 @@
+{"workbook":{"name":"Partner Landscape","hasExtracts":false}}

--- a/corpus/tableau/partner-crosstab-controls/master-columns.json
+++ b/corpus/tableau/partner-crosstab-controls/master-columns.json
@@ -1,0 +1,10 @@
+{
+  "(?i)^partner name$":            { "id": "m-partner",  "name": "Partner Name" },
+  "(?i)created fyqq":              { "id": "m-fyqq",     "name": "Created FYQQ" },
+  "(?i)customer geo":              { "id": "m-geo",      "name": "Customer Geo" },
+  "(?i)partner level":             { "id": "m-plevel",   "name": "Partner Level" },
+  "(?i)mkt sourced":               { "id": "m-mkt",      "name": "Mkt Sourced Influenced" },
+  "(?i)^product tcv$":             { "id": "m-ptcv",     "name": "Product TCV" },
+  "(?i)^tcv$":                     { "id": "m-tcv",      "name": "TCV" },
+  "(?i)^acv$":                     { "id": "m-acv",      "name": "ACV" }
+}

--- a/corpus/tableau/partner-crosstab-controls/workbook-content.twb
+++ b/corpus/tableau/partner-crosstab-controls/workbook-content.twb
@@ -74,6 +74,34 @@
         </panes>
       </table>
     </worksheet>
+    <worksheet name='Bookings by Quarter Bar'>
+      <!-- OVER-FIRE GUARD: Automatic mark + Measure Names on cols, but the
+           measure VALUES are on rows as the `[Multiple Values]` pill (a VISUAL
+           multi-measure bar). Must stay a BAR, NOT become a pivot-table — the
+           measure-values discriminator distinguishes it from the text crosstab
+           above (modeled on a real public "Barchart of accident factors"). -->
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Partner Bookings (CSA.TJ)' name='federated.primary' />
+          </datasources>
+          <datasource-dependencies datasource='federated.primary'>
+            <column datatype='string' name='[Created FYQQ]' role='dimension' type='nominal' />
+            <column caption='TCV' datatype='real' name='[TCV]' role='measure' type='quantitative' />
+            <column caption='ACV' datatype='real' name='[ACV]' role='measure' type='quantitative' />
+            <column-instance column='[Created FYQQ]' derivation='None' name='[none:Created FYQQ:nk]' pivot='key' type='nominal' />
+            <column-instance column='[TCV]' derivation='Sum' name='[sum:TCV:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+        </view>
+        <rows>([federated.primary].[Multiple Values] + [federated.primary].[sum:TCV:qk])</rows>
+        <cols>([federated.primary].[none:Created FYQQ:nk] / [federated.primary].[:Measure Names])</cols>
+        <panes>
+          <pane>
+            <mark class='Automatic' />
+          </pane>
+        </panes>
+      </table>
+    </worksheet>
   </worksheets>
   <dashboards>
     <dashboard name='Partner Summary'>

--- a/corpus/tableau/partner-crosstab-controls/workbook-content.twb
+++ b/corpus/tableau/partner-crosstab-controls/workbook-content.twb
@@ -1,0 +1,103 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<workbook source-build='2024.1.0' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <datasources>
+    <datasource caption='Partner Bookings (CSA.TJ)' inline='true' name='federated.primary' version='18.1'>
+      <!-- Plain warehouse dimensions referenced by quick filters. These carry NO
+           caption attribute (their name IS the display name) and multi-word /
+           slash names — the COL_BY_GUID registration + guid_from_param fixes
+           must resolve all of them. -->
+      <column datatype='string' name='[Customer Geo]' role='dimension' type='nominal' />
+      <column datatype='string' name='[Mkt Sourced/Influenced]' role='dimension' type='nominal' />
+      <column datatype='string' name='[Partner Name]' role='dimension' type='nominal' />
+      <column datatype='string' name='[Created FYQQ]' role='dimension' type='nominal' />
+      <!-- Tableau GROUP field (has a caption, name carries a (group) suffix). -->
+      <column caption='Partner Level (g)' datatype='string' name='[Partner Level (group)]' role='dimension' type='nominal'>
+        <groupfilter function='level-members' level='[Partner Level (group)]' />
+      </column>
+      <!-- Measures the param switches between. -->
+      <column caption='TCV' datatype='real' name='[TCV]' role='measure' type='quantitative' />
+      <column caption='Product TCV' datatype='real' name='[PRODUCT_TCV]' role='measure' type='quantitative' />
+      <column caption='ACV' datatype='real' name='[ACV]' role='measure' type='quantitative' />
+      <!-- Measure-SWAP calc: a CASE on the integer param returns a different
+           aggregated FIELD per value. Must translate to Switch([ctl-param-...],
+           "1", Sum([Master/TCV]), ...). References the param → not orphan. -->
+      <column caption='Summary $' datatype='real' name='[Calculation_summary]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='CASE [Summary $ Choose] WHEN 1 THEN SUM([TCV]) WHEN 2 THEN SUM([Product TCV]) WHEN 3 THEN SUM([ACV]) END' />
+      </column>
+    </datasource>
+    <datasource hasconnection='false' inline='true' name='Parameters'>
+      <!-- Integer measure-switcher parameter with value ALIASES (1->TCV, ...).
+           The segmented control must show the alias labels, not raw 1/2/3. -->
+      <column caption='Summary $ Choose' datatype='integer' name='[Parameter 4]' param-domain-type='list' role='measure' type='quantitative' value='1'>
+        <members>
+          <member value='1' />
+          <member value='2' />
+          <member value='3' />
+        </members>
+        <aliases>
+          <alias key='&quot;1&quot;' value='TCV' />
+          <alias key='&quot;2&quot;' value='Product TCV' />
+          <alias key='&quot;3&quot;' value='ACV' />
+        </aliases>
+      </column>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Metric Partner Closed Won'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Partner Bookings (CSA.TJ)' name='federated.primary' />
+          </datasources>
+          <datasource-dependencies datasource='federated.primary'>
+            <column datatype='string' name='[Partner Name]' role='dimension' type='nominal' />
+            <column datatype='string' name='[Created FYQQ]' role='dimension' type='nominal' />
+            <column caption='TCV' datatype='real' name='[TCV]' role='measure' type='quantitative' />
+            <column caption='ACV' datatype='real' name='[ACV]' role='measure' type='quantitative' />
+            <column caption='Product TCV' datatype='real' name='[PRODUCT_TCV]' role='measure' type='quantitative' />
+            <column caption='Summary $' datatype='real' name='[Calculation_summary]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='CASE [Summary $ Choose] WHEN 1 THEN SUM([TCV]) WHEN 2 THEN SUM([Product TCV]) WHEN 3 THEN SUM([ACV]) END' />
+            </column>
+            <column-instance column='[Partner Name]' derivation='None' name='[none:Partner Name:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Created FYQQ]' derivation='None' name='[none:Created FYQQ:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Calculation_summary]' derivation='User' name='[usr:Calculation_summary:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[ACV]' derivation='Sum' name='[sum:ACV:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+        </view>
+        <rows>[federated.primary].[none:Partner Name:nk]</rows>
+        <cols>([federated.primary].[none:Created FYQQ:nk] / [federated.primary].[:Measure Names])</cols>
+        <panes>
+          <pane>
+            <mark class='Automatic' />
+          </pane>
+        </panes>
+      </table>
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Partner Summary'>
+      <size maxheight='900' maxwidth='1400' minheight='900' minwidth='1400' />
+      <zones>
+        <zone h='100000' id='1' type-v2='layout-basic' w='100000' x='0' y='0'>
+          <zone h='80000' id='2' name='Metric Partner Closed Won' w='80000' x='20000' y='0' />
+          <zone h='20000' id='3' param='[Parameters].[Parameter 4]' type-v2='paramctrl' w='20000' x='0' y='0' />
+          <zone h='20000' id='4' param='[federated.primary].[none:Customer Geo:nk]' type-v2='filter' w='20000' x='0' y='20000' />
+          <zone h='20000' id='5' param='[federated.primary].[Partner Level (group)]' type-v2='filter' w='20000' x='0' y='40000' />
+          <zone h='20000' id='6' param='[federated.primary].[none:Mkt Sourced/Influenced:nk]' type-v2='filter' w='20000' x='0' y='60000' />
+        </zone>
+      </zones>
+    </dashboard>
+  </dashboards>
+  <shared-view name='federated.primary'>
+    <filter class='categorical' column='[federated.primary].[none:Customer Geo:nk]'>
+      <groupfilter function='level-members' level='[federated.primary].[none:Customer Geo:nk]' />
+    </filter>
+    <filter class='categorical' column='[federated.primary].[Partner Level (group)]'>
+      <groupfilter function='level-members' level='[federated.primary].[Partner Level (group)]' />
+    </filter>
+    <filter class='categorical' column='[federated.primary].[none:Mkt Sourced/Influenced:nk]'>
+      <groupfilter function='level-members' level='[federated.primary].[none:Mkt Sourced/Influenced:nk]' />
+    </filter>
+  </shared-view>
+</workbook>

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb
@@ -75,8 +75,13 @@ def lint(spec)
         #  (the slider handle position), so only flag `value` when it is a Hash.
         errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
 
-        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
-        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an EDNA measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
           errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
         end
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb
@@ -75,8 +75,13 @@ def lint(spec)
         #  (the slider handle position), so only flag `value` when it is a Hash.
         errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
 
-        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
-        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an EDNA measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
           errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
         end
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
@@ -75,8 +75,13 @@ def lint(spec)
         #  (the slider handle position), so only flag `value` when it is a Hash.
         errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
 
-        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
-        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an EDNA measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
           errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
         end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb
@@ -75,8 +75,13 @@ def lint(spec)
         #  (the slider handle position), so only flag `value` when it is a Hash.
         errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
 
-        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
-        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an EDNA measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
           errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
         end
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/preflight_lint.rb
@@ -75,8 +75,13 @@ def lint(spec)
         #  (the slider handle position), so only flag `value` when it is a Hash.
         errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
 
-        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
-        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an EDNA measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
           errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
         end
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
@@ -75,8 +75,13 @@ def lint(spec)
         #  (the slider handle position), so only flag `value` when it is a Hash.
         errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
 
-        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
-        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an EDNA measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
           errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
         end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1408,7 +1408,18 @@ def build_pivot_element(z, meta, mmap, opts, warnings, data_elements = [])
         "[Master/#{m['name']}]"
       end
 
-    col_obj = { 'id' => col_id, 'name' => m['name'], 'formula' => formula }
+    # A calc field referenced on a shelf surfaces by its INTERNAL id
+    # (`Calculation_1466…` / `Calculation_summary`), which would render as an
+    # ugly column header. Resolve it to the calc's human caption (captured in
+    # columns_by_guid) when available — purely a display-name fix; the value
+    # array, Switch branch refs, and ws_calc match all key off ids / the raw
+    # name, so this is safe.
+    display_name = m['name']
+    if display_name.to_s =~ /\ACalculation_/i
+      cbg_cap = (meta['columns_by_guid'] || {}).dig(display_name.to_s, 'caption')
+      display_name = cbg_cap if cbg_cap && !cbg_cap.to_s.strip.empty? && cbg_cap.to_s !~ /\ACalculation_/i
+    end
+    col_obj = { 'id' => col_id, 'name' => display_name, 'formula' => formula }
     if field['role'] == 'measure'
       tab_fmt = pick_tableau_format(z['formats'], m['name'])
       col_obj['format'] = tab_fmt if tab_fmt

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -3190,9 +3190,26 @@ if opts[:auto_controls]
     }
     if p['param_domain'] == 'list'
       spec['controlType']   = 'segmented'
+      values = p['members'] || []
+      # Tableau list parameters often store integer-coded members (1..13) whose
+      # human meaning lives in the parameter's value ALIASES (1→"TCV", 3→"ACV").
+      # parse-twb-layout captures these in column_aliases keyed by the param
+      # caption. Map each member value to its alias label so the segmented
+      # control shows "TCV"/"ACV" instead of raw "1"/"3" — the selection VALUE
+      # stays the code (what the translated Switch([ctl-param-…], "1", …)
+      # compares against), only the display label changes. Without this the
+      # measure-switcher renders as a row of meaningless numbers (EDNA).
+      alias_pairs = (meta['column_aliases'] || {})[cap] ||
+                    (meta['column_aliases'] || {})[p['name'].to_s.gsub(/^\[|\]$/, '')]
+      labels = []
+      if alias_pairs && !alias_pairs.empty?
+        amap = alias_pairs.each_with_object({}) { |a, h| h[a['key'].to_s] = a['value'] }
+        labels = values.map { |v| amap[v.to_s] || v.to_s }
+        labels = [] if labels == values.map(&:to_s) # all unmapped → omit (no value-add)
+      end
       spec['source'] = {
         'kind' => 'manual', 'valueType' => 'text',
-        'values' => p['members'] || [], 'labels' => []
+        'values' => values, 'labels' => labels
       }
       spec['value'] = p['default_value']
     elsif p['param_domain'] == 'range' && %w[integer real].include?(p['datatype'])

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/preflight_lint.rb
@@ -75,8 +75,13 @@ def lint(spec)
         #  (the slider handle position), so only flag `value` when it is a Hash.
         errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
 
-        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
-        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an EDNA measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
           errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
         end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -233,8 +233,16 @@ end
 # Parse a `<rows>` or `<cols>` shelf string into a structured summary.
 def parse_shelf(shelf_str)
   out = { 'raw' => shelf_str, 'fields' => [], 'dim_count' => 0,
-          'measure_count' => 0, 'has_measure_names' => false }
+          'measure_count' => 0, 'has_measure_names' => false,
+          'has_measure_values' => false }
   return out if shelf_str.nil? || shelf_str.strip.empty?
+  # The Measure-VALUES pill (`[Multiple Values]` / `[Measure Values]`) signals
+  # measures placed on this shelf as a VISUAL encoding (bar lengths / line
+  # values). Detect it from the RAW string as a flag — NOT as a per-field role —
+  # because a shelf can hold it ALONGSIDE a real measure pill
+  # (`([Multiple Values] + [usr:Calc:qk])`), and classifying the whole field as
+  # measure-values would drop that real measure and break line/bar inference.
+  out['has_measure_values'] = true if shelf_str =~ /\[(?:Multiple|Measure)\s+Values\]/i
   shelf_str.split('/').each do |f|
     # Nested shelves wrap the field list in parens —
     #   `([ds].[none:A:nk] / [ds].[none:B:nk])`
@@ -552,31 +560,35 @@ xml.elements.each('//worksheet') do |ws|
   cols_shelf = parse_shelf(cols_node&.text)
 
   # Crosstab signal:
-  #   (a) explicit Text/Square mark with ≥1 real dim on BOTH shelves, OR
-  #   (b) a shelf carrying Measure Names (with ≥2 measures + ≥1 dim) under a
-  #       crosstab-capable mark.
-  # Measure Names on a shelf is an UNAMBIGUOUS crosstab signal — you can't put
-  # the Measure-Names pill on a true bar/line; it lays measures out as a text
-  # grid. Tableau's DEFAULT "Automatic" mark renders that grid as text, so a
-  # multi-measure crosstab authored without flipping the mark to "Text" reports
-  # mark_class="Automatic" (or blank). Gating only on text/square missed every
-  # such table — EDNA's "Metric Partner Closed Won" / "1T.PartnerClosed
-  # size&Status" (Automatic mark, Measure Names on cols) fell through to flat
-  # `table`/`kpi`, dropping the grouped quarter headers + Grand Total the
-  # customer flagged. We keep the strict text/square gate for the (a) branch
-  # (a 1-dim×1-dim Automatic sheet with one measure is a heatmap/bar matrix, not
-  # a pivot) and relax ONLY the Measure-Names branch.
+  #   (a) explicit Text/Square mark with ≥1 real dim on BOTH shelves, OR a
+  #       Measure-Names shelf (≥2 measures + ≥1 dim) — the mark is unambiguous, OR
+  #   (b) Automatic/blank mark with Measure Names AND dims on BOTH shelves.
+  # Measure Names on a shelf lays measures out as a text grid, and Tableau's
+  # DEFAULT "Automatic" mark renders that grid as text — so a crosstab authored
+  # without flipping the mark to "Text" reports mark_class="Automatic" (or blank).
+  # Gating only on text/square missed every such table (EDNA's "Metric Partner
+  # Closed Won" / "1T.PartnerClosed size&Status" → flat table/kpi, losing the
+  # grouped quarter headers + Grand Total).
+  #
+  # BUT the AUTOMATIC relaxation excludes sheets carrying the Measure-VALUES pill
+  # (`[Multiple Values]` / `[Measure Values]`) on a shelf: that places the
+  # measures as a VISUAL encoding (bar lengths / line values), so an
+  # Automatic-mark sheet with Measure Names on one shelf and Measure Values on the
+  # other is a MULTI-MEASURE BAR, not a text crosstab (real-world catch: a public
+  # "Barchart of accident factors" sheet — Measure Names on cols, `[Multiple
+  # Values]` on rows — must stay a bar). A genuine text crosstab carries the
+  # measure values on the Text marks card, never as a row/col pill. Explicit
+  # Text/Square marks keep the lenient rule — the author's intent is unambiguous.
   is_text_mark = %w[text square].include?(mark_class.to_s.downcase)
-  crosstab_capable_mark = is_text_mark ||
-                          mark_class.to_s.downcase == 'automatic' ||
-                          mark_class.to_s.strip.empty?
+  automatic_mark = mark_class.to_s.downcase == 'automatic' || mark_class.to_s.strip.empty?
   both_have_dims = rows_shelf['dim_count'] >= 1 && cols_shelf['dim_count'] >= 1
+  shelf_has_measure_values = rows_shelf['has_measure_values'] || cols_shelf['has_measure_values']
   measure_names_crosstab =
     (rows_shelf['has_measure_names'] || cols_shelf['has_measure_names']) &&
     (rows_shelf['dim_count'] + cols_shelf['dim_count']) >= 1 &&
     (rows_shelf['measure_count'] + cols_shelf['measure_count'] + measures.size) >= 2
-  is_crosstab = (is_text_mark && both_have_dims) ||
-                (crosstab_capable_mark && measure_names_crosstab)
+  is_crosstab = (is_text_mark && (both_have_dims || measure_names_crosstab)) ||
+                (automatic_mark && measure_names_crosstab && !shelf_has_measure_values)
 
   # KPI signal: Text/Square/AUTOMATIC mark with ZERO dims on both shelves AND
   # ≥1 measure (on shelves or on the worksheet's Marks card). Tableau

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -59,11 +59,28 @@ xml.elements.each('//column') do |c|
   cap = c.attributes['caption']
   dt  = c.attributes['datatype']
   next if raw.empty?
-  # Names look like `[guid]` or `[guid (foo)]` or `[Friendly Name]`. Strip
-  # surrounding brackets and lift out the GUID-looking head.
+  # Names look like `[guid]`, `[guid (foo)]`, `[Friendly Name]`,
+  # `[Calculation_123]`, or a Tableau group/copy `[Partner Level (group)]`.
+  # Strip surrounding brackets.
   body = raw.sub(/^\[/, '').sub(/\]$/, '')
-  head = body.split(/\s/, 2).first
-  COL_BY_GUID[head] ||= { caption: cap, datatype: dt } if cap && !cap.empty?
+  # GUID-shaped heads (hex UUID, possibly `(suffix)`-tagged) and Calculation_
+  # ids resolve via their leading token — keep the historical head-split so
+  # instance refs that quote only the GUID still match. These are only useful
+  # when a caption exists (the GUID itself is not human-readable).
+  if body =~ /\A([0-9a-f]{8}-[0-9a-f\-]{20,}|Calculation_\d+)/i
+    head = body.split(/\s/, 2).first
+    COL_BY_GUID[head] ||= { caption: cap, datatype: dt } if cap && !cap.empty?
+  else
+    # Friendly / group / copy names are referenced VERBATIM by their full body
+    # (e.g. instance ref `[none:Customer Geo:nk]` → "Customer Geo", filter
+    # `[Partner Level (group)]` → "Partner Level (group)"). Register under the
+    # FULL body — NOT the first word — or multi-word names ("Customer Geo")
+    # collapse to "Customer" and never resolve. Plain warehouse columns carry NO
+    # caption attribute (their name IS the display name), so fall the caption
+    # back to the body; that is the fix for the ~40 EDNA quick-filters that were
+    # silently dropped ("shared filter has no resolvable column_caption").
+    COL_BY_GUID[body] ||= { caption: (cap && !cap.empty? ? cap : body), datatype: dt }
+  end
 end
 
 # Filter columns use a column-instance level reference like
@@ -84,7 +101,14 @@ end
 #     friendly head (`Region`) is registered in COL_BY_GUID too.
 def guid_from_param(param)
   return nil if param.nil? || param.empty?
-  m = param.match(/\.\[(?:[a-z\-]+:)?([0-9a-f\-]{36}|Calculation_\d+|[A-Za-z_][\w. ]*)(?::[a-z]+)?\]$/i)
+  # Friendly/group/copy names carry parens, slashes ("Mkt Sourced/Influenced"),
+  # hyphens, ampersands, and trailing `(copy)_<digits>` / `(group)` suffixes —
+  # the friendly char class keeps them all so refs like `[Partner Level
+  # (group)]`, `[none:Region (copy)_4720…:nk]`, and `[none:Mkt
+  # Sourced/Influenced:nk]` resolve instead of returning nil (which dropped
+  # those quick-filters entirely). `:` stays excluded — it's the structural
+  # `<deriv>:<name>:<qual>` delimiter.
+  m = param.match(%r{\.\[(?:[a-z\-]+:)?([0-9a-f\-]{36}|Calculation_\d+|[A-Za-z_][\w. ()/&-]*)(?::[a-z]+)?\]$}i)
   m && m[1]
 end
 
@@ -111,11 +135,21 @@ def normalize_filter(f)
   guid  = guid_from_param(param)
   info  = guid ? COL_BY_GUID[guid] : nil
 
+  # Caption fallback: when the ref resolved to a friendly name (not a hex GUID /
+  # Calculation_ id) but no <column> def registered it, the extracted token IS
+  # the display name — use it rather than dropping the filter as "unresolvable".
+  # Strip Tableau's `(copy)_<digits>` / `(group)` decorations for a clean label.
+  friendly = guid && guid !~ /\A([0-9a-f]{8}-[0-9a-f\-]{20,}|Calculation_\d+)\z/i
+  fallback_caption =
+    if friendly
+      guid.sub(/\s*\(copy\)_\d+\z/i, '').sub(/\s*\(group\)\z/i, ' (group)').strip
+    end
+
   out = {
     'raw_class'      => cls,
     'raw_param'      => param,
     'column_guid'    => guid,
-    'column_caption' => info && info[:caption],
+    'column_caption' => (info && info[:caption]) || fallback_caption,
     'datatype'       => info && info[:datatype],
     'is_action'      => is_action
   }
@@ -517,17 +551,32 @@ xml.elements.each('//worksheet') do |ws|
   rows_shelf = parse_shelf(rows_node&.text)
   cols_shelf = parse_shelf(cols_node&.text)
 
-  # Crosstab signal: requires Text/Square mark AND either
-  #   (a) ≥1 real dim on BOTH shelves, or
-  #   (b) one shelf has a real dim + the other carries Measure Names
-  #       (with ≥2 measures on the worksheet)
+  # Crosstab signal:
+  #   (a) explicit Text/Square mark with ≥1 real dim on BOTH shelves, OR
+  #   (b) a shelf carrying Measure Names (with ≥2 measures + ≥1 dim) under a
+  #       crosstab-capable mark.
+  # Measure Names on a shelf is an UNAMBIGUOUS crosstab signal — you can't put
+  # the Measure-Names pill on a true bar/line; it lays measures out as a text
+  # grid. Tableau's DEFAULT "Automatic" mark renders that grid as text, so a
+  # multi-measure crosstab authored without flipping the mark to "Text" reports
+  # mark_class="Automatic" (or blank). Gating only on text/square missed every
+  # such table — EDNA's "Metric Partner Closed Won" / "1T.PartnerClosed
+  # size&Status" (Automatic mark, Measure Names on cols) fell through to flat
+  # `table`/`kpi`, dropping the grouped quarter headers + Grand Total the
+  # customer flagged. We keep the strict text/square gate for the (a) branch
+  # (a 1-dim×1-dim Automatic sheet with one measure is a heatmap/bar matrix, not
+  # a pivot) and relax ONLY the Measure-Names branch.
   is_text_mark = %w[text square].include?(mark_class.to_s.downcase)
+  crosstab_capable_mark = is_text_mark ||
+                          mark_class.to_s.downcase == 'automatic' ||
+                          mark_class.to_s.strip.empty?
   both_have_dims = rows_shelf['dim_count'] >= 1 && cols_shelf['dim_count'] >= 1
   measure_names_crosstab =
     (rows_shelf['has_measure_names'] || cols_shelf['has_measure_names']) &&
     (rows_shelf['dim_count'] + cols_shelf['dim_count']) >= 1 &&
     (rows_shelf['measure_count'] + cols_shelf['measure_count'] + measures.size) >= 2
-  is_crosstab = is_text_mark && (both_have_dims || measure_names_crosstab)
+  is_crosstab = (is_text_mark && both_have_dims) ||
+                (crosstab_capable_mark && measure_names_crosstab)
 
   # KPI signal: Text/Square/AUTOMATIC mark with ZERO dims on both shelves AND
   # ≥1 measure (on shelves or on the worksheet's Marks card). Tableau
@@ -697,11 +746,19 @@ def chart_kind_for(meta)
   # Automatic is Tableau's default-pick — but a zero-dim single-measure sheet
   # under Automatic renders as a big-number text table, i.e. a KPI (bead 3w4d).
   when 'automatic'
-    # A measure on BOTH axes is unambiguously a scatter (not a big-number KPI),
-    # so it overrides the zero-dim KPI heuristic; otherwise zero-dim → KPI.
-    inferred = infer_automatic_kind(meta)
-    inferred == 'scatter' ? 'scatter' : (meta[:is_kpi] ? 'kpi' : inferred)
-  when ''           then 'other'
+    # An Automatic-mark sheet with the crosstab shape (Measure Names + dims) is
+    # a text grid pivot — honor is_crosstab BEFORE the bar/KPI inference, else
+    # the grouped headers + Grand Total are lost to a flat table (EDNA partner
+    # tables). A measure on BOTH axes is unambiguously a scatter (not a
+    # big-number KPI), so it overrides the zero-dim KPI heuristic; otherwise
+    # zero-dim → KPI.
+    if meta[:is_crosstab]
+      'pivot-table'
+    else
+      inferred = infer_automatic_kind(meta)
+      inferred == 'scatter' ? 'scatter' : (meta[:is_kpi] ? 'kpi' : inferred)
+    end
+  when ''           then (meta[:is_crosstab] ? 'pivot-table' : 'other')
   else 'other'
   end
 end
@@ -971,6 +1028,20 @@ xml.elements.each("//column[@param-domain-type]") do |col|
     'step'          => rng && rng.attributes['granularity']
   }
 end
+
+# A global parameter is redeclared in EVERY worksheet's embedded
+# datasource-dependencies — so the raw scan finds the same `[Parameter N]`
+# hundreds of times (EDNA: 604 declarations for ~50 params), and the COPIES
+# carry empty <members> while the canonical Parameters-datasource declaration
+# carries the real domain. Dedup by internal NAME, keeping the richest entry
+# (most members; tie-break on a non-empty default). Without this the meta is
+# bloated AND a downstream consumer that takes the first-seen declaration can
+# land on an empty-members copy and emit a domainless control.
+parameters = parameters
+  .group_by { |p| p['name'] }
+  .map do |_name, dups|
+    dups.max_by { |p| [(p['members'] || []).size, p['default_value'].to_s.empty? ? 0 : 1] }
+  end
 
 # Detect which worksheet calcs reference a parameter so the build script knows
 # which calcs to translate via Switch(). A calc references a parameter when its

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/preflight_lint.rb
@@ -75,8 +75,13 @@ def lint(spec)
         #  (the slider handle position), so only flag `value` when it is a Hash.
         errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
 
-        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
-        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an EDNA measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
           errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
         end
 

--- a/shared/lib/preflight_lint.rb
+++ b/shared/lib/preflight_lint.rb
@@ -75,8 +75,13 @@ def lint(spec)
         #  (the slider handle position), so only flag `value` when it is a Hash.
         errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
 
-        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
-        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an EDNA measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
           errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
         end
 


### PR DESCRIPTION
## Why

A customer's EDNA **Partner Landscape** workbook (10 MB, 86 worksheets, 8 dashboards) migrated poorly: grouped/pivot tables came out as flat tables, most dashboard filters were missing, and the measure-switcher parameters "weren't handled well." We don't have EDNA's warehouse data, so this re-creates the *shapes* on the live CSA.TJ retail star and pins them as a regression fixture.

Diagnosed three regressions on the real `.twb`, each a one-spot root cause:

| # | Symptom | Root cause | EDNA before → after |
|---|---|---|---|
| 1 | Grouped/pivot tables built as flat tables | `parse-twb-layout` `is_crosstab` required a `Text`/`Square` mark, but the tables use Tableau's **default `Automatic`** mark (renders Measure-Names as a text grid) | crosstabs detected **2 → 44** |
| 2 | ~40 dashboard quick-filters dropped | `COL_BY_GUID` only registered caption-bearing columns + truncated multi-word names to the first word; `guid_from_param` choked on `(group)`/`(copy)`/slash | shared filters resolved **0/70 → 70/70** |
| 3 | Measure-switcher params showed raw `1/2/3` | `build-charts` set `labels: []` on the segmented control | now shows alias labels (TCV/ACV/…); params deduped **604 → 38** |

Plus a `preflight_lint` C2 false-positive: it flagged the `{kind:manual}` segmented source (which Sigma **accepts** — live-verified) as malformed, which would have blocked every measure-switcher at the migrate gate. Fixed in the canonical `shared/lib` copy and synced to all 8 converters.

## Validation

- **Live E2E on `CSA.TJ.ORDER_FACT`** (org tj-wells-1989): POSTed DM + workbook, applied layout, rendered the page. The pivot renders as a true grouped crosstab with a **Grand-total row + column**; the segmented control shows the alias labels; flipping it Net Revenue → Quantity swaps the measure column (grand total **119,038 → 1,593**) while the static Net Revenue column holds — proving the parameter switches the calculation. Throwaway artifacts deleted.
- **New corpus fixture** `tableau/partner-crosstab-controls` pins all four fixes through `parse-twb-layout` + `build-charts` (exercises caption-less, group, and slash filter columns + the integer measure-swap param). `corpus --check`: **4/4 tableau cases pass** (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)