### PR TITLE
fix(powerbi): nameless DimDate element overwrites a named master (KitchenSink POST blocker)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -105,6 +105,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-element-match.rb
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_element_match.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_element_match.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+# pbi_element_match.rb — pair each converter element to its posted-DM (readback)
+# element when deriving the master-map in migrate-powerbi.rb.
+#
+# WHY THIS IS NOT A SIMPLE POSITIONAL MATCH: a DM POST does NOT preserve element
+# order. It floats NAMELESS Custom SQL elements (rule 3 omits their `name`) to the
+# FRONT of the readback. A raw positional index (`dm_elements[i]`) is therefore
+# unsafe for a nameless converter element: it grabs whatever NAMED element now
+# sits at that shifted index, and the master-builder then OVERWRITES that named
+# master with the SQL element's columns.
+#
+# Live failure (KitchenSink, contract run-2): the nameless DimDate spine sat at
+# converter idx 3, but POST moved it to readback idx 0, shifting SAFETY_INCIDENTS
+# down into idx 3. The nameless element positional-matched idx 3 = SAFETY_INCIDENTS
+# and overwrote its 8 base columns with 4 date-hierarchy cols → workbook POST
+# "Dependency not found: 'safety_incidents/year'" (and the dependent KPI/table refs).
+#
+# The fix, encapsulated here: match nameless-to-nameless. Named converter elements
+# bind by NAME (POST/PUT keep names; only ids churn); nameless converter elements
+# consume the readback's nameless elements IN ORDER and never claim a named one.
+module PbiElementMatch
+  module_function
+
+  # conv_elements : the converter's elements, in converter order.
+  # dm_elements   : the posted-DM readback elements (REORDERED by POST).
+  # Returns an Array aligned to conv_elements: dmel_for[i] is the readback element
+  # that converter element i maps to (may be nil only if the readback is emptier
+  # than the converter output, which never happens for a successful POST).
+  def pair(conv_elements, dm_elements)
+    conv_elements ||= []
+    dm_elements   ||= []
+    nameless_readback = dm_elements.select { |e| nameless?(e) }
+    nameless_cursor = 0
+    conv_elements.each_with_index.map do |cel, idx|
+      cname = cel && cel['name']
+      if cname && !cname.to_s.empty?
+        # named: by NAME first, then by ID, then positionally (named elements keep
+        # their relative order across the POST).
+        dm_elements.find { |e| e['name'] == cname } ||
+          dm_elements.find { |e| e['id'] == cel['id'] } ||
+          dm_elements[idx] || dm_elements.first
+      else
+        # nameless (Custom SQL): the next unclaimed nameless readback element —
+        # NEVER a named element via a stale positional index.
+        dmel = nameless_readback[nameless_cursor]
+        nameless_cursor += 1
+        dmel || (cel && dm_elements.find { |e| e['id'] == cel['id'] }) ||
+          dm_elements[idx] || dm_elements.first
+      end
+    end
+  end
+
+  def nameless?(el)
+    el.nil? || el['name'].nil? || el['name'].to_s.empty?
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -68,6 +68,7 @@ $LOAD_PATH.unshift File.expand_path('lib', HERE)
 require 'scout_gate'    # run-each-time gap-scout gate (bead beads-sigma-5l5e)
 require 'dax_gate'      # DAX warning → decision-question classifier (regression-tested)
 require 'coverage_gate' # workbook-build coverage.json → consolidated report + assistance prompt
+require 'pbi_element_match' # converter→readback element pairing (POST reorders; regression-tested)
 
 opts = { db: '', schema: '' }
 OptionParser.new do |o|
@@ -697,19 +698,14 @@ rescue StandardError
 end
 masters = {}
 field_map = {}
+# Pair each converter element to its posted-DM readback element. A DM POST does
+# NOT preserve element order (it floats nameless Custom SQL elements to the front),
+# so this is NOT a positional index — see lib/pbi_element_match.rb for the full
+# rationale + the run-2 SAFETY_INCIDENTS overwrite it prevents.
+dmel_for = PbiElementMatch.pair(conv_elements, dm_elements)
 conv_elements.each_with_index do |cel, cel_idx|
   cname = cel['name']
-  # match the posted DM element: by NAME first (PUT keeps names; ids may change),
-  # then by ID, then POSITIONALLY (POST /spec preserves element order). A Custom
-  # SQL element is NAMELESS in the spec (rule 3) and the readback can ALSO carry
-  # name:null — the old `|| dm_elements.first` fallback then bound it to the
-  # FIRST element (usually the fact table), OVERWRITING that master with the SQL
-  # element's columns (live failure: EMPLOYEES master got SalaryBands' "Band
-  # Floor" -> "Dependency not found: 'employees/band floor'"). Positional match
-  # keeps the nameless element its OWN master (Bug E: nameless SQL element).
-  dmel = (cname && dm_elements.find { |e| e['name'] == cname }) ||
-         dm_elements.find { |e| e['id'] == cel['id'] } ||
-         dm_elements[cel_idx] || dm_elements.first
+  dmel = dmel_for[cel_idx]
   cname ||= (dmel && dmel['name']) || 'Custom SQL'
   # POSTED-spec column display names for this element (matched the same way the
   # dm element was), keyed by formula — overrides the formula-leaf derivation.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-element-match.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-element-match.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-pbi-element-match.rb — regression test for lib/pbi_element_match.rb.
+# Offline: no API, no creds. Run: ruby scripts/test-pbi-element-match.rb
+#
+# Pins the live KitchenSink contract run-2 failure: a DM POST floated the nameless
+# DimDate Custom SQL element to the FRONT of the readback, so a positional index
+# bound it to SAFETY_INCIDENTS and overwrote that master's 8 base columns with 4
+# date-hierarchy cols → POST "Dependency not found: 'safety_incidents/year'".
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'pbi_element_match'
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+# --- run-2 ground truth (names + ids), exactly as captured from dm-raw.json /
+# dm-readback.json. CONVERTER order has the nameless SQL element at idx 3; the
+# POSTED READBACK floats it to idx 0 and assigns fresh ids.
+CONV = [
+  { 'name' => 'EMPLOYEES',            'id' => 'c-emp' },
+  { 'name' => 'ABSENCE_RECORDS',      'id' => 'c-abs' },
+  { 'name' => 'SAFETY_INCIDENTS',     'id' => 'c-saf' },
+  { 'name' => nil,                    'id' => 'ilkqRTsLzU' }, # DimDate spine (nameless)
+  { 'name' => 'EMPLOYEES View',       'id' => 'c-empv' },
+  { 'name' => 'ABSENCE_RECORDS View', 'id' => 'c-absv' },
+  { 'name' => 'SAFETY_INCIDENTS View','id' => 'c-safv' },
+  { 'name' => 'YTD Absence Hours',    'id' => 'c-ytd' },
+  { 'name' => 'PY Absence Hours',     'id' => 'c-py' },
+  { 'name' => 'Dense Rank DEPARTMENT','id' => 'c-dr1' },
+  { 'name' => 'Dense Rank DEPARTMENT 2', 'id' => 'c-dr2' },
+].freeze
+
+READBACK = [
+  { 'name' => nil,                    'id' => 'WdTXIPR-xf' }, # POST floated nameless to front
+  { 'name' => 'EMPLOYEES',            'id' => 'HIg5RXBtF6' },
+  { 'name' => 'ABSENCE_RECORDS',      'id' => 'GCkMYGTS2s' },
+  { 'name' => 'SAFETY_INCIDENTS',     'id' => 'ayk9b6xcXm' },
+  { 'name' => 'EMPLOYEES View',       'id' => 'Q8zpKF0Ul8' },
+  { 'name' => 'ABSENCE_RECORDS View', 'id' => 'CaKAtlAm53' },
+  { 'name' => 'SAFETY_INCIDENTS View','id' => 'ytfP0hb3HP' },
+  { 'name' => 'YTD Absence Hours',    'id' => 'OQ3ZWIc1Fv' },
+  { 'name' => 'PY Absence Hours',     'id' => '_HfO_10O0y' },
+  { 'name' => 'Dense Rank DEPARTMENT','id' => 'u3gEIc9Otk' },
+  { 'name' => 'Dense Rank DEPARTMENT 2', 'id' => 'J1BMo5DGVx' },
+].freeze
+
+pairing = PbiElementMatch.pair(CONV, READBACK)
+
+# The bug: nameless converter element (idx 3) must NOT bind to SAFETY_INCIDENTS.
+nameless_dmel = pairing[3]
+ok('nameless converter element pairs to the nameless readback element',
+   nameless_dmel && nameless_dmel['id'] == 'WdTXIPR-xf')
+ok('nameless converter element does NOT hijack SAFETY_INCIDENTS (the run-2 bug)',
+   nameless_dmel && nameless_dmel['name'].to_s.empty?)
+
+# The real SAFETY_INCIDENTS converter element keeps its own DM element.
+saf = pairing[2]
+ok('SAFETY_INCIDENTS pairs to its own readback element (ayk9b6xcXm)',
+   saf && saf['id'] == 'ayk9b6xcXm' && saf['name'] == 'SAFETY_INCIDENTS')
+
+# Every NAMED converter element pairs to the like-named readback element.
+named_ok = CONV.each_with_index.all? do |cel, i|
+  next true if PbiElementMatch.nameless?(cel)
+  pairing[i] && pairing[i]['name'] == cel['name']
+end
+ok('every named converter element pairs to its like-named readback element', named_ok)
+
+# No two converter elements collapse onto the same readback element (1:1).
+ids = pairing.map { |d| d && d['id'] }
+ok('pairing is 1:1 — no readback element claimed twice', ids.compact.uniq.length == ids.compact.length)
+
+# --- second fixture: no reorder + a single nameless at the end still works.
+CONV2 = [{ 'name' => 'FACT', 'id' => 'a' }, { 'name' => nil, 'id' => 'b' }]
+RB2   = [{ 'name' => 'FACT', 'id' => 'A' }, { 'name' => nil, 'id' => 'B' }]
+p2 = PbiElementMatch.pair(CONV2, RB2)
+ok('trailing nameless element binds to the nameless readback', p2[1]['id'] == 'B')
+ok('named FACT still binds by name', p2[0]['id'] == 'A')
+
+puts $fail.zero? ? "\nall pbi-element-match tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
## What this fixes (FIX 5, binding layer — beads 4hl3 + the BUG A/B root cause)

The KitchenSink workbook POST failed with `Dependency not found: 'safety_incidents/year'`. Run-2 ground-truth analysis (`~/powerbi-migration/contract-e2e-run2-artifacts/`) traced it to a **single root cause** — and it is **not** the converter.

A **DM POST does not preserve element order**: it floats nameless Custom SQL elements (rule 3 omits their `name`) to the **front** of the readback. The master-map derivation in `migrate-powerbi.rb` matched nameless converter elements to the readback by raw **positional index**, so the nameless element grabbed whatever **named** element now sat at that shifted index and overwrote its master.

Concretely:
- Converter order: `…SAFETY_INCIDENTS(idx2), nameless-DimDate-SQL(idx3)…`
- Readback order (POST-reordered): `nameless(idx0), EMPLOYEES(1), ABSENCE(2), SAFETY_INCIDENTS(3)…`
- The nameless DimDate element (`cname=nil`, id reassigned on POST so id-match misses) fell to `dm_elements[3]` = **SAFETY_INCIDENTS**, and since it's processed after the real SAFETY element it **overwrote** that master's 8 base columns with 4 date-hierarchy cols (`[SAFETY_INCIDENTS/Year]` …).

This one bug produces **both** handoff symptoms:
- **BUG A** — phantom `[SAFETY_INCIDENTS/Year]` (the literal POST error).
- **BUG B** — base SAFETY master built with the wrong column subset (so `master-93edeb66/incident id` and the dependent KPI/table refs were unreachable).

The converter output (`dm-raw.json`) was verified **correct**: `SAFETY_INCIDENTS` carries its 8 base cols; the date parts live on a separate nameless DimDate spine.

## Fix
Extract the converter→readback pairing into `lib/pbi_element_match.rb` and match **nameless-to-nameless**: named elements bind by name; nameless ones consume the readback's nameless elements in order and never claim a named element. Strictly supersedes the older positional fix (which the comment wrongly justified with "POST preserves element order").

## Validation
- New offline regression test `test-pbi-element-match.rb` uses the **real run-2 element ordering** — asserts the nameless element pairs to the nameless readback (not SAFETY_INCIDENTS), every named element binds by name, and the pairing is 1:1. Added to the CI offline allowlist.
- `check-shared.rb` / `lint-skills.rb` green (change is plugin-local).

## Not in this PR (separate beads, post-merge live run)
- **BUG C** — time-intel cross-wiring (`PY Incident Count → [master-e172c292/Hours YTD]`) and the `DimDate.Month` line-chart reachability degradations. These do not block the POST; they're tracked as `md3e/uze2/zngm/gfu8` and will be validated one-at-a-time after a live run confirms this fix reaches exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)