### PR TITLE
fix(powerbi): time-intel fallback router cross-wires measures across facts (BUG C)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -106,6 +106,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-warehouse.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-element-match.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_timeintel_route.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_timeintel_route.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# pbi_timeintel_route.rb — provenance guard for the time-intel fallback router in
+# migrate-powerbi.rb.
+#
+# The converter turns DAX SAMEPERIODLASTYEAR / TOTALYTD measures into synthesized
+# grouped elements (DateLookback / CumulativeSum). A fallback pass routes any
+# REMAINING time-intel-shaped measure (one with no element of its own) to "the
+# best-matching time-intel column". That pass used to scan ALL synthesized
+# elements with no regard for which FACT they belong to.
+#
+# Live failure (KitchenSink run-2): "PY Incident Count" is a SAFETY_INCIDENTS
+# measure, but the only synthesized elements were ABSENCE-derived ("YTD Absence
+# Hours" / "PY Absence Hours", both sourcing ABSENCE_RECORDS View). The router
+# bound the prior-year INCIDENT count to the absence-hours YTD column —
+# `SAFETY_INCIDENTS.PY Incident Count -> [YTD Absence Hours/Hours YTD]` — i.e.
+# semantically garbage numbers from an unrelated fact.
+#
+# Guard: a prior-year/YTD measure may only borrow a time-intel element built from
+# its OWN fact. If no same-fact element exists, DON'T route — leave it unresolved
+# so it degrades honestly into coverage.json, never cross-wired to another table.
+module PbiTimeIntelRoute
+  module_function
+
+  # base fact of a synthesized time-intel element = the table its source View
+  # denormalizes ("ABSENCE_RECORDS View" -> "ABSENCE_RECORDS"). A plain table name
+  # passes through unchanged.
+  def fact_of(view_or_table_name)
+    view_or_table_name.to_s.sub(/\s+View\z/i, '').strip
+  end
+
+  # may a measure on `measure_table` borrow a time-intel element whose base fact is
+  # `ti_fact`? Only when they are the SAME fact (whitespace/case-insensitive).
+  def same_fact?(measure_table, ti_fact)
+    a = norm(measure_table)
+    b = norm(ti_fact)
+    !a.empty? && a == b
+  end
+
+  def norm(str)
+    str.to_s.gsub(/\s+/, '').downcase
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -69,6 +69,7 @@ require 'scout_gate'    # run-each-time gap-scout gate (bead beads-sigma-5l5e)
 require 'dax_gate'      # DAX warning → decision-question classifier (regression-tested)
 require 'coverage_gate' # workbook-build coverage.json → consolidated report + assistance prompt
 require 'pbi_element_match' # converter→readback element pairing (POST reorders; regression-tested)
+require 'pbi_timeintel_route' # time-intel fallback-router fact-provenance guard (regression-tested)
 
 opts = { db: '', schema: '' }
 OptionParser.new do |o|
@@ -909,6 +910,10 @@ end
 #   measure name -> original TMSL table (from Phase 1's all_measures).
 ti_orig_table = {}
 all_measures.each { |tbl, mname, _expr| ti_orig_table[mname] = tbl }
+# converter element id -> name, so a synthesized time-intel element can report the
+# FACT it was built from (its source View's table) — used to stop the fallback
+# router from cross-wiring a measure to an unrelated fact's time-intel element.
+conv_name_by_id = conv_elements.each_with_object({}) { |e, h| h[e['id']] = e['name'] }
 # collect the emitted time-intel elements (element-sourced, DateLookback/CumulativeSum).
 ti_elements = []
 conv_elements.each do |cel|
@@ -944,8 +949,9 @@ conv_elements.each do |cel|
     next nil unless date_col
     "Sum(If([#{mid}/#{date_col['name']}] = Max([#{mid}/#{date_col['name']}]), [#{mid}/#{colname}], Null))"
   end
+  ti_fact = PbiTimeIntelRoute.fact_of(conv_name_by_id[src['elementId']])
   ti_elements << { 'name' => mname, 'mid' => mid, 'cols' => cols,
-                   'date' => (date_col && date_col['name']) }
+                   'date' => (date_col && date_col['name']), 'fact' => ti_fact }
   ref = { 'master' => mkey, 'ref' => "[#{mid}/#{pick['name']}]", 'agg' => nil }
   hf = headline.call(pick['name'])
   ref['formula'] = hf if hf
@@ -1017,9 +1023,14 @@ if ti_elements.any?
       elsif mname =~ /\b(PY|Prior Year|Last Year|LY)\b/i then :prior
       end
     next unless shape
-    # choose a target column across the emitted time-intel elements.
+    # choose a target column across the emitted time-intel elements — but ONLY
+    # those built from THIS measure's own fact. Cross-fact borrowing produced
+    # garbage (live run-2: SAFETY "PY Incident Count" -> ABSENCE "Hours YTD").
+    # If no same-fact element exists, leave the measure unresolved so it degrades
+    # into coverage.json rather than binding to an unrelated table's column.
     target = nil; tmid = nil; tname = nil; tdate = nil
     ti_elements.each do |te|
+      next unless PbiTimeIntelRoute.same_fact?(tbl, te['fact'])
       cand =
         case shape
         when :yoy   then te['cols'].find { |c| c['name'].to_s =~ /YoY/i }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-pbi-timeintel-route.rb — regression test for lib/pbi_timeintel_route.rb.
+# Offline: no API, no creds. Run: ruby scripts/test-pbi-timeintel-route.rb
+#
+# Pins the live KitchenSink run-2 cross-fact mis-route: the prior-year SAFETY
+# measure "PY Incident Count" was bound to the ABSENCE "Hours YTD" column because
+# the fallback router scanned every synthesized time-intel element regardless of
+# which fact it belonged to.
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'pbi_timeintel_route'
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+R = PbiTimeIntelRoute
+
+# fact_of: a View denormalizes a fact; a plain table passes through.
+ok('fact_of strips " View"',            R.fact_of('ABSENCE_RECORDS View') == 'ABSENCE_RECORDS')
+ok('fact_of case-insensitive on View',  R.fact_of('Safety_Incidents view') == 'Safety_Incidents')
+ok('fact_of leaves a plain table',      R.fact_of('SAFETY_INCIDENTS') == 'SAFETY_INCIDENTS')
+ok('fact_of handles nil',               R.fact_of(nil) == '')
+
+# same_fact?: only the SAME fact may share a time-intel element.
+ok('SAFETY measure vs ABSENCE ti → NOT same fact (the run-2 bug)',
+   R.same_fact?('SAFETY_INCIDENTS', 'ABSENCE_RECORDS') == false)
+ok('SAFETY measure vs SAFETY ti → same fact',
+   R.same_fact?('SAFETY_INCIDENTS', 'SAFETY_INCIDENTS') == true)
+ok('whitespace/case tolerant',
+   R.same_fact?('Order Fact', 'ORDER  FACT') == true)
+ok('empty fact never matches',
+   R.same_fact?('SAFETY_INCIDENTS', '') == false)
+
+# --- routing simulation: mirror the gate in migrate-powerbi.rb. Only same-fact
+# elements are considered; a SAFETY prior-year measure with only ABSENCE elements
+# must find NO target (→ unresolved → honest coverage degradation).
+TI = [
+  { 'name' => 'YTD Absence Hours', 'fact' => 'ABSENCE_RECORDS',
+    'cols' => [{ 'name' => 'Hours YTD', 'formula' => 'CumulativeSum([Hours])' }] },
+  { 'name' => 'PY Absence Hours',  'fact' => 'ABSENCE_RECORDS',
+    'cols' => [{ 'name' => 'Hours (Prior Year)', 'formula' => 'DateLookback([Hours],[Year],1,"year")' }] },
+].freeze
+
+def route(measure_table, ti_elements)
+  ti_elements.find { |te| PbiTimeIntelRoute.same_fact?(measure_table, te['fact']) }
+end
+
+ok('PY Incident Count (SAFETY) routes to NO absence element',
+   route('SAFETY_INCIDENTS', TI).nil?)
+ok('an ABSENCE prior-year measure still routes to its own fact',
+   route('ABSENCE_RECORDS', TI)&.fetch('name') == 'YTD Absence Hours')
+
+puts $fail.zero? ? "\nall pbi-timeintel-route tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
## What this fixes (handoff FIX 5, BUG C — the cross-wiring)

Run-2 ground truth: `SAFETY_INCIDENTS.PY Incident Count` was bound to `[YTD Absence Hours/Hours YTD]` — a prior-year **incident count** wired to **absence-hours YTD**, semantically garbage from an unrelated fact.

Root cause: the converter synthesizes time-intel measures (SAMEPERIODLASTYEAR/TOTALYTD) into grouped elements (DateLookback/CumulativeSum). A fallback pass in `migrate-powerbi.rb` routes any *remaining* time-intel-shaped measure to "the best-matching time-intel column" — but it scanned **every** synthesized element regardless of which fact it was built from. The only synthesized elements here were ABSENCE-derived (`YTD/PY Absence Hours`, both sourcing `ABSENCE_RECORDS View`), so the SAFETY measure grabbed an ABSENCE column.

## Fix
`lib/pbi_timeintel_route.rb` records each synthesized element's **base fact** (its source View's table, `ABSENCE_RECORDS View` → `ABSENCE_RECORDS`) and gates the fallback router to **same-fact elements only**. A measure with no same-fact time-intel element is left unresolved → it degrades honestly into `coverage.json` rather than cross-wiring to another table's column.

Offline regression test `test-pbi-timeintel-route.rb` (run-2 facts) in the CI allowlist; all green.

## Status of the other run-2 degradations
- **`DimDate.Month` line-chart drop (degradation #1)** — *already addressed by #188*. Before that fix, the nameless DimDate spine's columns landed on the SAFETY master as `[SAFETY_INCIDENTS/...]` instead of `[Custom SQL/...]`, so the Bug-E calc-table aliasing found no SQL master and never created `DimDate.Month`. With #188 the DimDate element is its own `Custom SQL` master → the alias fires → `DimDate.Month` resolves. No new code.
- **Department Summary / Absence Hours by Type (degradations #2, #3)** — genuine **single-master-per-element** limitations (cross-fact department-grain composition; pivoting a year/month-windowed YTD element by Absence Type). The converter surfaces these honestly in `coverage.json` with a recoverable action. Not mechanical bugs; resolving them means synthesizing join/grain masters — a real modeling change, not shipped blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)