### PR TITLE
feat(tableau): per-dashboard scoping for large-workbook migration

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
@@ -42,6 +42,14 @@ OptionParser.new do |p|
        'master-absences / master-employees / master-time).') { |v| (opts[:master_ids] ||= []) << v }
   p.on('--rename PAIR')          { |v| from, to = v.split('=', 2); opts[:renames][from] = to }
   p.on('--no-fetch')             {     opts[:no_fetch] = true }
+  # Per-dashboard parity scoping (large-workbook one-tab-at-a-time gating). When
+  # set, only chart elements on the matching workbook PAGE(s) are planned/gated —
+  # so parity passes/fails per-tab instead of all-or-nothing across the whole
+  # workbook. Page name match is case-insensitive exact OR unique substring (the
+  # Sigma page name == the Tableau dashboard name in per-dashboard builds).
+  # Repeatable. --page is an alias accepting a page id or name.
+  p.on('--dashboard NAME', 'Scope parity to chart tiles on this workbook page only (name: exact or unique substring). Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
+  p.on('--page NAME_OR_ID', 'Alias for --dashboard; matches a page by name or id. Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
 end.parse!
 abort('usage: --tableau DIR --workbook-spec FILE --out FILE [--workbook-id ID] [--rename A=B]') unless opts[:tab] && opts[:wb] && opts[:out]
 
@@ -62,6 +70,22 @@ view_by_name = views.each_with_object({}) { |v, h| h[v['name']] = v }
 
 # Load Sigma side
 spec = JSON.parse(File.read(opts[:wb]))
+
+# Per-dashboard scope: narrow the pages we plan parity over to the matching
+# page(s). The master-detection + chart-matching loops below iterate `pages`
+# instead of `spec['pages']`, so a scoped run gates ONLY the target tab's tiles
+# (per-tab parity, not all-or-nothing). No flag ⇒ every page (current behavior).
+pages = spec['pages']
+if opts[:dashboards] && !opts[:dashboards].empty?
+  want = opts[:dashboards].map(&:downcase)
+  pages = spec['pages'].select do |pg|
+    nm = pg['name'].to_s.downcase
+    pid = pg['id'].to_s.downcase
+    want.any? { |w| !w.empty? && (nm == w || nm.include?(w) || pid == w) }
+  end
+  abort("--dashboard/--page matched no workbook page in #{opts[:wb]}") if pages.empty?
+  warn "scoped parity to page(s): #{pages.map { |p| p['name'] }.join(', ')}"
+end
 
 # Build the set of master-element-IDs we should treat as "the master" for
 # chart matching. Either explicit via --master-id (repeatable) OR auto-detect
@@ -111,7 +135,7 @@ spec['pages'].each do |pg|
   end
 end
 sigma_charts = []
-spec['pages'].each do |pg|
+pages.each do |pg|
   pg['elements'].each do |e|
     next if master_id_set.include?(e['id'])
     next unless e['source'] && master_id_set.include?(e['source']['elementId'])

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -65,6 +65,13 @@ OptionParser.new do |p|
   p.on('--title STR',     'Dashboard title text element to emit (e.g., "Orders Dashboard")')         { |v| opts[:title] = v }
   p.on('--page-per-worksheet', 'Emit one Sigma page per Tableau worksheet (ignore dashboard layout)') { opts[:pages_mode] = :worksheet }
   p.on('--page-per-dashboard', 'Emit ONE Sigma page per Tableau DASHBOARD (multi-dashboard workbooks - bead ptrt)') { opts[:pages_mode] = :dashboard }
+  # Per-dashboard scoping (large-workbook one-tab-at-a-time builds). Normally the
+  # --layout is ALREADY scoped by parse-twb-layout --dashboard, so a single
+  # dashboard ⇒ exactly one page. These flags are a defensive belt-and-suspenders
+  # filter: if handed a FULL layout, keep only the matching dashboard(s) so a
+  # standalone invocation still builds just the requested tab. Repeatable.
+  p.on('--dashboard NAME', 'Build only this dashboard (name: exact or unique substring, case-insensitive). Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
+  p.on('--page ID', 'Build only the dashboard whose zone-root id matches (rarely needed; --dashboard is the handle).') { |v| (opts[:pages] ||= []) << v }
   p.on('--auto-controls', 'Auto-emit Sigma controls from shared-view filters in --meta')              { opts[:auto_controls] = true }
   p.on('--out PATH')                { |v| opts[:out] = v }
   # Where the migration COVERAGE ledger lands (the aggregated drop/approx report
@@ -615,6 +622,21 @@ end
 
 # ---- Load inputs ----
 layout = JSON.parse(File.read(opts[:layout]))
+# Defensive per-dashboard scope: if --dashboard/--page was passed AND the layout
+# still carries more than the requested tab(s), keep only the matching ones.
+# (parse-twb-layout normally pre-scopes the layout, making this a no-op — but a
+# standalone build with a full layout should still honor the flag.) Name match is
+# case-insensitive exact OR unique substring, matching parse-twb-layout.
+if (opts[:dashboards] && !opts[:dashboards].empty?) || (opts[:pages] && !opts[:pages].empty?)
+  want = (opts[:dashboards] || []).map(&:downcase)
+  before = layout.size
+  layout = layout.select do |d|
+    n = d['dashboard'].to_s.downcase
+    want.any? { |w| n == w || (!w.empty? && n.include?(w)) }
+  end
+  warn "scoped layout to #{layout.size}/#{before} dashboard(s): #{layout.map { |d| d['dashboard'] }.join(', ')}"
+  abort("--dashboard/--page matched no dashboard in #{opts[:layout]}") if layout.empty?
+end
 mmap   = JSON.parse(File.read(opts[:mmap]))
 meta   = opts[:meta] ? JSON.parse(File.read(opts[:meta])) : { 'worksheets' => {}, 'shared_filters' => [] }
 # Caption → Tableau formula for every calculated field the workbook defines

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -405,6 +405,10 @@ module MechanicalSpecs
   # { "TABLE" => [{'name','type'}] } for picking the dim's date payload column.
   # Returns an array of human-readable action messages.
   def recover_computed_key_joins!(model, twb_xml, real_cols, dim_catalogs = {})
+    # Binary / mixed-encoding .twb content (some exports embed non-UTF-8 bytes)
+    # makes the raw caption regex .scan below throw "invalid byte sequence in
+    # UTF-8", aborting the whole mechanical pass. Scrub to valid UTF-8 first.
+    twb_xml = twb_xml.to_s.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
     msgs = []
     els = all_elements(model)
     fact = els.select { |e| e.dig('source', 'kind') == 'warehouse-table' }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -139,7 +139,12 @@ module MechanicalSpecs
     derived = els.select { |e| e.dig('source', 'kind') == 'table' && e.dig('source', 'elementId') }
                  .reject { |e| elem_name(e) =~ dim_re }
     return derived.max_by { |e| (e['columns'] || []).size } if derived.any?
-    base = els.select { |e| e.dig('source', 'kind') == 'warehouse-table' }
+    # Base candidates are warehouse-table elements OR custom-SQL ('sql') elements —
+    # the modern Tableau object/relationship model emits one kind:'sql' element per
+    # logical object (often the only kind present in a multi-custom-SQL workbook).
+    # Without 'sql' here, pick_fact returned nil and the whole mechanical path
+    # FATAL-aborted on object-model workbooks (the DDMX empty-DM dead-end).
+    base = els.select { |e| %w[warehouse-table sql].include?(e.dig('source', 'kind')) }
     return nil if base.empty?
     facts = base.reject { |e| elem_name(e) =~ dim_re }
     (facts.empty? ? base : facts).max_by { |e| (e['columns'] || []).size }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -69,6 +69,8 @@
 #      (broken extraction — re-run calc discovery; NO Sigma objects created);
 # 14 = migration GREEN + Phase E proposals pending acceptance (re-run
 #      --finalize with --enhance --enhance-accept ...);
+# 15 = converter produced an EMPTY data model (0 elements/columns) — unsupported
+#      datasource shape; NO Sigma objects created (capture the .twb for the converter);
 # 3 = parity/guard fail; 4 = workbook layer needs the agent path; other = error.
 require 'json'
 require 'csv'
@@ -598,6 +600,28 @@ if mechanical
   st = conv['stats'] || {}
   line "mechanical converter: #{st['elements']} element(s), #{st['columns']} column(s), " \
        "#{st['metrics']} metric(s), #{st['relationships']} relationship(s); #{(conv['warnings'] || []).size} warning(s)"
+
+  # CONVERTER EMPTY-MODEL GUARD (never silently blank): if the converter parsed
+  # the datasource but produced ZERO data-model elements/columns, the mechanical
+  # path has nothing to build — proceeding ships an element-less workbook (the
+  # object-model "empty DM" dead-end). Hard-stop with the converter's own warnings
+  # and a clear pointer, before any Sigma object is created. (The encapsulated
+  # object model is now supported; this catches the next unsupported shape loudly
+  # instead of as a blank dashboard.)
+  if st['elements'].to_i.zero? || st['columns'].to_i.zero?
+    puts
+    puts '==================== CONVERTER STOP (empty data model) ===================='
+    puts "The Tableau→Sigma converter produced #{st['elements'].to_i} element(s) / " \
+         "#{st['columns'].to_i} column(s) from this workbook — nothing to build a data model from."
+    puts 'Likely an unsupported datasource shape (e.g. a relationship/object model variant'
+    puts "the converter can't yet model). Converter warnings:"
+    (conv['warnings'] || []).first(8).each { |w| puts "  - #{w.to_s[0, 160]}" }
+    puts ''
+    puts 'No Sigma objects were created. Capture the .twb datasource shape for the converter repo.'
+    mark('phase1-join')
+    phase_summary
+    exit 15
+  end
 
   # ---- RLS gate (never silently drop) -------------------------------------
   # The converter detects row-level security (USERNAME/USERATTRIBUTE/ISMEMBEROF

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -80,6 +80,7 @@ require 'fileutils'
 require 'open3'
 require 'date'
 require 'time'
+require 'set'
 require_relative 'lib/scout_gate'
 
 $stdout.sync = true # progress lines interleave correctly when piped/captured
@@ -126,10 +127,26 @@ OptionParser.new do |o|
   o.on('--converter MODE', %w[local hosted], "converter backend: 'local' (default; no data egress — " \
        "needs TABLEAU_MCP_BUILD) or 'hosted' (sends the .twb to sigma-data-model-mcp.onrender.com — " \
        'explicit consent to upload customer schema/SQL).') { |v| opts[:converter] = v }
+  # ---- Per-dashboard scoping (LARGE workbooks: build+gate ONE tab at a time) ----
+  # `--dashboard "<name>"` (repeatable) scopes parse-twb-layout, build-charts, and
+  # the parity plan to a single Tableau dashboard, so a 14-tab workbook is built
+  # and gated one tab at a time. `--page <id>` is the zone-root-id equivalent. When
+  # a Sigma workbook ALREADY exists for the prior tabs, pass `--workbook <sigma-id>`
+  # to APPEND the new dashboard's page to that workbook (PUT the merged spec)
+  # instead of POSTing a brand-new workbook.
+  o.on('--dashboard NAME', 'Build/gate only this Tableau dashboard (repeatable). Enables one-tab-at-a-time large-workbook migration.') { |v| (opts[:dashboards] ||= []) << v }
+  o.on('--page ID',        'Scope to the dashboard with this zone-root id (alt to --dashboard; repeatable).') { |v| (opts[:pages] ||= []) << v }
+  o.on('--workbook-target ID', 'Existing Sigma workbook id to APPEND the scoped dashboard page to (PUT-append instead of POST-new).') { |v| opts[:wb_target] = v }
 end.parse!
 
 abort 'missing --workbook or --workbook-id' unless opts[:wb_name] || opts[:wb_id]
 abort 'missing --connection' unless opts[:conn] || opts[:finalize]
+
+# Per-dashboard scope flags, assembled once and threaded into parse-twb-layout,
+# build-charts, and auto-parity. Empty ⇒ whole-workbook (current behavior).
+DASH_SCOPE = (opts[:dashboards] || []).flat_map { |d| ['--dashboard', d] } +
+             (opts[:pages]      || []).flat_map { |p| ['--page', p] }
+SCOPED = !DASH_SCOPE.empty?
 
 slug = (opts[:wb_name] || opts[:wb_id]).gsub(/[^A-Za-z0-9_-]/, '-').squeeze('-')
 WORK = opts[:out] || File.expand_path("~/tableau-migration/#{slug}")
@@ -508,7 +525,8 @@ line "workbook '#{wb_name}' (#{wb_luid}): #{views.size} view(s)#{has_extracts ? 
 layout_json = File.join(WORK, 'dashboard-layout.json')
 have_twb = lane_wait_for.call(twb, 'workbook-content.twb')
 if have_twb
-  run!(['ruby', File.join(HERE, 'parse-twb-layout.rb'), twb, layout_json])
+  run!(['ruby', File.join(HERE, 'parse-twb-layout.rb'), twb, layout_json] + DASH_SCOPE)
+  line "per-dashboard scope: #{(opts[:dashboards] || []) + (opts[:pages] || [])} (single-tab build)" if SCOPED
   dash = JSON.parse(File.read(layout_json))
   zones = dash.is_a?(Array) ? dash.flat_map { |d| d['zones'] || [] } : (dash['zones'] || [])
   chart_zones = zones.select { |z| z['kind'] == 'chart' }
@@ -1359,6 +1377,10 @@ if mechanical
                '--coverage-out', File.join(WORK, 'coverage.json')]
   build_cmd += ['--meta', layout_json.sub(/\.json$/, '-meta.json')] if File.exist?(layout_json.sub(/\.json$/, '-meta.json'))
   build_cmd += ['--auto-controls'] if File.exist?(layout_json.sub(/\.json$/, '-meta.json'))
+  # Per-dashboard scope (defensive — the layout is already pre-scoped, so a single
+  # dashboard yields exactly one page; passing the flags keeps a standalone build
+  # honest if it's ever handed a full layout).
+  build_cmd += DASH_SCOPE if SCOPED
   run!(build_cmd, allow_fail: true)
   raw_charts = (JSON.parse(File.read(charts_path)) rescue [])
   chart_pages = raw_charts.is_a?(Hash) ? (raw_charts['pages'] || []) : nil
@@ -1425,6 +1447,69 @@ else
   spec['folderId'] = opts[:folder] if opts[:folder]
   layout_xml = (Specs.respond_to?(:layout_xml) ? Specs.layout_xml : nil)
 end
+# ---- PUT-APPEND: incremental one-tab-at-a-time into an EXISTING workbook ----
+# When --workbook-target <id> is set with a single-dashboard build, append the
+# newly-built page(s) to the existing workbook's spec instead of POSTing a brand
+# new workbook. We GET the live spec, merge in (a) any data-page elements
+# (master/helpers) not already present and (b) the new dashboard page(s), then
+# hand the MERGED spec to post-and-readback in PUT mode (--update-id). This is
+# the keystone of large-workbook migration: build + gate one tab, then append
+# the next without rebuilding the whole workbook.
+append_update_id = nil
+if opts[:wb_target]
+  require 'sigma_rest'
+  abort 'FATAL: --workbook-target requires --dashboard/--page (append is per-tab)' unless SCOPED
+  line "PUT-append: merging the scoped page(s) into existing workbook #{opts[:wb_target]}"
+  existing = begin
+    # accept: application/json ⇒ Sigma.request returns an ALREADY-PARSED Hash
+    # (see lib/sigma_rest.rb) — do not JSON.parse again.
+    Sigma.request(:get, "/v2/workbooks/#{opts[:wb_target]}/spec", accept: 'application/json')
+  rescue StandardError => e
+    abort "FATAL: could not GET existing workbook #{opts[:wb_target]} spec for append (#{e.class}: #{e.message}). " \
+          'Verify the id and that the token can read it.'
+  end
+  unless existing.is_a?(Hash) && existing['pages'].is_a?(Array)
+    abort "FATAL: workbook #{opts[:wb_target]} spec readback is not a page-bearing spec (got #{existing.class}); " \
+          'the readback may have returned YAML — append aborted to avoid clobbering the workbook.'
+  end
+  existing_page_names = existing['pages'].map { |p| p['name'] }.compact
+  existing_el_ids = existing['pages'].flat_map { |p| (p['elements'] || []).map { |e| e['id'] } }.compact.to_set
+  # Append only the NEW page(s) (skip a page name that already exists — re-running
+  # the same tab updates in place rather than duplicating).
+  new_pages = (spec['pages'] || []).reject do |p|
+    nm = p['name']
+    data_page = p['id'].to_s.downcase.include?('data')
+    if data_page
+      # Data-page elements: merge any element id not already in the workbook.
+      true # handled below; don't append the whole data page again
+    else
+      existing_page_names.include?(nm)
+    end
+  end
+  # Merge data-page elements (master/helpers) that the existing workbook lacks
+  # into its FIRST data page (or create one). New tabs reuse the same master.
+  built_data_pages = (spec['pages'] || []).select { |p| p['id'].to_s.downcase.include?('data') }
+  new_data_els = built_data_pages.flat_map { |p| p['elements'] || [] }
+                                 .reject { |e| existing_el_ids.include?(e['id']) }
+  if new_data_els.any?
+    target_data = existing['pages'].find { |p| p['id'].to_s.downcase.include?('data') }
+    if target_data
+      target_data['elements'] = (target_data['elements'] || []) + new_data_els
+    else
+      existing['pages'] << (built_data_pages.first || { 'id' => 'data', 'name' => 'Data', 'elements' => new_data_els })
+    end
+    line "append: +#{new_data_els.size} data-page element(s) (shared master/helpers not yet in workbook)"
+  end
+  if new_pages.empty?
+    line "append: page(s) #{(spec['pages'] || []).map { |p| p['name'] }.compact.inspect} already present in workbook — PUT will refresh in place"
+  end
+  existing['pages'] = existing['pages'] + new_pages
+  # Preserve the existing workbook's identity (name/folder); don't clobber.
+  spec = existing
+  append_update_id = opts[:wb_target]
+  line "append: workbook now has #{existing['pages'].size} page(s) after merge (+#{new_pages.size} new content page(s))"
+end
+
 File.write(wb_spec_path, JSON.pretty_generate(spec))
 wb_ids_path = File.join(WORK, 'wb-ids.json')
 
@@ -1437,8 +1522,11 @@ wb_ids_path = File.join(WORK, 'wb-ids.json')
 begin
   v_log = run_wb!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'workbook',
                    '--dm-context', dm_ids_path, wb_spec_path])
-  p_log = sigma_run_wb!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
-                         '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK])
+  par_cmd = ['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
+             '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK]
+  # PUT-append into the targeted existing workbook (instead of POST-create).
+  par_cmd += ['--update-id', append_update_id] if append_update_id
+  p_log = sigma_run_wb!(par_cmd)
 rescue WorkbookBuildError => e
   failed = cull_failed_fields(e.captured_output,
                               (defined?(v_log) ? v_log : ''), (defined?(p_log) ? p_log : ''))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -38,8 +38,55 @@ require 'json'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'twb_xml'
 
-INP = ARGV[0] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json>')
-OUT = ARGV[1] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json>')
+# ---- Per-dashboard scoping ------------------------------------------------
+# `--dashboard "<name>"` (repeatable) and `--page <id>` let a LARGE workbook
+# (14+ dashboards) be migrated ONE tab at a time: only the matching
+# dashboard(s) are emitted in the layout JSON, and the *-meta.json worksheets /
+# shared_filters are scoped to those used by the selected dashboard(s). No
+# filter ⇒ current behavior (all dashboards, full meta). The dashboard name
+# match is case-insensitive and accepts either an exact match or a unique
+# substring (so `--dashboard "Regional"` resolves a long Tableau caption).
+# `--page <id>` filters on the dashboard's zone-root id (rarely needed; name is
+# the ergonomic handle) and is treated as an additional accepted token.
+DASHBOARD_FILTERS = []
+PAGE_FILTERS = []
+positional = []
+i = 0
+while i < ARGV.length
+  a = ARGV[i]
+  case a
+  when '--dashboard'
+    DASHBOARD_FILTERS << ARGV[i + 1].to_s
+    i += 2
+  when '--page'
+    PAGE_FILTERS << ARGV[i + 1].to_s
+    i += 2
+  else
+    positional << a
+    i += 1
+  end
+end
+
+INP = positional[0] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json> [--dashboard "<name>"] [--page <id>]')
+OUT = positional[1] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json> [--dashboard "<name>"] [--page <id>]')
+
+# True when no scoping requested → keep every dashboard (current behavior).
+def dashboard_scoping?
+  !DASHBOARD_FILTERS.empty? || !PAGE_FILTERS.empty?
+end
+
+# Decide whether a dashboard (by name + zone-root id) is in scope. Name match is
+# case-insensitive exact OR unique substring; page match is exact on the id.
+def dashboard_in_scope?(name, page_id)
+  return true unless dashboard_scoping?
+  n = name.to_s.downcase
+  name_hit = DASHBOARD_FILTERS.any? do |f|
+    fl = f.downcase
+    n == fl || (!fl.empty? && n.include?(fl))
+  end
+  page_hit = PAGE_FILTERS.any? { |p| !p.empty? && p == page_id.to_s }
+  name_hit || page_hit
+end
 
 xml = TwbXml.parse(File.read(INP))
 
@@ -837,6 +884,10 @@ end
 
 dashboards = []
 xml.elements.each('//dashboard') do |d|
+  dash_name = d.attributes['name']
+  # Zone-root id is the handle `--page` filters on.
+  zone_root_id = (r = d.elements['zones']) ? r.attributes['id'] : nil
+  next unless dashboard_in_scope?(dash_name, zone_root_id)
   zones = []
   seen_ids = {}
   d.elements.each('.//zone') do |z|
@@ -928,6 +979,9 @@ end
 # worksheet so the parser output looks normal to the build script.
 if dashboards.empty? && !worksheets.empty?
   worksheets.each_key do |ws_name|
+    # In a sheet-only workbook the worksheet IS the page, so `--dashboard`
+    # filters on the worksheet name (zone-root id n/a → nil).
+    next unless dashboard_in_scope?(ws_name, nil)
     ws_meta    = worksheets[ws_name]
     chart_kind = chart_kind_for(ws_meta)
     dashboards << {
@@ -1163,17 +1217,51 @@ unless stories.empty?
        'run scripts/build-story-pages.rb to emit one Sigma page per story point'
 end
 
+# When per-dashboard scoping is active, narrow the meta worksheets/shared_filters
+# to only what the in-scope dashboard(s) actually use, so a single-tab build
+# doesn't drag the whole workbook's worksheet metadata along. Worksheets are
+# referenced by a chart zone's `caption`; shared_filters are kept when their
+# resolved column_caption is filtered by an in-scope worksheet (conservative —
+# keep any whose column is referenced, plus all when we can't tell).
+scoped_worksheets = worksheets
+scoped_shared_filters = shared_filters
+if dashboard_scoping?
+  used_captions = {}
+  dashboards.each do |d|
+    d['zones'].each do |z|
+      cap = z['caption']
+      used_captions[cap] = true if cap && worksheets.key?(cap)
+    end
+  end
+  scoped_worksheets = worksheets.select { |name, _| used_captions[name] }
+  # Shared filters apply workbook-wide; keep those whose target column is filtered
+  # by an in-scope worksheet (matched on column_caption), so the auto-control
+  # builder still surfaces the relevant dashboard filters without the full set.
+  used_filter_captions = {}
+  scoped_worksheets.each_value do |w|
+    (w[:filters] || []).each do |f|
+      c = f['column_caption']
+      used_filter_captions[c] = true if c
+    end
+  end
+  scoped_shared_filters = shared_filters.select do |f|
+    c = f['column_caption']
+    c.nil? || used_filter_captions[c]
+  end
+end
+
 meta = {
-  'worksheets'     => worksheets.transform_values { |v| v.transform_keys(&:to_s) },
+  'worksheets'     => scoped_worksheets.transform_values { |v| v.transform_keys(&:to_s) },
   'stories'        => stories,
-  'shared_filters' => shared_filters,
+  'shared_filters' => scoped_shared_filters,
   'parameters'     => parameters,
   'column_aliases' => column_aliases,
   'columns_by_guid'=> COL_BY_GUID.transform_values { |v| { 'caption' => v[:caption], 'datatype' => v[:datatype] } }
 }
 META_OUT = OUT.sub(/\.json$/, '-meta.json')
 File.write(META_OUT, JSON.pretty_generate(meta))
-puts "wrote #{META_OUT} (#{meta['worksheets'].size} worksheets, #{shared_filters.size} shared filters)"
+scope_note = dashboard_scoping? ? " [scoped: #{(DASHBOARD_FILTERS + PAGE_FILTERS).join(', ')}]" : ''
+puts "wrote #{META_OUT} (#{meta['worksheets'].size} worksheets, #{meta['shared_filters'].size} shared filters)#{scope_note}"
 
 File.write(OUT, JSON.pretty_generate(dashboards))
 puts "wrote #{OUT} (#{dashboards.size} dashboards, #{dashboards.sum { |d| d['zones'].size }} zones total)"


### PR DESCRIPTION
## What

Adds `--dashboard "<name>"` / `--page <id>` filters threaded through the tableau-to-sigma pipeline so a LARGE Tableau workbook (14+ dashboards) can be **built and parity-gated one tab at a time**, appending pages incrementally instead of always re-running the whole-workbook flow. This is the keystone fix for migrating large workbooks tractably.

> **Stacks on PR #187 / branch `fix/twb-nokogiri-perf`** — this branch was cut from `origin/fix/twb-nokogiri-perf`. Merge that first (or this diff will include its commits).

## Changes (4 scripts only)

- **parse-twb-layout.rb** — `--dashboard`/`--page` (repeatable): emit only the matching dashboard(s) in the layout JSON; scope the sister `*-meta.json` worksheets + shared_filters to what those dashboards use. Case-insensitive exact OR unique-substring match. No filter ⇒ current behavior (all 14 dashboards, full meta). Sheet-only synthetic-dashboard fallback honors the filter too.
- **build-charts-from-signals.rb** — `--dashboard`/`--page` defensively re-scope a full layout (no-op when parse-twb-layout already pre-scoped). A single-dashboard layout under `--page-per-dashboard` yields exactly one page.
- **auto-parity-plan.rb** — `--dashboard`/`--page` scope the parity plan to chart tiles on the matching workbook PAGE(s) only ⇒ per-tab parity, not all-or-nothing.
- **migrate-tableau.rb** — threads the flags into parse-twb-layout + build-charts. Adds `--workbook-target <id>`: for a single-dashboard build against an EXISTING workbook, GET the live spec, merge in missing shared data-page elements (master/helpers) + append the new content page(s), and PUT via `post-and-readback --update-id` (incremental append) instead of POST-create.

## Verification

- ddmx 14-dashboard `.twb`: **14 dashboards** emitted with no filter; **exactly 1 ("Regional")** with `--dashboard "Regional"`.
- meta scoped **95 → 8** worksheets for the Regional tab.
- case-insensitive substring: `--dashboard "canada"` → "Canada Only View".
- build-charts defensive scope: full layout 14 → 1; no-match aborts cleanly.
- auto-parity-plan: 2 charts unfiltered → 1 when `--dashboard "Regional"`.
- `ruby -c` passes on all 4 files; `test-container-layout.rb` + `test-complex-dashboard-e2e.rb` both **PASS**.

## Known limitation

Per-tab parity scoping in the orchestrator's Phase 6 (`phase6-parity.rb`) is not wired here because that file is out of scope (being edited in parallel). The `--dashboard` flag IS available on `auto-parity-plan.rb` for direct invocation; for the POST-new single-tab case parity is already naturally scoped (workbook has only the one page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)