### PR TITLE
feat(intake): one-time connection resolution + run-metadata front-door (PR 2/3)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -102,6 +102,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake.rb
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/intake.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/intake.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# intake.rb — migration front-door. Run this ONCE, first, before discovery.
+#
+# It does the two things every converter otherwise improvises (badly):
+#
+#  1. RESOLVE THE SIGMA CONNECTION ONCE and cache it, so no downstream phase
+#     free-searches /v2/connections (the token sink). Precedence (decision D2 —
+#     config-first, prompt on miss):
+#       a. --connection <UUID>                  explicit flag wins
+#       b. cached <workdir>/connection.json     idempotent re-runs reuse it
+#       c. ENV['SIGMA_CONNECTION_ID']           from ~/.sigma-migration/env (setup.rb)
+#       d. list /v2/connections ONCE:
+#            - exactly one connection            -> auto-pick
+#            - --name SUBSTR uniquely matches     -> auto-pick
+#            - otherwise -> write connection-candidates.json and exit 3 so the
+#              agent ASKS THE USER, then re-runs with --connection <id>.
+#              (We never guess among multiple, and never free-search per phase.)
+#
+#  2. RECORD RUN METADATA to <workdir>/intake.json: run_start (feeds telemetry
+#     duration), input_mode (live|file|both — feeds telemetry --mode), and the
+#     source tool/identifier. Prints an expectations banner for the mode.
+#
+# Usage:
+#   ruby scripts/intake.rb --workdir <dir> --tool tableau-to-sigma --mode live \
+#     [--connection <UUID>] [--name <connection-name-substring>] [--source "<wb name/app id>"]
+#
+# Exit codes:
+#   0  connection resolved (connection.json written) + intake.json written
+#   2  --connection given but not a full UUID
+#   3  connection ambiguous — connection-candidates.json written; ask the user
+#   4  no connections found / API error while listing
+#   1  usage error
+
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { mode: 'unknown' }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--tool NAME')        { |v| opts[:tool] = v }
+  p.on('--mode MODE', 'live | file | both (input mode)') { |v| opts[:mode] = v }
+  p.on('--connection ID')    { |v| opts[:conn] = v }
+  p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
+  p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
+  p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
+end.parse!
+
+abort('[FAIL] intake: --workdir required') unless opts[:dir]
+require 'fileutils'
+FileUtils.mkdir_p(opts[:dir])
+
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+conn_path  = File.join(opts[:dir], 'connection.json')
+cand_path  = File.join(opts[:dir], 'connection-candidates.json')
+intake_path = File.join(opts[:dir], 'intake.json')
+
+def write_json(path, obj)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(obj))
+  File.rename(tmp, path)   # atomic — no half-written sidecar reads
+end
+
+# Normalize a connection record from /v2/connections (entries[]) into our shape.
+def norm_conn(c)
+  {
+    'connection_id' => c['connectionId'] || c['id'],
+    'name'          => c['name'] || c['label'],
+    'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+  }
+end
+
+# Fetch the connection list once (or from a fixture, for tests).
+def list_connections(opts)
+  if opts[:fixture]
+    data = JSON.parse(File.read(opts[:fixture]))
+  else
+    require_relative 'lib/sigma_rest'
+    data = Sigma.request(:get, '/v2/connections?limit=500')
+  end
+  rows = data.is_a?(Hash) ? (data['entries'] || data['connections'] || []) : (data || [])
+  rows.map { |c| norm_conn(c) }.reject { |c| c['connection_id'].to_s.empty? }
+end
+
+resolved = nil
+resolved_via = nil
+
+# (a) explicit flag
+if opts[:conn]
+  unless opts[:conn] =~ UUID_RE
+    warn "[FAIL] intake: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}."
+    exit 2
+  end
+  resolved = { 'connection_id' => opts[:conn], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'flag'
+end
+
+# (b) cached connection.json
+if resolved.nil? && !opts[:force] && File.exist?(conn_path)
+  cached = (JSON.parse(File.read(conn_path)) rescue nil)
+  if cached.is_a?(Hash) && cached['connection_id'].to_s =~ UUID_RE
+    resolved = cached.slice('connection_id', 'name', 'type')
+    resolved_via = 'cache'
+  end
+end
+
+# (c) ENV (loaded from ~/.sigma-migration/env by setup.rb / sigma_rest.rb)
+if resolved.nil? && ENV['SIGMA_CONNECTION_ID'].to_s =~ UUID_RE
+  resolved = { 'connection_id' => ENV['SIGMA_CONNECTION_ID'], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'env'
+end
+
+# (d) list /v2/connections ONCE and pick deterministically
+if resolved.nil?
+  begin
+    conns = list_connections(opts)
+  rescue => e
+    warn "[FAIL] intake: could not list connections — #{e.message}"
+    exit 4
+  end
+  if conns.empty?
+    warn '[FAIL] intake: no Sigma connections found for these credentials.'
+    exit 4
+  end
+  pick = nil
+  if opts[:name]
+    matches = conns.select { |c| c['name'].to_s.downcase.include?(opts[:name].downcase) }
+    pick = matches.first if matches.size == 1
+  end
+  pick ||= conns.first if conns.size == 1
+  if pick
+    resolved = pick
+    resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
+  else
+    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
+    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
+    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
+    exit 3
+  end
+end
+
+resolved['resolved_via'] = resolved_via
+resolved['at'] = Time.now.utc.iso8601
+write_json(conn_path, resolved)
+File.delete(cand_path) if File.exist?(cand_path)   # resolved now; clear stale candidates
+
+# Run metadata for telemetry + audit.
+mode = %w[live file both].include?(opts[:mode]) ? opts[:mode] : 'unknown'
+write_json(intake_path, {
+  'run_start'  => Time.now.utc.iso8601,
+  'input_mode' => mode,
+  'tool'       => opts[:tool],
+  'source'     => opts[:source],
+})
+
+puts "[OK] intake: connection #{resolved['connection_id']} (#{resolved['name'] || '?'}) via #{resolved_via} → #{conn_path}"
+puts "[OK] intake: mode=#{mode}, tool=#{opts[:tool] || '?'} → #{intake_path}"
+case mode
+when 'file'
+  puts '     INPUT MODE = file (raw export, no live source connection). The build runs from the'
+  puts '     export; parity is verified against the live SIGMA WAREHOUSE, not the source tool.'
+when 'both', 'live'
+  puts "     INPUT MODE = #{mode}. Live source available — full source-side parity verification applies."
+else
+  puts '     INPUT MODE = unknown. Pass --mode live|file|both so telemetry + the raw-mode banner are accurate.'
+end
+exit 0

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
@@ -58,13 +58,39 @@ def _write_marker(workdir, record):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
-parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds (auto-derived from intake.json run_start if omitted)')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
-                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+                    help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+
+def _from_intake(workdir):
+    """intake.rb (the front-door step) records run_start + input_mode in
+    intake.json. If --duration / --mode were not passed explicitly, derive them
+    from it so the agent doesn't have to track elapsed time by hand. Returns
+    (duration_seconds_or_None, mode_or_None)."""
+    if not workdir:
+        return None, None
+    try:
+        from datetime import datetime, timezone
+        intake = json.load(open(os.path.join(workdir, 'intake.json')))
+        dur = None
+        if intake.get('run_start'):
+            started = datetime.fromisoformat(intake['run_start'])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            dur = max(0, int((datetime.now(timezone.utc) - started).total_seconds()))
+        return dur, intake.get('input_mode')
+    except Exception:
+        return None, None
+
+
+_intake_dur, _intake_mode = _from_intake(args.workdir)
+duration = args.duration if args.duration else (_intake_dur or 0)
+mode = args.mode if args.mode != 'unknown' else (_intake_mode or 'unknown')
 
 if args.declined:
     print("\nTelemetry declined by user — nothing sent.")
@@ -75,13 +101,13 @@ report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
-    duration_seconds=args.duration,
+    duration_seconds=duration,
     success=not args.failed,
-    mode=args.mode,
+    mode=mode,
 )
 _write_marker(args.workdir, {
     'status': 'sent',
     'tool': args.tool,
     'success': not args.failed,
-    'mode': args.mode,
+    'mode': mode,
 })

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/intake.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/intake.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# intake.rb — migration front-door. Run this ONCE, first, before discovery.
+#
+# It does the two things every converter otherwise improvises (badly):
+#
+#  1. RESOLVE THE SIGMA CONNECTION ONCE and cache it, so no downstream phase
+#     free-searches /v2/connections (the token sink). Precedence (decision D2 —
+#     config-first, prompt on miss):
+#       a. --connection <UUID>                  explicit flag wins
+#       b. cached <workdir>/connection.json     idempotent re-runs reuse it
+#       c. ENV['SIGMA_CONNECTION_ID']           from ~/.sigma-migration/env (setup.rb)
+#       d. list /v2/connections ONCE:
+#            - exactly one connection            -> auto-pick
+#            - --name SUBSTR uniquely matches     -> auto-pick
+#            - otherwise -> write connection-candidates.json and exit 3 so the
+#              agent ASKS THE USER, then re-runs with --connection <id>.
+#              (We never guess among multiple, and never free-search per phase.)
+#
+#  2. RECORD RUN METADATA to <workdir>/intake.json: run_start (feeds telemetry
+#     duration), input_mode (live|file|both — feeds telemetry --mode), and the
+#     source tool/identifier. Prints an expectations banner for the mode.
+#
+# Usage:
+#   ruby scripts/intake.rb --workdir <dir> --tool tableau-to-sigma --mode live \
+#     [--connection <UUID>] [--name <connection-name-substring>] [--source "<wb name/app id>"]
+#
+# Exit codes:
+#   0  connection resolved (connection.json written) + intake.json written
+#   2  --connection given but not a full UUID
+#   3  connection ambiguous — connection-candidates.json written; ask the user
+#   4  no connections found / API error while listing
+#   1  usage error
+
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { mode: 'unknown' }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--tool NAME')        { |v| opts[:tool] = v }
+  p.on('--mode MODE', 'live | file | both (input mode)') { |v| opts[:mode] = v }
+  p.on('--connection ID')    { |v| opts[:conn] = v }
+  p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
+  p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
+  p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
+end.parse!
+
+abort('[FAIL] intake: --workdir required') unless opts[:dir]
+require 'fileutils'
+FileUtils.mkdir_p(opts[:dir])
+
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+conn_path  = File.join(opts[:dir], 'connection.json')
+cand_path  = File.join(opts[:dir], 'connection-candidates.json')
+intake_path = File.join(opts[:dir], 'intake.json')
+
+def write_json(path, obj)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(obj))
+  File.rename(tmp, path)   # atomic — no half-written sidecar reads
+end
+
+# Normalize a connection record from /v2/connections (entries[]) into our shape.
+def norm_conn(c)
+  {
+    'connection_id' => c['connectionId'] || c['id'],
+    'name'          => c['name'] || c['label'],
+    'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+  }
+end
+
+# Fetch the connection list once (or from a fixture, for tests).
+def list_connections(opts)
+  if opts[:fixture]
+    data = JSON.parse(File.read(opts[:fixture]))
+  else
+    require_relative 'lib/sigma_rest'
+    data = Sigma.request(:get, '/v2/connections?limit=500')
+  end
+  rows = data.is_a?(Hash) ? (data['entries'] || data['connections'] || []) : (data || [])
+  rows.map { |c| norm_conn(c) }.reject { |c| c['connection_id'].to_s.empty? }
+end
+
+resolved = nil
+resolved_via = nil
+
+# (a) explicit flag
+if opts[:conn]
+  unless opts[:conn] =~ UUID_RE
+    warn "[FAIL] intake: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}."
+    exit 2
+  end
+  resolved = { 'connection_id' => opts[:conn], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'flag'
+end
+
+# (b) cached connection.json
+if resolved.nil? && !opts[:force] && File.exist?(conn_path)
+  cached = (JSON.parse(File.read(conn_path)) rescue nil)
+  if cached.is_a?(Hash) && cached['connection_id'].to_s =~ UUID_RE
+    resolved = cached.slice('connection_id', 'name', 'type')
+    resolved_via = 'cache'
+  end
+end
+
+# (c) ENV (loaded from ~/.sigma-migration/env by setup.rb / sigma_rest.rb)
+if resolved.nil? && ENV['SIGMA_CONNECTION_ID'].to_s =~ UUID_RE
+  resolved = { 'connection_id' => ENV['SIGMA_CONNECTION_ID'], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'env'
+end
+
+# (d) list /v2/connections ONCE and pick deterministically
+if resolved.nil?
+  begin
+    conns = list_connections(opts)
+  rescue => e
+    warn "[FAIL] intake: could not list connections — #{e.message}"
+    exit 4
+  end
+  if conns.empty?
+    warn '[FAIL] intake: no Sigma connections found for these credentials.'
+    exit 4
+  end
+  pick = nil
+  if opts[:name]
+    matches = conns.select { |c| c['name'].to_s.downcase.include?(opts[:name].downcase) }
+    pick = matches.first if matches.size == 1
+  end
+  pick ||= conns.first if conns.size == 1
+  if pick
+    resolved = pick
+    resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
+  else
+    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
+    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
+    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
+    exit 3
+  end
+end
+
+resolved['resolved_via'] = resolved_via
+resolved['at'] = Time.now.utc.iso8601
+write_json(conn_path, resolved)
+File.delete(cand_path) if File.exist?(cand_path)   # resolved now; clear stale candidates
+
+# Run metadata for telemetry + audit.
+mode = %w[live file both].include?(opts[:mode]) ? opts[:mode] : 'unknown'
+write_json(intake_path, {
+  'run_start'  => Time.now.utc.iso8601,
+  'input_mode' => mode,
+  'tool'       => opts[:tool],
+  'source'     => opts[:source],
+})
+
+puts "[OK] intake: connection #{resolved['connection_id']} (#{resolved['name'] || '?'}) via #{resolved_via} → #{conn_path}"
+puts "[OK] intake: mode=#{mode}, tool=#{opts[:tool] || '?'} → #{intake_path}"
+case mode
+when 'file'
+  puts '     INPUT MODE = file (raw export, no live source connection). The build runs from the'
+  puts '     export; parity is verified against the live SIGMA WAREHOUSE, not the source tool.'
+when 'both', 'live'
+  puts "     INPUT MODE = #{mode}. Live source available — full source-side parity verification applies."
+else
+  puts '     INPUT MODE = unknown. Pass --mode live|file|both so telemetry + the raw-mode banner are accurate.'
+end
+exit 0

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
@@ -58,13 +58,39 @@ def _write_marker(workdir, record):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
-parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds (auto-derived from intake.json run_start if omitted)')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
-                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+                    help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+
+def _from_intake(workdir):
+    """intake.rb (the front-door step) records run_start + input_mode in
+    intake.json. If --duration / --mode were not passed explicitly, derive them
+    from it so the agent doesn't have to track elapsed time by hand. Returns
+    (duration_seconds_or_None, mode_or_None)."""
+    if not workdir:
+        return None, None
+    try:
+        from datetime import datetime, timezone
+        intake = json.load(open(os.path.join(workdir, 'intake.json')))
+        dur = None
+        if intake.get('run_start'):
+            started = datetime.fromisoformat(intake['run_start'])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            dur = max(0, int((datetime.now(timezone.utc) - started).total_seconds()))
+        return dur, intake.get('input_mode')
+    except Exception:
+        return None, None
+
+
+_intake_dur, _intake_mode = _from_intake(args.workdir)
+duration = args.duration if args.duration else (_intake_dur or 0)
+mode = args.mode if args.mode != 'unknown' else (_intake_mode or 'unknown')
 
 if args.declined:
     print("\nTelemetry declined by user — nothing sent.")
@@ -75,13 +101,13 @@ report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
-    duration_seconds=args.duration,
+    duration_seconds=duration,
     success=not args.failed,
-    mode=args.mode,
+    mode=mode,
 )
 _write_marker(args.workdir, {
     'status': 'sent',
     'tool': args.tool,
     'success': not args.failed,
-    'mode': args.mode,
+    'mode': mode,
 })

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/intake.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/intake.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# intake.rb — migration front-door. Run this ONCE, first, before discovery.
+#
+# It does the two things every converter otherwise improvises (badly):
+#
+#  1. RESOLVE THE SIGMA CONNECTION ONCE and cache it, so no downstream phase
+#     free-searches /v2/connections (the token sink). Precedence (decision D2 —
+#     config-first, prompt on miss):
+#       a. --connection <UUID>                  explicit flag wins
+#       b. cached <workdir>/connection.json     idempotent re-runs reuse it
+#       c. ENV['SIGMA_CONNECTION_ID']           from ~/.sigma-migration/env (setup.rb)
+#       d. list /v2/connections ONCE:
+#            - exactly one connection            -> auto-pick
+#            - --name SUBSTR uniquely matches     -> auto-pick
+#            - otherwise -> write connection-candidates.json and exit 3 so the
+#              agent ASKS THE USER, then re-runs with --connection <id>.
+#              (We never guess among multiple, and never free-search per phase.)
+#
+#  2. RECORD RUN METADATA to <workdir>/intake.json: run_start (feeds telemetry
+#     duration), input_mode (live|file|both — feeds telemetry --mode), and the
+#     source tool/identifier. Prints an expectations banner for the mode.
+#
+# Usage:
+#   ruby scripts/intake.rb --workdir <dir> --tool tableau-to-sigma --mode live \
+#     [--connection <UUID>] [--name <connection-name-substring>] [--source "<wb name/app id>"]
+#
+# Exit codes:
+#   0  connection resolved (connection.json written) + intake.json written
+#   2  --connection given but not a full UUID
+#   3  connection ambiguous — connection-candidates.json written; ask the user
+#   4  no connections found / API error while listing
+#   1  usage error
+
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { mode: 'unknown' }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--tool NAME')        { |v| opts[:tool] = v }
+  p.on('--mode MODE', 'live | file | both (input mode)') { |v| opts[:mode] = v }
+  p.on('--connection ID')    { |v| opts[:conn] = v }
+  p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
+  p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
+  p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
+end.parse!
+
+abort('[FAIL] intake: --workdir required') unless opts[:dir]
+require 'fileutils'
+FileUtils.mkdir_p(opts[:dir])
+
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+conn_path  = File.join(opts[:dir], 'connection.json')
+cand_path  = File.join(opts[:dir], 'connection-candidates.json')
+intake_path = File.join(opts[:dir], 'intake.json')
+
+def write_json(path, obj)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(obj))
+  File.rename(tmp, path)   # atomic — no half-written sidecar reads
+end
+
+# Normalize a connection record from /v2/connections (entries[]) into our shape.
+def norm_conn(c)
+  {
+    'connection_id' => c['connectionId'] || c['id'],
+    'name'          => c['name'] || c['label'],
+    'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+  }
+end
+
+# Fetch the connection list once (or from a fixture, for tests).
+def list_connections(opts)
+  if opts[:fixture]
+    data = JSON.parse(File.read(opts[:fixture]))
+  else
+    require_relative 'lib/sigma_rest'
+    data = Sigma.request(:get, '/v2/connections?limit=500')
+  end
+  rows = data.is_a?(Hash) ? (data['entries'] || data['connections'] || []) : (data || [])
+  rows.map { |c| norm_conn(c) }.reject { |c| c['connection_id'].to_s.empty? }
+end
+
+resolved = nil
+resolved_via = nil
+
+# (a) explicit flag
+if opts[:conn]
+  unless opts[:conn] =~ UUID_RE
+    warn "[FAIL] intake: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}."
+    exit 2
+  end
+  resolved = { 'connection_id' => opts[:conn], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'flag'
+end
+
+# (b) cached connection.json
+if resolved.nil? && !opts[:force] && File.exist?(conn_path)
+  cached = (JSON.parse(File.read(conn_path)) rescue nil)
+  if cached.is_a?(Hash) && cached['connection_id'].to_s =~ UUID_RE
+    resolved = cached.slice('connection_id', 'name', 'type')
+    resolved_via = 'cache'
+  end
+end
+
+# (c) ENV (loaded from ~/.sigma-migration/env by setup.rb / sigma_rest.rb)
+if resolved.nil? && ENV['SIGMA_CONNECTION_ID'].to_s =~ UUID_RE
+  resolved = { 'connection_id' => ENV['SIGMA_CONNECTION_ID'], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'env'
+end
+
+# (d) list /v2/connections ONCE and pick deterministically
+if resolved.nil?
+  begin
+    conns = list_connections(opts)
+  rescue => e
+    warn "[FAIL] intake: could not list connections — #{e.message}"
+    exit 4
+  end
+  if conns.empty?
+    warn '[FAIL] intake: no Sigma connections found for these credentials.'
+    exit 4
+  end
+  pick = nil
+  if opts[:name]
+    matches = conns.select { |c| c['name'].to_s.downcase.include?(opts[:name].downcase) }
+    pick = matches.first if matches.size == 1
+  end
+  pick ||= conns.first if conns.size == 1
+  if pick
+    resolved = pick
+    resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
+  else
+    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
+    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
+    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
+    exit 3
+  end
+end
+
+resolved['resolved_via'] = resolved_via
+resolved['at'] = Time.now.utc.iso8601
+write_json(conn_path, resolved)
+File.delete(cand_path) if File.exist?(cand_path)   # resolved now; clear stale candidates
+
+# Run metadata for telemetry + audit.
+mode = %w[live file both].include?(opts[:mode]) ? opts[:mode] : 'unknown'
+write_json(intake_path, {
+  'run_start'  => Time.now.utc.iso8601,
+  'input_mode' => mode,
+  'tool'       => opts[:tool],
+  'source'     => opts[:source],
+})
+
+puts "[OK] intake: connection #{resolved['connection_id']} (#{resolved['name'] || '?'}) via #{resolved_via} → #{conn_path}"
+puts "[OK] intake: mode=#{mode}, tool=#{opts[:tool] || '?'} → #{intake_path}"
+case mode
+when 'file'
+  puts '     INPUT MODE = file (raw export, no live source connection). The build runs from the'
+  puts '     export; parity is verified against the live SIGMA WAREHOUSE, not the source tool.'
+when 'both', 'live'
+  puts "     INPUT MODE = #{mode}. Live source available — full source-side parity verification applies."
+else
+  puts '     INPUT MODE = unknown. Pass --mode live|file|both so telemetry + the raw-mode banner are accurate.'
+end
+exit 0

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
@@ -58,13 +58,39 @@ def _write_marker(workdir, record):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
-parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds (auto-derived from intake.json run_start if omitted)')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
-                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+                    help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+
+def _from_intake(workdir):
+    """intake.rb (the front-door step) records run_start + input_mode in
+    intake.json. If --duration / --mode were not passed explicitly, derive them
+    from it so the agent doesn't have to track elapsed time by hand. Returns
+    (duration_seconds_or_None, mode_or_None)."""
+    if not workdir:
+        return None, None
+    try:
+        from datetime import datetime, timezone
+        intake = json.load(open(os.path.join(workdir, 'intake.json')))
+        dur = None
+        if intake.get('run_start'):
+            started = datetime.fromisoformat(intake['run_start'])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            dur = max(0, int((datetime.now(timezone.utc) - started).total_seconds()))
+        return dur, intake.get('input_mode')
+    except Exception:
+        return None, None
+
+
+_intake_dur, _intake_mode = _from_intake(args.workdir)
+duration = args.duration if args.duration else (_intake_dur or 0)
+mode = args.mode if args.mode != 'unknown' else (_intake_mode or 'unknown')
 
 if args.declined:
     print("\nTelemetry declined by user — nothing sent.")
@@ -75,13 +101,13 @@ report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
-    duration_seconds=args.duration,
+    duration_seconds=duration,
     success=not args.failed,
-    mode=args.mode,
+    mode=mode,
 )
 _write_marker(args.workdir, {
     'status': 'sent',
     'tool': args.tool,
     'success': not args.failed,
-    'mode': args.mode,
+    'mode': mode,
 })

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/intake.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/intake.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# intake.rb — migration front-door. Run this ONCE, first, before discovery.
+#
+# It does the two things every converter otherwise improvises (badly):
+#
+#  1. RESOLVE THE SIGMA CONNECTION ONCE and cache it, so no downstream phase
+#     free-searches /v2/connections (the token sink). Precedence (decision D2 —
+#     config-first, prompt on miss):
+#       a. --connection <UUID>                  explicit flag wins
+#       b. cached <workdir>/connection.json     idempotent re-runs reuse it
+#       c. ENV['SIGMA_CONNECTION_ID']           from ~/.sigma-migration/env (setup.rb)
+#       d. list /v2/connections ONCE:
+#            - exactly one connection            -> auto-pick
+#            - --name SUBSTR uniquely matches     -> auto-pick
+#            - otherwise -> write connection-candidates.json and exit 3 so the
+#              agent ASKS THE USER, then re-runs with --connection <id>.
+#              (We never guess among multiple, and never free-search per phase.)
+#
+#  2. RECORD RUN METADATA to <workdir>/intake.json: run_start (feeds telemetry
+#     duration), input_mode (live|file|both — feeds telemetry --mode), and the
+#     source tool/identifier. Prints an expectations banner for the mode.
+#
+# Usage:
+#   ruby scripts/intake.rb --workdir <dir> --tool tableau-to-sigma --mode live \
+#     [--connection <UUID>] [--name <connection-name-substring>] [--source "<wb name/app id>"]
+#
+# Exit codes:
+#   0  connection resolved (connection.json written) + intake.json written
+#   2  --connection given but not a full UUID
+#   3  connection ambiguous — connection-candidates.json written; ask the user
+#   4  no connections found / API error while listing
+#   1  usage error
+
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { mode: 'unknown' }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--tool NAME')        { |v| opts[:tool] = v }
+  p.on('--mode MODE', 'live | file | both (input mode)') { |v| opts[:mode] = v }
+  p.on('--connection ID')    { |v| opts[:conn] = v }
+  p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
+  p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
+  p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
+end.parse!
+
+abort('[FAIL] intake: --workdir required') unless opts[:dir]
+require 'fileutils'
+FileUtils.mkdir_p(opts[:dir])
+
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+conn_path  = File.join(opts[:dir], 'connection.json')
+cand_path  = File.join(opts[:dir], 'connection-candidates.json')
+intake_path = File.join(opts[:dir], 'intake.json')
+
+def write_json(path, obj)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(obj))
+  File.rename(tmp, path)   # atomic — no half-written sidecar reads
+end
+
+# Normalize a connection record from /v2/connections (entries[]) into our shape.
+def norm_conn(c)
+  {
+    'connection_id' => c['connectionId'] || c['id'],
+    'name'          => c['name'] || c['label'],
+    'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+  }
+end
+
+# Fetch the connection list once (or from a fixture, for tests).
+def list_connections(opts)
+  if opts[:fixture]
+    data = JSON.parse(File.read(opts[:fixture]))
+  else
+    require_relative 'lib/sigma_rest'
+    data = Sigma.request(:get, '/v2/connections?limit=500')
+  end
+  rows = data.is_a?(Hash) ? (data['entries'] || data['connections'] || []) : (data || [])
+  rows.map { |c| norm_conn(c) }.reject { |c| c['connection_id'].to_s.empty? }
+end
+
+resolved = nil
+resolved_via = nil
+
+# (a) explicit flag
+if opts[:conn]
+  unless opts[:conn] =~ UUID_RE
+    warn "[FAIL] intake: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}."
+    exit 2
+  end
+  resolved = { 'connection_id' => opts[:conn], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'flag'
+end
+
+# (b) cached connection.json
+if resolved.nil? && !opts[:force] && File.exist?(conn_path)
+  cached = (JSON.parse(File.read(conn_path)) rescue nil)
+  if cached.is_a?(Hash) && cached['connection_id'].to_s =~ UUID_RE
+    resolved = cached.slice('connection_id', 'name', 'type')
+    resolved_via = 'cache'
+  end
+end
+
+# (c) ENV (loaded from ~/.sigma-migration/env by setup.rb / sigma_rest.rb)
+if resolved.nil? && ENV['SIGMA_CONNECTION_ID'].to_s =~ UUID_RE
+  resolved = { 'connection_id' => ENV['SIGMA_CONNECTION_ID'], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'env'
+end
+
+# (d) list /v2/connections ONCE and pick deterministically
+if resolved.nil?
+  begin
+    conns = list_connections(opts)
+  rescue => e
+    warn "[FAIL] intake: could not list connections — #{e.message}"
+    exit 4
+  end
+  if conns.empty?
+    warn '[FAIL] intake: no Sigma connections found for these credentials.'
+    exit 4
+  end
+  pick = nil
+  if opts[:name]
+    matches = conns.select { |c| c['name'].to_s.downcase.include?(opts[:name].downcase) }
+    pick = matches.first if matches.size == 1
+  end
+  pick ||= conns.first if conns.size == 1
+  if pick
+    resolved = pick
+    resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
+  else
+    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
+    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
+    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
+    exit 3
+  end
+end
+
+resolved['resolved_via'] = resolved_via
+resolved['at'] = Time.now.utc.iso8601
+write_json(conn_path, resolved)
+File.delete(cand_path) if File.exist?(cand_path)   # resolved now; clear stale candidates
+
+# Run metadata for telemetry + audit.
+mode = %w[live file both].include?(opts[:mode]) ? opts[:mode] : 'unknown'
+write_json(intake_path, {
+  'run_start'  => Time.now.utc.iso8601,
+  'input_mode' => mode,
+  'tool'       => opts[:tool],
+  'source'     => opts[:source],
+})
+
+puts "[OK] intake: connection #{resolved['connection_id']} (#{resolved['name'] || '?'}) via #{resolved_via} → #{conn_path}"
+puts "[OK] intake: mode=#{mode}, tool=#{opts[:tool] || '?'} → #{intake_path}"
+case mode
+when 'file'
+  puts '     INPUT MODE = file (raw export, no live source connection). The build runs from the'
+  puts '     export; parity is verified against the live SIGMA WAREHOUSE, not the source tool.'
+when 'both', 'live'
+  puts "     INPUT MODE = #{mode}. Live source available — full source-side parity verification applies."
+else
+  puts '     INPUT MODE = unknown. Pass --mode live|file|both so telemetry + the raw-mode banner are accurate.'
+end
+exit 0

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
@@ -58,13 +58,39 @@ def _write_marker(workdir, record):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
-parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds (auto-derived from intake.json run_start if omitted)')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
-                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+                    help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+
+def _from_intake(workdir):
+    """intake.rb (the front-door step) records run_start + input_mode in
+    intake.json. If --duration / --mode were not passed explicitly, derive them
+    from it so the agent doesn't have to track elapsed time by hand. Returns
+    (duration_seconds_or_None, mode_or_None)."""
+    if not workdir:
+        return None, None
+    try:
+        from datetime import datetime, timezone
+        intake = json.load(open(os.path.join(workdir, 'intake.json')))
+        dur = None
+        if intake.get('run_start'):
+            started = datetime.fromisoformat(intake['run_start'])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            dur = max(0, int((datetime.now(timezone.utc) - started).total_seconds()))
+        return dur, intake.get('input_mode')
+    except Exception:
+        return None, None
+
+
+_intake_dur, _intake_mode = _from_intake(args.workdir)
+duration = args.duration if args.duration else (_intake_dur or 0)
+mode = args.mode if args.mode != 'unknown' else (_intake_mode or 'unknown')
 
 if args.declined:
     print("\nTelemetry declined by user — nothing sent.")
@@ -75,13 +101,13 @@ report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
-    duration_seconds=args.duration,
+    duration_seconds=duration,
     success=not args.failed,
-    mode=args.mode,
+    mode=mode,
 )
 _write_marker(args.workdir, {
     'status': 'sent',
     'tool': args.tool,
     'success': not args.failed,
-    'mode': args.mode,
+    'mode': mode,
 })

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -38,6 +38,21 @@ If a destination is already supplied, honor it silently — don't ask.
 7. VERIFY    sigma-mcp-v2 query each element returns real rows; Phase 6 = compare vs PBI executeQueries (DAX)
 ```
 
+## Step 0 — Front door: resolve the connection once (`scripts/intake.rb`)
+
+Resolve the Sigma warehouse connection a SINGLE time up front so no phase free-searches
+`/v2/connections` (the token sink):
+
+```bash
+ruby scripts/intake.rb --workdir <WORK> --tool powerbi-to-sigma --mode file \
+  [--connection <id>] [--name <connection-name-substring>]
+```
+
+Caches `<WORK>/connection.json` (the orchestrator reads it when `--connection` is omitted —
+point `--out` at the same `<WORK>`) and writes `intake.json` (run-start + mode feed the
+telemetry ping). Multiple connections + no id/name → it lists them and asks you to pick;
+never guesses. (Power BI input is almost always `--mode file` — TMSL + PBIR exports.)
+
 ## Phase 1 — Connect (no Entra app required)
 The corporate tenant blocks Entra app creation, Git integration, and XMLA (PPU). The working path:
 - `scripts/fabric-extract.py` — device-code via well-known public client **`ea0616ba-638b-4df5-95b9-636659ae5121`** (Power BI Desktop), scope `https://api.fabric.microsoft.com/.default`. User signs in once at the device URL; token cached.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/intake.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/intake.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# intake.rb — migration front-door. Run this ONCE, first, before discovery.
+#
+# It does the two things every converter otherwise improvises (badly):
+#
+#  1. RESOLVE THE SIGMA CONNECTION ONCE and cache it, so no downstream phase
+#     free-searches /v2/connections (the token sink). Precedence (decision D2 —
+#     config-first, prompt on miss):
+#       a. --connection <UUID>                  explicit flag wins
+#       b. cached <workdir>/connection.json     idempotent re-runs reuse it
+#       c. ENV['SIGMA_CONNECTION_ID']           from ~/.sigma-migration/env (setup.rb)
+#       d. list /v2/connections ONCE:
+#            - exactly one connection            -> auto-pick
+#            - --name SUBSTR uniquely matches     -> auto-pick
+#            - otherwise -> write connection-candidates.json and exit 3 so the
+#              agent ASKS THE USER, then re-runs with --connection <id>.
+#              (We never guess among multiple, and never free-search per phase.)
+#
+#  2. RECORD RUN METADATA to <workdir>/intake.json: run_start (feeds telemetry
+#     duration), input_mode (live|file|both — feeds telemetry --mode), and the
+#     source tool/identifier. Prints an expectations banner for the mode.
+#
+# Usage:
+#   ruby scripts/intake.rb --workdir <dir> --tool tableau-to-sigma --mode live \
+#     [--connection <UUID>] [--name <connection-name-substring>] [--source "<wb name/app id>"]
+#
+# Exit codes:
+#   0  connection resolved (connection.json written) + intake.json written
+#   2  --connection given but not a full UUID
+#   3  connection ambiguous — connection-candidates.json written; ask the user
+#   4  no connections found / API error while listing
+#   1  usage error
+
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { mode: 'unknown' }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--tool NAME')        { |v| opts[:tool] = v }
+  p.on('--mode MODE', 'live | file | both (input mode)') { |v| opts[:mode] = v }
+  p.on('--connection ID')    { |v| opts[:conn] = v }
+  p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
+  p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
+  p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
+end.parse!
+
+abort('[FAIL] intake: --workdir required') unless opts[:dir]
+require 'fileutils'
+FileUtils.mkdir_p(opts[:dir])
+
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+conn_path  = File.join(opts[:dir], 'connection.json')
+cand_path  = File.join(opts[:dir], 'connection-candidates.json')
+intake_path = File.join(opts[:dir], 'intake.json')
+
+def write_json(path, obj)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(obj))
+  File.rename(tmp, path)   # atomic — no half-written sidecar reads
+end
+
+# Normalize a connection record from /v2/connections (entries[]) into our shape.
+def norm_conn(c)
+  {
+    'connection_id' => c['connectionId'] || c['id'],
+    'name'          => c['name'] || c['label'],
+    'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+  }
+end
+
+# Fetch the connection list once (or from a fixture, for tests).
+def list_connections(opts)
+  if opts[:fixture]
+    data = JSON.parse(File.read(opts[:fixture]))
+  else
+    require_relative 'lib/sigma_rest'
+    data = Sigma.request(:get, '/v2/connections?limit=500')
+  end
+  rows = data.is_a?(Hash) ? (data['entries'] || data['connections'] || []) : (data || [])
+  rows.map { |c| norm_conn(c) }.reject { |c| c['connection_id'].to_s.empty? }
+end
+
+resolved = nil
+resolved_via = nil
+
+# (a) explicit flag
+if opts[:conn]
+  unless opts[:conn] =~ UUID_RE
+    warn "[FAIL] intake: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}."
+    exit 2
+  end
+  resolved = { 'connection_id' => opts[:conn], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'flag'
+end
+
+# (b) cached connection.json
+if resolved.nil? && !opts[:force] && File.exist?(conn_path)
+  cached = (JSON.parse(File.read(conn_path)) rescue nil)
+  if cached.is_a?(Hash) && cached['connection_id'].to_s =~ UUID_RE
+    resolved = cached.slice('connection_id', 'name', 'type')
+    resolved_via = 'cache'
+  end
+end
+
+# (c) ENV (loaded from ~/.sigma-migration/env by setup.rb / sigma_rest.rb)
+if resolved.nil? && ENV['SIGMA_CONNECTION_ID'].to_s =~ UUID_RE
+  resolved = { 'connection_id' => ENV['SIGMA_CONNECTION_ID'], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'env'
+end
+
+# (d) list /v2/connections ONCE and pick deterministically
+if resolved.nil?
+  begin
+    conns = list_connections(opts)
+  rescue => e
+    warn "[FAIL] intake: could not list connections — #{e.message}"
+    exit 4
+  end
+  if conns.empty?
+    warn '[FAIL] intake: no Sigma connections found for these credentials.'
+    exit 4
+  end
+  pick = nil
+  if opts[:name]
+    matches = conns.select { |c| c['name'].to_s.downcase.include?(opts[:name].downcase) }
+    pick = matches.first if matches.size == 1
+  end
+  pick ||= conns.first if conns.size == 1
+  if pick
+    resolved = pick
+    resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
+  else
+    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
+    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
+    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
+    exit 3
+  end
+end
+
+resolved['resolved_via'] = resolved_via
+resolved['at'] = Time.now.utc.iso8601
+write_json(conn_path, resolved)
+File.delete(cand_path) if File.exist?(cand_path)   # resolved now; clear stale candidates
+
+# Run metadata for telemetry + audit.
+mode = %w[live file both].include?(opts[:mode]) ? opts[:mode] : 'unknown'
+write_json(intake_path, {
+  'run_start'  => Time.now.utc.iso8601,
+  'input_mode' => mode,
+  'tool'       => opts[:tool],
+  'source'     => opts[:source],
+})
+
+puts "[OK] intake: connection #{resolved['connection_id']} (#{resolved['name'] || '?'}) via #{resolved_via} → #{conn_path}"
+puts "[OK] intake: mode=#{mode}, tool=#{opts[:tool] || '?'} → #{intake_path}"
+case mode
+when 'file'
+  puts '     INPUT MODE = file (raw export, no live source connection). The build runs from the'
+  puts '     export; parity is verified against the live SIGMA WAREHOUSE, not the source tool.'
+when 'both', 'live'
+  puts "     INPUT MODE = #{mode}. Live source available — full source-side parity verification applies."
+else
+  puts '     INPUT MODE = unknown. Pass --mode live|file|both so telemetry + the raw-mode banner are accurate.'
+end
+exit 0

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -119,6 +119,9 @@ abort 'missing --tmsl' unless opts[:tmsl]
 abort "--tmsl not found: #{opts[:tmsl]}" unless opts[:tmsl] && File.exist?(opts[:tmsl])
 abort 'missing --pbir' unless opts[:pbir]
 abort "--pbir not found: #{opts[:pbir]}" unless File.exist?(opts[:pbir])
+# intake.rb (front-door) caches the resolved connection in <out>/connection.json; honor it
+# when --connection is omitted so the agent need not re-pass the id it just resolved.
+opts[:conn] ||= (JSON.parse(File.read(File.join(opts[:out], 'connection.json')))['connection_id'] rescue nil) if opts[:out]
 # bead hjke(a): abort early on a truncated/partial connection id — it survives
 # all the way to the DM POST and fails there opaquely ("Source not found").
 if opts[:conn] && opts[:conn] !~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
@@ -58,13 +58,39 @@ def _write_marker(workdir, record):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
-parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds (auto-derived from intake.json run_start if omitted)')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
-                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+                    help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+
+def _from_intake(workdir):
+    """intake.rb (the front-door step) records run_start + input_mode in
+    intake.json. If --duration / --mode were not passed explicitly, derive them
+    from it so the agent doesn't have to track elapsed time by hand. Returns
+    (duration_seconds_or_None, mode_or_None)."""
+    if not workdir:
+        return None, None
+    try:
+        from datetime import datetime, timezone
+        intake = json.load(open(os.path.join(workdir, 'intake.json')))
+        dur = None
+        if intake.get('run_start'):
+            started = datetime.fromisoformat(intake['run_start'])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            dur = max(0, int((datetime.now(timezone.utc) - started).total_seconds()))
+        return dur, intake.get('input_mode')
+    except Exception:
+        return None, None
+
+
+_intake_dur, _intake_mode = _from_intake(args.workdir)
+duration = args.duration if args.duration else (_intake_dur or 0)
+mode = args.mode if args.mode != 'unknown' else (_intake_mode or 'unknown')
 
 if args.declined:
     print("\nTelemetry declined by user — nothing sent.")
@@ -75,13 +101,13 @@ report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
-    duration_seconds=args.duration,
+    duration_seconds=duration,
     success=not args.failed,
-    mode=args.mode,
+    mode=mode,
 )
 _write_marker(args.workdir, {
     'status': 'sent',
     'tool': args.tool,
     'success': not args.failed,
-    'mode': args.mode,
+    'mode': mode,
 })

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# test-intake.rb — unit test for the migration front-door (intake.rb): connection
+# resolution precedence + intake.json run metadata. Offline — the /v2/connections
+# listing is exercised via the --connections-fixture test seam, never the network.
+# Canonical in shared/scripts (epic beads-sigma-p5y2). Run: ruby scripts/test-intake.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+INTAKE = File.join(__dir__, 'intake.rb')
+RUBY   = RbConfig.ruby
+UUID   = '11111111-2222-3333-4444-555555555555'
+UUID2  = '66666666-2222-3333-4444-555555555555'
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+def run(dir, *args, env: {})
+  # returns [exit_status, connection_hash_or_nil]
+  base = { 'SIGMA_CONNECTION_ID' => nil }   # neutralize ambient env by default
+  system(base.merge(env), RUBY, INTAKE, '--workdir', dir, *args, out: File::NULL, err: File::NULL)
+  st = $?.exitstatus
+  conn = (JSON.parse(File.read(File.join(dir, 'connection.json'))) rescue nil)
+  [st, conn]
+end
+
+def fixture(dir, *conns)
+  path = File.join(dir, 'fx.json')
+  entries = conns.map { |id, name, type| { 'connectionId' => id, 'name' => name, 'type' => type } }
+  File.write(path, JSON.generate('entries' => entries))
+  path
+end
+
+# 1. explicit UUID wins
+Dir.mktmpdir do |d|
+  st, c = run(d, '--tool', 'tableau-to-sigma', '--mode', 'live', '--connection', UUID)
+  ok('explicit UUID → exit 0', st == 0)
+  ok('explicit UUID cached', c && c['connection_id'] == UUID && c['resolved_via'] == 'flag')
+  intake = JSON.parse(File.read(File.join(d, 'intake.json')))
+  ok('intake.json mode', intake['input_mode'] == 'live')
+  ok('intake.json run_start present', !intake['run_start'].to_s.empty?)
+end
+
+# 2. malformed UUID → exit 2
+Dir.mktmpdir { |d| st, _ = run(d, '--connection', 'nope'); ok('bad UUID → exit 2', st == 2) }
+
+# 3. cached connection.json reused (no flag)
+Dir.mktmpdir do |d|
+  run(d, '--connection', UUID)
+  st, c = run(d, '--mode', 'live')
+  ok('cache reused → exit 0', st == 0)
+  ok('resolved_via cache', c && c['resolved_via'] == 'cache')
+end
+
+# 4. fixture with a single connection → auto-pick
+Dir.mktmpdir do |d|
+  fx = fixture(d, [UUID, 'Snowflake Prod', 'snowflake'])
+  st, c = run(d, '--mode', 'file', '--connections-fixture', fx)
+  ok('single connection auto-picked', st == 0 && c['connection_id'] == UUID && c['resolved_via'] == 'only-connection')
+end
+
+# 5. fixture with multiple → exit 3 + candidates written, no connection.json
+Dir.mktmpdir do |d|
+  fx = fixture(d, [UUID, 'SF', 'snowflake'], [UUID2, 'BQ', 'bigquery'])
+  st, c = run(d, '--connections-fixture', fx)
+  ok('ambiguous → exit 3', st == 3)
+  ok('no connection.json written when ambiguous', c.nil?)
+  ok('candidates file written', File.exist?(File.join(d, 'connection-candidates.json')))
+end
+
+# 6. fixture multiple + unique --name match → auto-pick
+Dir.mktmpdir do |d|
+  fx = fixture(d, [UUID, 'SF', 'snowflake'], [UUID2, 'BigQuery', 'bigquery'])
+  st, c = run(d, '--name', 'bigquery', '--connections-fixture', fx)
+  ok('name-match auto-pick', st == 0 && c['connection_id'] == UUID2 && c['resolved_via'] == 'name-match')
+end
+
+# 7. ENV SIGMA_CONNECTION_ID used when no flag/cache/fixture
+Dir.mktmpdir do |d|
+  st, c = run(d, '--mode', 'both', env: { 'SIGMA_CONNECTION_ID' => UUID })
+  ok('env connection used', st == 0 && c['connection_id'] == UUID && c['resolved_via'] == 'env')
+end
+
+puts $fail.zero? ? "\nall intake tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -36,6 +36,21 @@ If a destination is already supplied, honor it silently — don't ask.
 > (one Sigma page per Qlik sheet, layout straight from the sheet cell grids) from ONE
 > command with zero hand-edits in under 2 minutes.
 
+## Step 0 — Front door: resolve the connection once (`scripts/intake.rb`)
+
+Resolve the Sigma warehouse connection a SINGLE time up front so no phase free-searches
+`/v2/connections` (the token sink):
+
+```bash
+ruby scripts/intake.rb --workdir <WORK> --tool qlik-to-sigma --mode live \
+  [--connection <id>] [--name <connection-name-substring>]
+```
+
+Caches `<WORK>/connection.json` (the orchestrator reads it when `--connection` is omitted —
+point `--out` at the same `<WORK>`) and writes `intake.json` (run-start + mode feed the
+telemetry ping). Multiple connections + no id/name → it lists them and asks you to pick;
+never guesses.
+
 ## The one command
 
 ```bash

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/intake.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/intake.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# intake.rb — migration front-door. Run this ONCE, first, before discovery.
+#
+# It does the two things every converter otherwise improvises (badly):
+#
+#  1. RESOLVE THE SIGMA CONNECTION ONCE and cache it, so no downstream phase
+#     free-searches /v2/connections (the token sink). Precedence (decision D2 —
+#     config-first, prompt on miss):
+#       a. --connection <UUID>                  explicit flag wins
+#       b. cached <workdir>/connection.json     idempotent re-runs reuse it
+#       c. ENV['SIGMA_CONNECTION_ID']           from ~/.sigma-migration/env (setup.rb)
+#       d. list /v2/connections ONCE:
+#            - exactly one connection            -> auto-pick
+#            - --name SUBSTR uniquely matches     -> auto-pick
+#            - otherwise -> write connection-candidates.json and exit 3 so the
+#              agent ASKS THE USER, then re-runs with --connection <id>.
+#              (We never guess among multiple, and never free-search per phase.)
+#
+#  2. RECORD RUN METADATA to <workdir>/intake.json: run_start (feeds telemetry
+#     duration), input_mode (live|file|both — feeds telemetry --mode), and the
+#     source tool/identifier. Prints an expectations banner for the mode.
+#
+# Usage:
+#   ruby scripts/intake.rb --workdir <dir> --tool tableau-to-sigma --mode live \
+#     [--connection <UUID>] [--name <connection-name-substring>] [--source "<wb name/app id>"]
+#
+# Exit codes:
+#   0  connection resolved (connection.json written) + intake.json written
+#   2  --connection given but not a full UUID
+#   3  connection ambiguous — connection-candidates.json written; ask the user
+#   4  no connections found / API error while listing
+#   1  usage error
+
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { mode: 'unknown' }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--tool NAME')        { |v| opts[:tool] = v }
+  p.on('--mode MODE', 'live | file | both (input mode)') { |v| opts[:mode] = v }
+  p.on('--connection ID')    { |v| opts[:conn] = v }
+  p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
+  p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
+  p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
+end.parse!
+
+abort('[FAIL] intake: --workdir required') unless opts[:dir]
+require 'fileutils'
+FileUtils.mkdir_p(opts[:dir])
+
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+conn_path  = File.join(opts[:dir], 'connection.json')
+cand_path  = File.join(opts[:dir], 'connection-candidates.json')
+intake_path = File.join(opts[:dir], 'intake.json')
+
+def write_json(path, obj)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(obj))
+  File.rename(tmp, path)   # atomic — no half-written sidecar reads
+end
+
+# Normalize a connection record from /v2/connections (entries[]) into our shape.
+def norm_conn(c)
+  {
+    'connection_id' => c['connectionId'] || c['id'],
+    'name'          => c['name'] || c['label'],
+    'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+  }
+end
+
+# Fetch the connection list once (or from a fixture, for tests).
+def list_connections(opts)
+  if opts[:fixture]
+    data = JSON.parse(File.read(opts[:fixture]))
+  else
+    require_relative 'lib/sigma_rest'
+    data = Sigma.request(:get, '/v2/connections?limit=500')
+  end
+  rows = data.is_a?(Hash) ? (data['entries'] || data['connections'] || []) : (data || [])
+  rows.map { |c| norm_conn(c) }.reject { |c| c['connection_id'].to_s.empty? }
+end
+
+resolved = nil
+resolved_via = nil
+
+# (a) explicit flag
+if opts[:conn]
+  unless opts[:conn] =~ UUID_RE
+    warn "[FAIL] intake: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}."
+    exit 2
+  end
+  resolved = { 'connection_id' => opts[:conn], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'flag'
+end
+
+# (b) cached connection.json
+if resolved.nil? && !opts[:force] && File.exist?(conn_path)
+  cached = (JSON.parse(File.read(conn_path)) rescue nil)
+  if cached.is_a?(Hash) && cached['connection_id'].to_s =~ UUID_RE
+    resolved = cached.slice('connection_id', 'name', 'type')
+    resolved_via = 'cache'
+  end
+end
+
+# (c) ENV (loaded from ~/.sigma-migration/env by setup.rb / sigma_rest.rb)
+if resolved.nil? && ENV['SIGMA_CONNECTION_ID'].to_s =~ UUID_RE
+  resolved = { 'connection_id' => ENV['SIGMA_CONNECTION_ID'], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'env'
+end
+
+# (d) list /v2/connections ONCE and pick deterministically
+if resolved.nil?
+  begin
+    conns = list_connections(opts)
+  rescue => e
+    warn "[FAIL] intake: could not list connections — #{e.message}"
+    exit 4
+  end
+  if conns.empty?
+    warn '[FAIL] intake: no Sigma connections found for these credentials.'
+    exit 4
+  end
+  pick = nil
+  if opts[:name]
+    matches = conns.select { |c| c['name'].to_s.downcase.include?(opts[:name].downcase) }
+    pick = matches.first if matches.size == 1
+  end
+  pick ||= conns.first if conns.size == 1
+  if pick
+    resolved = pick
+    resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
+  else
+    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
+    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
+    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
+    exit 3
+  end
+end
+
+resolved['resolved_via'] = resolved_via
+resolved['at'] = Time.now.utc.iso8601
+write_json(conn_path, resolved)
+File.delete(cand_path) if File.exist?(cand_path)   # resolved now; clear stale candidates
+
+# Run metadata for telemetry + audit.
+mode = %w[live file both].include?(opts[:mode]) ? opts[:mode] : 'unknown'
+write_json(intake_path, {
+  'run_start'  => Time.now.utc.iso8601,
+  'input_mode' => mode,
+  'tool'       => opts[:tool],
+  'source'     => opts[:source],
+})
+
+puts "[OK] intake: connection #{resolved['connection_id']} (#{resolved['name'] || '?'}) via #{resolved_via} → #{conn_path}"
+puts "[OK] intake: mode=#{mode}, tool=#{opts[:tool] || '?'} → #{intake_path}"
+case mode
+when 'file'
+  puts '     INPUT MODE = file (raw export, no live source connection). The build runs from the'
+  puts '     export; parity is verified against the live SIGMA WAREHOUSE, not the source tool.'
+when 'both', 'live'
+  puts "     INPUT MODE = #{mode}. Live source available — full source-side parity verification applies."
+else
+  puts '     INPUT MODE = unknown. Pass --mode live|file|both so telemetry + the raw-mode banner are accurate.'
+end
+exit 0

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -135,7 +135,10 @@ OptionParser.new do |o|
 end.parse!
 
 abort 'missing --app (or --from-discovery)' unless opts[:app] || opts[:from]
-abort 'missing --connection' unless opts[:conn]
+# intake.rb (front-door) caches the resolved connection in <out>/connection.json; honor it
+# when --connection is omitted so the agent need not re-pass the id it just resolved.
+opts[:conn] ||= (JSON.parse(File.read(File.join(opts[:out], 'connection.json')))['connection_id'] rescue nil) if opts[:out]
+abort 'missing --connection (pass --connection <id>, or run intake.rb first and point --out at its --workdir)' unless opts[:conn]
 
 # Locate the sigma-data-model-mcp converter build (exports convertQlikToSigma).
 MCP_DIR = ENV['QLIK_MCP_DIR'] || %w[

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
@@ -58,13 +58,39 @@ def _write_marker(workdir, record):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
-parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds (auto-derived from intake.json run_start if omitted)')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
-                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+                    help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+
+def _from_intake(workdir):
+    """intake.rb (the front-door step) records run_start + input_mode in
+    intake.json. If --duration / --mode were not passed explicitly, derive them
+    from it so the agent doesn't have to track elapsed time by hand. Returns
+    (duration_seconds_or_None, mode_or_None)."""
+    if not workdir:
+        return None, None
+    try:
+        from datetime import datetime, timezone
+        intake = json.load(open(os.path.join(workdir, 'intake.json')))
+        dur = None
+        if intake.get('run_start'):
+            started = datetime.fromisoformat(intake['run_start'])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            dur = max(0, int((datetime.now(timezone.utc) - started).total_seconds()))
+        return dur, intake.get('input_mode')
+    except Exception:
+        return None, None
+
+
+_intake_dur, _intake_mode = _from_intake(args.workdir)
+duration = args.duration if args.duration else (_intake_dur or 0)
+mode = args.mode if args.mode != 'unknown' else (_intake_mode or 'unknown')
 
 if args.declined:
     print("\nTelemetry declined by user — nothing sent.")
@@ -75,13 +101,13 @@ report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
-    duration_seconds=args.duration,
+    duration_seconds=duration,
     success=not args.failed,
-    mode=args.mode,
+    mode=mode,
 )
 _write_marker(args.workdir, {
     'status': 'sent',
     'tool': args.tool,
     'success': not args.failed,
-    'mode': args.mode,
+    'mode': mode,
 })

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -40,6 +40,21 @@ If a destination is already supplied, honor it silently — don't ask.
 
 See `refs/migration-test-slate.md` for the complexity taxonomy + 20-dashboard test slate that grounds the converter's coverage and known gaps.
 
+## Step 0 — Front door: resolve the connection once (`scripts/intake.rb`)
+
+Resolve the Sigma warehouse connection a SINGLE time up front so no phase free-searches
+`/v2/connections` (the token sink):
+
+```bash
+ruby scripts/intake.rb --workdir <WORK> --tool quicksight-to-sigma --mode live \
+  [--connection <id>] [--name <connection-name-substring>]
+```
+
+Caches `<WORK>/connection.json` (the orchestrator reads it when `--connection` is omitted —
+point `--out` at the same `<WORK>`) and writes `intake.json` (run-start + mode feed the
+telemetry ping). Multiple connections + no id/name → it lists them and asks you to pick;
+never guesses.
+
 ## One command (preferred): `scripts/migrate-quicksight.rb`
 
 The single-process orchestrator chains every phase below — discover (live AWS or `--from-fixtures <dir>`), convert (local MCP build, or `convert-model.rb --emit-mcp` gate + `--converted` resume), the **Phase 3.5 DM-reuse check** (`qs-dm-signature.py` + `find-or-pick-dm.rb`; **reuse-first** — auto-reuses an existing DM covering all the analysis's source tables, `--reuse-dm <id>` pins one, `--skip-reuse-check` forces build new), fixup `--folder-id` → validate → post-and-readback, workbook build, layout, then the **two-pass Phase 7 parity** (`phase6-parity-quicksight.rb` emits the per-chart query list and gates; write `parity-expected.json` + `parity-actuals.json` and re-run the SAME command — phases 1–5 skip automatically) and the `assert-phase6-ran.rb --workdir` hard gate:

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/intake.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/intake.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# intake.rb — migration front-door. Run this ONCE, first, before discovery.
+#
+# It does the two things every converter otherwise improvises (badly):
+#
+#  1. RESOLVE THE SIGMA CONNECTION ONCE and cache it, so no downstream phase
+#     free-searches /v2/connections (the token sink). Precedence (decision D2 —
+#     config-first, prompt on miss):
+#       a. --connection <UUID>                  explicit flag wins
+#       b. cached <workdir>/connection.json     idempotent re-runs reuse it
+#       c. ENV['SIGMA_CONNECTION_ID']           from ~/.sigma-migration/env (setup.rb)
+#       d. list /v2/connections ONCE:
+#            - exactly one connection            -> auto-pick
+#            - --name SUBSTR uniquely matches     -> auto-pick
+#            - otherwise -> write connection-candidates.json and exit 3 so the
+#              agent ASKS THE USER, then re-runs with --connection <id>.
+#              (We never guess among multiple, and never free-search per phase.)
+#
+#  2. RECORD RUN METADATA to <workdir>/intake.json: run_start (feeds telemetry
+#     duration), input_mode (live|file|both — feeds telemetry --mode), and the
+#     source tool/identifier. Prints an expectations banner for the mode.
+#
+# Usage:
+#   ruby scripts/intake.rb --workdir <dir> --tool tableau-to-sigma --mode live \
+#     [--connection <UUID>] [--name <connection-name-substring>] [--source "<wb name/app id>"]
+#
+# Exit codes:
+#   0  connection resolved (connection.json written) + intake.json written
+#   2  --connection given but not a full UUID
+#   3  connection ambiguous — connection-candidates.json written; ask the user
+#   4  no connections found / API error while listing
+#   1  usage error
+
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { mode: 'unknown' }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--tool NAME')        { |v| opts[:tool] = v }
+  p.on('--mode MODE', 'live | file | both (input mode)') { |v| opts[:mode] = v }
+  p.on('--connection ID')    { |v| opts[:conn] = v }
+  p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
+  p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
+  p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
+end.parse!
+
+abort('[FAIL] intake: --workdir required') unless opts[:dir]
+require 'fileutils'
+FileUtils.mkdir_p(opts[:dir])
+
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+conn_path  = File.join(opts[:dir], 'connection.json')
+cand_path  = File.join(opts[:dir], 'connection-candidates.json')
+intake_path = File.join(opts[:dir], 'intake.json')
+
+def write_json(path, obj)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(obj))
+  File.rename(tmp, path)   # atomic — no half-written sidecar reads
+end
+
+# Normalize a connection record from /v2/connections (entries[]) into our shape.
+def norm_conn(c)
+  {
+    'connection_id' => c['connectionId'] || c['id'],
+    'name'          => c['name'] || c['label'],
+    'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+  }
+end
+
+# Fetch the connection list once (or from a fixture, for tests).
+def list_connections(opts)
+  if opts[:fixture]
+    data = JSON.parse(File.read(opts[:fixture]))
+  else
+    require_relative 'lib/sigma_rest'
+    data = Sigma.request(:get, '/v2/connections?limit=500')
+  end
+  rows = data.is_a?(Hash) ? (data['entries'] || data['connections'] || []) : (data || [])
+  rows.map { |c| norm_conn(c) }.reject { |c| c['connection_id'].to_s.empty? }
+end
+
+resolved = nil
+resolved_via = nil
+
+# (a) explicit flag
+if opts[:conn]
+  unless opts[:conn] =~ UUID_RE
+    warn "[FAIL] intake: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}."
+    exit 2
+  end
+  resolved = { 'connection_id' => opts[:conn], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'flag'
+end
+
+# (b) cached connection.json
+if resolved.nil? && !opts[:force] && File.exist?(conn_path)
+  cached = (JSON.parse(File.read(conn_path)) rescue nil)
+  if cached.is_a?(Hash) && cached['connection_id'].to_s =~ UUID_RE
+    resolved = cached.slice('connection_id', 'name', 'type')
+    resolved_via = 'cache'
+  end
+end
+
+# (c) ENV (loaded from ~/.sigma-migration/env by setup.rb / sigma_rest.rb)
+if resolved.nil? && ENV['SIGMA_CONNECTION_ID'].to_s =~ UUID_RE
+  resolved = { 'connection_id' => ENV['SIGMA_CONNECTION_ID'], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'env'
+end
+
+# (d) list /v2/connections ONCE and pick deterministically
+if resolved.nil?
+  begin
+    conns = list_connections(opts)
+  rescue => e
+    warn "[FAIL] intake: could not list connections — #{e.message}"
+    exit 4
+  end
+  if conns.empty?
+    warn '[FAIL] intake: no Sigma connections found for these credentials.'
+    exit 4
+  end
+  pick = nil
+  if opts[:name]
+    matches = conns.select { |c| c['name'].to_s.downcase.include?(opts[:name].downcase) }
+    pick = matches.first if matches.size == 1
+  end
+  pick ||= conns.first if conns.size == 1
+  if pick
+    resolved = pick
+    resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
+  else
+    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
+    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
+    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
+    exit 3
+  end
+end
+
+resolved['resolved_via'] = resolved_via
+resolved['at'] = Time.now.utc.iso8601
+write_json(conn_path, resolved)
+File.delete(cand_path) if File.exist?(cand_path)   # resolved now; clear stale candidates
+
+# Run metadata for telemetry + audit.
+mode = %w[live file both].include?(opts[:mode]) ? opts[:mode] : 'unknown'
+write_json(intake_path, {
+  'run_start'  => Time.now.utc.iso8601,
+  'input_mode' => mode,
+  'tool'       => opts[:tool],
+  'source'     => opts[:source],
+})
+
+puts "[OK] intake: connection #{resolved['connection_id']} (#{resolved['name'] || '?'}) via #{resolved_via} → #{conn_path}"
+puts "[OK] intake: mode=#{mode}, tool=#{opts[:tool] || '?'} → #{intake_path}"
+case mode
+when 'file'
+  puts '     INPUT MODE = file (raw export, no live source connection). The build runs from the'
+  puts '     export; parity is verified against the live SIGMA WAREHOUSE, not the source tool.'
+when 'both', 'live'
+  puts "     INPUT MODE = #{mode}. Live source available — full source-side parity verification applies."
+else
+  puts '     INPUT MODE = unknown. Pass --mode live|file|both so telemetry + the raw-mode banner are accurate.'
+end
+exit 0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
@@ -84,7 +84,10 @@ end.parse!
 
 abort 'missing --analysis-id (or --from-fixtures)' unless opts[:analysis] || opts[:fixtures]
 abort 'missing --account-id (live discovery)' if opts[:analysis] && !opts[:fixtures] && !opts[:account]
-abort 'missing --connection' unless opts[:conn]
+# intake.rb (front-door) caches the resolved connection in <out>/connection.json; honor it
+# when --connection is omitted so the agent need not re-pass the id it just resolved.
+opts[:conn] ||= (JSON.parse(File.read(File.join(opts[:out], 'connection.json')))['connection_id'] rescue nil) if opts[:out]
+abort 'missing --connection (pass --connection <id>, or run intake.rb first and point --out at its --workdir)' unless opts[:conn]
 if opts[:conn] !~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
   abort "FATAL: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}"
 end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
@@ -58,13 +58,39 @@ def _write_marker(workdir, record):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
-parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds (auto-derived from intake.json run_start if omitted)')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
-                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+                    help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+
+def _from_intake(workdir):
+    """intake.rb (the front-door step) records run_start + input_mode in
+    intake.json. If --duration / --mode were not passed explicitly, derive them
+    from it so the agent doesn't have to track elapsed time by hand. Returns
+    (duration_seconds_or_None, mode_or_None)."""
+    if not workdir:
+        return None, None
+    try:
+        from datetime import datetime, timezone
+        intake = json.load(open(os.path.join(workdir, 'intake.json')))
+        dur = None
+        if intake.get('run_start'):
+            started = datetime.fromisoformat(intake['run_start'])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            dur = max(0, int((datetime.now(timezone.utc) - started).total_seconds()))
+        return dur, intake.get('input_mode')
+    except Exception:
+        return None, None
+
+
+_intake_dur, _intake_mode = _from_intake(args.workdir)
+duration = args.duration if args.duration else (_intake_dur or 0)
+mode = args.mode if args.mode != 'unknown' else (_intake_mode or 'unknown')
 
 if args.declined:
     print("\nTelemetry declined by user — nothing sent.")
@@ -75,13 +101,13 @@ report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
-    duration_seconds=args.duration,
+    duration_seconds=duration,
     success=not args.failed,
-    mode=args.mode,
+    mode=mode,
 )
 _write_marker(args.workdir, {
     'status': 'sent',
     'tool': args.tool,
     'success': not args.failed,
-    'mode': args.mode,
+    'mode': mode,
 })

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -27,6 +27,23 @@ that mirrors the Tableau dashboard layout as closely as possible.
 
 ---
 
+## Step 0 — Front door: resolve the connection once (`scripts/intake.rb`)
+
+Before the run, resolve the Sigma warehouse connection a SINGLE time so no phase
+free-searches `/v2/connections` (the token sink):
+
+```bash
+eval "$(scripts/get-token.sh)"
+ruby scripts/intake.rb --workdir <WORK> --tool tableau-to-sigma --mode live \
+  [--connection <id>] [--name <connection-name-substring>] [--source "<workbook name>"]
+```
+
+It caches `<WORK>/connection.json` (the orchestrator reads it when `--connection` is
+omitted — just point `--out` at the same `<WORK>`) and writes `intake.json` (run-start +
+input mode, which feed the telemetry ping's duration and `mode`). Precedence: explicit
+`--connection` → cached → `SIGMA_CONNECTION_ID` env → list once. With no id/name and
+multiple connections it lists them and asks you to pick — it never guesses.
+
 ## One command (orchestrated path)
 
 ```bash

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/intake.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/intake.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# intake.rb — migration front-door. Run this ONCE, first, before discovery.
+#
+# It does the two things every converter otherwise improvises (badly):
+#
+#  1. RESOLVE THE SIGMA CONNECTION ONCE and cache it, so no downstream phase
+#     free-searches /v2/connections (the token sink). Precedence (decision D2 —
+#     config-first, prompt on miss):
+#       a. --connection <UUID>                  explicit flag wins
+#       b. cached <workdir>/connection.json     idempotent re-runs reuse it
+#       c. ENV['SIGMA_CONNECTION_ID']           from ~/.sigma-migration/env (setup.rb)
+#       d. list /v2/connections ONCE:
+#            - exactly one connection            -> auto-pick
+#            - --name SUBSTR uniquely matches     -> auto-pick
+#            - otherwise -> write connection-candidates.json and exit 3 so the
+#              agent ASKS THE USER, then re-runs with --connection <id>.
+#              (We never guess among multiple, and never free-search per phase.)
+#
+#  2. RECORD RUN METADATA to <workdir>/intake.json: run_start (feeds telemetry
+#     duration), input_mode (live|file|both — feeds telemetry --mode), and the
+#     source tool/identifier. Prints an expectations banner for the mode.
+#
+# Usage:
+#   ruby scripts/intake.rb --workdir <dir> --tool tableau-to-sigma --mode live \
+#     [--connection <UUID>] [--name <connection-name-substring>] [--source "<wb name/app id>"]
+#
+# Exit codes:
+#   0  connection resolved (connection.json written) + intake.json written
+#   2  --connection given but not a full UUID
+#   3  connection ambiguous — connection-candidates.json written; ask the user
+#   4  no connections found / API error while listing
+#   1  usage error
+
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { mode: 'unknown' }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--tool NAME')        { |v| opts[:tool] = v }
+  p.on('--mode MODE', 'live | file | both (input mode)') { |v| opts[:mode] = v }
+  p.on('--connection ID')    { |v| opts[:conn] = v }
+  p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
+  p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
+  p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
+end.parse!
+
+abort('[FAIL] intake: --workdir required') unless opts[:dir]
+require 'fileutils'
+FileUtils.mkdir_p(opts[:dir])
+
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+conn_path  = File.join(opts[:dir], 'connection.json')
+cand_path  = File.join(opts[:dir], 'connection-candidates.json')
+intake_path = File.join(opts[:dir], 'intake.json')
+
+def write_json(path, obj)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(obj))
+  File.rename(tmp, path)   # atomic — no half-written sidecar reads
+end
+
+# Normalize a connection record from /v2/connections (entries[]) into our shape.
+def norm_conn(c)
+  {
+    'connection_id' => c['connectionId'] || c['id'],
+    'name'          => c['name'] || c['label'],
+    'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+  }
+end
+
+# Fetch the connection list once (or from a fixture, for tests).
+def list_connections(opts)
+  if opts[:fixture]
+    data = JSON.parse(File.read(opts[:fixture]))
+  else
+    require_relative 'lib/sigma_rest'
+    data = Sigma.request(:get, '/v2/connections?limit=500')
+  end
+  rows = data.is_a?(Hash) ? (data['entries'] || data['connections'] || []) : (data || [])
+  rows.map { |c| norm_conn(c) }.reject { |c| c['connection_id'].to_s.empty? }
+end
+
+resolved = nil
+resolved_via = nil
+
+# (a) explicit flag
+if opts[:conn]
+  unless opts[:conn] =~ UUID_RE
+    warn "[FAIL] intake: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}."
+    exit 2
+  end
+  resolved = { 'connection_id' => opts[:conn], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'flag'
+end
+
+# (b) cached connection.json
+if resolved.nil? && !opts[:force] && File.exist?(conn_path)
+  cached = (JSON.parse(File.read(conn_path)) rescue nil)
+  if cached.is_a?(Hash) && cached['connection_id'].to_s =~ UUID_RE
+    resolved = cached.slice('connection_id', 'name', 'type')
+    resolved_via = 'cache'
+  end
+end
+
+# (c) ENV (loaded from ~/.sigma-migration/env by setup.rb / sigma_rest.rb)
+if resolved.nil? && ENV['SIGMA_CONNECTION_ID'].to_s =~ UUID_RE
+  resolved = { 'connection_id' => ENV['SIGMA_CONNECTION_ID'], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'env'
+end
+
+# (d) list /v2/connections ONCE and pick deterministically
+if resolved.nil?
+  begin
+    conns = list_connections(opts)
+  rescue => e
+    warn "[FAIL] intake: could not list connections — #{e.message}"
+    exit 4
+  end
+  if conns.empty?
+    warn '[FAIL] intake: no Sigma connections found for these credentials.'
+    exit 4
+  end
+  pick = nil
+  if opts[:name]
+    matches = conns.select { |c| c['name'].to_s.downcase.include?(opts[:name].downcase) }
+    pick = matches.first if matches.size == 1
+  end
+  pick ||= conns.first if conns.size == 1
+  if pick
+    resolved = pick
+    resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
+  else
+    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
+    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
+    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
+    exit 3
+  end
+end
+
+resolved['resolved_via'] = resolved_via
+resolved['at'] = Time.now.utc.iso8601
+write_json(conn_path, resolved)
+File.delete(cand_path) if File.exist?(cand_path)   # resolved now; clear stale candidates
+
+# Run metadata for telemetry + audit.
+mode = %w[live file both].include?(opts[:mode]) ? opts[:mode] : 'unknown'
+write_json(intake_path, {
+  'run_start'  => Time.now.utc.iso8601,
+  'input_mode' => mode,
+  'tool'       => opts[:tool],
+  'source'     => opts[:source],
+})
+
+puts "[OK] intake: connection #{resolved['connection_id']} (#{resolved['name'] || '?'}) via #{resolved_via} → #{conn_path}"
+puts "[OK] intake: mode=#{mode}, tool=#{opts[:tool] || '?'} → #{intake_path}"
+case mode
+when 'file'
+  puts '     INPUT MODE = file (raw export, no live source connection). The build runs from the'
+  puts '     export; parity is verified against the live SIGMA WAREHOUSE, not the source tool.'
+when 'both', 'live'
+  puts "     INPUT MODE = #{mode}. Live source available — full source-side parity verification applies."
+else
+  puts '     INPUT MODE = unknown. Pass --mode live|file|both so telemetry + the raw-mode banner are accurate.'
+end
+exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -125,7 +125,10 @@ OptionParser.new do |o|
 end.parse!
 
 abort 'missing --workbook or --workbook-id' unless opts[:wb_name] || opts[:wb_id]
-abort 'missing --connection' unless opts[:conn] || opts[:finalize]
+# intake.rb (front-door) caches the resolved connection in <out>/connection.json; honor it
+# when --connection is omitted so the agent need not re-pass the id it just resolved.
+opts[:conn] ||= (JSON.parse(File.read(File.join(opts[:out], 'connection.json')))['connection_id'] rescue nil) if opts[:out]
+abort 'missing --connection (pass --connection <id>, or run intake.rb first and point --out at its --workdir)' unless opts[:conn] || opts[:finalize]
 
 slug = (opts[:wb_name] || opts[:wb_id]).gsub(/[^A-Za-z0-9_-]/, '-').squeeze('-')
 WORK = opts[:out] || File.expand_path("~/tableau-migration/#{slug}")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
@@ -58,13 +58,39 @@ def _write_marker(workdir, record):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
-parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds (auto-derived from intake.json run_start if omitted)')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
-                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+                    help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+
+def _from_intake(workdir):
+    """intake.rb (the front-door step) records run_start + input_mode in
+    intake.json. If --duration / --mode were not passed explicitly, derive them
+    from it so the agent doesn't have to track elapsed time by hand. Returns
+    (duration_seconds_or_None, mode_or_None)."""
+    if not workdir:
+        return None, None
+    try:
+        from datetime import datetime, timezone
+        intake = json.load(open(os.path.join(workdir, 'intake.json')))
+        dur = None
+        if intake.get('run_start'):
+            started = datetime.fromisoformat(intake['run_start'])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            dur = max(0, int((datetime.now(timezone.utc) - started).total_seconds()))
+        return dur, intake.get('input_mode')
+    except Exception:
+        return None, None
+
+
+_intake_dur, _intake_mode = _from_intake(args.workdir)
+duration = args.duration if args.duration else (_intake_dur or 0)
+mode = args.mode if args.mode != 'unknown' else (_intake_mode or 'unknown')
 
 if args.declined:
     print("\nTelemetry declined by user — nothing sent.")
@@ -75,13 +101,13 @@ report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
-    duration_seconds=args.duration,
+    duration_seconds=duration,
     success=not args.failed,
-    mode=args.mode,
+    mode=mode,
 )
 _write_marker(args.workdir, {
     'status': 'sent',
     'tool': args.tool,
     'success': not args.failed,
-    'mode': args.mode,
+    'mode': mode,
 })

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-intake.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-intake.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# test-intake.rb — unit test for the migration front-door (intake.rb): connection
+# resolution precedence + intake.json run metadata. Offline — the /v2/connections
+# listing is exercised via the --connections-fixture test seam, never the network.
+# Canonical in shared/scripts (epic beads-sigma-p5y2). Run: ruby scripts/test-intake.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+INTAKE = File.join(__dir__, 'intake.rb')
+RUBY   = RbConfig.ruby
+UUID   = '11111111-2222-3333-4444-555555555555'
+UUID2  = '66666666-2222-3333-4444-555555555555'
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+def run(dir, *args, env: {})
+  # returns [exit_status, connection_hash_or_nil]
+  base = { 'SIGMA_CONNECTION_ID' => nil }   # neutralize ambient env by default
+  system(base.merge(env), RUBY, INTAKE, '--workdir', dir, *args, out: File::NULL, err: File::NULL)
+  st = $?.exitstatus
+  conn = (JSON.parse(File.read(File.join(dir, 'connection.json'))) rescue nil)
+  [st, conn]
+end
+
+def fixture(dir, *conns)
+  path = File.join(dir, 'fx.json')
+  entries = conns.map { |id, name, type| { 'connectionId' => id, 'name' => name, 'type' => type } }
+  File.write(path, JSON.generate('entries' => entries))
+  path
+end
+
+# 1. explicit UUID wins
+Dir.mktmpdir do |d|
+  st, c = run(d, '--tool', 'tableau-to-sigma', '--mode', 'live', '--connection', UUID)
+  ok('explicit UUID → exit 0', st == 0)
+  ok('explicit UUID cached', c && c['connection_id'] == UUID && c['resolved_via'] == 'flag')
+  intake = JSON.parse(File.read(File.join(d, 'intake.json')))
+  ok('intake.json mode', intake['input_mode'] == 'live')
+  ok('intake.json run_start present', !intake['run_start'].to_s.empty?)
+end
+
+# 2. malformed UUID → exit 2
+Dir.mktmpdir { |d| st, _ = run(d, '--connection', 'nope'); ok('bad UUID → exit 2', st == 2) }
+
+# 3. cached connection.json reused (no flag)
+Dir.mktmpdir do |d|
+  run(d, '--connection', UUID)
+  st, c = run(d, '--mode', 'live')
+  ok('cache reused → exit 0', st == 0)
+  ok('resolved_via cache', c && c['resolved_via'] == 'cache')
+end
+
+# 4. fixture with a single connection → auto-pick
+Dir.mktmpdir do |d|
+  fx = fixture(d, [UUID, 'Snowflake Prod', 'snowflake'])
+  st, c = run(d, '--mode', 'file', '--connections-fixture', fx)
+  ok('single connection auto-picked', st == 0 && c['connection_id'] == UUID && c['resolved_via'] == 'only-connection')
+end
+
+# 5. fixture with multiple → exit 3 + candidates written, no connection.json
+Dir.mktmpdir do |d|
+  fx = fixture(d, [UUID, 'SF', 'snowflake'], [UUID2, 'BQ', 'bigquery'])
+  st, c = run(d, '--connections-fixture', fx)
+  ok('ambiguous → exit 3', st == 3)
+  ok('no connection.json written when ambiguous', c.nil?)
+  ok('candidates file written', File.exist?(File.join(d, 'connection-candidates.json')))
+end
+
+# 6. fixture multiple + unique --name match → auto-pick
+Dir.mktmpdir do |d|
+  fx = fixture(d, [UUID, 'SF', 'snowflake'], [UUID2, 'BigQuery', 'bigquery'])
+  st, c = run(d, '--name', 'bigquery', '--connections-fixture', fx)
+  ok('name-match auto-pick', st == 0 && c['connection_id'] == UUID2 && c['resolved_via'] == 'name-match')
+end
+
+# 7. ENV SIGMA_CONNECTION_ID used when no flag/cache/fixture
+Dir.mktmpdir do |d|
+  st, c = run(d, '--mode', 'both', env: { 'SIGMA_CONNECTION_ID' => UUID })
+  ok('env connection used', st == 0 && c['connection_id'] == UUID && c['resolved_via'] == 'env')
+end
+
+puts $fail.zero? ? "\nall intake tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/intake.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/intake.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# intake.rb — migration front-door. Run this ONCE, first, before discovery.
+#
+# It does the two things every converter otherwise improvises (badly):
+#
+#  1. RESOLVE THE SIGMA CONNECTION ONCE and cache it, so no downstream phase
+#     free-searches /v2/connections (the token sink). Precedence (decision D2 —
+#     config-first, prompt on miss):
+#       a. --connection <UUID>                  explicit flag wins
+#       b. cached <workdir>/connection.json     idempotent re-runs reuse it
+#       c. ENV['SIGMA_CONNECTION_ID']           from ~/.sigma-migration/env (setup.rb)
+#       d. list /v2/connections ONCE:
+#            - exactly one connection            -> auto-pick
+#            - --name SUBSTR uniquely matches     -> auto-pick
+#            - otherwise -> write connection-candidates.json and exit 3 so the
+#              agent ASKS THE USER, then re-runs with --connection <id>.
+#              (We never guess among multiple, and never free-search per phase.)
+#
+#  2. RECORD RUN METADATA to <workdir>/intake.json: run_start (feeds telemetry
+#     duration), input_mode (live|file|both — feeds telemetry --mode), and the
+#     source tool/identifier. Prints an expectations banner for the mode.
+#
+# Usage:
+#   ruby scripts/intake.rb --workdir <dir> --tool tableau-to-sigma --mode live \
+#     [--connection <UUID>] [--name <connection-name-substring>] [--source "<wb name/app id>"]
+#
+# Exit codes:
+#   0  connection resolved (connection.json written) + intake.json written
+#   2  --connection given but not a full UUID
+#   3  connection ambiguous — connection-candidates.json written; ask the user
+#   4  no connections found / API error while listing
+#   1  usage error
+
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { mode: 'unknown' }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--tool NAME')        { |v| opts[:tool] = v }
+  p.on('--mode MODE', 'live | file | both (input mode)') { |v| opts[:mode] = v }
+  p.on('--connection ID')    { |v| opts[:conn] = v }
+  p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
+  p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
+  p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
+end.parse!
+
+abort('[FAIL] intake: --workdir required') unless opts[:dir]
+require 'fileutils'
+FileUtils.mkdir_p(opts[:dir])
+
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+conn_path  = File.join(opts[:dir], 'connection.json')
+cand_path  = File.join(opts[:dir], 'connection-candidates.json')
+intake_path = File.join(opts[:dir], 'intake.json')
+
+def write_json(path, obj)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(obj))
+  File.rename(tmp, path)   # atomic — no half-written sidecar reads
+end
+
+# Normalize a connection record from /v2/connections (entries[]) into our shape.
+def norm_conn(c)
+  {
+    'connection_id' => c['connectionId'] || c['id'],
+    'name'          => c['name'] || c['label'],
+    'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+  }
+end
+
+# Fetch the connection list once (or from a fixture, for tests).
+def list_connections(opts)
+  if opts[:fixture]
+    data = JSON.parse(File.read(opts[:fixture]))
+  else
+    require_relative 'lib/sigma_rest'
+    data = Sigma.request(:get, '/v2/connections?limit=500')
+  end
+  rows = data.is_a?(Hash) ? (data['entries'] || data['connections'] || []) : (data || [])
+  rows.map { |c| norm_conn(c) }.reject { |c| c['connection_id'].to_s.empty? }
+end
+
+resolved = nil
+resolved_via = nil
+
+# (a) explicit flag
+if opts[:conn]
+  unless opts[:conn] =~ UUID_RE
+    warn "[FAIL] intake: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}."
+    exit 2
+  end
+  resolved = { 'connection_id' => opts[:conn], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'flag'
+end
+
+# (b) cached connection.json
+if resolved.nil? && !opts[:force] && File.exist?(conn_path)
+  cached = (JSON.parse(File.read(conn_path)) rescue nil)
+  if cached.is_a?(Hash) && cached['connection_id'].to_s =~ UUID_RE
+    resolved = cached.slice('connection_id', 'name', 'type')
+    resolved_via = 'cache'
+  end
+end
+
+# (c) ENV (loaded from ~/.sigma-migration/env by setup.rb / sigma_rest.rb)
+if resolved.nil? && ENV['SIGMA_CONNECTION_ID'].to_s =~ UUID_RE
+  resolved = { 'connection_id' => ENV['SIGMA_CONNECTION_ID'], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'env'
+end
+
+# (d) list /v2/connections ONCE and pick deterministically
+if resolved.nil?
+  begin
+    conns = list_connections(opts)
+  rescue => e
+    warn "[FAIL] intake: could not list connections — #{e.message}"
+    exit 4
+  end
+  if conns.empty?
+    warn '[FAIL] intake: no Sigma connections found for these credentials.'
+    exit 4
+  end
+  pick = nil
+  if opts[:name]
+    matches = conns.select { |c| c['name'].to_s.downcase.include?(opts[:name].downcase) }
+    pick = matches.first if matches.size == 1
+  end
+  pick ||= conns.first if conns.size == 1
+  if pick
+    resolved = pick
+    resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
+  else
+    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
+    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
+    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
+    exit 3
+  end
+end
+
+resolved['resolved_via'] = resolved_via
+resolved['at'] = Time.now.utc.iso8601
+write_json(conn_path, resolved)
+File.delete(cand_path) if File.exist?(cand_path)   # resolved now; clear stale candidates
+
+# Run metadata for telemetry + audit.
+mode = %w[live file both].include?(opts[:mode]) ? opts[:mode] : 'unknown'
+write_json(intake_path, {
+  'run_start'  => Time.now.utc.iso8601,
+  'input_mode' => mode,
+  'tool'       => opts[:tool],
+  'source'     => opts[:source],
+})
+
+puts "[OK] intake: connection #{resolved['connection_id']} (#{resolved['name'] || '?'}) via #{resolved_via} → #{conn_path}"
+puts "[OK] intake: mode=#{mode}, tool=#{opts[:tool] || '?'} → #{intake_path}"
+case mode
+when 'file'
+  puts '     INPUT MODE = file (raw export, no live source connection). The build runs from the'
+  puts '     export; parity is verified against the live SIGMA WAREHOUSE, not the source tool.'
+when 'both', 'live'
+  puts "     INPUT MODE = #{mode}. Live source available — full source-side parity verification applies."
+else
+  puts '     INPUT MODE = unknown. Pass --mode live|file|both so telemetry + the raw-mode banner are accurate.'
+end
+exit 0

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
@@ -58,13 +58,39 @@ def _write_marker(workdir, record):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
-parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds (auto-derived from intake.json run_start if omitted)')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
-                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+                    help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+
+def _from_intake(workdir):
+    """intake.rb (the front-door step) records run_start + input_mode in
+    intake.json. If --duration / --mode were not passed explicitly, derive them
+    from it so the agent doesn't have to track elapsed time by hand. Returns
+    (duration_seconds_or_None, mode_or_None)."""
+    if not workdir:
+        return None, None
+    try:
+        from datetime import datetime, timezone
+        intake = json.load(open(os.path.join(workdir, 'intake.json')))
+        dur = None
+        if intake.get('run_start'):
+            started = datetime.fromisoformat(intake['run_start'])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            dur = max(0, int((datetime.now(timezone.utc) - started).total_seconds()))
+        return dur, intake.get('input_mode')
+    except Exception:
+        return None, None
+
+
+_intake_dur, _intake_mode = _from_intake(args.workdir)
+duration = args.duration if args.duration else (_intake_dur or 0)
+mode = args.mode if args.mode != 'unknown' else (_intake_mode or 'unknown')
 
 if args.declined:
     print("\nTelemetry declined by user — nothing sent.")
@@ -75,13 +101,13 @@ report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
-    duration_seconds=args.duration,
+    duration_seconds=duration,
     success=not args.failed,
-    mode=args.mode,
+    mode=mode,
 )
 _write_marker(args.workdir, {
     'status': 'sent',
     'tool': args.tool,
     'success': not args.failed,
-    'mode': args.mode,
+    'mode': mode,
 })

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -91,6 +91,20 @@
       ]
     },
     {
+      "canonical": "shared/scripts/intake.rb",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/intake.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/intake.rb",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/intake.rb",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/intake.rb",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/intake.rb",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/intake.rb",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/intake.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/intake.rb",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/intake.rb"
+      ]
+    },
+    {
       "canonical": "shared/scripts/assert-telemetry-ran.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/assert-telemetry-ran.rb",
@@ -266,6 +280,13 @@
       "targets": [
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb",
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-telemetry-gate.rb"
+      ]
+    },
+    {
+      "canonical": "shared/scripts/test-intake.rb",
+      "targets": [
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-intake.rb"
       ]
     }
   ]

--- a/shared/scripts/intake.rb
+++ b/shared/scripts/intake.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# intake.rb — migration front-door. Run this ONCE, first, before discovery.
+#
+# It does the two things every converter otherwise improvises (badly):
+#
+#  1. RESOLVE THE SIGMA CONNECTION ONCE and cache it, so no downstream phase
+#     free-searches /v2/connections (the token sink). Precedence (decision D2 —
+#     config-first, prompt on miss):
+#       a. --connection <UUID>                  explicit flag wins
+#       b. cached <workdir>/connection.json     idempotent re-runs reuse it
+#       c. ENV['SIGMA_CONNECTION_ID']           from ~/.sigma-migration/env (setup.rb)
+#       d. list /v2/connections ONCE:
+#            - exactly one connection            -> auto-pick
+#            - --name SUBSTR uniquely matches     -> auto-pick
+#            - otherwise -> write connection-candidates.json and exit 3 so the
+#              agent ASKS THE USER, then re-runs with --connection <id>.
+#              (We never guess among multiple, and never free-search per phase.)
+#
+#  2. RECORD RUN METADATA to <workdir>/intake.json: run_start (feeds telemetry
+#     duration), input_mode (live|file|both — feeds telemetry --mode), and the
+#     source tool/identifier. Prints an expectations banner for the mode.
+#
+# Usage:
+#   ruby scripts/intake.rb --workdir <dir> --tool tableau-to-sigma --mode live \
+#     [--connection <UUID>] [--name <connection-name-substring>] [--source "<wb name/app id>"]
+#
+# Exit codes:
+#   0  connection resolved (connection.json written) + intake.json written
+#   2  --connection given but not a full UUID
+#   3  connection ambiguous — connection-candidates.json written; ask the user
+#   4  no connections found / API error while listing
+#   1  usage error
+
+require 'json'
+require 'optparse'
+require 'time'
+
+opts = { mode: 'unknown' }
+OptionParser.new do |p|
+  p.on('--workdir DIR')      { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--tool NAME')        { |v| opts[:tool] = v }
+  p.on('--mode MODE', 'live | file | both (input mode)') { |v| opts[:mode] = v }
+  p.on('--connection ID')    { |v| opts[:conn] = v }
+  p.on('--name SUBSTR', 'connection display-name substring to disambiguate') { |v| opts[:name] = v }
+  p.on('--source STR', 'source identifier (workbook name / app id) for the audit record') { |v| opts[:source] = v }
+  p.on('--connections-fixture FILE', 'TEST ONLY: read the connections list from FILE instead of the API') { |v| opts[:fixture] = v }
+  p.on('--force', 'ignore a cached connection.json and re-resolve') { opts[:force] = true }
+end.parse!
+
+abort('[FAIL] intake: --workdir required') unless opts[:dir]
+require 'fileutils'
+FileUtils.mkdir_p(opts[:dir])
+
+UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+conn_path  = File.join(opts[:dir], 'connection.json')
+cand_path  = File.join(opts[:dir], 'connection-candidates.json')
+intake_path = File.join(opts[:dir], 'intake.json')
+
+def write_json(path, obj)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(obj))
+  File.rename(tmp, path)   # atomic — no half-written sidecar reads
+end
+
+# Normalize a connection record from /v2/connections (entries[]) into our shape.
+def norm_conn(c)
+  {
+    'connection_id' => c['connectionId'] || c['id'],
+    'name'          => c['name'] || c['label'],
+    'type'          => c['type'] || c['connectionType'] || c.dig('warehouse', 'type'),
+  }
+end
+
+# Fetch the connection list once (or from a fixture, for tests).
+def list_connections(opts)
+  if opts[:fixture]
+    data = JSON.parse(File.read(opts[:fixture]))
+  else
+    require_relative 'lib/sigma_rest'
+    data = Sigma.request(:get, '/v2/connections?limit=500')
+  end
+  rows = data.is_a?(Hash) ? (data['entries'] || data['connections'] || []) : (data || [])
+  rows.map { |c| norm_conn(c) }.reject { |c| c['connection_id'].to_s.empty? }
+end
+
+resolved = nil
+resolved_via = nil
+
+# (a) explicit flag
+if opts[:conn]
+  unless opts[:conn] =~ UUID_RE
+    warn "[FAIL] intake: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}."
+    exit 2
+  end
+  resolved = { 'connection_id' => opts[:conn], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'flag'
+end
+
+# (b) cached connection.json
+if resolved.nil? && !opts[:force] && File.exist?(conn_path)
+  cached = (JSON.parse(File.read(conn_path)) rescue nil)
+  if cached.is_a?(Hash) && cached['connection_id'].to_s =~ UUID_RE
+    resolved = cached.slice('connection_id', 'name', 'type')
+    resolved_via = 'cache'
+  end
+end
+
+# (c) ENV (loaded from ~/.sigma-migration/env by setup.rb / sigma_rest.rb)
+if resolved.nil? && ENV['SIGMA_CONNECTION_ID'].to_s =~ UUID_RE
+  resolved = { 'connection_id' => ENV['SIGMA_CONNECTION_ID'], 'name' => opts[:name], 'type' => nil }
+  resolved_via = 'env'
+end
+
+# (d) list /v2/connections ONCE and pick deterministically
+if resolved.nil?
+  begin
+    conns = list_connections(opts)
+  rescue => e
+    warn "[FAIL] intake: could not list connections — #{e.message}"
+    exit 4
+  end
+  if conns.empty?
+    warn '[FAIL] intake: no Sigma connections found for these credentials.'
+    exit 4
+  end
+  pick = nil
+  if opts[:name]
+    matches = conns.select { |c| c['name'].to_s.downcase.include?(opts[:name].downcase) }
+    pick = matches.first if matches.size == 1
+  end
+  pick ||= conns.first if conns.size == 1
+  if pick
+    resolved = pick
+    resolved_via = (conns.size == 1 ? 'only-connection' : 'name-match')
+  else
+    write_json(cand_path, { 'count' => conns.size, 'candidates' => conns })
+    warn "[ASK] intake: #{conns.size} connections available — cannot pick safely."
+    warn "      Candidates written to #{cand_path}. Ask the user which to use, then re-run:"
+    warn "        ruby scripts/intake.rb --workdir #{opts[:dir]} --connection <id>"
+    conns.first(10).each { |c| warn "        - #{c['connection_id']}  #{c['name']} (#{c['type']})" }
+    exit 3
+  end
+end
+
+resolved['resolved_via'] = resolved_via
+resolved['at'] = Time.now.utc.iso8601
+write_json(conn_path, resolved)
+File.delete(cand_path) if File.exist?(cand_path)   # resolved now; clear stale candidates
+
+# Run metadata for telemetry + audit.
+mode = %w[live file both].include?(opts[:mode]) ? opts[:mode] : 'unknown'
+write_json(intake_path, {
+  'run_start'  => Time.now.utc.iso8601,
+  'input_mode' => mode,
+  'tool'       => opts[:tool],
+  'source'     => opts[:source],
+})
+
+puts "[OK] intake: connection #{resolved['connection_id']} (#{resolved['name'] || '?'}) via #{resolved_via} → #{conn_path}"
+puts "[OK] intake: mode=#{mode}, tool=#{opts[:tool] || '?'} → #{intake_path}"
+case mode
+when 'file'
+  puts '     INPUT MODE = file (raw export, no live source connection). The build runs from the'
+  puts '     export; parity is verified against the live SIGMA WAREHOUSE, not the source tool.'
+when 'both', 'live'
+  puts "     INPUT MODE = #{mode}. Live source available — full source-side parity verification applies."
+else
+  puts '     INPUT MODE = unknown. Pass --mode live|file|both so telemetry + the raw-mode banner are accurate.'
+end
+exit 0

--- a/shared/scripts/report-telemetry.py
+++ b/shared/scripts/report-telemetry.py
@@ -58,13 +58,39 @@ def _write_marker(workdir, record):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--tool',     required=True, help='Migration skill name, e.g. tableau-to-sigma')
-parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds')
+parser.add_argument('--duration', type=int, default=0, help='Elapsed seconds (auto-derived from intake.json run_start if omitted)')
 parser.add_argument('--failed',   action='store_true', help='Pass if the migration did not reach GREEN')
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
-                    help='Input mode: live (source API), file (raw export only), both, or unknown')
+                    help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
+
+
+def _from_intake(workdir):
+    """intake.rb (the front-door step) records run_start + input_mode in
+    intake.json. If --duration / --mode were not passed explicitly, derive them
+    from it so the agent doesn't have to track elapsed time by hand. Returns
+    (duration_seconds_or_None, mode_or_None)."""
+    if not workdir:
+        return None, None
+    try:
+        from datetime import datetime, timezone
+        intake = json.load(open(os.path.join(workdir, 'intake.json')))
+        dur = None
+        if intake.get('run_start'):
+            started = datetime.fromisoformat(intake['run_start'])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            dur = max(0, int((datetime.now(timezone.utc) - started).total_seconds()))
+        return dur, intake.get('input_mode')
+    except Exception:
+        return None, None
+
+
+_intake_dur, _intake_mode = _from_intake(args.workdir)
+duration = args.duration if args.duration else (_intake_dur or 0)
+mode = args.mode if args.mode != 'unknown' else (_intake_mode or 'unknown')
 
 if args.declined:
     print("\nTelemetry declined by user — nothing sent.")
@@ -75,13 +101,13 @@ report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
-    duration_seconds=args.duration,
+    duration_seconds=duration,
     success=not args.failed,
-    mode=args.mode,
+    mode=mode,
 )
 _write_marker(args.workdir, {
     'status': 'sent',
     'tool': args.tool,
     'success': not args.failed,
-    'mode': args.mode,
+    'mode': mode,
 })

--- a/shared/scripts/test-intake.rb
+++ b/shared/scripts/test-intake.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# test-intake.rb — unit test for the migration front-door (intake.rb): connection
+# resolution precedence + intake.json run metadata. Offline — the /v2/connections
+# listing is exercised via the --connections-fixture test seam, never the network.
+# Canonical in shared/scripts (epic beads-sigma-p5y2). Run: ruby scripts/test-intake.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+INTAKE = File.join(__dir__, 'intake.rb')
+RUBY   = RbConfig.ruby
+UUID   = '11111111-2222-3333-4444-555555555555'
+UUID2  = '66666666-2222-3333-4444-555555555555'
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+def run(dir, *args, env: {})
+  # returns [exit_status, connection_hash_or_nil]
+  base = { 'SIGMA_CONNECTION_ID' => nil }   # neutralize ambient env by default
+  system(base.merge(env), RUBY, INTAKE, '--workdir', dir, *args, out: File::NULL, err: File::NULL)
+  st = $?.exitstatus
+  conn = (JSON.parse(File.read(File.join(dir, 'connection.json'))) rescue nil)
+  [st, conn]
+end
+
+def fixture(dir, *conns)
+  path = File.join(dir, 'fx.json')
+  entries = conns.map { |id, name, type| { 'connectionId' => id, 'name' => name, 'type' => type } }
+  File.write(path, JSON.generate('entries' => entries))
+  path
+end
+
+# 1. explicit UUID wins
+Dir.mktmpdir do |d|
+  st, c = run(d, '--tool', 'tableau-to-sigma', '--mode', 'live', '--connection', UUID)
+  ok('explicit UUID → exit 0', st == 0)
+  ok('explicit UUID cached', c && c['connection_id'] == UUID && c['resolved_via'] == 'flag')
+  intake = JSON.parse(File.read(File.join(d, 'intake.json')))
+  ok('intake.json mode', intake['input_mode'] == 'live')
+  ok('intake.json run_start present', !intake['run_start'].to_s.empty?)
+end
+
+# 2. malformed UUID → exit 2
+Dir.mktmpdir { |d| st, _ = run(d, '--connection', 'nope'); ok('bad UUID → exit 2', st == 2) }
+
+# 3. cached connection.json reused (no flag)
+Dir.mktmpdir do |d|
+  run(d, '--connection', UUID)
+  st, c = run(d, '--mode', 'live')
+  ok('cache reused → exit 0', st == 0)
+  ok('resolved_via cache', c && c['resolved_via'] == 'cache')
+end
+
+# 4. fixture with a single connection → auto-pick
+Dir.mktmpdir do |d|
+  fx = fixture(d, [UUID, 'Snowflake Prod', 'snowflake'])
+  st, c = run(d, '--mode', 'file', '--connections-fixture', fx)
+  ok('single connection auto-picked', st == 0 && c['connection_id'] == UUID && c['resolved_via'] == 'only-connection')
+end
+
+# 5. fixture with multiple → exit 3 + candidates written, no connection.json
+Dir.mktmpdir do |d|
+  fx = fixture(d, [UUID, 'SF', 'snowflake'], [UUID2, 'BQ', 'bigquery'])
+  st, c = run(d, '--connections-fixture', fx)
+  ok('ambiguous → exit 3', st == 3)
+  ok('no connection.json written when ambiguous', c.nil?)
+  ok('candidates file written', File.exist?(File.join(d, 'connection-candidates.json')))
+end
+
+# 6. fixture multiple + unique --name match → auto-pick
+Dir.mktmpdir do |d|
+  fx = fixture(d, [UUID, 'SF', 'snowflake'], [UUID2, 'BigQuery', 'bigquery'])
+  st, c = run(d, '--name', 'bigquery', '--connections-fixture', fx)
+  ok('name-match auto-pick', st == 0 && c['connection_id'] == UUID2 && c['resolved_via'] == 'name-match')
+end
+
+# 7. ENV SIGMA_CONNECTION_ID used when no flag/cache/fixture
+Dir.mktmpdir do |d|
+  st, c = run(d, '--mode', 'both', env: { 'SIGMA_CONNECTION_ID' => UUID })
+  ok('env connection used', st == 0 && c['connection_id'] == UUID && c['resolved_via'] == 'env')
+end
+
+puts $fail.zero? ? "\nall intake tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
**PR 2 of 3** in the migration runtime contract (design: #181, epic `beads-sigma-p5y2`). **Stacked on #182** — base is `feat/completion-gate-telemetry`, so review/merge #182 first; this diff shows only PR 2's changes.

## Problem
Agents burn tokens free-searching `/v2/connections` to find the warehouse connection that backs the data model — re-resolved per phase, every run. And there was no run-start record, so PR 1's telemetry duration had to be hand-tracked.

## Fix — a shared front-door (`intake.rb`), run once, first
- **Resolve the connection ONCE**, config-first precedence (decision **D2**): `--connection` flag → cached `connection.json` → `SIGMA_CONNECTION_ID` env → list `/v2/connections` **once**. A single connection (or a unique `--name` match) auto-picks; otherwise it writes `connection-candidates.json` and **exits 3 so the agent asks the user** — it never guesses among multiple and never re-searches per phase.
- **Records `intake.json`**: `run_start`, `input_mode` (live|file|both), tool. Atomic writes.
- **Closes the telemetry loop (D3)**: `report-telemetry.py` now auto-derives `--duration` (now − run_start) and `--mode` from `intake.json` when omitted. Backward compatible.
- **Orchestrator fallback**: the 4 orchestrators (tableau/powerbi/qlik/quicksight) read `<out>/connection.json` when `--connection` is omitted. Purely additive — unchanged when the flag is passed.
- **SKILL Step 0** documents the front door in all 4 orchestrator-backed skills.

## Tests
`test-intake.rb` — offline, 13 assertions (precedence flag/cache/env, single/name auto-pick, ambiguous→candidates exit 3, `intake.json` fields), via a `--connections-fixture` seam (no network). Wired into `corpus-check.yml`. All governance + telemetry tests still green.

## Deferred to PR 3
Raw-mode warehouse self-verify (the `.twb`-only path) builds on this PR's `mode` detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)