### PR TITLE
feat(raw-mode): warehouse self-verify when source tool is unreachable (PR 3/3)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -104,6 +104,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -103,6 +103,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/assert-telemetry-ran.rb
@@ -57,8 +57,11 @@ end
 
 rec = (JSON.parse(File.read(marker)) rescue nil)
 status = rec.is_a?(Hash) ? rec['status'] : nil
-unless %w[sent declined].include?(status)
-  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+# "skipped" = consent given + send attempted but the endpoint was unreachable
+# (handoff FIX 3). Telemetry must never block, so it still passes — the marker is
+# honest about non-delivery instead of faking "sent".
+unless %w[sent declined skipped].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\", \"declined\", or \"skipped\")."
   warn '       Re-run report-telemetry.py to write a valid marker.'
   exit 12
 end

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/build-parity-plan.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-plan.rb — emit a parity-plan.json (and a normalized wb-readback.json)
+# straight from a built Sigma workbook spec, with NO source-tool views required.
+#
+# Normal Phase 6 (auto-parity-plan.rb) matches each chart to a SOURCE view to get
+# expected values. In raw-mode (only a .twb/.pbix/.qvf, no live source) there are
+# no source views — but verify-warehouse.rb only needs the LIST of visible chart
+# elements + their plotted columns to confirm each evaluates against the warehouse.
+# This helper produces exactly that, so an agent in file-mode does not hand-roll
+# the plan (handoff FIX 1).
+#
+# Usage:
+#   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
+#     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#
+# Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
+#   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
+# element (hidden data-page masters, controls, text/image/containers excluded).
+#
+# Exit codes: 0 = plan written (>=1 chart); 2 = zero chartable elements; 1 = bad invocation.
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--emit-spec PATH')     { |v| opts[:emit] = v }
+end.parse!
+abort 'missing --out' unless opts[:out]
+abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
+
+# Load the spec: from a file if given, else from the live workbook.
+if opts[:spec] && File.exist?(opts[:spec])
+  spec = JSON.parse(File.read(opts[:spec]))
+else
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
+  # /spec may wrap the spec under a key; accept either shape.
+  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+end
+
+# Non-data element kinds we never verify (controls, text, images, containers).
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false        # hidden data-page master
+  (el['columns'] || []).any?
+end
+
+# Plotted channel columns = every columnId the element's channels reference that
+# the element actually owns. Best-effort: if none resolve, leave empty (verify-
+# warehouse then just asserts the element returns non-empty, non-error data).
+def plotted_column_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }.compact.to_set
+  ids = []
+  walk = lambda do |v|
+    case v
+    when Hash
+      v.each do |k, val|
+        next if k == 'columns'                          # skip the column definitions
+        if k == 'columnId' && val.is_a?(String)
+          ids << val
+        elsif k == 'columnIds' && val.is_a?(Array)
+          val.each { |x| ids << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+        else
+          walk.call(val)
+        end
+      end
+    when Array then v.each { |x| walk.call(x) }
+    end
+  end
+  walk.call(el)
+  ids.compact.uniq.select { |i| own.include?(i) }
+end
+
+pages = spec['pages'] || []
+charts = []
+pages.each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless chartable?(el)
+    charts << {
+      'chart'            => (el['name'] || el['title'] || el['id']).to_s,
+      'sigma_element_id' => el['id'],
+      'sigma_kind'       => el['kind'],
+      'sigma_columns'    => plotted_column_ids(el),
+    }
+  end
+end
+
+if charts.empty?
+  warn '[FAIL] build-parity-plan: found zero visible chart elements in the workbook spec.'
+  warn '       (All elements were controls/text/images/containers or hidden masters.)'
+  exit 2
+end
+
+File.write(opts[:out], JSON.pretty_generate('charts' => charts))
+File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+
+puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
+puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]
+charts.first(12).each { |c| puts "    - #{c['chart']} [#{c['sigma_kind']}] #{c['sigma_columns'].size} col(s)" }
+exit 0

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
@@ -51,7 +51,7 @@ def report_migration(
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
-) -> None:
+) -> bool:
     """
     Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
     must never block or fail a migration.
@@ -90,16 +90,60 @@ def report_migration(
         if k != "event":
             print(f"  {k}: {v}")
 
+    body = json.dumps(payload).encode("utf-8")
+    # Returns True on HTTP 2xx, False on any skip/failure. NEVER raises — telemetry
+    # must never block or fail a migration. The caller writes an honest marker
+    # ("sent" vs "skipped") based on this return (handoff FIX 3).
+    return _post(endpoint, body, timeout)
+
+
+def _ssl_context():
+    """Prefer certifi's CA bundle — stock macOS / homebrew-python urllib often
+    fails CERTIFICATE_VERIFY_FAILED against the endpoint where curl succeeds
+    (handoff FIX 4). Fall back to the default context if certifi isn't present."""
     try:
-        body = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            print(f"  → telemetry sent ({resp.status})\n")
+        import ssl
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
     except Exception:
-        # Never surface telemetry errors to the user
-        print("  → telemetry unavailable (skipped)\n")
+        try:
+            import ssl
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def _post(endpoint, body, timeout):
+    # 1) urllib with a certifi-backed SSL context.
+    try:
+        req = urllib.request.Request(
+            endpoint, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        ctx = _ssl_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  → telemetry sent ({resp.status})\n")
+                return True
+            print(f"  → telemetry endpoint returned {resp.status} — skipped\n")
+            return False
+    except Exception as e:
+        first = str(e).splitlines()[0] if str(e) else type(e).__name__
+        # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
+                 "-w", "%{http_code}", "-X", "POST",
+                 "-H", "Content-Type: application/json", "--data-binary", "@-", endpoint],
+                input=body, capture_output=True, timeout=timeout + 5,
+            )
+            code = (r.stdout or b"").decode("ascii", "ignore").strip()
+            if code.startswith("2"):
+                print(f"  → telemetry sent ({code}, via curl)\n")
+                return True
+            print(f"  → telemetry unavailable (urllib: {first}; curl HTTP {code or 'n/a'}) — skipped\n")
+            return False
+        except Exception as e2:
+            print(f"  → telemetry unavailable (urllib: {first}; curl: {str(e2).splitlines()[0]}) — skipped\n")
+            return False

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
@@ -97,7 +97,7 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
-report_migration(
+sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
@@ -105,8 +105,11 @@ report_migration(
     success=not args.failed,
     mode=mode,
 )
+# Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
+# otherwise "skipped" so the audit record never claims a delivery that failed.
+# The gate accepts sent|declined|skipped — telemetry must never block.
 _write_marker(args.workdir, {
-    'status': 'sent',
+    'status': 'sent' if sent else 'skipped',
     'tool': args.tool,
     'success': not args.failed,
     'mode': mode,

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-warehouse.rb
@@ -92,7 +92,17 @@ end
 
 # Verify one element returns real warehouse data: non-empty rows, all plan
 # columns present in the export headers, and at least one non-blank cell.
-def verify_chart(c, el_by_id, wb, timeout, fixture)
+# A cell that is itself a Sigma query-error string is NOT real data — the element
+# rendered "Invalid Query: Unknown…" / "#ERROR". The old has_value check treated
+# these as non-blank and PASSed a visibly-broken workbook (handoff FIX 2).
+ERROR_CELL = /\A\s*(Invalid Query|Error\b|#REF|#ERROR|#VALUE|#NAME)/i
+
+def verify_chart(c, el_by_id, error_element_ids, wb, timeout, fixture)
+  # An element that owns a type=error column (the signal Gate 3 uses) can never
+  # be warehouse-verified — fail it before we even look at the CSV.
+  if error_element_ids.include?(c['sigma_element_id'])
+    return [:fail, 'element owns a type=error column (broken formula — see /columns)']
+  end
   status, payload = element_csv(c, wb, timeout, fixture)
   return [:fail, payload] if status == :fail
   rows = (CSV.parse(payload) rescue [])
@@ -100,6 +110,10 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   headers = rows.shift.map { |h| h.to_s.strip }
   data = rows
   return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # Reject query-error sentinels appearing as cell values.
+  bad = data.flatten.find { |cell| cell.to_s =~ ERROR_CELL }
+  return [:fail, "element returned query-error cells: #{bad.to_s.strip[0, 60]}"] if bad
 
   # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
   # grid is the strongest honest assertion we can make for it.
@@ -118,7 +132,22 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   [:ok, "#{data.size} row(s)"]
 end
 
+# Belt-and-suspenders: the warehouse-verified stamp must never land on a workbook
+# with type=error columns. Fetch /columns ONCE and collect the owning element ids
+# (the same signal assert-phase6 Gate 3 uses). Skipped in fixture/test mode.
+error_element_ids = []
+unless opts[:fixture]
+  begin
+    cols = (Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/columns")['entries'] rescue []) || []
+    error_element_ids = cols.select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['elementId'] }.compact.uniq
+    warn "verify-warehouse: #{error_element_ids.size} element(s) own type=error columns — will fail" unless error_element_ids.empty?
+  rescue => e
+    warn "verify-warehouse: /columns scan unavailable (#{e.message.lines.first.to_s.strip[0, 80]}) — relying on per-cell error detection"
+  end
+end
+
 require 'thread'
+fixture_data = opts[:fixture] && JSON.parse(File.read(opts[:fixture]))
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -127,7 +156,7 @@ Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
   Thread.new do
     loop do
       c = (queue.pop(true) rescue break)
-      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      st, why = verify_chart(c, el_by_id, error_element_ids, opts[:wb], opts[:timeout], fixture_data)
       mutex.synchronize { results[c['chart']] = [st, why] }
     end
   end

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-warehouse.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# verify-warehouse.rb — RAW-MODE parity: verify the built workbook against the
+# LIVE SIGMA WAREHOUSE when the source tool is unreachable.
+#
+# Normal Phase 6 diffs each Sigma element against the SOURCE tool's values
+# (Tableau view CSV, Looker API, …). When a customer hands over only a raw export
+# (.twb/.pbix/.qvf) with no live source, there is nothing to diff against — but
+# the warehouse IS reachable. This script proves the next-best, honest thing:
+# every built element EVALUATES against the live warehouse connection and returns
+# real, column-resolvable, non-empty data (no broken joins, error columns, or
+# empty results — the failure modes that make a raw-file conversion "look done"
+# but be wrong). It does NOT claim the numbers match the source's rendered output
+# — assert-phase6-ran.rb prints a loud banner saying exactly that.
+#
+# It reuses the verified element-CSV export flow (POST /v2/workbooks/{wb}/export →
+# poll GET /v2/query/{q}/download) that collect-parity-actuals.rb uses, through
+# lib/sigma_rest (auto-refresh on 401).
+#
+# Usage:
+#   ruby scripts/verify-warehouse.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --workbook-spec <dir>/wb-readback.json \
+#     --out <dir>/parity-final.json [--pool 5] [--timeout 120]
+#     [--fixture <file>]   # TEST ONLY: {"<element_id>": "<csv text>", ...} instead of the API
+#
+# Exit codes: 0 = all elements returned warehouse data (status PASS written);
+#             2 = one or more elements empty / errored (status FAIL written);
+#             1 = bad invocation.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 5, timeout: 120 }
+OptionParser.new do |p|
+  p.on('--plan PATH')          { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: element_id → CSV text map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+unless opts[:fixture]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+spec = JSON.parse(File.read(opts[:spec]))
+elements = (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+
+# Pull one element's CSV — from the fixture (tests) or the live export API.
+def element_csv(c, wb, timeout, fixture)
+  if fixture
+    txt = fixture[c['sigma_element_id']]
+    return [:fail, 'no fixture row for element'] if txt.nil?
+    return [:ok, txt]
+  end
+  attempts = 0
+  begin
+    attempts += 1
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+    t0 = Time.now
+    loop do
+      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+  rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+    msg = e.message.lines.first.to_s
+    if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+      retry
+    end
+    [:fail, msg[0, 160]]
+  end
+end
+
+# Verify one element returns real warehouse data: non-empty rows, all plan
+# columns present in the export headers, and at least one non-blank cell.
+def verify_chart(c, el_by_id, wb, timeout, fixture)
+  status, payload = element_csv(c, wb, timeout, fixture)
+  return [:fail, payload] if status == :fail
+  rows = (CSV.parse(payload) rescue [])
+  return [:fail, 'export CSV empty / unparseable'] if rows.empty?
+  headers = rows.shift.map { |h| h.to_s.strip }
+  data = rows
+  return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
+  # grid is the strongest honest assertion we can make for it.
+  unless c['sigma_kind'] == 'pivot-table'
+    el = el_by_id[c['sigma_element_id']]
+    if el
+      name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
+      want = (c['sigma_columns'] || []).map { |id| name_for[id] }.compact
+      missing = want.reject { |n| headers.any? { |h| h.casecmp?(n) } }
+      return [:fail, "plotted column(s) absent from export: #{missing.join(', ')}"] unless missing.empty?
+    end
+  end
+
+  has_value = data.any? { |r| r.any? { |cell| !cell.to_s.strip.empty? } }
+  return [:fail, 'all cells blank (element evaluated to nothing)'] unless has_value
+  [:ok, "#{data.size} row(s)"]
+end
+
+require 'thread'
+queue = Queue.new
+charts.each { |c| queue << c }
+results = {}
+mutex = Mutex.new
+Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
+  Thread.new do
+    loop do
+      c = (queue.pop(true) rescue break)
+      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      mutex.synchronize { results[c['chart']] = [st, why] }
+    end
+  end
+end.each(&:join)
+
+passed = results.select { |_, (s, _)| s == :ok }.keys
+failed = results.select { |_, (s, _)| s == :fail }
+total = results.size
+status = (total > 0 && failed.empty?) ? 'PASS' : 'FAIL'
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => 'warehouse',
+  'verified_against' => 'warehouse',
+  'charts_total'     => total,
+  'charts_pass'      => passed.size,
+  'charts_fail'      => failed.size,
+  'pass_names'       => passed,
+  'fail_names'       => failed.keys,
+  'status'           => status,
+  'note'             => 'Raw-mode: each element verified to evaluate against the live Sigma ' \
+                        'warehouse and return data. NOT diffed against the source tool (unreachable).',
+}
+# preserve tile_census if a prior parity-final.json had one (dashboard zone gate)
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue {})
+  summary['tile_census'] = prior['tile_census'] if prior.is_a?(Hash) && prior['tile_census']
+end
+File.write(opts[:out], JSON.pretty_generate(summary))
+
+puts "verify-warehouse: #{passed.size}/#{total} element(s) returned live warehouse data → status=#{status}"
+failed.each { |name, (_, why)| puts "  FAIL  #{name}: #{why}" }
+puts "  → #{opts[:out]} (verified_against=warehouse). assert-phase6-ran.rb will flag this as warehouse-verified."
+exit(status == 'PASS' ? 0 : 2)

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/assert-telemetry-ran.rb
@@ -57,8 +57,11 @@ end
 
 rec = (JSON.parse(File.read(marker)) rescue nil)
 status = rec.is_a?(Hash) ? rec['status'] : nil
-unless %w[sent declined].include?(status)
-  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+# "skipped" = consent given + send attempted but the endpoint was unreachable
+# (handoff FIX 3). Telemetry must never block, so it still passes — the marker is
+# honest about non-delivery instead of faking "sent".
+unless %w[sent declined skipped].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\", \"declined\", or \"skipped\")."
   warn '       Re-run report-telemetry.py to write a valid marker.'
   exit 12
 end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/build-parity-plan.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-plan.rb — emit a parity-plan.json (and a normalized wb-readback.json)
+# straight from a built Sigma workbook spec, with NO source-tool views required.
+#
+# Normal Phase 6 (auto-parity-plan.rb) matches each chart to a SOURCE view to get
+# expected values. In raw-mode (only a .twb/.pbix/.qvf, no live source) there are
+# no source views — but verify-warehouse.rb only needs the LIST of visible chart
+# elements + their plotted columns to confirm each evaluates against the warehouse.
+# This helper produces exactly that, so an agent in file-mode does not hand-roll
+# the plan (handoff FIX 1).
+#
+# Usage:
+#   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
+#     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#
+# Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
+#   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
+# element (hidden data-page masters, controls, text/image/containers excluded).
+#
+# Exit codes: 0 = plan written (>=1 chart); 2 = zero chartable elements; 1 = bad invocation.
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--emit-spec PATH')     { |v| opts[:emit] = v }
+end.parse!
+abort 'missing --out' unless opts[:out]
+abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
+
+# Load the spec: from a file if given, else from the live workbook.
+if opts[:spec] && File.exist?(opts[:spec])
+  spec = JSON.parse(File.read(opts[:spec]))
+else
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
+  # /spec may wrap the spec under a key; accept either shape.
+  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+end
+
+# Non-data element kinds we never verify (controls, text, images, containers).
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false        # hidden data-page master
+  (el['columns'] || []).any?
+end
+
+# Plotted channel columns = every columnId the element's channels reference that
+# the element actually owns. Best-effort: if none resolve, leave empty (verify-
+# warehouse then just asserts the element returns non-empty, non-error data).
+def plotted_column_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }.compact.to_set
+  ids = []
+  walk = lambda do |v|
+    case v
+    when Hash
+      v.each do |k, val|
+        next if k == 'columns'                          # skip the column definitions
+        if k == 'columnId' && val.is_a?(String)
+          ids << val
+        elsif k == 'columnIds' && val.is_a?(Array)
+          val.each { |x| ids << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+        else
+          walk.call(val)
+        end
+      end
+    when Array then v.each { |x| walk.call(x) }
+    end
+  end
+  walk.call(el)
+  ids.compact.uniq.select { |i| own.include?(i) }
+end
+
+pages = spec['pages'] || []
+charts = []
+pages.each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless chartable?(el)
+    charts << {
+      'chart'            => (el['name'] || el['title'] || el['id']).to_s,
+      'sigma_element_id' => el['id'],
+      'sigma_kind'       => el['kind'],
+      'sigma_columns'    => plotted_column_ids(el),
+    }
+  end
+end
+
+if charts.empty?
+  warn '[FAIL] build-parity-plan: found zero visible chart elements in the workbook spec.'
+  warn '       (All elements were controls/text/images/containers or hidden masters.)'
+  exit 2
+end
+
+File.write(opts[:out], JSON.pretty_generate('charts' => charts))
+File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+
+puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
+puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]
+charts.first(12).each { |c| puts "    - #{c['chart']} [#{c['sigma_kind']}] #{c['sigma_columns'].size} col(s)" }
+exit 0

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
@@ -51,7 +51,7 @@ def report_migration(
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
-) -> None:
+) -> bool:
     """
     Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
     must never block or fail a migration.
@@ -90,16 +90,60 @@ def report_migration(
         if k != "event":
             print(f"  {k}: {v}")
 
+    body = json.dumps(payload).encode("utf-8")
+    # Returns True on HTTP 2xx, False on any skip/failure. NEVER raises — telemetry
+    # must never block or fail a migration. The caller writes an honest marker
+    # ("sent" vs "skipped") based on this return (handoff FIX 3).
+    return _post(endpoint, body, timeout)
+
+
+def _ssl_context():
+    """Prefer certifi's CA bundle — stock macOS / homebrew-python urllib often
+    fails CERTIFICATE_VERIFY_FAILED against the endpoint where curl succeeds
+    (handoff FIX 4). Fall back to the default context if certifi isn't present."""
     try:
-        body = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            print(f"  → telemetry sent ({resp.status})\n")
+        import ssl
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
     except Exception:
-        # Never surface telemetry errors to the user
-        print("  → telemetry unavailable (skipped)\n")
+        try:
+            import ssl
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def _post(endpoint, body, timeout):
+    # 1) urllib with a certifi-backed SSL context.
+    try:
+        req = urllib.request.Request(
+            endpoint, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        ctx = _ssl_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  → telemetry sent ({resp.status})\n")
+                return True
+            print(f"  → telemetry endpoint returned {resp.status} — skipped\n")
+            return False
+    except Exception as e:
+        first = str(e).splitlines()[0] if str(e) else type(e).__name__
+        # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
+                 "-w", "%{http_code}", "-X", "POST",
+                 "-H", "Content-Type: application/json", "--data-binary", "@-", endpoint],
+                input=body, capture_output=True, timeout=timeout + 5,
+            )
+            code = (r.stdout or b"").decode("ascii", "ignore").strip()
+            if code.startswith("2"):
+                print(f"  → telemetry sent ({code}, via curl)\n")
+                return True
+            print(f"  → telemetry unavailable (urllib: {first}; curl HTTP {code or 'n/a'}) — skipped\n")
+            return False
+        except Exception as e2:
+            print(f"  → telemetry unavailable (urllib: {first}; curl: {str(e2).splitlines()[0]}) — skipped\n")
+            return False

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
@@ -97,7 +97,7 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
-report_migration(
+sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
@@ -105,8 +105,11 @@ report_migration(
     success=not args.failed,
     mode=mode,
 )
+# Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
+# otherwise "skipped" so the audit record never claims a delivery that failed.
+# The gate accepts sent|declined|skipped — telemetry must never block.
 _write_marker(args.workdir, {
-    'status': 'sent',
+    'status': 'sent' if sent else 'skipped',
     'tool': args.tool,
     'success': not args.failed,
     'mode': mode,

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-warehouse.rb
@@ -92,7 +92,17 @@ end
 
 # Verify one element returns real warehouse data: non-empty rows, all plan
 # columns present in the export headers, and at least one non-blank cell.
-def verify_chart(c, el_by_id, wb, timeout, fixture)
+# A cell that is itself a Sigma query-error string is NOT real data — the element
+# rendered "Invalid Query: Unknown…" / "#ERROR". The old has_value check treated
+# these as non-blank and PASSed a visibly-broken workbook (handoff FIX 2).
+ERROR_CELL = /\A\s*(Invalid Query|Error\b|#REF|#ERROR|#VALUE|#NAME)/i
+
+def verify_chart(c, el_by_id, error_element_ids, wb, timeout, fixture)
+  # An element that owns a type=error column (the signal Gate 3 uses) can never
+  # be warehouse-verified — fail it before we even look at the CSV.
+  if error_element_ids.include?(c['sigma_element_id'])
+    return [:fail, 'element owns a type=error column (broken formula — see /columns)']
+  end
   status, payload = element_csv(c, wb, timeout, fixture)
   return [:fail, payload] if status == :fail
   rows = (CSV.parse(payload) rescue [])
@@ -100,6 +110,10 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   headers = rows.shift.map { |h| h.to_s.strip }
   data = rows
   return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # Reject query-error sentinels appearing as cell values.
+  bad = data.flatten.find { |cell| cell.to_s =~ ERROR_CELL }
+  return [:fail, "element returned query-error cells: #{bad.to_s.strip[0, 60]}"] if bad
 
   # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
   # grid is the strongest honest assertion we can make for it.
@@ -118,7 +132,22 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   [:ok, "#{data.size} row(s)"]
 end
 
+# Belt-and-suspenders: the warehouse-verified stamp must never land on a workbook
+# with type=error columns. Fetch /columns ONCE and collect the owning element ids
+# (the same signal assert-phase6 Gate 3 uses). Skipped in fixture/test mode.
+error_element_ids = []
+unless opts[:fixture]
+  begin
+    cols = (Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/columns")['entries'] rescue []) || []
+    error_element_ids = cols.select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['elementId'] }.compact.uniq
+    warn "verify-warehouse: #{error_element_ids.size} element(s) own type=error columns — will fail" unless error_element_ids.empty?
+  rescue => e
+    warn "verify-warehouse: /columns scan unavailable (#{e.message.lines.first.to_s.strip[0, 80]}) — relying on per-cell error detection"
+  end
+end
+
 require 'thread'
+fixture_data = opts[:fixture] && JSON.parse(File.read(opts[:fixture]))
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -127,7 +156,7 @@ Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
   Thread.new do
     loop do
       c = (queue.pop(true) rescue break)
-      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      st, why = verify_chart(c, el_by_id, error_element_ids, opts[:wb], opts[:timeout], fixture_data)
       mutex.synchronize { results[c['chart']] = [st, why] }
     end
   end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-warehouse.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# verify-warehouse.rb — RAW-MODE parity: verify the built workbook against the
+# LIVE SIGMA WAREHOUSE when the source tool is unreachable.
+#
+# Normal Phase 6 diffs each Sigma element against the SOURCE tool's values
+# (Tableau view CSV, Looker API, …). When a customer hands over only a raw export
+# (.twb/.pbix/.qvf) with no live source, there is nothing to diff against — but
+# the warehouse IS reachable. This script proves the next-best, honest thing:
+# every built element EVALUATES against the live warehouse connection and returns
+# real, column-resolvable, non-empty data (no broken joins, error columns, or
+# empty results — the failure modes that make a raw-file conversion "look done"
+# but be wrong). It does NOT claim the numbers match the source's rendered output
+# — assert-phase6-ran.rb prints a loud banner saying exactly that.
+#
+# It reuses the verified element-CSV export flow (POST /v2/workbooks/{wb}/export →
+# poll GET /v2/query/{q}/download) that collect-parity-actuals.rb uses, through
+# lib/sigma_rest (auto-refresh on 401).
+#
+# Usage:
+#   ruby scripts/verify-warehouse.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --workbook-spec <dir>/wb-readback.json \
+#     --out <dir>/parity-final.json [--pool 5] [--timeout 120]
+#     [--fixture <file>]   # TEST ONLY: {"<element_id>": "<csv text>", ...} instead of the API
+#
+# Exit codes: 0 = all elements returned warehouse data (status PASS written);
+#             2 = one or more elements empty / errored (status FAIL written);
+#             1 = bad invocation.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 5, timeout: 120 }
+OptionParser.new do |p|
+  p.on('--plan PATH')          { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: element_id → CSV text map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+unless opts[:fixture]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+spec = JSON.parse(File.read(opts[:spec]))
+elements = (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+
+# Pull one element's CSV — from the fixture (tests) or the live export API.
+def element_csv(c, wb, timeout, fixture)
+  if fixture
+    txt = fixture[c['sigma_element_id']]
+    return [:fail, 'no fixture row for element'] if txt.nil?
+    return [:ok, txt]
+  end
+  attempts = 0
+  begin
+    attempts += 1
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+    t0 = Time.now
+    loop do
+      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+  rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+    msg = e.message.lines.first.to_s
+    if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+      retry
+    end
+    [:fail, msg[0, 160]]
+  end
+end
+
+# Verify one element returns real warehouse data: non-empty rows, all plan
+# columns present in the export headers, and at least one non-blank cell.
+def verify_chart(c, el_by_id, wb, timeout, fixture)
+  status, payload = element_csv(c, wb, timeout, fixture)
+  return [:fail, payload] if status == :fail
+  rows = (CSV.parse(payload) rescue [])
+  return [:fail, 'export CSV empty / unparseable'] if rows.empty?
+  headers = rows.shift.map { |h| h.to_s.strip }
+  data = rows
+  return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
+  # grid is the strongest honest assertion we can make for it.
+  unless c['sigma_kind'] == 'pivot-table'
+    el = el_by_id[c['sigma_element_id']]
+    if el
+      name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
+      want = (c['sigma_columns'] || []).map { |id| name_for[id] }.compact
+      missing = want.reject { |n| headers.any? { |h| h.casecmp?(n) } }
+      return [:fail, "plotted column(s) absent from export: #{missing.join(', ')}"] unless missing.empty?
+    end
+  end
+
+  has_value = data.any? { |r| r.any? { |cell| !cell.to_s.strip.empty? } }
+  return [:fail, 'all cells blank (element evaluated to nothing)'] unless has_value
+  [:ok, "#{data.size} row(s)"]
+end
+
+require 'thread'
+queue = Queue.new
+charts.each { |c| queue << c }
+results = {}
+mutex = Mutex.new
+Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
+  Thread.new do
+    loop do
+      c = (queue.pop(true) rescue break)
+      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      mutex.synchronize { results[c['chart']] = [st, why] }
+    end
+  end
+end.each(&:join)
+
+passed = results.select { |_, (s, _)| s == :ok }.keys
+failed = results.select { |_, (s, _)| s == :fail }
+total = results.size
+status = (total > 0 && failed.empty?) ? 'PASS' : 'FAIL'
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => 'warehouse',
+  'verified_against' => 'warehouse',
+  'charts_total'     => total,
+  'charts_pass'      => passed.size,
+  'charts_fail'      => failed.size,
+  'pass_names'       => passed,
+  'fail_names'       => failed.keys,
+  'status'           => status,
+  'note'             => 'Raw-mode: each element verified to evaluate against the live Sigma ' \
+                        'warehouse and return data. NOT diffed against the source tool (unreachable).',
+}
+# preserve tile_census if a prior parity-final.json had one (dashboard zone gate)
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue {})
+  summary['tile_census'] = prior['tile_census'] if prior.is_a?(Hash) && prior['tile_census']
+end
+File.write(opts[:out], JSON.pretty_generate(summary))
+
+puts "verify-warehouse: #{passed.size}/#{total} element(s) returned live warehouse data → status=#{status}"
+failed.each { |name, (_, why)| puts "  FAIL  #{name}: #{why}" }
+puts "  → #{opts[:out]} (verified_against=warehouse). assert-phase6-ran.rb will flag this as warehouse-verified."
+exit(status == 'PASS' ? 0 : 2)

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -4,7 +4,11 @@
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
-#      → beads-sigma-4pm
+#      → beads-sigma-4pm. Raw-mode: when the source tool is unreachable,
+#      verify-warehouse.rb writes parity-final.json with
+#      verified_against=warehouse — accepted as PASS but flagged with a loud
+#      banner ("verified vs warehouse, NOT source"). intake.json input_mode=file
+#      without a warehouse-verified parity triggers an advisory WARN.
 #   2. No orphan workbooks left in the customer's My Documents
 #      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
 #      cleanup ran with no failed deletes)  → beads-sigma-38a
@@ -188,6 +192,29 @@ else
          "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
   else
     puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  end
+
+  # Raw-mode honesty banner. When the source tool was unreachable, parity is run
+  # against the live Sigma WAREHOUSE (verify-warehouse.rb) instead of the source —
+  # every element evaluates against real warehouse data, but the values were NOT
+  # diffed against the source tool's rendered output. Surface that loudly so a
+  # warehouse-verified run is never mistaken for source parity.
+  verified_against = summary['verified_against'].to_s
+  if verified_against == 'warehouse'
+    puts '     ┌─────────────────────────────────────────────────────────────────────────┐'
+    puts '     │ VERIFIED AGAINST THE LIVE SIGMA WAREHOUSE — NOT against the source tool.   │'
+    puts '     │ Each element evaluates against real warehouse data; values were NOT diffed │'
+    puts '     │ vs the source (it was unreachable). State this in the migration report.    │'
+    puts '     └─────────────────────────────────────────────────────────────────────────┘'
+  else
+    # Advisory only: if intake recorded file-mode (no live source) but parity was
+    # not warehouse-verified, the run may be over-claiming source parity.
+    intake = (JSON.parse(File.read(File.join(opts[:tab], 'intake.json'))) rescue nil)
+    if intake.is_a?(Hash) && intake['input_mode'].to_s == 'file'
+      warn '[WARN] gate 1: intake.json records input_mode=file (no live source) but parity-final.json is'
+      warn '       not marked verified_against=warehouse. In raw-mode, verify against the warehouse'
+      warn '       (ruby scripts/verify-warehouse.rb) so the result is not mistaken for source parity.'
+    end
   end
 end
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-telemetry-ran.rb
@@ -57,8 +57,11 @@ end
 
 rec = (JSON.parse(File.read(marker)) rescue nil)
 status = rec.is_a?(Hash) ? rec['status'] : nil
-unless %w[sent declined].include?(status)
-  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+# "skipped" = consent given + send attempted but the endpoint was unreachable
+# (handoff FIX 3). Telemetry must never block, so it still passes — the marker is
+# honest about non-delivery instead of faking "sent".
+unless %w[sent declined skipped].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\", \"declined\", or \"skipped\")."
   warn '       Re-run report-telemetry.py to write a valid marker.'
   exit 12
 end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build-parity-plan.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-plan.rb — emit a parity-plan.json (and a normalized wb-readback.json)
+# straight from a built Sigma workbook spec, with NO source-tool views required.
+#
+# Normal Phase 6 (auto-parity-plan.rb) matches each chart to a SOURCE view to get
+# expected values. In raw-mode (only a .twb/.pbix/.qvf, no live source) there are
+# no source views — but verify-warehouse.rb only needs the LIST of visible chart
+# elements + their plotted columns to confirm each evaluates against the warehouse.
+# This helper produces exactly that, so an agent in file-mode does not hand-roll
+# the plan (handoff FIX 1).
+#
+# Usage:
+#   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
+#     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#
+# Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
+#   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
+# element (hidden data-page masters, controls, text/image/containers excluded).
+#
+# Exit codes: 0 = plan written (>=1 chart); 2 = zero chartable elements; 1 = bad invocation.
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--emit-spec PATH')     { |v| opts[:emit] = v }
+end.parse!
+abort 'missing --out' unless opts[:out]
+abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
+
+# Load the spec: from a file if given, else from the live workbook.
+if opts[:spec] && File.exist?(opts[:spec])
+  spec = JSON.parse(File.read(opts[:spec]))
+else
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
+  # /spec may wrap the spec under a key; accept either shape.
+  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+end
+
+# Non-data element kinds we never verify (controls, text, images, containers).
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false        # hidden data-page master
+  (el['columns'] || []).any?
+end
+
+# Plotted channel columns = every columnId the element's channels reference that
+# the element actually owns. Best-effort: if none resolve, leave empty (verify-
+# warehouse then just asserts the element returns non-empty, non-error data).
+def plotted_column_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }.compact.to_set
+  ids = []
+  walk = lambda do |v|
+    case v
+    when Hash
+      v.each do |k, val|
+        next if k == 'columns'                          # skip the column definitions
+        if k == 'columnId' && val.is_a?(String)
+          ids << val
+        elsif k == 'columnIds' && val.is_a?(Array)
+          val.each { |x| ids << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+        else
+          walk.call(val)
+        end
+      end
+    when Array then v.each { |x| walk.call(x) }
+    end
+  end
+  walk.call(el)
+  ids.compact.uniq.select { |i| own.include?(i) }
+end
+
+pages = spec['pages'] || []
+charts = []
+pages.each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless chartable?(el)
+    charts << {
+      'chart'            => (el['name'] || el['title'] || el['id']).to_s,
+      'sigma_element_id' => el['id'],
+      'sigma_kind'       => el['kind'],
+      'sigma_columns'    => plotted_column_ids(el),
+    }
+  end
+end
+
+if charts.empty?
+  warn '[FAIL] build-parity-plan: found zero visible chart elements in the workbook spec.'
+  warn '       (All elements were controls/text/images/containers or hidden masters.)'
+  exit 2
+end
+
+File.write(opts[:out], JSON.pretty_generate('charts' => charts))
+File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+
+puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
+puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]
+charts.first(12).each { |c| puts "    - #{c['chart']} [#{c['sigma_kind']}] #{c['sigma_columns'].size} col(s)" }
+exit 0

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
@@ -51,7 +51,7 @@ def report_migration(
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
-) -> None:
+) -> bool:
     """
     Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
     must never block or fail a migration.
@@ -90,16 +90,60 @@ def report_migration(
         if k != "event":
             print(f"  {k}: {v}")
 
+    body = json.dumps(payload).encode("utf-8")
+    # Returns True on HTTP 2xx, False on any skip/failure. NEVER raises — telemetry
+    # must never block or fail a migration. The caller writes an honest marker
+    # ("sent" vs "skipped") based on this return (handoff FIX 3).
+    return _post(endpoint, body, timeout)
+
+
+def _ssl_context():
+    """Prefer certifi's CA bundle — stock macOS / homebrew-python urllib often
+    fails CERTIFICATE_VERIFY_FAILED against the endpoint where curl succeeds
+    (handoff FIX 4). Fall back to the default context if certifi isn't present."""
     try:
-        body = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            print(f"  → telemetry sent ({resp.status})\n")
+        import ssl
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
     except Exception:
-        # Never surface telemetry errors to the user
-        print("  → telemetry unavailable (skipped)\n")
+        try:
+            import ssl
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def _post(endpoint, body, timeout):
+    # 1) urllib with a certifi-backed SSL context.
+    try:
+        req = urllib.request.Request(
+            endpoint, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        ctx = _ssl_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  → telemetry sent ({resp.status})\n")
+                return True
+            print(f"  → telemetry endpoint returned {resp.status} — skipped\n")
+            return False
+    except Exception as e:
+        first = str(e).splitlines()[0] if str(e) else type(e).__name__
+        # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
+                 "-w", "%{http_code}", "-X", "POST",
+                 "-H", "Content-Type: application/json", "--data-binary", "@-", endpoint],
+                input=body, capture_output=True, timeout=timeout + 5,
+            )
+            code = (r.stdout or b"").decode("ascii", "ignore").strip()
+            if code.startswith("2"):
+                print(f"  → telemetry sent ({code}, via curl)\n")
+                return True
+            print(f"  → telemetry unavailable (urllib: {first}; curl HTTP {code or 'n/a'}) — skipped\n")
+            return False
+        except Exception as e2:
+            print(f"  → telemetry unavailable (urllib: {first}; curl: {str(e2).splitlines()[0]}) — skipped\n")
+            return False

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
@@ -97,7 +97,7 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
-report_migration(
+sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
@@ -105,8 +105,11 @@ report_migration(
     success=not args.failed,
     mode=mode,
 )
+# Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
+# otherwise "skipped" so the audit record never claims a delivery that failed.
+# The gate accepts sent|declined|skipped — telemetry must never block.
 _write_marker(args.workdir, {
-    'status': 'sent',
+    'status': 'sent' if sent else 'skipped',
     'tool': args.tool,
     'success': not args.failed,
     'mode': mode,

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-warehouse.rb
@@ -92,7 +92,17 @@ end
 
 # Verify one element returns real warehouse data: non-empty rows, all plan
 # columns present in the export headers, and at least one non-blank cell.
-def verify_chart(c, el_by_id, wb, timeout, fixture)
+# A cell that is itself a Sigma query-error string is NOT real data — the element
+# rendered "Invalid Query: Unknown…" / "#ERROR". The old has_value check treated
+# these as non-blank and PASSed a visibly-broken workbook (handoff FIX 2).
+ERROR_CELL = /\A\s*(Invalid Query|Error\b|#REF|#ERROR|#VALUE|#NAME)/i
+
+def verify_chart(c, el_by_id, error_element_ids, wb, timeout, fixture)
+  # An element that owns a type=error column (the signal Gate 3 uses) can never
+  # be warehouse-verified — fail it before we even look at the CSV.
+  if error_element_ids.include?(c['sigma_element_id'])
+    return [:fail, 'element owns a type=error column (broken formula — see /columns)']
+  end
   status, payload = element_csv(c, wb, timeout, fixture)
   return [:fail, payload] if status == :fail
   rows = (CSV.parse(payload) rescue [])
@@ -100,6 +110,10 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   headers = rows.shift.map { |h| h.to_s.strip }
   data = rows
   return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # Reject query-error sentinels appearing as cell values.
+  bad = data.flatten.find { |cell| cell.to_s =~ ERROR_CELL }
+  return [:fail, "element returned query-error cells: #{bad.to_s.strip[0, 60]}"] if bad
 
   # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
   # grid is the strongest honest assertion we can make for it.
@@ -118,7 +132,22 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   [:ok, "#{data.size} row(s)"]
 end
 
+# Belt-and-suspenders: the warehouse-verified stamp must never land on a workbook
+# with type=error columns. Fetch /columns ONCE and collect the owning element ids
+# (the same signal assert-phase6 Gate 3 uses). Skipped in fixture/test mode.
+error_element_ids = []
+unless opts[:fixture]
+  begin
+    cols = (Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/columns")['entries'] rescue []) || []
+    error_element_ids = cols.select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['elementId'] }.compact.uniq
+    warn "verify-warehouse: #{error_element_ids.size} element(s) own type=error columns — will fail" unless error_element_ids.empty?
+  rescue => e
+    warn "verify-warehouse: /columns scan unavailable (#{e.message.lines.first.to_s.strip[0, 80]}) — relying on per-cell error detection"
+  end
+end
+
 require 'thread'
+fixture_data = opts[:fixture] && JSON.parse(File.read(opts[:fixture]))
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -127,7 +156,7 @@ Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
   Thread.new do
     loop do
       c = (queue.pop(true) rescue break)
-      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      st, why = verify_chart(c, el_by_id, error_element_ids, opts[:wb], opts[:timeout], fixture_data)
       mutex.synchronize { results[c['chart']] = [st, why] }
     end
   end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-warehouse.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# verify-warehouse.rb — RAW-MODE parity: verify the built workbook against the
+# LIVE SIGMA WAREHOUSE when the source tool is unreachable.
+#
+# Normal Phase 6 diffs each Sigma element against the SOURCE tool's values
+# (Tableau view CSV, Looker API, …). When a customer hands over only a raw export
+# (.twb/.pbix/.qvf) with no live source, there is nothing to diff against — but
+# the warehouse IS reachable. This script proves the next-best, honest thing:
+# every built element EVALUATES against the live warehouse connection and returns
+# real, column-resolvable, non-empty data (no broken joins, error columns, or
+# empty results — the failure modes that make a raw-file conversion "look done"
+# but be wrong). It does NOT claim the numbers match the source's rendered output
+# — assert-phase6-ran.rb prints a loud banner saying exactly that.
+#
+# It reuses the verified element-CSV export flow (POST /v2/workbooks/{wb}/export →
+# poll GET /v2/query/{q}/download) that collect-parity-actuals.rb uses, through
+# lib/sigma_rest (auto-refresh on 401).
+#
+# Usage:
+#   ruby scripts/verify-warehouse.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --workbook-spec <dir>/wb-readback.json \
+#     --out <dir>/parity-final.json [--pool 5] [--timeout 120]
+#     [--fixture <file>]   # TEST ONLY: {"<element_id>": "<csv text>", ...} instead of the API
+#
+# Exit codes: 0 = all elements returned warehouse data (status PASS written);
+#             2 = one or more elements empty / errored (status FAIL written);
+#             1 = bad invocation.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 5, timeout: 120 }
+OptionParser.new do |p|
+  p.on('--plan PATH')          { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: element_id → CSV text map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+unless opts[:fixture]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+spec = JSON.parse(File.read(opts[:spec]))
+elements = (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+
+# Pull one element's CSV — from the fixture (tests) or the live export API.
+def element_csv(c, wb, timeout, fixture)
+  if fixture
+    txt = fixture[c['sigma_element_id']]
+    return [:fail, 'no fixture row for element'] if txt.nil?
+    return [:ok, txt]
+  end
+  attempts = 0
+  begin
+    attempts += 1
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+    t0 = Time.now
+    loop do
+      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+  rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+    msg = e.message.lines.first.to_s
+    if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+      retry
+    end
+    [:fail, msg[0, 160]]
+  end
+end
+
+# Verify one element returns real warehouse data: non-empty rows, all plan
+# columns present in the export headers, and at least one non-blank cell.
+def verify_chart(c, el_by_id, wb, timeout, fixture)
+  status, payload = element_csv(c, wb, timeout, fixture)
+  return [:fail, payload] if status == :fail
+  rows = (CSV.parse(payload) rescue [])
+  return [:fail, 'export CSV empty / unparseable'] if rows.empty?
+  headers = rows.shift.map { |h| h.to_s.strip }
+  data = rows
+  return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
+  # grid is the strongest honest assertion we can make for it.
+  unless c['sigma_kind'] == 'pivot-table'
+    el = el_by_id[c['sigma_element_id']]
+    if el
+      name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
+      want = (c['sigma_columns'] || []).map { |id| name_for[id] }.compact
+      missing = want.reject { |n| headers.any? { |h| h.casecmp?(n) } }
+      return [:fail, "plotted column(s) absent from export: #{missing.join(', ')}"] unless missing.empty?
+    end
+  end
+
+  has_value = data.any? { |r| r.any? { |cell| !cell.to_s.strip.empty? } }
+  return [:fail, 'all cells blank (element evaluated to nothing)'] unless has_value
+  [:ok, "#{data.size} row(s)"]
+end
+
+require 'thread'
+queue = Queue.new
+charts.each { |c| queue << c }
+results = {}
+mutex = Mutex.new
+Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
+  Thread.new do
+    loop do
+      c = (queue.pop(true) rescue break)
+      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      mutex.synchronize { results[c['chart']] = [st, why] }
+    end
+  end
+end.each(&:join)
+
+passed = results.select { |_, (s, _)| s == :ok }.keys
+failed = results.select { |_, (s, _)| s == :fail }
+total = results.size
+status = (total > 0 && failed.empty?) ? 'PASS' : 'FAIL'
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => 'warehouse',
+  'verified_against' => 'warehouse',
+  'charts_total'     => total,
+  'charts_pass'      => passed.size,
+  'charts_fail'      => failed.size,
+  'pass_names'       => passed,
+  'fail_names'       => failed.keys,
+  'status'           => status,
+  'note'             => 'Raw-mode: each element verified to evaluate against the live Sigma ' \
+                        'warehouse and return data. NOT diffed against the source tool (unreachable).',
+}
+# preserve tile_census if a prior parity-final.json had one (dashboard zone gate)
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue {})
+  summary['tile_census'] = prior['tile_census'] if prior.is_a?(Hash) && prior['tile_census']
+end
+File.write(opts[:out], JSON.pretty_generate(summary))
+
+puts "verify-warehouse: #{passed.size}/#{total} element(s) returned live warehouse data → status=#{status}"
+failed.each { |name, (_, why)| puts "  FAIL  #{name}: #{why}" }
+puts "  → #{opts[:out]} (verified_against=warehouse). assert-phase6-ran.rb will flag this as warehouse-verified."
+exit(status == 'PASS' ? 0 : 2)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -4,7 +4,11 @@
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
-#      → beads-sigma-4pm
+#      → beads-sigma-4pm. Raw-mode: when the source tool is unreachable,
+#      verify-warehouse.rb writes parity-final.json with
+#      verified_against=warehouse — accepted as PASS but flagged with a loud
+#      banner ("verified vs warehouse, NOT source"). intake.json input_mode=file
+#      without a warehouse-verified parity triggers an advisory WARN.
 #   2. No orphan workbooks left in the customer's My Documents
 #      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
 #      cleanup ran with no failed deletes)  → beads-sigma-38a
@@ -188,6 +192,29 @@ else
          "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
   else
     puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  end
+
+  # Raw-mode honesty banner. When the source tool was unreachable, parity is run
+  # against the live Sigma WAREHOUSE (verify-warehouse.rb) instead of the source —
+  # every element evaluates against real warehouse data, but the values were NOT
+  # diffed against the source tool's rendered output. Surface that loudly so a
+  # warehouse-verified run is never mistaken for source parity.
+  verified_against = summary['verified_against'].to_s
+  if verified_against == 'warehouse'
+    puts '     ┌─────────────────────────────────────────────────────────────────────────┐'
+    puts '     │ VERIFIED AGAINST THE LIVE SIGMA WAREHOUSE — NOT against the source tool.   │'
+    puts '     │ Each element evaluates against real warehouse data; values were NOT diffed │'
+    puts '     │ vs the source (it was unreachable). State this in the migration report.    │'
+    puts '     └─────────────────────────────────────────────────────────────────────────┘'
+  else
+    # Advisory only: if intake recorded file-mode (no live source) but parity was
+    # not warehouse-verified, the run may be over-claiming source parity.
+    intake = (JSON.parse(File.read(File.join(opts[:tab], 'intake.json'))) rescue nil)
+    if intake.is_a?(Hash) && intake['input_mode'].to_s == 'file'
+      warn '[WARN] gate 1: intake.json records input_mode=file (no live source) but parity-final.json is'
+      warn '       not marked verified_against=warehouse. In raw-mode, verify against the warehouse'
+      warn '       (ruby scripts/verify-warehouse.rb) so the result is not mistaken for source parity.'
+    end
   end
 end
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-telemetry-ran.rb
@@ -57,8 +57,11 @@ end
 
 rec = (JSON.parse(File.read(marker)) rescue nil)
 status = rec.is_a?(Hash) ? rec['status'] : nil
-unless %w[sent declined].include?(status)
-  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+# "skipped" = consent given + send attempted but the endpoint was unreachable
+# (handoff FIX 3). Telemetry must never block, so it still passes — the marker is
+# honest about non-delivery instead of faking "sent".
+unless %w[sent declined skipped].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\", \"declined\", or \"skipped\")."
   warn '       Re-run report-telemetry.py to write a valid marker.'
   exit 12
 end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/build-parity-plan.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-plan.rb — emit a parity-plan.json (and a normalized wb-readback.json)
+# straight from a built Sigma workbook spec, with NO source-tool views required.
+#
+# Normal Phase 6 (auto-parity-plan.rb) matches each chart to a SOURCE view to get
+# expected values. In raw-mode (only a .twb/.pbix/.qvf, no live source) there are
+# no source views — but verify-warehouse.rb only needs the LIST of visible chart
+# elements + their plotted columns to confirm each evaluates against the warehouse.
+# This helper produces exactly that, so an agent in file-mode does not hand-roll
+# the plan (handoff FIX 1).
+#
+# Usage:
+#   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
+#     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#
+# Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
+#   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
+# element (hidden data-page masters, controls, text/image/containers excluded).
+#
+# Exit codes: 0 = plan written (>=1 chart); 2 = zero chartable elements; 1 = bad invocation.
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--emit-spec PATH')     { |v| opts[:emit] = v }
+end.parse!
+abort 'missing --out' unless opts[:out]
+abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
+
+# Load the spec: from a file if given, else from the live workbook.
+if opts[:spec] && File.exist?(opts[:spec])
+  spec = JSON.parse(File.read(opts[:spec]))
+else
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
+  # /spec may wrap the spec under a key; accept either shape.
+  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+end
+
+# Non-data element kinds we never verify (controls, text, images, containers).
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false        # hidden data-page master
+  (el['columns'] || []).any?
+end
+
+# Plotted channel columns = every columnId the element's channels reference that
+# the element actually owns. Best-effort: if none resolve, leave empty (verify-
+# warehouse then just asserts the element returns non-empty, non-error data).
+def plotted_column_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }.compact.to_set
+  ids = []
+  walk = lambda do |v|
+    case v
+    when Hash
+      v.each do |k, val|
+        next if k == 'columns'                          # skip the column definitions
+        if k == 'columnId' && val.is_a?(String)
+          ids << val
+        elsif k == 'columnIds' && val.is_a?(Array)
+          val.each { |x| ids << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+        else
+          walk.call(val)
+        end
+      end
+    when Array then v.each { |x| walk.call(x) }
+    end
+  end
+  walk.call(el)
+  ids.compact.uniq.select { |i| own.include?(i) }
+end
+
+pages = spec['pages'] || []
+charts = []
+pages.each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless chartable?(el)
+    charts << {
+      'chart'            => (el['name'] || el['title'] || el['id']).to_s,
+      'sigma_element_id' => el['id'],
+      'sigma_kind'       => el['kind'],
+      'sigma_columns'    => plotted_column_ids(el),
+    }
+  end
+end
+
+if charts.empty?
+  warn '[FAIL] build-parity-plan: found zero visible chart elements in the workbook spec.'
+  warn '       (All elements were controls/text/images/containers or hidden masters.)'
+  exit 2
+end
+
+File.write(opts[:out], JSON.pretty_generate('charts' => charts))
+File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+
+puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
+puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]
+charts.first(12).each { |c| puts "    - #{c['chart']} [#{c['sigma_kind']}] #{c['sigma_columns'].size} col(s)" }
+exit 0

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
@@ -51,7 +51,7 @@ def report_migration(
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
-) -> None:
+) -> bool:
     """
     Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
     must never block or fail a migration.
@@ -90,16 +90,60 @@ def report_migration(
         if k != "event":
             print(f"  {k}: {v}")
 
+    body = json.dumps(payload).encode("utf-8")
+    # Returns True on HTTP 2xx, False on any skip/failure. NEVER raises — telemetry
+    # must never block or fail a migration. The caller writes an honest marker
+    # ("sent" vs "skipped") based on this return (handoff FIX 3).
+    return _post(endpoint, body, timeout)
+
+
+def _ssl_context():
+    """Prefer certifi's CA bundle — stock macOS / homebrew-python urllib often
+    fails CERTIFICATE_VERIFY_FAILED against the endpoint where curl succeeds
+    (handoff FIX 4). Fall back to the default context if certifi isn't present."""
     try:
-        body = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            print(f"  → telemetry sent ({resp.status})\n")
+        import ssl
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
     except Exception:
-        # Never surface telemetry errors to the user
-        print("  → telemetry unavailable (skipped)\n")
+        try:
+            import ssl
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def _post(endpoint, body, timeout):
+    # 1) urllib with a certifi-backed SSL context.
+    try:
+        req = urllib.request.Request(
+            endpoint, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        ctx = _ssl_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  → telemetry sent ({resp.status})\n")
+                return True
+            print(f"  → telemetry endpoint returned {resp.status} — skipped\n")
+            return False
+    except Exception as e:
+        first = str(e).splitlines()[0] if str(e) else type(e).__name__
+        # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
+                 "-w", "%{http_code}", "-X", "POST",
+                 "-H", "Content-Type: application/json", "--data-binary", "@-", endpoint],
+                input=body, capture_output=True, timeout=timeout + 5,
+            )
+            code = (r.stdout or b"").decode("ascii", "ignore").strip()
+            if code.startswith("2"):
+                print(f"  → telemetry sent ({code}, via curl)\n")
+                return True
+            print(f"  → telemetry unavailable (urllib: {first}; curl HTTP {code or 'n/a'}) — skipped\n")
+            return False
+        except Exception as e2:
+            print(f"  → telemetry unavailable (urllib: {first}; curl: {str(e2).splitlines()[0]}) — skipped\n")
+            return False

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
@@ -97,7 +97,7 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
-report_migration(
+sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
@@ -105,8 +105,11 @@ report_migration(
     success=not args.failed,
     mode=mode,
 )
+# Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
+# otherwise "skipped" so the audit record never claims a delivery that failed.
+# The gate accepts sent|declined|skipped — telemetry must never block.
 _write_marker(args.workdir, {
-    'status': 'sent',
+    'status': 'sent' if sent else 'skipped',
     'tool': args.tool,
     'success': not args.failed,
     'mode': mode,

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-warehouse.rb
@@ -92,7 +92,17 @@ end
 
 # Verify one element returns real warehouse data: non-empty rows, all plan
 # columns present in the export headers, and at least one non-blank cell.
-def verify_chart(c, el_by_id, wb, timeout, fixture)
+# A cell that is itself a Sigma query-error string is NOT real data — the element
+# rendered "Invalid Query: Unknown…" / "#ERROR". The old has_value check treated
+# these as non-blank and PASSed a visibly-broken workbook (handoff FIX 2).
+ERROR_CELL = /\A\s*(Invalid Query|Error\b|#REF|#ERROR|#VALUE|#NAME)/i
+
+def verify_chart(c, el_by_id, error_element_ids, wb, timeout, fixture)
+  # An element that owns a type=error column (the signal Gate 3 uses) can never
+  # be warehouse-verified — fail it before we even look at the CSV.
+  if error_element_ids.include?(c['sigma_element_id'])
+    return [:fail, 'element owns a type=error column (broken formula — see /columns)']
+  end
   status, payload = element_csv(c, wb, timeout, fixture)
   return [:fail, payload] if status == :fail
   rows = (CSV.parse(payload) rescue [])
@@ -100,6 +110,10 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   headers = rows.shift.map { |h| h.to_s.strip }
   data = rows
   return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # Reject query-error sentinels appearing as cell values.
+  bad = data.flatten.find { |cell| cell.to_s =~ ERROR_CELL }
+  return [:fail, "element returned query-error cells: #{bad.to_s.strip[0, 60]}"] if bad
 
   # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
   # grid is the strongest honest assertion we can make for it.
@@ -118,7 +132,22 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   [:ok, "#{data.size} row(s)"]
 end
 
+# Belt-and-suspenders: the warehouse-verified stamp must never land on a workbook
+# with type=error columns. Fetch /columns ONCE and collect the owning element ids
+# (the same signal assert-phase6 Gate 3 uses). Skipped in fixture/test mode.
+error_element_ids = []
+unless opts[:fixture]
+  begin
+    cols = (Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/columns")['entries'] rescue []) || []
+    error_element_ids = cols.select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['elementId'] }.compact.uniq
+    warn "verify-warehouse: #{error_element_ids.size} element(s) own type=error columns — will fail" unless error_element_ids.empty?
+  rescue => e
+    warn "verify-warehouse: /columns scan unavailable (#{e.message.lines.first.to_s.strip[0, 80]}) — relying on per-cell error detection"
+  end
+end
+
 require 'thread'
+fixture_data = opts[:fixture] && JSON.parse(File.read(opts[:fixture]))
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -127,7 +156,7 @@ Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
   Thread.new do
     loop do
       c = (queue.pop(true) rescue break)
-      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      st, why = verify_chart(c, el_by_id, error_element_ids, opts[:wb], opts[:timeout], fixture_data)
       mutex.synchronize { results[c['chart']] = [st, why] }
     end
   end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-warehouse.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# verify-warehouse.rb — RAW-MODE parity: verify the built workbook against the
+# LIVE SIGMA WAREHOUSE when the source tool is unreachable.
+#
+# Normal Phase 6 diffs each Sigma element against the SOURCE tool's values
+# (Tableau view CSV, Looker API, …). When a customer hands over only a raw export
+# (.twb/.pbix/.qvf) with no live source, there is nothing to diff against — but
+# the warehouse IS reachable. This script proves the next-best, honest thing:
+# every built element EVALUATES against the live warehouse connection and returns
+# real, column-resolvable, non-empty data (no broken joins, error columns, or
+# empty results — the failure modes that make a raw-file conversion "look done"
+# but be wrong). It does NOT claim the numbers match the source's rendered output
+# — assert-phase6-ran.rb prints a loud banner saying exactly that.
+#
+# It reuses the verified element-CSV export flow (POST /v2/workbooks/{wb}/export →
+# poll GET /v2/query/{q}/download) that collect-parity-actuals.rb uses, through
+# lib/sigma_rest (auto-refresh on 401).
+#
+# Usage:
+#   ruby scripts/verify-warehouse.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --workbook-spec <dir>/wb-readback.json \
+#     --out <dir>/parity-final.json [--pool 5] [--timeout 120]
+#     [--fixture <file>]   # TEST ONLY: {"<element_id>": "<csv text>", ...} instead of the API
+#
+# Exit codes: 0 = all elements returned warehouse data (status PASS written);
+#             2 = one or more elements empty / errored (status FAIL written);
+#             1 = bad invocation.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 5, timeout: 120 }
+OptionParser.new do |p|
+  p.on('--plan PATH')          { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: element_id → CSV text map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+unless opts[:fixture]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+spec = JSON.parse(File.read(opts[:spec]))
+elements = (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+
+# Pull one element's CSV — from the fixture (tests) or the live export API.
+def element_csv(c, wb, timeout, fixture)
+  if fixture
+    txt = fixture[c['sigma_element_id']]
+    return [:fail, 'no fixture row for element'] if txt.nil?
+    return [:ok, txt]
+  end
+  attempts = 0
+  begin
+    attempts += 1
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+    t0 = Time.now
+    loop do
+      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+  rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+    msg = e.message.lines.first.to_s
+    if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+      retry
+    end
+    [:fail, msg[0, 160]]
+  end
+end
+
+# Verify one element returns real warehouse data: non-empty rows, all plan
+# columns present in the export headers, and at least one non-blank cell.
+def verify_chart(c, el_by_id, wb, timeout, fixture)
+  status, payload = element_csv(c, wb, timeout, fixture)
+  return [:fail, payload] if status == :fail
+  rows = (CSV.parse(payload) rescue [])
+  return [:fail, 'export CSV empty / unparseable'] if rows.empty?
+  headers = rows.shift.map { |h| h.to_s.strip }
+  data = rows
+  return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
+  # grid is the strongest honest assertion we can make for it.
+  unless c['sigma_kind'] == 'pivot-table'
+    el = el_by_id[c['sigma_element_id']]
+    if el
+      name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
+      want = (c['sigma_columns'] || []).map { |id| name_for[id] }.compact
+      missing = want.reject { |n| headers.any? { |h| h.casecmp?(n) } }
+      return [:fail, "plotted column(s) absent from export: #{missing.join(', ')}"] unless missing.empty?
+    end
+  end
+
+  has_value = data.any? { |r| r.any? { |cell| !cell.to_s.strip.empty? } }
+  return [:fail, 'all cells blank (element evaluated to nothing)'] unless has_value
+  [:ok, "#{data.size} row(s)"]
+end
+
+require 'thread'
+queue = Queue.new
+charts.each { |c| queue << c }
+results = {}
+mutex = Mutex.new
+Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
+  Thread.new do
+    loop do
+      c = (queue.pop(true) rescue break)
+      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      mutex.synchronize { results[c['chart']] = [st, why] }
+    end
+  end
+end.each(&:join)
+
+passed = results.select { |_, (s, _)| s == :ok }.keys
+failed = results.select { |_, (s, _)| s == :fail }
+total = results.size
+status = (total > 0 && failed.empty?) ? 'PASS' : 'FAIL'
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => 'warehouse',
+  'verified_against' => 'warehouse',
+  'charts_total'     => total,
+  'charts_pass'      => passed.size,
+  'charts_fail'      => failed.size,
+  'pass_names'       => passed,
+  'fail_names'       => failed.keys,
+  'status'           => status,
+  'note'             => 'Raw-mode: each element verified to evaluate against the live Sigma ' \
+                        'warehouse and return data. NOT diffed against the source tool (unreachable).',
+}
+# preserve tile_census if a prior parity-final.json had one (dashboard zone gate)
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue {})
+  summary['tile_census'] = prior['tile_census'] if prior.is_a?(Hash) && prior['tile_census']
+end
+File.write(opts[:out], JSON.pretty_generate(summary))
+
+puts "verify-warehouse: #{passed.size}/#{total} element(s) returned live warehouse data → status=#{status}"
+failed.each { |name, (_, why)| puts "  FAIL  #{name}: #{why}" }
+puts "  → #{opts[:out]} (verified_against=warehouse). assert-phase6-ran.rb will flag this as warehouse-verified."
+exit(status == 'PASS' ? 0 : 2)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -4,7 +4,11 @@
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
-#      → beads-sigma-4pm
+#      → beads-sigma-4pm. Raw-mode: when the source tool is unreachable,
+#      verify-warehouse.rb writes parity-final.json with
+#      verified_against=warehouse — accepted as PASS but flagged with a loud
+#      banner ("verified vs warehouse, NOT source"). intake.json input_mode=file
+#      without a warehouse-verified parity triggers an advisory WARN.
 #   2. No orphan workbooks left in the customer's My Documents
 #      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
 #      cleanup ran with no failed deletes)  → beads-sigma-38a
@@ -188,6 +192,29 @@ else
          "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
   else
     puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  end
+
+  # Raw-mode honesty banner. When the source tool was unreachable, parity is run
+  # against the live Sigma WAREHOUSE (verify-warehouse.rb) instead of the source —
+  # every element evaluates against real warehouse data, but the values were NOT
+  # diffed against the source tool's rendered output. Surface that loudly so a
+  # warehouse-verified run is never mistaken for source parity.
+  verified_against = summary['verified_against'].to_s
+  if verified_against == 'warehouse'
+    puts '     ┌─────────────────────────────────────────────────────────────────────────┐'
+    puts '     │ VERIFIED AGAINST THE LIVE SIGMA WAREHOUSE — NOT against the source tool.   │'
+    puts '     │ Each element evaluates against real warehouse data; values were NOT diffed │'
+    puts '     │ vs the source (it was unreachable). State this in the migration report.    │'
+    puts '     └─────────────────────────────────────────────────────────────────────────┘'
+  else
+    # Advisory only: if intake recorded file-mode (no live source) but parity was
+    # not warehouse-verified, the run may be over-claiming source parity.
+    intake = (JSON.parse(File.read(File.join(opts[:tab], 'intake.json'))) rescue nil)
+    if intake.is_a?(Hash) && intake['input_mode'].to_s == 'file'
+      warn '[WARN] gate 1: intake.json records input_mode=file (no live source) but parity-final.json is'
+      warn '       not marked verified_against=warehouse. In raw-mode, verify against the warehouse'
+      warn '       (ruby scripts/verify-warehouse.rb) so the result is not mistaken for source parity.'
+    end
   end
 end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-telemetry-ran.rb
@@ -57,8 +57,11 @@ end
 
 rec = (JSON.parse(File.read(marker)) rescue nil)
 status = rec.is_a?(Hash) ? rec['status'] : nil
-unless %w[sent declined].include?(status)
-  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+# "skipped" = consent given + send attempted but the endpoint was unreachable
+# (handoff FIX 3). Telemetry must never block, so it still passes — the marker is
+# honest about non-delivery instead of faking "sent".
+unless %w[sent declined skipped].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\", \"declined\", or \"skipped\")."
   warn '       Re-run report-telemetry.py to write a valid marker.'
   exit 12
 end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-parity-plan.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-plan.rb — emit a parity-plan.json (and a normalized wb-readback.json)
+# straight from a built Sigma workbook spec, with NO source-tool views required.
+#
+# Normal Phase 6 (auto-parity-plan.rb) matches each chart to a SOURCE view to get
+# expected values. In raw-mode (only a .twb/.pbix/.qvf, no live source) there are
+# no source views — but verify-warehouse.rb only needs the LIST of visible chart
+# elements + their plotted columns to confirm each evaluates against the warehouse.
+# This helper produces exactly that, so an agent in file-mode does not hand-roll
+# the plan (handoff FIX 1).
+#
+# Usage:
+#   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
+#     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#
+# Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
+#   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
+# element (hidden data-page masters, controls, text/image/containers excluded).
+#
+# Exit codes: 0 = plan written (>=1 chart); 2 = zero chartable elements; 1 = bad invocation.
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--emit-spec PATH')     { |v| opts[:emit] = v }
+end.parse!
+abort 'missing --out' unless opts[:out]
+abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
+
+# Load the spec: from a file if given, else from the live workbook.
+if opts[:spec] && File.exist?(opts[:spec])
+  spec = JSON.parse(File.read(opts[:spec]))
+else
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
+  # /spec may wrap the spec under a key; accept either shape.
+  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+end
+
+# Non-data element kinds we never verify (controls, text, images, containers).
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false        # hidden data-page master
+  (el['columns'] || []).any?
+end
+
+# Plotted channel columns = every columnId the element's channels reference that
+# the element actually owns. Best-effort: if none resolve, leave empty (verify-
+# warehouse then just asserts the element returns non-empty, non-error data).
+def plotted_column_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }.compact.to_set
+  ids = []
+  walk = lambda do |v|
+    case v
+    when Hash
+      v.each do |k, val|
+        next if k == 'columns'                          # skip the column definitions
+        if k == 'columnId' && val.is_a?(String)
+          ids << val
+        elsif k == 'columnIds' && val.is_a?(Array)
+          val.each { |x| ids << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+        else
+          walk.call(val)
+        end
+      end
+    when Array then v.each { |x| walk.call(x) }
+    end
+  end
+  walk.call(el)
+  ids.compact.uniq.select { |i| own.include?(i) }
+end
+
+pages = spec['pages'] || []
+charts = []
+pages.each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless chartable?(el)
+    charts << {
+      'chart'            => (el['name'] || el['title'] || el['id']).to_s,
+      'sigma_element_id' => el['id'],
+      'sigma_kind'       => el['kind'],
+      'sigma_columns'    => plotted_column_ids(el),
+    }
+  end
+end
+
+if charts.empty?
+  warn '[FAIL] build-parity-plan: found zero visible chart elements in the workbook spec.'
+  warn '       (All elements were controls/text/images/containers or hidden masters.)'
+  exit 2
+end
+
+File.write(opts[:out], JSON.pretty_generate('charts' => charts))
+File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+
+puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
+puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]
+charts.first(12).each { |c| puts "    - #{c['chart']} [#{c['sigma_kind']}] #{c['sigma_columns'].size} col(s)" }
+exit 0

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
@@ -51,7 +51,7 @@ def report_migration(
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
-) -> None:
+) -> bool:
     """
     Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
     must never block or fail a migration.
@@ -90,16 +90,60 @@ def report_migration(
         if k != "event":
             print(f"  {k}: {v}")
 
+    body = json.dumps(payload).encode("utf-8")
+    # Returns True on HTTP 2xx, False on any skip/failure. NEVER raises — telemetry
+    # must never block or fail a migration. The caller writes an honest marker
+    # ("sent" vs "skipped") based on this return (handoff FIX 3).
+    return _post(endpoint, body, timeout)
+
+
+def _ssl_context():
+    """Prefer certifi's CA bundle — stock macOS / homebrew-python urllib often
+    fails CERTIFICATE_VERIFY_FAILED against the endpoint where curl succeeds
+    (handoff FIX 4). Fall back to the default context if certifi isn't present."""
     try:
-        body = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            print(f"  → telemetry sent ({resp.status})\n")
+        import ssl
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
     except Exception:
-        # Never surface telemetry errors to the user
-        print("  → telemetry unavailable (skipped)\n")
+        try:
+            import ssl
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def _post(endpoint, body, timeout):
+    # 1) urllib with a certifi-backed SSL context.
+    try:
+        req = urllib.request.Request(
+            endpoint, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        ctx = _ssl_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  → telemetry sent ({resp.status})\n")
+                return True
+            print(f"  → telemetry endpoint returned {resp.status} — skipped\n")
+            return False
+    except Exception as e:
+        first = str(e).splitlines()[0] if str(e) else type(e).__name__
+        # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
+                 "-w", "%{http_code}", "-X", "POST",
+                 "-H", "Content-Type: application/json", "--data-binary", "@-", endpoint],
+                input=body, capture_output=True, timeout=timeout + 5,
+            )
+            code = (r.stdout or b"").decode("ascii", "ignore").strip()
+            if code.startswith("2"):
+                print(f"  → telemetry sent ({code}, via curl)\n")
+                return True
+            print(f"  → telemetry unavailable (urllib: {first}; curl HTTP {code or 'n/a'}) — skipped\n")
+            return False
+        except Exception as e2:
+            print(f"  → telemetry unavailable (urllib: {first}; curl: {str(e2).splitlines()[0]}) — skipped\n")
+            return False

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
@@ -97,7 +97,7 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
-report_migration(
+sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
@@ -105,8 +105,11 @@ report_migration(
     success=not args.failed,
     mode=mode,
 )
+# Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
+# otherwise "skipped" so the audit record never claims a delivery that failed.
+# The gate accepts sent|declined|skipped — telemetry must never block.
 _write_marker(args.workdir, {
-    'status': 'sent',
+    'status': 'sent' if sent else 'skipped',
     'tool': args.tool,
     'success': not args.failed,
     'mode': mode,

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+# test-build-parity-plan.rb — unit test for build-parity-plan.rb (raw-mode helper,
+# handoff FIX 1). Offline: reads a synthetic spec via --workbook-spec, never the API.
+# Canonical in shared/scripts. Run: ruby scripts/test-build-parity-plan.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+BPP  = File.join(__dir__, 'build-parity-plan.rb')
+RUBY = RbConfig.ruby
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+SPEC = { 'pages' => [{ 'elements' => [
+  { 'id' => 'el-master', 'kind' => 'table', 'visibleAsSource' => false, 'columns' => [{ 'id' => 'm1', 'name' => 'X' }] },
+  { 'id' => 'el-ctl', 'kind' => 'list-control', 'columns' => [{ 'id' => 'c1', 'name' => 'Region' }] },
+  { 'id' => 'el-txt', 'kind' => 'text', 'columns' => [] },
+  { 'id' => 'el-kpi', 'kind' => 'kpi-chart', 'name' => 'Net Revenue',
+    'columns' => [{ 'id' => 'v1', 'name' => 'Net Revenue' }], 'value' => { 'columnId' => 'v1' } },
+  { 'id' => 'el-bar', 'kind' => 'bar-chart', 'name' => 'Sales by Region',
+    'columns' => [{ 'id' => 'x1', 'name' => 'Region' }, { 'id' => 'y1', 'name' => 'Sales' }, { 'id' => 'h1', 'name' => 'Hidden' }],
+    'xAxis' => { 'columnId' => 'x1' }, 'yAxis' => { 'columnIds' => [{ 'columnId' => 'y1' }] } },
+] }] }
+
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'spec.json'), JSON.generate(SPEC))
+  out = File.join(d, 'parity-plan.json')
+  emit = File.join(d, 'wb-readback.json')
+  st = system(RUBY, BPP, '--workbook-id', 'WB', '--workbook-spec', File.join(d, 'spec.json'),
+              '--out', out, '--emit-spec', emit, out: File::NULL, err: File::NULL)
+  ok('exit 0', st)
+  plan = JSON.parse(File.read(out))['charts']
+  names = plan.map { |c| c['sigma_element_id'] }.sort
+  ok('only the 2 visible charts (master/control/text excluded)', names == %w[el-bar el-kpi])
+  bar = plan.find { |c| c['sigma_element_id'] == 'el-bar' }
+  ok('plotted channels only (hidden filter h1 excluded)', bar['sigma_columns'].sort == %w[x1 y1])
+  kpi = plan.find { |c| c['sigma_element_id'] == 'el-kpi' }
+  ok('kpi value column captured', kpi['sigma_columns'] == ['v1'])
+  ok('emit-spec wrote wb-readback {pages:[...]}', JSON.parse(File.read(emit)).key?('pages'))
+end
+
+# zero chartable elements → exit 2
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'spec.json'), JSON.generate('pages' => [{ 'elements' => [{ 'id' => 't', 'kind' => 'text', 'columns' => [] }] }]))
+  st = system(RUBY, BPP, '--workbook-id', 'WB', '--workbook-spec', File.join(d, 'spec.json'),
+              '--out', File.join(d, 'p.json'), out: File::NULL, err: File::NULL)
+  ok('zero charts → exit 2', !st && $?.exitstatus == 2)
+end
+
+puts $fail.zero? ? "\nall build-parity-plan tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
@@ -39,12 +39,14 @@ Dir.mktmpdir do |d|
 end
 
 Dir.mktmpdir do |d|
-  # 4. send path writes status=sent + carries the mode enum
+  # 4. send path: status is "sent" when the POST lands, "skipped" when the endpoint
+  #    is unreachable (offline CI). Both are honest (handoff FIX 3) and both satisfy
+  #    the gate — telemetry must never block. NEVER "sent" on a failed delivery.
   ok('send writes a marker', report(d, '--duration', '120', '--mode', 'file'))
   rec = JSON.parse(File.read(File.join(d, 'telemetry-sent.json')))
-  ok('sent marker status',  rec['status'] == 'sent')
-  ok('sent marker mode',    rec['mode'] == 'file')
-  ok('sent marker satisfies the gate', gate(d) == true)
+  ok('send marker status sent|skipped', %w[sent skipped].include?(rec['status']))
+  ok('send marker mode',    rec['mode'] == 'file')
+  ok('send marker satisfies the gate', gate(d) == true)
 end
 
 Dir.mktmpdir do |d|

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb
@@ -76,5 +76,14 @@ Dir.mktmpdir do |d|
   ok('all-blank → FAIL', st == 2)
 end
 
+# 6. query-error cell ("Invalid Query: …") → FAIL (handoff FIX 2: must not PASS a broken element)
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Broken', 'sigma_element_id' => 'el-rev', 'sigma_kind' => 'kpi-chart', 'sigma_columns' => %w[c-m c-r] }],
+    { 'el-rev' => "Month,Net Revenue\n2025-01,Invalid Query: Unknown column DimDate.Month\n" })
+  ok('query-error cell → exit 2', st == 2)
+  ok('query-error cell listed as FAIL', s['fail_names'] == ['Broken'])
+end
+
 puts $fail.zero? ? "\nall verify-warehouse tests passed" : "\n#{$fail} FAILED"
 exit($fail.zero? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# test-verify-warehouse.rb — unit test for raw-mode warehouse verification
+# (verify-warehouse.rb). Offline: element CSVs come from the --fixture seam, never
+# the export API. Canonical in shared/scripts (epic beads-sigma-p5y2).
+# Run: ruby scripts/test-verify-warehouse.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+VW   = File.join(__dir__, 'verify-warehouse.rb')
+RUBY = RbConfig.ruby
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+SPEC = {
+  'pages' => [{ 'elements' => [
+    { 'id' => 'el-rev',   'columns' => [{ 'id' => 'c-m', 'name' => 'Month' }, { 'id' => 'c-r', 'name' => 'Net Revenue' }] },
+    { 'id' => 'el-empty', 'columns' => [{ 'id' => 'c-x', 'name' => 'Region' }, { 'id' => 'c-y', 'name' => 'Sales' }] },
+    { 'id' => 'el-piv',   'columns' => [{ 'id' => 'c-a', 'name' => 'A' }] },
+    { 'id' => 'el-blank', 'columns' => [{ 'id' => 'c-b', 'name' => 'B' }] },
+  ] }],
+}
+
+def run(dir, charts, fixture)
+  File.write(File.join(dir, 'wb-readback.json'), JSON.generate(SPEC))
+  File.write(File.join(dir, 'parity-plan.json'), JSON.generate('charts' => charts))
+  File.write(File.join(dir, 'fx.json'), JSON.generate(fixture))
+  out = File.join(dir, 'parity-final.json')
+  system(RUBY, VW, '--plan', File.join(dir, 'parity-plan.json'), '--workbook-id', 'WB',
+         '--workbook-spec', File.join(dir, 'wb-readback.json'), '--out', out, '--fixture', File.join(dir, 'fx.json'),
+         out: File::NULL, err: File::NULL)
+  [$?.exitstatus, JSON.parse(File.read(out))]
+end
+
+# 1. all elements return data → PASS, verified_against=warehouse
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Rev', 'sigma_element_id' => 'el-rev', 'sigma_kind' => 'line-chart', 'sigma_columns' => %w[c-m c-r] }],
+    { 'el-rev' => "Month,Net Revenue\n2025-01,42508.08\n2025-02,51200.10\n" })
+  ok('all-data → exit 0', st == 0)
+  ok('status PASS', s['status'] == 'PASS')
+  ok('verified_against=warehouse', s['verified_against'] == 'warehouse')
+end
+
+# 2. element returns headers only (broken join / empty) → FAIL
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Empty', 'sigma_element_id' => 'el-empty', 'sigma_kind' => 'bar-chart', 'sigma_columns' => %w[c-x c-y] }],
+    { 'el-empty' => "Region,Sales\n" })
+  ok('headers-only → exit 2', st == 2)
+  ok('listed in fail_names', s['fail_names'] == ['Empty'])
+end
+
+# 3. plotted column missing from export → FAIL
+Dir.mktmpdir do |d|
+  st, _ = run(d,
+    [{ 'chart' => 'Rev', 'sigma_element_id' => 'el-rev', 'sigma_kind' => 'line-chart', 'sigma_columns' => %w[c-m c-r] }],
+    { 'el-rev' => "Month,Other\n2025-01,5\n" })   # 'Net Revenue' absent
+  ok('missing plotted column → FAIL', st == 2)
+end
+
+# 4. pivot-table wide grid (non-empty) → PASS without column enforcement
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Piv', 'sigma_element_id' => 'el-piv', 'sigma_kind' => 'pivot-table', 'sigma_columns' => %w[c-a] }],
+    { 'el-piv' => "Region,Jan,Feb\nWest,1,2\nEast,3,4\n" })
+  ok('pivot non-empty → PASS', st == 0 && s['status'] == 'PASS')
+end
+
+# 5. all cells blank → FAIL
+Dir.mktmpdir do |d|
+  st, _ = run(d,
+    [{ 'chart' => 'Blank', 'sigma_element_id' => 'el-blank', 'sigma_kind' => 'kpi-chart', 'sigma_columns' => %w[c-b] }],
+    { 'el-blank' => "B\n\n" })
+  ok('all-blank → FAIL', st == 2)
+end
+
+puts $fail.zero? ? "\nall verify-warehouse tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-warehouse.rb
@@ -92,7 +92,17 @@ end
 
 # Verify one element returns real warehouse data: non-empty rows, all plan
 # columns present in the export headers, and at least one non-blank cell.
-def verify_chart(c, el_by_id, wb, timeout, fixture)
+# A cell that is itself a Sigma query-error string is NOT real data — the element
+# rendered "Invalid Query: Unknown…" / "#ERROR". The old has_value check treated
+# these as non-blank and PASSed a visibly-broken workbook (handoff FIX 2).
+ERROR_CELL = /\A\s*(Invalid Query|Error\b|#REF|#ERROR|#VALUE|#NAME)/i
+
+def verify_chart(c, el_by_id, error_element_ids, wb, timeout, fixture)
+  # An element that owns a type=error column (the signal Gate 3 uses) can never
+  # be warehouse-verified — fail it before we even look at the CSV.
+  if error_element_ids.include?(c['sigma_element_id'])
+    return [:fail, 'element owns a type=error column (broken formula — see /columns)']
+  end
   status, payload = element_csv(c, wb, timeout, fixture)
   return [:fail, payload] if status == :fail
   rows = (CSV.parse(payload) rescue [])
@@ -100,6 +110,10 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   headers = rows.shift.map { |h| h.to_s.strip }
   data = rows
   return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # Reject query-error sentinels appearing as cell values.
+  bad = data.flatten.find { |cell| cell.to_s =~ ERROR_CELL }
+  return [:fail, "element returned query-error cells: #{bad.to_s.strip[0, 60]}"] if bad
 
   # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
   # grid is the strongest honest assertion we can make for it.
@@ -118,7 +132,22 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   [:ok, "#{data.size} row(s)"]
 end
 
+# Belt-and-suspenders: the warehouse-verified stamp must never land on a workbook
+# with type=error columns. Fetch /columns ONCE and collect the owning element ids
+# (the same signal assert-phase6 Gate 3 uses). Skipped in fixture/test mode.
+error_element_ids = []
+unless opts[:fixture]
+  begin
+    cols = (Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/columns")['entries'] rescue []) || []
+    error_element_ids = cols.select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['elementId'] }.compact.uniq
+    warn "verify-warehouse: #{error_element_ids.size} element(s) own type=error columns — will fail" unless error_element_ids.empty?
+  rescue => e
+    warn "verify-warehouse: /columns scan unavailable (#{e.message.lines.first.to_s.strip[0, 80]}) — relying on per-cell error detection"
+  end
+end
+
 require 'thread'
+fixture_data = opts[:fixture] && JSON.parse(File.read(opts[:fixture]))
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -127,7 +156,7 @@ Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
   Thread.new do
     loop do
       c = (queue.pop(true) rescue break)
-      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      st, why = verify_chart(c, el_by_id, error_element_ids, opts[:wb], opts[:timeout], fixture_data)
       mutex.synchronize { results[c['chart']] = [st, why] }
     end
   end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-warehouse.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# verify-warehouse.rb — RAW-MODE parity: verify the built workbook against the
+# LIVE SIGMA WAREHOUSE when the source tool is unreachable.
+#
+# Normal Phase 6 diffs each Sigma element against the SOURCE tool's values
+# (Tableau view CSV, Looker API, …). When a customer hands over only a raw export
+# (.twb/.pbix/.qvf) with no live source, there is nothing to diff against — but
+# the warehouse IS reachable. This script proves the next-best, honest thing:
+# every built element EVALUATES against the live warehouse connection and returns
+# real, column-resolvable, non-empty data (no broken joins, error columns, or
+# empty results — the failure modes that make a raw-file conversion "look done"
+# but be wrong). It does NOT claim the numbers match the source's rendered output
+# — assert-phase6-ran.rb prints a loud banner saying exactly that.
+#
+# It reuses the verified element-CSV export flow (POST /v2/workbooks/{wb}/export →
+# poll GET /v2/query/{q}/download) that collect-parity-actuals.rb uses, through
+# lib/sigma_rest (auto-refresh on 401).
+#
+# Usage:
+#   ruby scripts/verify-warehouse.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --workbook-spec <dir>/wb-readback.json \
+#     --out <dir>/parity-final.json [--pool 5] [--timeout 120]
+#     [--fixture <file>]   # TEST ONLY: {"<element_id>": "<csv text>", ...} instead of the API
+#
+# Exit codes: 0 = all elements returned warehouse data (status PASS written);
+#             2 = one or more elements empty / errored (status FAIL written);
+#             1 = bad invocation.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 5, timeout: 120 }
+OptionParser.new do |p|
+  p.on('--plan PATH')          { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: element_id → CSV text map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+unless opts[:fixture]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+spec = JSON.parse(File.read(opts[:spec]))
+elements = (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+
+# Pull one element's CSV — from the fixture (tests) or the live export API.
+def element_csv(c, wb, timeout, fixture)
+  if fixture
+    txt = fixture[c['sigma_element_id']]
+    return [:fail, 'no fixture row for element'] if txt.nil?
+    return [:ok, txt]
+  end
+  attempts = 0
+  begin
+    attempts += 1
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+    t0 = Time.now
+    loop do
+      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+  rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+    msg = e.message.lines.first.to_s
+    if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+      retry
+    end
+    [:fail, msg[0, 160]]
+  end
+end
+
+# Verify one element returns real warehouse data: non-empty rows, all plan
+# columns present in the export headers, and at least one non-blank cell.
+def verify_chart(c, el_by_id, wb, timeout, fixture)
+  status, payload = element_csv(c, wb, timeout, fixture)
+  return [:fail, payload] if status == :fail
+  rows = (CSV.parse(payload) rescue [])
+  return [:fail, 'export CSV empty / unparseable'] if rows.empty?
+  headers = rows.shift.map { |h| h.to_s.strip }
+  data = rows
+  return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
+  # grid is the strongest honest assertion we can make for it.
+  unless c['sigma_kind'] == 'pivot-table'
+    el = el_by_id[c['sigma_element_id']]
+    if el
+      name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
+      want = (c['sigma_columns'] || []).map { |id| name_for[id] }.compact
+      missing = want.reject { |n| headers.any? { |h| h.casecmp?(n) } }
+      return [:fail, "plotted column(s) absent from export: #{missing.join(', ')}"] unless missing.empty?
+    end
+  end
+
+  has_value = data.any? { |r| r.any? { |cell| !cell.to_s.strip.empty? } }
+  return [:fail, 'all cells blank (element evaluated to nothing)'] unless has_value
+  [:ok, "#{data.size} row(s)"]
+end
+
+require 'thread'
+queue = Queue.new
+charts.each { |c| queue << c }
+results = {}
+mutex = Mutex.new
+Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
+  Thread.new do
+    loop do
+      c = (queue.pop(true) rescue break)
+      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      mutex.synchronize { results[c['chart']] = [st, why] }
+    end
+  end
+end.each(&:join)
+
+passed = results.select { |_, (s, _)| s == :ok }.keys
+failed = results.select { |_, (s, _)| s == :fail }
+total = results.size
+status = (total > 0 && failed.empty?) ? 'PASS' : 'FAIL'
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => 'warehouse',
+  'verified_against' => 'warehouse',
+  'charts_total'     => total,
+  'charts_pass'      => passed.size,
+  'charts_fail'      => failed.size,
+  'pass_names'       => passed,
+  'fail_names'       => failed.keys,
+  'status'           => status,
+  'note'             => 'Raw-mode: each element verified to evaluate against the live Sigma ' \
+                        'warehouse and return data. NOT diffed against the source tool (unreachable).',
+}
+# preserve tile_census if a prior parity-final.json had one (dashboard zone gate)
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue {})
+  summary['tile_census'] = prior['tile_census'] if prior.is_a?(Hash) && prior['tile_census']
+end
+File.write(opts[:out], JSON.pretty_generate(summary))
+
+puts "verify-warehouse: #{passed.size}/#{total} element(s) returned live warehouse data → status=#{status}"
+failed.each { |name, (_, why)| puts "  FAIL  #{name}: #{why}" }
+puts "  → #{opts[:out]} (verified_against=warehouse). assert-phase6-ran.rb will flag this as warehouse-verified."
+exit(status == 'PASS' ? 0 : 2)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/assert-telemetry-ran.rb
@@ -57,8 +57,11 @@ end
 
 rec = (JSON.parse(File.read(marker)) rescue nil)
 status = rec.is_a?(Hash) ? rec['status'] : nil
-unless %w[sent declined].include?(status)
-  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+# "skipped" = consent given + send attempted but the endpoint was unreachable
+# (handoff FIX 3). Telemetry must never block, so it still passes — the marker is
+# honest about non-delivery instead of faking "sent".
+unless %w[sent declined skipped].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\", \"declined\", or \"skipped\")."
   warn '       Re-run report-telemetry.py to write a valid marker.'
   exit 12
 end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-parity-plan.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-plan.rb — emit a parity-plan.json (and a normalized wb-readback.json)
+# straight from a built Sigma workbook spec, with NO source-tool views required.
+#
+# Normal Phase 6 (auto-parity-plan.rb) matches each chart to a SOURCE view to get
+# expected values. In raw-mode (only a .twb/.pbix/.qvf, no live source) there are
+# no source views — but verify-warehouse.rb only needs the LIST of visible chart
+# elements + their plotted columns to confirm each evaluates against the warehouse.
+# This helper produces exactly that, so an agent in file-mode does not hand-roll
+# the plan (handoff FIX 1).
+#
+# Usage:
+#   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
+#     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#
+# Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
+#   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
+# element (hidden data-page masters, controls, text/image/containers excluded).
+#
+# Exit codes: 0 = plan written (>=1 chart); 2 = zero chartable elements; 1 = bad invocation.
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--emit-spec PATH')     { |v| opts[:emit] = v }
+end.parse!
+abort 'missing --out' unless opts[:out]
+abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
+
+# Load the spec: from a file if given, else from the live workbook.
+if opts[:spec] && File.exist?(opts[:spec])
+  spec = JSON.parse(File.read(opts[:spec]))
+else
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
+  # /spec may wrap the spec under a key; accept either shape.
+  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+end
+
+# Non-data element kinds we never verify (controls, text, images, containers).
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false        # hidden data-page master
+  (el['columns'] || []).any?
+end
+
+# Plotted channel columns = every columnId the element's channels reference that
+# the element actually owns. Best-effort: if none resolve, leave empty (verify-
+# warehouse then just asserts the element returns non-empty, non-error data).
+def plotted_column_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }.compact.to_set
+  ids = []
+  walk = lambda do |v|
+    case v
+    when Hash
+      v.each do |k, val|
+        next if k == 'columns'                          # skip the column definitions
+        if k == 'columnId' && val.is_a?(String)
+          ids << val
+        elsif k == 'columnIds' && val.is_a?(Array)
+          val.each { |x| ids << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+        else
+          walk.call(val)
+        end
+      end
+    when Array then v.each { |x| walk.call(x) }
+    end
+  end
+  walk.call(el)
+  ids.compact.uniq.select { |i| own.include?(i) }
+end
+
+pages = spec['pages'] || []
+charts = []
+pages.each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless chartable?(el)
+    charts << {
+      'chart'            => (el['name'] || el['title'] || el['id']).to_s,
+      'sigma_element_id' => el['id'],
+      'sigma_kind'       => el['kind'],
+      'sigma_columns'    => plotted_column_ids(el),
+    }
+  end
+end
+
+if charts.empty?
+  warn '[FAIL] build-parity-plan: found zero visible chart elements in the workbook spec.'
+  warn '       (All elements were controls/text/images/containers or hidden masters.)'
+  exit 2
+end
+
+File.write(opts[:out], JSON.pretty_generate('charts' => charts))
+File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+
+puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
+puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]
+charts.first(12).each { |c| puts "    - #{c['chart']} [#{c['sigma_kind']}] #{c['sigma_columns'].size} col(s)" }
+exit 0

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
@@ -51,7 +51,7 @@ def report_migration(
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
-) -> None:
+) -> bool:
     """
     Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
     must never block or fail a migration.
@@ -90,16 +90,60 @@ def report_migration(
         if k != "event":
             print(f"  {k}: {v}")
 
+    body = json.dumps(payload).encode("utf-8")
+    # Returns True on HTTP 2xx, False on any skip/failure. NEVER raises — telemetry
+    # must never block or fail a migration. The caller writes an honest marker
+    # ("sent" vs "skipped") based on this return (handoff FIX 3).
+    return _post(endpoint, body, timeout)
+
+
+def _ssl_context():
+    """Prefer certifi's CA bundle — stock macOS / homebrew-python urllib often
+    fails CERTIFICATE_VERIFY_FAILED against the endpoint where curl succeeds
+    (handoff FIX 4). Fall back to the default context if certifi isn't present."""
     try:
-        body = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            print(f"  → telemetry sent ({resp.status})\n")
+        import ssl
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
     except Exception:
-        # Never surface telemetry errors to the user
-        print("  → telemetry unavailable (skipped)\n")
+        try:
+            import ssl
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def _post(endpoint, body, timeout):
+    # 1) urllib with a certifi-backed SSL context.
+    try:
+        req = urllib.request.Request(
+            endpoint, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        ctx = _ssl_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  → telemetry sent ({resp.status})\n")
+                return True
+            print(f"  → telemetry endpoint returned {resp.status} — skipped\n")
+            return False
+    except Exception as e:
+        first = str(e).splitlines()[0] if str(e) else type(e).__name__
+        # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
+                 "-w", "%{http_code}", "-X", "POST",
+                 "-H", "Content-Type: application/json", "--data-binary", "@-", endpoint],
+                input=body, capture_output=True, timeout=timeout + 5,
+            )
+            code = (r.stdout or b"").decode("ascii", "ignore").strip()
+            if code.startswith("2"):
+                print(f"  → telemetry sent ({code}, via curl)\n")
+                return True
+            print(f"  → telemetry unavailable (urllib: {first}; curl HTTP {code or 'n/a'}) — skipped\n")
+            return False
+        except Exception as e2:
+            print(f"  → telemetry unavailable (urllib: {first}; curl: {str(e2).splitlines()[0]}) — skipped\n")
+            return False

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
@@ -97,7 +97,7 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
-report_migration(
+sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
@@ -105,8 +105,11 @@ report_migration(
     success=not args.failed,
     mode=mode,
 )
+# Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
+# otherwise "skipped" so the audit record never claims a delivery that failed.
+# The gate accepts sent|declined|skipped — telemetry must never block.
 _write_marker(args.workdir, {
-    'status': 'sent',
+    'status': 'sent' if sent else 'skipped',
     'tool': args.tool,
     'success': not args.failed,
     'mode': mode,

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-warehouse.rb
@@ -92,7 +92,17 @@ end
 
 # Verify one element returns real warehouse data: non-empty rows, all plan
 # columns present in the export headers, and at least one non-blank cell.
-def verify_chart(c, el_by_id, wb, timeout, fixture)
+# A cell that is itself a Sigma query-error string is NOT real data — the element
+# rendered "Invalid Query: Unknown…" / "#ERROR". The old has_value check treated
+# these as non-blank and PASSed a visibly-broken workbook (handoff FIX 2).
+ERROR_CELL = /\A\s*(Invalid Query|Error\b|#REF|#ERROR|#VALUE|#NAME)/i
+
+def verify_chart(c, el_by_id, error_element_ids, wb, timeout, fixture)
+  # An element that owns a type=error column (the signal Gate 3 uses) can never
+  # be warehouse-verified — fail it before we even look at the CSV.
+  if error_element_ids.include?(c['sigma_element_id'])
+    return [:fail, 'element owns a type=error column (broken formula — see /columns)']
+  end
   status, payload = element_csv(c, wb, timeout, fixture)
   return [:fail, payload] if status == :fail
   rows = (CSV.parse(payload) rescue [])
@@ -100,6 +110,10 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   headers = rows.shift.map { |h| h.to_s.strip }
   data = rows
   return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # Reject query-error sentinels appearing as cell values.
+  bad = data.flatten.find { |cell| cell.to_s =~ ERROR_CELL }
+  return [:fail, "element returned query-error cells: #{bad.to_s.strip[0, 60]}"] if bad
 
   # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
   # grid is the strongest honest assertion we can make for it.
@@ -118,7 +132,22 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   [:ok, "#{data.size} row(s)"]
 end
 
+# Belt-and-suspenders: the warehouse-verified stamp must never land on a workbook
+# with type=error columns. Fetch /columns ONCE and collect the owning element ids
+# (the same signal assert-phase6 Gate 3 uses). Skipped in fixture/test mode.
+error_element_ids = []
+unless opts[:fixture]
+  begin
+    cols = (Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/columns")['entries'] rescue []) || []
+    error_element_ids = cols.select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['elementId'] }.compact.uniq
+    warn "verify-warehouse: #{error_element_ids.size} element(s) own type=error columns — will fail" unless error_element_ids.empty?
+  rescue => e
+    warn "verify-warehouse: /columns scan unavailable (#{e.message.lines.first.to_s.strip[0, 80]}) — relying on per-cell error detection"
+  end
+end
+
 require 'thread'
+fixture_data = opts[:fixture] && JSON.parse(File.read(opts[:fixture]))
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -127,7 +156,7 @@ Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
   Thread.new do
     loop do
       c = (queue.pop(true) rescue break)
-      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      st, why = verify_chart(c, el_by_id, error_element_ids, opts[:wb], opts[:timeout], fixture_data)
       mutex.synchronize { results[c['chart']] = [st, why] }
     end
   end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-warehouse.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# verify-warehouse.rb — RAW-MODE parity: verify the built workbook against the
+# LIVE SIGMA WAREHOUSE when the source tool is unreachable.
+#
+# Normal Phase 6 diffs each Sigma element against the SOURCE tool's values
+# (Tableau view CSV, Looker API, …). When a customer hands over only a raw export
+# (.twb/.pbix/.qvf) with no live source, there is nothing to diff against — but
+# the warehouse IS reachable. This script proves the next-best, honest thing:
+# every built element EVALUATES against the live warehouse connection and returns
+# real, column-resolvable, non-empty data (no broken joins, error columns, or
+# empty results — the failure modes that make a raw-file conversion "look done"
+# but be wrong). It does NOT claim the numbers match the source's rendered output
+# — assert-phase6-ran.rb prints a loud banner saying exactly that.
+#
+# It reuses the verified element-CSV export flow (POST /v2/workbooks/{wb}/export →
+# poll GET /v2/query/{q}/download) that collect-parity-actuals.rb uses, through
+# lib/sigma_rest (auto-refresh on 401).
+#
+# Usage:
+#   ruby scripts/verify-warehouse.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --workbook-spec <dir>/wb-readback.json \
+#     --out <dir>/parity-final.json [--pool 5] [--timeout 120]
+#     [--fixture <file>]   # TEST ONLY: {"<element_id>": "<csv text>", ...} instead of the API
+#
+# Exit codes: 0 = all elements returned warehouse data (status PASS written);
+#             2 = one or more elements empty / errored (status FAIL written);
+#             1 = bad invocation.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 5, timeout: 120 }
+OptionParser.new do |p|
+  p.on('--plan PATH')          { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: element_id → CSV text map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+unless opts[:fixture]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+spec = JSON.parse(File.read(opts[:spec]))
+elements = (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+
+# Pull one element's CSV — from the fixture (tests) or the live export API.
+def element_csv(c, wb, timeout, fixture)
+  if fixture
+    txt = fixture[c['sigma_element_id']]
+    return [:fail, 'no fixture row for element'] if txt.nil?
+    return [:ok, txt]
+  end
+  attempts = 0
+  begin
+    attempts += 1
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+    t0 = Time.now
+    loop do
+      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+  rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+    msg = e.message.lines.first.to_s
+    if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+      retry
+    end
+    [:fail, msg[0, 160]]
+  end
+end
+
+# Verify one element returns real warehouse data: non-empty rows, all plan
+# columns present in the export headers, and at least one non-blank cell.
+def verify_chart(c, el_by_id, wb, timeout, fixture)
+  status, payload = element_csv(c, wb, timeout, fixture)
+  return [:fail, payload] if status == :fail
+  rows = (CSV.parse(payload) rescue [])
+  return [:fail, 'export CSV empty / unparseable'] if rows.empty?
+  headers = rows.shift.map { |h| h.to_s.strip }
+  data = rows
+  return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
+  # grid is the strongest honest assertion we can make for it.
+  unless c['sigma_kind'] == 'pivot-table'
+    el = el_by_id[c['sigma_element_id']]
+    if el
+      name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
+      want = (c['sigma_columns'] || []).map { |id| name_for[id] }.compact
+      missing = want.reject { |n| headers.any? { |h| h.casecmp?(n) } }
+      return [:fail, "plotted column(s) absent from export: #{missing.join(', ')}"] unless missing.empty?
+    end
+  end
+
+  has_value = data.any? { |r| r.any? { |cell| !cell.to_s.strip.empty? } }
+  return [:fail, 'all cells blank (element evaluated to nothing)'] unless has_value
+  [:ok, "#{data.size} row(s)"]
+end
+
+require 'thread'
+queue = Queue.new
+charts.each { |c| queue << c }
+results = {}
+mutex = Mutex.new
+Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
+  Thread.new do
+    loop do
+      c = (queue.pop(true) rescue break)
+      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      mutex.synchronize { results[c['chart']] = [st, why] }
+    end
+  end
+end.each(&:join)
+
+passed = results.select { |_, (s, _)| s == :ok }.keys
+failed = results.select { |_, (s, _)| s == :fail }
+total = results.size
+status = (total > 0 && failed.empty?) ? 'PASS' : 'FAIL'
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => 'warehouse',
+  'verified_against' => 'warehouse',
+  'charts_total'     => total,
+  'charts_pass'      => passed.size,
+  'charts_fail'      => failed.size,
+  'pass_names'       => passed,
+  'fail_names'       => failed.keys,
+  'status'           => status,
+  'note'             => 'Raw-mode: each element verified to evaluate against the live Sigma ' \
+                        'warehouse and return data. NOT diffed against the source tool (unreachable).',
+}
+# preserve tile_census if a prior parity-final.json had one (dashboard zone gate)
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue {})
+  summary['tile_census'] = prior['tile_census'] if prior.is_a?(Hash) && prior['tile_census']
+end
+File.write(opts[:out], JSON.pretty_generate(summary))
+
+puts "verify-warehouse: #{passed.size}/#{total} element(s) returned live warehouse data → status=#{status}"
+failed.each { |name, (_, why)| puts "  FAIL  #{name}: #{why}" }
+puts "  → #{opts[:out]} (verified_against=warehouse). assert-phase6-ran.rb will flag this as warehouse-verified."
+exit(status == 'PASS' ? 0 : 2)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -4,7 +4,11 @@
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
-#      → beads-sigma-4pm
+#      → beads-sigma-4pm. Raw-mode: when the source tool is unreachable,
+#      verify-warehouse.rb writes parity-final.json with
+#      verified_against=warehouse — accepted as PASS but flagged with a loud
+#      banner ("verified vs warehouse, NOT source"). intake.json input_mode=file
+#      without a warehouse-verified parity triggers an advisory WARN.
 #   2. No orphan workbooks left in the customer's My Documents
 #      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
 #      cleanup ran with no failed deletes)  → beads-sigma-38a
@@ -188,6 +192,29 @@ else
          "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
   else
     puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  end
+
+  # Raw-mode honesty banner. When the source tool was unreachable, parity is run
+  # against the live Sigma WAREHOUSE (verify-warehouse.rb) instead of the source —
+  # every element evaluates against real warehouse data, but the values were NOT
+  # diffed against the source tool's rendered output. Surface that loudly so a
+  # warehouse-verified run is never mistaken for source parity.
+  verified_against = summary['verified_against'].to_s
+  if verified_against == 'warehouse'
+    puts '     ┌─────────────────────────────────────────────────────────────────────────┐'
+    puts '     │ VERIFIED AGAINST THE LIVE SIGMA WAREHOUSE — NOT against the source tool.   │'
+    puts '     │ Each element evaluates against real warehouse data; values were NOT diffed │'
+    puts '     │ vs the source (it was unreachable). State this in the migration report.    │'
+    puts '     └─────────────────────────────────────────────────────────────────────────┘'
+  else
+    # Advisory only: if intake recorded file-mode (no live source) but parity was
+    # not warehouse-verified, the run may be over-claiming source parity.
+    intake = (JSON.parse(File.read(File.join(opts[:tab], 'intake.json'))) rescue nil)
+    if intake.is_a?(Hash) && intake['input_mode'].to_s == 'file'
+      warn '[WARN] gate 1: intake.json records input_mode=file (no live source) but parity-final.json is'
+      warn '       not marked verified_against=warehouse. In raw-mode, verify against the warehouse'
+      warn '       (ruby scripts/verify-warehouse.rb) so the result is not mistaken for source parity.'
+    end
   end
 end
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-telemetry-ran.rb
@@ -57,8 +57,11 @@ end
 
 rec = (JSON.parse(File.read(marker)) rescue nil)
 status = rec.is_a?(Hash) ? rec['status'] : nil
-unless %w[sent declined].include?(status)
-  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+# "skipped" = consent given + send attempted but the endpoint was unreachable
+# (handoff FIX 3). Telemetry must never block, so it still passes — the marker is
+# honest about non-delivery instead of faking "sent".
+unless %w[sent declined skipped].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\", \"declined\", or \"skipped\")."
   warn '       Re-run report-telemetry.py to write a valid marker.'
   exit 12
 end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-parity-plan.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-plan.rb — emit a parity-plan.json (and a normalized wb-readback.json)
+# straight from a built Sigma workbook spec, with NO source-tool views required.
+#
+# Normal Phase 6 (auto-parity-plan.rb) matches each chart to a SOURCE view to get
+# expected values. In raw-mode (only a .twb/.pbix/.qvf, no live source) there are
+# no source views — but verify-warehouse.rb only needs the LIST of visible chart
+# elements + their plotted columns to confirm each evaluates against the warehouse.
+# This helper produces exactly that, so an agent in file-mode does not hand-roll
+# the plan (handoff FIX 1).
+#
+# Usage:
+#   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
+#     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#
+# Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
+#   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
+# element (hidden data-page masters, controls, text/image/containers excluded).
+#
+# Exit codes: 0 = plan written (>=1 chart); 2 = zero chartable elements; 1 = bad invocation.
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--emit-spec PATH')     { |v| opts[:emit] = v }
+end.parse!
+abort 'missing --out' unless opts[:out]
+abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
+
+# Load the spec: from a file if given, else from the live workbook.
+if opts[:spec] && File.exist?(opts[:spec])
+  spec = JSON.parse(File.read(opts[:spec]))
+else
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
+  # /spec may wrap the spec under a key; accept either shape.
+  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+end
+
+# Non-data element kinds we never verify (controls, text, images, containers).
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false        # hidden data-page master
+  (el['columns'] || []).any?
+end
+
+# Plotted channel columns = every columnId the element's channels reference that
+# the element actually owns. Best-effort: if none resolve, leave empty (verify-
+# warehouse then just asserts the element returns non-empty, non-error data).
+def plotted_column_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }.compact.to_set
+  ids = []
+  walk = lambda do |v|
+    case v
+    when Hash
+      v.each do |k, val|
+        next if k == 'columns'                          # skip the column definitions
+        if k == 'columnId' && val.is_a?(String)
+          ids << val
+        elsif k == 'columnIds' && val.is_a?(Array)
+          val.each { |x| ids << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+        else
+          walk.call(val)
+        end
+      end
+    when Array then v.each { |x| walk.call(x) }
+    end
+  end
+  walk.call(el)
+  ids.compact.uniq.select { |i| own.include?(i) }
+end
+
+pages = spec['pages'] || []
+charts = []
+pages.each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless chartable?(el)
+    charts << {
+      'chart'            => (el['name'] || el['title'] || el['id']).to_s,
+      'sigma_element_id' => el['id'],
+      'sigma_kind'       => el['kind'],
+      'sigma_columns'    => plotted_column_ids(el),
+    }
+  end
+end
+
+if charts.empty?
+  warn '[FAIL] build-parity-plan: found zero visible chart elements in the workbook spec.'
+  warn '       (All elements were controls/text/images/containers or hidden masters.)'
+  exit 2
+end
+
+File.write(opts[:out], JSON.pretty_generate('charts' => charts))
+File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+
+puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
+puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]
+charts.first(12).each { |c| puts "    - #{c['chart']} [#{c['sigma_kind']}] #{c['sigma_columns'].size} col(s)" }
+exit 0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
@@ -51,7 +51,7 @@ def report_migration(
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
-) -> None:
+) -> bool:
     """
     Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
     must never block or fail a migration.
@@ -90,16 +90,60 @@ def report_migration(
         if k != "event":
             print(f"  {k}: {v}")
 
+    body = json.dumps(payload).encode("utf-8")
+    # Returns True on HTTP 2xx, False on any skip/failure. NEVER raises — telemetry
+    # must never block or fail a migration. The caller writes an honest marker
+    # ("sent" vs "skipped") based on this return (handoff FIX 3).
+    return _post(endpoint, body, timeout)
+
+
+def _ssl_context():
+    """Prefer certifi's CA bundle — stock macOS / homebrew-python urllib often
+    fails CERTIFICATE_VERIFY_FAILED against the endpoint where curl succeeds
+    (handoff FIX 4). Fall back to the default context if certifi isn't present."""
     try:
-        body = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            print(f"  → telemetry sent ({resp.status})\n")
+        import ssl
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
     except Exception:
-        # Never surface telemetry errors to the user
-        print("  → telemetry unavailable (skipped)\n")
+        try:
+            import ssl
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def _post(endpoint, body, timeout):
+    # 1) urllib with a certifi-backed SSL context.
+    try:
+        req = urllib.request.Request(
+            endpoint, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        ctx = _ssl_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  → telemetry sent ({resp.status})\n")
+                return True
+            print(f"  → telemetry endpoint returned {resp.status} — skipped\n")
+            return False
+    except Exception as e:
+        first = str(e).splitlines()[0] if str(e) else type(e).__name__
+        # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
+                 "-w", "%{http_code}", "-X", "POST",
+                 "-H", "Content-Type: application/json", "--data-binary", "@-", endpoint],
+                input=body, capture_output=True, timeout=timeout + 5,
+            )
+            code = (r.stdout or b"").decode("ascii", "ignore").strip()
+            if code.startswith("2"):
+                print(f"  → telemetry sent ({code}, via curl)\n")
+                return True
+            print(f"  → telemetry unavailable (urllib: {first}; curl HTTP {code or 'n/a'}) — skipped\n")
+            return False
+        except Exception as e2:
+            print(f"  → telemetry unavailable (urllib: {first}; curl: {str(e2).splitlines()[0]}) — skipped\n")
+            return False

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
@@ -97,7 +97,7 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
-report_migration(
+sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
@@ -105,8 +105,11 @@ report_migration(
     success=not args.failed,
     mode=mode,
 )
+# Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
+# otherwise "skipped" so the audit record never claims a delivery that failed.
+# The gate accepts sent|declined|skipped — telemetry must never block.
 _write_marker(args.workdir, {
-    'status': 'sent',
+    'status': 'sent' if sent else 'skipped',
     'tool': args.tool,
     'success': not args.failed,
     'mode': mode,

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-warehouse.rb
@@ -92,7 +92,17 @@ end
 
 # Verify one element returns real warehouse data: non-empty rows, all plan
 # columns present in the export headers, and at least one non-blank cell.
-def verify_chart(c, el_by_id, wb, timeout, fixture)
+# A cell that is itself a Sigma query-error string is NOT real data — the element
+# rendered "Invalid Query: Unknown…" / "#ERROR". The old has_value check treated
+# these as non-blank and PASSed a visibly-broken workbook (handoff FIX 2).
+ERROR_CELL = /\A\s*(Invalid Query|Error\b|#REF|#ERROR|#VALUE|#NAME)/i
+
+def verify_chart(c, el_by_id, error_element_ids, wb, timeout, fixture)
+  # An element that owns a type=error column (the signal Gate 3 uses) can never
+  # be warehouse-verified — fail it before we even look at the CSV.
+  if error_element_ids.include?(c['sigma_element_id'])
+    return [:fail, 'element owns a type=error column (broken formula — see /columns)']
+  end
   status, payload = element_csv(c, wb, timeout, fixture)
   return [:fail, payload] if status == :fail
   rows = (CSV.parse(payload) rescue [])
@@ -100,6 +110,10 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   headers = rows.shift.map { |h| h.to_s.strip }
   data = rows
   return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # Reject query-error sentinels appearing as cell values.
+  bad = data.flatten.find { |cell| cell.to_s =~ ERROR_CELL }
+  return [:fail, "element returned query-error cells: #{bad.to_s.strip[0, 60]}"] if bad
 
   # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
   # grid is the strongest honest assertion we can make for it.
@@ -118,7 +132,22 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   [:ok, "#{data.size} row(s)"]
 end
 
+# Belt-and-suspenders: the warehouse-verified stamp must never land on a workbook
+# with type=error columns. Fetch /columns ONCE and collect the owning element ids
+# (the same signal assert-phase6 Gate 3 uses). Skipped in fixture/test mode.
+error_element_ids = []
+unless opts[:fixture]
+  begin
+    cols = (Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/columns")['entries'] rescue []) || []
+    error_element_ids = cols.select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['elementId'] }.compact.uniq
+    warn "verify-warehouse: #{error_element_ids.size} element(s) own type=error columns — will fail" unless error_element_ids.empty?
+  rescue => e
+    warn "verify-warehouse: /columns scan unavailable (#{e.message.lines.first.to_s.strip[0, 80]}) — relying on per-cell error detection"
+  end
+end
+
 require 'thread'
+fixture_data = opts[:fixture] && JSON.parse(File.read(opts[:fixture]))
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -127,7 +156,7 @@ Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
   Thread.new do
     loop do
       c = (queue.pop(true) rescue break)
-      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      st, why = verify_chart(c, el_by_id, error_element_ids, opts[:wb], opts[:timeout], fixture_data)
       mutex.synchronize { results[c['chart']] = [st, why] }
     end
   end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-warehouse.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# verify-warehouse.rb — RAW-MODE parity: verify the built workbook against the
+# LIVE SIGMA WAREHOUSE when the source tool is unreachable.
+#
+# Normal Phase 6 diffs each Sigma element against the SOURCE tool's values
+# (Tableau view CSV, Looker API, …). When a customer hands over only a raw export
+# (.twb/.pbix/.qvf) with no live source, there is nothing to diff against — but
+# the warehouse IS reachable. This script proves the next-best, honest thing:
+# every built element EVALUATES against the live warehouse connection and returns
+# real, column-resolvable, non-empty data (no broken joins, error columns, or
+# empty results — the failure modes that make a raw-file conversion "look done"
+# but be wrong). It does NOT claim the numbers match the source's rendered output
+# — assert-phase6-ran.rb prints a loud banner saying exactly that.
+#
+# It reuses the verified element-CSV export flow (POST /v2/workbooks/{wb}/export →
+# poll GET /v2/query/{q}/download) that collect-parity-actuals.rb uses, through
+# lib/sigma_rest (auto-refresh on 401).
+#
+# Usage:
+#   ruby scripts/verify-warehouse.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --workbook-spec <dir>/wb-readback.json \
+#     --out <dir>/parity-final.json [--pool 5] [--timeout 120]
+#     [--fixture <file>]   # TEST ONLY: {"<element_id>": "<csv text>", ...} instead of the API
+#
+# Exit codes: 0 = all elements returned warehouse data (status PASS written);
+#             2 = one or more elements empty / errored (status FAIL written);
+#             1 = bad invocation.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 5, timeout: 120 }
+OptionParser.new do |p|
+  p.on('--plan PATH')          { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: element_id → CSV text map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+unless opts[:fixture]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+spec = JSON.parse(File.read(opts[:spec]))
+elements = (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+
+# Pull one element's CSV — from the fixture (tests) or the live export API.
+def element_csv(c, wb, timeout, fixture)
+  if fixture
+    txt = fixture[c['sigma_element_id']]
+    return [:fail, 'no fixture row for element'] if txt.nil?
+    return [:ok, txt]
+  end
+  attempts = 0
+  begin
+    attempts += 1
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+    t0 = Time.now
+    loop do
+      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+  rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+    msg = e.message.lines.first.to_s
+    if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+      retry
+    end
+    [:fail, msg[0, 160]]
+  end
+end
+
+# Verify one element returns real warehouse data: non-empty rows, all plan
+# columns present in the export headers, and at least one non-blank cell.
+def verify_chart(c, el_by_id, wb, timeout, fixture)
+  status, payload = element_csv(c, wb, timeout, fixture)
+  return [:fail, payload] if status == :fail
+  rows = (CSV.parse(payload) rescue [])
+  return [:fail, 'export CSV empty / unparseable'] if rows.empty?
+  headers = rows.shift.map { |h| h.to_s.strip }
+  data = rows
+  return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
+  # grid is the strongest honest assertion we can make for it.
+  unless c['sigma_kind'] == 'pivot-table'
+    el = el_by_id[c['sigma_element_id']]
+    if el
+      name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
+      want = (c['sigma_columns'] || []).map { |id| name_for[id] }.compact
+      missing = want.reject { |n| headers.any? { |h| h.casecmp?(n) } }
+      return [:fail, "plotted column(s) absent from export: #{missing.join(', ')}"] unless missing.empty?
+    end
+  end
+
+  has_value = data.any? { |r| r.any? { |cell| !cell.to_s.strip.empty? } }
+  return [:fail, 'all cells blank (element evaluated to nothing)'] unless has_value
+  [:ok, "#{data.size} row(s)"]
+end
+
+require 'thread'
+queue = Queue.new
+charts.each { |c| queue << c }
+results = {}
+mutex = Mutex.new
+Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
+  Thread.new do
+    loop do
+      c = (queue.pop(true) rescue break)
+      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      mutex.synchronize { results[c['chart']] = [st, why] }
+    end
+  end
+end.each(&:join)
+
+passed = results.select { |_, (s, _)| s == :ok }.keys
+failed = results.select { |_, (s, _)| s == :fail }
+total = results.size
+status = (total > 0 && failed.empty?) ? 'PASS' : 'FAIL'
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => 'warehouse',
+  'verified_against' => 'warehouse',
+  'charts_total'     => total,
+  'charts_pass'      => passed.size,
+  'charts_fail'      => failed.size,
+  'pass_names'       => passed,
+  'fail_names'       => failed.keys,
+  'status'           => status,
+  'note'             => 'Raw-mode: each element verified to evaluate against the live Sigma ' \
+                        'warehouse and return data. NOT diffed against the source tool (unreachable).',
+}
+# preserve tile_census if a prior parity-final.json had one (dashboard zone gate)
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue {})
+  summary['tile_census'] = prior['tile_census'] if prior.is_a?(Hash) && prior['tile_census']
+end
+File.write(opts[:out], JSON.pretty_generate(summary))
+
+puts "verify-warehouse: #{passed.size}/#{total} element(s) returned live warehouse data → status=#{status}"
+failed.each { |name, (_, why)| puts "  FAIL  #{name}: #{why}" }
+puts "  → #{opts[:out]} (verified_against=warehouse). assert-phase6-ran.rb will flag this as warehouse-verified."
+exit(status == 'PASS' ? 0 : 2)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -1446,20 +1446,27 @@ diff against (you ran intake with `--mode file`), you cannot do source-side pari
 no Tableau view CSVs. But the Sigma **warehouse** is reachable, so verify there instead:
 
 ```bash
-# build as usual from the .twb, then in place of the Tableau-side parity diff:
+# build the workbook as usual from the .twb, then — in place of the Tableau-side
+# parity diff — derive the plan from the LIVE workbook spec and verify vs the warehouse:
+ruby scripts/build-parity-plan.rb --workbook-id <wb> \
+  --out <WORK>/parity-plan.json --emit-spec <WORK>/wb-readback.json
 ruby scripts/verify-warehouse.rb --plan <WORK>/parity-plan.json \
   --workbook-id <wb> --workbook-spec <WORK>/wb-readback.json --out <WORK>/parity-final.json
-ruby scripts/assert-phase6-ran.rb --workdir <WORK>     # Gate 1 accepts it + prints the banner
+ruby scripts/assert-phase6-ran.rb --workdir <WORK> --workbook-id <wb>   # Gate 1 + banner
 ```
 
-`verify-warehouse.rb` exports every built element and confirms it **evaluates against the live
-warehouse and returns real, column-resolvable, non-empty data** — catching the broken joins,
-error columns, and empty results that make a raw-file conversion *look* done but be wrong. It
-writes `parity-final.json` with `verified_against: warehouse`; `assert-phase6-ran.rb` accepts
-that as PASS but prints a loud banner: **verified vs the warehouse, NOT vs Tableau's rendered
-output**. State that in the migration report. This is honest degradation — real numbers from
-real data, minus the source-side value/visual diff that needs a live Tableau. (For a stronger
-check, supply a warehouse-SQL oracle of expected values and run the normal `verify-parity.rb`.)
+`build-parity-plan.rb` reads the built workbook spec and lists every **visible** chart element
+(excluding hidden masters, controls, text/image/containers) with its plotted columns — so you
+never hand-roll `parity-plan.json`. `verify-warehouse.rb` then exports each element and confirms
+it **evaluates against the live warehouse and returns real, column-resolvable, non-empty data**,
+FAILing any element that returns a query-error cell (`Invalid Query …`) or owns a `type=error`
+column — catching the broken joins / error columns / empty results that make a raw-file
+conversion *look* done but be wrong. It writes `parity-final.json` with `verified_against:
+warehouse`; `assert-phase6-ran.rb` accepts that as PASS but prints a loud banner: **verified vs
+the warehouse, NOT vs Tableau's rendered output**. State that in the migration report. This is
+honest degradation — real numbers from real data, minus the source-side value/visual diff that
+needs a live Tableau. (For a stronger check, supply a warehouse-SQL oracle of expected values
+and run the normal `verify-parity.rb`.)
 
 ### 6 — one-step (preferred)
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -1439,6 +1439,28 @@ This step is mandatory and must run before declaring the conversion done.
 
 > **If `mcp__sigma-mcp-v2__query` errors with an auth-related message mid-Phase-6**, the Sigma MCP session has staled. Re-call `mcp__sigma-mcp-v2__begin_session` and retry the query. Do NOT skip Phase 6 because of a recoverable auth error — that's the 2026-05-22 cluster-follower regression.
 
+### Raw-mode — only a `.twb`, no live Tableau (`scripts/verify-warehouse.rb`)
+
+When the customer hands over a raw `.twb` export with **no live Tableau Server/Cloud** to
+diff against (you ran intake with `--mode file`), you cannot do source-side parity — there are
+no Tableau view CSVs. But the Sigma **warehouse** is reachable, so verify there instead:
+
+```bash
+# build as usual from the .twb, then in place of the Tableau-side parity diff:
+ruby scripts/verify-warehouse.rb --plan <WORK>/parity-plan.json \
+  --workbook-id <wb> --workbook-spec <WORK>/wb-readback.json --out <WORK>/parity-final.json
+ruby scripts/assert-phase6-ran.rb --workdir <WORK>     # Gate 1 accepts it + prints the banner
+```
+
+`verify-warehouse.rb` exports every built element and confirms it **evaluates against the live
+warehouse and returns real, column-resolvable, non-empty data** — catching the broken joins,
+error columns, and empty results that make a raw-file conversion *look* done but be wrong. It
+writes `parity-final.json` with `verified_against: warehouse`; `assert-phase6-ran.rb` accepts
+that as PASS but prints a loud banner: **verified vs the warehouse, NOT vs Tableau's rendered
+output**. State that in the migration report. This is honest degradation — real numbers from
+real data, minus the source-side value/visual diff that needs a live Tableau. (For a stronger
+check, supply a warehouse-SQL oracle of expected values and run the normal `verify-parity.rb`.)
+
 ### 6 — one-step (preferred)
 
 ```bash

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -4,7 +4,11 @@
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
-#      → beads-sigma-4pm
+#      → beads-sigma-4pm. Raw-mode: when the source tool is unreachable,
+#      verify-warehouse.rb writes parity-final.json with
+#      verified_against=warehouse — accepted as PASS but flagged with a loud
+#      banner ("verified vs warehouse, NOT source"). intake.json input_mode=file
+#      without a warehouse-verified parity triggers an advisory WARN.
 #   2. No orphan workbooks left in the customer's My Documents
 #      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
 #      cleanup ran with no failed deletes)  → beads-sigma-38a
@@ -188,6 +192,29 @@ else
          "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
   else
     puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  end
+
+  # Raw-mode honesty banner. When the source tool was unreachable, parity is run
+  # against the live Sigma WAREHOUSE (verify-warehouse.rb) instead of the source —
+  # every element evaluates against real warehouse data, but the values were NOT
+  # diffed against the source tool's rendered output. Surface that loudly so a
+  # warehouse-verified run is never mistaken for source parity.
+  verified_against = summary['verified_against'].to_s
+  if verified_against == 'warehouse'
+    puts '     ┌─────────────────────────────────────────────────────────────────────────┐'
+    puts '     │ VERIFIED AGAINST THE LIVE SIGMA WAREHOUSE — NOT against the source tool.   │'
+    puts '     │ Each element evaluates against real warehouse data; values were NOT diffed │'
+    puts '     │ vs the source (it was unreachable). State this in the migration report.    │'
+    puts '     └─────────────────────────────────────────────────────────────────────────┘'
+  else
+    # Advisory only: if intake recorded file-mode (no live source) but parity was
+    # not warehouse-verified, the run may be over-claiming source parity.
+    intake = (JSON.parse(File.read(File.join(opts[:tab], 'intake.json'))) rescue nil)
+    if intake.is_a?(Hash) && intake['input_mode'].to_s == 'file'
+      warn '[WARN] gate 1: intake.json records input_mode=file (no live source) but parity-final.json is'
+      warn '       not marked verified_against=warehouse. In raw-mode, verify against the warehouse'
+      warn '       (ruby scripts/verify-warehouse.rb) so the result is not mistaken for source parity.'
+    end
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-telemetry-ran.rb
@@ -57,8 +57,11 @@ end
 
 rec = (JSON.parse(File.read(marker)) rescue nil)
 status = rec.is_a?(Hash) ? rec['status'] : nil
-unless %w[sent declined].include?(status)
-  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+# "skipped" = consent given + send attempted but the endpoint was unreachable
+# (handoff FIX 3). Telemetry must never block, so it still passes — the marker is
+# honest about non-delivery instead of faking "sent".
+unless %w[sent declined skipped].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\", \"declined\", or \"skipped\")."
   warn '       Re-run report-telemetry.py to write a valid marker.'
   exit 12
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-parity-plan.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-plan.rb — emit a parity-plan.json (and a normalized wb-readback.json)
+# straight from a built Sigma workbook spec, with NO source-tool views required.
+#
+# Normal Phase 6 (auto-parity-plan.rb) matches each chart to a SOURCE view to get
+# expected values. In raw-mode (only a .twb/.pbix/.qvf, no live source) there are
+# no source views — but verify-warehouse.rb only needs the LIST of visible chart
+# elements + their plotted columns to confirm each evaluates against the warehouse.
+# This helper produces exactly that, so an agent in file-mode does not hand-roll
+# the plan (handoff FIX 1).
+#
+# Usage:
+#   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
+#     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#
+# Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
+#   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
+# element (hidden data-page masters, controls, text/image/containers excluded).
+#
+# Exit codes: 0 = plan written (>=1 chart); 2 = zero chartable elements; 1 = bad invocation.
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--emit-spec PATH')     { |v| opts[:emit] = v }
+end.parse!
+abort 'missing --out' unless opts[:out]
+abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
+
+# Load the spec: from a file if given, else from the live workbook.
+if opts[:spec] && File.exist?(opts[:spec])
+  spec = JSON.parse(File.read(opts[:spec]))
+else
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
+  # /spec may wrap the spec under a key; accept either shape.
+  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+end
+
+# Non-data element kinds we never verify (controls, text, images, containers).
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false        # hidden data-page master
+  (el['columns'] || []).any?
+end
+
+# Plotted channel columns = every columnId the element's channels reference that
+# the element actually owns. Best-effort: if none resolve, leave empty (verify-
+# warehouse then just asserts the element returns non-empty, non-error data).
+def plotted_column_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }.compact.to_set
+  ids = []
+  walk = lambda do |v|
+    case v
+    when Hash
+      v.each do |k, val|
+        next if k == 'columns'                          # skip the column definitions
+        if k == 'columnId' && val.is_a?(String)
+          ids << val
+        elsif k == 'columnIds' && val.is_a?(Array)
+          val.each { |x| ids << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+        else
+          walk.call(val)
+        end
+      end
+    when Array then v.each { |x| walk.call(x) }
+    end
+  end
+  walk.call(el)
+  ids.compact.uniq.select { |i| own.include?(i) }
+end
+
+pages = spec['pages'] || []
+charts = []
+pages.each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless chartable?(el)
+    charts << {
+      'chart'            => (el['name'] || el['title'] || el['id']).to_s,
+      'sigma_element_id' => el['id'],
+      'sigma_kind'       => el['kind'],
+      'sigma_columns'    => plotted_column_ids(el),
+    }
+  end
+end
+
+if charts.empty?
+  warn '[FAIL] build-parity-plan: found zero visible chart elements in the workbook spec.'
+  warn '       (All elements were controls/text/images/containers or hidden masters.)'
+  exit 2
+end
+
+File.write(opts[:out], JSON.pretty_generate('charts' => charts))
+File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+
+puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
+puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]
+charts.first(12).each { |c| puts "    - #{c['chart']} [#{c['sigma_kind']}] #{c['sigma_columns'].size} col(s)" }
+exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
@@ -51,7 +51,7 @@ def report_migration(
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
-) -> None:
+) -> bool:
     """
     Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
     must never block or fail a migration.
@@ -90,16 +90,60 @@ def report_migration(
         if k != "event":
             print(f"  {k}: {v}")
 
+    body = json.dumps(payload).encode("utf-8")
+    # Returns True on HTTP 2xx, False on any skip/failure. NEVER raises — telemetry
+    # must never block or fail a migration. The caller writes an honest marker
+    # ("sent" vs "skipped") based on this return (handoff FIX 3).
+    return _post(endpoint, body, timeout)
+
+
+def _ssl_context():
+    """Prefer certifi's CA bundle — stock macOS / homebrew-python urllib often
+    fails CERTIFICATE_VERIFY_FAILED against the endpoint where curl succeeds
+    (handoff FIX 4). Fall back to the default context if certifi isn't present."""
     try:
-        body = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            print(f"  → telemetry sent ({resp.status})\n")
+        import ssl
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
     except Exception:
-        # Never surface telemetry errors to the user
-        print("  → telemetry unavailable (skipped)\n")
+        try:
+            import ssl
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def _post(endpoint, body, timeout):
+    # 1) urllib with a certifi-backed SSL context.
+    try:
+        req = urllib.request.Request(
+            endpoint, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        ctx = _ssl_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  → telemetry sent ({resp.status})\n")
+                return True
+            print(f"  → telemetry endpoint returned {resp.status} — skipped\n")
+            return False
+    except Exception as e:
+        first = str(e).splitlines()[0] if str(e) else type(e).__name__
+        # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
+                 "-w", "%{http_code}", "-X", "POST",
+                 "-H", "Content-Type: application/json", "--data-binary", "@-", endpoint],
+                input=body, capture_output=True, timeout=timeout + 5,
+            )
+            code = (r.stdout or b"").decode("ascii", "ignore").strip()
+            if code.startswith("2"):
+                print(f"  → telemetry sent ({code}, via curl)\n")
+                return True
+            print(f"  → telemetry unavailable (urllib: {first}; curl HTTP {code or 'n/a'}) — skipped\n")
+            return False
+        except Exception as e2:
+            print(f"  → telemetry unavailable (urllib: {first}; curl: {str(e2).splitlines()[0]}) — skipped\n")
+            return False

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
@@ -97,7 +97,7 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
-report_migration(
+sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
@@ -105,8 +105,11 @@ report_migration(
     success=not args.failed,
     mode=mode,
 )
+# Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
+# otherwise "skipped" so the audit record never claims a delivery that failed.
+# The gate accepts sent|declined|skipped — telemetry must never block.
 _write_marker(args.workdir, {
-    'status': 'sent',
+    'status': 'sent' if sent else 'skipped',
     'tool': args.tool,
     'success': not args.failed,
     'mode': mode,

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-build-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-build-parity-plan.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+# test-build-parity-plan.rb — unit test for build-parity-plan.rb (raw-mode helper,
+# handoff FIX 1). Offline: reads a synthetic spec via --workbook-spec, never the API.
+# Canonical in shared/scripts. Run: ruby scripts/test-build-parity-plan.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+BPP  = File.join(__dir__, 'build-parity-plan.rb')
+RUBY = RbConfig.ruby
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+SPEC = { 'pages' => [{ 'elements' => [
+  { 'id' => 'el-master', 'kind' => 'table', 'visibleAsSource' => false, 'columns' => [{ 'id' => 'm1', 'name' => 'X' }] },
+  { 'id' => 'el-ctl', 'kind' => 'list-control', 'columns' => [{ 'id' => 'c1', 'name' => 'Region' }] },
+  { 'id' => 'el-txt', 'kind' => 'text', 'columns' => [] },
+  { 'id' => 'el-kpi', 'kind' => 'kpi-chart', 'name' => 'Net Revenue',
+    'columns' => [{ 'id' => 'v1', 'name' => 'Net Revenue' }], 'value' => { 'columnId' => 'v1' } },
+  { 'id' => 'el-bar', 'kind' => 'bar-chart', 'name' => 'Sales by Region',
+    'columns' => [{ 'id' => 'x1', 'name' => 'Region' }, { 'id' => 'y1', 'name' => 'Sales' }, { 'id' => 'h1', 'name' => 'Hidden' }],
+    'xAxis' => { 'columnId' => 'x1' }, 'yAxis' => { 'columnIds' => [{ 'columnId' => 'y1' }] } },
+] }] }
+
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'spec.json'), JSON.generate(SPEC))
+  out = File.join(d, 'parity-plan.json')
+  emit = File.join(d, 'wb-readback.json')
+  st = system(RUBY, BPP, '--workbook-id', 'WB', '--workbook-spec', File.join(d, 'spec.json'),
+              '--out', out, '--emit-spec', emit, out: File::NULL, err: File::NULL)
+  ok('exit 0', st)
+  plan = JSON.parse(File.read(out))['charts']
+  names = plan.map { |c| c['sigma_element_id'] }.sort
+  ok('only the 2 visible charts (master/control/text excluded)', names == %w[el-bar el-kpi])
+  bar = plan.find { |c| c['sigma_element_id'] == 'el-bar' }
+  ok('plotted channels only (hidden filter h1 excluded)', bar['sigma_columns'].sort == %w[x1 y1])
+  kpi = plan.find { |c| c['sigma_element_id'] == 'el-kpi' }
+  ok('kpi value column captured', kpi['sigma_columns'] == ['v1'])
+  ok('emit-spec wrote wb-readback {pages:[...]}', JSON.parse(File.read(emit)).key?('pages'))
+end
+
+# zero chartable elements → exit 2
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'spec.json'), JSON.generate('pages' => [{ 'elements' => [{ 'id' => 't', 'kind' => 'text', 'columns' => [] }] }]))
+  st = system(RUBY, BPP, '--workbook-id', 'WB', '--workbook-spec', File.join(d, 'spec.json'),
+              '--out', File.join(d, 'p.json'), out: File::NULL, err: File::NULL)
+  ok('zero charts → exit 2', !st && $?.exitstatus == 2)
+end
+
+puts $fail.zero? ? "\nall build-parity-plan tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-telemetry-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-telemetry-gate.rb
@@ -39,12 +39,14 @@ Dir.mktmpdir do |d|
 end
 
 Dir.mktmpdir do |d|
-  # 4. send path writes status=sent + carries the mode enum
+  # 4. send path: status is "sent" when the POST lands, "skipped" when the endpoint
+  #    is unreachable (offline CI). Both are honest (handoff FIX 3) and both satisfy
+  #    the gate — telemetry must never block. NEVER "sent" on a failed delivery.
   ok('send writes a marker', report(d, '--duration', '120', '--mode', 'file'))
   rec = JSON.parse(File.read(File.join(d, 'telemetry-sent.json')))
-  ok('sent marker status',  rec['status'] == 'sent')
-  ok('sent marker mode',    rec['mode'] == 'file')
-  ok('sent marker satisfies the gate', gate(d) == true)
+  ok('send marker status sent|skipped', %w[sent skipped].include?(rec['status']))
+  ok('send marker mode',    rec['mode'] == 'file')
+  ok('send marker satisfies the gate', gate(d) == true)
 end
 
 Dir.mktmpdir do |d|

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-warehouse.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-warehouse.rb
@@ -76,5 +76,14 @@ Dir.mktmpdir do |d|
   ok('all-blank → FAIL', st == 2)
 end
 
+# 6. query-error cell ("Invalid Query: …") → FAIL (handoff FIX 2: must not PASS a broken element)
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Broken', 'sigma_element_id' => 'el-rev', 'sigma_kind' => 'kpi-chart', 'sigma_columns' => %w[c-m c-r] }],
+    { 'el-rev' => "Month,Net Revenue\n2025-01,Invalid Query: Unknown column DimDate.Month\n" })
+  ok('query-error cell → exit 2', st == 2)
+  ok('query-error cell listed as FAIL', s['fail_names'] == ['Broken'])
+end
+
 puts $fail.zero? ? "\nall verify-warehouse tests passed" : "\n#{$fail} FAILED"
 exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-warehouse.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-warehouse.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# test-verify-warehouse.rb — unit test for raw-mode warehouse verification
+# (verify-warehouse.rb). Offline: element CSVs come from the --fixture seam, never
+# the export API. Canonical in shared/scripts (epic beads-sigma-p5y2).
+# Run: ruby scripts/test-verify-warehouse.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+VW   = File.join(__dir__, 'verify-warehouse.rb')
+RUBY = RbConfig.ruby
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+SPEC = {
+  'pages' => [{ 'elements' => [
+    { 'id' => 'el-rev',   'columns' => [{ 'id' => 'c-m', 'name' => 'Month' }, { 'id' => 'c-r', 'name' => 'Net Revenue' }] },
+    { 'id' => 'el-empty', 'columns' => [{ 'id' => 'c-x', 'name' => 'Region' }, { 'id' => 'c-y', 'name' => 'Sales' }] },
+    { 'id' => 'el-piv',   'columns' => [{ 'id' => 'c-a', 'name' => 'A' }] },
+    { 'id' => 'el-blank', 'columns' => [{ 'id' => 'c-b', 'name' => 'B' }] },
+  ] }],
+}
+
+def run(dir, charts, fixture)
+  File.write(File.join(dir, 'wb-readback.json'), JSON.generate(SPEC))
+  File.write(File.join(dir, 'parity-plan.json'), JSON.generate('charts' => charts))
+  File.write(File.join(dir, 'fx.json'), JSON.generate(fixture))
+  out = File.join(dir, 'parity-final.json')
+  system(RUBY, VW, '--plan', File.join(dir, 'parity-plan.json'), '--workbook-id', 'WB',
+         '--workbook-spec', File.join(dir, 'wb-readback.json'), '--out', out, '--fixture', File.join(dir, 'fx.json'),
+         out: File::NULL, err: File::NULL)
+  [$?.exitstatus, JSON.parse(File.read(out))]
+end
+
+# 1. all elements return data → PASS, verified_against=warehouse
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Rev', 'sigma_element_id' => 'el-rev', 'sigma_kind' => 'line-chart', 'sigma_columns' => %w[c-m c-r] }],
+    { 'el-rev' => "Month,Net Revenue\n2025-01,42508.08\n2025-02,51200.10\n" })
+  ok('all-data → exit 0', st == 0)
+  ok('status PASS', s['status'] == 'PASS')
+  ok('verified_against=warehouse', s['verified_against'] == 'warehouse')
+end
+
+# 2. element returns headers only (broken join / empty) → FAIL
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Empty', 'sigma_element_id' => 'el-empty', 'sigma_kind' => 'bar-chart', 'sigma_columns' => %w[c-x c-y] }],
+    { 'el-empty' => "Region,Sales\n" })
+  ok('headers-only → exit 2', st == 2)
+  ok('listed in fail_names', s['fail_names'] == ['Empty'])
+end
+
+# 3. plotted column missing from export → FAIL
+Dir.mktmpdir do |d|
+  st, _ = run(d,
+    [{ 'chart' => 'Rev', 'sigma_element_id' => 'el-rev', 'sigma_kind' => 'line-chart', 'sigma_columns' => %w[c-m c-r] }],
+    { 'el-rev' => "Month,Other\n2025-01,5\n" })   # 'Net Revenue' absent
+  ok('missing plotted column → FAIL', st == 2)
+end
+
+# 4. pivot-table wide grid (non-empty) → PASS without column enforcement
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Piv', 'sigma_element_id' => 'el-piv', 'sigma_kind' => 'pivot-table', 'sigma_columns' => %w[c-a] }],
+    { 'el-piv' => "Region,Jan,Feb\nWest,1,2\nEast,3,4\n" })
+  ok('pivot non-empty → PASS', st == 0 && s['status'] == 'PASS')
+end
+
+# 5. all cells blank → FAIL
+Dir.mktmpdir do |d|
+  st, _ = run(d,
+    [{ 'chart' => 'Blank', 'sigma_element_id' => 'el-blank', 'sigma_kind' => 'kpi-chart', 'sigma_columns' => %w[c-b] }],
+    { 'el-blank' => "B\n\n" })
+  ok('all-blank → FAIL', st == 2)
+end
+
+puts $fail.zero? ? "\nall verify-warehouse tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-warehouse.rb
@@ -92,7 +92,17 @@ end
 
 # Verify one element returns real warehouse data: non-empty rows, all plan
 # columns present in the export headers, and at least one non-blank cell.
-def verify_chart(c, el_by_id, wb, timeout, fixture)
+# A cell that is itself a Sigma query-error string is NOT real data — the element
+# rendered "Invalid Query: Unknown…" / "#ERROR". The old has_value check treated
+# these as non-blank and PASSed a visibly-broken workbook (handoff FIX 2).
+ERROR_CELL = /\A\s*(Invalid Query|Error\b|#REF|#ERROR|#VALUE|#NAME)/i
+
+def verify_chart(c, el_by_id, error_element_ids, wb, timeout, fixture)
+  # An element that owns a type=error column (the signal Gate 3 uses) can never
+  # be warehouse-verified — fail it before we even look at the CSV.
+  if error_element_ids.include?(c['sigma_element_id'])
+    return [:fail, 'element owns a type=error column (broken formula — see /columns)']
+  end
   status, payload = element_csv(c, wb, timeout, fixture)
   return [:fail, payload] if status == :fail
   rows = (CSV.parse(payload) rescue [])
@@ -100,6 +110,10 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   headers = rows.shift.map { |h| h.to_s.strip }
   data = rows
   return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # Reject query-error sentinels appearing as cell values.
+  bad = data.flatten.find { |cell| cell.to_s =~ ERROR_CELL }
+  return [:fail, "element returned query-error cells: #{bad.to_s.strip[0, 60]}"] if bad
 
   # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
   # grid is the strongest honest assertion we can make for it.
@@ -118,7 +132,22 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   [:ok, "#{data.size} row(s)"]
 end
 
+# Belt-and-suspenders: the warehouse-verified stamp must never land on a workbook
+# with type=error columns. Fetch /columns ONCE and collect the owning element ids
+# (the same signal assert-phase6 Gate 3 uses). Skipped in fixture/test mode.
+error_element_ids = []
+unless opts[:fixture]
+  begin
+    cols = (Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/columns")['entries'] rescue []) || []
+    error_element_ids = cols.select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['elementId'] }.compact.uniq
+    warn "verify-warehouse: #{error_element_ids.size} element(s) own type=error columns — will fail" unless error_element_ids.empty?
+  rescue => e
+    warn "verify-warehouse: /columns scan unavailable (#{e.message.lines.first.to_s.strip[0, 80]}) — relying on per-cell error detection"
+  end
+end
+
 require 'thread'
+fixture_data = opts[:fixture] && JSON.parse(File.read(opts[:fixture]))
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -127,7 +156,7 @@ Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
   Thread.new do
     loop do
       c = (queue.pop(true) rescue break)
-      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      st, why = verify_chart(c, el_by_id, error_element_ids, opts[:wb], opts[:timeout], fixture_data)
       mutex.synchronize { results[c['chart']] = [st, why] }
     end
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-warehouse.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# verify-warehouse.rb — RAW-MODE parity: verify the built workbook against the
+# LIVE SIGMA WAREHOUSE when the source tool is unreachable.
+#
+# Normal Phase 6 diffs each Sigma element against the SOURCE tool's values
+# (Tableau view CSV, Looker API, …). When a customer hands over only a raw export
+# (.twb/.pbix/.qvf) with no live source, there is nothing to diff against — but
+# the warehouse IS reachable. This script proves the next-best, honest thing:
+# every built element EVALUATES against the live warehouse connection and returns
+# real, column-resolvable, non-empty data (no broken joins, error columns, or
+# empty results — the failure modes that make a raw-file conversion "look done"
+# but be wrong). It does NOT claim the numbers match the source's rendered output
+# — assert-phase6-ran.rb prints a loud banner saying exactly that.
+#
+# It reuses the verified element-CSV export flow (POST /v2/workbooks/{wb}/export →
+# poll GET /v2/query/{q}/download) that collect-parity-actuals.rb uses, through
+# lib/sigma_rest (auto-refresh on 401).
+#
+# Usage:
+#   ruby scripts/verify-warehouse.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --workbook-spec <dir>/wb-readback.json \
+#     --out <dir>/parity-final.json [--pool 5] [--timeout 120]
+#     [--fixture <file>]   # TEST ONLY: {"<element_id>": "<csv text>", ...} instead of the API
+#
+# Exit codes: 0 = all elements returned warehouse data (status PASS written);
+#             2 = one or more elements empty / errored (status FAIL written);
+#             1 = bad invocation.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 5, timeout: 120 }
+OptionParser.new do |p|
+  p.on('--plan PATH')          { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: element_id → CSV text map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+unless opts[:fixture]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+spec = JSON.parse(File.read(opts[:spec]))
+elements = (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+
+# Pull one element's CSV — from the fixture (tests) or the live export API.
+def element_csv(c, wb, timeout, fixture)
+  if fixture
+    txt = fixture[c['sigma_element_id']]
+    return [:fail, 'no fixture row for element'] if txt.nil?
+    return [:ok, txt]
+  end
+  attempts = 0
+  begin
+    attempts += 1
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+    t0 = Time.now
+    loop do
+      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+  rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+    msg = e.message.lines.first.to_s
+    if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+      retry
+    end
+    [:fail, msg[0, 160]]
+  end
+end
+
+# Verify one element returns real warehouse data: non-empty rows, all plan
+# columns present in the export headers, and at least one non-blank cell.
+def verify_chart(c, el_by_id, wb, timeout, fixture)
+  status, payload = element_csv(c, wb, timeout, fixture)
+  return [:fail, payload] if status == :fail
+  rows = (CSV.parse(payload) rescue [])
+  return [:fail, 'export CSV empty / unparseable'] if rows.empty?
+  headers = rows.shift.map { |h| h.to_s.strip }
+  data = rows
+  return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
+  # grid is the strongest honest assertion we can make for it.
+  unless c['sigma_kind'] == 'pivot-table'
+    el = el_by_id[c['sigma_element_id']]
+    if el
+      name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
+      want = (c['sigma_columns'] || []).map { |id| name_for[id] }.compact
+      missing = want.reject { |n| headers.any? { |h| h.casecmp?(n) } }
+      return [:fail, "plotted column(s) absent from export: #{missing.join(', ')}"] unless missing.empty?
+    end
+  end
+
+  has_value = data.any? { |r| r.any? { |cell| !cell.to_s.strip.empty? } }
+  return [:fail, 'all cells blank (element evaluated to nothing)'] unless has_value
+  [:ok, "#{data.size} row(s)"]
+end
+
+require 'thread'
+queue = Queue.new
+charts.each { |c| queue << c }
+results = {}
+mutex = Mutex.new
+Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
+  Thread.new do
+    loop do
+      c = (queue.pop(true) rescue break)
+      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      mutex.synchronize { results[c['chart']] = [st, why] }
+    end
+  end
+end.each(&:join)
+
+passed = results.select { |_, (s, _)| s == :ok }.keys
+failed = results.select { |_, (s, _)| s == :fail }
+total = results.size
+status = (total > 0 && failed.empty?) ? 'PASS' : 'FAIL'
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => 'warehouse',
+  'verified_against' => 'warehouse',
+  'charts_total'     => total,
+  'charts_pass'      => passed.size,
+  'charts_fail'      => failed.size,
+  'pass_names'       => passed,
+  'fail_names'       => failed.keys,
+  'status'           => status,
+  'note'             => 'Raw-mode: each element verified to evaluate against the live Sigma ' \
+                        'warehouse and return data. NOT diffed against the source tool (unreachable).',
+}
+# preserve tile_census if a prior parity-final.json had one (dashboard zone gate)
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue {})
+  summary['tile_census'] = prior['tile_census'] if prior.is_a?(Hash) && prior['tile_census']
+end
+File.write(opts[:out], JSON.pretty_generate(summary))
+
+puts "verify-warehouse: #{passed.size}/#{total} element(s) returned live warehouse data → status=#{status}"
+failed.each { |name, (_, why)| puts "  FAIL  #{name}: #{why}" }
+puts "  → #{opts[:out]} (verified_against=warehouse). assert-phase6-ran.rb will flag this as warehouse-verified."
+exit(status == 'PASS' ? 0 : 2)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -4,7 +4,11 @@
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
-#      → beads-sigma-4pm
+#      → beads-sigma-4pm. Raw-mode: when the source tool is unreachable,
+#      verify-warehouse.rb writes parity-final.json with
+#      verified_against=warehouse — accepted as PASS but flagged with a loud
+#      banner ("verified vs warehouse, NOT source"). intake.json input_mode=file
+#      without a warehouse-verified parity triggers an advisory WARN.
 #   2. No orphan workbooks left in the customer's My Documents
 #      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
 #      cleanup ran with no failed deletes)  → beads-sigma-38a
@@ -188,6 +192,29 @@ else
          "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
   else
     puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  end
+
+  # Raw-mode honesty banner. When the source tool was unreachable, parity is run
+  # against the live Sigma WAREHOUSE (verify-warehouse.rb) instead of the source —
+  # every element evaluates against real warehouse data, but the values were NOT
+  # diffed against the source tool's rendered output. Surface that loudly so a
+  # warehouse-verified run is never mistaken for source parity.
+  verified_against = summary['verified_against'].to_s
+  if verified_against == 'warehouse'
+    puts '     ┌─────────────────────────────────────────────────────────────────────────┐'
+    puts '     │ VERIFIED AGAINST THE LIVE SIGMA WAREHOUSE — NOT against the source tool.   │'
+    puts '     │ Each element evaluates against real warehouse data; values were NOT diffed │'
+    puts '     │ vs the source (it was unreachable). State this in the migration report.    │'
+    puts '     └─────────────────────────────────────────────────────────────────────────┘'
+  else
+    # Advisory only: if intake recorded file-mode (no live source) but parity was
+    # not warehouse-verified, the run may be over-claiming source parity.
+    intake = (JSON.parse(File.read(File.join(opts[:tab], 'intake.json'))) rescue nil)
+    if intake.is_a?(Hash) && intake['input_mode'].to_s == 'file'
+      warn '[WARN] gate 1: intake.json records input_mode=file (no live source) but parity-final.json is'
+      warn '       not marked verified_against=warehouse. In raw-mode, verify against the warehouse'
+      warn '       (ruby scripts/verify-warehouse.rb) so the result is not mistaken for source parity.'
+    end
   end
 end
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-telemetry-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-telemetry-ran.rb
@@ -57,8 +57,11 @@ end
 
 rec = (JSON.parse(File.read(marker)) rescue nil)
 status = rec.is_a?(Hash) ? rec['status'] : nil
-unless %w[sent declined].include?(status)
-  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+# "skipped" = consent given + send attempted but the endpoint was unreachable
+# (handoff FIX 3). Telemetry must never block, so it still passes — the marker is
+# honest about non-delivery instead of faking "sent".
+unless %w[sent declined skipped].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\", \"declined\", or \"skipped\")."
   warn '       Re-run report-telemetry.py to write a valid marker.'
   exit 12
 end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/build-parity-plan.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/build-parity-plan.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-plan.rb — emit a parity-plan.json (and a normalized wb-readback.json)
+# straight from a built Sigma workbook spec, with NO source-tool views required.
+#
+# Normal Phase 6 (auto-parity-plan.rb) matches each chart to a SOURCE view to get
+# expected values. In raw-mode (only a .twb/.pbix/.qvf, no live source) there are
+# no source views — but verify-warehouse.rb only needs the LIST of visible chart
+# elements + their plotted columns to confirm each evaluates against the warehouse.
+# This helper produces exactly that, so an agent in file-mode does not hand-roll
+# the plan (handoff FIX 1).
+#
+# Usage:
+#   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
+#     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#
+# Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
+#   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
+# element (hidden data-page masters, controls, text/image/containers excluded).
+#
+# Exit codes: 0 = plan written (>=1 chart); 2 = zero chartable elements; 1 = bad invocation.
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--emit-spec PATH')     { |v| opts[:emit] = v }
+end.parse!
+abort 'missing --out' unless opts[:out]
+abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
+
+# Load the spec: from a file if given, else from the live workbook.
+if opts[:spec] && File.exist?(opts[:spec])
+  spec = JSON.parse(File.read(opts[:spec]))
+else
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
+  # /spec may wrap the spec under a key; accept either shape.
+  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+end
+
+# Non-data element kinds we never verify (controls, text, images, containers).
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false        # hidden data-page master
+  (el['columns'] || []).any?
+end
+
+# Plotted channel columns = every columnId the element's channels reference that
+# the element actually owns. Best-effort: if none resolve, leave empty (verify-
+# warehouse then just asserts the element returns non-empty, non-error data).
+def plotted_column_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }.compact.to_set
+  ids = []
+  walk = lambda do |v|
+    case v
+    when Hash
+      v.each do |k, val|
+        next if k == 'columns'                          # skip the column definitions
+        if k == 'columnId' && val.is_a?(String)
+          ids << val
+        elsif k == 'columnIds' && val.is_a?(Array)
+          val.each { |x| ids << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+        else
+          walk.call(val)
+        end
+      end
+    when Array then v.each { |x| walk.call(x) }
+    end
+  end
+  walk.call(el)
+  ids.compact.uniq.select { |i| own.include?(i) }
+end
+
+pages = spec['pages'] || []
+charts = []
+pages.each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless chartable?(el)
+    charts << {
+      'chart'            => (el['name'] || el['title'] || el['id']).to_s,
+      'sigma_element_id' => el['id'],
+      'sigma_kind'       => el['kind'],
+      'sigma_columns'    => plotted_column_ids(el),
+    }
+  end
+end
+
+if charts.empty?
+  warn '[FAIL] build-parity-plan: found zero visible chart elements in the workbook spec.'
+  warn '       (All elements were controls/text/images/containers or hidden masters.)'
+  exit 2
+end
+
+File.write(opts[:out], JSON.pretty_generate('charts' => charts))
+File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+
+puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
+puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]
+charts.first(12).each { |c| puts "    - #{c['chart']} [#{c['sigma_kind']}] #{c['sigma_columns'].size} col(s)" }
+exit 0

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
@@ -51,7 +51,7 @@ def report_migration(
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
-) -> None:
+) -> bool:
     """
     Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
     must never block or fail a migration.
@@ -90,16 +90,60 @@ def report_migration(
         if k != "event":
             print(f"  {k}: {v}")
 
+    body = json.dumps(payload).encode("utf-8")
+    # Returns True on HTTP 2xx, False on any skip/failure. NEVER raises — telemetry
+    # must never block or fail a migration. The caller writes an honest marker
+    # ("sent" vs "skipped") based on this return (handoff FIX 3).
+    return _post(endpoint, body, timeout)
+
+
+def _ssl_context():
+    """Prefer certifi's CA bundle — stock macOS / homebrew-python urllib often
+    fails CERTIFICATE_VERIFY_FAILED against the endpoint where curl succeeds
+    (handoff FIX 4). Fall back to the default context if certifi isn't present."""
     try:
-        body = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            print(f"  → telemetry sent ({resp.status})\n")
+        import ssl
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
     except Exception:
-        # Never surface telemetry errors to the user
-        print("  → telemetry unavailable (skipped)\n")
+        try:
+            import ssl
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def _post(endpoint, body, timeout):
+    # 1) urllib with a certifi-backed SSL context.
+    try:
+        req = urllib.request.Request(
+            endpoint, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        ctx = _ssl_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  → telemetry sent ({resp.status})\n")
+                return True
+            print(f"  → telemetry endpoint returned {resp.status} — skipped\n")
+            return False
+    except Exception as e:
+        first = str(e).splitlines()[0] if str(e) else type(e).__name__
+        # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
+                 "-w", "%{http_code}", "-X", "POST",
+                 "-H", "Content-Type: application/json", "--data-binary", "@-", endpoint],
+                input=body, capture_output=True, timeout=timeout + 5,
+            )
+            code = (r.stdout or b"").decode("ascii", "ignore").strip()
+            if code.startswith("2"):
+                print(f"  → telemetry sent ({code}, via curl)\n")
+                return True
+            print(f"  → telemetry unavailable (urllib: {first}; curl HTTP {code or 'n/a'}) — skipped\n")
+            return False
+        except Exception as e2:
+            print(f"  → telemetry unavailable (urllib: {first}; curl: {str(e2).splitlines()[0]}) — skipped\n")
+            return False

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
@@ -97,7 +97,7 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
-report_migration(
+sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
@@ -105,8 +105,11 @@ report_migration(
     success=not args.failed,
     mode=mode,
 )
+# Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
+# otherwise "skipped" so the audit record never claims a delivery that failed.
+# The gate accepts sent|declined|skipped — telemetry must never block.
 _write_marker(args.workdir, {
-    'status': 'sent',
+    'status': 'sent' if sent else 'skipped',
     'tool': args.tool,
     'success': not args.failed,
     'mode': mode,

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-warehouse.rb
@@ -92,7 +92,17 @@ end
 
 # Verify one element returns real warehouse data: non-empty rows, all plan
 # columns present in the export headers, and at least one non-blank cell.
-def verify_chart(c, el_by_id, wb, timeout, fixture)
+# A cell that is itself a Sigma query-error string is NOT real data — the element
+# rendered "Invalid Query: Unknown…" / "#ERROR". The old has_value check treated
+# these as non-blank and PASSed a visibly-broken workbook (handoff FIX 2).
+ERROR_CELL = /\A\s*(Invalid Query|Error\b|#REF|#ERROR|#VALUE|#NAME)/i
+
+def verify_chart(c, el_by_id, error_element_ids, wb, timeout, fixture)
+  # An element that owns a type=error column (the signal Gate 3 uses) can never
+  # be warehouse-verified — fail it before we even look at the CSV.
+  if error_element_ids.include?(c['sigma_element_id'])
+    return [:fail, 'element owns a type=error column (broken formula — see /columns)']
+  end
   status, payload = element_csv(c, wb, timeout, fixture)
   return [:fail, payload] if status == :fail
   rows = (CSV.parse(payload) rescue [])
@@ -100,6 +110,10 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   headers = rows.shift.map { |h| h.to_s.strip }
   data = rows
   return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # Reject query-error sentinels appearing as cell values.
+  bad = data.flatten.find { |cell| cell.to_s =~ ERROR_CELL }
+  return [:fail, "element returned query-error cells: #{bad.to_s.strip[0, 60]}"] if bad
 
   # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
   # grid is the strongest honest assertion we can make for it.
@@ -118,7 +132,22 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   [:ok, "#{data.size} row(s)"]
 end
 
+# Belt-and-suspenders: the warehouse-verified stamp must never land on a workbook
+# with type=error columns. Fetch /columns ONCE and collect the owning element ids
+# (the same signal assert-phase6 Gate 3 uses). Skipped in fixture/test mode.
+error_element_ids = []
+unless opts[:fixture]
+  begin
+    cols = (Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/columns")['entries'] rescue []) || []
+    error_element_ids = cols.select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['elementId'] }.compact.uniq
+    warn "verify-warehouse: #{error_element_ids.size} element(s) own type=error columns — will fail" unless error_element_ids.empty?
+  rescue => e
+    warn "verify-warehouse: /columns scan unavailable (#{e.message.lines.first.to_s.strip[0, 80]}) — relying on per-cell error detection"
+  end
+end
+
 require 'thread'
+fixture_data = opts[:fixture] && JSON.parse(File.read(opts[:fixture]))
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -127,7 +156,7 @@ Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
   Thread.new do
     loop do
       c = (queue.pop(true) rescue break)
-      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      st, why = verify_chart(c, el_by_id, error_element_ids, opts[:wb], opts[:timeout], fixture_data)
       mutex.synchronize { results[c['chart']] = [st, why] }
     end
   end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-warehouse.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-warehouse.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# verify-warehouse.rb — RAW-MODE parity: verify the built workbook against the
+# LIVE SIGMA WAREHOUSE when the source tool is unreachable.
+#
+# Normal Phase 6 diffs each Sigma element against the SOURCE tool's values
+# (Tableau view CSV, Looker API, …). When a customer hands over only a raw export
+# (.twb/.pbix/.qvf) with no live source, there is nothing to diff against — but
+# the warehouse IS reachable. This script proves the next-best, honest thing:
+# every built element EVALUATES against the live warehouse connection and returns
+# real, column-resolvable, non-empty data (no broken joins, error columns, or
+# empty results — the failure modes that make a raw-file conversion "look done"
+# but be wrong). It does NOT claim the numbers match the source's rendered output
+# — assert-phase6-ran.rb prints a loud banner saying exactly that.
+#
+# It reuses the verified element-CSV export flow (POST /v2/workbooks/{wb}/export →
+# poll GET /v2/query/{q}/download) that collect-parity-actuals.rb uses, through
+# lib/sigma_rest (auto-refresh on 401).
+#
+# Usage:
+#   ruby scripts/verify-warehouse.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --workbook-spec <dir>/wb-readback.json \
+#     --out <dir>/parity-final.json [--pool 5] [--timeout 120]
+#     [--fixture <file>]   # TEST ONLY: {"<element_id>": "<csv text>", ...} instead of the API
+#
+# Exit codes: 0 = all elements returned warehouse data (status PASS written);
+#             2 = one or more elements empty / errored (status FAIL written);
+#             1 = bad invocation.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 5, timeout: 120 }
+OptionParser.new do |p|
+  p.on('--plan PATH')          { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: element_id → CSV text map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+unless opts[:fixture]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+spec = JSON.parse(File.read(opts[:spec]))
+elements = (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+
+# Pull one element's CSV — from the fixture (tests) or the live export API.
+def element_csv(c, wb, timeout, fixture)
+  if fixture
+    txt = fixture[c['sigma_element_id']]
+    return [:fail, 'no fixture row for element'] if txt.nil?
+    return [:ok, txt]
+  end
+  attempts = 0
+  begin
+    attempts += 1
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+    t0 = Time.now
+    loop do
+      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+  rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+    msg = e.message.lines.first.to_s
+    if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+      retry
+    end
+    [:fail, msg[0, 160]]
+  end
+end
+
+# Verify one element returns real warehouse data: non-empty rows, all plan
+# columns present in the export headers, and at least one non-blank cell.
+def verify_chart(c, el_by_id, wb, timeout, fixture)
+  status, payload = element_csv(c, wb, timeout, fixture)
+  return [:fail, payload] if status == :fail
+  rows = (CSV.parse(payload) rescue [])
+  return [:fail, 'export CSV empty / unparseable'] if rows.empty?
+  headers = rows.shift.map { |h| h.to_s.strip }
+  data = rows
+  return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
+  # grid is the strongest honest assertion we can make for it.
+  unless c['sigma_kind'] == 'pivot-table'
+    el = el_by_id[c['sigma_element_id']]
+    if el
+      name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
+      want = (c['sigma_columns'] || []).map { |id| name_for[id] }.compact
+      missing = want.reject { |n| headers.any? { |h| h.casecmp?(n) } }
+      return [:fail, "plotted column(s) absent from export: #{missing.join(', ')}"] unless missing.empty?
+    end
+  end
+
+  has_value = data.any? { |r| r.any? { |cell| !cell.to_s.strip.empty? } }
+  return [:fail, 'all cells blank (element evaluated to nothing)'] unless has_value
+  [:ok, "#{data.size} row(s)"]
+end
+
+require 'thread'
+queue = Queue.new
+charts.each { |c| queue << c }
+results = {}
+mutex = Mutex.new
+Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
+  Thread.new do
+    loop do
+      c = (queue.pop(true) rescue break)
+      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      mutex.synchronize { results[c['chart']] = [st, why] }
+    end
+  end
+end.each(&:join)
+
+passed = results.select { |_, (s, _)| s == :ok }.keys
+failed = results.select { |_, (s, _)| s == :fail }
+total = results.size
+status = (total > 0 && failed.empty?) ? 'PASS' : 'FAIL'
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => 'warehouse',
+  'verified_against' => 'warehouse',
+  'charts_total'     => total,
+  'charts_pass'      => passed.size,
+  'charts_fail'      => failed.size,
+  'pass_names'       => passed,
+  'fail_names'       => failed.keys,
+  'status'           => status,
+  'note'             => 'Raw-mode: each element verified to evaluate against the live Sigma ' \
+                        'warehouse and return data. NOT diffed against the source tool (unreachable).',
+}
+# preserve tile_census if a prior parity-final.json had one (dashboard zone gate)
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue {})
+  summary['tile_census'] = prior['tile_census'] if prior.is_a?(Hash) && prior['tile_census']
+end
+File.write(opts[:out], JSON.pretty_generate(summary))
+
+puts "verify-warehouse: #{passed.size}/#{total} element(s) returned live warehouse data → status=#{status}"
+failed.each { |name, (_, why)| puts "  FAIL  #{name}: #{why}" }
+puts "  → #{opts[:out]} (verified_against=warehouse). assert-phase6-ran.rb will flag this as warehouse-verified."
+exit(status == 'PASS' ? 0 : 2)

--- a/shared/lib/sigma_telemetry.py
+++ b/shared/lib/sigma_telemetry.py
@@ -51,7 +51,7 @@ def report_migration(
     skill_version: str = SKILL_VERSION,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
-) -> None:
+) -> bool:
     """
     Fire-and-forget anonymous usage ping. Never raises — a telemetry failure
     must never block or fail a migration.
@@ -90,16 +90,60 @@ def report_migration(
         if k != "event":
             print(f"  {k}: {v}")
 
+    body = json.dumps(payload).encode("utf-8")
+    # Returns True on HTTP 2xx, False on any skip/failure. NEVER raises — telemetry
+    # must never block or fail a migration. The caller writes an honest marker
+    # ("sent" vs "skipped") based on this return (handoff FIX 3).
+    return _post(endpoint, body, timeout)
+
+
+def _ssl_context():
+    """Prefer certifi's CA bundle — stock macOS / homebrew-python urllib often
+    fails CERTIFICATE_VERIFY_FAILED against the endpoint where curl succeeds
+    (handoff FIX 4). Fall back to the default context if certifi isn't present."""
     try:
-        body = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            endpoint,
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            print(f"  → telemetry sent ({resp.status})\n")
+        import ssl
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
     except Exception:
-        # Never surface telemetry errors to the user
-        print("  → telemetry unavailable (skipped)\n")
+        try:
+            import ssl
+            return ssl.create_default_context()
+        except Exception:
+            return None
+
+
+def _post(endpoint, body, timeout):
+    # 1) urllib with a certifi-backed SSL context.
+    try:
+        req = urllib.request.Request(
+            endpoint, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        ctx = _ssl_context()
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  → telemetry sent ({resp.status})\n")
+                return True
+            print(f"  → telemetry endpoint returned {resp.status} — skipped\n")
+            return False
+    except Exception as e:
+        first = str(e).splitlines()[0] if str(e) else type(e).__name__
+        # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
+                 "-w", "%{http_code}", "-X", "POST",
+                 "-H", "Content-Type: application/json", "--data-binary", "@-", endpoint],
+                input=body, capture_output=True, timeout=timeout + 5,
+            )
+            code = (r.stdout or b"").decode("ascii", "ignore").strip()
+            if code.startswith("2"):
+                print(f"  → telemetry sent ({code}, via curl)\n")
+                return True
+            print(f"  → telemetry unavailable (urllib: {first}; curl HTTP {code or 'n/a'}) — skipped\n")
+            return False
+        except Exception as e2:
+            print(f"  → telemetry unavailable (urllib: {first}; curl: {str(e2).splitlines()[0]}) — skipped\n")
+            return False

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -105,6 +105,20 @@
       ]
     },
     {
+      "canonical": "shared/scripts/build-parity-plan.rb",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/build-parity-plan.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/build-parity-plan.rb",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build-parity-plan.rb",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/build-parity-plan.rb",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-parity-plan.rb",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-parity-plan.rb",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-parity-plan.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-parity-plan.rb",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/build-parity-plan.rb"
+      ]
+    },
+    {
       "canonical": "shared/scripts/verify-warehouse.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-warehouse.rb",
@@ -308,6 +322,13 @@
       "targets": [
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb",
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-warehouse.rb"
+      ]
+    },
+    {
+      "canonical": "shared/scripts/test-build-parity-plan.rb",
+      "targets": [
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-build-parity-plan.rb"
       ]
     }
   ]

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -105,6 +105,20 @@
       ]
     },
     {
+      "canonical": "shared/scripts/verify-warehouse.rb",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/verify-warehouse.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/verify-warehouse.rb",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-warehouse.rb",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify-warehouse.rb",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-warehouse.rb",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-warehouse.rb",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-warehouse.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-warehouse.rb",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-warehouse.rb"
+      ]
+    },
+    {
       "canonical": "shared/scripts/assert-telemetry-ran.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/assert-telemetry-ran.rb",
@@ -287,6 +301,13 @@
       "targets": [
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake.rb",
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-intake.rb"
+      ]
+    },
+    {
+      "canonical": "shared/scripts/test-verify-warehouse.rb",
+      "targets": [
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-warehouse.rb"
       ]
     }
   ]

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -4,7 +4,11 @@
 # independent things — failing ANY of them blocks the GREEN declaration:
 #
 #   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
-#      → beads-sigma-4pm
+#      → beads-sigma-4pm. Raw-mode: when the source tool is unreachable,
+#      verify-warehouse.rb writes parity-final.json with
+#      verified_against=warehouse — accepted as PASS but flagged with a loud
+#      banner ("verified vs warehouse, NOT source"). intake.json input_mode=file
+#      without a warehouse-verified parity triggers an advisory WARN.
 #   2. No orphan workbooks left in the customer's My Documents
 #      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
 #      cleanup ran with no failed deletes)  → beads-sigma-38a
@@ -188,6 +192,29 @@ else
          "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
   else
     puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  end
+
+  # Raw-mode honesty banner. When the source tool was unreachable, parity is run
+  # against the live Sigma WAREHOUSE (verify-warehouse.rb) instead of the source —
+  # every element evaluates against real warehouse data, but the values were NOT
+  # diffed against the source tool's rendered output. Surface that loudly so a
+  # warehouse-verified run is never mistaken for source parity.
+  verified_against = summary['verified_against'].to_s
+  if verified_against == 'warehouse'
+    puts '     ┌─────────────────────────────────────────────────────────────────────────┐'
+    puts '     │ VERIFIED AGAINST THE LIVE SIGMA WAREHOUSE — NOT against the source tool.   │'
+    puts '     │ Each element evaluates against real warehouse data; values were NOT diffed │'
+    puts '     │ vs the source (it was unreachable). State this in the migration report.    │'
+    puts '     └─────────────────────────────────────────────────────────────────────────┘'
+  else
+    # Advisory only: if intake recorded file-mode (no live source) but parity was
+    # not warehouse-verified, the run may be over-claiming source parity.
+    intake = (JSON.parse(File.read(File.join(opts[:tab], 'intake.json'))) rescue nil)
+    if intake.is_a?(Hash) && intake['input_mode'].to_s == 'file'
+      warn '[WARN] gate 1: intake.json records input_mode=file (no live source) but parity-final.json is'
+      warn '       not marked verified_against=warehouse. In raw-mode, verify against the warehouse'
+      warn '       (ruby scripts/verify-warehouse.rb) so the result is not mistaken for source parity.'
+    end
   end
 end
 

--- a/shared/scripts/assert-telemetry-ran.rb
+++ b/shared/scripts/assert-telemetry-ran.rb
@@ -57,8 +57,11 @@ end
 
 rec = (JSON.parse(File.read(marker)) rescue nil)
 status = rec.is_a?(Hash) ? rec['status'] : nil
-unless %w[sent declined].include?(status)
-  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\" or \"declined\")."
+# "skipped" = consent given + send attempted but the endpoint was unreachable
+# (handoff FIX 3). Telemetry must never block, so it still passes — the marker is
+# honest about non-delivery instead of faking "sent".
+unless %w[sent declined skipped].include?(status)
+  warn "[FAIL] telemetry gate: #{marker} present but status is #{status.inspect} (expected \"sent\", \"declined\", or \"skipped\")."
   warn '       Re-run report-telemetry.py to write a valid marker.'
   exit 12
 end

--- a/shared/scripts/build-parity-plan.rb
+++ b/shared/scripts/build-parity-plan.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# build-parity-plan.rb — emit a parity-plan.json (and a normalized wb-readback.json)
+# straight from a built Sigma workbook spec, with NO source-tool views required.
+#
+# Normal Phase 6 (auto-parity-plan.rb) matches each chart to a SOURCE view to get
+# expected values. In raw-mode (only a .twb/.pbix/.qvf, no live source) there are
+# no source views — but verify-warehouse.rb only needs the LIST of visible chart
+# elements + their plotted columns to confirm each evaluates against the warehouse.
+# This helper produces exactly that, so an agent in file-mode does not hand-roll
+# the plan (handoff FIX 1).
+#
+# Usage:
+#   ruby scripts/build-parity-plan.rb --workbook-id <wb> --out <wd>/parity-plan.json \
+#     [--workbook-spec <wd>/wb-readback.json]   # use this spec instead of GET /spec
+#     [--emit-spec <wd>/wb-readback.json]        # also write the spec here ({pages:[...]})
+#
+# Output parity-plan.json: { "charts": [ { chart, sigma_element_id, sigma_kind,
+#   sigma_columns:[<plotted column ids>] }, ... ] } — one entry per VISIBLE chart
+# element (hidden data-page masters, controls, text/image/containers excluded).
+#
+# Exit codes: 0 = plan written (>=1 chart); 2 = zero chartable elements; 1 = bad invocation.
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--emit-spec PATH')     { |v| opts[:emit] = v }
+end.parse!
+abort 'missing --out' unless opts[:out]
+abort 'missing --workbook-id (or --workbook-spec)' unless opts[:wb] || opts[:spec]
+
+# Load the spec: from a file if given, else from the live workbook.
+if opts[:spec] && File.exist?(opts[:spec])
+  spec = JSON.parse(File.read(opts[:spec]))
+else
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  resp = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec")
+  # /spec may wrap the spec under a key; accept either shape.
+  spec = resp.is_a?(Hash) && resp['spec'] ? resp['spec'] : resp
+end
+
+# Non-data element kinds we never verify (controls, text, images, containers).
+SKIP_KIND = /control|^text$|^image$|^button|container|^iframe|^embed|^divider/i
+
+def chartable?(el)
+  k = el['kind'].to_s
+  return false if k.empty? || k =~ SKIP_KIND
+  return false if el['visibleAsSource'] == false        # hidden data-page master
+  (el['columns'] || []).any?
+end
+
+# Plotted channel columns = every columnId the element's channels reference that
+# the element actually owns. Best-effort: if none resolve, leave empty (verify-
+# warehouse then just asserts the element returns non-empty, non-error data).
+def plotted_column_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }.compact.to_set
+  ids = []
+  walk = lambda do |v|
+    case v
+    when Hash
+      v.each do |k, val|
+        next if k == 'columns'                          # skip the column definitions
+        if k == 'columnId' && val.is_a?(String)
+          ids << val
+        elsif k == 'columnIds' && val.is_a?(Array)
+          val.each { |x| ids << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+        else
+          walk.call(val)
+        end
+      end
+    when Array then v.each { |x| walk.call(x) }
+    end
+  end
+  walk.call(el)
+  ids.compact.uniq.select { |i| own.include?(i) }
+end
+
+pages = spec['pages'] || []
+charts = []
+pages.each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless chartable?(el)
+    charts << {
+      'chart'            => (el['name'] || el['title'] || el['id']).to_s,
+      'sigma_element_id' => el['id'],
+      'sigma_kind'       => el['kind'],
+      'sigma_columns'    => plotted_column_ids(el),
+    }
+  end
+end
+
+if charts.empty?
+  warn '[FAIL] build-parity-plan: found zero visible chart elements in the workbook spec.'
+  warn '       (All elements were controls/text/images/containers or hidden masters.)'
+  exit 2
+end
+
+File.write(opts[:out], JSON.pretty_generate('charts' => charts))
+File.write(opts[:emit], JSON.pretty_generate('pages' => pages)) if opts[:emit]
+
+puts "build-parity-plan: #{charts.size} visible chart element(s) → #{opts[:out]}"
+puts "  (wb-readback spec → #{opts[:emit]})" if opts[:emit]
+charts.first(12).each { |c| puts "    - #{c['chart']} [#{c['sigma_kind']}] #{c['sigma_columns'].size} col(s)" }
+exit 0

--- a/shared/scripts/report-telemetry.py
+++ b/shared/scripts/report-telemetry.py
@@ -97,7 +97,7 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
-report_migration(
+sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
     client_id=os.environ.get('SIGMA_CLIENT_ID', ''),
@@ -105,8 +105,11 @@ report_migration(
     success=not args.failed,
     mode=mode,
 )
+# Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
+# otherwise "skipped" so the audit record never claims a delivery that failed.
+# The gate accepts sent|declined|skipped — telemetry must never block.
 _write_marker(args.workdir, {
-    'status': 'sent',
+    'status': 'sent' if sent else 'skipped',
     'tool': args.tool,
     'success': not args.failed,
     'mode': mode,

--- a/shared/scripts/test-build-parity-plan.rb
+++ b/shared/scripts/test-build-parity-plan.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+# test-build-parity-plan.rb — unit test for build-parity-plan.rb (raw-mode helper,
+# handoff FIX 1). Offline: reads a synthetic spec via --workbook-spec, never the API.
+# Canonical in shared/scripts. Run: ruby scripts/test-build-parity-plan.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+BPP  = File.join(__dir__, 'build-parity-plan.rb')
+RUBY = RbConfig.ruby
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+SPEC = { 'pages' => [{ 'elements' => [
+  { 'id' => 'el-master', 'kind' => 'table', 'visibleAsSource' => false, 'columns' => [{ 'id' => 'm1', 'name' => 'X' }] },
+  { 'id' => 'el-ctl', 'kind' => 'list-control', 'columns' => [{ 'id' => 'c1', 'name' => 'Region' }] },
+  { 'id' => 'el-txt', 'kind' => 'text', 'columns' => [] },
+  { 'id' => 'el-kpi', 'kind' => 'kpi-chart', 'name' => 'Net Revenue',
+    'columns' => [{ 'id' => 'v1', 'name' => 'Net Revenue' }], 'value' => { 'columnId' => 'v1' } },
+  { 'id' => 'el-bar', 'kind' => 'bar-chart', 'name' => 'Sales by Region',
+    'columns' => [{ 'id' => 'x1', 'name' => 'Region' }, { 'id' => 'y1', 'name' => 'Sales' }, { 'id' => 'h1', 'name' => 'Hidden' }],
+    'xAxis' => { 'columnId' => 'x1' }, 'yAxis' => { 'columnIds' => [{ 'columnId' => 'y1' }] } },
+] }] }
+
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'spec.json'), JSON.generate(SPEC))
+  out = File.join(d, 'parity-plan.json')
+  emit = File.join(d, 'wb-readback.json')
+  st = system(RUBY, BPP, '--workbook-id', 'WB', '--workbook-spec', File.join(d, 'spec.json'),
+              '--out', out, '--emit-spec', emit, out: File::NULL, err: File::NULL)
+  ok('exit 0', st)
+  plan = JSON.parse(File.read(out))['charts']
+  names = plan.map { |c| c['sigma_element_id'] }.sort
+  ok('only the 2 visible charts (master/control/text excluded)', names == %w[el-bar el-kpi])
+  bar = plan.find { |c| c['sigma_element_id'] == 'el-bar' }
+  ok('plotted channels only (hidden filter h1 excluded)', bar['sigma_columns'].sort == %w[x1 y1])
+  kpi = plan.find { |c| c['sigma_element_id'] == 'el-kpi' }
+  ok('kpi value column captured', kpi['sigma_columns'] == ['v1'])
+  ok('emit-spec wrote wb-readback {pages:[...]}', JSON.parse(File.read(emit)).key?('pages'))
+end
+
+# zero chartable elements → exit 2
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'spec.json'), JSON.generate('pages' => [{ 'elements' => [{ 'id' => 't', 'kind' => 'text', 'columns' => [] }] }]))
+  st = system(RUBY, BPP, '--workbook-id', 'WB', '--workbook-spec', File.join(d, 'spec.json'),
+              '--out', File.join(d, 'p.json'), out: File::NULL, err: File::NULL)
+  ok('zero charts → exit 2', !st && $?.exitstatus == 2)
+end
+
+puts $fail.zero? ? "\nall build-parity-plan tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/shared/scripts/test-telemetry-gate.rb
+++ b/shared/scripts/test-telemetry-gate.rb
@@ -39,12 +39,14 @@ Dir.mktmpdir do |d|
 end
 
 Dir.mktmpdir do |d|
-  # 4. send path writes status=sent + carries the mode enum
+  # 4. send path: status is "sent" when the POST lands, "skipped" when the endpoint
+  #    is unreachable (offline CI). Both are honest (handoff FIX 3) and both satisfy
+  #    the gate — telemetry must never block. NEVER "sent" on a failed delivery.
   ok('send writes a marker', report(d, '--duration', '120', '--mode', 'file'))
   rec = JSON.parse(File.read(File.join(d, 'telemetry-sent.json')))
-  ok('sent marker status',  rec['status'] == 'sent')
-  ok('sent marker mode',    rec['mode'] == 'file')
-  ok('sent marker satisfies the gate', gate(d) == true)
+  ok('send marker status sent|skipped', %w[sent skipped].include?(rec['status']))
+  ok('send marker mode',    rec['mode'] == 'file')
+  ok('send marker satisfies the gate', gate(d) == true)
 end
 
 Dir.mktmpdir do |d|

--- a/shared/scripts/test-verify-warehouse.rb
+++ b/shared/scripts/test-verify-warehouse.rb
@@ -76,5 +76,14 @@ Dir.mktmpdir do |d|
   ok('all-blank → FAIL', st == 2)
 end
 
+# 6. query-error cell ("Invalid Query: …") → FAIL (handoff FIX 2: must not PASS a broken element)
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Broken', 'sigma_element_id' => 'el-rev', 'sigma_kind' => 'kpi-chart', 'sigma_columns' => %w[c-m c-r] }],
+    { 'el-rev' => "Month,Net Revenue\n2025-01,Invalid Query: Unknown column DimDate.Month\n" })
+  ok('query-error cell → exit 2', st == 2)
+  ok('query-error cell listed as FAIL', s['fail_names'] == ['Broken'])
+end
+
 puts $fail.zero? ? "\nall verify-warehouse tests passed" : "\n#{$fail} FAILED"
 exit($fail.zero? ? 0 : 1)

--- a/shared/scripts/test-verify-warehouse.rb
+++ b/shared/scripts/test-verify-warehouse.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# test-verify-warehouse.rb — unit test for raw-mode warehouse verification
+# (verify-warehouse.rb). Offline: element CSVs come from the --fixture seam, never
+# the export API. Canonical in shared/scripts (epic beads-sigma-p5y2).
+# Run: ruby scripts/test-verify-warehouse.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+VW   = File.join(__dir__, 'verify-warehouse.rb')
+RUBY = RbConfig.ruby
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+SPEC = {
+  'pages' => [{ 'elements' => [
+    { 'id' => 'el-rev',   'columns' => [{ 'id' => 'c-m', 'name' => 'Month' }, { 'id' => 'c-r', 'name' => 'Net Revenue' }] },
+    { 'id' => 'el-empty', 'columns' => [{ 'id' => 'c-x', 'name' => 'Region' }, { 'id' => 'c-y', 'name' => 'Sales' }] },
+    { 'id' => 'el-piv',   'columns' => [{ 'id' => 'c-a', 'name' => 'A' }] },
+    { 'id' => 'el-blank', 'columns' => [{ 'id' => 'c-b', 'name' => 'B' }] },
+  ] }],
+}
+
+def run(dir, charts, fixture)
+  File.write(File.join(dir, 'wb-readback.json'), JSON.generate(SPEC))
+  File.write(File.join(dir, 'parity-plan.json'), JSON.generate('charts' => charts))
+  File.write(File.join(dir, 'fx.json'), JSON.generate(fixture))
+  out = File.join(dir, 'parity-final.json')
+  system(RUBY, VW, '--plan', File.join(dir, 'parity-plan.json'), '--workbook-id', 'WB',
+         '--workbook-spec', File.join(dir, 'wb-readback.json'), '--out', out, '--fixture', File.join(dir, 'fx.json'),
+         out: File::NULL, err: File::NULL)
+  [$?.exitstatus, JSON.parse(File.read(out))]
+end
+
+# 1. all elements return data → PASS, verified_against=warehouse
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Rev', 'sigma_element_id' => 'el-rev', 'sigma_kind' => 'line-chart', 'sigma_columns' => %w[c-m c-r] }],
+    { 'el-rev' => "Month,Net Revenue\n2025-01,42508.08\n2025-02,51200.10\n" })
+  ok('all-data → exit 0', st == 0)
+  ok('status PASS', s['status'] == 'PASS')
+  ok('verified_against=warehouse', s['verified_against'] == 'warehouse')
+end
+
+# 2. element returns headers only (broken join / empty) → FAIL
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Empty', 'sigma_element_id' => 'el-empty', 'sigma_kind' => 'bar-chart', 'sigma_columns' => %w[c-x c-y] }],
+    { 'el-empty' => "Region,Sales\n" })
+  ok('headers-only → exit 2', st == 2)
+  ok('listed in fail_names', s['fail_names'] == ['Empty'])
+end
+
+# 3. plotted column missing from export → FAIL
+Dir.mktmpdir do |d|
+  st, _ = run(d,
+    [{ 'chart' => 'Rev', 'sigma_element_id' => 'el-rev', 'sigma_kind' => 'line-chart', 'sigma_columns' => %w[c-m c-r] }],
+    { 'el-rev' => "Month,Other\n2025-01,5\n" })   # 'Net Revenue' absent
+  ok('missing plotted column → FAIL', st == 2)
+end
+
+# 4. pivot-table wide grid (non-empty) → PASS without column enforcement
+Dir.mktmpdir do |d|
+  st, s = run(d,
+    [{ 'chart' => 'Piv', 'sigma_element_id' => 'el-piv', 'sigma_kind' => 'pivot-table', 'sigma_columns' => %w[c-a] }],
+    { 'el-piv' => "Region,Jan,Feb\nWest,1,2\nEast,3,4\n" })
+  ok('pivot non-empty → PASS', st == 0 && s['status'] == 'PASS')
+end
+
+# 5. all cells blank → FAIL
+Dir.mktmpdir do |d|
+  st, _ = run(d,
+    [{ 'chart' => 'Blank', 'sigma_element_id' => 'el-blank', 'sigma_kind' => 'kpi-chart', 'sigma_columns' => %w[c-b] }],
+    { 'el-blank' => "B\n\n" })
+  ok('all-blank → FAIL', st == 2)
+end
+
+puts $fail.zero? ? "\nall verify-warehouse tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)

--- a/shared/scripts/verify-warehouse.rb
+++ b/shared/scripts/verify-warehouse.rb
@@ -92,7 +92,17 @@ end
 
 # Verify one element returns real warehouse data: non-empty rows, all plan
 # columns present in the export headers, and at least one non-blank cell.
-def verify_chart(c, el_by_id, wb, timeout, fixture)
+# A cell that is itself a Sigma query-error string is NOT real data — the element
+# rendered "Invalid Query: Unknown…" / "#ERROR". The old has_value check treated
+# these as non-blank and PASSed a visibly-broken workbook (handoff FIX 2).
+ERROR_CELL = /\A\s*(Invalid Query|Error\b|#REF|#ERROR|#VALUE|#NAME)/i
+
+def verify_chart(c, el_by_id, error_element_ids, wb, timeout, fixture)
+  # An element that owns a type=error column (the signal Gate 3 uses) can never
+  # be warehouse-verified — fail it before we even look at the CSV.
+  if error_element_ids.include?(c['sigma_element_id'])
+    return [:fail, 'element owns a type=error column (broken formula — see /columns)']
+  end
   status, payload = element_csv(c, wb, timeout, fixture)
   return [:fail, payload] if status == :fail
   rows = (CSV.parse(payload) rescue [])
@@ -100,6 +110,10 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   headers = rows.shift.map { |h| h.to_s.strip }
   data = rows
   return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # Reject query-error sentinels appearing as cell values.
+  bad = data.flatten.find { |cell| cell.to_s =~ ERROR_CELL }
+  return [:fail, "element returned query-error cells: #{bad.to_s.strip[0, 60]}"] if bad
 
   # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
   # grid is the strongest honest assertion we can make for it.
@@ -118,7 +132,22 @@ def verify_chart(c, el_by_id, wb, timeout, fixture)
   [:ok, "#{data.size} row(s)"]
 end
 
+# Belt-and-suspenders: the warehouse-verified stamp must never land on a workbook
+# with type=error columns. Fetch /columns ONCE and collect the owning element ids
+# (the same signal assert-phase6 Gate 3 uses). Skipped in fixture/test mode.
+error_element_ids = []
+unless opts[:fixture]
+  begin
+    cols = (Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/columns")['entries'] rescue []) || []
+    error_element_ids = cols.select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['elementId'] }.compact.uniq
+    warn "verify-warehouse: #{error_element_ids.size} element(s) own type=error columns — will fail" unless error_element_ids.empty?
+  rescue => e
+    warn "verify-warehouse: /columns scan unavailable (#{e.message.lines.first.to_s.strip[0, 80]}) — relying on per-cell error detection"
+  end
+end
+
 require 'thread'
+fixture_data = opts[:fixture] && JSON.parse(File.read(opts[:fixture]))
 queue = Queue.new
 charts.each { |c| queue << c }
 results = {}
@@ -127,7 +156,7 @@ Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
   Thread.new do
     loop do
       c = (queue.pop(true) rescue break)
-      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      st, why = verify_chart(c, el_by_id, error_element_ids, opts[:wb], opts[:timeout], fixture_data)
       mutex.synchronize { results[c['chart']] = [st, why] }
     end
   end

--- a/shared/scripts/verify-warehouse.rb
+++ b/shared/scripts/verify-warehouse.rb
@@ -1,0 +1,165 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# verify-warehouse.rb — RAW-MODE parity: verify the built workbook against the
+# LIVE SIGMA WAREHOUSE when the source tool is unreachable.
+#
+# Normal Phase 6 diffs each Sigma element against the SOURCE tool's values
+# (Tableau view CSV, Looker API, …). When a customer hands over only a raw export
+# (.twb/.pbix/.qvf) with no live source, there is nothing to diff against — but
+# the warehouse IS reachable. This script proves the next-best, honest thing:
+# every built element EVALUATES against the live warehouse connection and returns
+# real, column-resolvable, non-empty data (no broken joins, error columns, or
+# empty results — the failure modes that make a raw-file conversion "look done"
+# but be wrong). It does NOT claim the numbers match the source's rendered output
+# — assert-phase6-ran.rb prints a loud banner saying exactly that.
+#
+# It reuses the verified element-CSV export flow (POST /v2/workbooks/{wb}/export →
+# poll GET /v2/query/{q}/download) that collect-parity-actuals.rb uses, through
+# lib/sigma_rest (auto-refresh on 401).
+#
+# Usage:
+#   ruby scripts/verify-warehouse.rb --plan <dir>/parity-plan.json \
+#     --workbook-id <wb> --workbook-spec <dir>/wb-readback.json \
+#     --out <dir>/parity-final.json [--pool 5] [--timeout 120]
+#     [--fixture <file>]   # TEST ONLY: {"<element_id>": "<csv text>", ...} instead of the API
+#
+# Exit codes: 0 = all elements returned warehouse data (status PASS written);
+#             2 = one or more elements empty / errored (status FAIL written);
+#             1 = bad invocation.
+
+require 'json'
+require 'csv'
+require 'optparse'
+require 'time'
+
+opts = { pool: 5, timeout: 120 }
+OptionParser.new do |p|
+  p.on('--plan PATH')          { |v| opts[:plan] = v }
+  p.on('--workbook-id ID')     { |v| opts[:wb] = v }
+  p.on('--workbook-spec PATH') { |v| opts[:spec] = v }
+  p.on('--out PATH')           { |v| opts[:out] = v }
+  p.on('--pool N', Integer)    { |v| opts[:pool] = v }
+  p.on('--timeout S', Integer) { |v| opts[:timeout] = v }
+  p.on('--fixture PATH', 'TEST ONLY: element_id → CSV text map, bypasses the export API') { |v| opts[:fixture] = v }
+end.parse!
+%i[plan wb spec out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+unless opts[:fixture]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+end
+
+plan = JSON.parse(File.read(opts[:plan]))
+charts = plan.is_a?(Hash) ? (plan['charts'] || []) : plan
+spec = JSON.parse(File.read(opts[:spec]))
+elements = (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+el_by_id = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+
+# Pull one element's CSV — from the fixture (tests) or the live export API.
+def element_csv(c, wb, timeout, fixture)
+  if fixture
+    txt = fixture[c['sigma_element_id']]
+    return [:fail, 'no fixture row for element'] if txt.nil?
+    return [:ok, txt]
+  end
+  attempts = 0
+  begin
+    attempts += 1
+    r = Sigma.request(:post, "/v2/workbooks/#{wb}/export",
+                      body: JSON.generate({ elementId: c['sigma_element_id'], format: { type: 'csv' } }))
+    qid = r && r['queryId']
+    return [:fail, "export POST returned no queryId: #{r.inspect[0, 120]}"] unless qid
+    t0 = Time.now
+    loop do
+      return [:fail, "export poll timed out (#{timeout}s)"] if Time.now - t0 > timeout
+      sleep 1.0
+      begin
+        b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+        return [:ok, b] if b && !b.to_s.empty?   # 204-empty = still rendering
+      rescue Sigma::Error => e
+        raise unless e.message.lines.first.to_s =~ /\b404\b/
+      end
+    end
+  rescue Sigma::Error, Timeout::Error, Errno::ETIMEDOUT => e
+    msg = e.message.lines.first.to_s
+    if attempts < 4 && msg =~ /\b(429|408|50[234])\b|Too Many Requests|timed? ?out/i
+      sleep((1.5 * (2**(attempts - 1))) + rand * 0.5)
+      retry
+    end
+    [:fail, msg[0, 160]]
+  end
+end
+
+# Verify one element returns real warehouse data: non-empty rows, all plan
+# columns present in the export headers, and at least one non-blank cell.
+def verify_chart(c, el_by_id, wb, timeout, fixture)
+  status, payload = element_csv(c, wb, timeout, fixture)
+  return [:fail, payload] if status == :fail
+  rows = (CSV.parse(payload) rescue [])
+  return [:fail, 'export CSV empty / unparseable'] if rows.empty?
+  headers = rows.shift.map { |h| h.to_s.strip }
+  data = rows
+  return [:fail, 'no data rows (element returned headers only — empty result / broken join)'] if data.empty?
+
+  # pivot-table exports the wide grid (not the plan's long tuples); a non-empty
+  # grid is the strongest honest assertion we can make for it.
+  unless c['sigma_kind'] == 'pivot-table'
+    el = el_by_id[c['sigma_element_id']]
+    if el
+      name_for = (el['columns'] || []).each_with_object({}) { |col, h| h[col['id']] = col['name'].to_s.strip }
+      want = (c['sigma_columns'] || []).map { |id| name_for[id] }.compact
+      missing = want.reject { |n| headers.any? { |h| h.casecmp?(n) } }
+      return [:fail, "plotted column(s) absent from export: #{missing.join(', ')}"] unless missing.empty?
+    end
+  end
+
+  has_value = data.any? { |r| r.any? { |cell| !cell.to_s.strip.empty? } }
+  return [:fail, 'all cells blank (element evaluated to nothing)'] unless has_value
+  [:ok, "#{data.size} row(s)"]
+end
+
+require 'thread'
+queue = Queue.new
+charts.each { |c| queue << c }
+results = {}
+mutex = Mutex.new
+Array.new([opts[:pool], [charts.size, 1].max].min.clamp(1, 16)) do
+  Thread.new do
+    loop do
+      c = (queue.pop(true) rescue break)
+      st, why = verify_chart(c, el_by_id, opts[:wb], opts[:timeout], opts[:fixture] && JSON.parse(File.read(opts[:fixture])))
+      mutex.synchronize { results[c['chart']] = [st, why] }
+    end
+  end
+end.each(&:join)
+
+passed = results.select { |_, (s, _)| s == :ok }.keys
+failed = results.select { |_, (s, _)| s == :fail }
+total = results.size
+status = (total > 0 && failed.empty?) ? 'PASS' : 'FAIL'
+
+summary = {
+  'workbook_id'      => opts[:wb],
+  'ran_at'           => Time.now.utc.iso8601,
+  'mode'             => 'warehouse',
+  'verified_against' => 'warehouse',
+  'charts_total'     => total,
+  'charts_pass'      => passed.size,
+  'charts_fail'      => failed.size,
+  'pass_names'       => passed,
+  'fail_names'       => failed.keys,
+  'status'           => status,
+  'note'             => 'Raw-mode: each element verified to evaluate against the live Sigma ' \
+                        'warehouse and return data. NOT diffed against the source tool (unreachable).',
+}
+# preserve tile_census if a prior parity-final.json had one (dashboard zone gate)
+if File.exist?(opts[:out])
+  prior = (JSON.parse(File.read(opts[:out])) rescue {})
+  summary['tile_census'] = prior['tile_census'] if prior.is_a?(Hash) && prior['tile_census']
+end
+File.write(opts[:out], JSON.pretty_generate(summary))
+
+puts "verify-warehouse: #{passed.size}/#{total} element(s) returned live warehouse data → status=#{status}"
+failed.each { |name, (_, why)| puts "  FAIL  #{name}: #{why}" }
+puts "  → #{opts[:out]} (verified_against=warehouse). assert-phase6-ran.rb will flag this as warehouse-verified."
+exit(status == 'PASS' ? 0 : 2)


### PR DESCRIPTION
**PR 3 of 3** — completes the migration runtime contract (design: #181, epic `beads-sigma-p5y2`). **Stacked on #184** (which is stacked on #182). Merge order: **#182 → #184 → this**.

## Problem
When a customer provides only a raw export (`.twb`/`.pbix`/`.qvf`) with no live source, Phase 6 has nothing to diff against — the "did a really bad job" case. The build proceeds but parity can't run, so either it's skipped (silent over-claim) or the run looks broken.

## Fix — verify against the live Sigma warehouse, and say so
- **`verify-warehouse.rb`** (shared, fanned to 9): reads `parity-plan.json`, exports each built Sigma element (the same `POST /export` → poll flow `collect-parity-actuals.rb` uses), and asserts it **evaluates against the live warehouse and returns real, column-resolvable, non-empty data**. Catches broken joins, error columns, and empty elements — the failure modes that make a raw-file conversion *look* done but be wrong. Writes `parity-final.json` with `verified_against: warehouse`.
- **`assert-phase6-ran.rb` Gate 1** accepts `verified_against: warehouse` as PASS and prints a loud banner: *verified vs the WAREHOUSE, NOT the source tool*. Advisory WARN if `intake.json` `input_mode=file` but parity isn't warehouse-verified (over-claim guard). Keys off PR #184's `intake.json` mode.
- **tableau SKILL** gets a "Raw-mode — only a `.twb`" section.

## Honest degradation
Real numbers from real warehouse data, minus the source-side value/visual diff that genuinely needs a live source. The stronger warehouse-**oracle** diff (supply expected rows, run `verify-parity.rb` — PBI's `--local-sql`) stays opt-in.

## Tests
`test-verify-warehouse.rb` — offline, 8 assertions (data/empty/missing-column/pivot/blank) via a `--fixture` seam. Wired into `corpus-check.yml`. All governance + prior tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)