### PR TITLE
tableau(n4pi.9): emit "Not Migrated (and why)" report in the migration pipeline

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -187,7 +187,11 @@ module MechanicalSpecs
       // Capture out.security too — detected RLS/CLS rules (architecture B:
       // reported, not injected). Dropping it here is how RLS silently
       // vanished from the orchestrated path; the orchestrator now gates on it.
-      writeFileSync(#{meta_out.to_json}, JSON.stringify({ model: bare, warnings: out.warnings || [], stats: out.stats || {}, security: out.security || [] }, null, 2));
+      // workbookPatterns (param measure-pickers → control-driven Switch,
+      // param-filters, window/LOD calcs) + parameters (control values/defaults)
+      // are needed by the build layer to materialise controls/Switch tiles and by
+      // the "Not Migrated (and why)" report — pass them through (was dropped).
+      writeFileSync(#{meta_out.to_json}, JSON.stringify({ model: bare, warnings: out.warnings || [], stats: out.stats || {}, security: out.security || [], workbookPatterns: out.workbookPatterns || [], parameters: out.parameters || [] }, null, 2));
     JS
     o, e, st = Open3.capture3('node', shim)
     raise "converter failed: #{e}#{o}" unless st.success?
@@ -226,7 +230,8 @@ module MechanicalSpecs
            'detected RLS/CLS may not have been surfaced. Verify security manually (RLS is never silently dropped).'
     end
     result = { 'model' => bare, 'warnings' => out['warnings'] || [],
-               'stats' => out['stats'] || {}, 'security' => out['security'] || [] }
+               'stats' => out['stats'] || {}, 'security' => out['security'] || [],
+               'workbookPatterns' => out['workbookPatterns'] || [], 'parameters' => out['parameters'] || [] }
     File.write(meta_out, JSON.pretty_generate(result))
     result
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -1579,6 +1579,25 @@ wb_id = wb_ids['workbookId']
 line "workbookId = #{wb_id}"
 mark('phase4-workbook')
 
+# "Not Migrated (and why)" punch-list — turn every dropped tile into an actionable
+# entry (param measure-picker → control-driven Switch, field absent from source SQL,
+# inert/commented source calc, window/LOD, aggregate-metric) so no empty/sparse tab
+# is mysterious. Best-effort: never fail the migration over the report.
+notes_meta   = File.join(WORK, 'conv-meta.json')
+notes_charts = File.join(WORK, 'chart-specs.json')
+if File.exist?(notes_meta) && File.exist?(notes_charts) && File.exist?(wb_spec_path)
+  notes_out = File.join(WORK, 'migration-notes.md')
+  nc = ['ruby', File.join(HERE, 'migration-notes.rb'), '--conv-meta', notes_meta,
+        '--chart-specs', notes_charts, '--wb-spec', wb_spec_path, '--twb', twb, '--out', notes_out]
+  _o, ne, nst = Open3.capture3(*nc)
+  if nst.success?
+    line "Not-Migrated report → #{notes_out}"
+    (ne || '').each_line { |l| line l.rstrip if l.strip.start_with?(/\d/) || l.include?('categorized') }
+  else
+    line "Not-Migrated report skipped (#{(ne || '').lines.first&.strip})"
+  end
+end
+
 # ---------------------------------------------------------------------------
 # Phase 5 — Layout. Prefer the generator's layout_xml; else auto-build from the
 # parsed Tableau zone tree via build-dashboard-layout.rb.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migration-notes.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migration-notes.rb
@@ -1,0 +1,127 @@
+#!/usr/bin/env ruby
+# Emit a "Not Migrated (and why)" punch-list (Markdown) for a Tableau→Sigma
+# migration: every source tile that did NOT make it into the final workbook gets a
+# binding-constraint category + an action, so no empty/sparse tab is mysterious.
+# Aligns with the cross-converter reason-taxonomy goal (bead ncwe).
+#
+# Reads the converter meta (conv-meta.json — must carry workbookPatterns +
+# parameters; see mechanical-specs.run_converter), the pre-prune chart specs, the
+# final posted workbook spec, and the source .twb (to detect calcs that are
+# commented-out in the source). No converter re-run.
+#
+# Usage:
+#   ruby scripts/migration-notes.rb \
+#     --conv-meta /tmp/<n>/conv-meta.json --chart-specs /tmp/<n>/chart-specs.json \
+#     --wb-spec /tmp/<n>/wb-spec.json --twb /tmp/<n>/workbook-content.twb \
+#     --out /tmp/<n>/migration-notes.md
+
+require 'json'
+require 'set'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--conv-meta PATH')   { |v| opts[:meta] = v }
+  p.on('--chart-specs PATH') { |v| opts[:specs] = v }
+  p.on('--wb-spec PATH')     { |v| opts[:wb] = v }
+  p.on('--twb PATH')         { |v| opts[:twb] = v }
+  p.on('--out PATH')         { |v| opts[:out] = v }
+end.parse!
+%i[meta specs wb out].each { |k| abort("missing --#{k.to_s.tr('_', '-')}") unless opts[k] }
+
+meta  = JSON.parse(File.read(opts[:meta]))
+specs = JSON.parse(File.read(opts[:specs]))
+wb    = JSON.parse(File.read(opts[:wb]))
+xml   = opts[:twb] && File.exist?(opts[:twb]) ? File.read(opts[:twb], encoding: 'utf-8', invalid: :replace, undef: :replace) : ''
+
+def nk(s)
+  (s || '').gsub(/[^a-z0-9]/i, '').downcase
+end
+
+# Merged kind:sql element → its columns + metrics (what the model can resolve).
+el = (meta.dig('model', 'pages') || []).flat_map { |p| p['elements'] || [] }
+         .find { |e| e.dig('source', 'kind') == 'sql' }
+col_lc   = Set.new((el&.dig('columns') || []).map { |c| (c['name'] || '').downcase })
+col_norm = Set.new((el&.dig('columns') || []).map { |c| nk(c['name']) })
+met_norm = Set.new((el&.dig('metrics') || []).map { |m| nk(m['name']) })
+
+wp = meta['workbookPatterns'] || []
+param_switch = {}; wp.select { |p| p['kind'] == 'param-switch' }.each { |p| param_switch[p['name']] = p }
+param_filter = Set.new(wp.select { |p| p['kind'] == 'param-filter' }.map { |p| p['name'] })
+
+# .twb: caption↔internal-name + which calcs are fully //-commented (inert in source).
+name_to_cap = {}; cap_by_norm = {}; inert = Set.new
+xml.scan(/<column\b[^>]*\bcaption='([^']*)'[^>]*\bname='\[([^']+)\]'[^>]*>(.*?)<\/column>/m) do |cap, name, body|
+  name_to_cap[name] = cap; cap_by_norm[nk(name)] = cap
+  if (fm = body.match(/formula='([^']*)'/))
+    f = fm[1].gsub('&#10;', "\n").gsub('&quot;', '"')
+    live = f.lines.map { |l| l.sub(%r{//.*$}, '').strip }.reject(&:empty?).join(' ')
+    (inert << cap; inert << name) if !f.strip.empty? && live.empty?
+  end
+end
+calc_internal = ->(s) { s =~ /\ACalculation_\d+/i || s =~ /_\d{6,}(:|\z)/ || s =~ /\(copy\)/i }
+
+def classify(ref, ctx)
+  base = ref.sub(/\s*\([^)]*\)\s*\z/, '').sub(/\s*\(copy\)_\d+\z/, '').sub(/:nk(:\d+)?\z/, '')
+  cap  = ctx[:name_to_cap][ref] || ctx[:cap_by_norm][ctx[:nk].call(ref)] || ref
+  if (ps = ctx[:param_switch][cap] || ctx[:param_switch][ref])
+    return ['param-measure-picker', %(Tableau parameter measure-picker "#{cap}" -> Sigma control-driven Switch. Emit control [#{ps['controlId']}] and set the tile's MEASURE column to the Switch.)]
+  end
+  return ['param-driven', %(references Tableau parameter "#{cap}" -> bind a Sigma control (segmented/list) to the SOURCE element (control->viz 400s).)] if ctx[:param_filter].include?(cap) || cap =~ /\bParam(eter)?\b/i || ref =~ /Parameter/i
+  return ['inert-in-source', %(the Tableau calc "#{cap}" is fully commented-out (//) in the source .twb -- dead in Tableau too; nothing to migrate.)] if ctx[:inert].include?(ref) || ctx[:inert].include?(cap)
+  return ['aggregate-metric', %("#{cap}" is an aggregate metric -- plot it as the tile MEASURE (chart-context aggregate), not a row column.)] if ctx[:met_norm].include?(ctx[:nk].call(base)) || ctx[:met_norm].include?(ctx[:nk].call(cap))
+  return ['unresolved-calc', %(calc "#{cap}" did not resolve (window/LOD/percent-of-total/copy) -- rebuild in a grouped chart element.)] if ctx[:calc_internal].call(ref)
+  return ['absent-from-sql', %(physical field "#{ref}" is not in the custom-SQL SELECT of the collapsed model -- add it to the source query to migrate.)] unless ctx[:col_norm].include?(ctx[:nk].call(base))
+  ['unresolved-calc', %(field "#{ref}" did not resolve to a model column.)]
+end
+
+ctx = { name_to_cap: name_to_cap, cap_by_norm: cap_by_norm, param_switch: param_switch,
+        param_filter: param_filter, inert: inert, met_norm: met_norm, col_norm: col_norm,
+        nk: method(:nk), calc_internal: calc_internal }
+
+kept = Set.new((wb['pages'] || []).flat_map { |pg| (pg['elements'] || []).map { |e| e['id'] } })
+ref_re = /\[master\/([^\]]+)\]/i
+collect = lambda do |o, acc|
+  case o
+  when Hash  then o.each_value { |v| collect.call(v, acc) }
+  when Array then o.each { |v| collect.call(v, acc) }
+  when String then o.scan(ref_re) { |m| acc << m[0] }
+  end
+  acc
+end
+
+PRIORITY = %w[absent-from-sql unresolved-calc aggregate-metric inert-in-source param-measure-picker param-driven].freeze
+rows = []
+(specs['pages'] || []).each do |pg|
+  (pg['elements'] || []).each do |e|
+    next if kept.include?(e['id'])
+    refs = collect.call(e, []).uniq.reject { |r| col_lc.include?(r.downcase) }
+    cats = refs.map { |r| classify(r, ctx) }
+    cats << ['unresolved-calc', 'no resolvable reason captured'] if cats.empty?
+    distinct = cats.map(&:first).uniq.sort_by { |c| PRIORITY.index(c) || 99 }
+    primary = distinct.first
+    reason = (cats.find { |c| c[0] == primary } || cats[0])[1]
+    rows << { page: pg['name'] || pg['id'], tile: e['id'], kind: e['kind'] || e['type'],
+              category: primary, also: distinct[1..] || [], reason: reason, refs: refs.first(5) }
+  end
+end
+
+by_cat = Hash.new(0); rows.each { |r| by_cat[r[:category]] += 1 }
+md = +"# Migration — Not Migrated (and why)\n\n#{rows.size} tile(s) not migrated, by reason:\n\n"
+by_cat.sort_by { |_, n| -n }.each { |c, n| md << "- **#{c}**: #{n}\n" }
+md << "\n> Categories: `absent-from-sql` = the source custom-SQL doesn't select the field (fix the query); "
+md << "`param-measure-picker`/`param-driven` = rebuild as a Sigma control-driven Switch/control; "
+md << "`inert-in-source` = the Tableau calc is commented-out in the source; "
+md << "`aggregate-metric` = plot as a measure; `unresolved-calc` = window/LOD/copy — rebuild in a grouped element.\n\n---\n\n"
+rows.group_by { |r| r[:page] }.each do |pg, list|
+  md << "## #{pg} (#{list.size})\n\n"
+  list.each do |r|
+    also = r[:also].empty? ? '' : " _(also: #{r[:also].join(', ')})_"
+    refs = r[:refs].empty? ? '' : " _[refs: #{r[:refs].join(', ')}]_"
+    md << "- `#{r[:tile]}` (#{r[:kind]}) — **#{r[:category]}**#{also}: #{r[:reason]}#{refs}\n"
+  end
+  md << "\n"
+end
+File.write(opts[:out], md)
+warn "migration-notes: #{rows.size} tile(s) categorized -> #{opts[:out]}"
+by_cat.sort_by { |_, n| -n }.each { |c, n| warn format('  %3d  %s', n, c) }


### PR DESCRIPTION
## Summary
Productionizes the empty-tab punch-list into the orchestrated Tableau→Sigma migration so **no empty/sparse Sigma tab is mysterious** for a customer.

- **`mechanical-specs.run_converter`** (local + hosted): pass through `out.workbookPatterns` (param measure-pickers → control-driven Switch, param-filters, window/LOD calcs) + `out.parameters` (control values/defaults) into `conv-meta.json` — these were dropped, starving the build layer + report.
- **`migration-notes.rb`** (new): reads `conv-meta.json` + `chart-specs.json` + final `wb-spec.json` + the source `.twb`, and categorizes every non-migrated tile with a binding-constraint reason + action: `absent-from-sql`, `param-measure-picker`, `param-driven`, `inert-in-source`, `aggregate-metric`, `unresolved-calc`. Resolves `Calculation_NNN` → captions and detects calcs that are fully `//`-commented in the source (dead in Tableau too). Aligns with the cross-converter reason-taxonomy goal (bead `ncwe`).
- **`migrate-tableau.rb`** Phase 4: emits `migration-notes.md` after the workbook posts (best-effort).

## DDMX result
30 dropped tiles → **16 absent-from-sql** (custom-SQL doesn't select `LINK_IMPLEMENTED`/`MEDAL_RANK`/`IS_HOLDOUT`), 8 window/copy calcs, 5 aggregate-metrics, 1 param-driven. i.e. the sparse tabs are **source-side**, not converter failures — and now each is an actionable line item.

## Companion
Converter capability (param-switch/filter/parameters) lands in twells89/sigma-data-model-mcp PR #70; the control-driven Switch recipe was verified live (KPI=24 proof).

## Follow-up (n4pi.9 remainder)
Auto-apply the Switch recipe in `build-charts`/`build-workbook` (tag param-picker charts → set the tile measure to the inlined Switch + emit the control). Needs the `Calculation_NNN`→caption resolution ported into the skill build layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)