### PR TITLE
fix(powerbi): drop unresolved-ref columns instead of shipping type=error (miu7)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -107,6 +107,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-element-match.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-timeintel-route.rb
+            plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-drop-unresolved-columns.rb
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -620,6 +620,56 @@ def resolve_map_kind(rec, name)
   'bar-chart'
 end
 
+# bead miu7: a column formula whose bracket holds a DOT ("[EMPLOYEES.Ghost]") is
+# field_spec's line-259 fallback for a queryRef ABSENT from the master-map. A valid
+# Sigma ref is [id/Name] or [Name] (slash, never a dot), so this form ALWAYS
+# compiles to a type=error column. The old code recorded it as "dropped" in
+# coverage but still SHIPPED the broken column (the lie the customer hit). This
+# matcher detects exactly that fallback so we can actually drop it.
+UNRESOLVED_REF = %r{\A\[[^\]/]*\.[^\]]*\]\z}.freeze
+
+# GUARANTEE no element ships an unresolved literal-ref column (bead miu7; mirrors
+# the slicer dropout). Drops every such column from `el` AND prunes its id from
+# every role reference build_element emits (value / xAxis / yAxis(2) / groupings /
+# rowsBy / columnsBy / values / sort), then records ONE honest 'dropped' entry.
+# The tile degrades (a role may lose a column) instead of carrying a broken one.
+def drop_unresolved_columns!(el, rec, kind)
+  cols = el['columns']
+  return unless cols.is_a?(Array)
+  bad = cols.select { |c| c['formula'].to_s =~ UNRESOLVED_REF }
+  return if bad.empty?
+  bad_ids = bad.map { |c| c['id'] }
+  has_bad = ->(x) { bad_ids.include?(x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+  el['columns'] = cols.reject { |c| bad_ids.include?(c['id']) }
+  el.delete('value') if bad_ids.include?(el.dig('value', 'columnId'))
+  if el['xAxis'].is_a?(Hash)
+    el['xAxis'].delete('sort') if bad_ids.include?(el.dig('xAxis', 'sort', 'by'))
+    el.delete('xAxis') if bad_ids.include?(el['xAxis']['columnId'])
+  end
+  %w[yAxis yAxis2].each do |ax|
+    next unless el[ax].is_a?(Hash) && el[ax]['columnIds'].is_a?(Array)
+    el[ax]['columnIds'] = el[ax]['columnIds'].reject(&has_bad)
+    el.delete(ax) if el[ax]['columnIds'].empty?
+  end
+  Array(el['groupings']).each do |g|
+    g['groupBy'] = Array(g['groupBy']).reject(&has_bad) if g['groupBy']
+    g['calculations'] = Array(g['calculations']).reject(&has_bad) if g['calculations']
+  end
+  el['groupings']&.reject! { |g| Array(g['groupBy']).empty? && Array(g['calculations']).empty? }
+  %w[rowsBy columnsBy].each do |k|
+    next unless el[k].is_a?(Array)
+    el[k] = el[k].reject(&has_bad)
+    el.delete(k) if el[k].empty?
+  end
+  el['values'] = Array(el['values']).reject(&has_bad) if el['values'].is_a?(Array)
+  leaves = bad.map { |c| c['name'] }.compact.join(', ')
+  record_unresolved(visual: (rec['title'] || rec['visual_id']), pbi_type: rec['visual_type'],
+                    sigma_kind: kind, severity: 'dropped', recoverable: true,
+                    detail: "field(s) #{leaves} could not be resolved to a master column — dropped " \
+                            '(would have shipped as a type=error column)',
+                    action: "Map the PBI queryRef(s) for #{leaves} to a master column in master-map.json and re-run.")
+end
+
 def build_element(rec, fields, masters, extra_data = [])
   kind = SIGMA_KIND[rec['sigma_kind']] || 'bar-chart'
   if kind == 'map'
@@ -691,7 +741,10 @@ def build_element(rec, fields, masters, extra_data = [])
   if master
     unreachable = rec['bindings'].values.flatten.compact.reject do |qr|
       fs = field_spec(qr, fields)
-      fs['master'] == master || Array(fs['alts']).any? { |a| a['master'] == master }
+      # master nil = absent from the master-map entirely; that case is owned by
+      # drop_unresolved_columns! (recorded as 'dropped', not double-counted here).
+      fs['master'].nil? ||
+        fs['master'] == master || Array(fs['alts']).any? { |a| a['master'] == master }
     end.map { |qr| qr.to_s }.uniq
     unless unreachable.empty?
       warn "[build-workbook] WARN visual '#{(rec['title'] || rec['visual_id'])}' has field(s) " \
@@ -1218,6 +1271,9 @@ def build_element(rec, fields, masters, extra_data = [])
 
   # Controls reference a master column; they carry no columns array of their own.
   el['columns'] = cols unless el['kind'] == 'control'
+  # bead miu7: never ship an unresolved literal-ref column (type=error). Drop it
+  # and prune its references — the tile degrades honestly into coverage instead.
+  drop_unresolved_columns!(el, rec, kind) unless el['kind'] == 'control'
   el
 end
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-drop-unresolved-columns.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-drop-unresolved-columns.rb
@@ -1,0 +1,106 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-drop-unresolved-columns.rb — end-to-end offline test for bead miu7. Runs
+# build-workbook-from-pbir.rb (NO API, NO creds — it only reads/writes files) on
+# crafted signals + master-map containing unresolvable queryRefs in every role,
+# and asserts the built spec ships NO type=error literal column and leaves NO
+# dangling id reference, while coverage.json records each drop honestly.
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+BUILD = File.join(__dir__, 'build-workbook-from-pbir.rb')
+RUBY  = RbConfig.ruby
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+MMAP = {
+  'masters' => {
+    'EMPLOYEES' => { 'id' => 'master-emp', 'element_id' => 'el-emp', 'data_model' => 'dm-x',
+      'columns' => [
+        { 'id' => 'mc-dept', 'name' => 'Department', 'formula' => '[EMPLOYEES/Department]' },
+        { 'id' => 'mc-hc',   'name' => 'Headcount',  'formula' => '[EMPLOYEES/Headcount]' },
+      ] },
+  },
+  'fields' => {
+    'EMPLOYEES.Department' => { 'master' => 'EMPLOYEES', 'ref' => '[master-emp/Department]', 'agg' => nil },
+    'EMPLOYEES.Headcount'  => { 'master' => 'EMPLOYEES', 'ref' => 'CountDistinct([master-emp/Headcount])', 'agg' => nil },
+  },
+}.freeze
+
+# Each visual binds at least one GHOST (absent from the master-map) queryRef in a
+# different role, plus a real field so the tile still has something.
+def vis(id, type, kind, bindings)
+  { 'visual_id' => id, 'visual_type' => type, 'sigma_kind' => kind, 'title' => "#{kind} #{id}",
+    'x' => 0, 'y' => 0, 'w' => 400, 'h' => 300, 'z' => 0, 'parent_group' => nil,
+    'bindings' => bindings, 'sort' => nil, 'formats' => {} }
+end
+
+SIGNALS = {
+  'source' => 'powerbi', 'pbir_dir' => '/tmp/none',
+  'pages' => [{ 'page_id' => 'p1', 'page_title' => 'P1', 'page_w' => 1280, 'page_h' => 720,
+    'interactions' => [], 'visuals' => [
+      vis('v_bar_x',  'barChart', 'bar',   { 'Category' => ['EMPLOYEES.GhostDim'], 'Y' => ['EMPLOYEES.Headcount'] }),
+      vis('v_bar_y',  'barChart', 'bar',   { 'Category' => ['EMPLOYEES.Department'], 'Y' => ['EMPLOYEES.Headcount', 'EMPLOYEES.GhostY'] }),
+      vis('v_kpi',    'card',     'kpi',   { 'Values' => ['EMPLOYEES.GhostKpi'] }),
+      vis('v_table',  'tableEx',  'table', { 'Values' => ['EMPLOYEES.Department', 'EMPLOYEES.Headcount', 'EMPLOYEES.GhostCol'] }),
+      vis('v_pivot',  'pivotTable', 'pivot-table', { 'Rows' => ['EMPLOYEES.Department'], 'Values' => ['EMPLOYEES.Headcount', 'EMPLOYEES.GhostVal'] }),
+      vis('v_clean',  'tableEx',  'table', { 'Values' => ['EMPLOYEES.Department', 'EMPLOYEES.Headcount'] }),
+    ] }],
+}.freeze
+
+# every column-id a Sigma element references must resolve to a real column on it.
+def dangling_ids(el)
+  own = (el['columns'] || []).map { |c| c['id'] }
+  refs = []
+  refs << el.dig('value', 'columnId')
+  refs << el.dig('xAxis', 'columnId')
+  refs << el.dig('xAxis', 'sort', 'by')
+  %w[yAxis yAxis2].each { |a| Array(el.dig(a, 'columnIds')).each { |x| refs << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) } }
+  Array(el['groupings']).each { |g| refs.concat(Array(g['groupBy'])); refs.concat(Array(g['calculations'])) }
+  %w[rowsBy columnsBy].each { |k| Array(el[k]).each { |x| refs << (x.is_a?(Hash) ? x['id'] : x) } }
+  Array(el['values']).each { |x| refs << (x.is_a?(Hash) ? (x['columnId'] || x['id']) : x) }
+  refs.compact.uniq.reject { |id| own.include?(id) }
+end
+
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'mmap.json'), JSON.generate(MMAP))
+  File.write(File.join(d, 'sig.json'), JSON.generate(SIGNALS))
+  wb  = File.join(d, 'wb.json')
+  cov = File.join(d, 'cov.json')
+  st = system(RUBY, BUILD, '--signals', File.join(d, 'sig.json'), '--master-map', File.join(d, 'mmap.json'),
+              '--data-model', 'dm-x', '--name', 'T', '--out', wb,
+              '--layout-out', File.join(d, 'l.xml'), '--coverage-out', cov,
+              out: File::NULL, err: File::NULL)
+  ok('builder exits 0', st)
+  spec = JSON.parse(File.read(wb))
+  raw = File.read(wb)
+
+  ok('NO dot-bracket literal ref anywhere in the spec', raw !~ %r{\[[^\]/"]*\.[^\]"]*\]})
+
+  content_els = spec['pages'].flat_map { |p| p['elements'] }.reject { |e| e['visibleAsSource'] == false }
+  bad_dangle = content_els.flat_map { |e| dangling_ids(e).map { |id| "#{e['id']}:#{id}" } }
+  ok('NO dangling column-id reference in any element', bad_dangle.empty? || (puts("    dangling: #{bad_dangle.inspect}") && false))
+
+  # the clean visual is untouched: still has both its columns.
+  clean = content_els.find { |e| e['name'].to_s.include?('v_clean') }
+  ok('clean visual keeps both resolvable columns', clean && (clean['columns'] || []).length == 2)
+
+  # the surviving real fields are still present (we dropped only the ghosts).
+  all_formulas = content_els.flat_map { |e| (e['columns'] || []).map { |c| c['formula'] } }
+  ok('resolvable refs survive (Headcount measure present)',
+     all_formulas.any? { |f| f.to_s.include?('master-emp/Headcount') })
+
+  cover = JSON.parse(File.read(cov))['unresolved'] || []
+  # the 4 visuals that keep a real field record the explicit miu7 "could not be
+  # resolved" drop; the kpi whose ONLY field is a ghost is dropped by the
+  # master-selection path ("element skipped") — also honest. All 5 ghost-bearing
+  # visuals must surface a 'dropped' entry; the clean visual must not.
+  miu7_drops = cover.count { |u| u['severity'] == 'dropped' && u['detail'].to_s =~ /could not be resolved/ }
+  all_drops  = cover.count { |u| u['severity'] == 'dropped' }
+  ok('>=4 visuals record the explicit miu7 column drop', miu7_drops >= 4)
+  ok('all 5 ghost-bearing visuals surface a dropped entry', all_drops >= 5)
+end
+
+puts $fail.zero? ? "\nall drop-unresolved-columns tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
## What this fixes (handoff FIX 5, bead miu7 — the last "no silent error columns" gap)

When a PBI queryRef is absent from the master-map, `field_spec` falls back to a literal bracket ref like `[EMPLOYEES.Ghost]`. A **dot inside brackets is never a valid Sigma ref** (valid is `[id/Name]`, slash), so it **always** compiles to a `type=error` column. The old code recorded these as "dropped" in `coverage.json` but **still shipped the broken column** — the exact lie behind the customer's *"silently drops components it cannot resolve"* report (coverage said dropped; the workbook carried an error column).

## Fix
`drop_unresolved_columns!` (mirrors the slicer dropout) removes every such column from the built element **and prunes its id from every role reference** — `value` / `xAxis` / `yAxis`(2) / `groupings` / `rowsBy` / `columnsBy` / `values` / `sort` — then records **one** honest `dropped` coverage entry. The tile degrades (a role may lose a column) instead of carrying a broken one. The visual-master precheck no longer double-counts the master-nil case as `degraded` (the sanitizer owns it).

Scope is tight: only the unresolvable **dot-bracket** form is touched. Wrong-master refs (`[id/Name]` on a different element — the genuine single-master-per-element limitation, degradations #2/#3) keep their existing `degraded` entry unchanged.

## Validation (offline, no API)
- `test-drop-unresolved-columns.rb` drives the real builder across **bar / kpi / table / pivot** with unresolvable refs in every role and asserts: **no literal ref survives**, **no dangling id reference remains**, clean visuals untouched, every ghost-bearing visual surfaces a `dropped` entry. Added to the CI allowlist.
- Re-run on the **real run-2 fixtures**: exit 0, zero dot-bracket literals, and the 3 prior silent-error leaks now surface as honest `dropped` (was `0 dropped / 3 degraded`).

## Epic `b32o` after this
All binding/coverage bugs closed. Remaining `uze2` (P2) is a RANKX cross-fact *composition* enhancement, not a gap — RANKX itself translates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)