### PR TITLE
feat(tableau): lazy + cached per-dashboard calc extraction

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
@@ -42,6 +42,14 @@ OptionParser.new do |p|
        'master-absences / master-employees / master-time).') { |v| (opts[:master_ids] ||= []) << v }
   p.on('--rename PAIR')          { |v| from, to = v.split('=', 2); opts[:renames][from] = to }
   p.on('--no-fetch')             {     opts[:no_fetch] = true }
+  # Per-dashboard parity scoping (large-workbook one-tab-at-a-time gating). When
+  # set, only chart elements on the matching workbook PAGE(s) are planned/gated —
+  # so parity passes/fails per-tab instead of all-or-nothing across the whole
+  # workbook. Page name match is case-insensitive exact OR unique substring (the
+  # Sigma page name == the Tableau dashboard name in per-dashboard builds).
+  # Repeatable. --page is an alias accepting a page id or name.
+  p.on('--dashboard NAME', 'Scope parity to chart tiles on this workbook page only (name: exact or unique substring). Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
+  p.on('--page NAME_OR_ID', 'Alias for --dashboard; matches a page by name or id. Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
 end.parse!
 abort('usage: --tableau DIR --workbook-spec FILE --out FILE [--workbook-id ID] [--rename A=B]') unless opts[:tab] && opts[:wb] && opts[:out]
 
@@ -62,6 +70,22 @@ view_by_name = views.each_with_object({}) { |v, h| h[v['name']] = v }
 
 # Load Sigma side
 spec = JSON.parse(File.read(opts[:wb]))
+
+# Per-dashboard scope: narrow the pages we plan parity over to the matching
+# page(s). The master-detection + chart-matching loops below iterate `pages`
+# instead of `spec['pages']`, so a scoped run gates ONLY the target tab's tiles
+# (per-tab parity, not all-or-nothing). No flag ⇒ every page (current behavior).
+pages = spec['pages']
+if opts[:dashboards] && !opts[:dashboards].empty?
+  want = opts[:dashboards].map(&:downcase)
+  pages = spec['pages'].select do |pg|
+    nm = pg['name'].to_s.downcase
+    pid = pg['id'].to_s.downcase
+    want.any? { |w| !w.empty? && (nm == w || nm.include?(w) || pid == w) }
+  end
+  abort("--dashboard/--page matched no workbook page in #{opts[:wb]}") if pages.empty?
+  warn "scoped parity to page(s): #{pages.map { |p| p['name'] }.join(', ')}"
+end
 
 # Build the set of master-element-IDs we should treat as "the master" for
 # chart matching. Either explicit via --master-id (repeatable) OR auto-detect
@@ -111,7 +135,7 @@ spec['pages'].each do |pg|
   end
 end
 sigma_charts = []
-spec['pages'].each do |pg|
+pages.each do |pg|
   pg['elements'].each do |e|
     next if master_id_set.include?(e['id'])
     next unless e['source'] && master_id_set.include?(e['source']['elementId'])

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -65,6 +65,13 @@ OptionParser.new do |p|
   p.on('--title STR',     'Dashboard title text element to emit (e.g., "Orders Dashboard")')         { |v| opts[:title] = v }
   p.on('--page-per-worksheet', 'Emit one Sigma page per Tableau worksheet (ignore dashboard layout)') { opts[:pages_mode] = :worksheet }
   p.on('--page-per-dashboard', 'Emit ONE Sigma page per Tableau DASHBOARD (multi-dashboard workbooks - bead ptrt)') { opts[:pages_mode] = :dashboard }
+  # Per-dashboard scoping (large-workbook one-tab-at-a-time builds). Normally the
+  # --layout is ALREADY scoped by parse-twb-layout --dashboard, so a single
+  # dashboard ⇒ exactly one page. These flags are a defensive belt-and-suspenders
+  # filter: if handed a FULL layout, keep only the matching dashboard(s) so a
+  # standalone invocation still builds just the requested tab. Repeatable.
+  p.on('--dashboard NAME', 'Build only this dashboard (name: exact or unique substring, case-insensitive). Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
+  p.on('--page ID', 'Build only the dashboard whose zone-root id matches (rarely needed; --dashboard is the handle).') { |v| (opts[:pages] ||= []) << v }
   p.on('--auto-controls', 'Auto-emit Sigma controls from shared-view filters in --meta')              { opts[:auto_controls] = true }
   p.on('--out PATH')                { |v| opts[:out] = v }
   # Where the migration COVERAGE ledger lands (the aggregated drop/approx report
@@ -615,6 +622,21 @@ end
 
 # ---- Load inputs ----
 layout = JSON.parse(File.read(opts[:layout]))
+# Defensive per-dashboard scope: if --dashboard/--page was passed AND the layout
+# still carries more than the requested tab(s), keep only the matching ones.
+# (parse-twb-layout normally pre-scopes the layout, making this a no-op — but a
+# standalone build with a full layout should still honor the flag.) Name match is
+# case-insensitive exact OR unique substring, matching parse-twb-layout.
+if (opts[:dashboards] && !opts[:dashboards].empty?) || (opts[:pages] && !opts[:pages].empty?)
+  want = (opts[:dashboards] || []).map(&:downcase)
+  before = layout.size
+  layout = layout.select do |d|
+    n = d['dashboard'].to_s.downcase
+    want.any? { |w| n == w || (!w.empty? && n.include?(w)) }
+  end
+  warn "scoped layout to #{layout.size}/#{before} dashboard(s): #{layout.map { |d| d['dashboard'] }.join(', ')}"
+  abort("--dashboard/--page matched no dashboard in #{opts[:layout]}") if layout.empty?
+end
 mmap   = JSON.parse(File.read(opts[:mmap]))
 meta   = opts[:meta] ? JSON.parse(File.read(opts[:meta])) : { 'worksheets' => {}, 'shared_filters' => [] }
 # Caption → Tableau formula for every calculated field the workbook defines

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/extract-calc-fields.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/extract-calc-fields.rb
@@ -12,7 +12,35 @@
 #     [--out <wb-dir>/calc-fields.json] \
 #     [--source auto|metadata|twb] \
 #     [--twb <path>] \
-#     [--refresh]
+#     [--dashboard "<name>"] [--used-by <layout-meta.json>] \
+#     [--refresh] [--no-cache]
+#
+# WORKING-SET SCOPING (--dashboard / --used-by):
+#   A big .twb can carry ~2000 calcs, but one dashboard uses only a few dozen.
+#   When --dashboard "<name>" (repeatable) and/or --used-by <meta.json>
+#   (repeatable) is given, the script resolves the FULL calc set first, then
+#   keeps ONLY the calcs the target dashboard's worksheets actually reference —
+#   transitively (a kept calc that depends on another calc pulls that one in
+#   too). The used-field set comes from the parse-twb-layout `*-meta.json`
+#   sidecar (per-worksheet column-instance / measure / filter / calc lists).
+#     --dashboard resolves the meta sidecar next to --twb (workbook-content.twb
+#       → workbook-content-meta.json or layout-meta.json) and reads the
+#       worksheets whose dashboard is in scope; if the sidecar isn't already
+#       dashboard-scoped, ALL worksheets in it are treated as the used set
+#       (still narrows to that workbook's referenced calcs).
+#     --used-by <meta.json> reads an explicit (already dashboard-scoped) meta
+#       sidecar. Use this from migrate-tableau when a scoped meta already exists.
+#   WITHOUT either flag, behavior is unchanged: every calc is emitted.
+#   The filtered output adds a `used_by` index (dashboard names → kept calc
+#   captions) plus `n_calcs_total` so downstream sees the reduction.
+#
+# TRANSLATION CACHE (~/.tableau-to-sigma/calc-cache.json):
+#   Each calc carries a `formula_hash` (SHA1 of its formula text). Per-calc
+#   derived translation signals (is_lod / requires_custom_sql / translation_notes)
+#   are memoized in the customer HOME cache keyed by that hash, matching the
+#   ~/.tableau-to-sigma/ convention used by learned-rules.rb. Re-runs over the
+#   same formulas are instant (cache HITs are logged to stderr). --no-cache
+#   bypasses read+write; --refresh still re-fetches the source but reuses cache.
 #
 # Exit codes:
 #   0 — success (metadata-api OR twb-xml-fallback)
@@ -28,6 +56,8 @@ require 'json'
 require 'time'
 require 'optparse'
 require 'fileutils'
+require 'digest'
+require 'set'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'tableau_rest'
 
@@ -35,14 +65,20 @@ require 'tableau_rest'
 
 opts = {
   source: 'auto',
-  refresh: false
+  refresh: false,
+  dashboards: [],
+  used_by: [],
+  cache: true
 }
 OptionParser.new do |p|
   p.on('--workbook-luid LUID')      { |v| opts[:workbook_luid] = v }
   p.on('--out PATH')                { |v| opts[:out] = v }
   p.on('--source {auto|metadata|twb}', %w[auto metadata twb]) { |v| opts[:source] = v }
   p.on('--twb PATH')                { |v| opts[:twb] = v }
+  p.on('--dashboard NAME')          { |v| opts[:dashboards] << v }
+  p.on('--used-by PATH')            { |v| opts[:used_by] << v }
   p.on('--refresh')                 { opts[:refresh] = true }
+  p.on('--no-cache')                { opts[:cache] = false }
 end.parse!
 
 unless opts[:workbook_luid]
@@ -56,6 +92,11 @@ out_path = opts[:out] || File.join('/tmp', "calc-fields-#{luid}.json")
 twb_path = opts[:twb] || "/tmp/assessment-dataflow/twbs/#{luid}.twb"
 
 FileUtils.mkdir_p(File.dirname(out_path))
+
+# True when the caller asked for a per-dashboard working set.
+def scoping?(opts)
+  !opts[:dashboards].empty? || !opts[:used_by].empty?
+end
 
 # ---- cache reuse --------------------------------------------------------
 
@@ -74,6 +115,53 @@ if !opts[:refresh] && cache_fresh?(out_path)
   warn "calc-fields.json fresh at #{out_path} (#{(Time.now - File.mtime(out_path)).to_i}s old); use --refresh to bypass"
   puts File.read(out_path)
   exit 0
+end
+
+# ---- per-calc translation cache (~/.tableau-to-sigma/calc-cache.json) ----
+#
+# Keyed by SHA1 of the formula text — formula identity, not field name — so the
+# SAME formula seen in a re-run (or in another workbook for the same customer)
+# reuses the already-computed translation signals instead of re-deriving them.
+# Lives under the customer HOME exactly like learned-rules.yaml, so `git pull`
+# of the skill never clobbers it. The cached payload is small (the derived
+# signals, not the formula), so the file stays tiny even for 2000-calc books.
+module CalcCache
+  HOME_OVERRIDE = ENV['TABLEAU_TO_SIGMA_HOME']
+  DEFAULT_HOME  = File.expand_path('~/.tableau-to-sigma')
+  CACHE_VERSION = 2 # bump when gotchas()/requires_custom_sql? logic changes
+
+  def self.home
+    HOME_OVERRIDE || DEFAULT_HOME
+  end
+
+  def self.path
+    File.join(home, 'calc-cache.json')
+  end
+
+  def self.key(formula)
+    Digest::SHA1.hexdigest("v#{CACHE_VERSION}\n#{formula}")
+  end
+
+  # Load the on-disk cache once. Missing file is the normal first-run case.
+  def self.load
+    return {} unless File.file?(path)
+    data = JSON.parse(File.read(path))
+    (data['entries'].is_a?(Hash) ? data['entries'] : {})
+  rescue StandardError => e
+    warn "WARN  calc-cache.json at #{path} unreadable: #{e.message}; starting fresh"
+    {}
+  end
+
+  def self.save(entries)
+    FileUtils.mkdir_p(home)
+    tmp = "#{path}.tmp#{Process.pid}"
+    File.write(tmp, JSON.pretty_generate('version' => CACHE_VERSION,
+                                         'updated_at' => Time.now.utc.iso8601,
+                                         'entries' => entries))
+    File.rename(tmp, path)
+  rescue StandardError => e
+    warn "WARN  could not persist calc-cache.json: #{e.message}"
+  end
 end
 
 # ---- formula translation hints (carried over from the v1 script) --------
@@ -173,6 +261,45 @@ def requires_custom_sql?(formula)
   detect_manual_window_fns(formula).any? || !!(formula =~ /\{\s*(INCLUDE|EXCLUDE)\b/i)
 end
 
+# Derive the translation signals for one formula. Pure function of the formula
+# text → safe to memoize by formula hash. Returns the subset of the calc record
+# that depends ONLY on the formula (not on name/role/datasource metadata).
+def compute_signals(formula)
+  {
+    is_lod: !!lod?(formula),
+    requires_custom_sql: requires_custom_sql?(formula),
+    translation_notes: gotchas(formula)
+  }
+end
+
+# Memoizing wrapper. $calc_cache is the loaded hash; $calc_cache_stats tracks
+# hits/misses for the run summary. Set $calc_cache to nil to bypass (--no-cache).
+$calc_cache = nil
+$calc_cache_stats = { hits: 0, misses: 0 }
+def cached_signals(formula)
+  return compute_signals(formula).merge(formula_hash: nil) if formula.to_s.empty?
+  h = CalcCache.key(formula)
+  if $calc_cache && (hit = $calc_cache[h])
+    $calc_cache_stats[:hits] += 1
+    return {
+      is_lod: hit['is_lod'],
+      requires_custom_sql: hit['requires_custom_sql'],
+      translation_notes: hit['translation_notes'] || [],
+      formula_hash: h
+    }
+  end
+  $calc_cache_stats[:misses] += 1
+  sig = compute_signals(formula)
+  if $calc_cache
+    $calc_cache[h] = {
+      'is_lod' => sig[:is_lod],
+      'requires_custom_sql' => sig[:requires_custom_sql],
+      'translation_notes' => sig[:translation_notes]
+    }
+  end
+  sig.merge(formula_hash: h)
+end
+
 # ---- Metadata API path --------------------------------------------------
 
 GRAPHQL_QUERY = <<~GRAPHQL
@@ -225,18 +352,21 @@ def fetch_via_metadata_api(luid)
       next unless f['__typename'] == 'CalculatedField'
       formula = f['formula'].to_s
       depends_on = (f['fields'] || []).map { |d| d['name'] }.compact.uniq
+      sig = cached_signals(formula)
       calcs << {
         name: f['name'],
+        internal_name: f['name'],
         datasource: ds_name,
         formula: formula,
         role: f['role'],
         data_type: f['dataType'],
         aggregation: f['aggregation'],
         is_hidden: f['isHidden'] == true,
-        is_lod: !!lod?(formula),
+        is_lod: sig[:is_lod],
         depends_on: depends_on,
-        requires_custom_sql: requires_custom_sql?(formula),
-        translation_notes: gotchas(formula)
+        formula_hash: sig[:formula_hash],
+        requires_custom_sql: sig[:requires_custom_sql],
+        translation_notes: sig[:translation_notes]
       }
     end
   end
@@ -276,18 +406,26 @@ def fetch_via_twb_xml(twb_path)
       role_norm = role == 'measure' ? 'MEASURE' : (role == 'dimension' ? 'DIMENSION' : role)
       hidden = col.attributes['hidden'] == 'true'
       default_agg = col.attributes['default-aggregation']
+      sig = cached_signals(formula)
       calcs << {
         name: caption || internal_name,
+        # internal_name is the .twb id (e.g. "[Calculation_123]" or
+        # "[Field (copy)_456]") that worksheet column-instances reference, used
+        # by the --dashboard/--used-by working-set resolver to match calcs.
+        internal_name: internal_name,
         datasource: ds_name,
         formula: formula,
         role: role_norm,
         data_type: data_type ? data_type.upcase : nil,
         aggregation: default_agg,
         is_hidden: hidden,
-        is_lod: !!lod?(formula),
-        depends_on: [], # not available without a resolved field graph
-        requires_custom_sql: requires_custom_sql?(formula),
-        translation_notes: gotchas(formula)
+        is_lod: sig[:is_lod],
+        # depends_on is derived post-hoc from the formula (see resolve_used_calcs)
+        # since the .twb path has no resolved field graph.
+        depends_on: [],
+        formula_hash: sig[:formula_hash],
+        requires_custom_sql: sig[:requires_custom_sql],
+        translation_notes: sig[:translation_notes]
       }
     end
   end
@@ -295,7 +433,140 @@ def fetch_via_twb_xml(twb_path)
   { ok: true, calcs: calcs }
 end
 
+# ---- working-set resolution (--dashboard / --used-by) -------------------
+
+# Resolve the parse-twb-layout meta sidecar path for a given .twb. The parser
+# writes "<base>-meta.json" next to its layout JSON; migrate-tableau names the
+# layout "layout.json" (→ layout-meta.json) and the cold path may use
+# "<twb-base>-meta.json". We probe the common spellings next to the .twb.
+def resolve_meta_path(twb_path)
+  return nil unless twb_path
+  dir  = File.dirname(twb_path)
+  base = File.basename(twb_path, '.twb')
+  candidates = [
+    File.join(dir, "#{base}-meta.json"),
+    File.join(dir, 'layout-meta.json'),
+    File.join(dir, 'layout-content-meta.json')
+  ]
+  candidates.find { |p| File.file?(p) }
+end
+
+# Normalize a field reference to a bare token usable for matching. Worksheet
+# column-instances and formulas reference fields as "[Calculation_123]",
+# "[Region]", "[federated.abc].[none:Region:nk]" etc. We strip brackets and any
+# "[ds].[col]" qualifier, returning the inner-most segment. Both the calc index
+# and the used-token set run through this so a worksheet ref and a calc id line
+# up regardless of bracketing.
+def norm_token(ref)
+  s = ref.to_s.strip
+  # Take the last bracketed segment of a qualified ref ([ds].[col] → col).
+  if s =~ /\]\.\[([^\]]+)\]\s*$/
+    s = Regexp.last_match(1)
+  end
+  s = s.sub(/\A\[/, '').sub(/\]\z/, '')
+  # Tableau instance refs sometimes carry a "none:Name:nk" derivation prefix.
+  if s =~ /\A(?:none|sum|avg|min|max|ctd|cnt|usr|qk|tmn|tdy|tyr|tqr|tmo|twk):(.+?):(?:nk|qk|ok|ck)\z/i
+    s = Regexp.last_match(1)
+  end
+  s.strip
+end
+
+# Harvest every field token a scoped meta sidecar's worksheets reference. Returns
+# a Hash: dashboard-or-meta label → Set-ish array of normalized tokens. We can't
+# always know the dashboard name from the meta alone (the sidecar is keyed by
+# worksheet), so when a label can't be derived we bucket under the meta file's
+# basename. The token harvest is deliberately broad — every place a worksheet
+# can name a field — because a missed reference silently drops a needed calc.
+def used_tokens_from_meta(meta)
+  tokens = []
+  (meta['worksheets'] || {}).each_value do |w|
+    # column-instance derivations (keyed by the column ref)
+    (w['aggregations'] || {}).each_key { |k| tokens << norm_token(k) }
+    (w['measures'] || []).each { |m| tokens << norm_token(m['column']) }
+    (w['channels'] || {}).each_value do |c|
+      tokens << norm_token(c['column']) if c['column']
+      tokens << norm_token(c['field'])  if c['field']
+    end
+    if (s = w['sort'])
+      tokens << norm_token(s['column']) if s['column']
+      tokens << norm_token(s['using'])  if s['using']
+    end
+    %w[rows_shelf cols_shelf].each do |shelf|
+      (w.dig(shelf, 'fields') || []).each { |f| tokens << norm_token(f['raw']) }
+    end
+    (w['filters'] || []).each do |f|
+      tokens << norm_token(f['column_guid']) if f['column_guid']
+      tokens << f['column_caption'] if f['column_caption']
+    end
+    (w['ref_marks'] || []).each do |r|
+      tokens << norm_token(r['axis_column'])  if r['axis_column']
+      tokens << norm_token(r['value_column']) if r['value_column']
+      tokens << norm_token(r['field_x'])      if r['field_x']
+      tokens << norm_token(r['field_y'])      if r['field_y']
+    end
+    # The worksheet's own calc list: match by BOTH internal id and caption.
+    (w['calculations'] || []).each do |c|
+      tokens << norm_token(c['name']) if c['name']
+      tokens << c['caption'] if c['caption']
+    end
+  end
+  tokens.compact.map(&:to_s).reject(&:empty?).uniq
+end
+
+# Pull the bracketed field references out of a formula so we can walk the
+# dependency graph even on the .twb path (no resolved graph there). Captures
+# "[Calculation_123]", "[Region]", "[Some Field (copy)_45]". Function names like
+# IF/SUM aren't bracketed, so this only yields field refs.
+def formula_refs(formula)
+  formula.to_s.scan(/\[[^\[\]]+\]/).map { |t| norm_token(t) }.uniq
+end
+
+# Given the full calc list + a set of directly-used tokens, return the
+# transitive closure of calcs needed: a calc is in-scope if its internal id or
+# caption is used, and every calc THAT calc's formula references is pulled in
+# too (walking depends_on when present, else parsed formula refs).
+def resolve_used_calcs(calcs, used_tokens)
+  used = used_tokens.map(&:to_s).to_set
+  by_token = {}
+  calcs.each do |c|
+    # Index each calc under its normalized internal id, its normalized caption,
+    # and its raw caption — a dependency ref may match any of these spellings.
+    by_token[norm_token(c[:internal_name])] = c if c[:internal_name]
+    if c[:name]
+      by_token[norm_token(c[:name])] = c
+      by_token[c[:name].to_s] = c
+    end
+  end
+  # Seed: any calc whose id/caption is directly referenced by a worksheet.
+  frontier = calcs.select do |c|
+    used.include?(norm_token(c[:internal_name])) ||
+      used.include?(c[:name].to_s) ||
+      used.include?(norm_token(c[:name]))
+  end
+  kept = {}
+  frontier.each { |c| kept[c.object_id] = c }
+  queue = frontier.dup
+  until queue.empty?
+    c = queue.shift
+    deps = (c[:depends_on] || []).map { |d| norm_token(d) }
+    deps += formula_refs(c[:formula])
+    deps.uniq.each do |d|
+      dep = by_token[d]
+      next unless dep
+      next if kept.key?(dep.object_id)
+      kept[dep.object_id] = dep
+      queue << dep
+    end
+  end
+  kept.values
+end
+
 # ---- orchestration ------------------------------------------------------
+
+# Prime the per-formula translation cache (unless --no-cache). cached_signals
+# reads/writes $calc_cache during both fetch paths below.
+$calc_cache = opts[:cache] ? CalcCache.load : nil
+warn "calc-cache: #{$calc_cache.size} entries loaded from #{CalcCache.path}" if $calc_cache
 
 source_chosen = nil
 final_calcs = nil
@@ -345,6 +616,64 @@ when 'auto'
   end
 end
 
+# Persist the per-formula cache (signals computed during this run). Cheap and
+# idempotent; safe even on an all-calcs run.
+if $calc_cache
+  CalcCache.save($calc_cache)
+  warn "calc-cache: #{$calc_cache_stats[:hits]} hit / #{$calc_cache_stats[:misses]} miss (saved #{$calc_cache.size} entries → #{CalcCache.path})"
+end
+
+n_calcs_total = final_calcs.size
+
+# ---- working-set filter -------------------------------------------------
+used_by = nil
+if scoping?(opts)
+  meta_inputs = []
+  # Explicit --used-by sidecars first.
+  opts[:used_by].each do |p|
+    if File.file?(p)
+      meta_inputs << [p, JSON.parse(File.read(p))]
+    else
+      warn "WARN  --used-by sidecar not found: #{p}; skipping"
+    end
+  end
+  # --dashboard resolves the sidecar next to the .twb. The base-branch parser
+  # writes a dashboard-SCOPED meta when run with --dashboard; if migrate-tableau
+  # already produced that scoped meta, --used-by is the precise handle. Here we
+  # fall back to whatever full/scoped meta sits next to the .twb.
+  if !opts[:dashboards].empty?
+    mp = resolve_meta_path(twb_path)
+    if mp
+      meta_inputs << [mp, JSON.parse(File.read(mp))]
+      warn "scoping: --dashboard #{opts[:dashboards].inspect} resolving against meta sidecar #{mp}"
+    else
+      warn "WARN  --dashboard given but no meta sidecar found next to #{twb_path}; " \
+           'run parse-twb-layout.rb (with --dashboard) first or pass --used-by. ' \
+           'Emitting UNFILTERED calc set.'
+    end
+  end
+
+  if meta_inputs.empty?
+    warn 'WARN  scoping requested but no usable meta sidecars; emitting all calcs.'
+  else
+    all_tokens = []
+    used_by = {}
+    meta_inputs.each do |path, meta|
+      toks = used_tokens_from_meta(meta)
+      label = (opts[:dashboards].empty? ? File.basename(path) : opts[:dashboards].join(' + '))
+      used_by[label] ||= []
+      all_tokens.concat(toks)
+    end
+    scoped = resolve_used_calcs(final_calcs, all_tokens.uniq)
+    # Build the per-label index of kept calc CAPTIONS (what downstream sees).
+    kept_captions = scoped.map { |c| c[:name] }.compact.uniq.sort
+    used_by.each_key { |k| used_by[k] = kept_captions }
+    warn "scoping: #{final_calcs.size} total calcs → #{scoped.size} used by " \
+         "#{used_by.keys.join(', ')} (transitive closure over #{all_tokens.uniq.size} tokens)"
+    final_calcs = scoped
+  end
+end
+
 n_calcs = final_calcs.size
 n_lods  = final_calcs.count { |c| c[:is_lod] }
 n_sql   = final_calcs.count { |c| c[:requires_custom_sql] }
@@ -354,14 +683,20 @@ result = {
   workbook_name: wb_name,
   source: source_chosen,
   generated_at: Time.now.utc.iso8601,
+  scoped: scoping?(opts) && !used_by.nil?,
+  scope_dashboards: (opts[:dashboards].empty? ? nil : opts[:dashboards]),
+  scope_used_by: (opts[:used_by].empty? ? nil : opts[:used_by]),
+  n_calcs_total: n_calcs_total,
   n_calcs: n_calcs,
   n_lods: n_lods,
   n_requires_custom_sql: n_sql,
+  used_by: used_by,
   metadata_api_error: metadata_err,
   calcs: final_calcs
 }
 
 File.write(out_path, JSON.pretty_generate(result))
-warn "wrote #{out_path}  (source=#{source_chosen}, n_calcs=#{n_calcs}, n_lods=#{n_lods}, n_sql=#{n_sql})"
+scope_note = result[:scoped] ? " scoped #{n_calcs}/#{n_calcs_total}" : ''
+warn "wrote #{out_path}  (source=#{source_chosen}, n_calcs=#{n_calcs}, n_lods=#{n_lods}, n_sql=#{n_sql})#{scope_note}"
 puts JSON.pretty_generate(result)
 exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -405,6 +405,10 @@ module MechanicalSpecs
   # { "TABLE" => [{'name','type'}] } for picking the dim's date payload column.
   # Returns an array of human-readable action messages.
   def recover_computed_key_joins!(model, twb_xml, real_cols, dim_catalogs = {})
+    # Binary / mixed-encoding .twb content (some exports embed non-UTF-8 bytes)
+    # makes the raw caption regex .scan below throw "invalid byte sequence in
+    # UTF-8", aborting the whole mechanical pass. Scrub to valid UTF-8 first.
+    twb_xml = twb_xml.to_s.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
     msgs = []
     els = all_elements(model)
     fact = els.select { |e| e.dig('source', 'kind') == 'warehouse-table' }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -139,7 +139,12 @@ module MechanicalSpecs
     derived = els.select { |e| e.dig('source', 'kind') == 'table' && e.dig('source', 'elementId') }
                  .reject { |e| elem_name(e) =~ dim_re }
     return derived.max_by { |e| (e['columns'] || []).size } if derived.any?
-    base = els.select { |e| e.dig('source', 'kind') == 'warehouse-table' }
+    # Base candidates are warehouse-table elements OR custom-SQL ('sql') elements —
+    # the modern Tableau object/relationship model emits one kind:'sql' element per
+    # logical object (often the only kind present in a multi-custom-SQL workbook).
+    # Without 'sql' here, pick_fact returned nil and the whole mechanical path
+    # FATAL-aborted on object-model workbooks (the DDMX empty-DM dead-end).
+    base = els.select { |e| %w[warehouse-table sql].include?(e.dig('source', 'kind')) }
     return nil if base.empty?
     facts = base.reject { |e| elem_name(e) =~ dim_re }
     (facts.empty? ? base : facts).max_by { |e| (e['columns'] || []).size }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -69,6 +69,8 @@
 #      (broken extraction — re-run calc discovery; NO Sigma objects created);
 # 14 = migration GREEN + Phase E proposals pending acceptance (re-run
 #      --finalize with --enhance --enhance-accept ...);
+# 15 = converter produced an EMPTY data model (0 elements/columns) — unsupported
+#      datasource shape; NO Sigma objects created (capture the .twb for the converter);
 # 3 = parity/guard fail; 4 = workbook layer needs the agent path; other = error.
 require 'json'
 require 'csv'
@@ -598,6 +600,28 @@ if mechanical
   st = conv['stats'] || {}
   line "mechanical converter: #{st['elements']} element(s), #{st['columns']} column(s), " \
        "#{st['metrics']} metric(s), #{st['relationships']} relationship(s); #{(conv['warnings'] || []).size} warning(s)"
+
+  # CONVERTER EMPTY-MODEL GUARD (never silently blank): if the converter parsed
+  # the datasource but produced ZERO data-model elements/columns, the mechanical
+  # path has nothing to build — proceeding ships an element-less workbook (the
+  # object-model "empty DM" dead-end). Hard-stop with the converter's own warnings
+  # and a clear pointer, before any Sigma object is created. (The encapsulated
+  # object model is now supported; this catches the next unsupported shape loudly
+  # instead of as a blank dashboard.)
+  if st['elements'].to_i.zero? || st['columns'].to_i.zero?
+    puts
+    puts '==================== CONVERTER STOP (empty data model) ===================='
+    puts "The Tableau→Sigma converter produced #{st['elements'].to_i} element(s) / " \
+         "#{st['columns'].to_i} column(s) from this workbook — nothing to build a data model from."
+    puts 'Likely an unsupported datasource shape (e.g. a relationship/object model variant'
+    puts "the converter can't yet model). Converter warnings:"
+    (conv['warnings'] || []).first(8).each { |w| puts "  - #{w.to_s[0, 160]}" }
+    puts ''
+    puts 'No Sigma objects were created. Capture the .twb datasource shape for the converter repo.'
+    mark('phase1-join')
+    phase_summary
+    exit 15
+  end
 
   # ---- RLS gate (never silently drop) -------------------------------------
   # The converter detects row-level security (USERNAME/USERATTRIBUTE/ISMEMBEROF

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -80,6 +80,7 @@ require 'fileutils'
 require 'open3'
 require 'date'
 require 'time'
+require 'set'
 require_relative 'lib/scout_gate'
 
 $stdout.sync = true # progress lines interleave correctly when piped/captured
@@ -126,10 +127,26 @@ OptionParser.new do |o|
   o.on('--converter MODE', %w[local hosted], "converter backend: 'local' (default; no data egress — " \
        "needs TABLEAU_MCP_BUILD) or 'hosted' (sends the .twb to sigma-data-model-mcp.onrender.com — " \
        'explicit consent to upload customer schema/SQL).') { |v| opts[:converter] = v }
+  # ---- Per-dashboard scoping (LARGE workbooks: build+gate ONE tab at a time) ----
+  # `--dashboard "<name>"` (repeatable) scopes parse-twb-layout, build-charts, and
+  # the parity plan to a single Tableau dashboard, so a 14-tab workbook is built
+  # and gated one tab at a time. `--page <id>` is the zone-root-id equivalent. When
+  # a Sigma workbook ALREADY exists for the prior tabs, pass `--workbook <sigma-id>`
+  # to APPEND the new dashboard's page to that workbook (PUT the merged spec)
+  # instead of POSTing a brand-new workbook.
+  o.on('--dashboard NAME', 'Build/gate only this Tableau dashboard (repeatable). Enables one-tab-at-a-time large-workbook migration.') { |v| (opts[:dashboards] ||= []) << v }
+  o.on('--page ID',        'Scope to the dashboard with this zone-root id (alt to --dashboard; repeatable).') { |v| (opts[:pages] ||= []) << v }
+  o.on('--workbook-target ID', 'Existing Sigma workbook id to APPEND the scoped dashboard page to (PUT-append instead of POST-new).') { |v| opts[:wb_target] = v }
 end.parse!
 
 abort 'missing --workbook or --workbook-id' unless opts[:wb_name] || opts[:wb_id]
 abort 'missing --connection' unless opts[:conn] || opts[:finalize]
+
+# Per-dashboard scope flags, assembled once and threaded into parse-twb-layout,
+# build-charts, and auto-parity. Empty ⇒ whole-workbook (current behavior).
+DASH_SCOPE = (opts[:dashboards] || []).flat_map { |d| ['--dashboard', d] } +
+             (opts[:pages]      || []).flat_map { |p| ['--page', p] }
+SCOPED = !DASH_SCOPE.empty?
 
 slug = (opts[:wb_name] || opts[:wb_id]).gsub(/[^A-Za-z0-9_-]/, '-').squeeze('-')
 WORK = opts[:out] || File.expand_path("~/tableau-migration/#{slug}")
@@ -508,7 +525,8 @@ line "workbook '#{wb_name}' (#{wb_luid}): #{views.size} view(s)#{has_extracts ? 
 layout_json = File.join(WORK, 'dashboard-layout.json')
 have_twb = lane_wait_for.call(twb, 'workbook-content.twb')
 if have_twb
-  run!(['ruby', File.join(HERE, 'parse-twb-layout.rb'), twb, layout_json])
+  run!(['ruby', File.join(HERE, 'parse-twb-layout.rb'), twb, layout_json] + DASH_SCOPE)
+  line "per-dashboard scope: #{(opts[:dashboards] || []) + (opts[:pages] || [])} (single-tab build)" if SCOPED
   dash = JSON.parse(File.read(layout_json))
   zones = dash.is_a?(Array) ? dash.flat_map { |d| d['zones'] || [] } : (dash['zones'] || [])
   chart_zones = zones.select { |z| z['kind'] == 'chart' }
@@ -1359,6 +1377,10 @@ if mechanical
                '--coverage-out', File.join(WORK, 'coverage.json')]
   build_cmd += ['--meta', layout_json.sub(/\.json$/, '-meta.json')] if File.exist?(layout_json.sub(/\.json$/, '-meta.json'))
   build_cmd += ['--auto-controls'] if File.exist?(layout_json.sub(/\.json$/, '-meta.json'))
+  # Per-dashboard scope (defensive — the layout is already pre-scoped, so a single
+  # dashboard yields exactly one page; passing the flags keeps a standalone build
+  # honest if it's ever handed a full layout).
+  build_cmd += DASH_SCOPE if SCOPED
   run!(build_cmd, allow_fail: true)
   raw_charts = (JSON.parse(File.read(charts_path)) rescue [])
   chart_pages = raw_charts.is_a?(Hash) ? (raw_charts['pages'] || []) : nil
@@ -1425,6 +1447,69 @@ else
   spec['folderId'] = opts[:folder] if opts[:folder]
   layout_xml = (Specs.respond_to?(:layout_xml) ? Specs.layout_xml : nil)
 end
+# ---- PUT-APPEND: incremental one-tab-at-a-time into an EXISTING workbook ----
+# When --workbook-target <id> is set with a single-dashboard build, append the
+# newly-built page(s) to the existing workbook's spec instead of POSTing a brand
+# new workbook. We GET the live spec, merge in (a) any data-page elements
+# (master/helpers) not already present and (b) the new dashboard page(s), then
+# hand the MERGED spec to post-and-readback in PUT mode (--update-id). This is
+# the keystone of large-workbook migration: build + gate one tab, then append
+# the next without rebuilding the whole workbook.
+append_update_id = nil
+if opts[:wb_target]
+  require 'sigma_rest'
+  abort 'FATAL: --workbook-target requires --dashboard/--page (append is per-tab)' unless SCOPED
+  line "PUT-append: merging the scoped page(s) into existing workbook #{opts[:wb_target]}"
+  existing = begin
+    # accept: application/json ⇒ Sigma.request returns an ALREADY-PARSED Hash
+    # (see lib/sigma_rest.rb) — do not JSON.parse again.
+    Sigma.request(:get, "/v2/workbooks/#{opts[:wb_target]}/spec", accept: 'application/json')
+  rescue StandardError => e
+    abort "FATAL: could not GET existing workbook #{opts[:wb_target]} spec for append (#{e.class}: #{e.message}). " \
+          'Verify the id and that the token can read it.'
+  end
+  unless existing.is_a?(Hash) && existing['pages'].is_a?(Array)
+    abort "FATAL: workbook #{opts[:wb_target]} spec readback is not a page-bearing spec (got #{existing.class}); " \
+          'the readback may have returned YAML — append aborted to avoid clobbering the workbook.'
+  end
+  existing_page_names = existing['pages'].map { |p| p['name'] }.compact
+  existing_el_ids = existing['pages'].flat_map { |p| (p['elements'] || []).map { |e| e['id'] } }.compact.to_set
+  # Append only the NEW page(s) (skip a page name that already exists — re-running
+  # the same tab updates in place rather than duplicating).
+  new_pages = (spec['pages'] || []).reject do |p|
+    nm = p['name']
+    data_page = p['id'].to_s.downcase.include?('data')
+    if data_page
+      # Data-page elements: merge any element id not already in the workbook.
+      true # handled below; don't append the whole data page again
+    else
+      existing_page_names.include?(nm)
+    end
+  end
+  # Merge data-page elements (master/helpers) that the existing workbook lacks
+  # into its FIRST data page (or create one). New tabs reuse the same master.
+  built_data_pages = (spec['pages'] || []).select { |p| p['id'].to_s.downcase.include?('data') }
+  new_data_els = built_data_pages.flat_map { |p| p['elements'] || [] }
+                                 .reject { |e| existing_el_ids.include?(e['id']) }
+  if new_data_els.any?
+    target_data = existing['pages'].find { |p| p['id'].to_s.downcase.include?('data') }
+    if target_data
+      target_data['elements'] = (target_data['elements'] || []) + new_data_els
+    else
+      existing['pages'] << (built_data_pages.first || { 'id' => 'data', 'name' => 'Data', 'elements' => new_data_els })
+    end
+    line "append: +#{new_data_els.size} data-page element(s) (shared master/helpers not yet in workbook)"
+  end
+  if new_pages.empty?
+    line "append: page(s) #{(spec['pages'] || []).map { |p| p['name'] }.compact.inspect} already present in workbook — PUT will refresh in place"
+  end
+  existing['pages'] = existing['pages'] + new_pages
+  # Preserve the existing workbook's identity (name/folder); don't clobber.
+  spec = existing
+  append_update_id = opts[:wb_target]
+  line "append: workbook now has #{existing['pages'].size} page(s) after merge (+#{new_pages.size} new content page(s))"
+end
+
 File.write(wb_spec_path, JSON.pretty_generate(spec))
 wb_ids_path = File.join(WORK, 'wb-ids.json')
 
@@ -1437,8 +1522,11 @@ wb_ids_path = File.join(WORK, 'wb-ids.json')
 begin
   v_log = run_wb!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'workbook',
                    '--dm-context', dm_ids_path, wb_spec_path])
-  p_log = sigma_run_wb!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
-                         '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK])
+  par_cmd = ['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
+             '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK]
+  # PUT-append into the targeted existing workbook (instead of POST-create).
+  par_cmd += ['--update-id', append_update_id] if append_update_id
+  p_log = sigma_run_wb!(par_cmd)
 rescue WorkbookBuildError => e
   failed = cull_failed_fields(e.captured_output,
                               (defined?(v_log) ? v_log : ''), (defined?(p_log) ? p_log : ''))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -38,8 +38,55 @@ require 'json'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'twb_xml'
 
-INP = ARGV[0] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json>')
-OUT = ARGV[1] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json>')
+# ---- Per-dashboard scoping ------------------------------------------------
+# `--dashboard "<name>"` (repeatable) and `--page <id>` let a LARGE workbook
+# (14+ dashboards) be migrated ONE tab at a time: only the matching
+# dashboard(s) are emitted in the layout JSON, and the *-meta.json worksheets /
+# shared_filters are scoped to those used by the selected dashboard(s). No
+# filter ⇒ current behavior (all dashboards, full meta). The dashboard name
+# match is case-insensitive and accepts either an exact match or a unique
+# substring (so `--dashboard "Regional"` resolves a long Tableau caption).
+# `--page <id>` filters on the dashboard's zone-root id (rarely needed; name is
+# the ergonomic handle) and is treated as an additional accepted token.
+DASHBOARD_FILTERS = []
+PAGE_FILTERS = []
+positional = []
+i = 0
+while i < ARGV.length
+  a = ARGV[i]
+  case a
+  when '--dashboard'
+    DASHBOARD_FILTERS << ARGV[i + 1].to_s
+    i += 2
+  when '--page'
+    PAGE_FILTERS << ARGV[i + 1].to_s
+    i += 2
+  else
+    positional << a
+    i += 1
+  end
+end
+
+INP = positional[0] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json> [--dashboard "<name>"] [--page <id>]')
+OUT = positional[1] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json> [--dashboard "<name>"] [--page <id>]')
+
+# True when no scoping requested → keep every dashboard (current behavior).
+def dashboard_scoping?
+  !DASHBOARD_FILTERS.empty? || !PAGE_FILTERS.empty?
+end
+
+# Decide whether a dashboard (by name + zone-root id) is in scope. Name match is
+# case-insensitive exact OR unique substring; page match is exact on the id.
+def dashboard_in_scope?(name, page_id)
+  return true unless dashboard_scoping?
+  n = name.to_s.downcase
+  name_hit = DASHBOARD_FILTERS.any? do |f|
+    fl = f.downcase
+    n == fl || (!fl.empty? && n.include?(fl))
+  end
+  page_hit = PAGE_FILTERS.any? { |p| !p.empty? && p == page_id.to_s }
+  name_hit || page_hit
+end
 
 xml = TwbXml.parse(File.read(INP))
 
@@ -837,6 +884,10 @@ end
 
 dashboards = []
 xml.elements.each('//dashboard') do |d|
+  dash_name = d.attributes['name']
+  # Zone-root id is the handle `--page` filters on.
+  zone_root_id = (r = d.elements['zones']) ? r.attributes['id'] : nil
+  next unless dashboard_in_scope?(dash_name, zone_root_id)
   zones = []
   seen_ids = {}
   d.elements.each('.//zone') do |z|
@@ -928,6 +979,9 @@ end
 # worksheet so the parser output looks normal to the build script.
 if dashboards.empty? && !worksheets.empty?
   worksheets.each_key do |ws_name|
+    # In a sheet-only workbook the worksheet IS the page, so `--dashboard`
+    # filters on the worksheet name (zone-root id n/a → nil).
+    next unless dashboard_in_scope?(ws_name, nil)
     ws_meta    = worksheets[ws_name]
     chart_kind = chart_kind_for(ws_meta)
     dashboards << {
@@ -1163,17 +1217,51 @@ unless stories.empty?
        'run scripts/build-story-pages.rb to emit one Sigma page per story point'
 end
 
+# When per-dashboard scoping is active, narrow the meta worksheets/shared_filters
+# to only what the in-scope dashboard(s) actually use, so a single-tab build
+# doesn't drag the whole workbook's worksheet metadata along. Worksheets are
+# referenced by a chart zone's `caption`; shared_filters are kept when their
+# resolved column_caption is filtered by an in-scope worksheet (conservative —
+# keep any whose column is referenced, plus all when we can't tell).
+scoped_worksheets = worksheets
+scoped_shared_filters = shared_filters
+if dashboard_scoping?
+  used_captions = {}
+  dashboards.each do |d|
+    d['zones'].each do |z|
+      cap = z['caption']
+      used_captions[cap] = true if cap && worksheets.key?(cap)
+    end
+  end
+  scoped_worksheets = worksheets.select { |name, _| used_captions[name] }
+  # Shared filters apply workbook-wide; keep those whose target column is filtered
+  # by an in-scope worksheet (matched on column_caption), so the auto-control
+  # builder still surfaces the relevant dashboard filters without the full set.
+  used_filter_captions = {}
+  scoped_worksheets.each_value do |w|
+    (w[:filters] || []).each do |f|
+      c = f['column_caption']
+      used_filter_captions[c] = true if c
+    end
+  end
+  scoped_shared_filters = shared_filters.select do |f|
+    c = f['column_caption']
+    c.nil? || used_filter_captions[c]
+  end
+end
+
 meta = {
-  'worksheets'     => worksheets.transform_values { |v| v.transform_keys(&:to_s) },
+  'worksheets'     => scoped_worksheets.transform_values { |v| v.transform_keys(&:to_s) },
   'stories'        => stories,
-  'shared_filters' => shared_filters,
+  'shared_filters' => scoped_shared_filters,
   'parameters'     => parameters,
   'column_aliases' => column_aliases,
   'columns_by_guid'=> COL_BY_GUID.transform_values { |v| { 'caption' => v[:caption], 'datatype' => v[:datatype] } }
 }
 META_OUT = OUT.sub(/\.json$/, '-meta.json')
 File.write(META_OUT, JSON.pretty_generate(meta))
-puts "wrote #{META_OUT} (#{meta['worksheets'].size} worksheets, #{shared_filters.size} shared filters)"
+scope_note = dashboard_scoping? ? " [scoped: #{(DASHBOARD_FILTERS + PAGE_FILTERS).join(', ')}]" : ''
+puts "wrote #{META_OUT} (#{meta['worksheets'].size} worksheets, #{meta['shared_filters'].size} shared filters)#{scope_note}"
 
 File.write(OUT, JSON.pretty_generate(dashboards))
 puts "wrote #{OUT} (#{dashboards.size} dashboards, #{dashboards.sum { |d| d['zones'].size }} zones total)"


### PR DESCRIPTION
## What

Make Tableau calc-field extraction (`extract-calc-fields.rb`) **filterable to a single dashboard's working set** and **cache per-formula translation signals** across runs. A big `.twb` can carry ~2000 calcs, but one dashboard uses only a few dozen — resolving and translating all of them is wasted work.

## Stacking

> ⚠️ This branch stacks on **PR #192 → PR #187** (the per-dashboard `--dashboard` plumbing in `parse-twb-layout.rb`/`migrate-tableau.rb` that this builds on). Until those merge, **this PR's diff will show their commits too**. Review only `extract-calc-fields.rb`. Merge order: #187 → #192 → this.

## Changes (only `extract-calc-fields.rb`)

- **`--dashboard "<name>"` / `--used-by <meta.json>`** (both repeatable): after resolving the full calc set, keep ONLY the calcs the target dashboard's worksheets reference — read from the `parse-twb-layout` `*-meta.json` sidecar (column-instances, measures, channels, rows/cols shelves, filters, ref-marks, and the per-worksheet calc list). Then the **transitive closure**: a kept calc pulls in every calc its formula references (walks `depends_on` when present, else parses `[...]` field refs from the formula — needed on the `.twb` path, which has no resolved graph). `--dashboard` resolves the sidecar next to `--twb`; `--used-by` takes an explicit (already dashboard-scoped) sidecar. **Without either flag, behavior is unchanged (all calcs).**
- **Per-formula translation cache** at `~/.tableau-to-sigma/calc-cache.json` (the same HOME convention `learned-rules.rb` uses, so `git pull` never clobbers it): `is_lod` / `requires_custom_sql` / `translation_notes` are memoized by SHA1 of the formula text. Re-runs are instant; cache HITs are logged to stderr. `--no-cache` bypasses read+write; `--refresh` still re-fetches the source but reuses the cache.
- **Filtered output** adds a `used_by` index (dashboard → kept calc captions), `n_calcs_total`, a `scoped` flag, and per-calc `formula_hash` + `internal_name`, so downstream sees the reduced set.

## Verification

On the DDMX `.twb` (399 Tableau calcs via the `--source twb` path):

| run | calcs |
|---|---|
| full (no filter) | **399** |
| `--dashboard "Regional"` | **25** |
| `--dashboard "TAM by Role"` | **8** |

Cache: cold run = 364 miss; warm re-run = **399 hit / 0 miss**. `--no-cache` and unscoped runs verified unchanged (`scoped=false`, `used_by=null`, additive fields present). `ruby -c` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)