### PR TITLE
tableau: param measure-pickers (n4pi.10) + synth-twb-e2e harness (n4pi.5)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -73,6 +73,10 @@ OptionParser.new do |p|
   p.on('--dashboard NAME', 'Build only this dashboard (name: exact or unique substring, case-insensitive). Repeatable.') { |v| (opts[:dashboards] ||= []) << v }
   p.on('--page ID', 'Build only the dashboard whose zone-root id matches (rarely needed; --dashboard is the handle).') { |v| (opts[:pages] ||= []) << v }
   p.on('--auto-controls', 'Auto-emit Sigma controls from shared-view filters in --meta')              { opts[:auto_controls] = true }
+  # Converter meta (conv-meta.json) carrying workbookPatterns — used to auto-wire
+  # parameter measure-pickers (kind:param-switch) into a control-driven Switch
+  # tile measure (n4pi.10). Optional; absent ⇒ pickers stay surfaced as notes.
+  p.on('--workbook-patterns PATH', 'converter conv-meta.json (workbookPatterns) — auto-wire param measure-pickers') { |v| opts[:wb_patterns] = v }
   p.on('--out PATH')                { |v| opts[:out] = v }
   # Where the migration COVERAGE ledger lands (the aggregated drop/approx report
   # migrate-tableau.rb surfaces). Default: coverage.json next to --out. bead beads-sigma-59mk.
@@ -1320,6 +1324,136 @@ def translate_if_chain_on_param(formula, param_captions, mmap = nil, columns_by_
   "Switch(#{parts.join(', ')})"
 end
 
+# ---- Converter param measure-pickers (workbookPatterns kind:param-switch) ----
+# The Tableau→Sigma converter detects a parameter measure-picker
+# (`CASE [Parameters].[P] WHEN v THEN <measure> … END`) and emits a clean
+# `param-switch` workbookPattern: { name (the calc CAPTION), controlId, paramName,
+# cases:[{when,then}], elseExpr, formula }. The build layer materialises it as a
+# control-driven Switch — a single-select control under the EXACT controlId the
+# converter baked into the formula, and the tile's MEASURE set to the Switch
+# (branch results remapped onto the master columns). This auto-wires the recipe
+# that was verified by hand (KPI=24) instead of leaving it a manual note.
+#
+# $param_switch_by_key bridges Calculation_NNN→caption: the layout references a
+# picker calc by its internal `Calculation_<id>`, but the converter keys the
+# pattern by the human caption — so we index BOTH (every Calculation_<id> whose
+# .twb caption equals the pattern name) and the caption itself.
+$param_switches = []
+$param_switch_by_key = {}
+$param_switch_used = [] # controlIds actually wired onto a tile — emit only these
+
+def load_param_switches(wb_patterns_path, meta)
+  return unless wb_patterns_path && File.exist?(wb_patterns_path)
+  raw = (JSON.parse(File.read(wb_patterns_path)) rescue {})
+  wp = raw['workbookPatterns'] || raw['workbook_patterns'] || []
+  cbg = meta['columns_by_guid'] || {}
+  cap_to_ids = Hash.new { |h, k| h[k] = [] }
+  cbg.each { |gid, info| c = (info || {})['caption']; cap_to_ids[c.to_s.downcase] << gid if c && !c.to_s.empty? }
+  wp.select { |p| p['kind'] == 'param-switch' }.each do |p|
+    name = p['name'].to_s
+    keys = ([name.downcase] + cap_to_ids[name.downcase].map(&:downcase)).uniq
+    sw = { 'name' => name, 'control_id' => p['controlId'], 'param_name' => p['paramName'],
+           'cases' => p['cases'] || [], 'else' => p['elseExpr'], 'keys' => keys }
+    $param_switches << sw
+    keys.each { |k| $param_switch_by_key[k] = sw }
+  end
+end
+
+# Look up a param-switch by a chart header / field caption OR its Calculation_NNN
+# internal id (any of several candidate refs). Returns the switch hash or nil.
+def param_switch_for(*candidates)
+  candidates.flatten.compact.each do |c|
+    key = c.to_s.gsub(/^\[|\]$/, '').strip.downcase
+    sw = $param_switch_by_key[key]
+    return sw if sw
+  end
+  nil
+end
+
+# Build the inline, SIBLING-form Switch measure formula for a param-switch + the
+# list of master columns the Switch's branches reference (to materialise as hidden
+# passthrough siblings — a `[Master/X]` nested inside Switch() does NOT resolve
+# standalone). Returns nil when a branch carries a chart-context-only window
+# function (window_sum / running_* / rank / lookup) that can't live in an inline
+# Switch — those stay surfaced as a migration note, never emitted broken.
+def param_switch_inline(sw, mmap, cbg)
+  branches = sw['cases'].map { |c| c['then'].to_s } + [sw['else'].to_s]
+  # A branch carrying a chart-context-only window/table calc can't live in an
+  # inline Switch — surface the whole picker as a note instead of emitting broken.
+  return nil if branches.any? { |b| b =~ /\b(?:window_\w+|running_\w+|rank|index|lookup|previous_value|total)\s*\(/i }
+  # Split the master-map into real COLUMNS (passthrough-able) vs aggregate METRICS
+  # (entries that carry a `formula` — derive_master registers these NOT as master
+  # columns but as inline aggregate formulas, e.g. "Signs - Actuals" =
+  # CountDistinct([Master/STORE_ACCOUNT_ID])). A metric ref can't be a passthrough
+  # sibling (the master table has no such column); it must be INLINED as its
+  # formula — exactly what the normal measure path does (meas['formula']).
+  col_names = {}
+  metric_formulas = {}
+  mmap.each_value do |v|
+    next unless v.is_a?(Hash) && v['name']
+    if v['formula'] && !v['formula'].to_s.empty?
+      metric_formulas[v['name'].downcase] = v['formula']
+    else
+      col_names[v['name'].downcase] = true
+    end
+  end
+  unresolved = []
+  # Remap a branch result onto [Master/…], inline any metric refs to their formula,
+  # then require every remaining ref to be the control or a real master COLUMN. A
+  # branch that still references something the master can't carry — an un-emitted
+  # calc, or a caption with a '/' like "TAM / CW" that remap skips (a slash signals
+  # an already-qualified ref) — is replaced with Null so the OTHER options + the
+  # control keep working (graceful degradation, never a broken dependency), and the
+  # dropped option is recorded so it's surfaced (never silent).
+  resolve_branch = lambda do |label, expr|
+    return 'Null' if expr.nil? || expr.empty?
+    r = remap_param_branch(expr, mmap, cbg)
+    4.times do
+      changed = false
+      r = r.gsub(%r{\[Master/([^\]]+)\]}) do
+        mf = metric_formulas[Regexp.last_match(1).downcase]
+        if mf then changed = true; "(#{mf})" else Regexp.last_match(0) end
+      end
+      break unless changed
+    end
+    bad = r.scan(/\[([^\]]+)\]/).flatten.reject do |ref|
+      ref.start_with?('ctl-') ||
+        (ref.start_with?('Master/') && col_names[ref.sub(%r{\AMaster/}, '').downcase])
+    end
+    if bad.any?
+      unresolved << label
+      'Null'
+    else
+      r
+    end
+  end
+  parts = ["[#{sw['control_id']}]"]
+  sw['cases'].each do |c|
+    parts << coerce_case_literal(%("#{c['when']}"))
+    parts << resolve_branch.call(c['when'].to_s, c['then'].to_s)
+  end
+  parts << resolve_branch.call('(else)', sw['else'].to_s) if sw['else'] && !sw['else'].to_s.empty?
+  # All branches unresolvable ⇒ nothing to plot; let it fall through to a note.
+  return nil if unresolved.size >= sw['cases'].size && (sw['else'].nil? || sw['else'].to_s.empty? || unresolved.include?('(else)'))
+  master_form = "Switch(#{parts.join(', ')})"
+  branch_refs = master_form.scan(%r{\[Master/([^\]]+)\]}).flatten.uniq
+  { 'sibling_form' => master_form.gsub(%r{\[Master/([^\]]+)\]}) { "[#{Regexp.last_match(1)}]" },
+    'branch_refs' => branch_refs, 'control_id' => sw['control_id'], 'name' => sw['name'],
+    'unresolved' => unresolved.uniq }
+end
+
+# Add hidden passthrough sibling columns ([Master/X] resolves standalone) for each
+# branch ref, so the nested-in-Switch [X] refs resolve. Idempotent on name.
+def add_switch_siblings!(element, branch_refs)
+  existing = (element['columns'] ||= []).map { |c| c['name'] }.compact
+  branch_refs.each do |b|
+    next if existing.include?(b)
+    bid = "swcol-#{b.downcase.gsub(/\W+/, '-')[0..40]}".sub(/-$/, '')
+    element['columns'] << { 'id' => bid, 'name' => b, 'formula' => "[Master/#{b}]" }
+    existing << b
+  end
+end
+
 # Pick the Tableau format for a given header against a worksheet's formats dict.
 # Match by best-effort: field ref contains a column GUID OR a friendly name
 # fragment that overlaps with the header.
@@ -1497,7 +1631,11 @@ def build_pivot_element(z, meta, mmap, opts, warnings, data_elements = [])
       col_obj['format'] = { 'kind' => 'datetime', 'formatString' => '%b %Y' }
     end
     cols_array << col_obj
-    user_vals << { 'col' => col_obj, 'name' => m['name'].to_s.strip } if target == :value && %w[usr user].include?(deriv)
+    # Carry the field's raw ref (its Calculation_<id> internal id) so a converter
+    # param measure-picker can be matched by id, not just the resolved caption
+    # (the Calculation_NNN→caption bridge — n4pi.10).
+    user_vals << { 'col' => col_obj, 'name' => m['name'].to_s.strip,
+                   'raw' => (field['column'] || field['raw']).to_s } if target == :value && %w[usr user].include?(deriv)
     case target
     when :row   then rows_by    << { 'id' => col_id }
     when :col   then cols_by    << { 'id' => col_id }
@@ -1555,6 +1693,30 @@ def build_pivot_element(z, meta, mmap, opts, warnings, data_elements = [])
   #     UNVALIDATED in pivot context — dropped from the grid with a loud warn.
   win_stage = [] # { 'col' =>, 'plan' => }
   user_vals.each do |uv|
+    # Converter param measure-picker (n4pi.10): if this value IS a param-switch
+    # calc (matched by its resolved caption OR its Calculation_<id> internal id),
+    # use the converter's CLEAN Switch — its cases are already resolved to captions,
+    # so it bridges the Calculation_NNN→caption gap that re-translating the raw
+    # Tableau formula below hits (the raw branch refs are [Calculation_<id>] sibling
+    # refs that don't resolve, and the ws_calc lookup keys off the internal id while
+    # this value keys off the caption). Materialize the [Master/Y] branch refs as
+    # hidden sibling cols and rewrite to [Y] (nested [Master/Y] doesn't resolve).
+    psw = param_switch_for(uv['name'], uv['raw'], uv['col']['name'])
+    if psw && (plan = param_switch_inline(psw, mmap, meta['columns_by_guid'] || {}))
+      existing_names = cols_array.map { |c| c['name'] }.compact
+      plan['branch_refs'].each do |bn|
+        next if existing_names.include?(bn)
+        bid = "pvsw-#{bn.downcase.gsub(/\W+/, '-')[0..36]}".sub(/-$/, '')
+        cols_array << { 'id' => bid, 'name' => bn, 'formula' => "[Master/#{bn}]" }
+        existing_names << bn
+      end
+      uv['col']['formula'] = plan['sibling_form']
+      $param_switch_used << plan['control_id'] unless $param_switch_used.include?(plan['control_id'])
+      drp = plan['unresolved'].any? ? " (option(s) #{plan['unresolved'].join(', ')} show blank — their measure isn't a master column)" : ''
+      warnings << "'#{cap}' pivot value '#{uv['name']}' → converter param measure-picker Switch over " \
+                  "[#{plan['control_id']}] (#{psw['cases'].size} option(s))#{drp}: #{plan['sibling_form'].gsub(/\s+/, ' ')[0..100]}"
+      next
+    end
     ws_calc = (z['calculations'] || []).find do |c|
       c['name'].to_s.gsub(/^\[|\]$/, '').strip.casecmp?(uv['name'])
     end
@@ -1725,6 +1887,12 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
   deriv = measure_field['derivation'].to_s.downcase
   norm = ->(x) { x.to_s.gsub(/^\[|\]$/, '').strip.downcase }
 
+  # Parameter measure-picker (n4pi.10): if this KPI's measure IS a converter
+  # param-switch calc (matched by caption OR its Calculation_NNN internal id),
+  # the value becomes a control-driven Switch over the materialised branch cols.
+  psw = param_switch_for(field_cap, measure_field['raw'], measure_field['guid'])
+  pswitch_plan = psw && param_switch_inline(psw, mmap, meta['columns_by_guid'] || {})
+
   source_eid = opts[:master_id]
   two_stage_formula = nil
   ws_calc_lod = (z['calculations'] || []).find { |c| norm.call(c['name']) == norm.call(field_cap) }
@@ -1767,7 +1935,7 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
   #   3. row-level worksheet calc (DATEDIFF(...)) → translate, wrap in the
   #      shelf aggregation (Avg/Sum/...)
   #   4. plain master column wrapped in the shelf aggregation
-  formula = two_stage_formula || master['formula']
+  formula = (pswitch_plan && pswitch_plan['sibling_form']) || two_stage_formula || master['formula']
   ws_calc = (z['calculations'] || []).find { |c| norm.call(c['name']) == norm.call(field_cap) }
   if formula.nil? && ws_calc && %w[usr user].include?(deriv)
     formula = translate_user_agg_formula(ws_calc['formula'], mmap, meta['columns_by_guid'] || {})
@@ -1828,6 +1996,15 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
     'value'   => { 'columnId' => measure_col_id }
   }
 
+  # Param measure-picker: materialise the hidden passthrough sibling cols the
+  # Switch's branches reference, and register the control for emission (n4pi.10).
+  if pswitch_plan
+    add_switch_siblings!(element, pswitch_plan['branch_refs'])
+    $param_switch_used << pswitch_plan['control_id'] unless $param_switch_used.include?(pswitch_plan['control_id'])
+    warnings << "'#{cap}' KPI measure '#{field_cap}' is a parameter measure-picker → control-driven Switch over " \
+                "[#{pswitch_plan['control_id']}] (#{psw['cases'].size} option(s)): #{pswitch_plan['sibling_form'][0..100]}"
+  end
+
   # If the Tableau worksheet had Show Mark Labels on (typical for KPIs since
   # the number IS the chart), we don't need a separate dataLabel — kpi-chart
   # always renders the value. No-op.
@@ -1837,6 +2014,14 @@ end
 
 # A workbook may have multiple dashboards; iterate all and concatenate elements.
 # Drop the chart_kind=automatic warnings to stderr so the caller can act on them.
+# Converter param measure-pickers (kind:param-switch) — indexed by caption +
+# Calculation_NNN id so a picker plotted as a tile measure becomes a control-
+# driven Switch (n4pi.10). Optional; no --workbook-patterns ⇒ empty index. Loaded
+# here (after the helper defs above, before the element loop) so the globals it
+# populates are initialised first.
+load_param_switches(opts[:wb_patterns], meta)
+warn "loaded #{$param_switches.size} param measure-picker(s) from #{opts[:wb_patterns]}" if $param_switches.any?
+
 elements = []
 data_elements = [] # hidden helper elements (scatter grouped sources — bead z1d0)
 warnings = []
@@ -2097,6 +2282,11 @@ layout.each do |dash|
       warnings << "no master column matched measure header '#{meas_hdr}' for '#{cap}'"
       meas = { 'id' => "m-#{meas_hdr.downcase.gsub(/\W+/,'-')}", 'name' => meas_hdr }
     end
+    # Parameter measure-picker (n4pi.10): a measure that IS a converter param-
+    # switch calc (matched by caption OR its Calculation_NNN id) becomes a
+    # control-driven Switch tile measure over materialised branch cols.
+    chart_pswitch = param_switch_for(meas_hdr, meas && meas['name'])
+    chart_pswitch_plan = chart_pswitch && param_switch_inline(chart_pswitch, mmap, meta['columns_by_guid'] || {})
     color_dim = nil
     if color_hdr
       color_dim = map_column(color_hdr, mmap)
@@ -2137,10 +2327,10 @@ layout.each do |dash|
     # aggregated (typically a ratio like SUM(a)/COUNT(b)). Wrapping it in
     # Sum([Master/X]) is unresolvable when no master column carries the ratio —
     # decompose the calc formula into a direct Sigma formula instead (bead k3kk).
-    user_agg_formula = nil
+    user_agg_formula = chart_pswitch_plan && chart_pswitch_plan['sibling_form']
     window_plan = nil
     window_calc_name = nil
-    if agg_label == 'User' && meas['formula'].nil?
+    if user_agg_formula.nil? && agg_label == 'User' && meas['formula'].nil?
       norm = ->(x) { x.to_s.gsub(/^\[|\]$/, '').strip.downcase }
       user_calc = (z['calculations'] || []).find do |c|
         n = norm.call(c['name'])
@@ -3105,6 +3295,16 @@ layout.each do |dash|
       warnings << "'#{cap}' uses Tableau calc #{c['name']}: #{hint}. Formula: #{formula[0..120]}"
     end
 
+    # Param measure-picker (n4pi.10): the tile measure was set to the control-
+    # driven Switch (sibling form) above — materialise the hidden passthrough
+    # sibling cols its branches reference, and register the control for emission.
+    if chart_pswitch_plan
+      add_switch_siblings!(element, chart_pswitch_plan['branch_refs'])
+      $param_switch_used << chart_pswitch_plan['control_id'] unless $param_switch_used.include?(chart_pswitch_plan['control_id'])
+      warnings << "'#{cap}' measure '#{meas_hdr}' is a parameter measure-picker → control-driven Switch over " \
+                  "[#{chart_pswitch_plan['control_id']}] (#{chart_pswitch['cases'].size} option(s))"
+    end
+
     # Stamp with worksheet + dashboard so the page emitters can group.
     element['_worksheet'] = cap
     element['_dashboard'] = dash['dashboard']
@@ -3249,6 +3449,16 @@ if opts[:auto_controls]
   referenced_caps = (meta['worksheets'] || {}).values
     .flat_map { |w| (w['calculations'] || []).flat_map { |c| c['parameter_refs'] || [] } }
     .uniq
+  # A Tableau parameter that drives a WIRED measure-picker Switch already has its
+  # control emitted under the converter's controlId (ctl-parameter-<n>); don't ALSO
+  # emit the legacy auto-param control (ctl-param-<caption>) for the same parameter
+  # — that second control binds nothing and trips the control lint (n4pi.10).
+  picker_param_caps = {}
+  $param_switches.each do |sw|
+    next unless $param_switch_used.include?(sw['control_id'])
+    pc = (meta['columns_by_guid'] || {}).dig(sw['param_name'], 'caption')
+    picker_param_caps[pc.to_s.downcase] = true if pc && !pc.to_s.empty?
+  end
   # A parameter is typically declared once in the workbook metadata AND again in
   # every worksheet's datasource-dependencies that references it, so
   # meta['parameters'] commonly carries many duplicates of the same caption
@@ -3261,6 +3471,10 @@ if opts[:auto_controls]
     next if cap.empty?
     next if seen_param_caps[cap.downcase]
     seen_param_caps[cap.downcase] = true
+    if picker_param_caps[cap.downcase]
+      warnings << "parameter '#{cap}' drives a measure-picker Switch — control emitted under the converter controlId; skipping the redundant auto-param control"
+      next
+    end
     unless referenced_caps.include?(cap)
       warnings << "parameter '#{cap}' is defined in Tableau but not referenced by any worksheet calc — skipped auto-control (orphan parameter)"
       next
@@ -3331,6 +3545,40 @@ if opts[:auto_controls]
       }.map { |e| { 'element_id' => e['id'], 'name' => e['name'] } }
     }
   end
+end
+
+# ---- Param measure-picker controls (n4pi.10) ------------------------------
+# Emit a single-select segmented control under the EXACT controlId the converter
+# baked into each param-switch's Switch formula (e.g. ctl-parameter-17), for every
+# picker actually wired onto a tile above. Values = the case match literals; the
+# control's display name is the parameter's caption when known. Not gated on
+# --auto-controls: the picker wiring already happened during chart building, and
+# the Switch tile measure is inert without its control.
+$param_switches.each do |sw|
+  next unless $param_switch_used.include?(sw['control_id'])
+  next if param_controls.any? { |c| c['controlId'] == sw['control_id'] }
+  values = sw['cases'].map { |c| c['when'].to_s }
+  next if values.empty?
+  pcap = (meta['columns_by_guid'] || {}).dig(sw['param_name'], 'caption') || sw['param_name'] || sw['name']
+  param_controls << {
+    'id'          => "el-#{sw['control_id']}",
+    'kind'        => 'control',
+    'controlId'   => sw['control_id'],
+    'name'        => pcap,
+    'controlType' => 'segmented',
+    'source'      => { 'kind' => 'manual', 'valueType' => 'text', 'values' => values, 'labels' => values },
+    'value'       => values.first,
+    'includeNulls' => 'when-no-value-is-selected'
+  }
+  control_scope_records << {
+    'controlId' => sw['control_id'], 'name' => pcap, 'mechanism' => 'formula',
+    'source_signal' => "tableau parameter measure-picker '#{sw['name']}' → control-driven Switch",
+    'intended' => elements.select { |e|
+      (e['columns'] || []).any? { |c| c['formula'].to_s.include?("[#{sw['control_id']}]") }
+    }.map { |e| { 'element_id' => e['id'], 'name' => e['name'] } }
+  }
+  warnings << "param measure-picker '#{sw['name']}' → segmented control [#{sw['control_id']}] " \
+              "with #{values.size} option(s): #{values.join(' / ')}"
 end
 
 # ---- Auto-generated controls from shared-view filters (--auto-controls) ----

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enrich-master-map.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enrich-master-map.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Enrich a derive_master master-map with caption-flexible lookup keys (n4pi.7).
+
+build-charts resolves a Tableau chart header to a master column by regex-matching
+the header against the master-map's keys. derive_master emits one key per master
+column (its display name, plus a few agg/date-part prefixes). Two classes of
+header still miss:
+
+  (a) space / underscore / case variants — a warehouse column "WEEK_OF" won't
+      match a chart header "Week Of" because the derive_master regex escapes the
+      literal underscore.
+  (b) friendly Tableau CAPTIONS — a chart plots "Weekly Goal" but the master
+      column is the warehouse-named "WEEK_GOAL"; the caption→field mapping lives
+      in the .twb (<column caption='..' name='[..]'>), not in the warehouse name.
+
+This adds both so signal-built charts (no view CSV) resolve their measures/dims.
+The selection VALUE never changes — only additional match keys are added; the
+existing keys win first (insertion order is preserved on re-load).
+
+Usage: enrich-master-map.py <run-dir> <twb-path>
+  <run-dir>/master-map.json   (read + rewritten in place)
+  <run-dir>/master-cols.yaml  (read-only; the authoritative column list)
+"""
+import json
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("enrich-master-map.py needs PyYAML (pip install pyyaml)")
+
+run = sys.argv[1] if len(sys.argv) > 1 else "."
+twb = sys.argv[2] if len(sys.argv) > 2 else None
+
+# Optional Tableau CSV aggregation / date-part prefix the chart header may carry
+# (mirrors mechanical-specs.header_regex so an enriched key tolerates the same).
+AGG = (
+    r"(?:(?:sum|avg|average|min|max|median|distinct count|count) of "
+    r"|(?:avg|sum|min|max|med|cnt|ctd)\.\s*"
+    r"|(?:second|minute|hour|day|week|month|quarter|year) of )?"
+)
+
+mmap = json.load(open(f"{run}/master-map.json"))
+mcols = yaml.safe_load(open(f"{run}/master-cols.yaml"))["columns"]
+
+
+def norm(s):
+    return re.sub(r"[^a-z0-9]", "", s.lower())
+
+
+def desuffix(name):
+    return re.sub(r"_\d+$", "", name)  # WEEK_OF_2 -> WEEK_OF
+
+
+# Index master cols by normalized de-suffixed warehouse base (first wins —
+# the un-suffixed/earlier-ordered column is preferred).
+by_base = {}
+for c in mcols:
+    by_base.setdefault(norm(desuffix(c["name"])), c)
+
+added = 0
+# (a) space/underscore/case-flexible entry for every master column name.
+for c in mcols:
+    pat = re.escape(c["name"]).replace("_", r"[\s_]*")
+    key = f"(?i)^{AGG}{pat}$"
+    if key not in mmap:
+        mmap[key] = {"id": c["id"], "name": c["name"]}
+        added += 1
+
+# (b) caption -> column via the .twb <column caption=.. name=..> metadata.
+capmap = 0
+if twb:
+    xml = open(twb, encoding="utf-8", errors="replace").read()
+    caps = re.findall(
+        r"<column\b[^>]*\bcaption='([^']+)'[^>]*\bname='\[([^']+)\]'", xml
+    )
+    for cap, field in caps:
+        base = re.sub(r"\s*\([^)]*\)\s*", "", field)       # strip (Custom SQL QueryN)
+        base = re.sub(r"\s*\(copy\)_\d+$", "", base)
+        col = by_base.get(norm(base))
+        if not col:
+            continue
+        key = f"(?i)^{AGG}{re.escape(cap)}$"
+        if key not in mmap:
+            mmap[key] = {"id": col["id"], "name": col["name"]}
+            capmap += 1
+
+json.dump(mmap, open(f"{run}/master-map.json", "w"), indent=2)
+print(
+    f"enriched mmap: +{added} normalized, +{capmap} caption entries "
+    f"(total {len(mmap)})"
+)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/synth-twb-e2e.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/synth-twb-e2e.rb
@@ -114,8 +114,14 @@ gw_path = File.join(WORK, 'get-workbook.json')
 unless File.exist?(gw_path)
   # Synthesize from the layout's worksheet names so build-charts can map each
   # chart zone to a "view" (id == slug(name)); no CSV → signal-built tile.
+  # build-charts keys the view lookup off z['caption'] (the worksheet name), so
+  # synthesize one stub per chart zone caption (not 'worksheet'/'name', which the
+  # layout zones don't carry — that left standard charts unmatched).
   layout = JSON.parse(File.read(layout_path))
-  names = layout.flat_map { |d| (d['zones'] || []).map { |z| z['worksheet'] || z['name'] } }.compact.uniq
+  names = layout.flat_map do |d|
+    (d['zones'] || []).select { |z| z['kind'] == 'chart' }
+                      .map { |z| z['caption'] || z['worksheet'] || z['name'] }
+  end.compact.uniq
   views = names.map { |n| { 'name' => n, 'id' => n.downcase.gsub(/\W+/, '-').gsub(/^-|-$/, '') } }
   File.write(gw_path, JSON.pretty_generate('views' => { 'view' => views }))
   puts "  synthesized get-workbook.json with #{views.size} view stub(s) from layout worksheets"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/synth-twb-e2e.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/synth-twb-e2e.rb
@@ -1,0 +1,359 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# synth-twb-e2e — live end-to-end test of the mechanical Tableau→Sigma chain
+# against a SYNTHETIC / EMPTY warehouse, with NO live Tableau (n4pi.5).
+#
+# WHY: a dataless .twb (customer can't share data) still has to MIGRATE — the
+# converter must emit a data model whose custom-SQL executes and a workbook whose
+# charts RESOLVE at live POST. A code-only Stage-1 "build" is optimistic: it
+# happily emits charts that reference columns the live model can't see. Only a
+# real POST against a warehouse reveals that. So we:
+#   1. (you, once) synthesize an EMPTY but correctly-TYPED warehouse from the
+#      .twb's custom-SQL — the DM POST executes kind:sql, so empty rows suffice,
+#      and custom-SQL elements bypass the Sigma catalog (no schema refresh).
+#   2. run converter → DM POST (with an error-column repair loop) → derive_master
+#      → build-charts → build-workbook → POST workbook → render.
+# Charts resolving at POST == the blend collapsed correctly and the build layer
+# wired every measure/dim/control. Empty tabs are then provably SOURCE-side
+# (custom-SQL omits the field) or inert source calcs, surfaced in migration-notes.
+#
+# This drives the skill's own scripts/*.rb directly (migrate-tableau.rb has no
+# offline mode). It does NOT touch the .twb — discovery artifacts are reused or
+# regenerated from the static workbook XML.
+#
+# Usage:
+#   ruby scripts/synth-twb-e2e.rb \
+#     --twb /path/workbook-content.twb \
+#     --conn <sigma-connection-id> --db <DB> --schema <SCHEMA> \
+#     --folder <sigma-folder-id> \
+#     [--build /path/build/tableau.js]   # local converter; omit → hosted MCP
+#     [--discover-dir DIR]               # pre-staged layout.json/get-workbook.json/views/
+#     [--workdir DIR] [--name "WB NAME"] \
+#     [--dashboard "Name"]...            # per-dashboard scoping (repeatable) \
+#     [--grant-role ROLE]                # GRANT SELECT on synth tables via `snow` CLI
+#     [--no-render] [--keep]
+#
+# Prereqs: SIGMA_API_TOKEN reachable via scripts/get-token.sh; node (for a local
+# --build); python3 + PyYAML (for enrich-master-map.py); the synth warehouse
+# tables already created + granted to the connection's role.
+require 'json'
+require 'yaml'
+require 'fileutils'
+require 'open3'
+require 'optparse'
+require 'set'
+require 'tmpdir'
+
+HERE = __dir__
+$LOAD_PATH.unshift HERE
+$LOAD_PATH.unshift File.join(HERE, 'lib')
+require File.join(HERE, 'mechanical-specs.rb')
+require 'sigma_rest'
+
+opts = { render: true }
+OptionParser.new do |p|
+  p.on('--twb PATH')          { |v| opts[:twb] = v }
+  p.on('--conn ID')           { |v| opts[:conn] = v }
+  p.on('--db DB')             { |v| opts[:db] = v }
+  p.on('--schema SCHEMA')     { |v| opts[:schema] = v }
+  p.on('--folder ID')         { |v| opts[:folder] = v }
+  p.on('--build PATH')        { |v| opts[:build] = v }
+  p.on('--discover-dir DIR')  { |v| opts[:discover] = v }
+  p.on('--workdir DIR')       { |v| opts[:workdir] = v }
+  p.on('--name NAME')         { |v| opts[:name] = v }
+  p.on('--dashboard NAME')    { |v| (opts[:dashboards] ||= []) << v }
+  p.on('--grant-role ROLE')   { |v| opts[:grant_role] = v }
+  p.on('--no-render')         { opts[:render] = false }
+  p.on('--keep')              { opts[:keep] = true }
+end.parse!
+
+%i[twb conn db schema folder].each { |k| abort("missing --#{k.to_s.tr('_', '-')}") unless opts[k] }
+abort("twb not found: #{opts[:twb]}") unless File.exist?(opts[:twb])
+
+WORK = opts[:workdir] || File.join(Dir.tmpdir, "synth-e2e-#{File.basename(opts[:twb], '.*')}")
+FileUtils.mkdir_p WORK
+NAME = opts[:name] || "Synth E2E — #{File.basename(opts[:twb], '.*')}"
+
+def run!(cmd, allow_fail: false)
+  puts "+ #{cmd.join(' ')}"
+  o, e, s = Open3.capture3(*cmd)
+  puts o[-2000..] || o unless o.to_s.empty?
+  warn e[-2000..] || e unless e.to_s.empty?
+  abort "FAILED (#{s.exitstatus}): #{cmd.first}" unless s.success? || allow_fail
+  [o, e, s]
+end
+
+# ---------------------------------------------------------------------------
+# 0. Discovery artifacts (layout.json, layout-meta.json, get-workbook.json,
+#    views/). Reuse a pre-staged --discover-dir if given; otherwise regenerate
+#    layout from the static .twb and SYNTHESIZE a get-workbook.json from the
+#    worksheet names the layout references (dataless run → no view CSVs → charts
+#    build from shelf signals via build-charts' synthesize_view_from_signals).
+# ---------------------------------------------------------------------------
+puts "\n== 0. discovery artifacts =="
+if opts[:discover]
+  %w[layout.json layout-meta.json get-workbook.json].each do |f|
+    src = File.join(opts[:discover], f)
+    FileUtils.cp(src, File.join(WORK, f)) if File.exist?(src)
+  end
+  vsrc = File.join(opts[:discover], 'views')
+  FileUtils.cp_r(vsrc, WORK) if File.directory?(vsrc) && !File.directory?(File.join(WORK, 'views'))
+end
+
+layout_path = File.join(WORK, 'layout.json')
+unless File.exist?(layout_path)
+  cmd = ['ruby', File.join(HERE, 'parse-twb-layout.rb'), opts[:twb], layout_path]
+  (opts[:dashboards] || []).each { |d| cmd += ['--dashboard', d] }
+  run!(cmd)
+end
+meta_path = File.join(WORK, 'layout-meta.json')
+abort("layout-meta.json missing after discovery (#{meta_path})") unless File.exist?(meta_path)
+
+gw_path = File.join(WORK, 'get-workbook.json')
+unless File.exist?(gw_path)
+  # Synthesize from the layout's worksheet names so build-charts can map each
+  # chart zone to a "view" (id == slug(name)); no CSV → signal-built tile.
+  layout = JSON.parse(File.read(layout_path))
+  names = layout.flat_map { |d| (d['zones'] || []).map { |z| z['worksheet'] || z['name'] } }.compact.uniq
+  views = names.map { |n| { 'name' => n, 'id' => n.downcase.gsub(/\W+/, '-').gsub(/^-|-$/, '') } }
+  File.write(gw_path, JSON.pretty_generate('views' => { 'view' => views }))
+  puts "  synthesized get-workbook.json with #{views.size} view stub(s) from layout worksheets"
+end
+FileUtils.mkdir_p File.join(WORK, 'views')
+# Also copy the .twb into WORK so migration-notes (and a later re-run) find it.
+FileUtils.cp(opts[:twb], File.join(WORK, 'workbook-content.twb')) unless
+  File.exist?(File.join(WORK, 'workbook-content.twb'))
+
+# ---------------------------------------------------------------------------
+# Optional: GRANT SELECT on the synth warehouse tables to the connection's role
+# (the converter qualifies tables as <db>.<schema>.<table>). Best-effort via the
+# `snow` CLI; the DM POST is the real verifier so a grant failure only warns.
+# ---------------------------------------------------------------------------
+if opts[:grant_role]
+  puts "\n== 0b. grant synth schema to #{opts[:grant_role]} =="
+  sql = "GRANT SELECT ON ALL TABLES IN SCHEMA #{opts[:db]}.#{opts[:schema]} TO ROLE #{opts[:grant_role]}; " \
+        "GRANT USAGE ON SCHEMA #{opts[:db]}.#{opts[:schema]} TO ROLE #{opts[:grant_role]}; " \
+        "GRANT USAGE ON DATABASE #{opts[:db]} TO ROLE #{opts[:grant_role]};"
+  run!(['snow', 'sql', '-q', sql], allow_fail: true)
+end
+
+# ---------------------------------------------------------------------------
+# 1. Converter (local build or hosted MCP) → DM spec.
+# ---------------------------------------------------------------------------
+puts "\n== 1. converter (#{opts[:build] ? 'local build' : 'hosted MCP'}) =="
+conv = MechanicalSpecs.run_converter(twb_path: opts[:twb], conn: opts[:conn], db: opts[:db],
+                                     schema: opts[:schema], mcp_build: opts[:build], workdir: WORK)
+puts "stats: #{conv['stats'].to_json}"
+fx = MechanicalSpecs.fixup_dm_spec(conv['model'])
+puts "fixup: fixed=#{fx[:fixed]} dropped=#{fx[:dropped].size}"
+
+# The converter now self-validates calc columns/metrics (decodes XML entities,
+# translates IN→or-chain, strips // comments, resolves calc-on-calc refs to
+# captions, reconciles caption↔SQL-alias, routes untranslatable table-calc/LOD/
+# param calcs to workbookPatterns, and drop-and-surfaces any calc with an
+# unresolvable sibling ref). So we DON'T pre-prune here (the old harness did, and
+# it dropped every calc column); we trust the output and just report its shape.
+conv['model']['pages'].each do |pg|
+  (pg['elements'] || []).each do |el|
+    next unless el.dig('source', 'kind') == 'sql'
+    alias_cols = (el['columns'] || []).count { |c| (c['formula'] || '') =~ %r{\A\[Custom SQL/[^\]]+\]\z} }
+    calc_cols  = (el['columns'] || []).size - alias_cols
+    puts "  element '#{el['name']}': #{alias_cols} alias + #{calc_cols} calc col(s), #{(el['metrics'] || []).size} metric(s)"
+  end
+end
+
+conv['model']['folderId'] = opts[:folder]
+dm_spec_path = File.join(WORK, 'dm-spec.json')
+File.write(dm_spec_path, JSON.pretty_generate(conv['model']))
+
+# ---------------------------------------------------------------------------
+# 2. POST DM with an error-column repair loop. The converter self-validates, but
+#    Sigma's authoritative type checker may still reject a calc for a reason we
+#    can't predict offline (a boolean comparison form, an exotic arg shape).
+#    post-and-readback exits 2 and names the error columns; use Sigma as ground
+#    truth — prune them + any calc that transitively depends on them, delete the
+#    bad DM, re-post. Never silent: every pruned column is printed.
+# ---------------------------------------------------------------------------
+def prune_error_cols!(spec, error_names)
+  bad = error_names.map(&:downcase).to_set
+  loop do
+    grew = false
+    spec['pages'].each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el.dig('source', 'kind') == 'sql'
+        %w[columns metrics].each do |k|
+          (el[k] || []).each do |c|
+            nm = (c['name'] || '').downcase
+            next if nm.empty? || bad.include?(nm)
+            refs = (c['formula'] || '').scan(/\[([^\]\[\/]+)\]/).flatten.map(&:downcase)
+            if refs.any? { |r| bad.include?(r) } && !(c['formula'] =~ %r{\A\[Custom SQL/})
+              bad << nm
+              grew = true
+            end
+          end
+        end
+      end
+    end
+    break unless grew
+  end
+  spec['pages'].each do |pg|
+    (pg['elements'] || []).each do |el|
+      next unless el.dig('source', 'kind') == 'sql'
+      if el['columns']
+        el['columns'] = el['columns'].reject { |c| bad.include?((c['name'] || '').downcase) }
+        keepids = el['columns'].map { |c| c['id'] }.to_set
+        el['order'] = (el['order'] || []).select { |i| keepids.include?(i) } if el['order']
+      end
+      el['metrics'] = el['metrics'].reject { |c| bad.include?((c['name'] || '').downcase) } if el['metrics']
+    end
+  end
+  bad
+end
+
+puts "\n== 2. POST DM (with error-column repair loop) =="
+dm_ids_path = File.join(WORK, 'dm-ids.json')
+dm = nil
+3.times do |attempt|
+  _o, _e, st = run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
+                     '--spec', dm_spec_path, '--out', dm_ids_path, '--workdir', WORK], allow_fail: true)
+  dm = (JSON.parse(File.read(dm_ids_path)) rescue nil)
+  break if st.success?
+  abort 'DM post failed and no dataModelId written — cannot repair' unless dm && dm['dataModelId']
+  cols = Sigma.request(:get, "/v2/dataModels/#{dm['dataModelId']}/columns")
+  errs = (cols['entries'] || []).select { |c| c.dig('type', 'type') == 'error' }.map { |c| c['label'] }
+  abort "post-and-readback failed (exit #{st.exitstatus}) but no error-type columns — different failure" if errs.empty?
+  puts "  repair attempt #{attempt + 1}: Sigma flagged #{errs.size} error column(s): #{errs.join(', ')}"
+  spec = JSON.parse(File.read(dm_spec_path))
+  pruned = prune_error_cols!(spec, errs)
+  puts "  pruned #{pruned.size} column(s)/metric(s) (incl. transitive dependents); deleting bad DM #{dm['dataModelId']} and re-posting"
+  Sigma.request(:delete, "/v2/files/#{dm['dataModelId']}") rescue nil
+  File.write(dm_spec_path, JSON.pretty_generate(spec))
+end
+abort 'DM still failing after repair attempts' unless dm
+# Re-sync the in-memory model with the (repaired) posted spec so master derivation
+# doesn't emit master columns for pruned fields (which would 400 the workbook POST).
+conv['model'] = JSON.parse(File.read(dm_spec_path))
+
+dm_els = dm['pages'].flat_map { |p| p['elements'] }
+dim_re = /(?i)\b(dim|date|calendar)\b/
+fact = dm_els.reject { |e| e['name'] =~ dim_re }.max_by { |e| (e['columnLabels'] || []).size } ||
+       dm_els.max_by { |e| (e['columnLabels'] || []).size }
+puts "DM #{dm['dataModelId']}: #{dm_els.size} element(s); fact='#{fact['name']}' (#{(fact['columnLabels'] || []).size} labels)"
+
+# ---------------------------------------------------------------------------
+# 3. derive_master. pick_fact only recognizes warehouse-table/derived elements;
+#    a collapsed blend is a single kind:sql element, so fall back to selecting
+#    the widest kind:sql element directly.
+# ---------------------------------------------------------------------------
+puts "\n== 3. derive_master =="
+conv_fact = MechanicalSpecs.pick_fact(conv['model']) ||
+            conv['model']['pages'].flat_map { |p| p['elements'] || [] }
+                                  .select { |e| e.dig('source', 'kind') == 'sql' }
+                                  .max_by { |e| (e['columns'] || []).size }
+conv_base = MechanicalSpecs.base_of(conv['model'], conv_fact)
+derived = MechanicalSpecs.derive_master(conv_fact, fact['name'], conv_base, fact['columnLabels'], conv['model'])
+mcols = derived['master_columns']
+mmap = derived['mmap']
+master_map_path = File.join(WORK, 'master-map.json')
+master_cols_path = File.join(WORK, 'master-cols.yaml')
+File.write(master_map_path, JSON.pretty_generate(mmap))
+File.write(master_cols_path, { 'columns' => mcols }.to_yaml)
+puts "master: #{mcols.size} column(s)"
+
+# Enrich the master-map with caption/space/underscore-flexible keys so chart refs
+# that use friendly captions resolve to warehouse-named master columns (n4pi.7).
+run!(['python3', File.join(HERE, 'enrich-master-map.py'), WORK, opts[:twb]])
+
+# ---------------------------------------------------------------------------
+# 4. build-charts. --auto-controls materializes Tableau parameters/shared-view
+#    filters as Sigma controls; --workbook-patterns (when the installed
+#    build-charts supports it) auto-wires param measure-pickers into a
+#    control-driven Switch tile measure (n4pi.10).
+# ---------------------------------------------------------------------------
+puts "\n== 4. build-charts =="
+chart_specs_path = File.join(WORK, 'chart-specs.json')
+conv_meta_path = File.join(WORK, 'conv-meta.json')
+bc = ['ruby', File.join(HERE, 'build-charts-from-signals.rb'),
+      '--tableau-dir', WORK, '--layout', layout_path, '--master-map', master_map_path,
+      '--master-element-id', 'master', '--page-per-dashboard',
+      '--out', chart_specs_path, '--coverage-out', File.join(WORK, 'coverage.json'),
+      '--meta', meta_path, '--auto-controls']
+if File.exist?(conv_meta_path) &&
+   File.read(File.join(HERE, 'build-charts-from-signals.rb')).include?('--workbook-patterns')
+  bc += ['--workbook-patterns', conv_meta_path]
+end
+run!(bc, allow_fail: true)
+
+# ---------------------------------------------------------------------------
+# 5. build-workbook-spec.
+# ---------------------------------------------------------------------------
+puts "\n== 5. build-workbook-spec =="
+wb_spec_path = File.join(WORK, 'wb-spec.json')
+run!(['ruby', File.join(HERE, 'build-workbook-spec.rb'),
+      '--chart-specs', chart_specs_path, '--dm-ids', dm_ids_path,
+      '--master-cols', master_cols_path, '--workbook-name', NAME,
+      '--folder-id', opts[:folder], '--mode', 'dashboard',
+      '--dm-element-name', fact['name'], '--out', wb_spec_path], allow_fail: true)
+
+wbspec = JSON.parse(File.read(wb_spec_path))
+# Sigma page ids must match /^[a-zA-Z0-9_-]{1,64}$/; the slug can contain invalid
+# chars (e.g. '+' from a dashboard caption). Sanitize before POST.
+(wbspec['pages'] || []).each { |pg| pg['id'] = pg['id'].gsub(/[^a-zA-Z0-9_-]/, '-')[0, 64] if pg['id'] }
+
+# Prune viz elements that still reference master columns we don't have (charts
+# plotting untranslated calcs/params). Surface the count — never silent.
+master_names = mcols.map { |c| c['name'].downcase }.to_set
+ref_re = %r{\[master/([^\]]+)\]}i
+collect = lambda do |o, acc|
+  case o
+  when Hash  then o.each_value { |v| v.is_a?(String) ? acc.concat(v.scan(ref_re).flatten) : collect.call(v, acc) }
+  when Array then o.each { |v| collect.call(v, acc) }
+  end
+  acc
+end
+dropped_viz = 0
+(wbspec['pages'] || []).each do |pg|
+  pg['elements'] = (pg['elements'] || []).select do |e|
+    miss = collect.call(e, []).reject { |r| master_names.include?(r.downcase) }
+    if miss.any? then dropped_viz += 1; false else true end
+  end
+end
+puts "viz prune: dropped #{dropped_viz} element(s) referencing untranslated calcs/params"
+File.write(wb_spec_path, JSON.pretty_generate(wbspec))
+
+# ---------------------------------------------------------------------------
+# 6. POST workbook.
+# ---------------------------------------------------------------------------
+puts "\n== 6. POST workbook =="
+wb_ids_path = File.join(WORK, 'wb-ids.json')
+_o, e, _s = run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
+                  '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK], allow_fail: true)
+puts "\n-- POST workbook stderr tail (resolution errors, if any) --"
+puts (e || '')[-3000..] || e
+
+# ---------------------------------------------------------------------------
+# 7. migration notes ("Not Migrated (and why)") + optional render.
+# ---------------------------------------------------------------------------
+puts "\n== 7. migration notes =="
+run!(['ruby', File.join(HERE, 'migration-notes.rb'),
+      '--conv-meta', conv_meta_path, '--chart-specs', chart_specs_path,
+      '--wb-spec', wb_spec_path, '--twb', opts[:twb],
+      '--out', File.join(WORK, 'migration-notes.md')], allow_fail: true)
+puts "→ #{File.join(WORK, 'migration-notes.md')}"
+
+if opts[:render]
+  wb = (JSON.parse(File.read(wb_ids_path)) rescue nil)
+  wb_id = wb && (wb['workbookId'] || wb['id'])
+  page_id = (wbspec['pages'] || []).map { |pg| pg['id'] }.compact.first
+  if wb_id && page_id
+    puts "\n== 8. render PNG =="
+    run!(['python3', File.join(HERE, 'sigma-export-png.py'), '--workbook', wb_id,
+          '--page', page_id, '--out', File.join(WORK, 'rendered.png')], allow_fail: true)
+  else
+    puts '  render skipped (no workbook id / page id)'
+  end
+end
+
+puts "\n✅ synth-twb-e2e complete. Artifacts in #{WORK}"
+puts "   DM: #{dm['dataModelId']}  workbook: #{(JSON.parse(File.read(wb_ids_path)) rescue {})['workbookId'] rescue '(see wb-ids.json)'}"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-measure-picker.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-measure-picker.rb
@@ -1,0 +1,106 @@
+#!/usr/bin/env ruby
+# Regression test for the parameter measure-picker wiring (n4pi.10): a Tableau
+# parameter that selects WHICH measure a tile shows → a Sigma control-driven
+# Switch tile measure. Exercises the build-layer helpers directly (no live POST):
+#   - load_param_switches: indexes a converter `param-switch` workbookPattern by
+#     the calc caption AND its Calculation_<id> (the Calculation_NNN→caption bridge)
+#   - param_switch_for:    looks a picker up by either key
+#   - param_switch_inline: builds the SIBLING-form Switch, INLINES aggregate-metric
+#     branch refs to their formula (not a passthrough column), gracefully NULLs an
+#     unresolvable branch (and surfaces it), and SKIPS window-function pickers
+#
+# Usage:  ruby scripts/test-param-measure-picker.rb
+require 'json'
+require 'set'
+
+DIR = __dir__
+SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+
+# Pull the pure helper methods out of the script (which otherwise runs main) and
+# define them here. Order doesn't matter — they're resolved at call time.
+%w[map_column coerce_case_literal remap_param_branch
+   load_param_switches param_switch_for param_switch_inline].each do |fn|
+  m = SRC.match(/^def #{fn}\b.*?\n^end$/m) or abort("could not extract #{fn} from build-charts-from-signals.rb")
+  eval(m[0]) # rubocop:disable Security/Eval — test-only extraction of first-party code
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# master-map: real COLUMNS (no formula) + an aggregate METRIC ("Signs" -> a
+# CountDistinct formula) so we can assert metric inlining vs column passthrough.
+MMAP = {
+  '(?i)^Region$'          => { 'id' => 'm-region', 'name' => 'Region' },
+  '(?i)^Net Revenue$'     => { 'id' => 'm-nr', 'name' => 'NET_REVENUE' },
+  '(?i)^Account$'         => { 'id' => 'm-acct', 'name' => 'ACCOUNT_ID' },
+  '(?i)^Signs$'           => { 'id' => 'm-signs', 'name' => 'Signs', 'formula' => 'CountDistinct([Master/ACCOUNT_ID])' }
+}
+CBG = {
+  'Calculation_777' => { 'caption' => 'Metric Picker', 'datatype' => 'real' },
+  'Parameter 3'     => { 'caption' => 'Metric Param', 'datatype' => 'string' }
+}
+
+# ---- 1. clean measure-picker: metric branch inlined, column branch passthrough -
+$param_switches = []; $param_switch_by_key = {}; $param_switch_used = []
+meta = { 'columns_by_guid' => CBG }
+patterns = { 'workbookPatterns' => [
+  { 'kind' => 'param-switch', 'name' => 'Metric Picker', 'controlId' => 'ctl-parameter-3',
+    'paramName' => 'Parameter 3',
+    'cases' => [{ 'when' => 'Revenue', 'then' => 'Sum([Net Revenue])' },
+                { 'when' => 'Signs',   'then' => '[Signs]' }],
+    'elseExpr' => nil }
+] }
+require 'tmpdir'
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'wp.json'), JSON.dump(patterns))
+  load_param_switches(File.join(d, 'wp.json'), meta)
+end
+
+check($param_switches.size == 1, 'loaded 1 param-switch', fails)
+# Calculation_NNN→caption bridge: found by caption AND by the internal id.
+check(!param_switch_for('Metric Picker').nil?, 'param_switch_for resolves by caption', fails)
+check(!param_switch_for('Calculation_777').nil?, 'param_switch_for resolves by Calculation_<id> (caption bridge)', fails)
+check(param_switch_for('Nope').nil?, 'param_switch_for returns nil for a non-picker', fails)
+
+plan = param_switch_inline($param_switches.first, MMAP, CBG)
+f = plan && plan['sibling_form']
+check(!plan.nil?, 'param_switch_inline builds a plan', fails)
+check(f.to_s.start_with?('Switch([ctl-parameter-3],'), "Switch references the converter controlId (got #{f.inspect})", fails)
+check(f.to_s.include?('Sum([NET_REVENUE])'), 'column branch → passthrough sibling form Sum([NET_REVENUE])', fails)
+check(f.to_s.include?('CountDistinct([ACCOUNT_ID])'), 'metric branch INLINED to its formula (CountDistinct([ACCOUNT_ID])), not a [Signs] passthrough', fails)
+check(!f.to_s.include?('[Signs]'), 'no dangling [Signs] metric passthrough (would not resolve on the master)', fails)
+check((plan['branch_refs'] & %w[NET_REVENUE ACCOUNT_ID]).sort == %w[ACCOUNT_ID NET_REVENUE],
+      "branch_refs are the real columns to materialise (got #{plan['branch_refs'].inspect})", fails)
+check(plan['unresolved'].empty?, 'no unresolved options when every branch resolves', fails)
+
+# ---- 2. graceful NULL for an unresolvable branch (surfaced, not silent) --------
+sw2 = { 'name' => 'P2', 'control_id' => 'ctl-parameter-9', 'param_name' => 'Parameter 9',
+        'cases' => [{ 'when' => 'Good', 'then' => 'Sum([Net Revenue])' },
+                    { 'when' => 'Bad',  'then' => '[Nonexistent Calc]' }], 'else' => nil }
+plan2 = param_switch_inline(sw2, MMAP, CBG)
+check(plan2 && plan2['sibling_form'].include?('"Bad", Null'), 'unresolvable branch → Null (other options keep working)', fails)
+check(plan2 && plan2['unresolved'] == ['Bad'], "unresolved option surfaced (got #{plan2 && plan2['unresolved'].inspect})", fails)
+
+# ---- 3. window-function picker is SKIPPED (can't inline in a Switch) -----------
+sw3 = { 'name' => 'P3', 'control_id' => 'ctl-parameter-4', 'param_name' => 'Parameter 4',
+        'cases' => [{ 'when' => 'Total', 'then' => '[Signs]' },
+                    { 'when' => 'Pct',   'then' => '[Signs]/window_sum([Signs])' }], 'else' => nil }
+check(param_switch_inline(sw3, MMAP, CBG).nil?, 'window-function picker → nil (surfaced as a note, never emitted broken)', fails)
+
+# ---- 4. all-branches-unresolvable → nil (nothing to plot) ----------------------
+sw4 = { 'name' => 'P4', 'control_id' => 'ctl-parameter-5', 'param_name' => 'Parameter 5',
+        'cases' => [{ 'when' => 'X', 'then' => '[Ghost A]' }, { 'when' => 'Y', 'then' => '[Ghost B]' }], 'else' => nil }
+check(param_switch_inline(sw4, MMAP, CBG).nil?, 'all branches unresolvable → nil (no empty Switch)', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — param measure-picker: control-driven Switch, metric inlining, graceful null, window skip'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end


### PR DESCRIPTION
Closes the two open P2 follow-ups under the DDMX blend epic (beads n4pi.10, n4pi.5).

## n4pi.10 — auto-wire param measure-pickers in the build layer
A Tableau parameter that selects WHICH measure a tile shows was only surfaced as a manual note. Now `build-charts-from-signals.rb` consumes the converter's clean `param-switch` workbookPattern (new `--workbook-patterns`) and emits:
- a single-select **segmented control** under the converter's exact controlId (e.g. `ctl-parameter-17`), values = the case match literals;
- the tile's **measure set to the control-driven Switch** — KPI, standard-chart, and pivot-table value paths.

Keyed by caption **and** `Calculation_<id>` (the Calculation_NNN→caption bridge). Branch results remap onto master columns; aggregate-**metric** refs are **inlined to their formula** (a metric isn't a master column → a passthrough would 400); an unresolvable branch (un-emitted calc, or a `/`-caption like `TAM / CW` that remap can't qualify) is **gracefully nulled and surfaced**; **window-function** pickers are skipped (left as a note). The redundant legacy auto-param control for a parameter now driven by a wired picker is suppressed.

## n4pi.5 — package the synth-twb-e2e harness
`synth-twb-e2e.rb`: live E2E of the mechanical chain against a synthetic/empty typed warehouse, **no live Tableau** — the durable way to prove a dataless `.twb` migrates with charts that resolve at POST. Parameterized; self-discovers layout via `parse-twb-layout` and synthesizes `get-workbook.json` when no live artifacts are staged. Folds in the DM **error-column repair loop**, `pick_fact(kind:sql)` fallback, page-id slug sanitize, viz-prune, migration-notes, and the bundled `enrich-master-map.py`.

## Verification
- **Live DDMX synth E2E** (real synth warehouse + Sigma): DM POST 497 columns clean (0 error types); workbook posts; the `ctl-parameter-17` picker control is **wired** (4 pivots drive the Switch); control-lint no longer flags it. Test orphans cleaned up.
- `test-param-measure-picker.rb` (new, 15 assertions) + existing tableau test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)