### PR TITLE
tableau: percent-format attainment/share ratios in pivot values (y9rd.5)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1762,6 +1762,15 @@ def build_pivot_element(z, meta, mmap, opts, warnings, data_elements = [])
       f = translate_user_agg_formula(ws_calc['formula'], mmap, meta['columns_by_guid'] || {})
       if f
         uv['col']['formula'] = f
+        # Attainment/share ratios (a measure ÷ a goal/target/budget/quota) are
+        # percentages by convention — the default ',.0f' would round e.g. 0.93 to
+        # "1". Detect by the value name OR a goal/target denominator in the source
+        # formula and apply a percent format. (Names like "Revenue Attainment"
+        # would otherwise false-match the currency heuristic on "revenue".)
+        if uv['name'].to_s =~ /attain|\bshare\b|sell[-\s]?through|win[-\s]?rate|conversion/i ||
+           ws_calc['formula'].to_s =~ /\b(goal|target|budget|quota|plan|forecast)\b/i
+          uv['col']['format'] = { 'kind' => 'number', 'formatString' => ',.1%' }
+        end
         warnings << "'#{cap}' pivot value '#{uv['name']}' is a Tableau User-aggregated calc — decomposed: #{f[0..120]}"
       else
         # Can't decompose → its emitted Sum([Master/<calc>]) references a


### PR DESCRIPTION
## y9rd.5 — build-layer companion (attainment format)

A pivot value that decomposes to a measure ÷ goal/target/budget/quota (e.g. "Revenue Attainment" = `Sum(Net Revenue)/Sum(Revenue Goal)`) is a percentage by convention, but the default `,.0f` rounds e.g. 0.93 to "1" — and a name-based heuristic would even false-match the *currency* format on "revenue".

Detect by the value name (`attain`/`share`/`sell-through`/`win-rate`/`conversion`) **or** a goal/target/budget/quota/plan/forecast denominator in the source formula, and apply `,.1%`.

Pairs with the converter de-fan twells89/sigma-data-model-mcp#y9rd5-blend-defan: once the goal denominator aggregates correctly, the attainment crosstab renders real percentages (testbed: ~92.6% per region, matching the warehouse) instead of "1".

🤖 Generated with [Claude Code](https://claude.com/claude-code)