### PR TITLE
feat(telemetry): VERSION-file fallback for skill_version + vendor-time stamp tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ __pycache__/
 *.pyc
 .DS_Store
 node_modules/
+
+# Generated at vendor/release time by tools/stamp-version.rb (do not commit)
+shared/lib/VERSION
+plugins/*/skills/*/scripts/lib/VERSION

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
@@ -50,14 +50,26 @@ def _org_hash(client_id: str) -> str:
 def _skill_version() -> str:
     """Real build identifier, best-effort and non-identifying:
       1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
-      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
-      3. "unknown"
+      2. a VERSION file next to this lib (or a parent dir), written at vendor/
+         release time by tools/stamp-version.rb — survives `.git` stripping, which
+         is exactly what the plugin-cache delivery path does
+      3. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      4. "unknown"
     Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
     env = os.environ.get("SIGMA_SKILL_VERSION")
     if env:
         return env[:32]
+    here = os.path.dirname(os.path.abspath(__file__))
+    # VERSION file: lib dir, then up to 2 parents (skill / plugin root)
+    for d in (here, os.path.dirname(here), os.path.dirname(os.path.dirname(here))):
+        try:
+            with open(os.path.join(d, "VERSION")) as fh:
+                v = fh.read().strip()
+            if v:
+                return v[:32]
+        except Exception:
+            pass
     try:
-        here = os.path.dirname(os.path.abspath(__file__))
         out = subprocess.run(
             ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
             capture_output=True, timeout=3,

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
@@ -50,14 +50,26 @@ def _org_hash(client_id: str) -> str:
 def _skill_version() -> str:
     """Real build identifier, best-effort and non-identifying:
       1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
-      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
-      3. "unknown"
+      2. a VERSION file next to this lib (or a parent dir), written at vendor/
+         release time by tools/stamp-version.rb — survives `.git` stripping, which
+         is exactly what the plugin-cache delivery path does
+      3. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      4. "unknown"
     Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
     env = os.environ.get("SIGMA_SKILL_VERSION")
     if env:
         return env[:32]
+    here = os.path.dirname(os.path.abspath(__file__))
+    # VERSION file: lib dir, then up to 2 parents (skill / plugin root)
+    for d in (here, os.path.dirname(here), os.path.dirname(os.path.dirname(here))):
+        try:
+            with open(os.path.join(d, "VERSION")) as fh:
+                v = fh.read().strip()
+            if v:
+                return v[:32]
+        except Exception:
+            pass
     try:
-        here = os.path.dirname(os.path.abspath(__file__))
         out = subprocess.run(
             ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
             capture_output=True, timeout=3,

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
@@ -50,14 +50,26 @@ def _org_hash(client_id: str) -> str:
 def _skill_version() -> str:
     """Real build identifier, best-effort and non-identifying:
       1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
-      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
-      3. "unknown"
+      2. a VERSION file next to this lib (or a parent dir), written at vendor/
+         release time by tools/stamp-version.rb — survives `.git` stripping, which
+         is exactly what the plugin-cache delivery path does
+      3. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      4. "unknown"
     Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
     env = os.environ.get("SIGMA_SKILL_VERSION")
     if env:
         return env[:32]
+    here = os.path.dirname(os.path.abspath(__file__))
+    # VERSION file: lib dir, then up to 2 parents (skill / plugin root)
+    for d in (here, os.path.dirname(here), os.path.dirname(os.path.dirname(here))):
+        try:
+            with open(os.path.join(d, "VERSION")) as fh:
+                v = fh.read().strip()
+            if v:
+                return v[:32]
+        except Exception:
+            pass
     try:
-        here = os.path.dirname(os.path.abspath(__file__))
         out = subprocess.run(
             ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
             capture_output=True, timeout=3,

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
@@ -50,14 +50,26 @@ def _org_hash(client_id: str) -> str:
 def _skill_version() -> str:
     """Real build identifier, best-effort and non-identifying:
       1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
-      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
-      3. "unknown"
+      2. a VERSION file next to this lib (or a parent dir), written at vendor/
+         release time by tools/stamp-version.rb — survives `.git` stripping, which
+         is exactly what the plugin-cache delivery path does
+      3. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      4. "unknown"
     Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
     env = os.environ.get("SIGMA_SKILL_VERSION")
     if env:
         return env[:32]
+    here = os.path.dirname(os.path.abspath(__file__))
+    # VERSION file: lib dir, then up to 2 parents (skill / plugin root)
+    for d in (here, os.path.dirname(here), os.path.dirname(os.path.dirname(here))):
+        try:
+            with open(os.path.join(d, "VERSION")) as fh:
+                v = fh.read().strip()
+            if v:
+                return v[:32]
+        except Exception:
+            pass
     try:
-        here = os.path.dirname(os.path.abspath(__file__))
         out = subprocess.run(
             ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
             capture_output=True, timeout=3,

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
@@ -50,14 +50,26 @@ def _org_hash(client_id: str) -> str:
 def _skill_version() -> str:
     """Real build identifier, best-effort and non-identifying:
       1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
-      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
-      3. "unknown"
+      2. a VERSION file next to this lib (or a parent dir), written at vendor/
+         release time by tools/stamp-version.rb — survives `.git` stripping, which
+         is exactly what the plugin-cache delivery path does
+      3. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      4. "unknown"
     Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
     env = os.environ.get("SIGMA_SKILL_VERSION")
     if env:
         return env[:32]
+    here = os.path.dirname(os.path.abspath(__file__))
+    # VERSION file: lib dir, then up to 2 parents (skill / plugin root)
+    for d in (here, os.path.dirname(here), os.path.dirname(os.path.dirname(here))):
+        try:
+            with open(os.path.join(d, "VERSION")) as fh:
+                v = fh.read().strip()
+            if v:
+                return v[:32]
+        except Exception:
+            pass
     try:
-        here = os.path.dirname(os.path.abspath(__file__))
         out = subprocess.run(
             ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
             capture_output=True, timeout=3,

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
@@ -50,14 +50,26 @@ def _org_hash(client_id: str) -> str:
 def _skill_version() -> str:
     """Real build identifier, best-effort and non-identifying:
       1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
-      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
-      3. "unknown"
+      2. a VERSION file next to this lib (or a parent dir), written at vendor/
+         release time by tools/stamp-version.rb — survives `.git` stripping, which
+         is exactly what the plugin-cache delivery path does
+      3. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      4. "unknown"
     Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
     env = os.environ.get("SIGMA_SKILL_VERSION")
     if env:
         return env[:32]
+    here = os.path.dirname(os.path.abspath(__file__))
+    # VERSION file: lib dir, then up to 2 parents (skill / plugin root)
+    for d in (here, os.path.dirname(here), os.path.dirname(os.path.dirname(here))):
+        try:
+            with open(os.path.join(d, "VERSION")) as fh:
+                v = fh.read().strip()
+            if v:
+                return v[:32]
+        except Exception:
+            pass
     try:
-        here = os.path.dirname(os.path.abspath(__file__))
         out = subprocess.run(
             ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
             capture_output=True, timeout=3,

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
@@ -50,14 +50,26 @@ def _org_hash(client_id: str) -> str:
 def _skill_version() -> str:
     """Real build identifier, best-effort and non-identifying:
       1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
-      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
-      3. "unknown"
+      2. a VERSION file next to this lib (or a parent dir), written at vendor/
+         release time by tools/stamp-version.rb — survives `.git` stripping, which
+         is exactly what the plugin-cache delivery path does
+      3. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      4. "unknown"
     Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
     env = os.environ.get("SIGMA_SKILL_VERSION")
     if env:
         return env[:32]
+    here = os.path.dirname(os.path.abspath(__file__))
+    # VERSION file: lib dir, then up to 2 parents (skill / plugin root)
+    for d in (here, os.path.dirname(here), os.path.dirname(os.path.dirname(here))):
+        try:
+            with open(os.path.join(d, "VERSION")) as fh:
+                v = fh.read().strip()
+            if v:
+                return v[:32]
+        except Exception:
+            pass
     try:
-        here = os.path.dirname(os.path.abspath(__file__))
         out = subprocess.run(
             ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
             capture_output=True, timeout=3,

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
@@ -50,14 +50,26 @@ def _org_hash(client_id: str) -> str:
 def _skill_version() -> str:
     """Real build identifier, best-effort and non-identifying:
       1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
-      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
-      3. "unknown"
+      2. a VERSION file next to this lib (or a parent dir), written at vendor/
+         release time by tools/stamp-version.rb — survives `.git` stripping, which
+         is exactly what the plugin-cache delivery path does
+      3. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      4. "unknown"
     Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
     env = os.environ.get("SIGMA_SKILL_VERSION")
     if env:
         return env[:32]
+    here = os.path.dirname(os.path.abspath(__file__))
+    # VERSION file: lib dir, then up to 2 parents (skill / plugin root)
+    for d in (here, os.path.dirname(here), os.path.dirname(os.path.dirname(here))):
+        try:
+            with open(os.path.join(d, "VERSION")) as fh:
+                v = fh.read().strip()
+            if v:
+                return v[:32]
+        except Exception:
+            pass
     try:
-        here = os.path.dirname(os.path.abspath(__file__))
         out = subprocess.run(
             ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
             capture_output=True, timeout=3,

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
@@ -50,14 +50,26 @@ def _org_hash(client_id: str) -> str:
 def _skill_version() -> str:
     """Real build identifier, best-effort and non-identifying:
       1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
-      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
-      3. "unknown"
+      2. a VERSION file next to this lib (or a parent dir), written at vendor/
+         release time by tools/stamp-version.rb — survives `.git` stripping, which
+         is exactly what the plugin-cache delivery path does
+      3. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      4. "unknown"
     Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
     env = os.environ.get("SIGMA_SKILL_VERSION")
     if env:
         return env[:32]
+    here = os.path.dirname(os.path.abspath(__file__))
+    # VERSION file: lib dir, then up to 2 parents (skill / plugin root)
+    for d in (here, os.path.dirname(here), os.path.dirname(os.path.dirname(here))):
+        try:
+            with open(os.path.join(d, "VERSION")) as fh:
+                v = fh.read().strip()
+            if v:
+                return v[:32]
+        except Exception:
+            pass
     try:
-        here = os.path.dirname(os.path.abspath(__file__))
         out = subprocess.run(
             ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
             capture_output=True, timeout=3,

--- a/shared/lib/sigma_telemetry.py
+++ b/shared/lib/sigma_telemetry.py
@@ -50,14 +50,26 @@ def _org_hash(client_id: str) -> str:
 def _skill_version() -> str:
     """Real build identifier, best-effort and non-identifying:
       1. SIGMA_SKILL_VERSION env override (set by a release/packaging step)
-      2. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
-      3. "unknown"
+      2. a VERSION file next to this lib (or a parent dir), written at vendor/
+         release time by tools/stamp-version.rb — survives `.git` stripping, which
+         is exactly what the plugin-cache delivery path does
+      3. `git describe` of the checkout this file lives in (e.g. "v1.3.0-2-gabc1234")
+      4. "unknown"
     Replaces the old hardcoded "1.0" so telemetry can distinguish builds."""
     env = os.environ.get("SIGMA_SKILL_VERSION")
     if env:
         return env[:32]
+    here = os.path.dirname(os.path.abspath(__file__))
+    # VERSION file: lib dir, then up to 2 parents (skill / plugin root)
+    for d in (here, os.path.dirname(here), os.path.dirname(os.path.dirname(here))):
+        try:
+            with open(os.path.join(d, "VERSION")) as fh:
+                v = fh.read().strip()
+            if v:
+                return v[:32]
+        except Exception:
+            pass
     try:
-        here = os.path.dirname(os.path.abspath(__file__))
         out = subprocess.run(
             ["git", "-C", here, "describe", "--tags", "--always", "--dirty"],
             capture_output=True, timeout=3,

--- a/tools/stamp-version.rb
+++ b/tools/stamp-version.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# stamp-version.rb — write a VERSION file next to every telemetry client copy so
+# the skill's `_skill_version()` resolves a real build id DOWNSTREAM, where the
+# plugin-cache delivery path strips `.git` (git describe then fails → "unknown").
+#
+# Run this at vendor/release time, BEFORE copying plugins into the distribution
+# (e.g. sigmacomputing/sigma-agent-skills-dev). In the dev checkout you don't need
+# it — `_skill_version()` falls back to `git describe`.
+#
+#   ruby tools/stamp-version.rb                 # version = `git describe --tags --always --dirty`
+#   ruby tools/stamp-version.rb v1.4.0          # explicit version string
+#   ruby tools/stamp-version.rb --clean         # remove all stamped VERSION files
+#
+# VERSION files are git-ignored (generated, not committed) so the dev repo keeps
+# using git describe and only vendored snapshots carry a frozen version.
+
+require 'fileutils'
+
+ROOT = File.expand_path('..', __dir__)
+Dir.chdir(ROOT)
+
+# Every dir that actually holds a telemetry lib → drop VERSION beside it (lib dir
+# is checked first by _skill_version). The canonical lib lives at shared/lib; the
+# fanned-out (and downstream-delivered) copies live at plugins/*/skills/*/scripts/lib.
+LIB_DIRS = (Dir.glob('shared/lib') + Dir.glob('plugins/*/skills/*/scripts/lib'))
+           .select { |d| File.exist?(File.join(d, 'sigma_telemetry.py')) || File.exist?(File.join(d, 'sigma_telemetry.rb')) }
+           .uniq
+abort 'FATAL: found no telemetry lib dirs to stamp' if LIB_DIRS.empty?
+
+if ARGV.include?('--clean')
+  removed = LIB_DIRS.map { |d| File.join(d, 'VERSION') }.select { |f| File.exist?(f) }
+  removed.each { |f| File.delete(f) }
+  puts "Removed #{removed.size} VERSION file(s)."
+  exit 0
+end
+
+version = ARGV.find { |a| !a.start_with?('--') }
+if version.nil? || version.empty?
+  version = `git describe --tags --always --dirty 2>/dev/null`.strip
+  abort 'FATAL: could not derive a version (pass one explicitly: stamp-version.rb v1.4.0)' if version.empty?
+end
+version = version[0, 32]
+
+LIB_DIRS.each { |d| File.write(File.join(d, 'VERSION'), "#{version}\n") }
+puts "Stamped VERSION=#{version} into #{LIB_DIRS.size} lib dir(s)."


### PR DESCRIPTION
## Why
Follow-up to #197. `skill_version` resolves via `git describe` — fine in the dev checkout, but **downstream it returns `"unknown"`**: the Claude Code plugin-cache delivery path (`~/.claude/plugins/cache/.../<version>`) strips `.git`, so `git describe` fails. Confirmed by inspecting the installed marketplace (cache copy has no `.git`).

## What
- **`_skill_version()` fallback chain:** `SIGMA_SKILL_VERSION` env → **`VERSION` file** next to the lib (or a parent dir) → `git describe` → `"unknown"`.
- **`tools/stamp-version.rb`:** writes `VERSION` into every telemetry lib dir (`shared/lib` + `plugins/*/skills/*/scripts/lib`). Run at vendor/release time before copying plugins into the distribution. Takes an explicit version (`stamp-version.rb v1.4.0`) or derives `git describe`; `--clean` removes them.
- **`VERSION` files are git-ignored** — generated, not committed. Dev keeps using `git describe`; only vendored snapshots carry a frozen version.

## Verified
Stamp → both a plugin lib and `shared/lib` read the `VERSION` file; `SIGMA_SKILL_VERSION` env still wins; `--clean` → falls back to `git describe`. Shared lib fanned out via `sync-shared.rb`; `check-shared.rb` green.

## Vendor step
Add one line to the vendoring process before the copy into `sigmacomputing/sigma-agent-skills-dev`:
```
ruby tools/stamp-version.rb            # or: ruby tools/stamp-version.rb v1.4.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)