### PR TITLE
tableau: percent-format share-of-total/rank-percentile pivot values (y9rd.3)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1784,6 +1784,14 @@ def build_pivot_element(z, meta, mmap, opts, warnings, data_elements = [])
       # conservative "UNVALIDATED in pivot context" behaviour lost real measures
       # like share-of-total and running-total from migrated crosstabs).
       uv['col']['formula'] = plan['formula']
+      # Window formulas that yield a 0–1 fraction (share-of-total, rank-percentile)
+      # must carry a percent format, else the default ',.0f' rounds every cell to
+      # "0" and the crosstab reads as all-zeros even though it computes correctly
+      # (grand total = 1.0). Mirrors the chart-path override (PercentOfTotal→',.2%').
+      case plan['formula']
+      when /\A\s*(?:CumulativeSum\(PercentOfTotal|PercentOfTotal)\(/ then uv['col']['format'] = { 'kind' => 'number', 'formatString' => ',.2%' }
+      when /\A\s*RankPercentile\(/ then uv['col']['format'] = { 'kind' => 'number', 'formatString' => ',.1%' }
+      end
       sort_note = plan['follows_sort'] ? ' (accumulates along the pivot sort — verify order vs Tableau)' : ''
       warnings << "'#{cap}' pivot value '#{uv['name']}' → window formula in grid: " \
                   "#{plan['formula'].gsub(/\s+/, ' ')[0..100]}#{sort_note}"


### PR DESCRIPTION
## y9rd.3 — build-layer companion (percent format)

The pivot inline-window path emitted the validated `PercentOfTotal(…, "grand_total")` formula but left the value column's default `,.0f` format, so every 0–1 fraction rounded to **"0"** — the share-of-total crosstab read as all-zeros even though it computed correctly (grand total = 1.0).

Apply the same percent-format override the chart path already uses:
- `PercentOfTotal` / `CumulativeSum(PercentOfTotal)` → `,.2%`
- `RankPercentile` → `,.1%`

## Verification
E2E on the DDMX parity testbed: the Pct Of Total crosstab now renders real percentages (West 36.77%, South 29.59%, NE 19.33%, MW 14.31%, total **100.00%**), matching warehouse region totals exactly.

Pairs with the converter fix twells89/sigma-data-model-mcp#73 that stopped the field being dropped upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)