### PR TITLE
feat(telemetry): enforce usage-ping consent decision as a hard gate (PR 1/3)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -101,6 +101,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -322,6 +322,17 @@ it returns an opt-in `scripts/escalate-gap.py` command to file a tracking issue 
 If the user does not object, run:
 
 ```bash
-python3 scripts/report-telemetry.py --tool cognos-to-sigma --duration <elapsed_seconds>
-# on failure: python3 scripts/report-telemetry.py --tool cognos-to-sigma --duration <elapsed_seconds> --failed
+python3 scripts/report-telemetry.py --tool cognos-to-sigma --duration <elapsed_seconds> --workdir <run-dir> [--mode live|file|both]
+# on failure:        python3 scripts/report-telemetry.py --tool cognos-to-sigma --duration <elapsed_seconds> --workdir <run-dir> --failed
+# if the user declines: python3 scripts/report-telemetry.py --tool cognos-to-sigma --workdir <run-dir> --declined
+# --workdir writes telemetry-sent.json, the marker the GREEN telemetry gate (assert-telemetry-ran.rb) requires.
+```
+
+**Then, before declaring the migration done, run the telemetry gate** (MANDATORY — proves the
+consent decision above was actually made, not skipped):
+
+```bash
+ruby scripts/assert-telemetry-ran.rb --workdir <run-dir>
+# exit 0 = decision recorded (sent or declined); exit 12 = you skipped the ping — go back and ask.
+# Escape hatch for unattended runs that genuinely cannot prompt: --skip-telemetry-gate "<reason>".
 ```

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/assert-telemetry-ran.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Hard gate that proves the telemetry step was not silently skipped.
+#
+# The migration skills send an anonymous usage ping at the end of a run, but
+# ONLY after asking the user for consent. That step lived as prose in each
+# SKILL.md, so an agent could (and did — the powerbi case) wrap up a migration
+# without ever prompting. This gate makes the decision mandatory: before a
+# conversion may declare GREEN, the agent must have EITHER sent the ping OR
+# recorded that the user declined. Either outcome writes a marker
+# (telemetry-sent.json) via report-telemetry.py; this gate checks the marker.
+#
+# It never touches the network and never inspects payload contents — telemetry
+# must never block or fail a migration. It only enforces that the consent
+# decision happened once.
+#
+# Usage:
+#   ruby scripts/assert-telemetry-ran.rb --workdir /tmp/<run>
+#     [--skip-telemetry-gate REASON]   # waive — REQUIRED reason, name it in
+#                                       # your migration report
+#
+# Exit codes:
+#   0  marker present (sent or declined) — telemetry step was handled
+#   1  --workdir missing / unreadable
+#   12 no telemetry marker — the consent step was skipped
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')               { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-telemetry-gate REASON',
+       'waive this gate — REQUIRED reason string. Name it in your migration report.') { |v| opts[:skip] = v }
+end.parse!
+
+unless opts[:dir]
+  warn '[FAIL] telemetry gate: --workdir (or --tableau) required'
+  exit 1
+end
+
+if opts[:skip]
+  puts "[SKIP] telemetry gate: WAIVED via --skip-telemetry-gate (#{opts[:skip]})."
+  puts '       This waiver MUST be named in the migration report — no usage ping decision was recorded.'
+  exit 0
+end
+
+marker = File.join(opts[:dir], 'telemetry-sent.json')
+unless File.exist?(marker)
+  warn '[FAIL] telemetry gate: no telemetry-sent.json marker — the anonymous usage ping was never handled.'
+  warn '       Before declaring GREEN you MUST ask the user for consent, then record the decision:'
+  warn "         send:    python3 scripts/report-telemetry.py --tool <skill> --duration <sec> --workdir #{opts[:dir]} [--mode live|file|both] [--failed]"
+  warn "         decline: python3 scripts/report-telemetry.py --tool <skill> --workdir #{opts[:dir]} --declined"
+  warn '       Escape hatch (genuinely cannot prompt — e.g. unattended CI): --skip-telemetry-gate "<reason>".'
+  exit 12
+end
+
+rec = (JSON.parse(File.read(marker)) rescue nil)
+status = rec.is_a?(Hash) ? rec['status'] : nil
+unless %w[sent declined].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+  warn '       Re-run report-telemetry.py to write a valid marker.'
+  exit 12
+end
+
+puts "[OK] telemetry gate: usage-ping decision recorded (status=#{status}" \
+     "#{rec['tool'] ? ", tool=#{rec['tool']}" : ''}#{rec['mode'] ? ", mode=#{rec['mode']}" : ''})"
+exit 0

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
@@ -47,6 +47,7 @@ def report_migration(
     client_id: str,
     duration_seconds: int,
     success: bool,
+    mode: str = "unknown",
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
@@ -62,6 +63,8 @@ def report_migration(
           → unique per org, not reversible to your credentials
       - migration duration in seconds
       - success flag
+      - input mode: "live" (source API), "file" (raw export only),
+          "both", or "unknown" — a coarse enum, no file names or content
       - skill version
 
     What is NOT sent:
@@ -78,6 +81,7 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "mode":             mode or "unknown",
         "skill_version":    skill_version,
     }
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
 Shared telemetry reporter for sigma-migration-skills.
-Call at the end of a successful (or failed) migration after all gates pass.
+Call at the end of a migration (success OR failure) after the user has been
+asked for consent. Writes a marker file so the telemetry gate
+(assert-telemetry-ran.rb) can confirm the step was not silently skipped.
 
 Usage:
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+    # send (consent given):
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312 --workdir /tmp/run --mode live
+    # send, but the migration failed:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --workdir /tmp/run --failed
+    # user declined the ping — record the decision without sending:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir /tmp/run --declined
 
 Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
 Prints what it sends; never raises; skips silently if endpoint unreachable.
@@ -13,17 +19,57 @@ See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
 """
 
 import argparse
+import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+# sigma_telemetry.py sits in a sibling/parent lib/ — its location differs by
+# layout: shared/scripts -> ../lib, but once fanned into a plugin it lives at
+# scripts/lib/. Add both candidates so the import works either way.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _cand in (os.path.join(_here, 'lib'), os.path.join(_here, '..', 'lib')):
+    if os.path.isdir(_cand):
+        sys.path.insert(0, _cand)
 from sigma_telemetry import report_migration
+
+MARKER = 'telemetry-sent.json'
+
+
+def _utc_now():
+    # Local import keeps the module importable in sandboxes that stub datetime.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_marker(workdir, record):
+    """Record that telemetry was handled (sent or declined). The gate checks
+    only for the marker's presence + a valid status — never the network."""
+    if not workdir:
+        return
+    try:
+        os.makedirs(workdir, exist_ok=True)
+        record['at'] = _utc_now()
+        with open(os.path.join(workdir, MARKER), 'w') as f:
+            json.dump(record, f, indent=2)
+        print(f"  → telemetry marker written ({os.path.join(workdir, MARKER)})")
+    except Exception as e:
+        print(f"  → could not write telemetry marker: {e}")
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
 parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
+parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
+                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+if args.declined:
+    print("\nTelemetry declined by user — nothing sent.")
+    _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
+    sys.exit(0)
 
 report_migration(
     tool=args.tool,
@@ -31,4 +77,11 @@ report_migration(
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
     duration_seconds=args.duration,
     success=not args.failed,
+    mode=args.mode,
 )
+_write_marker(args.workdir, {
+    'status': 'sent',
+    'tool': args.tool,
+    'success': not args.failed,
+    'mode': args.mode,
+})

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/assert-telemetry-ran.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Hard gate that proves the telemetry step was not silently skipped.
+#
+# The migration skills send an anonymous usage ping at the end of a run, but
+# ONLY after asking the user for consent. That step lived as prose in each
+# SKILL.md, so an agent could (and did — the powerbi case) wrap up a migration
+# without ever prompting. This gate makes the decision mandatory: before a
+# conversion may declare GREEN, the agent must have EITHER sent the ping OR
+# recorded that the user declined. Either outcome writes a marker
+# (telemetry-sent.json) via report-telemetry.py; this gate checks the marker.
+#
+# It never touches the network and never inspects payload contents — telemetry
+# must never block or fail a migration. It only enforces that the consent
+# decision happened once.
+#
+# Usage:
+#   ruby scripts/assert-telemetry-ran.rb --workdir /tmp/<run>
+#     [--skip-telemetry-gate REASON]   # waive — REQUIRED reason, name it in
+#                                       # your migration report
+#
+# Exit codes:
+#   0  marker present (sent or declined) — telemetry step was handled
+#   1  --workdir missing / unreadable
+#   12 no telemetry marker — the consent step was skipped
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')               { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-telemetry-gate REASON',
+       'waive this gate — REQUIRED reason string. Name it in your migration report.') { |v| opts[:skip] = v }
+end.parse!
+
+unless opts[:dir]
+  warn '[FAIL] telemetry gate: --workdir (or --tableau) required'
+  exit 1
+end
+
+if opts[:skip]
+  puts "[SKIP] telemetry gate: WAIVED via --skip-telemetry-gate (#{opts[:skip]})."
+  puts '       This waiver MUST be named in the migration report — no usage ping decision was recorded.'
+  exit 0
+end
+
+marker = File.join(opts[:dir], 'telemetry-sent.json')
+unless File.exist?(marker)
+  warn '[FAIL] telemetry gate: no telemetry-sent.json marker — the anonymous usage ping was never handled.'
+  warn '       Before declaring GREEN you MUST ask the user for consent, then record the decision:'
+  warn "         send:    python3 scripts/report-telemetry.py --tool <skill> --duration <sec> --workdir #{opts[:dir]} [--mode live|file|both] [--failed]"
+  warn "         decline: python3 scripts/report-telemetry.py --tool <skill> --workdir #{opts[:dir]} --declined"
+  warn '       Escape hatch (genuinely cannot prompt — e.g. unattended CI): --skip-telemetry-gate "<reason>".'
+  exit 12
+end
+
+rec = (JSON.parse(File.read(marker)) rescue nil)
+status = rec.is_a?(Hash) ? rec['status'] : nil
+unless %w[sent declined].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+  warn '       Re-run report-telemetry.py to write a valid marker.'
+  exit 12
+end
+
+puts "[OK] telemetry gate: usage-ping decision recorded (status=#{status}" \
+     "#{rec['tool'] ? ", tool=#{rec['tool']}" : ''}#{rec['mode'] ? ", mode=#{rec['mode']}" : ''})"
+exit 0

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
@@ -47,6 +47,7 @@ def report_migration(
     client_id: str,
     duration_seconds: int,
     success: bool,
+    mode: str = "unknown",
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
@@ -62,6 +63,8 @@ def report_migration(
           → unique per org, not reversible to your credentials
       - migration duration in seconds
       - success flag
+      - input mode: "live" (source API), "file" (raw export only),
+          "both", or "unknown" — a coarse enum, no file names or content
       - skill version
 
     What is NOT sent:
@@ -78,6 +81,7 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "mode":             mode or "unknown",
         "skill_version":    skill_version,
     }
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
 Shared telemetry reporter for sigma-migration-skills.
-Call at the end of a successful (or failed) migration after all gates pass.
+Call at the end of a migration (success OR failure) after the user has been
+asked for consent. Writes a marker file so the telemetry gate
+(assert-telemetry-ran.rb) can confirm the step was not silently skipped.
 
 Usage:
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+    # send (consent given):
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312 --workdir /tmp/run --mode live
+    # send, but the migration failed:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --workdir /tmp/run --failed
+    # user declined the ping — record the decision without sending:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir /tmp/run --declined
 
 Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
 Prints what it sends; never raises; skips silently if endpoint unreachable.
@@ -13,17 +19,57 @@ See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
 """
 
 import argparse
+import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+# sigma_telemetry.py sits in a sibling/parent lib/ — its location differs by
+# layout: shared/scripts -> ../lib, but once fanned into a plugin it lives at
+# scripts/lib/. Add both candidates so the import works either way.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _cand in (os.path.join(_here, 'lib'), os.path.join(_here, '..', 'lib')):
+    if os.path.isdir(_cand):
+        sys.path.insert(0, _cand)
 from sigma_telemetry import report_migration
+
+MARKER = 'telemetry-sent.json'
+
+
+def _utc_now():
+    # Local import keeps the module importable in sandboxes that stub datetime.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_marker(workdir, record):
+    """Record that telemetry was handled (sent or declined). The gate checks
+    only for the marker's presence + a valid status — never the network."""
+    if not workdir:
+        return
+    try:
+        os.makedirs(workdir, exist_ok=True)
+        record['at'] = _utc_now()
+        with open(os.path.join(workdir, MARKER), 'w') as f:
+            json.dump(record, f, indent=2)
+        print(f"  → telemetry marker written ({os.path.join(workdir, MARKER)})")
+    except Exception as e:
+        print(f"  → could not write telemetry marker: {e}")
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
 parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
+parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
+                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+if args.declined:
+    print("\nTelemetry declined by user — nothing sent.")
+    _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
+    sys.exit(0)
 
 report_migration(
     tool=args.tool,
@@ -31,4 +77,11 @@ report_migration(
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
     duration_seconds=args.duration,
     success=not args.failed,
+    mode=args.mode,
 )
+_write_marker(args.workdir, {
+    'status': 'sent',
+    'tool': args.tool,
+    'success': not args.failed,
+    'mode': args.mode,
+})

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -805,6 +805,8 @@ declaring Phase 4 green.
 If the user does not object, run:
 
 ```bash
-python3 scripts/report-telemetry.py --tool looker-to-sigma --duration <elapsed_seconds>
-# on failure: python3 scripts/report-telemetry.py --tool looker-to-sigma --duration <elapsed_seconds> --failed
+python3 scripts/report-telemetry.py --tool looker-to-sigma --duration <elapsed_seconds> --workdir <run-dir> [--mode live|file|both]
+# on failure:        python3 scripts/report-telemetry.py --tool looker-to-sigma --duration <elapsed_seconds> --workdir <run-dir> --failed
+# if the user declines: python3 scripts/report-telemetry.py --tool looker-to-sigma --workdir <run-dir> --declined
+# --workdir writes telemetry-sent.json, the marker the GREEN telemetry gate (assert-telemetry-ran.rb) requires.
 ```

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -88,6 +88,12 @@
 #      ("declared done on HTTP 200" regression; gate 8). Render with
 #      scripts/sigma-export-png.py --page <pageId>, Read it against the source
 #      dashboard PNG, then re-run. Escape hatch: --skip-visual-gate "<reason>".
+#  11  Build-from-signals tile(s) not image-verified (gate 9). Escape hatch:
+#      --skip-visual-tiles "<reason>".
+#  12  Telemetry consent decision missing — the anonymous usage ping was never
+#      sent or declined (no telemetry-sent.json marker; gate 10, delegated to
+#      assert-telemetry-ran.rb). Ask the user, then run report-telemetry.py
+#      (--declined if they decline). Escape hatch: --skip-telemetry-gate "<reason>".
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -95,6 +101,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'optparse'
+require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0 }
@@ -116,6 +123,7 @@ OptionParser.new do |p|
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
   p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
+  p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -656,6 +664,27 @@ if File.exist?(vv_sidecar)
     end
     puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 10 — Telemetry consent decision. The anonymous usage ping (and the
+# consent prompt that precedes it) lived as prose in each SKILL.md, so an agent
+# could wrap up without ever asking — telemetry silently never fired. This gate
+# delegates to the standalone assert-telemetry-ran.rb (single source of truth)
+# which checks for the telemetry-sent.json marker written by report-telemetry.py
+# on send OR decline. Never touches the network. The 3 converters that don't run
+# THIS script (qlik/cognos/gooddata) call assert-telemetry-ran.rb directly.
+# ---------------------------------------------------------------------------
+tele_gate = File.join(__dir__, 'assert-telemetry-ran.rb')
+if File.exist?(tele_gate)
+  cmd = [RbConfig.ruby, tele_gate, '--workdir', opts[:tab]]
+  cmd += ['--skip-telemetry-gate', opts[:skip_telemetry]] if opts[:skip_telemetry]
+  unless system(*cmd)
+    # assert-telemetry-ran.rb already printed the actionable failure message.
+    exit 12
+  end
+else
+  warn '[WARN] gate 10: assert-telemetry-ran.rb not found alongside this script — telemetry not enforced.'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-telemetry-ran.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Hard gate that proves the telemetry step was not silently skipped.
+#
+# The migration skills send an anonymous usage ping at the end of a run, but
+# ONLY after asking the user for consent. That step lived as prose in each
+# SKILL.md, so an agent could (and did — the powerbi case) wrap up a migration
+# without ever prompting. This gate makes the decision mandatory: before a
+# conversion may declare GREEN, the agent must have EITHER sent the ping OR
+# recorded that the user declined. Either outcome writes a marker
+# (telemetry-sent.json) via report-telemetry.py; this gate checks the marker.
+#
+# It never touches the network and never inspects payload contents — telemetry
+# must never block or fail a migration. It only enforces that the consent
+# decision happened once.
+#
+# Usage:
+#   ruby scripts/assert-telemetry-ran.rb --workdir /tmp/<run>
+#     [--skip-telemetry-gate REASON]   # waive — REQUIRED reason, name it in
+#                                       # your migration report
+#
+# Exit codes:
+#   0  marker present (sent or declined) — telemetry step was handled
+#   1  --workdir missing / unreadable
+#   12 no telemetry marker — the consent step was skipped
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')               { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-telemetry-gate REASON',
+       'waive this gate — REQUIRED reason string. Name it in your migration report.') { |v| opts[:skip] = v }
+end.parse!
+
+unless opts[:dir]
+  warn '[FAIL] telemetry gate: --workdir (or --tableau) required'
+  exit 1
+end
+
+if opts[:skip]
+  puts "[SKIP] telemetry gate: WAIVED via --skip-telemetry-gate (#{opts[:skip]})."
+  puts '       This waiver MUST be named in the migration report — no usage ping decision was recorded.'
+  exit 0
+end
+
+marker = File.join(opts[:dir], 'telemetry-sent.json')
+unless File.exist?(marker)
+  warn '[FAIL] telemetry gate: no telemetry-sent.json marker — the anonymous usage ping was never handled.'
+  warn '       Before declaring GREEN you MUST ask the user for consent, then record the decision:'
+  warn "         send:    python3 scripts/report-telemetry.py --tool <skill> --duration <sec> --workdir #{opts[:dir]} [--mode live|file|both] [--failed]"
+  warn "         decline: python3 scripts/report-telemetry.py --tool <skill> --workdir #{opts[:dir]} --declined"
+  warn '       Escape hatch (genuinely cannot prompt — e.g. unattended CI): --skip-telemetry-gate "<reason>".'
+  exit 12
+end
+
+rec = (JSON.parse(File.read(marker)) rescue nil)
+status = rec.is_a?(Hash) ? rec['status'] : nil
+unless %w[sent declined].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+  warn '       Re-run report-telemetry.py to write a valid marker.'
+  exit 12
+end
+
+puts "[OK] telemetry gate: usage-ping decision recorded (status=#{status}" \
+     "#{rec['tool'] ? ", tool=#{rec['tool']}" : ''}#{rec['mode'] ? ", mode=#{rec['mode']}" : ''})"
+exit 0

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
@@ -47,6 +47,7 @@ def report_migration(
     client_id: str,
     duration_seconds: int,
     success: bool,
+    mode: str = "unknown",
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
@@ -62,6 +63,8 @@ def report_migration(
           → unique per org, not reversible to your credentials
       - migration duration in seconds
       - success flag
+      - input mode: "live" (source API), "file" (raw export only),
+          "both", or "unknown" — a coarse enum, no file names or content
       - skill version
 
     What is NOT sent:
@@ -78,6 +81,7 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "mode":             mode or "unknown",
         "skill_version":    skill_version,
     }
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
 Shared telemetry reporter for sigma-migration-skills.
-Call at the end of a successful (or failed) migration after all gates pass.
+Call at the end of a migration (success OR failure) after the user has been
+asked for consent. Writes a marker file so the telemetry gate
+(assert-telemetry-ran.rb) can confirm the step was not silently skipped.
 
 Usage:
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+    # send (consent given):
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312 --workdir /tmp/run --mode live
+    # send, but the migration failed:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --workdir /tmp/run --failed
+    # user declined the ping — record the decision without sending:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir /tmp/run --declined
 
 Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
 Prints what it sends; never raises; skips silently if endpoint unreachable.
@@ -13,17 +19,57 @@ See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
 """
 
 import argparse
+import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+# sigma_telemetry.py sits in a sibling/parent lib/ — its location differs by
+# layout: shared/scripts -> ../lib, but once fanned into a plugin it lives at
+# scripts/lib/. Add both candidates so the import works either way.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _cand in (os.path.join(_here, 'lib'), os.path.join(_here, '..', 'lib')):
+    if os.path.isdir(_cand):
+        sys.path.insert(0, _cand)
 from sigma_telemetry import report_migration
+
+MARKER = 'telemetry-sent.json'
+
+
+def _utc_now():
+    # Local import keeps the module importable in sandboxes that stub datetime.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_marker(workdir, record):
+    """Record that telemetry was handled (sent or declined). The gate checks
+    only for the marker's presence + a valid status — never the network."""
+    if not workdir:
+        return
+    try:
+        os.makedirs(workdir, exist_ok=True)
+        record['at'] = _utc_now()
+        with open(os.path.join(workdir, MARKER), 'w') as f:
+            json.dump(record, f, indent=2)
+        print(f"  → telemetry marker written ({os.path.join(workdir, MARKER)})")
+    except Exception as e:
+        print(f"  → could not write telemetry marker: {e}")
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
 parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
+parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
+                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+if args.declined:
+    print("\nTelemetry declined by user — nothing sent.")
+    _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
+    sys.exit(0)
 
 report_migration(
     tool=args.tool,
@@ -31,4 +77,11 @@ report_migration(
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
     duration_seconds=args.duration,
     success=not args.failed,
+    mode=args.mode,
 )
+_write_marker(args.workdir, {
+    'status': 'sent',
+    'tool': args.tool,
+    'success': not args.failed,
+    'mode': args.mode,
+})

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -418,6 +418,8 @@ doesn't carry them).
 If the user does not object, run:
 
 ```bash
-python3 scripts/report-telemetry.py --tool microstrategy-to-sigma --duration <elapsed_seconds>
-# on failure: python3 scripts/report-telemetry.py --tool microstrategy-to-sigma --duration <elapsed_seconds> --failed
+python3 scripts/report-telemetry.py --tool microstrategy-to-sigma --duration <elapsed_seconds> --workdir <run-dir> [--mode live|file|both]
+# on failure:        python3 scripts/report-telemetry.py --tool microstrategy-to-sigma --duration <elapsed_seconds> --workdir <run-dir> --failed
+# if the user declines: python3 scripts/report-telemetry.py --tool microstrategy-to-sigma --workdir <run-dir> --declined
+# --workdir writes telemetry-sent.json, the marker the GREEN telemetry gate (assert-telemetry-ran.rb) requires.
 ```

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -88,6 +88,12 @@
 #      ("declared done on HTTP 200" regression; gate 8). Render with
 #      scripts/sigma-export-png.py --page <pageId>, Read it against the source
 #      dashboard PNG, then re-run. Escape hatch: --skip-visual-gate "<reason>".
+#  11  Build-from-signals tile(s) not image-verified (gate 9). Escape hatch:
+#      --skip-visual-tiles "<reason>".
+#  12  Telemetry consent decision missing — the anonymous usage ping was never
+#      sent or declined (no telemetry-sent.json marker; gate 10, delegated to
+#      assert-telemetry-ran.rb). Ask the user, then run report-telemetry.py
+#      (--declined if they decline). Escape hatch: --skip-telemetry-gate "<reason>".
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -95,6 +101,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'optparse'
+require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0 }
@@ -116,6 +123,7 @@ OptionParser.new do |p|
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
   p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
+  p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -656,6 +664,27 @@ if File.exist?(vv_sidecar)
     end
     puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 10 — Telemetry consent decision. The anonymous usage ping (and the
+# consent prompt that precedes it) lived as prose in each SKILL.md, so an agent
+# could wrap up without ever asking — telemetry silently never fired. This gate
+# delegates to the standalone assert-telemetry-ran.rb (single source of truth)
+# which checks for the telemetry-sent.json marker written by report-telemetry.py
+# on send OR decline. Never touches the network. The 3 converters that don't run
+# THIS script (qlik/cognos/gooddata) call assert-telemetry-ran.rb directly.
+# ---------------------------------------------------------------------------
+tele_gate = File.join(__dir__, 'assert-telemetry-ran.rb')
+if File.exist?(tele_gate)
+  cmd = [RbConfig.ruby, tele_gate, '--workdir', opts[:tab]]
+  cmd += ['--skip-telemetry-gate', opts[:skip_telemetry]] if opts[:skip_telemetry]
+  unless system(*cmd)
+    # assert-telemetry-ran.rb already printed the actionable failure message.
+    exit 12
+  end
+else
+  warn '[WARN] gate 10: assert-telemetry-ran.rb not found alongside this script — telemetry not enforced.'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-telemetry-ran.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Hard gate that proves the telemetry step was not silently skipped.
+#
+# The migration skills send an anonymous usage ping at the end of a run, but
+# ONLY after asking the user for consent. That step lived as prose in each
+# SKILL.md, so an agent could (and did — the powerbi case) wrap up a migration
+# without ever prompting. This gate makes the decision mandatory: before a
+# conversion may declare GREEN, the agent must have EITHER sent the ping OR
+# recorded that the user declined. Either outcome writes a marker
+# (telemetry-sent.json) via report-telemetry.py; this gate checks the marker.
+#
+# It never touches the network and never inspects payload contents — telemetry
+# must never block or fail a migration. It only enforces that the consent
+# decision happened once.
+#
+# Usage:
+#   ruby scripts/assert-telemetry-ran.rb --workdir /tmp/<run>
+#     [--skip-telemetry-gate REASON]   # waive — REQUIRED reason, name it in
+#                                       # your migration report
+#
+# Exit codes:
+#   0  marker present (sent or declined) — telemetry step was handled
+#   1  --workdir missing / unreadable
+#   12 no telemetry marker — the consent step was skipped
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')               { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-telemetry-gate REASON',
+       'waive this gate — REQUIRED reason string. Name it in your migration report.') { |v| opts[:skip] = v }
+end.parse!
+
+unless opts[:dir]
+  warn '[FAIL] telemetry gate: --workdir (or --tableau) required'
+  exit 1
+end
+
+if opts[:skip]
+  puts "[SKIP] telemetry gate: WAIVED via --skip-telemetry-gate (#{opts[:skip]})."
+  puts '       This waiver MUST be named in the migration report — no usage ping decision was recorded.'
+  exit 0
+end
+
+marker = File.join(opts[:dir], 'telemetry-sent.json')
+unless File.exist?(marker)
+  warn '[FAIL] telemetry gate: no telemetry-sent.json marker — the anonymous usage ping was never handled.'
+  warn '       Before declaring GREEN you MUST ask the user for consent, then record the decision:'
+  warn "         send:    python3 scripts/report-telemetry.py --tool <skill> --duration <sec> --workdir #{opts[:dir]} [--mode live|file|both] [--failed]"
+  warn "         decline: python3 scripts/report-telemetry.py --tool <skill> --workdir #{opts[:dir]} --declined"
+  warn '       Escape hatch (genuinely cannot prompt — e.g. unattended CI): --skip-telemetry-gate "<reason>".'
+  exit 12
+end
+
+rec = (JSON.parse(File.read(marker)) rescue nil)
+status = rec.is_a?(Hash) ? rec['status'] : nil
+unless %w[sent declined].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+  warn '       Re-run report-telemetry.py to write a valid marker.'
+  exit 12
+end
+
+puts "[OK] telemetry gate: usage-ping decision recorded (status=#{status}" \
+     "#{rec['tool'] ? ", tool=#{rec['tool']}" : ''}#{rec['mode'] ? ", mode=#{rec['mode']}" : ''})"
+exit 0

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
@@ -47,6 +47,7 @@ def report_migration(
     client_id: str,
     duration_seconds: int,
     success: bool,
+    mode: str = "unknown",
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
@@ -62,6 +63,8 @@ def report_migration(
           → unique per org, not reversible to your credentials
       - migration duration in seconds
       - success flag
+      - input mode: "live" (source API), "file" (raw export only),
+          "both", or "unknown" — a coarse enum, no file names or content
       - skill version
 
     What is NOT sent:
@@ -78,6 +81,7 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "mode":             mode or "unknown",
         "skill_version":    skill_version,
     }
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
 Shared telemetry reporter for sigma-migration-skills.
-Call at the end of a successful (or failed) migration after all gates pass.
+Call at the end of a migration (success OR failure) after the user has been
+asked for consent. Writes a marker file so the telemetry gate
+(assert-telemetry-ran.rb) can confirm the step was not silently skipped.
 
 Usage:
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+    # send (consent given):
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312 --workdir /tmp/run --mode live
+    # send, but the migration failed:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --workdir /tmp/run --failed
+    # user declined the ping — record the decision without sending:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir /tmp/run --declined
 
 Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
 Prints what it sends; never raises; skips silently if endpoint unreachable.
@@ -13,17 +19,57 @@ See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
 """
 
 import argparse
+import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+# sigma_telemetry.py sits in a sibling/parent lib/ — its location differs by
+# layout: shared/scripts -> ../lib, but once fanned into a plugin it lives at
+# scripts/lib/. Add both candidates so the import works either way.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _cand in (os.path.join(_here, 'lib'), os.path.join(_here, '..', 'lib')):
+    if os.path.isdir(_cand):
+        sys.path.insert(0, _cand)
 from sigma_telemetry import report_migration
+
+MARKER = 'telemetry-sent.json'
+
+
+def _utc_now():
+    # Local import keeps the module importable in sandboxes that stub datetime.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_marker(workdir, record):
+    """Record that telemetry was handled (sent or declined). The gate checks
+    only for the marker's presence + a valid status — never the network."""
+    if not workdir:
+        return
+    try:
+        os.makedirs(workdir, exist_ok=True)
+        record['at'] = _utc_now()
+        with open(os.path.join(workdir, MARKER), 'w') as f:
+            json.dump(record, f, indent=2)
+        print(f"  → telemetry marker written ({os.path.join(workdir, MARKER)})")
+    except Exception as e:
+        print(f"  → could not write telemetry marker: {e}")
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
 parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
+parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
+                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+if args.declined:
+    print("\nTelemetry declined by user — nothing sent.")
+    _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
+    sys.exit(0)
 
 report_migration(
     tool=args.tool,
@@ -31,4 +77,11 @@ report_migration(
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
     duration_seconds=args.duration,
     success=not args.failed,
+    mode=args.mode,
 )
+_write_marker(args.workdir, {
+    'status': 'sent',
+    'tool': args.tool,
+    'success': not args.failed,
+    'mode': args.mode,
+})

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -362,6 +362,8 @@ Row/column security is **never silently dropped and never silently ported** — 
 If the user does not object, run:
 
 ```bash
-python3 scripts/report-telemetry.py --tool powerbi-to-sigma --duration <elapsed_seconds>
-# on failure: python3 scripts/report-telemetry.py --tool powerbi-to-sigma --duration <elapsed_seconds> --failed
+python3 scripts/report-telemetry.py --tool powerbi-to-sigma --duration <elapsed_seconds> --workdir <run-dir> [--mode live|file|both]
+# on failure:        python3 scripts/report-telemetry.py --tool powerbi-to-sigma --duration <elapsed_seconds> --workdir <run-dir> --failed
+# if the user declines: python3 scripts/report-telemetry.py --tool powerbi-to-sigma --workdir <run-dir> --declined
+# --workdir writes telemetry-sent.json, the marker the GREEN telemetry gate (assert-telemetry-ran.rb) requires.
 ```

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -88,6 +88,12 @@
 #      ("declared done on HTTP 200" regression; gate 8). Render with
 #      scripts/sigma-export-png.py --page <pageId>, Read it against the source
 #      dashboard PNG, then re-run. Escape hatch: --skip-visual-gate "<reason>".
+#  11  Build-from-signals tile(s) not image-verified (gate 9). Escape hatch:
+#      --skip-visual-tiles "<reason>".
+#  12  Telemetry consent decision missing — the anonymous usage ping was never
+#      sent or declined (no telemetry-sent.json marker; gate 10, delegated to
+#      assert-telemetry-ran.rb). Ask the user, then run report-telemetry.py
+#      (--declined if they decline). Escape hatch: --skip-telemetry-gate "<reason>".
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -95,6 +101,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'optparse'
+require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0 }
@@ -116,6 +123,7 @@ OptionParser.new do |p|
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
   p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
+  p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -656,6 +664,27 @@ if File.exist?(vv_sidecar)
     end
     puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 10 — Telemetry consent decision. The anonymous usage ping (and the
+# consent prompt that precedes it) lived as prose in each SKILL.md, so an agent
+# could wrap up without ever asking — telemetry silently never fired. This gate
+# delegates to the standalone assert-telemetry-ran.rb (single source of truth)
+# which checks for the telemetry-sent.json marker written by report-telemetry.py
+# on send OR decline. Never touches the network. The 3 converters that don't run
+# THIS script (qlik/cognos/gooddata) call assert-telemetry-ran.rb directly.
+# ---------------------------------------------------------------------------
+tele_gate = File.join(__dir__, 'assert-telemetry-ran.rb')
+if File.exist?(tele_gate)
+  cmd = [RbConfig.ruby, tele_gate, '--workdir', opts[:tab]]
+  cmd += ['--skip-telemetry-gate', opts[:skip_telemetry]] if opts[:skip_telemetry]
+  unless system(*cmd)
+    # assert-telemetry-ran.rb already printed the actionable failure message.
+    exit 12
+  end
+else
+  warn '[WARN] gate 10: assert-telemetry-ran.rb not found alongside this script — telemetry not enforced.'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-telemetry-ran.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Hard gate that proves the telemetry step was not silently skipped.
+#
+# The migration skills send an anonymous usage ping at the end of a run, but
+# ONLY after asking the user for consent. That step lived as prose in each
+# SKILL.md, so an agent could (and did — the powerbi case) wrap up a migration
+# without ever prompting. This gate makes the decision mandatory: before a
+# conversion may declare GREEN, the agent must have EITHER sent the ping OR
+# recorded that the user declined. Either outcome writes a marker
+# (telemetry-sent.json) via report-telemetry.py; this gate checks the marker.
+#
+# It never touches the network and never inspects payload contents — telemetry
+# must never block or fail a migration. It only enforces that the consent
+# decision happened once.
+#
+# Usage:
+#   ruby scripts/assert-telemetry-ran.rb --workdir /tmp/<run>
+#     [--skip-telemetry-gate REASON]   # waive — REQUIRED reason, name it in
+#                                       # your migration report
+#
+# Exit codes:
+#   0  marker present (sent or declined) — telemetry step was handled
+#   1  --workdir missing / unreadable
+#   12 no telemetry marker — the consent step was skipped
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')               { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-telemetry-gate REASON',
+       'waive this gate — REQUIRED reason string. Name it in your migration report.') { |v| opts[:skip] = v }
+end.parse!
+
+unless opts[:dir]
+  warn '[FAIL] telemetry gate: --workdir (or --tableau) required'
+  exit 1
+end
+
+if opts[:skip]
+  puts "[SKIP] telemetry gate: WAIVED via --skip-telemetry-gate (#{opts[:skip]})."
+  puts '       This waiver MUST be named in the migration report — no usage ping decision was recorded.'
+  exit 0
+end
+
+marker = File.join(opts[:dir], 'telemetry-sent.json')
+unless File.exist?(marker)
+  warn '[FAIL] telemetry gate: no telemetry-sent.json marker — the anonymous usage ping was never handled.'
+  warn '       Before declaring GREEN you MUST ask the user for consent, then record the decision:'
+  warn "         send:    python3 scripts/report-telemetry.py --tool <skill> --duration <sec> --workdir #{opts[:dir]} [--mode live|file|both] [--failed]"
+  warn "         decline: python3 scripts/report-telemetry.py --tool <skill> --workdir #{opts[:dir]} --declined"
+  warn '       Escape hatch (genuinely cannot prompt — e.g. unattended CI): --skip-telemetry-gate "<reason>".'
+  exit 12
+end
+
+rec = (JSON.parse(File.read(marker)) rescue nil)
+status = rec.is_a?(Hash) ? rec['status'] : nil
+unless %w[sent declined].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+  warn '       Re-run report-telemetry.py to write a valid marker.'
+  exit 12
+end
+
+puts "[OK] telemetry gate: usage-ping decision recorded (status=#{status}" \
+     "#{rec['tool'] ? ", tool=#{rec['tool']}" : ''}#{rec['mode'] ? ", mode=#{rec['mode']}" : ''})"
+exit 0

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
@@ -47,6 +47,7 @@ def report_migration(
     client_id: str,
     duration_seconds: int,
     success: bool,
+    mode: str = "unknown",
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
@@ -62,6 +63,8 @@ def report_migration(
           → unique per org, not reversible to your credentials
       - migration duration in seconds
       - success flag
+      - input mode: "live" (source API), "file" (raw export only),
+          "both", or "unknown" — a coarse enum, no file names or content
       - skill version
 
     What is NOT sent:
@@ -78,6 +81,7 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "mode":             mode or "unknown",
         "skill_version":    skill_version,
     }
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
 Shared telemetry reporter for sigma-migration-skills.
-Call at the end of a successful (or failed) migration after all gates pass.
+Call at the end of a migration (success OR failure) after the user has been
+asked for consent. Writes a marker file so the telemetry gate
+(assert-telemetry-ran.rb) can confirm the step was not silently skipped.
 
 Usage:
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+    # send (consent given):
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312 --workdir /tmp/run --mode live
+    # send, but the migration failed:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --workdir /tmp/run --failed
+    # user declined the ping — record the decision without sending:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir /tmp/run --declined
 
 Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
 Prints what it sends; never raises; skips silently if endpoint unreachable.
@@ -13,17 +19,57 @@ See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
 """
 
 import argparse
+import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+# sigma_telemetry.py sits in a sibling/parent lib/ — its location differs by
+# layout: shared/scripts -> ../lib, but once fanned into a plugin it lives at
+# scripts/lib/. Add both candidates so the import works either way.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _cand in (os.path.join(_here, 'lib'), os.path.join(_here, '..', 'lib')):
+    if os.path.isdir(_cand):
+        sys.path.insert(0, _cand)
 from sigma_telemetry import report_migration
+
+MARKER = 'telemetry-sent.json'
+
+
+def _utc_now():
+    # Local import keeps the module importable in sandboxes that stub datetime.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_marker(workdir, record):
+    """Record that telemetry was handled (sent or declined). The gate checks
+    only for the marker's presence + a valid status — never the network."""
+    if not workdir:
+        return
+    try:
+        os.makedirs(workdir, exist_ok=True)
+        record['at'] = _utc_now()
+        with open(os.path.join(workdir, MARKER), 'w') as f:
+            json.dump(record, f, indent=2)
+        print(f"  → telemetry marker written ({os.path.join(workdir, MARKER)})")
+    except Exception as e:
+        print(f"  → could not write telemetry marker: {e}")
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
 parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
+parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
+                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+if args.declined:
+    print("\nTelemetry declined by user — nothing sent.")
+    _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
+    sys.exit(0)
 
 report_migration(
     tool=args.tool,
@@ -31,4 +77,11 @@ report_migration(
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
     duration_seconds=args.duration,
     success=not args.failed,
+    mode=args.mode,
 )
+_write_marker(args.workdir, {
+    'status': 'sent',
+    'tool': args.tool,
+    'success': not args.failed,
+    'mode': args.mode,
+})

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# test-telemetry-gate.rb — unit test for the telemetry consent gate
+# (assert-telemetry-ran.rb) and the marker written by report-telemetry.py.
+# Offline: the telemetry endpoint is never required — report-telemetry.py
+# degrades gracefully and still writes the marker, which is all the gate checks.
+# Canonical in shared/scripts (epic beads-sigma-p5y2). Run: ruby scripts/test-telemetry-gate.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+GATE   = File.join(__dir__, 'assert-telemetry-ran.rb')
+REPORT = File.join(__dir__, 'report-telemetry.py')
+RUBY   = RbConfig.ruby
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+def gate(dir, *extra)
+  system(RUBY, GATE, '--workdir', dir, *extra, out: File::NULL, err: File::NULL)
+end
+
+def report(dir, *extra)
+  env = { 'SIGMA_CLIENT_ID' => 'testclient', 'SIGMA_BASE_URL' => 'https://api.au.aws.sigmacomputing.com' }
+  system(env, 'python3', REPORT, '--tool', 'tableau-to-sigma', '--workdir', dir, *extra,
+         out: File::NULL, err: File::NULL)
+end
+
+Dir.mktmpdir do |d|
+  # 1. fresh run, no marker → gate FAILS (exit 12)
+  ok('missing marker fails the gate', gate(d) == false)
+
+  # 2. user declines → marker written, no network, status=declined
+  ok('--declined writes a marker', report(d, '--declined'))
+  rec = JSON.parse(File.read(File.join(d, 'telemetry-sent.json')))
+  ok('declined marker status', rec['status'] == 'declined')
+
+  # 3. gate now PASSES on the declined marker
+  ok('declined marker satisfies the gate', gate(d) == true)
+end
+
+Dir.mktmpdir do |d|
+  # 4. send path writes status=sent + carries the mode enum
+  ok('send writes a marker', report(d, '--duration', '120', '--mode', 'file'))
+  rec = JSON.parse(File.read(File.join(d, 'telemetry-sent.json')))
+  ok('sent marker status',  rec['status'] == 'sent')
+  ok('sent marker mode',    rec['mode'] == 'file')
+  ok('sent marker satisfies the gate', gate(d) == true)
+end
+
+Dir.mktmpdir do |d|
+  # 5. escape hatch waives a missing marker
+  ok('--skip-telemetry-gate waives', gate(d, '--skip-telemetry-gate', 'unattended CI') == true)
+
+  # 6. corrupt/invalid status → gate FAILS
+  File.write(File.join(d, 'telemetry-sent.json'), '{"status":"bogus"}')
+  ok('invalid marker status fails', gate(d) == false)
+end
+
+puts $fail.zero? ? "\nall telemetry-gate tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -371,6 +371,17 @@ Row/column security is **never silently dropped and never silently ported** — 
 If the user does not object, run:
 
 ```bash
-python3 scripts/report-telemetry.py --tool qlik-to-sigma --duration <elapsed_seconds>
-# on failure: python3 scripts/report-telemetry.py --tool qlik-to-sigma --duration <elapsed_seconds> --failed
+python3 scripts/report-telemetry.py --tool qlik-to-sigma --duration <elapsed_seconds> --workdir <run-dir> [--mode live|file|both]
+# on failure:        python3 scripts/report-telemetry.py --tool qlik-to-sigma --duration <elapsed_seconds> --workdir <run-dir> --failed
+# if the user declines: python3 scripts/report-telemetry.py --tool qlik-to-sigma --workdir <run-dir> --declined
+# --workdir writes telemetry-sent.json, the marker the GREEN telemetry gate (assert-telemetry-ran.rb) requires.
+```
+
+**Then, before declaring the migration done, run the telemetry gate** (MANDATORY — proves the
+consent decision above was actually made, not skipped):
+
+```bash
+ruby scripts/assert-telemetry-ran.rb --workdir <run-dir>
+# exit 0 = decision recorded (sent or declined); exit 12 = you skipped the ping — go back and ask.
+# Escape hatch for unattended runs that genuinely cannot prompt: --skip-telemetry-gate "<reason>".
 ```

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/assert-telemetry-ran.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Hard gate that proves the telemetry step was not silently skipped.
+#
+# The migration skills send an anonymous usage ping at the end of a run, but
+# ONLY after asking the user for consent. That step lived as prose in each
+# SKILL.md, so an agent could (and did — the powerbi case) wrap up a migration
+# without ever prompting. This gate makes the decision mandatory: before a
+# conversion may declare GREEN, the agent must have EITHER sent the ping OR
+# recorded that the user declined. Either outcome writes a marker
+# (telemetry-sent.json) via report-telemetry.py; this gate checks the marker.
+#
+# It never touches the network and never inspects payload contents — telemetry
+# must never block or fail a migration. It only enforces that the consent
+# decision happened once.
+#
+# Usage:
+#   ruby scripts/assert-telemetry-ran.rb --workdir /tmp/<run>
+#     [--skip-telemetry-gate REASON]   # waive — REQUIRED reason, name it in
+#                                       # your migration report
+#
+# Exit codes:
+#   0  marker present (sent or declined) — telemetry step was handled
+#   1  --workdir missing / unreadable
+#   12 no telemetry marker — the consent step was skipped
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')               { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-telemetry-gate REASON',
+       'waive this gate — REQUIRED reason string. Name it in your migration report.') { |v| opts[:skip] = v }
+end.parse!
+
+unless opts[:dir]
+  warn '[FAIL] telemetry gate: --workdir (or --tableau) required'
+  exit 1
+end
+
+if opts[:skip]
+  puts "[SKIP] telemetry gate: WAIVED via --skip-telemetry-gate (#{opts[:skip]})."
+  puts '       This waiver MUST be named in the migration report — no usage ping decision was recorded.'
+  exit 0
+end
+
+marker = File.join(opts[:dir], 'telemetry-sent.json')
+unless File.exist?(marker)
+  warn '[FAIL] telemetry gate: no telemetry-sent.json marker — the anonymous usage ping was never handled.'
+  warn '       Before declaring GREEN you MUST ask the user for consent, then record the decision:'
+  warn "         send:    python3 scripts/report-telemetry.py --tool <skill> --duration <sec> --workdir #{opts[:dir]} [--mode live|file|both] [--failed]"
+  warn "         decline: python3 scripts/report-telemetry.py --tool <skill> --workdir #{opts[:dir]} --declined"
+  warn '       Escape hatch (genuinely cannot prompt — e.g. unattended CI): --skip-telemetry-gate "<reason>".'
+  exit 12
+end
+
+rec = (JSON.parse(File.read(marker)) rescue nil)
+status = rec.is_a?(Hash) ? rec['status'] : nil
+unless %w[sent declined].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+  warn '       Re-run report-telemetry.py to write a valid marker.'
+  exit 12
+end
+
+puts "[OK] telemetry gate: usage-ping decision recorded (status=#{status}" \
+     "#{rec['tool'] ? ", tool=#{rec['tool']}" : ''}#{rec['mode'] ? ", mode=#{rec['mode']}" : ''})"
+exit 0

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
@@ -47,6 +47,7 @@ def report_migration(
     client_id: str,
     duration_seconds: int,
     success: bool,
+    mode: str = "unknown",
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
@@ -62,6 +63,8 @@ def report_migration(
           → unique per org, not reversible to your credentials
       - migration duration in seconds
       - success flag
+      - input mode: "live" (source API), "file" (raw export only),
+          "both", or "unknown" — a coarse enum, no file names or content
       - skill version
 
     What is NOT sent:
@@ -78,6 +81,7 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "mode":             mode or "unknown",
         "skill_version":    skill_version,
     }
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
 Shared telemetry reporter for sigma-migration-skills.
-Call at the end of a successful (or failed) migration after all gates pass.
+Call at the end of a migration (success OR failure) after the user has been
+asked for consent. Writes a marker file so the telemetry gate
+(assert-telemetry-ran.rb) can confirm the step was not silently skipped.
 
 Usage:
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+    # send (consent given):
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312 --workdir /tmp/run --mode live
+    # send, but the migration failed:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --workdir /tmp/run --failed
+    # user declined the ping — record the decision without sending:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir /tmp/run --declined
 
 Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
 Prints what it sends; never raises; skips silently if endpoint unreachable.
@@ -13,17 +19,57 @@ See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
 """
 
 import argparse
+import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+# sigma_telemetry.py sits in a sibling/parent lib/ — its location differs by
+# layout: shared/scripts -> ../lib, but once fanned into a plugin it lives at
+# scripts/lib/. Add both candidates so the import works either way.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _cand in (os.path.join(_here, 'lib'), os.path.join(_here, '..', 'lib')):
+    if os.path.isdir(_cand):
+        sys.path.insert(0, _cand)
 from sigma_telemetry import report_migration
+
+MARKER = 'telemetry-sent.json'
+
+
+def _utc_now():
+    # Local import keeps the module importable in sandboxes that stub datetime.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_marker(workdir, record):
+    """Record that telemetry was handled (sent or declined). The gate checks
+    only for the marker's presence + a valid status — never the network."""
+    if not workdir:
+        return
+    try:
+        os.makedirs(workdir, exist_ok=True)
+        record['at'] = _utc_now()
+        with open(os.path.join(workdir, MARKER), 'w') as f:
+            json.dump(record, f, indent=2)
+        print(f"  → telemetry marker written ({os.path.join(workdir, MARKER)})")
+    except Exception as e:
+        print(f"  → could not write telemetry marker: {e}")
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
 parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
+parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
+                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+if args.declined:
+    print("\nTelemetry declined by user — nothing sent.")
+    _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
+    sys.exit(0)
 
 report_migration(
     tool=args.tool,
@@ -31,4 +77,11 @@ report_migration(
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
     duration_seconds=args.duration,
     success=not args.failed,
+    mode=args.mode,
 )
+_write_marker(args.workdir, {
+    'status': 'sent',
+    'tool': args.tool,
+    'success': not args.failed,
+    'mode': args.mode,
+})

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -264,6 +264,8 @@ Row/column security is **never silently dropped and never silently ported** — 
 If the user does not object, run:
 
 ```bash
-python3 scripts/report-telemetry.py --tool quicksight-to-sigma --duration <elapsed_seconds>
-# on failure: python3 scripts/report-telemetry.py --tool quicksight-to-sigma --duration <elapsed_seconds> --failed
+python3 scripts/report-telemetry.py --tool quicksight-to-sigma --duration <elapsed_seconds> --workdir <run-dir> [--mode live|file|both]
+# on failure:        python3 scripts/report-telemetry.py --tool quicksight-to-sigma --duration <elapsed_seconds> --workdir <run-dir> --failed
+# if the user declines: python3 scripts/report-telemetry.py --tool quicksight-to-sigma --workdir <run-dir> --declined
+# --workdir writes telemetry-sent.json, the marker the GREEN telemetry gate (assert-telemetry-ran.rb) requires.
 ```

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -88,6 +88,12 @@
 #      ("declared done on HTTP 200" regression; gate 8). Render with
 #      scripts/sigma-export-png.py --page <pageId>, Read it against the source
 #      dashboard PNG, then re-run. Escape hatch: --skip-visual-gate "<reason>".
+#  11  Build-from-signals tile(s) not image-verified (gate 9). Escape hatch:
+#      --skip-visual-tiles "<reason>".
+#  12  Telemetry consent decision missing — the anonymous usage ping was never
+#      sent or declined (no telemetry-sent.json marker; gate 10, delegated to
+#      assert-telemetry-ran.rb). Ask the user, then run report-telemetry.py
+#      (--declined if they decline). Escape hatch: --skip-telemetry-gate "<reason>".
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -95,6 +101,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'optparse'
+require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0 }
@@ -116,6 +123,7 @@ OptionParser.new do |p|
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
   p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
+  p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -656,6 +664,27 @@ if File.exist?(vv_sidecar)
     end
     puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 10 — Telemetry consent decision. The anonymous usage ping (and the
+# consent prompt that precedes it) lived as prose in each SKILL.md, so an agent
+# could wrap up without ever asking — telemetry silently never fired. This gate
+# delegates to the standalone assert-telemetry-ran.rb (single source of truth)
+# which checks for the telemetry-sent.json marker written by report-telemetry.py
+# on send OR decline. Never touches the network. The 3 converters that don't run
+# THIS script (qlik/cognos/gooddata) call assert-telemetry-ran.rb directly.
+# ---------------------------------------------------------------------------
+tele_gate = File.join(__dir__, 'assert-telemetry-ran.rb')
+if File.exist?(tele_gate)
+  cmd = [RbConfig.ruby, tele_gate, '--workdir', opts[:tab]]
+  cmd += ['--skip-telemetry-gate', opts[:skip_telemetry]] if opts[:skip_telemetry]
+  unless system(*cmd)
+    # assert-telemetry-ran.rb already printed the actionable failure message.
+    exit 12
+  end
+else
+  warn '[WARN] gate 10: assert-telemetry-ran.rb not found alongside this script — telemetry not enforced.'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-telemetry-ran.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Hard gate that proves the telemetry step was not silently skipped.
+#
+# The migration skills send an anonymous usage ping at the end of a run, but
+# ONLY after asking the user for consent. That step lived as prose in each
+# SKILL.md, so an agent could (and did — the powerbi case) wrap up a migration
+# without ever prompting. This gate makes the decision mandatory: before a
+# conversion may declare GREEN, the agent must have EITHER sent the ping OR
+# recorded that the user declined. Either outcome writes a marker
+# (telemetry-sent.json) via report-telemetry.py; this gate checks the marker.
+#
+# It never touches the network and never inspects payload contents — telemetry
+# must never block or fail a migration. It only enforces that the consent
+# decision happened once.
+#
+# Usage:
+#   ruby scripts/assert-telemetry-ran.rb --workdir /tmp/<run>
+#     [--skip-telemetry-gate REASON]   # waive — REQUIRED reason, name it in
+#                                       # your migration report
+#
+# Exit codes:
+#   0  marker present (sent or declined) — telemetry step was handled
+#   1  --workdir missing / unreadable
+#   12 no telemetry marker — the consent step was skipped
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')               { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-telemetry-gate REASON',
+       'waive this gate — REQUIRED reason string. Name it in your migration report.') { |v| opts[:skip] = v }
+end.parse!
+
+unless opts[:dir]
+  warn '[FAIL] telemetry gate: --workdir (or --tableau) required'
+  exit 1
+end
+
+if opts[:skip]
+  puts "[SKIP] telemetry gate: WAIVED via --skip-telemetry-gate (#{opts[:skip]})."
+  puts '       This waiver MUST be named in the migration report — no usage ping decision was recorded.'
+  exit 0
+end
+
+marker = File.join(opts[:dir], 'telemetry-sent.json')
+unless File.exist?(marker)
+  warn '[FAIL] telemetry gate: no telemetry-sent.json marker — the anonymous usage ping was never handled.'
+  warn '       Before declaring GREEN you MUST ask the user for consent, then record the decision:'
+  warn "         send:    python3 scripts/report-telemetry.py --tool <skill> --duration <sec> --workdir #{opts[:dir]} [--mode live|file|both] [--failed]"
+  warn "         decline: python3 scripts/report-telemetry.py --tool <skill> --workdir #{opts[:dir]} --declined"
+  warn '       Escape hatch (genuinely cannot prompt — e.g. unattended CI): --skip-telemetry-gate "<reason>".'
+  exit 12
+end
+
+rec = (JSON.parse(File.read(marker)) rescue nil)
+status = rec.is_a?(Hash) ? rec['status'] : nil
+unless %w[sent declined].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+  warn '       Re-run report-telemetry.py to write a valid marker.'
+  exit 12
+end
+
+puts "[OK] telemetry gate: usage-ping decision recorded (status=#{status}" \
+     "#{rec['tool'] ? ", tool=#{rec['tool']}" : ''}#{rec['mode'] ? ", mode=#{rec['mode']}" : ''})"
+exit 0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
@@ -47,6 +47,7 @@ def report_migration(
     client_id: str,
     duration_seconds: int,
     success: bool,
+    mode: str = "unknown",
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
@@ -62,6 +63,8 @@ def report_migration(
           → unique per org, not reversible to your credentials
       - migration duration in seconds
       - success flag
+      - input mode: "live" (source API), "file" (raw export only),
+          "both", or "unknown" — a coarse enum, no file names or content
       - skill version
 
     What is NOT sent:
@@ -78,6 +81,7 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "mode":             mode or "unknown",
         "skill_version":    skill_version,
     }
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
 Shared telemetry reporter for sigma-migration-skills.
-Call at the end of a successful (or failed) migration after all gates pass.
+Call at the end of a migration (success OR failure) after the user has been
+asked for consent. Writes a marker file so the telemetry gate
+(assert-telemetry-ran.rb) can confirm the step was not silently skipped.
 
 Usage:
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+    # send (consent given):
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312 --workdir /tmp/run --mode live
+    # send, but the migration failed:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --workdir /tmp/run --failed
+    # user declined the ping — record the decision without sending:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir /tmp/run --declined
 
 Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
 Prints what it sends; never raises; skips silently if endpoint unreachable.
@@ -13,17 +19,57 @@ See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
 """
 
 import argparse
+import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+# sigma_telemetry.py sits in a sibling/parent lib/ — its location differs by
+# layout: shared/scripts -> ../lib, but once fanned into a plugin it lives at
+# scripts/lib/. Add both candidates so the import works either way.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _cand in (os.path.join(_here, 'lib'), os.path.join(_here, '..', 'lib')):
+    if os.path.isdir(_cand):
+        sys.path.insert(0, _cand)
 from sigma_telemetry import report_migration
+
+MARKER = 'telemetry-sent.json'
+
+
+def _utc_now():
+    # Local import keeps the module importable in sandboxes that stub datetime.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_marker(workdir, record):
+    """Record that telemetry was handled (sent or declined). The gate checks
+    only for the marker's presence + a valid status — never the network."""
+    if not workdir:
+        return
+    try:
+        os.makedirs(workdir, exist_ok=True)
+        record['at'] = _utc_now()
+        with open(os.path.join(workdir, MARKER), 'w') as f:
+            json.dump(record, f, indent=2)
+        print(f"  → telemetry marker written ({os.path.join(workdir, MARKER)})")
+    except Exception as e:
+        print(f"  → could not write telemetry marker: {e}")
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
 parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
+parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
+                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+if args.declined:
+    print("\nTelemetry declined by user — nothing sent.")
+    _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
+    sys.exit(0)
 
 report_migration(
     tool=args.tool,
@@ -31,4 +77,11 @@ report_migration(
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
     duration_seconds=args.duration,
     success=not args.failed,
+    mode=args.mode,
 )
+_write_marker(args.workdir, {
+    'status': 'sent',
+    'tool': args.tool,
+    'success': not args.failed,
+    'mode': args.mode,
+})

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -1823,6 +1823,8 @@ Row/column security is **never silently dropped and never silently ported** — 
 If the user does not object, run:
 
 ```bash
-python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration <elapsed_seconds>
-# on failure: python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration <elapsed_seconds> --failed
+python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration <elapsed_seconds> --workdir <run-dir> [--mode live|file|both]
+# on failure:        python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration <elapsed_seconds> --workdir <run-dir> --failed
+# if the user declines: python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir <run-dir> --declined
+# --workdir writes telemetry-sent.json, the marker the GREEN telemetry gate (assert-telemetry-ran.rb) requires.
 ```

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -88,6 +88,12 @@
 #      ("declared done on HTTP 200" regression; gate 8). Render with
 #      scripts/sigma-export-png.py --page <pageId>, Read it against the source
 #      dashboard PNG, then re-run. Escape hatch: --skip-visual-gate "<reason>".
+#  11  Build-from-signals tile(s) not image-verified (gate 9). Escape hatch:
+#      --skip-visual-tiles "<reason>".
+#  12  Telemetry consent decision missing — the anonymous usage ping was never
+#      sent or declined (no telemetry-sent.json marker; gate 10, delegated to
+#      assert-telemetry-ran.rb). Ask the user, then run report-telemetry.py
+#      (--declined if they decline). Escape hatch: --skip-telemetry-gate "<reason>".
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -95,6 +101,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'optparse'
+require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0 }
@@ -116,6 +123,7 @@ OptionParser.new do |p|
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
   p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
+  p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -656,6 +664,27 @@ if File.exist?(vv_sidecar)
     end
     puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 10 — Telemetry consent decision. The anonymous usage ping (and the
+# consent prompt that precedes it) lived as prose in each SKILL.md, so an agent
+# could wrap up without ever asking — telemetry silently never fired. This gate
+# delegates to the standalone assert-telemetry-ran.rb (single source of truth)
+# which checks for the telemetry-sent.json marker written by report-telemetry.py
+# on send OR decline. Never touches the network. The 3 converters that don't run
+# THIS script (qlik/cognos/gooddata) call assert-telemetry-ran.rb directly.
+# ---------------------------------------------------------------------------
+tele_gate = File.join(__dir__, 'assert-telemetry-ran.rb')
+if File.exist?(tele_gate)
+  cmd = [RbConfig.ruby, tele_gate, '--workdir', opts[:tab]]
+  cmd += ['--skip-telemetry-gate', opts[:skip_telemetry]] if opts[:skip_telemetry]
+  unless system(*cmd)
+    # assert-telemetry-ran.rb already printed the actionable failure message.
+    exit 12
+  end
+else
+  warn '[WARN] gate 10: assert-telemetry-ran.rb not found alongside this script — telemetry not enforced.'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-telemetry-ran.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Hard gate that proves the telemetry step was not silently skipped.
+#
+# The migration skills send an anonymous usage ping at the end of a run, but
+# ONLY after asking the user for consent. That step lived as prose in each
+# SKILL.md, so an agent could (and did — the powerbi case) wrap up a migration
+# without ever prompting. This gate makes the decision mandatory: before a
+# conversion may declare GREEN, the agent must have EITHER sent the ping OR
+# recorded that the user declined. Either outcome writes a marker
+# (telemetry-sent.json) via report-telemetry.py; this gate checks the marker.
+#
+# It never touches the network and never inspects payload contents — telemetry
+# must never block or fail a migration. It only enforces that the consent
+# decision happened once.
+#
+# Usage:
+#   ruby scripts/assert-telemetry-ran.rb --workdir /tmp/<run>
+#     [--skip-telemetry-gate REASON]   # waive — REQUIRED reason, name it in
+#                                       # your migration report
+#
+# Exit codes:
+#   0  marker present (sent or declined) — telemetry step was handled
+#   1  --workdir missing / unreadable
+#   12 no telemetry marker — the consent step was skipped
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')               { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-telemetry-gate REASON',
+       'waive this gate — REQUIRED reason string. Name it in your migration report.') { |v| opts[:skip] = v }
+end.parse!
+
+unless opts[:dir]
+  warn '[FAIL] telemetry gate: --workdir (or --tableau) required'
+  exit 1
+end
+
+if opts[:skip]
+  puts "[SKIP] telemetry gate: WAIVED via --skip-telemetry-gate (#{opts[:skip]})."
+  puts '       This waiver MUST be named in the migration report — no usage ping decision was recorded.'
+  exit 0
+end
+
+marker = File.join(opts[:dir], 'telemetry-sent.json')
+unless File.exist?(marker)
+  warn '[FAIL] telemetry gate: no telemetry-sent.json marker — the anonymous usage ping was never handled.'
+  warn '       Before declaring GREEN you MUST ask the user for consent, then record the decision:'
+  warn "         send:    python3 scripts/report-telemetry.py --tool <skill> --duration <sec> --workdir #{opts[:dir]} [--mode live|file|both] [--failed]"
+  warn "         decline: python3 scripts/report-telemetry.py --tool <skill> --workdir #{opts[:dir]} --declined"
+  warn '       Escape hatch (genuinely cannot prompt — e.g. unattended CI): --skip-telemetry-gate "<reason>".'
+  exit 12
+end
+
+rec = (JSON.parse(File.read(marker)) rescue nil)
+status = rec.is_a?(Hash) ? rec['status'] : nil
+unless %w[sent declined].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+  warn '       Re-run report-telemetry.py to write a valid marker.'
+  exit 12
+end
+
+puts "[OK] telemetry gate: usage-ping decision recorded (status=#{status}" \
+     "#{rec['tool'] ? ", tool=#{rec['tool']}" : ''}#{rec['mode'] ? ", mode=#{rec['mode']}" : ''})"
+exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
@@ -47,6 +47,7 @@ def report_migration(
     client_id: str,
     duration_seconds: int,
     success: bool,
+    mode: str = "unknown",
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
@@ -62,6 +63,8 @@ def report_migration(
           → unique per org, not reversible to your credentials
       - migration duration in seconds
       - success flag
+      - input mode: "live" (source API), "file" (raw export only),
+          "both", or "unknown" — a coarse enum, no file names or content
       - skill version
 
     What is NOT sent:
@@ -78,6 +81,7 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "mode":             mode or "unknown",
         "skill_version":    skill_version,
     }
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
 Shared telemetry reporter for sigma-migration-skills.
-Call at the end of a successful (or failed) migration after all gates pass.
+Call at the end of a migration (success OR failure) after the user has been
+asked for consent. Writes a marker file so the telemetry gate
+(assert-telemetry-ran.rb) can confirm the step was not silently skipped.
 
 Usage:
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+    # send (consent given):
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312 --workdir /tmp/run --mode live
+    # send, but the migration failed:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --workdir /tmp/run --failed
+    # user declined the ping — record the decision without sending:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir /tmp/run --declined
 
 Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
 Prints what it sends; never raises; skips silently if endpoint unreachable.
@@ -13,17 +19,57 @@ See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
 """
 
 import argparse
+import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+# sigma_telemetry.py sits in a sibling/parent lib/ — its location differs by
+# layout: shared/scripts -> ../lib, but once fanned into a plugin it lives at
+# scripts/lib/. Add both candidates so the import works either way.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _cand in (os.path.join(_here, 'lib'), os.path.join(_here, '..', 'lib')):
+    if os.path.isdir(_cand):
+        sys.path.insert(0, _cand)
 from sigma_telemetry import report_migration
+
+MARKER = 'telemetry-sent.json'
+
+
+def _utc_now():
+    # Local import keeps the module importable in sandboxes that stub datetime.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_marker(workdir, record):
+    """Record that telemetry was handled (sent or declined). The gate checks
+    only for the marker's presence + a valid status — never the network."""
+    if not workdir:
+        return
+    try:
+        os.makedirs(workdir, exist_ok=True)
+        record['at'] = _utc_now()
+        with open(os.path.join(workdir, MARKER), 'w') as f:
+            json.dump(record, f, indent=2)
+        print(f"  → telemetry marker written ({os.path.join(workdir, MARKER)})")
+    except Exception as e:
+        print(f"  → could not write telemetry marker: {e}")
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
 parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
+parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
+                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+if args.declined:
+    print("\nTelemetry declined by user — nothing sent.")
+    _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
+    sys.exit(0)
 
 report_migration(
     tool=args.tool,
@@ -31,4 +77,11 @@ report_migration(
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
     duration_seconds=args.duration,
     success=not args.failed,
+    mode=args.mode,
 )
+_write_marker(args.workdir, {
+    'status': 'sent',
+    'tool': args.tool,
+    'success': not args.failed,
+    'mode': args.mode,
+})

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-telemetry-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-telemetry-gate.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# test-telemetry-gate.rb — unit test for the telemetry consent gate
+# (assert-telemetry-ran.rb) and the marker written by report-telemetry.py.
+# Offline: the telemetry endpoint is never required — report-telemetry.py
+# degrades gracefully and still writes the marker, which is all the gate checks.
+# Canonical in shared/scripts (epic beads-sigma-p5y2). Run: ruby scripts/test-telemetry-gate.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+GATE   = File.join(__dir__, 'assert-telemetry-ran.rb')
+REPORT = File.join(__dir__, 'report-telemetry.py')
+RUBY   = RbConfig.ruby
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+def gate(dir, *extra)
+  system(RUBY, GATE, '--workdir', dir, *extra, out: File::NULL, err: File::NULL)
+end
+
+def report(dir, *extra)
+  env = { 'SIGMA_CLIENT_ID' => 'testclient', 'SIGMA_BASE_URL' => 'https://api.au.aws.sigmacomputing.com' }
+  system(env, 'python3', REPORT, '--tool', 'tableau-to-sigma', '--workdir', dir, *extra,
+         out: File::NULL, err: File::NULL)
+end
+
+Dir.mktmpdir do |d|
+  # 1. fresh run, no marker → gate FAILS (exit 12)
+  ok('missing marker fails the gate', gate(d) == false)
+
+  # 2. user declines → marker written, no network, status=declined
+  ok('--declined writes a marker', report(d, '--declined'))
+  rec = JSON.parse(File.read(File.join(d, 'telemetry-sent.json')))
+  ok('declined marker status', rec['status'] == 'declined')
+
+  # 3. gate now PASSES on the declined marker
+  ok('declined marker satisfies the gate', gate(d) == true)
+end
+
+Dir.mktmpdir do |d|
+  # 4. send path writes status=sent + carries the mode enum
+  ok('send writes a marker', report(d, '--duration', '120', '--mode', 'file'))
+  rec = JSON.parse(File.read(File.join(d, 'telemetry-sent.json')))
+  ok('sent marker status',  rec['status'] == 'sent')
+  ok('sent marker mode',    rec['mode'] == 'file')
+  ok('sent marker satisfies the gate', gate(d) == true)
+end
+
+Dir.mktmpdir do |d|
+  # 5. escape hatch waives a missing marker
+  ok('--skip-telemetry-gate waives', gate(d, '--skip-telemetry-gate', 'unattended CI') == true)
+
+  # 6. corrupt/invalid status → gate FAILS
+  File.write(File.join(d, 'telemetry-sent.json'), '{"status":"bogus"}')
+  ok('invalid marker status fails', gate(d) == false)
+end
+
+puts $fail.zero? ? "\nall telemetry-gate tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -327,6 +327,8 @@ Row/column security is **never silently dropped and never silently ported** — 
 If the user does not object, run:
 
 ```bash
-python3 scripts/report-telemetry.py --tool thoughtspot-to-sigma --duration <elapsed_seconds>
-# on failure: python3 scripts/report-telemetry.py --tool thoughtspot-to-sigma --duration <elapsed_seconds> --failed
+python3 scripts/report-telemetry.py --tool thoughtspot-to-sigma --duration <elapsed_seconds> --workdir <run-dir> [--mode live|file|both]
+# on failure:        python3 scripts/report-telemetry.py --tool thoughtspot-to-sigma --duration <elapsed_seconds> --workdir <run-dir> --failed
+# if the user declines: python3 scripts/report-telemetry.py --tool thoughtspot-to-sigma --workdir <run-dir> --declined
+# --workdir writes telemetry-sent.json, the marker the GREEN telemetry gate (assert-telemetry-ran.rb) requires.
 ```

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -88,6 +88,12 @@
 #      ("declared done on HTTP 200" regression; gate 8). Render with
 #      scripts/sigma-export-png.py --page <pageId>, Read it against the source
 #      dashboard PNG, then re-run. Escape hatch: --skip-visual-gate "<reason>".
+#  11  Build-from-signals tile(s) not image-verified (gate 9). Escape hatch:
+#      --skip-visual-tiles "<reason>".
+#  12  Telemetry consent decision missing — the anonymous usage ping was never
+#      sent or declined (no telemetry-sent.json marker; gate 10, delegated to
+#      assert-telemetry-ran.rb). Ask the user, then run report-telemetry.py
+#      (--declined if they decline). Escape hatch: --skip-telemetry-gate "<reason>".
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -95,6 +101,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'optparse'
+require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0 }
@@ -116,6 +123,7 @@ OptionParser.new do |p|
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
   p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
+  p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -656,6 +664,27 @@ if File.exist?(vv_sidecar)
     end
     puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 10 — Telemetry consent decision. The anonymous usage ping (and the
+# consent prompt that precedes it) lived as prose in each SKILL.md, so an agent
+# could wrap up without ever asking — telemetry silently never fired. This gate
+# delegates to the standalone assert-telemetry-ran.rb (single source of truth)
+# which checks for the telemetry-sent.json marker written by report-telemetry.py
+# on send OR decline. Never touches the network. The 3 converters that don't run
+# THIS script (qlik/cognos/gooddata) call assert-telemetry-ran.rb directly.
+# ---------------------------------------------------------------------------
+tele_gate = File.join(__dir__, 'assert-telemetry-ran.rb')
+if File.exist?(tele_gate)
+  cmd = [RbConfig.ruby, tele_gate, '--workdir', opts[:tab]]
+  cmd += ['--skip-telemetry-gate', opts[:skip_telemetry]] if opts[:skip_telemetry]
+  unless system(*cmd)
+    # assert-telemetry-ran.rb already printed the actionable failure message.
+    exit 12
+  end
+else
+  warn '[WARN] gate 10: assert-telemetry-ran.rb not found alongside this script — telemetry not enforced.'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-telemetry-ran.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Hard gate that proves the telemetry step was not silently skipped.
+#
+# The migration skills send an anonymous usage ping at the end of a run, but
+# ONLY after asking the user for consent. That step lived as prose in each
+# SKILL.md, so an agent could (and did — the powerbi case) wrap up a migration
+# without ever prompting. This gate makes the decision mandatory: before a
+# conversion may declare GREEN, the agent must have EITHER sent the ping OR
+# recorded that the user declined. Either outcome writes a marker
+# (telemetry-sent.json) via report-telemetry.py; this gate checks the marker.
+#
+# It never touches the network and never inspects payload contents — telemetry
+# must never block or fail a migration. It only enforces that the consent
+# decision happened once.
+#
+# Usage:
+#   ruby scripts/assert-telemetry-ran.rb --workdir /tmp/<run>
+#     [--skip-telemetry-gate REASON]   # waive — REQUIRED reason, name it in
+#                                       # your migration report
+#
+# Exit codes:
+#   0  marker present (sent or declined) — telemetry step was handled
+#   1  --workdir missing / unreadable
+#   12 no telemetry marker — the consent step was skipped
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')               { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-telemetry-gate REASON',
+       'waive this gate — REQUIRED reason string. Name it in your migration report.') { |v| opts[:skip] = v }
+end.parse!
+
+unless opts[:dir]
+  warn '[FAIL] telemetry gate: --workdir (or --tableau) required'
+  exit 1
+end
+
+if opts[:skip]
+  puts "[SKIP] telemetry gate: WAIVED via --skip-telemetry-gate (#{opts[:skip]})."
+  puts '       This waiver MUST be named in the migration report — no usage ping decision was recorded.'
+  exit 0
+end
+
+marker = File.join(opts[:dir], 'telemetry-sent.json')
+unless File.exist?(marker)
+  warn '[FAIL] telemetry gate: no telemetry-sent.json marker — the anonymous usage ping was never handled.'
+  warn '       Before declaring GREEN you MUST ask the user for consent, then record the decision:'
+  warn "         send:    python3 scripts/report-telemetry.py --tool <skill> --duration <sec> --workdir #{opts[:dir]} [--mode live|file|both] [--failed]"
+  warn "         decline: python3 scripts/report-telemetry.py --tool <skill> --workdir #{opts[:dir]} --declined"
+  warn '       Escape hatch (genuinely cannot prompt — e.g. unattended CI): --skip-telemetry-gate "<reason>".'
+  exit 12
+end
+
+rec = (JSON.parse(File.read(marker)) rescue nil)
+status = rec.is_a?(Hash) ? rec['status'] : nil
+unless %w[sent declined].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+  warn '       Re-run report-telemetry.py to write a valid marker.'
+  exit 12
+end
+
+puts "[OK] telemetry gate: usage-ping decision recorded (status=#{status}" \
+     "#{rec['tool'] ? ", tool=#{rec['tool']}" : ''}#{rec['mode'] ? ", mode=#{rec['mode']}" : ''})"
+exit 0

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
@@ -47,6 +47,7 @@ def report_migration(
     client_id: str,
     duration_seconds: int,
     success: bool,
+    mode: str = "unknown",
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
@@ -62,6 +63,8 @@ def report_migration(
           → unique per org, not reversible to your credentials
       - migration duration in seconds
       - success flag
+      - input mode: "live" (source API), "file" (raw export only),
+          "both", or "unknown" — a coarse enum, no file names or content
       - skill version
 
     What is NOT sent:
@@ -78,6 +81,7 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "mode":             mode or "unknown",
         "skill_version":    skill_version,
     }
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
 Shared telemetry reporter for sigma-migration-skills.
-Call at the end of a successful (or failed) migration after all gates pass.
+Call at the end of a migration (success OR failure) after the user has been
+asked for consent. Writes a marker file so the telemetry gate
+(assert-telemetry-ran.rb) can confirm the step was not silently skipped.
 
 Usage:
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+    # send (consent given):
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312 --workdir /tmp/run --mode live
+    # send, but the migration failed:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --workdir /tmp/run --failed
+    # user declined the ping — record the decision without sending:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir /tmp/run --declined
 
 Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
 Prints what it sends; never raises; skips silently if endpoint unreachable.
@@ -13,17 +19,57 @@ See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
 """
 
 import argparse
+import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+# sigma_telemetry.py sits in a sibling/parent lib/ — its location differs by
+# layout: shared/scripts -> ../lib, but once fanned into a plugin it lives at
+# scripts/lib/. Add both candidates so the import works either way.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _cand in (os.path.join(_here, 'lib'), os.path.join(_here, '..', 'lib')):
+    if os.path.isdir(_cand):
+        sys.path.insert(0, _cand)
 from sigma_telemetry import report_migration
+
+MARKER = 'telemetry-sent.json'
+
+
+def _utc_now():
+    # Local import keeps the module importable in sandboxes that stub datetime.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_marker(workdir, record):
+    """Record that telemetry was handled (sent or declined). The gate checks
+    only for the marker's presence + a valid status — never the network."""
+    if not workdir:
+        return
+    try:
+        os.makedirs(workdir, exist_ok=True)
+        record['at'] = _utc_now()
+        with open(os.path.join(workdir, MARKER), 'w') as f:
+            json.dump(record, f, indent=2)
+        print(f"  → telemetry marker written ({os.path.join(workdir, MARKER)})")
+    except Exception as e:
+        print(f"  → could not write telemetry marker: {e}")
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
 parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
+parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
+                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+if args.declined:
+    print("\nTelemetry declined by user — nothing sent.")
+    _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
+    sys.exit(0)
 
 report_migration(
     tool=args.tool,
@@ -31,4 +77,11 @@ report_migration(
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
     duration_seconds=args.duration,
     success=not args.failed,
+    mode=args.mode,
 )
+_write_marker(args.workdir, {
+    'status': 'sent',
+    'tool': args.tool,
+    'success': not args.failed,
+    'mode': args.mode,
+})

--- a/shared/lib/sigma_telemetry.py
+++ b/shared/lib/sigma_telemetry.py
@@ -47,6 +47,7 @@ def report_migration(
     client_id: str,
     duration_seconds: int,
     success: bool,
+    mode: str = "unknown",
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
@@ -62,6 +63,8 @@ def report_migration(
           → unique per org, not reversible to your credentials
       - migration duration in seconds
       - success flag
+      - input mode: "live" (source API), "file" (raw export only),
+          "both", or "unknown" — a coarse enum, no file names or content
       - skill version
 
     What is NOT sent:
@@ -78,6 +81,7 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "mode":             mode or "unknown",
         "skill_version":    skill_version,
     }
 

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -91,6 +91,20 @@
       ]
     },
     {
+      "canonical": "shared/scripts/assert-telemetry-ran.rb",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/assert-telemetry-ran.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/assert-telemetry-ran.rb",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-telemetry-ran.rb",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-telemetry-ran.rb",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-telemetry-ran.rb",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/assert-telemetry-ran.rb",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-telemetry-ran.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-telemetry-ran.rb",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-telemetry-ran.rb"
+      ]
+    },
+    {
       "canonical": "shared/scripts/escalate-gap.py",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/escalate-gap.py",
@@ -245,6 +259,13 @@
       "targets": [
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-coverage-gate.rb",
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-coverage-gate.rb"
+      ]
+    },
+    {
+      "canonical": "shared/scripts/test-telemetry-gate.rb",
+      "targets": [
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-telemetry-gate.rb"
       ]
     }
   ]

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -88,6 +88,12 @@
 #      ("declared done on HTTP 200" regression; gate 8). Render with
 #      scripts/sigma-export-png.py --page <pageId>, Read it against the source
 #      dashboard PNG, then re-run. Escape hatch: --skip-visual-gate "<reason>".
+#  11  Build-from-signals tile(s) not image-verified (gate 9). Escape hatch:
+#      --skip-visual-tiles "<reason>".
+#  12  Telemetry consent decision missing — the anonymous usage ping was never
+#      sent or declined (no telemetry-sent.json marker; gate 10, delegated to
+#      assert-telemetry-ran.rb). Ask the user, then run report-telemetry.py
+#      (--declined if they decline). Escape hatch: --skip-telemetry-gate "<reason>".
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -95,6 +101,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'optparse'
+require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
          allow_missing_tiles: 0 }
@@ -116,6 +123,7 @@ OptionParser.new do |p|
   p.on('--sigma-render PATH', 'gate 8: path to the rendered Sigma dashboard PNG (default: <workdir>/sigma-render.png; also accepts <workdir>/screenshots/_manifest.json)') { |v| opts[:sigma_render] = v }
   p.on('--skip-visual-gate REASON', 'waive gate 8 (Phase 6f visual render) — REQUIRED reason string. Use ONLY when the workbook genuinely cannot be rendered (e.g. export API unavailable). The reason MUST be named in your migration report.') { |v| opts[:skip_visual] = v }
   p.on('--skip-visual-tiles REASON', 'waive gate 9 (build-from-signals tile image-verification) — REQUIRED reason string. The reason MUST be named in your migration report.') { |v| opts[:skip_visual_tiles] = v }
+  p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
 
@@ -656,6 +664,27 @@ if File.exist?(vv_sidecar)
     end
     puts "[OK] gate 9: #{man.size} build-from-signals tile(s) image-verified (empty data export → visual parity)"
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 10 — Telemetry consent decision. The anonymous usage ping (and the
+# consent prompt that precedes it) lived as prose in each SKILL.md, so an agent
+# could wrap up without ever asking — telemetry silently never fired. This gate
+# delegates to the standalone assert-telemetry-ran.rb (single source of truth)
+# which checks for the telemetry-sent.json marker written by report-telemetry.py
+# on send OR decline. Never touches the network. The 3 converters that don't run
+# THIS script (qlik/cognos/gooddata) call assert-telemetry-ran.rb directly.
+# ---------------------------------------------------------------------------
+tele_gate = File.join(__dir__, 'assert-telemetry-ran.rb')
+if File.exist?(tele_gate)
+  cmd = [RbConfig.ruby, tele_gate, '--workdir', opts[:tab]]
+  cmd += ['--skip-telemetry-gate', opts[:skip_telemetry]] if opts[:skip_telemetry]
+  unless system(*cmd)
+    # assert-telemetry-ran.rb already printed the actionable failure message.
+    exit 12
+  end
+else
+  warn '[WARN] gate 10: assert-telemetry-ran.rb not found alongside this script — telemetry not enforced.'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/shared/scripts/assert-telemetry-ran.rb
+++ b/shared/scripts/assert-telemetry-ran.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# Hard gate that proves the telemetry step was not silently skipped.
+#
+# The migration skills send an anonymous usage ping at the end of a run, but
+# ONLY after asking the user for consent. That step lived as prose in each
+# SKILL.md, so an agent could (and did — the powerbi case) wrap up a migration
+# without ever prompting. This gate makes the decision mandatory: before a
+# conversion may declare GREEN, the agent must have EITHER sent the ping OR
+# recorded that the user declined. Either outcome writes a marker
+# (telemetry-sent.json) via report-telemetry.py; this gate checks the marker.
+#
+# It never touches the network and never inspects payload contents — telemetry
+# must never block or fail a migration. It only enforces that the consent
+# decision happened once.
+#
+# Usage:
+#   ruby scripts/assert-telemetry-ran.rb --workdir /tmp/<run>
+#     [--skip-telemetry-gate REASON]   # waive — REQUIRED reason, name it in
+#                                       # your migration report
+#
+# Exit codes:
+#   0  marker present (sent or declined) — telemetry step was handled
+#   1  --workdir missing / unreadable
+#   12 no telemetry marker — the consent step was skipped
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR')               { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-telemetry-gate REASON',
+       'waive this gate — REQUIRED reason string. Name it in your migration report.') { |v| opts[:skip] = v }
+end.parse!
+
+unless opts[:dir]
+  warn '[FAIL] telemetry gate: --workdir (or --tableau) required'
+  exit 1
+end
+
+if opts[:skip]
+  puts "[SKIP] telemetry gate: WAIVED via --skip-telemetry-gate (#{opts[:skip]})."
+  puts '       This waiver MUST be named in the migration report — no usage ping decision was recorded.'
+  exit 0
+end
+
+marker = File.join(opts[:dir], 'telemetry-sent.json')
+unless File.exist?(marker)
+  warn '[FAIL] telemetry gate: no telemetry-sent.json marker — the anonymous usage ping was never handled.'
+  warn '       Before declaring GREEN you MUST ask the user for consent, then record the decision:'
+  warn "         send:    python3 scripts/report-telemetry.py --tool <skill> --duration <sec> --workdir #{opts[:dir]} [--mode live|file|both] [--failed]"
+  warn "         decline: python3 scripts/report-telemetry.py --tool <skill> --workdir #{opts[:dir]} --declined"
+  warn '       Escape hatch (genuinely cannot prompt — e.g. unattended CI): --skip-telemetry-gate "<reason>".'
+  exit 12
+end
+
+rec = (JSON.parse(File.read(marker)) rescue nil)
+status = rec.is_a?(Hash) ? rec['status'] : nil
+unless %w[sent declined].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+  warn '       Re-run report-telemetry.py to write a valid marker.'
+  exit 12
+end
+
+puts "[OK] telemetry gate: usage-ping decision recorded (status=#{status}" \
+     "#{rec['tool'] ? ", tool=#{rec['tool']}" : ''}#{rec['mode'] ? ", mode=#{rec['mode']}" : ''})"
+exit 0

--- a/shared/scripts/report-telemetry.py
+++ b/shared/scripts/report-telemetry.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
 Shared telemetry reporter for sigma-migration-skills.
-Call at the end of a successful (or failed) migration after all gates pass.
+Call at the end of a migration (success OR failure) after the user has been
+asked for consent. Writes a marker file so the telemetry gate
+(assert-telemetry-ran.rb) can confirm the step was not silently skipped.
 
 Usage:
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312
-    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --failed
+    # send (consent given):
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 312 --workdir /tmp/run --mode live
+    # send, but the migration failed:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --duration 180 --workdir /tmp/run --failed
+    # user declined the ping — record the decision without sending:
+    python3 scripts/report-telemetry.py --tool tableau-to-sigma --workdir /tmp/run --declined
 
 Reads SIGMA_BASE_URL and SIGMA_CLIENT_ID from environment (set by get-token.sh).
 Prints what it sends; never raises; skips silently if endpoint unreachable.
@@ -13,17 +19,57 @@ See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
 """
 
 import argparse
+import json
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../lib'))
+# sigma_telemetry.py sits in a sibling/parent lib/ — its location differs by
+# layout: shared/scripts -> ../lib, but once fanned into a plugin it lives at
+# scripts/lib/. Add both candidates so the import works either way.
+_here = os.path.dirname(os.path.abspath(__file__))
+for _cand in (os.path.join(_here, 'lib'), os.path.join(_here, '..', 'lib')):
+    if os.path.isdir(_cand):
+        sys.path.insert(0, _cand)
 from sigma_telemetry import report_migration
+
+MARKER = 'telemetry-sent.json'
+
+
+def _utc_now():
+    # Local import keeps the module importable in sandboxes that stub datetime.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_marker(workdir, record):
+    """Record that telemetry was handled (sent or declined). The gate checks
+    only for the marker's presence + a valid status — never the network."""
+    if not workdir:
+        return
+    try:
+        os.makedirs(workdir, exist_ok=True)
+        record['at'] = _utc_now()
+        with open(os.path.join(workdir, MARKER), 'w') as f:
+            json.dump(record, f, indent=2)
+        print(f"  → telemetry marker written ({os.path.join(workdir, MARKER)})")
+    except Exception as e:
+        print(f"  → could not write telemetry marker: {e}")
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
 parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
+parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
+parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
+                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+if args.declined:
+    print("\nTelemetry declined by user — nothing sent.")
+    _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
+    sys.exit(0)
 
 report_migration(
     tool=args.tool,
@@ -31,4 +77,11 @@ report_migration(
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
     duration_seconds=args.duration,
     success=not args.failed,
+    mode=args.mode,
 )
+_write_marker(args.workdir, {
+    'status': 'sent',
+    'tool': args.tool,
+    'success': not args.failed,
+    'mode': args.mode,
+})

--- a/shared/scripts/test-telemetry-gate.rb
+++ b/shared/scripts/test-telemetry-gate.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# test-telemetry-gate.rb — unit test for the telemetry consent gate
+# (assert-telemetry-ran.rb) and the marker written by report-telemetry.py.
+# Offline: the telemetry endpoint is never required — report-telemetry.py
+# degrades gracefully and still writes the marker, which is all the gate checks.
+# Canonical in shared/scripts (epic beads-sigma-p5y2). Run: ruby scripts/test-telemetry-gate.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+GATE   = File.join(__dir__, 'assert-telemetry-ran.rb')
+REPORT = File.join(__dir__, 'report-telemetry.py')
+RUBY   = RbConfig.ruby
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+def gate(dir, *extra)
+  system(RUBY, GATE, '--workdir', dir, *extra, out: File::NULL, err: File::NULL)
+end
+
+def report(dir, *extra)
+  env = { 'SIGMA_CLIENT_ID' => 'testclient', 'SIGMA_BASE_URL' => 'https://api.au.aws.sigmacomputing.com' }
+  system(env, 'python3', REPORT, '--tool', 'tableau-to-sigma', '--workdir', dir, *extra,
+         out: File::NULL, err: File::NULL)
+end
+
+Dir.mktmpdir do |d|
+  # 1. fresh run, no marker → gate FAILS (exit 12)
+  ok('missing marker fails the gate', gate(d) == false)
+
+  # 2. user declines → marker written, no network, status=declined
+  ok('--declined writes a marker', report(d, '--declined'))
+  rec = JSON.parse(File.read(File.join(d, 'telemetry-sent.json')))
+  ok('declined marker status', rec['status'] == 'declined')
+
+  # 3. gate now PASSES on the declined marker
+  ok('declined marker satisfies the gate', gate(d) == true)
+end
+
+Dir.mktmpdir do |d|
+  # 4. send path writes status=sent + carries the mode enum
+  ok('send writes a marker', report(d, '--duration', '120', '--mode', 'file'))
+  rec = JSON.parse(File.read(File.join(d, 'telemetry-sent.json')))
+  ok('sent marker status',  rec['status'] == 'sent')
+  ok('sent marker mode',    rec['mode'] == 'file')
+  ok('sent marker satisfies the gate', gate(d) == true)
+end
+
+Dir.mktmpdir do |d|
+  # 5. escape hatch waives a missing marker
+  ok('--skip-telemetry-gate waives', gate(d, '--skip-telemetry-gate', 'unattended CI') == true)
+
+  # 6. corrupt/invalid status → gate FAILS
+  File.write(File.join(d, 'telemetry-sent.json'), '{"status":"bogus"}')
+  ok('invalid marker status fails', gate(d) == false)
+end
+
+puts $fail.zero? ? "\nall telemetry-gate tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
**PR 1 of 3** in the migration runtime contract (design: #181, epic bead `beads-sigma-p5y2`).

## Problem
The anonymous Render usage ping (`sigma_telemetry.py` → `/track`) already worked, but firing it was **optional prose** in each `SKILL.md`. So an agent could wrap up a migration without ever asking the user — the PowerBI case TJ hit. Telemetry was effectively never sent.

## Fix — make the consent decision mandatory, without bypassing consent
- **New shared gate `assert-telemetry-ran.rb`**: before GREEN, requires a `telemetry-sent.json` marker (`status: sent|declined`). It **never touches the network** — it only proves the agent made the consent decision once. Escape hatch `--skip-telemetry-gate "<reason>"` for unattended runs.
- **`assert-phase6-ran.rb` Gate 10** delegates to it (single source of truth). Fanned out to **all 9 plugins** (decision D1) so the 3 that don't run `assert-phase6` (qlik/cognos/gooddata) still enforce telemetry via the standalone script.
- **`report-telemetry.py`**: `--workdir` writes the marker; `--declined` records a decline without sending; `--mode live|file|both` added to the payload (D3).
- **Latent bug fixed** (surfaced by making telemetry mandatory): `report-telemetry.py` imported `sigma_telemetry` via `../lib` — correct for `shared/` but broken once fanned into a plugin where the lib sits at `scripts/lib/`. Now resolves both layouts. *Telemetry from a plugin dir was silently failing before this.*
- **SKILL.md (8)**: telemetry block now passes `--workdir` + documents the decline path; qlik & cognos add the standalone gate as their final step. gooddata is scaffold-only (no SKILL.md) — scripts stay synced.

## Tests
`test-telemetry-gate.rb` — offline, 10 assertions (missing/declined/sent/invalid marker, mode enum, escape hatch), passing from shared + both plugin layouts. Wired into `corpus-check.yml` CI. Full integration verified: `assert-phase6` blocks at Gate 10 with no marker, reaches GREEN after a decision. All governance checks green.

## Not in this PR
Decisions D2 (config-first connection resolution) and the failure-path orchestrator wiring land with PR 2 (intake). Success-path telemetry is fully covered here because every conversion runs the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)