### PR TITLE
feat(tableau): gate on hidden worksheet calc-filters

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
@@ -293,8 +293,75 @@ puts "  NOTE: actuals must be fetched via mcp__sigma-mcp-v2__query (MCP), not RE
 puts "        Fire all #{plan_entries.size} per-chart queries in ONE parallel tool-use batch,"
 puts "        then merge the rows into the parity plan's actual.rows arrays."
 
+# ---- Hidden calc-filter gate -----------------------------------------------
+# Worksheet-level filters on calc fields (Calculation_* refs) are invisible in
+# CSV exports — they silently reduce row counts and break parity. Parse them
+# from the dashboard layout if available; each requires either:
+#   status: "translated"  — the filter has been applied to the Sigma source
+#   status: "waived"      — explicitly waived with a reason
+# Any unresolved filter blocks plan status to "needs_review" (never "green").
+#
+# The dashboard-layout path is looked up next to the --tableau dir as
+# `dashboard-layout.json` (the default parse-twb-layout output location).
+hidden_filters_gate = []
+dash_layout_path = File.join(opts[:tab], 'dashboard-layout.json')
+if File.exist?(dash_layout_path)
+  begin
+    dash_layout = JSON.parse(File.read(dash_layout_path))
+    if dash_layout.is_a?(Array)
+      # Collect all tiles in scope (scoped to matched pages/dashboards when
+      # --dashboard was given; otherwise everything in the layout).
+      scoped_dash_names = opts[:dashboards]&.map(&:downcase)
+      dash_layout.each do |d|
+        next if scoped_dash_names &&
+                !scoped_dash_names.any? { |dn| d['dashboard'].to_s.downcase.include?(dn) }
+        (d['zones'] || []).each do |z|
+          next unless z['kind'] == 'chart'
+          hf_list = z['hidden_filters']
+          next if hf_list.nil? || hf_list.empty?
+          hf_list.each do |hf|
+            hidden_filters_gate << {
+              'tile'        => z['caption'],
+              'calc_ref'    => hf['calc_ref'],
+              'caption'     => hf['caption'],
+              'filter_type' => hf['filter_type'],
+              'members'     => hf['members'],
+              # Default status: unresolved. Caller must set "translated" or "waived".
+              'status'      => 'unresolved'
+            }.compact
+          end
+        end
+      end
+      if hidden_filters_gate.any?
+        warn "hidden_filters gate: #{hidden_filters_gate.size} unresolved calc-filter(s) found — " \
+             "plan will be 'needs_review' until each is translated or waived"
+        hidden_filters_gate.each do |hf|
+          warn "  [#{hf['tile']}] #{hf['calc_ref']} (#{hf['caption']}) filter_type=#{hf['filter_type']}"
+        end
+      else
+        warn "hidden_filters gate: no hidden calc-filters found in dashboard layout"
+      end
+    end
+  rescue JSON::ParserError => e
+    warn "hidden_filters gate: could not parse #{dash_layout_path}: #{e.message}"
+  end
+else
+  warn "hidden_filters gate: no dashboard-layout.json at #{dash_layout_path} (run parse-twb-layout first)"
+end
+
+# Derive plan-level status
+unresolved_hf = hidden_filters_gate.reject { |hf| %w[translated waived].include?(hf['status']) }
+plan_status = unresolved_hf.any? ? 'needs_review' : 'green'
+warn "plan status: #{plan_status}" \
+     "#{unresolved_hf.any? ? " (#{unresolved_hf.size} unresolved hidden calc-filter(s))" : ''}"
+
 # Wrap output
-output = { 'extract' => extract, 'charts' => plan_entries }
+output = {
+  'extract'        => extract,
+  'charts'         => plan_entries,
+  'hidden_filters' => hidden_filters_gate,
+  'plan_status'    => plan_status
+}
 File.write(opts[:out], JSON.pretty_generate(output))
 
 puts "wrote #{opts[:out]}"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
@@ -42,6 +42,14 @@ OptionParser.new do |p|
        'master-absences / master-employees / master-time).') { |v| (opts[:master_ids] ||= []) << v }
   p.on('--rename PAIR')          { |v| from, to = v.split('=', 2); opts[:renames][from] = to }
   p.on('--no-fetch')             {     opts[:no_fetch] = true }
+  # Per-dashboard parity scoping (large-workbook one-tab-at-a-time gating). When
+  # set, only chart elements on the matching workbook PAGE(s) are planned/gated —
+  # so parity passes/fails per-tab instead of all-or-nothing across the whole
+  # workbook. Page name match is case-insensitive exact OR unique substring (the
+  # Sigma page name == the Tableau dashboard name in per-dashboard builds).
+  # Repeatable. --page is an alias accepting a page id or name.
+  p.on('--dashboard NAME', 'Scope parity to chart tiles on this workbook page only (name: exact or unique substring). Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
+  p.on('--page NAME_OR_ID', 'Alias for --dashboard; matches a page by name or id. Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
 end.parse!
 abort('usage: --tableau DIR --workbook-spec FILE --out FILE [--workbook-id ID] [--rename A=B]') unless opts[:tab] && opts[:wb] && opts[:out]
 
@@ -62,6 +70,22 @@ view_by_name = views.each_with_object({}) { |v, h| h[v['name']] = v }
 
 # Load Sigma side
 spec = JSON.parse(File.read(opts[:wb]))
+
+# Per-dashboard scope: narrow the pages we plan parity over to the matching
+# page(s). The master-detection + chart-matching loops below iterate `pages`
+# instead of `spec['pages']`, so a scoped run gates ONLY the target tab's tiles
+# (per-tab parity, not all-or-nothing). No flag ⇒ every page (current behavior).
+pages = spec['pages']
+if opts[:dashboards] && !opts[:dashboards].empty?
+  want = opts[:dashboards].map(&:downcase)
+  pages = spec['pages'].select do |pg|
+    nm = pg['name'].to_s.downcase
+    pid = pg['id'].to_s.downcase
+    want.any? { |w| !w.empty? && (nm == w || nm.include?(w) || pid == w) }
+  end
+  abort("--dashboard/--page matched no workbook page in #{opts[:wb]}") if pages.empty?
+  warn "scoped parity to page(s): #{pages.map { |p| p['name'] }.join(', ')}"
+end
 
 # Build the set of master-element-IDs we should treat as "the master" for
 # chart matching. Either explicit via --master-id (repeatable) OR auto-detect
@@ -111,7 +135,7 @@ spec['pages'].each do |pg|
   end
 end
 sigma_charts = []
-spec['pages'].each do |pg|
+pages.each do |pg|
   pg['elements'].each do |e|
     next if master_id_set.include?(e['id'])
     next unless e['source'] && master_id_set.include?(e['source']['elementId'])

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -65,6 +65,13 @@ OptionParser.new do |p|
   p.on('--title STR',     'Dashboard title text element to emit (e.g., "Orders Dashboard")')         { |v| opts[:title] = v }
   p.on('--page-per-worksheet', 'Emit one Sigma page per Tableau worksheet (ignore dashboard layout)') { opts[:pages_mode] = :worksheet }
   p.on('--page-per-dashboard', 'Emit ONE Sigma page per Tableau DASHBOARD (multi-dashboard workbooks - bead ptrt)') { opts[:pages_mode] = :dashboard }
+  # Per-dashboard scoping (large-workbook one-tab-at-a-time builds). Normally the
+  # --layout is ALREADY scoped by parse-twb-layout --dashboard, so a single
+  # dashboard ⇒ exactly one page. These flags are a defensive belt-and-suspenders
+  # filter: if handed a FULL layout, keep only the matching dashboard(s) so a
+  # standalone invocation still builds just the requested tab. Repeatable.
+  p.on('--dashboard NAME', 'Build only this dashboard (name: exact or unique substring, case-insensitive). Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
+  p.on('--page ID', 'Build only the dashboard whose zone-root id matches (rarely needed; --dashboard is the handle).') { |v| (opts[:pages] ||= []) << v }
   p.on('--auto-controls', 'Auto-emit Sigma controls from shared-view filters in --meta')              { opts[:auto_controls] = true }
   p.on('--out PATH')                { |v| opts[:out] = v }
   # Where the migration COVERAGE ledger lands (the aggregated drop/approx report
@@ -615,6 +622,21 @@ end
 
 # ---- Load inputs ----
 layout = JSON.parse(File.read(opts[:layout]))
+# Defensive per-dashboard scope: if --dashboard/--page was passed AND the layout
+# still carries more than the requested tab(s), keep only the matching ones.
+# (parse-twb-layout normally pre-scopes the layout, making this a no-op — but a
+# standalone build with a full layout should still honor the flag.) Name match is
+# case-insensitive exact OR unique substring, matching parse-twb-layout.
+if (opts[:dashboards] && !opts[:dashboards].empty?) || (opts[:pages] && !opts[:pages].empty?)
+  want = (opts[:dashboards] || []).map(&:downcase)
+  before = layout.size
+  layout = layout.select do |d|
+    n = d['dashboard'].to_s.downcase
+    want.any? { |w| n == w || (!w.empty? && n.include?(w)) }
+  end
+  warn "scoped layout to #{layout.size}/#{before} dashboard(s): #{layout.map { |d| d['dashboard'] }.join(', ')}"
+  abort("--dashboard/--page matched no dashboard in #{opts[:layout]}") if layout.empty?
+end
 mmap   = JSON.parse(File.read(opts[:mmap]))
 meta   = opts[:meta] ? JSON.parse(File.read(opts[:meta])) : { 'worksheets' => {}, 'shared_filters' => [] }
 # Caption → Tableau formula for every calculated field the workbook defines

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -405,6 +405,10 @@ module MechanicalSpecs
   # { "TABLE" => [{'name','type'}] } for picking the dim's date payload column.
   # Returns an array of human-readable action messages.
   def recover_computed_key_joins!(model, twb_xml, real_cols, dim_catalogs = {})
+    # Binary / mixed-encoding .twb content (some exports embed non-UTF-8 bytes)
+    # makes the raw caption regex .scan below throw "invalid byte sequence in
+    # UTF-8", aborting the whole mechanical pass. Scrub to valid UTF-8 first.
+    twb_xml = twb_xml.to_s.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
     msgs = []
     els = all_elements(model)
     fact = els.select { |e| e.dig('source', 'kind') == 'warehouse-table' }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -139,7 +139,12 @@ module MechanicalSpecs
     derived = els.select { |e| e.dig('source', 'kind') == 'table' && e.dig('source', 'elementId') }
                  .reject { |e| elem_name(e) =~ dim_re }
     return derived.max_by { |e| (e['columns'] || []).size } if derived.any?
-    base = els.select { |e| e.dig('source', 'kind') == 'warehouse-table' }
+    # Base candidates are warehouse-table elements OR custom-SQL ('sql') elements —
+    # the modern Tableau object/relationship model emits one kind:'sql' element per
+    # logical object (often the only kind present in a multi-custom-SQL workbook).
+    # Without 'sql' here, pick_fact returned nil and the whole mechanical path
+    # FATAL-aborted on object-model workbooks (the DDMX empty-DM dead-end).
+    base = els.select { |e| %w[warehouse-table sql].include?(e.dig('source', 'kind')) }
     return nil if base.empty?
     facts = base.reject { |e| elem_name(e) =~ dim_re }
     (facts.empty? ? base : facts).max_by { |e| (e['columns'] || []).size }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -69,6 +69,8 @@
 #      (broken extraction — re-run calc discovery; NO Sigma objects created);
 # 14 = migration GREEN + Phase E proposals pending acceptance (re-run
 #      --finalize with --enhance --enhance-accept ...);
+# 15 = converter produced an EMPTY data model (0 elements/columns) — unsupported
+#      datasource shape; NO Sigma objects created (capture the .twb for the converter);
 # 3 = parity/guard fail; 4 = workbook layer needs the agent path; other = error.
 require 'json'
 require 'csv'
@@ -598,6 +600,28 @@ if mechanical
   st = conv['stats'] || {}
   line "mechanical converter: #{st['elements']} element(s), #{st['columns']} column(s), " \
        "#{st['metrics']} metric(s), #{st['relationships']} relationship(s); #{(conv['warnings'] || []).size} warning(s)"
+
+  # CONVERTER EMPTY-MODEL GUARD (never silently blank): if the converter parsed
+  # the datasource but produced ZERO data-model elements/columns, the mechanical
+  # path has nothing to build — proceeding ships an element-less workbook (the
+  # object-model "empty DM" dead-end). Hard-stop with the converter's own warnings
+  # and a clear pointer, before any Sigma object is created. (The encapsulated
+  # object model is now supported; this catches the next unsupported shape loudly
+  # instead of as a blank dashboard.)
+  if st['elements'].to_i.zero? || st['columns'].to_i.zero?
+    puts
+    puts '==================== CONVERTER STOP (empty data model) ===================='
+    puts "The Tableau→Sigma converter produced #{st['elements'].to_i} element(s) / " \
+         "#{st['columns'].to_i} column(s) from this workbook — nothing to build a data model from."
+    puts 'Likely an unsupported datasource shape (e.g. a relationship/object model variant'
+    puts "the converter can't yet model). Converter warnings:"
+    (conv['warnings'] || []).first(8).each { |w| puts "  - #{w.to_s[0, 160]}" }
+    puts ''
+    puts 'No Sigma objects were created. Capture the .twb datasource shape for the converter repo.'
+    mark('phase1-join')
+    phase_summary
+    exit 15
+  end
 
   # ---- RLS gate (never silently drop) -------------------------------------
   # The converter detects row-level security (USERNAME/USERATTRIBUTE/ISMEMBEROF

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -80,6 +80,7 @@ require 'fileutils'
 require 'open3'
 require 'date'
 require 'time'
+require 'set'
 require_relative 'lib/scout_gate'
 
 $stdout.sync = true # progress lines interleave correctly when piped/captured
@@ -126,10 +127,26 @@ OptionParser.new do |o|
   o.on('--converter MODE', %w[local hosted], "converter backend: 'local' (default; no data egress — " \
        "needs TABLEAU_MCP_BUILD) or 'hosted' (sends the .twb to sigma-data-model-mcp.onrender.com — " \
        'explicit consent to upload customer schema/SQL).') { |v| opts[:converter] = v }
+  # ---- Per-dashboard scoping (LARGE workbooks: build+gate ONE tab at a time) ----
+  # `--dashboard "<name>"` (repeatable) scopes parse-twb-layout, build-charts, and
+  # the parity plan to a single Tableau dashboard, so a 14-tab workbook is built
+  # and gated one tab at a time. `--page <id>` is the zone-root-id equivalent. When
+  # a Sigma workbook ALREADY exists for the prior tabs, pass `--workbook <sigma-id>`
+  # to APPEND the new dashboard's page to that workbook (PUT the merged spec)
+  # instead of POSTing a brand-new workbook.
+  o.on('--dashboard NAME', 'Build/gate only this Tableau dashboard (repeatable). Enables one-tab-at-a-time large-workbook migration.') { |v| (opts[:dashboards] ||= []) << v }
+  o.on('--page ID',        'Scope to the dashboard with this zone-root id (alt to --dashboard; repeatable).') { |v| (opts[:pages] ||= []) << v }
+  o.on('--workbook-target ID', 'Existing Sigma workbook id to APPEND the scoped dashboard page to (PUT-append instead of POST-new).') { |v| opts[:wb_target] = v }
 end.parse!
 
 abort 'missing --workbook or --workbook-id' unless opts[:wb_name] || opts[:wb_id]
 abort 'missing --connection' unless opts[:conn] || opts[:finalize]
+
+# Per-dashboard scope flags, assembled once and threaded into parse-twb-layout,
+# build-charts, and auto-parity. Empty ⇒ whole-workbook (current behavior).
+DASH_SCOPE = (opts[:dashboards] || []).flat_map { |d| ['--dashboard', d] } +
+             (opts[:pages]      || []).flat_map { |p| ['--page', p] }
+SCOPED = !DASH_SCOPE.empty?
 
 slug = (opts[:wb_name] || opts[:wb_id]).gsub(/[^A-Za-z0-9_-]/, '-').squeeze('-')
 WORK = opts[:out] || File.expand_path("~/tableau-migration/#{slug}")
@@ -508,7 +525,8 @@ line "workbook '#{wb_name}' (#{wb_luid}): #{views.size} view(s)#{has_extracts ? 
 layout_json = File.join(WORK, 'dashboard-layout.json')
 have_twb = lane_wait_for.call(twb, 'workbook-content.twb')
 if have_twb
-  run!(['ruby', File.join(HERE, 'parse-twb-layout.rb'), twb, layout_json])
+  run!(['ruby', File.join(HERE, 'parse-twb-layout.rb'), twb, layout_json] + DASH_SCOPE)
+  line "per-dashboard scope: #{(opts[:dashboards] || []) + (opts[:pages] || [])} (single-tab build)" if SCOPED
   dash = JSON.parse(File.read(layout_json))
   zones = dash.is_a?(Array) ? dash.flat_map { |d| d['zones'] || [] } : (dash['zones'] || [])
   chart_zones = zones.select { |z| z['kind'] == 'chart' }
@@ -1359,6 +1377,10 @@ if mechanical
                '--coverage-out', File.join(WORK, 'coverage.json')]
   build_cmd += ['--meta', layout_json.sub(/\.json$/, '-meta.json')] if File.exist?(layout_json.sub(/\.json$/, '-meta.json'))
   build_cmd += ['--auto-controls'] if File.exist?(layout_json.sub(/\.json$/, '-meta.json'))
+  # Per-dashboard scope (defensive — the layout is already pre-scoped, so a single
+  # dashboard yields exactly one page; passing the flags keeps a standalone build
+  # honest if it's ever handed a full layout).
+  build_cmd += DASH_SCOPE if SCOPED
   run!(build_cmd, allow_fail: true)
   raw_charts = (JSON.parse(File.read(charts_path)) rescue [])
   chart_pages = raw_charts.is_a?(Hash) ? (raw_charts['pages'] || []) : nil
@@ -1425,6 +1447,69 @@ else
   spec['folderId'] = opts[:folder] if opts[:folder]
   layout_xml = (Specs.respond_to?(:layout_xml) ? Specs.layout_xml : nil)
 end
+# ---- PUT-APPEND: incremental one-tab-at-a-time into an EXISTING workbook ----
+# When --workbook-target <id> is set with a single-dashboard build, append the
+# newly-built page(s) to the existing workbook's spec instead of POSTing a brand
+# new workbook. We GET the live spec, merge in (a) any data-page elements
+# (master/helpers) not already present and (b) the new dashboard page(s), then
+# hand the MERGED spec to post-and-readback in PUT mode (--update-id). This is
+# the keystone of large-workbook migration: build + gate one tab, then append
+# the next without rebuilding the whole workbook.
+append_update_id = nil
+if opts[:wb_target]
+  require 'sigma_rest'
+  abort 'FATAL: --workbook-target requires --dashboard/--page (append is per-tab)' unless SCOPED
+  line "PUT-append: merging the scoped page(s) into existing workbook #{opts[:wb_target]}"
+  existing = begin
+    # accept: application/json ⇒ Sigma.request returns an ALREADY-PARSED Hash
+    # (see lib/sigma_rest.rb) — do not JSON.parse again.
+    Sigma.request(:get, "/v2/workbooks/#{opts[:wb_target]}/spec", accept: 'application/json')
+  rescue StandardError => e
+    abort "FATAL: could not GET existing workbook #{opts[:wb_target]} spec for append (#{e.class}: #{e.message}). " \
+          'Verify the id and that the token can read it.'
+  end
+  unless existing.is_a?(Hash) && existing['pages'].is_a?(Array)
+    abort "FATAL: workbook #{opts[:wb_target]} spec readback is not a page-bearing spec (got #{existing.class}); " \
+          'the readback may have returned YAML — append aborted to avoid clobbering the workbook.'
+  end
+  existing_page_names = existing['pages'].map { |p| p['name'] }.compact
+  existing_el_ids = existing['pages'].flat_map { |p| (p['elements'] || []).map { |e| e['id'] } }.compact.to_set
+  # Append only the NEW page(s) (skip a page name that already exists — re-running
+  # the same tab updates in place rather than duplicating).
+  new_pages = (spec['pages'] || []).reject do |p|
+    nm = p['name']
+    data_page = p['id'].to_s.downcase.include?('data')
+    if data_page
+      # Data-page elements: merge any element id not already in the workbook.
+      true # handled below; don't append the whole data page again
+    else
+      existing_page_names.include?(nm)
+    end
+  end
+  # Merge data-page elements (master/helpers) that the existing workbook lacks
+  # into its FIRST data page (or create one). New tabs reuse the same master.
+  built_data_pages = (spec['pages'] || []).select { |p| p['id'].to_s.downcase.include?('data') }
+  new_data_els = built_data_pages.flat_map { |p| p['elements'] || [] }
+                                 .reject { |e| existing_el_ids.include?(e['id']) }
+  if new_data_els.any?
+    target_data = existing['pages'].find { |p| p['id'].to_s.downcase.include?('data') }
+    if target_data
+      target_data['elements'] = (target_data['elements'] || []) + new_data_els
+    else
+      existing['pages'] << (built_data_pages.first || { 'id' => 'data', 'name' => 'Data', 'elements' => new_data_els })
+    end
+    line "append: +#{new_data_els.size} data-page element(s) (shared master/helpers not yet in workbook)"
+  end
+  if new_pages.empty?
+    line "append: page(s) #{(spec['pages'] || []).map { |p| p['name'] }.compact.inspect} already present in workbook — PUT will refresh in place"
+  end
+  existing['pages'] = existing['pages'] + new_pages
+  # Preserve the existing workbook's identity (name/folder); don't clobber.
+  spec = existing
+  append_update_id = opts[:wb_target]
+  line "append: workbook now has #{existing['pages'].size} page(s) after merge (+#{new_pages.size} new content page(s))"
+end
+
 File.write(wb_spec_path, JSON.pretty_generate(spec))
 wb_ids_path = File.join(WORK, 'wb-ids.json')
 
@@ -1437,8 +1522,11 @@ wb_ids_path = File.join(WORK, 'wb-ids.json')
 begin
   v_log = run_wb!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'workbook',
                    '--dm-context', dm_ids_path, wb_spec_path])
-  p_log = sigma_run_wb!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
-                         '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK])
+  par_cmd = ['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
+             '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK]
+  # PUT-append into the targeted existing workbook (instead of POST-create).
+  par_cmd += ['--update-id', append_update_id] if append_update_id
+  p_log = sigma_run_wb!(par_cmd)
 rescue WorkbookBuildError => e
   failed = cull_failed_fields(e.captured_output,
                               (defined?(v_log) ? v_log : ''), (defined?(p_log) ? p_log : ''))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -656,6 +656,44 @@ xml.elements.each('//worksheet') do |ws|
   is_kpi = kpi_capable_mark && !is_crosstab &&
            total_dim_count == 0 && total_measure_count >= 1
 
+  # Hidden calc filters: worksheet-level filters whose target column is a
+  # calculated field. These are invisible in Tableau CSV exports — they silently
+  # reduce row counts and cause parity divergences with no warning. A filter is
+  # "calc-targeted" when:
+  #   - the column ref contains `Calculation_`
+  #   - the column ref starts with `[Parameters.`
+  #   - OR the resolved COL_BY_GUID entry matches a calc we know about
+  # We walk the already-built filters_info (worksheet-level only, NOT
+  # shared-view filters — those are dashboard-level).
+  # Build a set of known calc column names from this worksheet's calcs plus
+  # top-level datasource calcs for quick membership test.
+  ws_calc_names = calcs.map { |c| c['name'].to_s }.to_set
+  ws_calc_captions = calcs.map { |c| c['caption'].to_s }.reject(&:empty?).to_set
+  hidden_filters = filters_info.select do |fi|
+    raw = fi['raw_param'].to_s
+    guid = fi['column_guid'].to_s
+    # Check 1: raw param contains Calculation_ or Parameters.
+    next true if raw =~ /Calculation_\d+/i
+    next true if raw =~ /\[Parameters\./i
+    # Check 2: resolved guid is a Calculation_ id
+    next true if guid =~ /\ACalculation_\d+\z/i
+    # Check 3: caption matches a known calc in this worksheet
+    cap = fi['column_caption'].to_s
+    next true if !cap.empty? && (ws_calc_captions.include?(cap) || ws_calc_names.include?("[#{cap}]"))
+    false
+  end.map do |fi|
+    hf = {
+      'calc_ref'    => fi['raw_param'],
+      'caption'     => fi['column_caption'],
+      'filter_type' => fi['raw_class'],
+      'kind'        => fi['kind']
+    }
+    hf['members'] = fi['members'] if fi['kind'] == 'list' && fi['members']
+    hf['min']     = fi['min']     if fi['min']
+    hf['max']     = fi['max']     if fi['max']
+    hf.compact
+  end
+
   worksheets[name] = {
     mark_class:       mark_class,
     geo_role:         geo_role,
@@ -664,6 +702,7 @@ xml.elements.each('//worksheet') do |ws|
     has_geometry:     has_geometry,
     sort:             sort_info,
     filters:          filters_info,
+    hidden_filters:   hidden_filters,
     aggregations:     aggregations,
     channels:         channels,
     formats:          formats,
@@ -933,9 +972,10 @@ xml.elements.each('//dashboard') do |d|
       'mark_class'   => ws_meta&.dig(:mark_class),
       'geo_role'     => ws_meta&.dig(:geo_role),
       # New per-worksheet signal fields (nil for non-chart zones)
-      'sort'         => (kind == 'chart' ? ws_meta&.dig(:sort)          : nil),
-      'filters'      => (kind == 'chart' ? ws_meta&.dig(:filters)       : nil),
-      'aggregations' => (kind == 'chart' ? ws_meta&.dig(:aggregations)  : nil),
+      'sort'           => (kind == 'chart' ? ws_meta&.dig(:sort)           : nil),
+      'filters'        => (kind == 'chart' ? ws_meta&.dig(:filters)       : nil),
+      'hidden_filters' => (kind == 'chart' ? (ws_meta&.dig(:hidden_filters) || []) : nil),
+      'aggregations'   => (kind == 'chart' ? ws_meta&.dig(:aggregations)  : nil),
       'channels'     => (kind == 'chart' ? ws_meta&.dig(:channels)      : nil),
       'formats'      => (kind == 'chart' ? ws_meta&.dig(:formats)       : nil),
       'calculations' => (kind == 'chart' ? ws_meta&.dig(:calculations)  : nil),
@@ -995,12 +1035,13 @@ if dashboards.empty? && !worksheets.empty?
         'y_pct'        => 0.0,
         'w_pct'        => 100.0,
         'h_pct'        => 100.0,
-        'chart_kind'   => chart_kind,
-        'mark_class'   => ws_meta[:mark_class],
-        'geo_role'     => ws_meta[:geo_role],
-        'sort'         => ws_meta[:sort],
-        'filters'      => ws_meta[:filters],
-        'aggregations' => ws_meta[:aggregations],
+        'chart_kind'     => chart_kind,
+        'mark_class'     => ws_meta[:mark_class],
+        'geo_role'       => ws_meta[:geo_role],
+        'sort'           => ws_meta[:sort],
+        'filters'        => ws_meta[:filters],
+        'hidden_filters' => ws_meta[:hidden_filters] || [],
+        'aggregations'   => ws_meta[:aggregations],
         'channels'     => ws_meta[:channels],
         'formats'      => ws_meta[:formats],
         'calculations' => ws_meta[:calculations],

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -38,8 +38,55 @@ require 'json'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'twb_xml'
 
-INP = ARGV[0] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json>')
-OUT = ARGV[1] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json>')
+# ---- Per-dashboard scoping ------------------------------------------------
+# `--dashboard "<name>"` (repeatable) and `--page <id>` let a LARGE workbook
+# (14+ dashboards) be migrated ONE tab at a time: only the matching
+# dashboard(s) are emitted in the layout JSON, and the *-meta.json worksheets /
+# shared_filters are scoped to those used by the selected dashboard(s). No
+# filter ⇒ current behavior (all dashboards, full meta). The dashboard name
+# match is case-insensitive and accepts either an exact match or a unique
+# substring (so `--dashboard "Regional"` resolves a long Tableau caption).
+# `--page <id>` filters on the dashboard's zone-root id (rarely needed; name is
+# the ergonomic handle) and is treated as an additional accepted token.
+DASHBOARD_FILTERS = []
+PAGE_FILTERS = []
+positional = []
+i = 0
+while i < ARGV.length
+  a = ARGV[i]
+  case a
+  when '--dashboard'
+    DASHBOARD_FILTERS << ARGV[i + 1].to_s
+    i += 2
+  when '--page'
+    PAGE_FILTERS << ARGV[i + 1].to_s
+    i += 2
+  else
+    positional << a
+    i += 1
+  end
+end
+
+INP = positional[0] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json> [--dashboard "<name>"] [--page <id>]')
+OUT = positional[1] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json> [--dashboard "<name>"] [--page <id>]')
+
+# True when no scoping requested → keep every dashboard (current behavior).
+def dashboard_scoping?
+  !DASHBOARD_FILTERS.empty? || !PAGE_FILTERS.empty?
+end
+
+# Decide whether a dashboard (by name + zone-root id) is in scope. Name match is
+# case-insensitive exact OR unique substring; page match is exact on the id.
+def dashboard_in_scope?(name, page_id)
+  return true unless dashboard_scoping?
+  n = name.to_s.downcase
+  name_hit = DASHBOARD_FILTERS.any? do |f|
+    fl = f.downcase
+    n == fl || (!fl.empty? && n.include?(fl))
+  end
+  page_hit = PAGE_FILTERS.any? { |p| !p.empty? && p == page_id.to_s }
+  name_hit || page_hit
+end
 
 xml = TwbXml.parse(File.read(INP))
 
@@ -837,6 +884,10 @@ end
 
 dashboards = []
 xml.elements.each('//dashboard') do |d|
+  dash_name = d.attributes['name']
+  # Zone-root id is the handle `--page` filters on.
+  zone_root_id = (r = d.elements['zones']) ? r.attributes['id'] : nil
+  next unless dashboard_in_scope?(dash_name, zone_root_id)
   zones = []
   seen_ids = {}
   d.elements.each('.//zone') do |z|
@@ -928,6 +979,9 @@ end
 # worksheet so the parser output looks normal to the build script.
 if dashboards.empty? && !worksheets.empty?
   worksheets.each_key do |ws_name|
+    # In a sheet-only workbook the worksheet IS the page, so `--dashboard`
+    # filters on the worksheet name (zone-root id n/a → nil).
+    next unless dashboard_in_scope?(ws_name, nil)
     ws_meta    = worksheets[ws_name]
     chart_kind = chart_kind_for(ws_meta)
     dashboards << {
@@ -1163,17 +1217,51 @@ unless stories.empty?
        'run scripts/build-story-pages.rb to emit one Sigma page per story point'
 end
 
+# When per-dashboard scoping is active, narrow the meta worksheets/shared_filters
+# to only what the in-scope dashboard(s) actually use, so a single-tab build
+# doesn't drag the whole workbook's worksheet metadata along. Worksheets are
+# referenced by a chart zone's `caption`; shared_filters are kept when their
+# resolved column_caption is filtered by an in-scope worksheet (conservative —
+# keep any whose column is referenced, plus all when we can't tell).
+scoped_worksheets = worksheets
+scoped_shared_filters = shared_filters
+if dashboard_scoping?
+  used_captions = {}
+  dashboards.each do |d|
+    d['zones'].each do |z|
+      cap = z['caption']
+      used_captions[cap] = true if cap && worksheets.key?(cap)
+    end
+  end
+  scoped_worksheets = worksheets.select { |name, _| used_captions[name] }
+  # Shared filters apply workbook-wide; keep those whose target column is filtered
+  # by an in-scope worksheet (matched on column_caption), so the auto-control
+  # builder still surfaces the relevant dashboard filters without the full set.
+  used_filter_captions = {}
+  scoped_worksheets.each_value do |w|
+    (w[:filters] || []).each do |f|
+      c = f['column_caption']
+      used_filter_captions[c] = true if c
+    end
+  end
+  scoped_shared_filters = shared_filters.select do |f|
+    c = f['column_caption']
+    c.nil? || used_filter_captions[c]
+  end
+end
+
 meta = {
-  'worksheets'     => worksheets.transform_values { |v| v.transform_keys(&:to_s) },
+  'worksheets'     => scoped_worksheets.transform_values { |v| v.transform_keys(&:to_s) },
   'stories'        => stories,
-  'shared_filters' => shared_filters,
+  'shared_filters' => scoped_shared_filters,
   'parameters'     => parameters,
   'column_aliases' => column_aliases,
   'columns_by_guid'=> COL_BY_GUID.transform_values { |v| { 'caption' => v[:caption], 'datatype' => v[:datatype] } }
 }
 META_OUT = OUT.sub(/\.json$/, '-meta.json')
 File.write(META_OUT, JSON.pretty_generate(meta))
-puts "wrote #{META_OUT} (#{meta['worksheets'].size} worksheets, #{shared_filters.size} shared filters)"
+scope_note = dashboard_scoping? ? " [scoped: #{(DASHBOARD_FILTERS + PAGE_FILTERS).join(', ')}]" : ''
+puts "wrote #{META_OUT} (#{meta['worksheets'].size} worksheets, #{meta['shared_filters'].size} shared filters)#{scope_note}"
 
 File.write(OUT, JSON.pretty_generate(dashboards))
 puts "wrote #{OUT} (#{dashboards.size} dashboards, #{dashboards.sum { |d| d['zones'].size }} zones total)"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
@@ -43,6 +43,11 @@ OptionParser.new do |p|
   p.on('--extract-tol F', Float) { |v| opts[:extract_tol] = v }
   p.on('--rename PAIR', 'Tableau-name=Sigma-name (repeat)') { |v| opts[:renames] << v }
   p.on('--dashboard-layout PATH', 'parse-twb-layout output for the tile census (default <tableau-dir>/dashboard-layout.json)') { |v| opts[:dash_layout] = v }
+  # Per-dashboard parity scoping: scope parity checks to only tiles on the
+  # named dashboard (case-insensitive exact or unique substring). Repeatable.
+  # Threaded through to auto-parity-plan.rb's --dashboard flag so both the
+  # plan and the gate operate on the same scoped tile set.
+  p.on('--dashboard NAME', 'Scope parity checks to tiles on this dashboard only (exact or substring). Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
   p.on('--finalize')             { opts[:finalize] = true }
   p.on('--actuals PATH', 'JSON: { "<chart name>": [[dim, val], ...] } — for --finalize') { |v| opts[:actuals] = v }
 end.parse!
@@ -80,12 +85,51 @@ if !opts[:finalize]
                '--workbook-spec', File.join(opts[:tab], 'wb-readback.json'),
                '--out', plan_path]
   opts[:renames].each { |r| plan_args.concat(['--rename', r]) }
+  # Thread --dashboard scoping through to the parity plan so both the chart
+  # matching and the hidden_filters gate operate on the same tile set.
+  (opts[:dashboards] || []).each { |d| plan_args.concat(['--dashboard', d]) }
   out, err, status = Open3.capture3(*plan_args)
   warn out unless out.empty?
   warn err unless err.empty?
   abort('auto-parity-plan failed') unless status.success?
 
   plan = JSON.parse(File.read(plan_path))
+
+  # ---- Hidden calc-filter gate (Phase 6 enforcement) -----------------------
+  # If the parity plan contains unresolved hidden calc-filters, Phase 6 must
+  # refuse to proceed. Worksheet-level calc-field filters are invisible in CSV
+  # exports; an unresolved filter means the Sigma source was NOT filtered to
+  # match, so any parity comparison would be against a row-superset and could
+  # silently PASS with wrong numbers. A real case dropped 248→52 rows.
+  unresolved_hf = (plan['hidden_filters'] || []).reject do |hf|
+    %w[translated waived].include?(hf['status'])
+  end
+  if unresolved_hf.any?
+    warn ""
+    warn "=" * 70
+    warn "PHASE 6 BLOCKED — unresolved hidden worksheet calc-filter(s)"
+    warn "=" * 70
+    warn ""
+    warn "The following worksheet-level filters target calculated fields and are"
+    warn "invisible in Tableau CSV exports. They must be either:"
+    warn "  translated — applied to the Sigma source so row counts match, OR"
+    warn "  waived     — explicitly waived (set status: 'waived' + reason in"
+    warn "               #{plan_path})"
+    warn ""
+    unresolved_hf.each_with_index do |hf, i|
+      warn "  [#{i + 1}] tile=#{hf['tile'].inspect} calc_ref=#{hf['calc_ref'].inspect}" \
+           " caption=#{hf['caption'].inspect} filter_type=#{hf['filter_type']}"
+      if hf['members'] && !hf['members'].empty?
+        warn "       members: #{hf['members'].inspect}"
+      end
+    end
+    warn ""
+    warn "To waive: open #{plan_path}, find each entry in hidden_filters, and"
+    warn "set \"status\": \"waived\" + add \"waive_reason\": \"<your reason>\"."
+    warn "Then re-run this script."
+    warn ""
+    abort("Phase 6 blocked: #{unresolved_hf.size} unresolved hidden calc-filter(s)")
+  end
 
   # Pooled Sigma-side actuals collection (collect-parity-actuals.rb): the
   # element CSV export serves every chart kind except pivot-tables, N-wide,


### PR DESCRIPTION
## Summary
- Detects worksheet-level filters on calc fields (Calculation_* refs) that are invisible in CSV exports
- These silently break parity — a real case dropped 248→52 rows with no warning
- Adds `hidden_filters[]` to parse-twb-layout output per tile
- auto-parity-plan now blocks GREEN until each filter is translated or waived
- phase6-parity honors the gate and gains `--dashboard <name>` for per-tab scoping

## Stacks on
- #192 → #187 (feat/tableau-per-dashboard-scoping)

## Test plan
- [ ] `ruby -c` passes all three files
- [ ] DDMX .twb shows hidden_filters on calc-filtered tiles
- [ ] Tiles with no calc filters show empty/absent hidden_filters
- [ ] Phase6 rejects plan with unresolved hidden calc filters
- [ ] `--dashboard` flag scopes parity to named dashboard's tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)