### PR TITLE
feat(telemetry): richer non-PII fields (real skill_version, environment, client_agent, run_id, outcome)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
@@ -19,12 +19,18 @@ import hashlib
 import re
 import time
 import os
+import subprocess
+import uuid
 import urllib.request
 import urllib.error
 import json
 
 TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
-SKILL_VERSION = "1.0"
+
+# Fallback only — the real value is resolved at runtime by _skill_version()
+# (git describe of the skills checkout). A constant here would make every event
+# look identical regardless of which build actually ran.
+SKILL_VERSION_FALLBACK = "unknown"
 
 
 def _region_from_base(sigma_base: str) -> str:
@@ -41,6 +47,55 @@ def _org_hash(client_id: str) -> str:
     return hashlib.sha256(client_id.encode()).hexdigest()[:8]
 
 
+def _skill_version() -> str:
+    """Real build identifier, best-effort and non-identifying:
+      1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
+      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      3. "unknown"
+    Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
+    env = os.environ.get("SIGMA_SKILL_VERSION")
+    if env:
+        return env[:32]
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
+            capture_output=True, timeout=3,
+        )
+        v = (out.stdout or b"").decode("ascii", "ignore").strip()
+        if v:
+            return v[:32]
+    except Exception:
+        pass
+    return SKILL_VERSION_FALLBACK
+
+
+def _environment() -> str:
+    """Coarse run environment — no host names, no PII. Lets us tell an automated
+    CI/benchmark loop apart from a human running a one-off migration."""
+    ci_vars = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "JENKINS_URL",
+               "BUILDKITE", "TF_BUILD", "TEAMCITY_VERSION")
+    if any(os.environ.get(v) for v in ci_vars):
+        return "ci"
+    cloud_vars = ("CODESPACES", "GITPOD_WORKSPACE_ID", "KUBERNETES_SERVICE_HOST",
+                  "AWS_EXECUTION_ENV", "RENDER", "FLY_APP_NAME", "K_SERVICE")
+    if any(os.environ.get(v) for v in cloud_vars) or os.path.exists("/.dockerenv"):
+        return "cloud"
+    return "local"
+
+
+def _client_agent() -> str:
+    """Which harness is driving the skill — no PII. Helps explain usage shape."""
+    e = os.environ
+    if e.get("CLAUDECODE") or e.get("CLAUDE_CODE_ENTRYPOINT") or e.get("CLAUDE_CODE"):
+        return "claude-code"
+    if e.get("CURSOR_TRACE_ID") or (e.get("TERM_PROGRAM") or "").lower() == "cursor":
+        return "cursor"
+    if e.get("CORTEX_AGENT") or e.get("SNOWFLAKE_CORTEX") or "cortex" in (e.get("TERM_PROGRAM") or "").lower():
+        return "cortex"
+    return "cli" if hasattr(__import__("sys").stdin, "isatty") and __import__("sys").stdin.isatty() else "unknown"
+
+
 def report_migration(
     tool: str,
     sigma_base: str,
@@ -48,7 +103,12 @@ def report_migration(
     duration_seconds: int,
     success: bool,
     mode: str = "unknown",
-    skill_version: str = SKILL_VERSION,
+    outcome: str = None,
+    failure_stage: str = None,
+    skill_version: str = None,
+    environment: str = None,
+    client_agent: str = None,
+    run_id: str = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -62,10 +122,15 @@ def report_migration(
       - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
           → unique per org, not reversible to your credentials
       - migration duration in seconds
-      - success flag
-      - input mode: "live" (source API), "file" (raw export only),
-          "both", or "unknown" — a coarse enum, no file names or content
-      - skill version
+      - success flag + outcome ("success" / "partial" / "failed")
+      - failure_stage when not successful: a coarse enum
+          ("auth" / "convert" / "spec_post" / "query_validate" / "other"),
+          never a stack trace or message
+      - input mode: "live" / "file" / "both" / "unknown" — coarse, no file names
+      - skill_version: build identifier (git describe), no longer a constant
+      - environment: "ci" / "cloud" / "local" — run context, no host names
+      - client_agent: "claude-code" / "cursor" / "cortex" / "cli" / "unknown"
+      - run_id: a random per-run UUID (dedupe + retry-vs-distinct-run grouping)
 
     What is NOT sent:
       - workbook names, IDs, or URLs
@@ -81,8 +146,13 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "outcome":          outcome or ("success" if success else "failed"),
+        "failure_stage":    failure_stage,
         "mode":             mode or "unknown",
-        "skill_version":    skill_version,
+        "skill_version":    skill_version or _skill_version(),
+        "environment":      environment or _environment(),
+        "client_agent":     client_agent or _client_agent(),
+        "run_id":           run_id or uuid.uuid4().hex,
     }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
@@ -131,7 +201,6 @@ def _post(endpoint, body, timeout):
         first = str(e).splitlines()[0] if str(e) else type(e).__name__
         # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
         try:
-            import subprocess
             r = subprocess.run(
                 ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
                  "-w", "%{http_code}", "-X", "POST",

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
@@ -63,6 +63,9 @@ parser.add_argument('--failed',   action='store_true', help='Pass if the migrati
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
                     help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
+parser.add_argument('--failure-stage', default=None,
+                    choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
+                    help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
 
@@ -104,6 +107,7 @@ sent = report_migration(
     duration_seconds=duration,
     success=not args.failed,
     mode=mode,
+    failure_stage=(args.failure_stage if args.failed else None),
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
@@ -19,12 +19,18 @@ import hashlib
 import re
 import time
 import os
+import subprocess
+import uuid
 import urllib.request
 import urllib.error
 import json
 
 TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
-SKILL_VERSION = "1.0"
+
+# Fallback only — the real value is resolved at runtime by _skill_version()
+# (git describe of the skills checkout). A constant here would make every event
+# look identical regardless of which build actually ran.
+SKILL_VERSION_FALLBACK = "unknown"
 
 
 def _region_from_base(sigma_base: str) -> str:
@@ -41,6 +47,55 @@ def _org_hash(client_id: str) -> str:
     return hashlib.sha256(client_id.encode()).hexdigest()[:8]
 
 
+def _skill_version() -> str:
+    """Real build identifier, best-effort and non-identifying:
+      1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
+      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      3. "unknown"
+    Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
+    env = os.environ.get("SIGMA_SKILL_VERSION")
+    if env:
+        return env[:32]
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
+            capture_output=True, timeout=3,
+        )
+        v = (out.stdout or b"").decode("ascii", "ignore").strip()
+        if v:
+            return v[:32]
+    except Exception:
+        pass
+    return SKILL_VERSION_FALLBACK
+
+
+def _environment() -> str:
+    """Coarse run environment — no host names, no PII. Lets us tell an automated
+    CI/benchmark loop apart from a human running a one-off migration."""
+    ci_vars = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "JENKINS_URL",
+               "BUILDKITE", "TF_BUILD", "TEAMCITY_VERSION")
+    if any(os.environ.get(v) for v in ci_vars):
+        return "ci"
+    cloud_vars = ("CODESPACES", "GITPOD_WORKSPACE_ID", "KUBERNETES_SERVICE_HOST",
+                  "AWS_EXECUTION_ENV", "RENDER", "FLY_APP_NAME", "K_SERVICE")
+    if any(os.environ.get(v) for v in cloud_vars) or os.path.exists("/.dockerenv"):
+        return "cloud"
+    return "local"
+
+
+def _client_agent() -> str:
+    """Which harness is driving the skill — no PII. Helps explain usage shape."""
+    e = os.environ
+    if e.get("CLAUDECODE") or e.get("CLAUDE_CODE_ENTRYPOINT") or e.get("CLAUDE_CODE"):
+        return "claude-code"
+    if e.get("CURSOR_TRACE_ID") or (e.get("TERM_PROGRAM") or "").lower() == "cursor":
+        return "cursor"
+    if e.get("CORTEX_AGENT") or e.get("SNOWFLAKE_CORTEX") or "cortex" in (e.get("TERM_PROGRAM") or "").lower():
+        return "cortex"
+    return "cli" if hasattr(__import__("sys").stdin, "isatty") and __import__("sys").stdin.isatty() else "unknown"
+
+
 def report_migration(
     tool: str,
     sigma_base: str,
@@ -48,7 +103,12 @@ def report_migration(
     duration_seconds: int,
     success: bool,
     mode: str = "unknown",
-    skill_version: str = SKILL_VERSION,
+    outcome: str = None,
+    failure_stage: str = None,
+    skill_version: str = None,
+    environment: str = None,
+    client_agent: str = None,
+    run_id: str = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -62,10 +122,15 @@ def report_migration(
       - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
           → unique per org, not reversible to your credentials
       - migration duration in seconds
-      - success flag
-      - input mode: "live" (source API), "file" (raw export only),
-          "both", or "unknown" — a coarse enum, no file names or content
-      - skill version
+      - success flag + outcome ("success" / "partial" / "failed")
+      - failure_stage when not successful: a coarse enum
+          ("auth" / "convert" / "spec_post" / "query_validate" / "other"),
+          never a stack trace or message
+      - input mode: "live" / "file" / "both" / "unknown" — coarse, no file names
+      - skill_version: build identifier (git describe), no longer a constant
+      - environment: "ci" / "cloud" / "local" — run context, no host names
+      - client_agent: "claude-code" / "cursor" / "cortex" / "cli" / "unknown"
+      - run_id: a random per-run UUID (dedupe + retry-vs-distinct-run grouping)
 
     What is NOT sent:
       - workbook names, IDs, or URLs
@@ -81,8 +146,13 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "outcome":          outcome or ("success" if success else "failed"),
+        "failure_stage":    failure_stage,
         "mode":             mode or "unknown",
-        "skill_version":    skill_version,
+        "skill_version":    skill_version or _skill_version(),
+        "environment":      environment or _environment(),
+        "client_agent":     client_agent or _client_agent(),
+        "run_id":           run_id or uuid.uuid4().hex,
     }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
@@ -131,7 +201,6 @@ def _post(endpoint, body, timeout):
         first = str(e).splitlines()[0] if str(e) else type(e).__name__
         # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
         try:
-            import subprocess
             r = subprocess.run(
                 ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
                  "-w", "%{http_code}", "-X", "POST",

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
@@ -63,6 +63,9 @@ parser.add_argument('--failed',   action='store_true', help='Pass if the migrati
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
                     help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
+parser.add_argument('--failure-stage', default=None,
+                    choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
+                    help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
 
@@ -104,6 +107,7 @@ sent = report_migration(
     duration_seconds=duration,
     success=not args.failed,
     mode=mode,
+    failure_stage=(args.failure_stage if args.failed else None),
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
@@ -19,12 +19,18 @@ import hashlib
 import re
 import time
 import os
+import subprocess
+import uuid
 import urllib.request
 import urllib.error
 import json
 
 TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
-SKILL_VERSION = "1.0"
+
+# Fallback only — the real value is resolved at runtime by _skill_version()
+# (git describe of the skills checkout). A constant here would make every event
+# look identical regardless of which build actually ran.
+SKILL_VERSION_FALLBACK = "unknown"
 
 
 def _region_from_base(sigma_base: str) -> str:
@@ -41,6 +47,55 @@ def _org_hash(client_id: str) -> str:
     return hashlib.sha256(client_id.encode()).hexdigest()[:8]
 
 
+def _skill_version() -> str:
+    """Real build identifier, best-effort and non-identifying:
+      1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
+      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      3. "unknown"
+    Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
+    env = os.environ.get("SIGMA_SKILL_VERSION")
+    if env:
+        return env[:32]
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
+            capture_output=True, timeout=3,
+        )
+        v = (out.stdout or b"").decode("ascii", "ignore").strip()
+        if v:
+            return v[:32]
+    except Exception:
+        pass
+    return SKILL_VERSION_FALLBACK
+
+
+def _environment() -> str:
+    """Coarse run environment — no host names, no PII. Lets us tell an automated
+    CI/benchmark loop apart from a human running a one-off migration."""
+    ci_vars = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "JENKINS_URL",
+               "BUILDKITE", "TF_BUILD", "TEAMCITY_VERSION")
+    if any(os.environ.get(v) for v in ci_vars):
+        return "ci"
+    cloud_vars = ("CODESPACES", "GITPOD_WORKSPACE_ID", "KUBERNETES_SERVICE_HOST",
+                  "AWS_EXECUTION_ENV", "RENDER", "FLY_APP_NAME", "K_SERVICE")
+    if any(os.environ.get(v) for v in cloud_vars) or os.path.exists("/.dockerenv"):
+        return "cloud"
+    return "local"
+
+
+def _client_agent() -> str:
+    """Which harness is driving the skill — no PII. Helps explain usage shape."""
+    e = os.environ
+    if e.get("CLAUDECODE") or e.get("CLAUDE_CODE_ENTRYPOINT") or e.get("CLAUDE_CODE"):
+        return "claude-code"
+    if e.get("CURSOR_TRACE_ID") or (e.get("TERM_PROGRAM") or "").lower() == "cursor":
+        return "cursor"
+    if e.get("CORTEX_AGENT") or e.get("SNOWFLAKE_CORTEX") or "cortex" in (e.get("TERM_PROGRAM") or "").lower():
+        return "cortex"
+    return "cli" if hasattr(__import__("sys").stdin, "isatty") and __import__("sys").stdin.isatty() else "unknown"
+
+
 def report_migration(
     tool: str,
     sigma_base: str,
@@ -48,7 +103,12 @@ def report_migration(
     duration_seconds: int,
     success: bool,
     mode: str = "unknown",
-    skill_version: str = SKILL_VERSION,
+    outcome: str = None,
+    failure_stage: str = None,
+    skill_version: str = None,
+    environment: str = None,
+    client_agent: str = None,
+    run_id: str = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -62,10 +122,15 @@ def report_migration(
       - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
           → unique per org, not reversible to your credentials
       - migration duration in seconds
-      - success flag
-      - input mode: "live" (source API), "file" (raw export only),
-          "both", or "unknown" — a coarse enum, no file names or content
-      - skill version
+      - success flag + outcome ("success" / "partial" / "failed")
+      - failure_stage when not successful: a coarse enum
+          ("auth" / "convert" / "spec_post" / "query_validate" / "other"),
+          never a stack trace or message
+      - input mode: "live" / "file" / "both" / "unknown" — coarse, no file names
+      - skill_version: build identifier (git describe), no longer a constant
+      - environment: "ci" / "cloud" / "local" — run context, no host names
+      - client_agent: "claude-code" / "cursor" / "cortex" / "cli" / "unknown"
+      - run_id: a random per-run UUID (dedupe + retry-vs-distinct-run grouping)
 
     What is NOT sent:
       - workbook names, IDs, or URLs
@@ -81,8 +146,13 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "outcome":          outcome or ("success" if success else "failed"),
+        "failure_stage":    failure_stage,
         "mode":             mode or "unknown",
-        "skill_version":    skill_version,
+        "skill_version":    skill_version or _skill_version(),
+        "environment":      environment or _environment(),
+        "client_agent":     client_agent or _client_agent(),
+        "run_id":           run_id or uuid.uuid4().hex,
     }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
@@ -131,7 +201,6 @@ def _post(endpoint, body, timeout):
         first = str(e).splitlines()[0] if str(e) else type(e).__name__
         # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
         try:
-            import subprocess
             r = subprocess.run(
                 ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
                  "-w", "%{http_code}", "-X", "POST",

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
@@ -63,6 +63,9 @@ parser.add_argument('--failed',   action='store_true', help='Pass if the migrati
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
                     help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
+parser.add_argument('--failure-stage', default=None,
+                    choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
+                    help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
 
@@ -104,6 +107,7 @@ sent = report_migration(
     duration_seconds=duration,
     success=not args.failed,
     mode=mode,
+    failure_stage=(args.failure_stage if args.failed else None),
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
@@ -19,12 +19,18 @@ import hashlib
 import re
 import time
 import os
+import subprocess
+import uuid
 import urllib.request
 import urllib.error
 import json
 
 TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
-SKILL_VERSION = "1.0"
+
+# Fallback only — the real value is resolved at runtime by _skill_version()
+# (git describe of the skills checkout). A constant here would make every event
+# look identical regardless of which build actually ran.
+SKILL_VERSION_FALLBACK = "unknown"
 
 
 def _region_from_base(sigma_base: str) -> str:
@@ -41,6 +47,55 @@ def _org_hash(client_id: str) -> str:
     return hashlib.sha256(client_id.encode()).hexdigest()[:8]
 
 
+def _skill_version() -> str:
+    """Real build identifier, best-effort and non-identifying:
+      1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
+      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      3. "unknown"
+    Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
+    env = os.environ.get("SIGMA_SKILL_VERSION")
+    if env:
+        return env[:32]
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
+            capture_output=True, timeout=3,
+        )
+        v = (out.stdout or b"").decode("ascii", "ignore").strip()
+        if v:
+            return v[:32]
+    except Exception:
+        pass
+    return SKILL_VERSION_FALLBACK
+
+
+def _environment() -> str:
+    """Coarse run environment — no host names, no PII. Lets us tell an automated
+    CI/benchmark loop apart from a human running a one-off migration."""
+    ci_vars = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "JENKINS_URL",
+               "BUILDKITE", "TF_BUILD", "TEAMCITY_VERSION")
+    if any(os.environ.get(v) for v in ci_vars):
+        return "ci"
+    cloud_vars = ("CODESPACES", "GITPOD_WORKSPACE_ID", "KUBERNETES_SERVICE_HOST",
+                  "AWS_EXECUTION_ENV", "RENDER", "FLY_APP_NAME", "K_SERVICE")
+    if any(os.environ.get(v) for v in cloud_vars) or os.path.exists("/.dockerenv"):
+        return "cloud"
+    return "local"
+
+
+def _client_agent() -> str:
+    """Which harness is driving the skill — no PII. Helps explain usage shape."""
+    e = os.environ
+    if e.get("CLAUDECODE") or e.get("CLAUDE_CODE_ENTRYPOINT") or e.get("CLAUDE_CODE"):
+        return "claude-code"
+    if e.get("CURSOR_TRACE_ID") or (e.get("TERM_PROGRAM") or "").lower() == "cursor":
+        return "cursor"
+    if e.get("CORTEX_AGENT") or e.get("SNOWFLAKE_CORTEX") or "cortex" in (e.get("TERM_PROGRAM") or "").lower():
+        return "cortex"
+    return "cli" if hasattr(__import__("sys").stdin, "isatty") and __import__("sys").stdin.isatty() else "unknown"
+
+
 def report_migration(
     tool: str,
     sigma_base: str,
@@ -48,7 +103,12 @@ def report_migration(
     duration_seconds: int,
     success: bool,
     mode: str = "unknown",
-    skill_version: str = SKILL_VERSION,
+    outcome: str = None,
+    failure_stage: str = None,
+    skill_version: str = None,
+    environment: str = None,
+    client_agent: str = None,
+    run_id: str = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -62,10 +122,15 @@ def report_migration(
       - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
           → unique per org, not reversible to your credentials
       - migration duration in seconds
-      - success flag
-      - input mode: "live" (source API), "file" (raw export only),
-          "both", or "unknown" — a coarse enum, no file names or content
-      - skill version
+      - success flag + outcome ("success" / "partial" / "failed")
+      - failure_stage when not successful: a coarse enum
+          ("auth" / "convert" / "spec_post" / "query_validate" / "other"),
+          never a stack trace or message
+      - input mode: "live" / "file" / "both" / "unknown" — coarse, no file names
+      - skill_version: build identifier (git describe), no longer a constant
+      - environment: "ci" / "cloud" / "local" — run context, no host names
+      - client_agent: "claude-code" / "cursor" / "cortex" / "cli" / "unknown"
+      - run_id: a random per-run UUID (dedupe + retry-vs-distinct-run grouping)
 
     What is NOT sent:
       - workbook names, IDs, or URLs
@@ -81,8 +146,13 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "outcome":          outcome or ("success" if success else "failed"),
+        "failure_stage":    failure_stage,
         "mode":             mode or "unknown",
-        "skill_version":    skill_version,
+        "skill_version":    skill_version or _skill_version(),
+        "environment":      environment or _environment(),
+        "client_agent":     client_agent or _client_agent(),
+        "run_id":           run_id or uuid.uuid4().hex,
     }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
@@ -131,7 +201,6 @@ def _post(endpoint, body, timeout):
         first = str(e).splitlines()[0] if str(e) else type(e).__name__
         # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
         try:
-            import subprocess
             r = subprocess.run(
                 ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
                  "-w", "%{http_code}", "-X", "POST",

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
@@ -63,6 +63,9 @@ parser.add_argument('--failed',   action='store_true', help='Pass if the migrati
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
                     help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
+parser.add_argument('--failure-stage', default=None,
+                    choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
+                    help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
 
@@ -104,6 +107,7 @@ sent = report_migration(
     duration_seconds=duration,
     success=not args.failed,
     mode=mode,
+    failure_stage=(args.failure_stage if args.failed else None),
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
@@ -19,12 +19,18 @@ import hashlib
 import re
 import time
 import os
+import subprocess
+import uuid
 import urllib.request
 import urllib.error
 import json
 
 TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
-SKILL_VERSION = "1.0"
+
+# Fallback only — the real value is resolved at runtime by _skill_version()
+# (git describe of the skills checkout). A constant here would make every event
+# look identical regardless of which build actually ran.
+SKILL_VERSION_FALLBACK = "unknown"
 
 
 def _region_from_base(sigma_base: str) -> str:
@@ -41,6 +47,55 @@ def _org_hash(client_id: str) -> str:
     return hashlib.sha256(client_id.encode()).hexdigest()[:8]
 
 
+def _skill_version() -> str:
+    """Real build identifier, best-effort and non-identifying:
+      1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
+      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      3. "unknown"
+    Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
+    env = os.environ.get("SIGMA_SKILL_VERSION")
+    if env:
+        return env[:32]
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
+            capture_output=True, timeout=3,
+        )
+        v = (out.stdout or b"").decode("ascii", "ignore").strip()
+        if v:
+            return v[:32]
+    except Exception:
+        pass
+    return SKILL_VERSION_FALLBACK
+
+
+def _environment() -> str:
+    """Coarse run environment — no host names, no PII. Lets us tell an automated
+    CI/benchmark loop apart from a human running a one-off migration."""
+    ci_vars = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "JENKINS_URL",
+               "BUILDKITE", "TF_BUILD", "TEAMCITY_VERSION")
+    if any(os.environ.get(v) for v in ci_vars):
+        return "ci"
+    cloud_vars = ("CODESPACES", "GITPOD_WORKSPACE_ID", "KUBERNETES_SERVICE_HOST",
+                  "AWS_EXECUTION_ENV", "RENDER", "FLY_APP_NAME", "K_SERVICE")
+    if any(os.environ.get(v) for v in cloud_vars) or os.path.exists("/.dockerenv"):
+        return "cloud"
+    return "local"
+
+
+def _client_agent() -> str:
+    """Which harness is driving the skill — no PII. Helps explain usage shape."""
+    e = os.environ
+    if e.get("CLAUDECODE") or e.get("CLAUDE_CODE_ENTRYPOINT") or e.get("CLAUDE_CODE"):
+        return "claude-code"
+    if e.get("CURSOR_TRACE_ID") or (e.get("TERM_PROGRAM") or "").lower() == "cursor":
+        return "cursor"
+    if e.get("CORTEX_AGENT") or e.get("SNOWFLAKE_CORTEX") or "cortex" in (e.get("TERM_PROGRAM") or "").lower():
+        return "cortex"
+    return "cli" if hasattr(__import__("sys").stdin, "isatty") and __import__("sys").stdin.isatty() else "unknown"
+
+
 def report_migration(
     tool: str,
     sigma_base: str,
@@ -48,7 +103,12 @@ def report_migration(
     duration_seconds: int,
     success: bool,
     mode: str = "unknown",
-    skill_version: str = SKILL_VERSION,
+    outcome: str = None,
+    failure_stage: str = None,
+    skill_version: str = None,
+    environment: str = None,
+    client_agent: str = None,
+    run_id: str = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -62,10 +122,15 @@ def report_migration(
       - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
           → unique per org, not reversible to your credentials
       - migration duration in seconds
-      - success flag
-      - input mode: "live" (source API), "file" (raw export only),
-          "both", or "unknown" — a coarse enum, no file names or content
-      - skill version
+      - success flag + outcome ("success" / "partial" / "failed")
+      - failure_stage when not successful: a coarse enum
+          ("auth" / "convert" / "spec_post" / "query_validate" / "other"),
+          never a stack trace or message
+      - input mode: "live" / "file" / "both" / "unknown" — coarse, no file names
+      - skill_version: build identifier (git describe), no longer a constant
+      - environment: "ci" / "cloud" / "local" — run context, no host names
+      - client_agent: "claude-code" / "cursor" / "cortex" / "cli" / "unknown"
+      - run_id: a random per-run UUID (dedupe + retry-vs-distinct-run grouping)
 
     What is NOT sent:
       - workbook names, IDs, or URLs
@@ -81,8 +146,13 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "outcome":          outcome or ("success" if success else "failed"),
+        "failure_stage":    failure_stage,
         "mode":             mode or "unknown",
-        "skill_version":    skill_version,
+        "skill_version":    skill_version or _skill_version(),
+        "environment":      environment or _environment(),
+        "client_agent":     client_agent or _client_agent(),
+        "run_id":           run_id or uuid.uuid4().hex,
     }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
@@ -131,7 +201,6 @@ def _post(endpoint, body, timeout):
         first = str(e).splitlines()[0] if str(e) else type(e).__name__
         # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
         try:
-            import subprocess
             r = subprocess.run(
                 ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
                  "-w", "%{http_code}", "-X", "POST",

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
@@ -63,6 +63,9 @@ parser.add_argument('--failed',   action='store_true', help='Pass if the migrati
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
                     help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
+parser.add_argument('--failure-stage', default=None,
+                    choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
+                    help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
 
@@ -104,6 +107,7 @@ sent = report_migration(
     duration_seconds=duration,
     success=not args.failed,
     mode=mode,
+    failure_stage=(args.failure_stage if args.failed else None),
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
@@ -19,12 +19,18 @@ import hashlib
 import re
 import time
 import os
+import subprocess
+import uuid
 import urllib.request
 import urllib.error
 import json
 
 TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
-SKILL_VERSION = "1.0"
+
+# Fallback only — the real value is resolved at runtime by _skill_version()
+# (git describe of the skills checkout). A constant here would make every event
+# look identical regardless of which build actually ran.
+SKILL_VERSION_FALLBACK = "unknown"
 
 
 def _region_from_base(sigma_base: str) -> str:
@@ -41,6 +47,55 @@ def _org_hash(client_id: str) -> str:
     return hashlib.sha256(client_id.encode()).hexdigest()[:8]
 
 
+def _skill_version() -> str:
+    """Real build identifier, best-effort and non-identifying:
+      1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
+      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      3. "unknown"
+    Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
+    env = os.environ.get("SIGMA_SKILL_VERSION")
+    if env:
+        return env[:32]
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
+            capture_output=True, timeout=3,
+        )
+        v = (out.stdout or b"").decode("ascii", "ignore").strip()
+        if v:
+            return v[:32]
+    except Exception:
+        pass
+    return SKILL_VERSION_FALLBACK
+
+
+def _environment() -> str:
+    """Coarse run environment — no host names, no PII. Lets us tell an automated
+    CI/benchmark loop apart from a human running a one-off migration."""
+    ci_vars = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "JENKINS_URL",
+               "BUILDKITE", "TF_BUILD", "TEAMCITY_VERSION")
+    if any(os.environ.get(v) for v in ci_vars):
+        return "ci"
+    cloud_vars = ("CODESPACES", "GITPOD_WORKSPACE_ID", "KUBERNETES_SERVICE_HOST",
+                  "AWS_EXECUTION_ENV", "RENDER", "FLY_APP_NAME", "K_SERVICE")
+    if any(os.environ.get(v) for v in cloud_vars) or os.path.exists("/.dockerenv"):
+        return "cloud"
+    return "local"
+
+
+def _client_agent() -> str:
+    """Which harness is driving the skill — no PII. Helps explain usage shape."""
+    e = os.environ
+    if e.get("CLAUDECODE") or e.get("CLAUDE_CODE_ENTRYPOINT") or e.get("CLAUDE_CODE"):
+        return "claude-code"
+    if e.get("CURSOR_TRACE_ID") or (e.get("TERM_PROGRAM") or "").lower() == "cursor":
+        return "cursor"
+    if e.get("CORTEX_AGENT") or e.get("SNOWFLAKE_CORTEX") or "cortex" in (e.get("TERM_PROGRAM") or "").lower():
+        return "cortex"
+    return "cli" if hasattr(__import__("sys").stdin, "isatty") and __import__("sys").stdin.isatty() else "unknown"
+
+
 def report_migration(
     tool: str,
     sigma_base: str,
@@ -48,7 +103,12 @@ def report_migration(
     duration_seconds: int,
     success: bool,
     mode: str = "unknown",
-    skill_version: str = SKILL_VERSION,
+    outcome: str = None,
+    failure_stage: str = None,
+    skill_version: str = None,
+    environment: str = None,
+    client_agent: str = None,
+    run_id: str = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -62,10 +122,15 @@ def report_migration(
       - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
           → unique per org, not reversible to your credentials
       - migration duration in seconds
-      - success flag
-      - input mode: "live" (source API), "file" (raw export only),
-          "both", or "unknown" — a coarse enum, no file names or content
-      - skill version
+      - success flag + outcome ("success" / "partial" / "failed")
+      - failure_stage when not successful: a coarse enum
+          ("auth" / "convert" / "spec_post" / "query_validate" / "other"),
+          never a stack trace or message
+      - input mode: "live" / "file" / "both" / "unknown" — coarse, no file names
+      - skill_version: build identifier (git describe), no longer a constant
+      - environment: "ci" / "cloud" / "local" — run context, no host names
+      - client_agent: "claude-code" / "cursor" / "cortex" / "cli" / "unknown"
+      - run_id: a random per-run UUID (dedupe + retry-vs-distinct-run grouping)
 
     What is NOT sent:
       - workbook names, IDs, or URLs
@@ -81,8 +146,13 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "outcome":          outcome or ("success" if success else "failed"),
+        "failure_stage":    failure_stage,
         "mode":             mode or "unknown",
-        "skill_version":    skill_version,
+        "skill_version":    skill_version or _skill_version(),
+        "environment":      environment or _environment(),
+        "client_agent":     client_agent or _client_agent(),
+        "run_id":           run_id or uuid.uuid4().hex,
     }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
@@ -131,7 +201,6 @@ def _post(endpoint, body, timeout):
         first = str(e).splitlines()[0] if str(e) else type(e).__name__
         # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
         try:
-            import subprocess
             r = subprocess.run(
                 ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
                  "-w", "%{http_code}", "-X", "POST",

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
@@ -63,6 +63,9 @@ parser.add_argument('--failed',   action='store_true', help='Pass if the migrati
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
                     help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
+parser.add_argument('--failure-stage', default=None,
+                    choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
+                    help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
 
@@ -104,6 +107,7 @@ sent = report_migration(
     duration_seconds=duration,
     success=not args.failed,
     mode=mode,
+    failure_stage=(args.failure_stage if args.failed else None),
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
@@ -19,12 +19,18 @@ import hashlib
 import re
 import time
 import os
+import subprocess
+import uuid
 import urllib.request
 import urllib.error
 import json
 
 TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
-SKILL_VERSION = "1.0"
+
+# Fallback only — the real value is resolved at runtime by _skill_version()
+# (git describe of the skills checkout). A constant here would make every event
+# look identical regardless of which build actually ran.
+SKILL_VERSION_FALLBACK = "unknown"
 
 
 def _region_from_base(sigma_base: str) -> str:
@@ -41,6 +47,55 @@ def _org_hash(client_id: str) -> str:
     return hashlib.sha256(client_id.encode()).hexdigest()[:8]
 
 
+def _skill_version() -> str:
+    """Real build identifier, best-effort and non-identifying:
+      1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
+      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      3. "unknown"
+    Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
+    env = os.environ.get("SIGMA_SKILL_VERSION")
+    if env:
+        return env[:32]
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
+            capture_output=True, timeout=3,
+        )
+        v = (out.stdout or b"").decode("ascii", "ignore").strip()
+        if v:
+            return v[:32]
+    except Exception:
+        pass
+    return SKILL_VERSION_FALLBACK
+
+
+def _environment() -> str:
+    """Coarse run environment — no host names, no PII. Lets us tell an automated
+    CI/benchmark loop apart from a human running a one-off migration."""
+    ci_vars = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "JENKINS_URL",
+               "BUILDKITE", "TF_BUILD", "TEAMCITY_VERSION")
+    if any(os.environ.get(v) for v in ci_vars):
+        return "ci"
+    cloud_vars = ("CODESPACES", "GITPOD_WORKSPACE_ID", "KUBERNETES_SERVICE_HOST",
+                  "AWS_EXECUTION_ENV", "RENDER", "FLY_APP_NAME", "K_SERVICE")
+    if any(os.environ.get(v) for v in cloud_vars) or os.path.exists("/.dockerenv"):
+        return "cloud"
+    return "local"
+
+
+def _client_agent() -> str:
+    """Which harness is driving the skill — no PII. Helps explain usage shape."""
+    e = os.environ
+    if e.get("CLAUDECODE") or e.get("CLAUDE_CODE_ENTRYPOINT") or e.get("CLAUDE_CODE"):
+        return "claude-code"
+    if e.get("CURSOR_TRACE_ID") or (e.get("TERM_PROGRAM") or "").lower() == "cursor":
+        return "cursor"
+    if e.get("CORTEX_AGENT") or e.get("SNOWFLAKE_CORTEX") or "cortex" in (e.get("TERM_PROGRAM") or "").lower():
+        return "cortex"
+    return "cli" if hasattr(__import__("sys").stdin, "isatty") and __import__("sys").stdin.isatty() else "unknown"
+
+
 def report_migration(
     tool: str,
     sigma_base: str,
@@ -48,7 +103,12 @@ def report_migration(
     duration_seconds: int,
     success: bool,
     mode: str = "unknown",
-    skill_version: str = SKILL_VERSION,
+    outcome: str = None,
+    failure_stage: str = None,
+    skill_version: str = None,
+    environment: str = None,
+    client_agent: str = None,
+    run_id: str = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -62,10 +122,15 @@ def report_migration(
       - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
           → unique per org, not reversible to your credentials
       - migration duration in seconds
-      - success flag
-      - input mode: "live" (source API), "file" (raw export only),
-          "both", or "unknown" — a coarse enum, no file names or content
-      - skill version
+      - success flag + outcome ("success" / "partial" / "failed")
+      - failure_stage when not successful: a coarse enum
+          ("auth" / "convert" / "spec_post" / "query_validate" / "other"),
+          never a stack trace or message
+      - input mode: "live" / "file" / "both" / "unknown" — coarse, no file names
+      - skill_version: build identifier (git describe), no longer a constant
+      - environment: "ci" / "cloud" / "local" — run context, no host names
+      - client_agent: "claude-code" / "cursor" / "cortex" / "cli" / "unknown"
+      - run_id: a random per-run UUID (dedupe + retry-vs-distinct-run grouping)
 
     What is NOT sent:
       - workbook names, IDs, or URLs
@@ -81,8 +146,13 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "outcome":          outcome or ("success" if success else "failed"),
+        "failure_stage":    failure_stage,
         "mode":             mode or "unknown",
-        "skill_version":    skill_version,
+        "skill_version":    skill_version or _skill_version(),
+        "environment":      environment or _environment(),
+        "client_agent":     client_agent or _client_agent(),
+        "run_id":           run_id or uuid.uuid4().hex,
     }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
@@ -131,7 +201,6 @@ def _post(endpoint, body, timeout):
         first = str(e).splitlines()[0] if str(e) else type(e).__name__
         # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
         try:
-            import subprocess
             r = subprocess.run(
                 ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
                  "-w", "%{http_code}", "-X", "POST",

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
@@ -63,6 +63,9 @@ parser.add_argument('--failed',   action='store_true', help='Pass if the migrati
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
                     help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
+parser.add_argument('--failure-stage', default=None,
+                    choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
+                    help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
 
@@ -104,6 +107,7 @@ sent = report_migration(
     duration_seconds=duration,
     success=not args.failed,
     mode=mode,
+    failure_stage=(args.failure_stage if args.failed else None),
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
@@ -19,12 +19,18 @@ import hashlib
 import re
 import time
 import os
+import subprocess
+import uuid
 import urllib.request
 import urllib.error
 import json
 
 TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
-SKILL_VERSION = "1.0"
+
+# Fallback only — the real value is resolved at runtime by _skill_version()
+# (git describe of the skills checkout). A constant here would make every event
+# look identical regardless of which build actually ran.
+SKILL_VERSION_FALLBACK = "unknown"
 
 
 def _region_from_base(sigma_base: str) -> str:
@@ -41,6 +47,55 @@ def _org_hash(client_id: str) -> str:
     return hashlib.sha256(client_id.encode()).hexdigest()[:8]
 
 
+def _skill_version() -> str:
+    """Real build identifier, best-effort and non-identifying:
+      1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
+      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      3. "unknown"
+    Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
+    env = os.environ.get("SIGMA_SKILL_VERSION")
+    if env:
+        return env[:32]
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
+            capture_output=True, timeout=3,
+        )
+        v = (out.stdout or b"").decode("ascii", "ignore").strip()
+        if v:
+            return v[:32]
+    except Exception:
+        pass
+    return SKILL_VERSION_FALLBACK
+
+
+def _environment() -> str:
+    """Coarse run environment — no host names, no PII. Lets us tell an automated
+    CI/benchmark loop apart from a human running a one-off migration."""
+    ci_vars = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "JENKINS_URL",
+               "BUILDKITE", "TF_BUILD", "TEAMCITY_VERSION")
+    if any(os.environ.get(v) for v in ci_vars):
+        return "ci"
+    cloud_vars = ("CODESPACES", "GITPOD_WORKSPACE_ID", "KUBERNETES_SERVICE_HOST",
+                  "AWS_EXECUTION_ENV", "RENDER", "FLY_APP_NAME", "K_SERVICE")
+    if any(os.environ.get(v) for v in cloud_vars) or os.path.exists("/.dockerenv"):
+        return "cloud"
+    return "local"
+
+
+def _client_agent() -> str:
+    """Which harness is driving the skill — no PII. Helps explain usage shape."""
+    e = os.environ
+    if e.get("CLAUDECODE") or e.get("CLAUDE_CODE_ENTRYPOINT") or e.get("CLAUDE_CODE"):
+        return "claude-code"
+    if e.get("CURSOR_TRACE_ID") or (e.get("TERM_PROGRAM") or "").lower() == "cursor":
+        return "cursor"
+    if e.get("CORTEX_AGENT") or e.get("SNOWFLAKE_CORTEX") or "cortex" in (e.get("TERM_PROGRAM") or "").lower():
+        return "cortex"
+    return "cli" if hasattr(__import__("sys").stdin, "isatty") and __import__("sys").stdin.isatty() else "unknown"
+
+
 def report_migration(
     tool: str,
     sigma_base: str,
@@ -48,7 +103,12 @@ def report_migration(
     duration_seconds: int,
     success: bool,
     mode: str = "unknown",
-    skill_version: str = SKILL_VERSION,
+    outcome: str = None,
+    failure_stage: str = None,
+    skill_version: str = None,
+    environment: str = None,
+    client_agent: str = None,
+    run_id: str = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -62,10 +122,15 @@ def report_migration(
       - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
           → unique per org, not reversible to your credentials
       - migration duration in seconds
-      - success flag
-      - input mode: "live" (source API), "file" (raw export only),
-          "both", or "unknown" — a coarse enum, no file names or content
-      - skill version
+      - success flag + outcome ("success" / "partial" / "failed")
+      - failure_stage when not successful: a coarse enum
+          ("auth" / "convert" / "spec_post" / "query_validate" / "other"),
+          never a stack trace or message
+      - input mode: "live" / "file" / "both" / "unknown" — coarse, no file names
+      - skill_version: build identifier (git describe), no longer a constant
+      - environment: "ci" / "cloud" / "local" — run context, no host names
+      - client_agent: "claude-code" / "cursor" / "cortex" / "cli" / "unknown"
+      - run_id: a random per-run UUID (dedupe + retry-vs-distinct-run grouping)
 
     What is NOT sent:
       - workbook names, IDs, or URLs
@@ -81,8 +146,13 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "outcome":          outcome or ("success" if success else "failed"),
+        "failure_stage":    failure_stage,
         "mode":             mode or "unknown",
-        "skill_version":    skill_version,
+        "skill_version":    skill_version or _skill_version(),
+        "environment":      environment or _environment(),
+        "client_agent":     client_agent or _client_agent(),
+        "run_id":           run_id or uuid.uuid4().hex,
     }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
@@ -131,7 +201,6 @@ def _post(endpoint, body, timeout):
         first = str(e).splitlines()[0] if str(e) else type(e).__name__
         # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
         try:
-            import subprocess
             r = subprocess.run(
                 ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
                  "-w", "%{http_code}", "-X", "POST",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
@@ -63,6 +63,9 @@ parser.add_argument('--failed',   action='store_true', help='Pass if the migrati
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
                     help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
+parser.add_argument('--failure-stage', default=None,
+                    choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
+                    help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
 
@@ -104,6 +107,7 @@ sent = report_migration(
     duration_seconds=duration,
     success=not args.failed,
     mode=mode,
+    failure_stage=(args.failure_stage if args.failed else None),
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
@@ -19,12 +19,18 @@ import hashlib
 import re
 import time
 import os
+import subprocess
+import uuid
 import urllib.request
 import urllib.error
 import json
 
 TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
-SKILL_VERSION = "1.0"
+
+# Fallback only — the real value is resolved at runtime by _skill_version()
+# (git describe of the skills checkout). A constant here would make every event
+# look identical regardless of which build actually ran.
+SKILL_VERSION_FALLBACK = "unknown"
 
 
 def _region_from_base(sigma_base: str) -> str:
@@ -41,6 +47,55 @@ def _org_hash(client_id: str) -> str:
     return hashlib.sha256(client_id.encode()).hexdigest()[:8]
 
 
+def _skill_version() -> str:
+    """Real build identifier, best-effort and non-identifying:
+      1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
+      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      3. "unknown"
+    Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
+    env = os.environ.get("SIGMA_SKILL_VERSION")
+    if env:
+        return env[:32]
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
+            capture_output=True, timeout=3,
+        )
+        v = (out.stdout or b"").decode("ascii", "ignore").strip()
+        if v:
+            return v[:32]
+    except Exception:
+        pass
+    return SKILL_VERSION_FALLBACK
+
+
+def _environment() -> str:
+    """Coarse run environment — no host names, no PII. Lets us tell an automated
+    CI/benchmark loop apart from a human running a one-off migration."""
+    ci_vars = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "JENKINS_URL",
+               "BUILDKITE", "TF_BUILD", "TEAMCITY_VERSION")
+    if any(os.environ.get(v) for v in ci_vars):
+        return "ci"
+    cloud_vars = ("CODESPACES", "GITPOD_WORKSPACE_ID", "KUBERNETES_SERVICE_HOST",
+                  "AWS_EXECUTION_ENV", "RENDER", "FLY_APP_NAME", "K_SERVICE")
+    if any(os.environ.get(v) for v in cloud_vars) or os.path.exists("/.dockerenv"):
+        return "cloud"
+    return "local"
+
+
+def _client_agent() -> str:
+    """Which harness is driving the skill — no PII. Helps explain usage shape."""
+    e = os.environ
+    if e.get("CLAUDECODE") or e.get("CLAUDE_CODE_ENTRYPOINT") or e.get("CLAUDE_CODE"):
+        return "claude-code"
+    if e.get("CURSOR_TRACE_ID") or (e.get("TERM_PROGRAM") or "").lower() == "cursor":
+        return "cursor"
+    if e.get("CORTEX_AGENT") or e.get("SNOWFLAKE_CORTEX") or "cortex" in (e.get("TERM_PROGRAM") or "").lower():
+        return "cortex"
+    return "cli" if hasattr(__import__("sys").stdin, "isatty") and __import__("sys").stdin.isatty() else "unknown"
+
+
 def report_migration(
     tool: str,
     sigma_base: str,
@@ -48,7 +103,12 @@ def report_migration(
     duration_seconds: int,
     success: bool,
     mode: str = "unknown",
-    skill_version: str = SKILL_VERSION,
+    outcome: str = None,
+    failure_stage: str = None,
+    skill_version: str = None,
+    environment: str = None,
+    client_agent: str = None,
+    run_id: str = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -62,10 +122,15 @@ def report_migration(
       - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
           → unique per org, not reversible to your credentials
       - migration duration in seconds
-      - success flag
-      - input mode: "live" (source API), "file" (raw export only),
-          "both", or "unknown" — a coarse enum, no file names or content
-      - skill version
+      - success flag + outcome ("success" / "partial" / "failed")
+      - failure_stage when not successful: a coarse enum
+          ("auth" / "convert" / "spec_post" / "query_validate" / "other"),
+          never a stack trace or message
+      - input mode: "live" / "file" / "both" / "unknown" — coarse, no file names
+      - skill_version: build identifier (git describe), no longer a constant
+      - environment: "ci" / "cloud" / "local" — run context, no host names
+      - client_agent: "claude-code" / "cursor" / "cortex" / "cli" / "unknown"
+      - run_id: a random per-run UUID (dedupe + retry-vs-distinct-run grouping)
 
     What is NOT sent:
       - workbook names, IDs, or URLs
@@ -81,8 +146,13 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "outcome":          outcome or ("success" if success else "failed"),
+        "failure_stage":    failure_stage,
         "mode":             mode or "unknown",
-        "skill_version":    skill_version,
+        "skill_version":    skill_version or _skill_version(),
+        "environment":      environment or _environment(),
+        "client_agent":     client_agent or _client_agent(),
+        "run_id":           run_id or uuid.uuid4().hex,
     }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
@@ -131,7 +201,6 @@ def _post(endpoint, body, timeout):
         first = str(e).splitlines()[0] if str(e) else type(e).__name__
         # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
         try:
-            import subprocess
             r = subprocess.run(
                 ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
                  "-w", "%{http_code}", "-X", "POST",

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
@@ -63,6 +63,9 @@ parser.add_argument('--failed',   action='store_true', help='Pass if the migrati
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
                     help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
+parser.add_argument('--failure-stage', default=None,
+                    choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
+                    help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
 
@@ -104,6 +107,7 @@ sent = report_migration(
     duration_seconds=duration,
     success=not args.failed,
     mode=mode,
+    failure_stage=(args.failure_stage if args.failed else None),
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/shared/lib/sigma_telemetry.py
+++ b/shared/lib/sigma_telemetry.py
@@ -19,12 +19,18 @@ import hashlib
 import re
 import time
 import os
+import subprocess
+import uuid
 import urllib.request
 import urllib.error
 import json
 
 TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
-SKILL_VERSION = "1.0"
+
+# Fallback only — the real value is resolved at runtime by _skill_version()
+# (git describe of the skills checkout). A constant here would make every event
+# look identical regardless of which build actually ran.
+SKILL_VERSION_FALLBACK = "unknown"
 
 
 def _region_from_base(sigma_base: str) -> str:
@@ -41,6 +47,55 @@ def _org_hash(client_id: str) -> str:
     return hashlib.sha256(client_id.encode()).hexdigest()[:8]
 
 
+def _skill_version() -> str:
+    """Real build identifier, best-effort and non-identifying:
+      1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
+      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      3. "unknown"
+    Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
+    env = os.environ.get("SIGMA_SKILL_VERSION")
+    if env:
+        return env[:32]
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        out = subprocess.run(
+            ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
+            capture_output=True, timeout=3,
+        )
+        v = (out.stdout or b"").decode("ascii", "ignore").strip()
+        if v:
+            return v[:32]
+    except Exception:
+        pass
+    return SKILL_VERSION_FALLBACK
+
+
+def _environment() -> str:
+    """Coarse run environment — no host names, no PII. Lets us tell an automated
+    CI/benchmark loop apart from a human running a one-off migration."""
+    ci_vars = ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "JENKINS_URL",
+               "BUILDKITE", "TF_BUILD", "TEAMCITY_VERSION")
+    if any(os.environ.get(v) for v in ci_vars):
+        return "ci"
+    cloud_vars = ("CODESPACES", "GITPOD_WORKSPACE_ID", "KUBERNETES_SERVICE_HOST",
+                  "AWS_EXECUTION_ENV", "RENDER", "FLY_APP_NAME", "K_SERVICE")
+    if any(os.environ.get(v) for v in cloud_vars) or os.path.exists("/.dockerenv"):
+        return "cloud"
+    return "local"
+
+
+def _client_agent() -> str:
+    """Which harness is driving the skill — no PII. Helps explain usage shape."""
+    e = os.environ
+    if e.get("CLAUDECODE") or e.get("CLAUDE_CODE_ENTRYPOINT") or e.get("CLAUDE_CODE"):
+        return "claude-code"
+    if e.get("CURSOR_TRACE_ID") or (e.get("TERM_PROGRAM") or "").lower() == "cursor":
+        return "cursor"
+    if e.get("CORTEX_AGENT") or e.get("SNOWFLAKE_CORTEX") or "cortex" in (e.get("TERM_PROGRAM") or "").lower():
+        return "cortex"
+    return "cli" if hasattr(__import__("sys").stdin, "isatty") and __import__("sys").stdin.isatty() else "unknown"
+
+
 def report_migration(
     tool: str,
     sigma_base: str,
@@ -48,7 +103,12 @@ def report_migration(
     duration_seconds: int,
     success: bool,
     mode: str = "unknown",
-    skill_version: str = SKILL_VERSION,
+    outcome: str = None,
+    failure_stage: str = None,
+    skill_version: str = None,
+    environment: str = None,
+    client_agent: str = None,
+    run_id: str = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -62,10 +122,15 @@ def report_migration(
       - org_id_hash: SHA256 of your SIGMA_CLIENT_ID, first 8 chars
           → unique per org, not reversible to your credentials
       - migration duration in seconds
-      - success flag
-      - input mode: "live" (source API), "file" (raw export only),
-          "both", or "unknown" — a coarse enum, no file names or content
-      - skill version
+      - success flag + outcome ("success" / "partial" / "failed")
+      - failure_stage when not successful: a coarse enum
+          ("auth" / "convert" / "spec_post" / "query_validate" / "other"),
+          never a stack trace or message
+      - input mode: "live" / "file" / "both" / "unknown" — coarse, no file names
+      - skill_version: build identifier (git describe), no longer a constant
+      - environment: "ci" / "cloud" / "local" — run context, no host names
+      - client_agent: "claude-code" / "cursor" / "cortex" / "cli" / "unknown"
+      - run_id: a random per-run UUID (dedupe + retry-vs-distinct-run grouping)
 
     What is NOT sent:
       - workbook names, IDs, or URLs
@@ -81,8 +146,13 @@ def report_migration(
         "org_id_hash":      _org_hash(client_id),
         "duration_seconds": duration_seconds,
         "success":          success,
+        "outcome":          outcome or ("success" if success else "failed"),
+        "failure_stage":    failure_stage,
         "mode":             mode or "unknown",
-        "skill_version":    skill_version,
+        "skill_version":    skill_version or _skill_version(),
+        "environment":      environment or _environment(),
+        "client_agent":     client_agent or _client_agent(),
+        "run_id":           run_id or uuid.uuid4().hex,
     }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
@@ -131,7 +201,6 @@ def _post(endpoint, body, timeout):
         first = str(e).splitlines()[0] if str(e) else type(e).__name__
         # 2) Fall back to curl — succeeds on boxes where python's CA store is broken.
         try:
-            import subprocess
             r = subprocess.run(
                 ["curl", "-sS", "-m", str(timeout), "-o", "/dev/null",
                  "-w", "%{http_code}", "-X", "POST",

--- a/shared/scripts/report-telemetry.py
+++ b/shared/scripts/report-telemetry.py
@@ -63,6 +63,9 @@ parser.add_argument('--failed',   action='store_true', help='Pass if the migrati
 parser.add_argument('--declined', action='store_true', help='User declined the ping: record the decision, send nothing')
 parser.add_argument('--mode',     default='unknown', choices=['live', 'file', 'both', 'unknown'],
                     help='Input mode (auto-derived from intake.json if omitted): live, file, both, or unknown')
+parser.add_argument('--failure-stage', default=None,
+                    choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
+                    help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
 args = parser.parse_args()
 
@@ -104,6 +107,7 @@ sent = report_migration(
     duration_seconds=duration,
     success=not args.failed,
     mode=mode,
+    failure_stage=(args.failure_stage if args.failed else None),
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.


### PR DESCRIPTION
## Why
Investigating the **Migration Skill Telemetry** dashboard, two questions were unanswerable from the data:
1. *Is org `846488f1` (33 migrations in 8h) a human or an automated/benchmark loop?*
2. *Which build of the skill ran?* — every row showed `skill_version = 1.0`.

Root cause: the `/track` payload is 7 thin fields, and `skill_version` was a **hardcoded `"1.0"` constant** in all 10 copies, never bumped or overridden.

## What (all non-PII)
| field | before | after |
|---|---|---|
| `skill_version` | constant `"1.0"` | `SIGMA_SKILL_VERSION` env, else `git describe` (e.g. `v1.3.0-2-gabc1234`) |
| `environment` | — | `ci｜cloud｜local` (auto from CI/CODESPACES/docker/etc. env vars) |
| `client_agent` | — | `claude-code｜cursor｜cortex｜cli｜unknown` |
| `outcome` | bare `success` bool | `success｜partial｜failed` (bool kept for back-compat) |
| `failure_stage` | — | optional coarse enum `auth｜convert｜spec_post｜query_validate｜other` — no messages/traces |
| `run_id` | — | random per-run UUID (dedupe; distinct-runs vs one-retried-N-times) |
| `mode` | sent but **dropped** by server allowlist | now part of the documented schema (server PR adds it) |

`environment` is the field that would have instantly answered Q1 — `846488f1`'s traffic is rotating Azure egress + `Python-urllib`, i.e. a cloud/automated loop, not a customer at a desk.

## Privacy posture (unchanged)
Still no org name, email, URLs, or customer content. `org_id_hash` stays client-side `SHA256(client_id)[:8]` — raw client_id never leaves the machine.

## Scope / mechanics
- Edited the canonical `shared/lib/sigma_telemetry.py` + `shared/scripts/report-telemetry.py`, fanned out to all 9 plugins via `tools/sync-shared.rb`. `tools/check-shared.rb` passes (181 copies in sync).
- No converter call-site changes (Phase 1). `report_migration()` auto-detects the new fields; `outcome` derives from `success` when not given.

## Paired change + deploy order
Server: **twells89/sigma-migration-telemetry** (allowlist + validation + INSERT + `ALTER TABLE` + `TELEMETRY.md`).
**Apply in this order** so no telemetry rows are lost:
1. `ALTER TABLE CSA.TJ.SKILL_USAGE_LOG` (add columns)
2. deploy the telemetry service
3. merge + release this client

🤖 Generated with [Claude Code](https://claude.com/claude-code)