### PR TITLE
tableau(n4pi.4): dedupe master column ids on workbook build

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
@@ -91,6 +91,22 @@ master_columns =
   end
 abort('no master columns to emit') if master_columns.empty?
 
+# Dedupe master column ids: two DM columns whose distinct display names slug to the
+# same id (e.g. a calc "Market Maker" alongside the physical "MARKET_MAKER") would
+# emit a duplicate id and 400 the workbook POST ("Duplicate id"). Names/formulas stay
+# distinct (charts reference by name), so we only need to make the ids unique — keep
+# the first, suffix later collisions (-2, -3, …).
+seen_master_ids = {}
+master_columns.each do |c|
+  base = c['id']
+  next unless seen_master_ids[base]
+  n = 2
+  n += 1 while seen_master_ids["#{base}-#{n}"]
+  c['id'] = "#{base}-#{n}"
+ensure
+  seen_master_ids[c['id']] = true
+end
+
 # Build the data page
 data_page = {
   'id'   => 'page-data',


### PR DESCRIPTION
## Summary
A collapsed multi-source-blend DM can carry two columns whose **distinct** display names slug to the **same** master id — e.g. a calc `Market Maker` (`If([MARKET_MAKER] = True, 1, 0)`) alongside the physical `MARKET_MAKER`. `build-workbook-spec.rb` minted `m-market-maker` for both, 400-ing the workbook POST with `Duplicate id: 'm-market-maker'`.

Names and formulas stay distinct (charts reference master columns by name), so we only need the **ids** unique: keep the first, suffix later collisions (`-2`, `-3`, …).

## Context
Surfaced by the DDMX-class blend E2E (epic beads-sigma-n4pi, bead n4pi.4). The converter side (calc-field translation + caption↔alias reconciliation) lands in twells89/sigma-data-model-mcp PR #70; this is the workbook-build companion fix.

## Test
`ruby -c` clean; DDMX E2E now posts the workbook with zero resolution errors (was blocked here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)