### PR TITLE
feat(tableau): first-class pivot crosstabs (long-tuple parity + Measure Names recipe)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
@@ -42,6 +42,14 @@ OptionParser.new do |p|
        'master-absences / master-employees / master-time).') { |v| (opts[:master_ids] ||= []) << v }
   p.on('--rename PAIR')          { |v| from, to = v.split('=', 2); opts[:renames][from] = to }
   p.on('--no-fetch')             {     opts[:no_fetch] = true }
+  # Per-dashboard parity scoping (large-workbook one-tab-at-a-time gating). When
+  # set, only chart elements on the matching workbook PAGE(s) are planned/gated —
+  # so parity passes/fails per-tab instead of all-or-nothing across the whole
+  # workbook. Page name match is case-insensitive exact OR unique substring (the
+  # Sigma page name == the Tableau dashboard name in per-dashboard builds).
+  # Repeatable. --page is an alias accepting a page id or name.
+  p.on('--dashboard NAME', 'Scope parity to chart tiles on this workbook page only (name: exact or unique substring). Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
+  p.on('--page NAME_OR_ID', 'Alias for --dashboard; matches a page by name or id. Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
 end.parse!
 abort('usage: --tableau DIR --workbook-spec FILE --out FILE [--workbook-id ID] [--rename A=B]') unless opts[:tab] && opts[:wb] && opts[:out]
 
@@ -62,6 +70,22 @@ view_by_name = views.each_with_object({}) { |v, h| h[v['name']] = v }
 
 # Load Sigma side
 spec = JSON.parse(File.read(opts[:wb]))
+
+# Per-dashboard scope: narrow the pages we plan parity over to the matching
+# page(s). The master-detection + chart-matching loops below iterate `pages`
+# instead of `spec['pages']`, so a scoped run gates ONLY the target tab's tiles
+# (per-tab parity, not all-or-nothing). No flag ⇒ every page (current behavior).
+pages = spec['pages']
+if opts[:dashboards] && !opts[:dashboards].empty?
+  want = opts[:dashboards].map(&:downcase)
+  pages = spec['pages'].select do |pg|
+    nm = pg['name'].to_s.downcase
+    pid = pg['id'].to_s.downcase
+    want.any? { |w| !w.empty? && (nm == w || nm.include?(w) || pid == w) }
+  end
+  abort("--dashboard/--page matched no workbook page in #{opts[:wb]}") if pages.empty?
+  warn "scoped parity to page(s): #{pages.map { |p| p['name'] }.join(', ')}"
+end
 
 # Build the set of master-element-IDs we should treat as "the master" for
 # chart matching. Either explicit via --master-id (repeatable) OR auto-detect
@@ -111,7 +135,7 @@ spec['pages'].each do |pg|
   end
 end
 sigma_charts = []
-spec['pages'].each do |pg|
+pages.each do |pg|
   pg['elements'].each do |e|
     next if master_id_set.include?(e['id'])
     next unless e['source'] && master_id_set.include?(e['source']['elementId'])

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1341,6 +1341,49 @@ def pick_tableau_format(formats, header)
   nil
 end
 
+# ---- "Measure Names on rows" → ordered values[] members -------------------
+# First-class the DDMX crosstab pattern (N bespoke calc measures stacked as the
+# rows of a crosstab). z['measures'] is the parser's document-order walk of the
+# worksheet's quantitative column-instances — i.e. the ORDERED Measure-Names
+# members as Tableau renders them. Return them as add_col-shaped field hashes,
+# IN ORDER, so build_pivot_element emits one ordered values[] entry per member:
+#
+#   - DROP dim-shaped entries (None / date-trunc derivations land in
+#     z['measures'] too; a Sum() over a date silently corrupts the grid).
+#   - A member whose caption matches a worksheet CALCULATION is emitted with
+#     derivation 'usr' so it registers in user_vals and the User-derivation
+#     resolver downstream translates its window/ratio formula (instead of the
+#     blind Sum([Master/<calc name>]) that the SHELF_AGG fallback would emit and
+#     which would HARD-FAIL the POST — the exact one-off-per-measure breakage
+#     this recipe replaces).
+#   - A plain warehouse measure keeps its OWN Tableau aggregation (Sum/Avg/
+#     CountD/…); add_col then resolves its per-measure format from z['formats'].
+#
+# Returns [] when there are no measure members (caller falls back / warns).
+def measure_names_members(z, meta)
+  cbg = meta['columns_by_guid'] || {}
+  calc_names = (z['calculations'] || []).map { |c| c['name'].to_s.gsub(/^\[|\]$/, '').strip.downcase }.reject(&:empty?)
+  (z['measures'] || []).each_with_object([]) do |m, out|
+    deriv = (m['derivation'] || 'Sum').to_s
+    next if deriv == 'None' || DATE_TRUNC.key?(deriv)
+    col_ref = m['column'].to_s
+    guid = guid_from_text(col_ref)
+    # Resolve the member's display caption (calc fields surface as a GUID /
+    # Calculation_ internal id; the human caption lives in columns_by_guid).
+    cap = (guid && cbg.dig(guid, 'caption')) ||
+          col_ref.sub(/^\[[^\]]+\]\./, '').gsub(/^\[|\]$/, '').sub(/^[a-z]+:/i, '').sub(/:[a-z]+$/i, '')
+    is_calc = calc_names.include?(cap.to_s.strip.downcase)
+    out << {
+      'role'       => 'measure',
+      # 'usr' routes calc members to the User-derivation resolver (window/ratio
+      # translation); plain measures keep their own warehouse aggregation.
+      'derivation' => is_calc ? 'usr' : deriv.downcase,
+      'raw'        => col_ref,
+      'guid'       => guid
+    }
+  end
+end
+
 # ---- Pivot-table emission --------------------------------------------------
 # Tableau crosstab worksheets (mark=Text or mark=Square with dims on both
 # Rows AND Cols shelves, OR the Measure Names crosstab pattern) translate to
@@ -1471,21 +1514,27 @@ def build_pivot_element(z, meta, mmap, opts, warnings, data_elements = [])
     add_col.call(f, :value) if f['role'] == 'measure'
   end
 
-  # Measure-Names pattern: shelves carry the placeholder but the actual
-  # measures live in z['measures']. Materialize them here — SKIPPING entries
-  # that are really shelf DIMS (date-trunc / None derivations land in
-  # z['measures'] too; emitting Sum() over a date silently corrupted the grid).
-  if values_arr.empty? && (z['measures'] || []).any?
-    z['measures'].each do |m|
-      deriv = (m['derivation'] || 'Sum').to_s
-      next if deriv == 'None' || DATE_TRUNC.key?(deriv)
-      add_col.call({
-        'role'       => 'measure',
-        'derivation' => deriv.downcase,
-        'raw'        => m['column'],
-        'guid'       => guid_from_text(m['column'].to_s)
-      }, :value)
-    end
+  # ---- "Measure Names on rows" crosstab recipe (first-classed) -------------
+  # The DDMX-class pattern: a worksheet stacks N bespoke calc measures as the
+  # rows of a crosstab (Measure Names on rows × week/quarter on columns) with
+  # Measure Values in the pane. The shelves carry only the [Measure Names]
+  # placeholder pill — the actual ORDERED members live in z['measures'] (the
+  # parser walks them in .twb document order, which IS the displayed stack
+  # order). Rather than treating each measure as a one-off, map the ordered
+  # members → an ordered Sigma pivot `values[]` array, one column per measure,
+  # in the same order Tableau renders them. add_col appends to values_arr in
+  # call order, so iterating the members in order yields an ordered values[].
+  #
+  # Per-member resolution mirrors the chart-side Measure-Names path: a member
+  # backed by a worksheet CALC is left for the User-derivation resolver below
+  # (emitted with derivation 'usr' so it registers in user_vals and gets its
+  # window/ratio formula translated), while a plain warehouse measure carries
+  # its own Tableau aggregation (Sum/Avg/CountD/…) instead of a blind Sum().
+  # Per-measure formats are picked by add_col from z['formats'] / the master
+  # map, so each stacked value keeps its own number/percent/currency format.
+  if values_arr.empty?
+    members = measure_names_members(z, meta)
+    members.each { |m| add_col.call(m, :value) }
   end
 
   if values_arr.empty? || (rows_by.empty? && cols_by.empty?)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -65,6 +65,13 @@ OptionParser.new do |p|
   p.on('--title STR',     'Dashboard title text element to emit (e.g., "Orders Dashboard")')         { |v| opts[:title] = v }
   p.on('--page-per-worksheet', 'Emit one Sigma page per Tableau worksheet (ignore dashboard layout)') { opts[:pages_mode] = :worksheet }
   p.on('--page-per-dashboard', 'Emit ONE Sigma page per Tableau DASHBOARD (multi-dashboard workbooks - bead ptrt)') { opts[:pages_mode] = :dashboard }
+  # Per-dashboard scoping (large-workbook one-tab-at-a-time builds). Normally the
+  # --layout is ALREADY scoped by parse-twb-layout --dashboard, so a single
+  # dashboard ⇒ exactly one page. These flags are a defensive belt-and-suspenders
+  # filter: if handed a FULL layout, keep only the matching dashboard(s) so a
+  # standalone invocation still builds just the requested tab. Repeatable.
+  p.on('--dashboard NAME', 'Build only this dashboard (name: exact or unique substring, case-insensitive). Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
+  p.on('--page ID', 'Build only the dashboard whose zone-root id matches (rarely needed; --dashboard is the handle).') { |v| (opts[:pages] ||= []) << v }
   p.on('--auto-controls', 'Auto-emit Sigma controls from shared-view filters in --meta')              { opts[:auto_controls] = true }
   p.on('--out PATH')                { |v| opts[:out] = v }
   # Where the migration COVERAGE ledger lands (the aggregated drop/approx report
@@ -615,6 +622,21 @@ end
 
 # ---- Load inputs ----
 layout = JSON.parse(File.read(opts[:layout]))
+# Defensive per-dashboard scope: if --dashboard/--page was passed AND the layout
+# still carries more than the requested tab(s), keep only the matching ones.
+# (parse-twb-layout normally pre-scopes the layout, making this a no-op — but a
+# standalone build with a full layout should still honor the flag.) Name match is
+# case-insensitive exact OR unique substring, matching parse-twb-layout.
+if (opts[:dashboards] && !opts[:dashboards].empty?) || (opts[:pages] && !opts[:pages].empty?)
+  want = (opts[:dashboards] || []).map(&:downcase)
+  before = layout.size
+  layout = layout.select do |d|
+    n = d['dashboard'].to_s.downcase
+    want.any? { |w| n == w || (!w.empty? && n.include?(w)) }
+  end
+  warn "scoped layout to #{layout.size}/#{before} dashboard(s): #{layout.map { |d| d['dashboard'] }.join(', ')}"
+  abort("--dashboard/--page matched no dashboard in #{opts[:layout]}") if layout.empty?
+end
 mmap   = JSON.parse(File.read(opts[:mmap]))
 meta   = opts[:meta] ? JSON.parse(File.read(opts[:meta])) : { 'worksheets' => {}, 'shared_filters' => [] }
 # Caption → Tableau formula for every calculated field the workbook defines

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -405,6 +405,10 @@ module MechanicalSpecs
   # { "TABLE" => [{'name','type'}] } for picking the dim's date payload column.
   # Returns an array of human-readable action messages.
   def recover_computed_key_joins!(model, twb_xml, real_cols, dim_catalogs = {})
+    # Binary / mixed-encoding .twb content (some exports embed non-UTF-8 bytes)
+    # makes the raw caption regex .scan below throw "invalid byte sequence in
+    # UTF-8", aborting the whole mechanical pass. Scrub to valid UTF-8 first.
+    twb_xml = twb_xml.to_s.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
     msgs = []
     els = all_elements(model)
     fact = els.select { |e| e.dig('source', 'kind') == 'warehouse-table' }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -139,7 +139,12 @@ module MechanicalSpecs
     derived = els.select { |e| e.dig('source', 'kind') == 'table' && e.dig('source', 'elementId') }
                  .reject { |e| elem_name(e) =~ dim_re }
     return derived.max_by { |e| (e['columns'] || []).size } if derived.any?
-    base = els.select { |e| e.dig('source', 'kind') == 'warehouse-table' }
+    # Base candidates are warehouse-table elements OR custom-SQL ('sql') elements —
+    # the modern Tableau object/relationship model emits one kind:'sql' element per
+    # logical object (often the only kind present in a multi-custom-SQL workbook).
+    # Without 'sql' here, pick_fact returned nil and the whole mechanical path
+    # FATAL-aborted on object-model workbooks (the DDMX empty-DM dead-end).
+    base = els.select { |e| %w[warehouse-table sql].include?(e.dig('source', 'kind')) }
     return nil if base.empty?
     facts = base.reject { |e| elem_name(e) =~ dim_re }
     (facts.empty? ? base : facts).max_by { |e| (e['columns'] || []).size }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -69,6 +69,8 @@
 #      (broken extraction — re-run calc discovery; NO Sigma objects created);
 # 14 = migration GREEN + Phase E proposals pending acceptance (re-run
 #      --finalize with --enhance --enhance-accept ...);
+# 15 = converter produced an EMPTY data model (0 elements/columns) — unsupported
+#      datasource shape; NO Sigma objects created (capture the .twb for the converter);
 # 3 = parity/guard fail; 4 = workbook layer needs the agent path; other = error.
 require 'json'
 require 'csv'
@@ -598,6 +600,28 @@ if mechanical
   st = conv['stats'] || {}
   line "mechanical converter: #{st['elements']} element(s), #{st['columns']} column(s), " \
        "#{st['metrics']} metric(s), #{st['relationships']} relationship(s); #{(conv['warnings'] || []).size} warning(s)"
+
+  # CONVERTER EMPTY-MODEL GUARD (never silently blank): if the converter parsed
+  # the datasource but produced ZERO data-model elements/columns, the mechanical
+  # path has nothing to build — proceeding ships an element-less workbook (the
+  # object-model "empty DM" dead-end). Hard-stop with the converter's own warnings
+  # and a clear pointer, before any Sigma object is created. (The encapsulated
+  # object model is now supported; this catches the next unsupported shape loudly
+  # instead of as a blank dashboard.)
+  if st['elements'].to_i.zero? || st['columns'].to_i.zero?
+    puts
+    puts '==================== CONVERTER STOP (empty data model) ===================='
+    puts "The Tableau→Sigma converter produced #{st['elements'].to_i} element(s) / " \
+         "#{st['columns'].to_i} column(s) from this workbook — nothing to build a data model from."
+    puts 'Likely an unsupported datasource shape (e.g. a relationship/object model variant'
+    puts "the converter can't yet model). Converter warnings:"
+    (conv['warnings'] || []).first(8).each { |w| puts "  - #{w.to_s[0, 160]}" }
+    puts ''
+    puts 'No Sigma objects were created. Capture the .twb datasource shape for the converter repo.'
+    mark('phase1-join')
+    phase_summary
+    exit 15
+  end
 
   # ---- RLS gate (never silently drop) -------------------------------------
   # The converter detects row-level security (USERNAME/USERATTRIBUTE/ISMEMBEROF

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -80,6 +80,7 @@ require 'fileutils'
 require 'open3'
 require 'date'
 require 'time'
+require 'set'
 require_relative 'lib/scout_gate'
 
 $stdout.sync = true # progress lines interleave correctly when piped/captured
@@ -126,10 +127,26 @@ OptionParser.new do |o|
   o.on('--converter MODE', %w[local hosted], "converter backend: 'local' (default; no data egress — " \
        "needs TABLEAU_MCP_BUILD) or 'hosted' (sends the .twb to sigma-data-model-mcp.onrender.com — " \
        'explicit consent to upload customer schema/SQL).') { |v| opts[:converter] = v }
+  # ---- Per-dashboard scoping (LARGE workbooks: build+gate ONE tab at a time) ----
+  # `--dashboard "<name>"` (repeatable) scopes parse-twb-layout, build-charts, and
+  # the parity plan to a single Tableau dashboard, so a 14-tab workbook is built
+  # and gated one tab at a time. `--page <id>` is the zone-root-id equivalent. When
+  # a Sigma workbook ALREADY exists for the prior tabs, pass `--workbook <sigma-id>`
+  # to APPEND the new dashboard's page to that workbook (PUT the merged spec)
+  # instead of POSTing a brand-new workbook.
+  o.on('--dashboard NAME', 'Build/gate only this Tableau dashboard (repeatable). Enables one-tab-at-a-time large-workbook migration.') { |v| (opts[:dashboards] ||= []) << v }
+  o.on('--page ID',        'Scope to the dashboard with this zone-root id (alt to --dashboard; repeatable).') { |v| (opts[:pages] ||= []) << v }
+  o.on('--workbook-target ID', 'Existing Sigma workbook id to APPEND the scoped dashboard page to (PUT-append instead of POST-new).') { |v| opts[:wb_target] = v }
 end.parse!
 
 abort 'missing --workbook or --workbook-id' unless opts[:wb_name] || opts[:wb_id]
 abort 'missing --connection' unless opts[:conn] || opts[:finalize]
+
+# Per-dashboard scope flags, assembled once and threaded into parse-twb-layout,
+# build-charts, and auto-parity. Empty ⇒ whole-workbook (current behavior).
+DASH_SCOPE = (opts[:dashboards] || []).flat_map { |d| ['--dashboard', d] } +
+             (opts[:pages]      || []).flat_map { |p| ['--page', p] }
+SCOPED = !DASH_SCOPE.empty?
 
 slug = (opts[:wb_name] || opts[:wb_id]).gsub(/[^A-Za-z0-9_-]/, '-').squeeze('-')
 WORK = opts[:out] || File.expand_path("~/tableau-migration/#{slug}")
@@ -508,7 +525,8 @@ line "workbook '#{wb_name}' (#{wb_luid}): #{views.size} view(s)#{has_extracts ? 
 layout_json = File.join(WORK, 'dashboard-layout.json')
 have_twb = lane_wait_for.call(twb, 'workbook-content.twb')
 if have_twb
-  run!(['ruby', File.join(HERE, 'parse-twb-layout.rb'), twb, layout_json])
+  run!(['ruby', File.join(HERE, 'parse-twb-layout.rb'), twb, layout_json] + DASH_SCOPE)
+  line "per-dashboard scope: #{(opts[:dashboards] || []) + (opts[:pages] || [])} (single-tab build)" if SCOPED
   dash = JSON.parse(File.read(layout_json))
   zones = dash.is_a?(Array) ? dash.flat_map { |d| d['zones'] || [] } : (dash['zones'] || [])
   chart_zones = zones.select { |z| z['kind'] == 'chart' }
@@ -1359,6 +1377,10 @@ if mechanical
                '--coverage-out', File.join(WORK, 'coverage.json')]
   build_cmd += ['--meta', layout_json.sub(/\.json$/, '-meta.json')] if File.exist?(layout_json.sub(/\.json$/, '-meta.json'))
   build_cmd += ['--auto-controls'] if File.exist?(layout_json.sub(/\.json$/, '-meta.json'))
+  # Per-dashboard scope (defensive — the layout is already pre-scoped, so a single
+  # dashboard yields exactly one page; passing the flags keeps a standalone build
+  # honest if it's ever handed a full layout).
+  build_cmd += DASH_SCOPE if SCOPED
   run!(build_cmd, allow_fail: true)
   raw_charts = (JSON.parse(File.read(charts_path)) rescue [])
   chart_pages = raw_charts.is_a?(Hash) ? (raw_charts['pages'] || []) : nil
@@ -1425,6 +1447,69 @@ else
   spec['folderId'] = opts[:folder] if opts[:folder]
   layout_xml = (Specs.respond_to?(:layout_xml) ? Specs.layout_xml : nil)
 end
+# ---- PUT-APPEND: incremental one-tab-at-a-time into an EXISTING workbook ----
+# When --workbook-target <id> is set with a single-dashboard build, append the
+# newly-built page(s) to the existing workbook's spec instead of POSTing a brand
+# new workbook. We GET the live spec, merge in (a) any data-page elements
+# (master/helpers) not already present and (b) the new dashboard page(s), then
+# hand the MERGED spec to post-and-readback in PUT mode (--update-id). This is
+# the keystone of large-workbook migration: build + gate one tab, then append
+# the next without rebuilding the whole workbook.
+append_update_id = nil
+if opts[:wb_target]
+  require 'sigma_rest'
+  abort 'FATAL: --workbook-target requires --dashboard/--page (append is per-tab)' unless SCOPED
+  line "PUT-append: merging the scoped page(s) into existing workbook #{opts[:wb_target]}"
+  existing = begin
+    # accept: application/json ⇒ Sigma.request returns an ALREADY-PARSED Hash
+    # (see lib/sigma_rest.rb) — do not JSON.parse again.
+    Sigma.request(:get, "/v2/workbooks/#{opts[:wb_target]}/spec", accept: 'application/json')
+  rescue StandardError => e
+    abort "FATAL: could not GET existing workbook #{opts[:wb_target]} spec for append (#{e.class}: #{e.message}). " \
+          'Verify the id and that the token can read it.'
+  end
+  unless existing.is_a?(Hash) && existing['pages'].is_a?(Array)
+    abort "FATAL: workbook #{opts[:wb_target]} spec readback is not a page-bearing spec (got #{existing.class}); " \
+          'the readback may have returned YAML — append aborted to avoid clobbering the workbook.'
+  end
+  existing_page_names = existing['pages'].map { |p| p['name'] }.compact
+  existing_el_ids = existing['pages'].flat_map { |p| (p['elements'] || []).map { |e| e['id'] } }.compact.to_set
+  # Append only the NEW page(s) (skip a page name that already exists — re-running
+  # the same tab updates in place rather than duplicating).
+  new_pages = (spec['pages'] || []).reject do |p|
+    nm = p['name']
+    data_page = p['id'].to_s.downcase.include?('data')
+    if data_page
+      # Data-page elements: merge any element id not already in the workbook.
+      true # handled below; don't append the whole data page again
+    else
+      existing_page_names.include?(nm)
+    end
+  end
+  # Merge data-page elements (master/helpers) that the existing workbook lacks
+  # into its FIRST data page (or create one). New tabs reuse the same master.
+  built_data_pages = (spec['pages'] || []).select { |p| p['id'].to_s.downcase.include?('data') }
+  new_data_els = built_data_pages.flat_map { |p| p['elements'] || [] }
+                                 .reject { |e| existing_el_ids.include?(e['id']) }
+  if new_data_els.any?
+    target_data = existing['pages'].find { |p| p['id'].to_s.downcase.include?('data') }
+    if target_data
+      target_data['elements'] = (target_data['elements'] || []) + new_data_els
+    else
+      existing['pages'] << (built_data_pages.first || { 'id' => 'data', 'name' => 'Data', 'elements' => new_data_els })
+    end
+    line "append: +#{new_data_els.size} data-page element(s) (shared master/helpers not yet in workbook)"
+  end
+  if new_pages.empty?
+    line "append: page(s) #{(spec['pages'] || []).map { |p| p['name'] }.compact.inspect} already present in workbook — PUT will refresh in place"
+  end
+  existing['pages'] = existing['pages'] + new_pages
+  # Preserve the existing workbook's identity (name/folder); don't clobber.
+  spec = existing
+  append_update_id = opts[:wb_target]
+  line "append: workbook now has #{existing['pages'].size} page(s) after merge (+#{new_pages.size} new content page(s))"
+end
+
 File.write(wb_spec_path, JSON.pretty_generate(spec))
 wb_ids_path = File.join(WORK, 'wb-ids.json')
 
@@ -1437,8 +1522,11 @@ wb_ids_path = File.join(WORK, 'wb-ids.json')
 begin
   v_log = run_wb!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'workbook',
                    '--dm-context', dm_ids_path, wb_spec_path])
-  p_log = sigma_run_wb!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
-                         '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK])
+  par_cmd = ['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
+             '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK]
+  # PUT-append into the targeted existing workbook (instead of POST-create).
+  par_cmd += ['--update-id', append_update_id] if append_update_id
+  p_log = sigma_run_wb!(par_cmd)
 rescue WorkbookBuildError => e
   failed = cull_failed_fields(e.captured_output,
                               (defined?(v_log) ? v_log : ''), (defined?(p_log) ? p_log : ''))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -38,8 +38,55 @@ require 'json'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'twb_xml'
 
-INP = ARGV[0] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json>')
-OUT = ARGV[1] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json>')
+# ---- Per-dashboard scoping ------------------------------------------------
+# `--dashboard "<name>"` (repeatable) and `--page <id>` let a LARGE workbook
+# (14+ dashboards) be migrated ONE tab at a time: only the matching
+# dashboard(s) are emitted in the layout JSON, and the *-meta.json worksheets /
+# shared_filters are scoped to those used by the selected dashboard(s). No
+# filter ⇒ current behavior (all dashboards, full meta). The dashboard name
+# match is case-insensitive and accepts either an exact match or a unique
+# substring (so `--dashboard "Regional"` resolves a long Tableau caption).
+# `--page <id>` filters on the dashboard's zone-root id (rarely needed; name is
+# the ergonomic handle) and is treated as an additional accepted token.
+DASHBOARD_FILTERS = []
+PAGE_FILTERS = []
+positional = []
+i = 0
+while i < ARGV.length
+  a = ARGV[i]
+  case a
+  when '--dashboard'
+    DASHBOARD_FILTERS << ARGV[i + 1].to_s
+    i += 2
+  when '--page'
+    PAGE_FILTERS << ARGV[i + 1].to_s
+    i += 2
+  else
+    positional << a
+    i += 1
+  end
+end
+
+INP = positional[0] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json> [--dashboard "<name>"] [--page <id>]')
+OUT = positional[1] || abort('usage: parse-twb-layout.rb <workbook-content.twb> <out.json> [--dashboard "<name>"] [--page <id>]')
+
+# True when no scoping requested → keep every dashboard (current behavior).
+def dashboard_scoping?
+  !DASHBOARD_FILTERS.empty? || !PAGE_FILTERS.empty?
+end
+
+# Decide whether a dashboard (by name + zone-root id) is in scope. Name match is
+# case-insensitive exact OR unique substring; page match is exact on the id.
+def dashboard_in_scope?(name, page_id)
+  return true unless dashboard_scoping?
+  n = name.to_s.downcase
+  name_hit = DASHBOARD_FILTERS.any? do |f|
+    fl = f.downcase
+    n == fl || (!fl.empty? && n.include?(fl))
+  end
+  page_hit = PAGE_FILTERS.any? { |p| !p.empty? && p == page_id.to_s }
+  name_hit || page_hit
+end
 
 xml = TwbXml.parse(File.read(INP))
 
@@ -837,6 +884,10 @@ end
 
 dashboards = []
 xml.elements.each('//dashboard') do |d|
+  dash_name = d.attributes['name']
+  # Zone-root id is the handle `--page` filters on.
+  zone_root_id = (r = d.elements['zones']) ? r.attributes['id'] : nil
+  next unless dashboard_in_scope?(dash_name, zone_root_id)
   zones = []
   seen_ids = {}
   d.elements.each('.//zone') do |z|
@@ -928,6 +979,9 @@ end
 # worksheet so the parser output looks normal to the build script.
 if dashboards.empty? && !worksheets.empty?
   worksheets.each_key do |ws_name|
+    # In a sheet-only workbook the worksheet IS the page, so `--dashboard`
+    # filters on the worksheet name (zone-root id n/a → nil).
+    next unless dashboard_in_scope?(ws_name, nil)
     ws_meta    = worksheets[ws_name]
     chart_kind = chart_kind_for(ws_meta)
     dashboards << {
@@ -1163,17 +1217,51 @@ unless stories.empty?
        'run scripts/build-story-pages.rb to emit one Sigma page per story point'
 end
 
+# When per-dashboard scoping is active, narrow the meta worksheets/shared_filters
+# to only what the in-scope dashboard(s) actually use, so a single-tab build
+# doesn't drag the whole workbook's worksheet metadata along. Worksheets are
+# referenced by a chart zone's `caption`; shared_filters are kept when their
+# resolved column_caption is filtered by an in-scope worksheet (conservative —
+# keep any whose column is referenced, plus all when we can't tell).
+scoped_worksheets = worksheets
+scoped_shared_filters = shared_filters
+if dashboard_scoping?
+  used_captions = {}
+  dashboards.each do |d|
+    d['zones'].each do |z|
+      cap = z['caption']
+      used_captions[cap] = true if cap && worksheets.key?(cap)
+    end
+  end
+  scoped_worksheets = worksheets.select { |name, _| used_captions[name] }
+  # Shared filters apply workbook-wide; keep those whose target column is filtered
+  # by an in-scope worksheet (matched on column_caption), so the auto-control
+  # builder still surfaces the relevant dashboard filters without the full set.
+  used_filter_captions = {}
+  scoped_worksheets.each_value do |w|
+    (w[:filters] || []).each do |f|
+      c = f['column_caption']
+      used_filter_captions[c] = true if c
+    end
+  end
+  scoped_shared_filters = shared_filters.select do |f|
+    c = f['column_caption']
+    c.nil? || used_filter_captions[c]
+  end
+end
+
 meta = {
-  'worksheets'     => worksheets.transform_values { |v| v.transform_keys(&:to_s) },
+  'worksheets'     => scoped_worksheets.transform_values { |v| v.transform_keys(&:to_s) },
   'stories'        => stories,
-  'shared_filters' => shared_filters,
+  'shared_filters' => scoped_shared_filters,
   'parameters'     => parameters,
   'column_aliases' => column_aliases,
   'columns_by_guid'=> COL_BY_GUID.transform_values { |v| { 'caption' => v[:caption], 'datatype' => v[:datatype] } }
 }
 META_OUT = OUT.sub(/\.json$/, '-meta.json')
 File.write(META_OUT, JSON.pretty_generate(meta))
-puts "wrote #{META_OUT} (#{meta['worksheets'].size} worksheets, #{shared_filters.size} shared filters)"
+scope_note = dashboard_scoping? ? " [scoped: #{(DASHBOARD_FILTERS + PAGE_FILTERS).join(', ')}]" : ''
+puts "wrote #{META_OUT} (#{meta['worksheets'].size} worksheets, #{meta['shared_filters'].size} shared filters)#{scope_note}"
 
 File.write(OUT, JSON.pretty_generate(dashboards))
 puts "wrote #{OUT} (#{dashboards.size} dashboards, #{dashboards.sum { |d| d['zones'].size }} zones total)"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/reshape-pivot-actuals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/reshape-pivot-actuals.rb
@@ -1,0 +1,244 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# reshape-pivot-actuals.rb — bring Tableau pivot CROSSTABS onto the AUTOMATED
+# Phase-6 parity path by reshaping a WIDE pivot grid back into LONG
+# (row-dim…, col-key, measure, value) tuples.
+#
+# THE PROBLEM
+# -----------
+# collect-parity-actuals.rb skips pivot-tables: a Sigma pivot element's CSV
+# export is the WIDE grid (measures × week/quarter columns), and a Tableau
+# crosstab exports just as wide. auto-parity-plan likewise builds `expected`
+# from the wide Tableau CSV. The two wide grids almost never share column
+# NAMES or ORDER (Tableau "Net Revenue / 2026-W12" vs Sigma "2026-W12 Net
+# Revenue", measures interleaved differently, Grand-Total columns, etc.), so
+# the by-display-name column matcher in auto-parity-plan can't align them and
+# the whole crosstab is punted to MANUAL. For a workbook that is almost
+# entirely crosstabs of ~22 bespoke calc measures × week columns (the DDMX
+# class), that means parity is essentially un-automatable.
+#
+# THE FIX
+# -------
+# verify-parity.rb compares expected vs actual as a SET of `round_row` tuples
+# (order-independent, full tuple width). So if we reshape BOTH sides into the
+# SAME canonical LONG form, the wide-column name/order mismatch evaporates and
+# `exp_set == act_set` works exactly as it does for every non-pivot chart.
+#
+# A wide pivot cell is fully identified by:
+#   (row-dim values…, the column-axis key, the measure name) → value
+# Reshaping melts every non-row-dim column into one long tuple:
+#   [ row_dim_1, …, row_dim_k, col_key, measure_name, value ]
+#
+# Run it on the Tableau wide CSV to produce the parity `expected`, AND on the
+# Sigma pivot export to produce the `actual` — same reshape, same tuple shape,
+# directly set-comparable.
+#
+# HEADER PARSING
+# --------------
+# Leading --row-dims columns are the pivot rowsBy dimensions (carried verbatim).
+# Every remaining column header encodes BOTH a measure and a column-axis key
+# (the columnsBy member — a week/quarter/etc). Three shapes are supported:
+#
+#   1) --measures "A,B,…"  (RECOMMENDED — the ordered Measure-Names members):
+#      the header is split into measure + col-key by locating which known
+#      measure name the header CONTAINS; the remainder (minus the separator) is
+#      the col-key. Robust to either ordering ("A / 2026-W12" or "2026-W12 / A")
+#      and to Tableau's "Week of Order Date" verbosity.
+#   2) --header-sep SEP (no --measures): split each header on SEP into exactly
+#      two parts; --measure-side first|last says which part is the measure
+#      (default last — Tableau's "<week> / <measure>" wide export order).
+#   3) single measure (--measures with ONE name, or --single-measure NAME):
+#      every wide column is a pure col-key for that one measure.
+#
+# Cells parse with the SAME rules as auto-parity-plan / collect-parity-actuals
+# (strip $ , %, percent→fraction) so expected & actual compare on identical
+# numeric representations. Blank cells (a measure not present for a col-key)
+# are DROPPED, not emitted as nil tuples — Tableau and Sigma agree on absence.
+#
+# Usage:
+#   ruby scripts/reshape-pivot-actuals.rb --csv wide.csv --row-dims 1 \
+#       --measures "Net Revenue,Orders,Margin %" [--header-sep " / "] \
+#       [--out long.json] [--name "<Sigma chart name>"]
+#
+#   # Reshape an in-place wide actuals entry (Sigma export already collected):
+#   ruby scripts/reshape-pivot-actuals.rb --actuals parity-actuals.json \
+#       --name "Weekly Metrics" --row-dims 1 --measures "…" --in-place
+#
+# Output (default): the long tuples as a JSON array [[…],…] on stdout, OR
+# merged into --out / --actuals (keyed by --name) when given. Exit 0 on success.
+
+require 'json'
+require 'csv'
+require 'optparse'
+
+module PivotReshape
+  module_function
+
+  # Cell parse — identical to collect-parity-actuals / auto-parity-plan so the
+  # reshaped expected & actual sets compare on the same representation.
+  def parse_cell(v)
+    return nil if v.nil? || v.to_s.strip.empty?
+    s = v.to_s.strip
+    pct = s.end_with?('%')
+    f = (Float(s.gsub(/[,$%]/, '')) rescue nil)
+    return v if f.nil?
+    pct ? f / 100.0 : f
+  end
+
+  # Strip Tableau's date-grain verbosity off a column-axis key so a Tableau
+  # "Week of Order Date" header aligns with a Sigma "Order Date" / bare-week key.
+  def clean_col_key(s)
+    s.to_s.strip
+     .sub(/^(?:second|minute|hour|day|week|month|quarter|year)\s+of\s+/i, '')
+     .strip
+  end
+
+  # Split ONE wide header into [measure_name, col_key] given the known ordered
+  # measure members. Locates the measure the header CONTAINS (longest match
+  # wins so "Margin %" beats a bare "Margin"); the rest, minus separators, is
+  # the col-key. Returns nil if no known measure is found in the header.
+  def split_by_measure(header, measures, sep)
+    h = header.to_s.strip
+    hit = measures
+          .select { |m| h.downcase.include?(m.to_s.strip.downcase) && !m.to_s.strip.empty? }
+          .max_by { |m| m.to_s.strip.length }
+    return nil unless hit
+    rest = h.dup
+    # Remove the measure occurrence (case-insensitive, once).
+    i = rest.downcase.index(hit.downcase)
+    rest = (rest[0, i].to_s + rest[(i + hit.length)..].to_s)
+    rest = rest.sub(Regexp.new('\A\s*' + Regexp.escape(sep.to_s.strip) + '\s*'), '')
+               .sub(Regexp.new('\s*' + Regexp.escape(sep.to_s.strip) + '\s*\z'), '')
+    [hit.to_s.strip, clean_col_key(rest)]
+  end
+
+  # Split ONE header on an explicit separator into [measure, col_key].
+  # measure_side = :first | :last says which split part is the measure.
+  def split_by_sep(header, sep, measure_side)
+    parts = header.to_s.split(sep).map(&:strip).reject(&:empty?)
+    return nil if parts.length < 2
+    if measure_side == :first
+      [parts.first, clean_col_key(parts[1..].join(sep))]
+    else
+      [parts.last, clean_col_key(parts[0..-2].join(sep))]
+    end
+  end
+
+  # Reshape a wide pivot grid (header row + body rows, as 2-D arrays of strings)
+  # into LONG tuples [row_dim…, col_key, measure, value]. See file header for the
+  # header-parsing modes. Returns the array of tuples.
+  #
+  #   row_dims:      count of leading row-dimension columns (carried verbatim)
+  #   measures:      ordered measure-member names (mode 1 / single-measure)
+  #   header_sep:    separator string for mode 2 / measure-extraction
+  #   measure_side:  :first | :last (mode 2 only)
+  def reshape(header, body, row_dims:, measures: nil, header_sep: ' / ',
+              measure_side: :last)
+    rd = row_dims.to_i
+    raise ArgumentError, "row-dims #{rd} >= column count #{header.length}" if rd >= header.length
+    wide_cols = (rd...header.length).to_a
+    single = measures && measures.length == 1
+
+    # Pre-resolve each wide column header → [measure, col_key].
+    split_for = {}
+    wide_cols.each do |ci|
+      hdr = header[ci].to_s
+      split_for[ci] =
+        if single
+          [measures.first.to_s.strip, clean_col_key(hdr)]
+        elsif measures && !measures.empty?
+          split_by_measure(hdr, measures, header_sep)
+        else
+          split_by_sep(hdr, header_sep, measure_side)
+        end
+    end
+
+    tuples = []
+    body.each do |row|
+      next if row.nil? || row.all? { |c| c.nil? || c.to_s.strip.empty? }
+      row_key = (0...rd).map { |i| parse_cell(row[i]) }
+      wide_cols.each do |ci|
+        ms = split_for[ci]
+        next unless ms # header we couldn't decode → skip (loudly handled by caller)
+        val = parse_cell(row[ci])
+        next if val.nil? # absent measure for this col-key — Tableau & Sigma agree
+        measure, col_key = ms
+        tuples << (row_key + [col_key, measure, val])
+      end
+    end
+    tuples
+  end
+
+  # Which wide headers failed to decode (so the CLI can warn — a silent drop
+  # here would understate parity coverage, the exact failure mode this fixes).
+  def undecodable_headers(header, row_dims:, measures: nil, header_sep: ' / ',
+                          measure_side: :last)
+    rd = row_dims.to_i
+    single = measures && measures.length == 1
+    (rd...header.length).to_a.reject do |ci|
+      hdr = header[ci].to_s
+      if single then true
+      elsif measures && !measures.empty? then !split_by_measure(hdr, measures, header_sep).nil?
+      else !split_by_sep(hdr, header_sep, measure_side).nil?
+      end
+    end.map { |ci| header[ci] }
+  end
+end
+
+# ---- CLI -------------------------------------------------------------------
+if $PROGRAM_NAME == __FILE__
+  opts = { row_dims: 1, header_sep: ' / ', measure_side: :last }
+  OptionParser.new do |p|
+    p.on('--csv PATH', 'wide pivot CSV to reshape (Tableau or Sigma export)') { |v| opts[:csv] = v }
+    p.on('--actuals PATH', 'existing actuals JSON whose --name entry is a WIDE [[header],[row]…] to reshape') { |v| opts[:actuals] = v }
+    p.on('--row-dims N', Integer, 'leading row-dimension column count (default 1)') { |v| opts[:row_dims] = v }
+    p.on('--measures LIST', 'ordered measure-member names, comma-separated') { |v| opts[:measures] = v.split(',').map(&:strip).reject(&:empty?) }
+    p.on('--single-measure NAME', 'single measure; all wide columns are col-keys') { |v| opts[:measures] = [v] }
+    p.on('--header-sep SEP', 'wide-header separator (default " / ")') { |v| opts[:header_sep] = v }
+    p.on('--measure-side SIDE', %w[first last], 'with --header-sep: which split part is the measure (default last)') { |v| opts[:measure_side] = v.to_sym }
+    p.on('--name NAME', 'Sigma chart name to key the output under (for --out/--actuals)') { |v| opts[:name] = v }
+    p.on('--out PATH', 'merge long tuples into this JSON file under --name (else stdout)') { |v| opts[:out] = v }
+    p.on('--in-place', 'with --actuals: rewrite the --name entry in place with the long tuples') { opts[:in_place] = true }
+  end.parse!
+
+  abort 'need --csv or --actuals' unless opts[:csv] || opts[:actuals]
+
+  header, body =
+    if opts[:csv]
+      rows = CSV.read(opts[:csv])
+      abort "empty CSV #{opts[:csv]}" if rows.empty?
+      [rows.first.map { |h| h.to_s.strip }, rows[1..] || []]
+    else
+      store = JSON.parse(File.read(opts[:actuals]))
+      abort '--actuals needs --name' unless opts[:name]
+      wide = store[opts[:name]]
+      abort "no entry #{opts[:name].inspect} in #{opts[:actuals]}" unless wide.is_a?(Array) && wide.length >= 1
+      [wide.first.map { |h| h.to_s.strip }, wide[1..] || []]
+    end
+
+  bad = PivotReshape.undecodable_headers(header, row_dims: opts[:row_dims],
+                                         measures: opts[:measures], header_sep: opts[:header_sep],
+                                         measure_side: opts[:measure_side])
+  warn "reshape-pivot-actuals: #{bad.length} wide header(s) could not be decoded (dropped): #{bad.inspect}" if bad.any?
+
+  tuples = PivotReshape.reshape(header, body, row_dims: opts[:row_dims],
+                                measures: opts[:measures], header_sep: opts[:header_sep],
+                                measure_side: opts[:measure_side])
+
+  if opts[:actuals] && opts[:in_place]
+    store = JSON.parse(File.read(opts[:actuals]))
+    store[opts[:name]] = tuples
+    File.write(opts[:actuals], JSON.pretty_generate(store))
+    warn "reshape-pivot-actuals: rewrote #{opts[:name].inspect} in #{opts[:actuals]} → #{tuples.length} long tuple(s)"
+  elsif opts[:out]
+    store = (JSON.parse(File.read(opts[:out])) rescue {}) if File.exist?(opts[:out])
+    store ||= {}
+    abort '--out needs --name' unless opts[:name]
+    store[opts[:name]] = tuples
+    File.write(opts[:out], JSON.pretty_generate(store))
+    warn "reshape-pivot-actuals: wrote #{tuples.length} long tuple(s) for #{opts[:name].inspect} → #{opts[:out]}"
+  else
+    puts JSON.pretty_generate(tuples)
+    warn "reshape-pivot-actuals: #{tuples.length} long tuple(s)"
+  end
+end


### PR DESCRIPTION
## Why

This customer's workbook is almost entirely **crosstabs of ~22 bespoke calc measures × week columns** (the DDMX class) — exactly the shape that has stayed **MANUAL** in Phase-6 parity. Both the Tableau view CSV export and the Sigma pivot-table export come back **WIDE** with different column names/order, so `auto-parity-plan`'s by-display-name column matcher can't align them and the whole crosstab is punted to manual. The "Measure Names on rows" stack was also handled one-off per measure rather than first-classed.

> Stacks on #192 → #187.

## What

**1. `reshape-pivot-actuals.rb` (NEW)** — melts a WIDE pivot grid (measures × weeks) into canonical **LONG tuples** `[row-dim…, col-key, measure, value]`. Run it on **both** sides (Tableau CSV → `expected`, Sigma export → `actual`). Because `verify-parity.rb` compares as a **SET** of `round_row` tuples, the wide-column name/order mismatch evaporates and `exp_set == act_set` works exactly as for every non-pivot chart. Three header modes (ordered `--measures` membership split / explicit `--header-sep` + `--measure-side` / single-measure); identical cell-parse rules to `collect-parity-actuals` so values compare on identical representations; undecodable headers are **reported**, not silently dropped (the exact surfacing gap this fixes).

**2. `build-charts-from-signals.rb` — "Measure Names on rows" recipe** — new `measure_names_members()` maps the **ORDERED** Measure-Names members (parser document order = displayed stack order) → an ordered Sigma pivot `values[]` array, one column per measure, each keeping its **own** Tableau aggregation + per-measure format. Calc-backed members route to the existing **User-derivation resolver** (window/ratio decomposition) instead of the blind `Sum([Master/<calc>])` that would hard-fail the POST. Surgical: replaces the prior inline one-off loop; `add_col`/`user_vals`/window-helper paths unchanged.

`collect-parity-actuals.rb` is intentionally left untouched — the reshape lives in the standalone script so it can be invoked on both the Tableau and Sigma sides without forking the pooled collector.

## Verification

- `ruby -c` clean on all touched files (Ruby 2.6-compatible — no `filter_map`).
- **Reshape**: synthetic wide CSVs (measures × weeks) → correct long tuples; two **differently-ordered & differently-named** wide grids reshape to an **EQUAL set** (emulated `verify-parity` strict → PASS); `$`/`,` stripped, `%`→fraction, blank cells dropped, longest-measure-match ("Margin %" beats "Margin").
- **Recipe** (e2e build on a synthetic Measure-Names crosstab with 36-hex GUIDs): emits an ordered `values[]` = `[Net Revenue, Order Id, Margin Pct]` (order preserved), per-measure agg (`Sum` / `CountDistinct`), and the calc member **decomposed** to `Sum([Master/Returns]) / Sum([Master/Net Revenue])` (not a blind Sum).
- Existing `test-table-calc-translation.rb` still passes; shared-file canonical check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)