### PR TITLE
feat(parity): value-parity SCORE — real, repeatable, CI-gateable number (y9rd.2)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -100,6 +100,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-id-namespacing.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-score.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake.rb

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -108,12 +108,13 @@ require 'optparse'
 require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
-         allow_missing_tiles: 0 }
+         allow_missing_tiles: 0, min_parity_score: 0.0 }
 OptionParser.new do |p|
   p.on('--tableau DIR')              { |v| opts[:tab] = v }
   p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
   p.on('--workbook-id ID')           { |v| opts[:wb] = v }
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
@@ -185,6 +186,26 @@ else
       warn "       Failing charts: #{fail_names.join(', ')}"
     end
     exit 2
+  end
+
+  # Value-parity SCORE gate (bead y9rd.2): the mean per-tile value-fidelity score
+  # is a finer signal than pass/fail — a tile can PASS the bucket check yet score
+  # low on value drift. When --min-parity-score is set, gate on the real number.
+  if opts[:min_parity_score] > 0.0
+    vps = summary['value_parity_score']
+    if vps.nil?
+      warn "[FAIL] --min-parity-score #{opts[:min_parity_score]} requested but parity-final.json has no value_parity_score."
+      warn "       Re-run phase6-parity.rb --finalize (it now writes the score via verify-parity --score-out)."
+      exit 2
+    end
+    if vps.to_f < opts[:min_parity_score]
+      warn "[FAIL] value-parity score=#{(vps.to_f * 100).round(1)}% < required #{(opts[:min_parity_score] * 100).round(1)}%"
+      low = (summary['per_tile_scores'] || []).select { |t| t['score'].to_f < opts[:min_parity_score] }
+                                              .sort_by { |t| t['score'].to_f }.first(5)
+      low.each { |t| warn format('       %-40s %.0f%% (%s)', t['chart'], t['score'].to_f * 100, t['status']) }
+      exit 2
+    end
+    puts "[OK] gate 1/7: value-parity score=#{(vps.to_f * 100).round(1)}% (>= #{(opts[:min_parity_score] * 100).round(1)}% required)"
   end
 
   if rate_gate_only && status != 'PASS'

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -108,12 +108,13 @@ require 'optparse'
 require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
-         allow_missing_tiles: 0 }
+         allow_missing_tiles: 0, min_parity_score: 0.0 }
 OptionParser.new do |p|
   p.on('--tableau DIR')              { |v| opts[:tab] = v }
   p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
   p.on('--workbook-id ID')           { |v| opts[:wb] = v }
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
@@ -185,6 +186,26 @@ else
       warn "       Failing charts: #{fail_names.join(', ')}"
     end
     exit 2
+  end
+
+  # Value-parity SCORE gate (bead y9rd.2): the mean per-tile value-fidelity score
+  # is a finer signal than pass/fail — a tile can PASS the bucket check yet score
+  # low on value drift. When --min-parity-score is set, gate on the real number.
+  if opts[:min_parity_score] > 0.0
+    vps = summary['value_parity_score']
+    if vps.nil?
+      warn "[FAIL] --min-parity-score #{opts[:min_parity_score]} requested but parity-final.json has no value_parity_score."
+      warn "       Re-run phase6-parity.rb --finalize (it now writes the score via verify-parity --score-out)."
+      exit 2
+    end
+    if vps.to_f < opts[:min_parity_score]
+      warn "[FAIL] value-parity score=#{(vps.to_f * 100).round(1)}% < required #{(opts[:min_parity_score] * 100).round(1)}%"
+      low = (summary['per_tile_scores'] || []).select { |t| t['score'].to_f < opts[:min_parity_score] }
+                                              .sort_by { |t| t['score'].to_f }.first(5)
+      low.each { |t| warn format('       %-40s %.0f%% (%s)', t['chart'], t['score'].to_f * 100, t['status']) }
+      exit 2
+    end
+    puts "[OK] gate 1/7: value-parity score=#{(vps.to_f * 100).round(1)}% (>= #{(opts[:min_parity_score] * 100).round(1)}% required)"
   end
 
   if rate_gate_only && status != 'PASS'

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -108,12 +108,13 @@ require 'optparse'
 require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
-         allow_missing_tiles: 0 }
+         allow_missing_tiles: 0, min_parity_score: 0.0 }
 OptionParser.new do |p|
   p.on('--tableau DIR')              { |v| opts[:tab] = v }
   p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
   p.on('--workbook-id ID')           { |v| opts[:wb] = v }
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
@@ -185,6 +186,26 @@ else
       warn "       Failing charts: #{fail_names.join(', ')}"
     end
     exit 2
+  end
+
+  # Value-parity SCORE gate (bead y9rd.2): the mean per-tile value-fidelity score
+  # is a finer signal than pass/fail — a tile can PASS the bucket check yet score
+  # low on value drift. When --min-parity-score is set, gate on the real number.
+  if opts[:min_parity_score] > 0.0
+    vps = summary['value_parity_score']
+    if vps.nil?
+      warn "[FAIL] --min-parity-score #{opts[:min_parity_score]} requested but parity-final.json has no value_parity_score."
+      warn "       Re-run phase6-parity.rb --finalize (it now writes the score via verify-parity --score-out)."
+      exit 2
+    end
+    if vps.to_f < opts[:min_parity_score]
+      warn "[FAIL] value-parity score=#{(vps.to_f * 100).round(1)}% < required #{(opts[:min_parity_score] * 100).round(1)}%"
+      low = (summary['per_tile_scores'] || []).select { |t| t['score'].to_f < opts[:min_parity_score] }
+                                              .sort_by { |t| t['score'].to_f }.first(5)
+      low.each { |t| warn format('       %-40s %.0f%% (%s)', t['chart'], t['score'].to_f * 100, t['status']) }
+      exit 2
+    end
+    puts "[OK] gate 1/7: value-parity score=#{(vps.to_f * 100).round(1)}% (>= #{(opts[:min_parity_score] * 100).round(1)}% required)"
   end
 
   if rate_gate_only && status != 'PASS'

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -108,12 +108,13 @@ require 'optparse'
 require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
-         allow_missing_tiles: 0 }
+         allow_missing_tiles: 0, min_parity_score: 0.0 }
 OptionParser.new do |p|
   p.on('--tableau DIR')              { |v| opts[:tab] = v }
   p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
   p.on('--workbook-id ID')           { |v| opts[:wb] = v }
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
@@ -185,6 +186,26 @@ else
       warn "       Failing charts: #{fail_names.join(', ')}"
     end
     exit 2
+  end
+
+  # Value-parity SCORE gate (bead y9rd.2): the mean per-tile value-fidelity score
+  # is a finer signal than pass/fail — a tile can PASS the bucket check yet score
+  # low on value drift. When --min-parity-score is set, gate on the real number.
+  if opts[:min_parity_score] > 0.0
+    vps = summary['value_parity_score']
+    if vps.nil?
+      warn "[FAIL] --min-parity-score #{opts[:min_parity_score]} requested but parity-final.json has no value_parity_score."
+      warn "       Re-run phase6-parity.rb --finalize (it now writes the score via verify-parity --score-out)."
+      exit 2
+    end
+    if vps.to_f < opts[:min_parity_score]
+      warn "[FAIL] value-parity score=#{(vps.to_f * 100).round(1)}% < required #{(opts[:min_parity_score] * 100).round(1)}%"
+      low = (summary['per_tile_scores'] || []).select { |t| t['score'].to_f < opts[:min_parity_score] }
+                                              .sort_by { |t| t['score'].to_f }.first(5)
+      low.each { |t| warn format('       %-40s %.0f%% (%s)', t['chart'], t['score'].to_f * 100, t['status']) }
+      exit 2
+    end
+    puts "[OK] gate 1/7: value-parity score=#{(vps.to_f * 100).round(1)}% (>= #{(opts[:min_parity_score] * 100).round(1)}% required)"
   end
 
   if rate_gate_only && status != 'PASS'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -108,12 +108,13 @@ require 'optparse'
 require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
-         allow_missing_tiles: 0 }
+         allow_missing_tiles: 0, min_parity_score: 0.0 }
 OptionParser.new do |p|
   p.on('--tableau DIR')              { |v| opts[:tab] = v }
   p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
   p.on('--workbook-id ID')           { |v| opts[:wb] = v }
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
@@ -185,6 +186,26 @@ else
       warn "       Failing charts: #{fail_names.join(', ')}"
     end
     exit 2
+  end
+
+  # Value-parity SCORE gate (bead y9rd.2): the mean per-tile value-fidelity score
+  # is a finer signal than pass/fail — a tile can PASS the bucket check yet score
+  # low on value drift. When --min-parity-score is set, gate on the real number.
+  if opts[:min_parity_score] > 0.0
+    vps = summary['value_parity_score']
+    if vps.nil?
+      warn "[FAIL] --min-parity-score #{opts[:min_parity_score]} requested but parity-final.json has no value_parity_score."
+      warn "       Re-run phase6-parity.rb --finalize (it now writes the score via verify-parity --score-out)."
+      exit 2
+    end
+    if vps.to_f < opts[:min_parity_score]
+      warn "[FAIL] value-parity score=#{(vps.to_f * 100).round(1)}% < required #{(opts[:min_parity_score] * 100).round(1)}%"
+      low = (summary['per_tile_scores'] || []).select { |t| t['score'].to_f < opts[:min_parity_score] }
+                                              .sort_by { |t| t['score'].to_f }.first(5)
+      low.each { |t| warn format('       %-40s %.0f%% (%s)', t['chart'], t['score'].to_f * 100, t['status']) }
+      exit 2
+    end
+    puts "[OK] gate 1/7: value-parity score=#{(vps.to_f * 100).round(1)}% (>= #{(opts[:min_parity_score] * 100).round(1)}% required)"
   end
 
   if rate_gate_only && status != 'PASS'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
@@ -43,6 +43,7 @@ OptionParser.new do |p|
   p.on('--extract-tol F', Float) { |v| opts[:extract_tol] = v }
   p.on('--rename PAIR', 'Tableau-name=Sigma-name (repeat)') { |v| opts[:renames] << v }
   p.on('--dashboard-layout PATH', 'parse-twb-layout output for the tile census (default <tableau-dir>/dashboard-layout.json)') { |v| opts[:dash_layout] = v }
+  p.on('--coverage PATH', 'build-charts coverage.json for the tier-coverage report (default <tableau-dir>/coverage.json)') { |v| opts[:coverage] = v }
   # Per-dashboard parity scoping: scope parity checks to only tiles on the
   # named dashboard (case-insensitive exact or unique substring). Repeatable.
   # Threaded through to auto-parity-plan.rb's --dashboard flag so both the
@@ -200,8 +201,9 @@ end
 File.write(plan_path, JSON.pretty_generate(plan))
 
 warn "Phase 6 PASS 2: running verifier (#{opts[:extract_mode] ? 'extract-mode' : 'strict'})"
+score_out_path = File.join(opts[:tab], 'parity-score.json')
 verifier_args = ['ruby', File.join(__dir__, 'verify-parity.rb'),
-                 '--plan', plan_path]
+                 '--plan', plan_path, '--score-out', score_out_path]
 if opts[:extract_mode]
   verifier_args.concat(['--extract-mode', '--extract-tol', opts[:extract_tol].to_s])
 end
@@ -216,8 +218,10 @@ File.write(opts[:out], out)
 # masked the cluster follower regression on 2026-05-22, see beads-sigma-4pm).
 summary_path = File.join(opts[:tab], 'parity-final.json')
 total = plan['charts'].size
-passed_chart_names = out.scan(/^PASS\s+\[[^\]]+\]\s+(.+)$/).flatten
-failed_chart_names = out.scan(/^DIVERGE\s+\[[^\]]+\]\s+(.+)$/).flatten
+# NB: verify-parity appends a "  (score NN%)" suffix (bead y9rd.2) — strip it so
+# chart names stay clean for the tile-census name match.
+passed_chart_names = out.scan(/^PASS\s+\[[^\]]+\]\s+(.+?)(?:\s+\(score [\d.]+%\))?$/).flatten
+failed_chart_names = out.scan(/^DIVERGE\s+\[[^\]]+\]\s+(.+?)(?:\s+\(score [\d.]+%\))?$/).flatten
 
 # ---- Tile census (bead gjhe) ------------------------------------------------
 # Compare the Tableau dashboard's chart-zone count against the charts that made
@@ -267,6 +271,27 @@ summary = {
   'status'       => (status.success? && total > 0 && passed_chart_names.size == total) ? 'PASS' : 'FAIL'
 }
 summary['tile_census'] = tile_census if tile_census
+
+# ---- Value-parity score + tier coverage report (bead y9rd.2) ----------------
+# Fold the verifier's per-tile value score (parity-score.json) and the
+# build-layer coverage tiers (coverage.json: built/approximated/degraded/dropped)
+# into one report so "N% parity" is a real number with a tier breakdown behind
+# it — repeatable and CI-gateable via assert-phase6-ran.rb --min-parity-score.
+if File.exist?(score_out_path)
+  score_doc = JSON.parse(File.read(score_out_path)) rescue nil
+  if score_doc
+    summary['value_parity_score'] = score_doc['value_parity_score']
+    summary['per_tile_scores'] = score_doc['tiles']
+    warn "value-parity score: #{(score_doc['value_parity_score'].to_f * 100).round(1)}% (#{score_doc['tiles_pass']}/#{score_doc['tiles_total']} tiles exact)"
+  end
+end
+coverage_path = opts[:coverage] || File.join(opts[:tab], 'coverage.json')
+if File.exist?(coverage_path)
+  cov = JSON.parse(File.read(coverage_path)) rescue nil
+  summary['tier_coverage'] = cov['summary'] if cov.is_a?(Hash) && cov['summary']
+end
+
 File.write(summary_path, JSON.pretty_generate(summary))
-warn "wrote #{summary_path} (status=#{summary['status']} #{summary['charts_pass']}/#{summary['charts_total']})"
+warn "wrote #{summary_path} (status=#{summary['status']} #{summary['charts_pass']}/#{summary['charts_total']}" \
+     "#{summary['value_parity_score'] ? format(' parity=%.1f%%', summary['value_parity_score'].to_f * 100) : ''})"
 exit(status.success? ? 0 : 2)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-score.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-score.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/env ruby
+# test-parity-score.rb — unit test for the value-parity SCORE (bead y9rd.2):
+# verify-parity.rb emits a per-tile + overall value_parity_score and a
+# --score-out JSON; assert-phase6-ran.rb gates on --min-parity-score. Offline:
+# crafts plan fixtures, never the API. Run: ruby scripts/test-parity-score.rb
+require 'json'
+require 'tmpdir'
+require 'rbconfig'
+
+VP   = File.join(__dir__, 'verify-parity.rb')
+GATE = File.join(__dir__, 'assert-phase6-ran.rb')
+RUBY = RbConfig.ruby
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+
+# ── verify-parity --score-out: per-tile + overall score ─────────────────────
+PLAN = { 'extract' => false, 'charts' => [
+  { 'chart' => 'Exact',     'expected' => [%w[East]+[100], %w[West]+[200]],
+    'actual' => { 'rows' => [%w[East]+[100], %w[West]+[200]] } },
+  { 'chart' => 'HalfMatch', 'expected' => [%w[East]+[100], %w[West]+[200], %w[North]+[300], %w[South]+[400]],
+    'actual' => { 'rows' => [%w[East]+[100], %w[West]+[200]] } },
+  { 'chart' => 'Drift', 'extract' => true, 'expected' => [%w[East]+[100], %w[West]+[200]],
+    'actual' => { 'rows' => [%w[East]+[110], %w[West]+[200]] } },
+] }
+
+Dir.mktmpdir do |d|
+  plan = File.join(d, 'plan.json')
+  score = File.join(d, 'parity-score.json')
+  File.write(plan, JSON.generate(PLAN))
+  # verify-parity exits 1 when any tile DIVERGEs (HalfMatch) — that's expected.
+  system(RUBY, VP, '--plan', plan, '--score-out', score, out: File::NULL, err: File::NULL)
+  ok('score-out written', File.exist?(score))
+  doc = JSON.parse(File.read(score))
+  tiles = doc['tiles'].each_with_object({}) { |t, h| h[t['chart']] = t }
+  ok('exact tile scores 1.0',            tiles['Exact']['score'] == 1.0)
+  ok('half-match tile scores 0.5 (2/4 Jaccard)', tiles['HalfMatch']['score'] == 0.5)
+  ok('half-match flagged DIVERGE',       tiles['HalfMatch']['status'] == 'DIVERGE')
+  ok('drift tile scores ~0.95 (9% drift, under tol → PASS)',
+     (tiles['Drift']['score'] - 0.9545).abs < 0.01 && tiles['Drift']['status'] == 'PASS')
+  ok('overall = mean per-tile (~0.818)', (doc['value_parity_score'] - 0.8182).abs < 0.001)
+  ok('tiles_total/pass counts', doc['tiles_total'] == 3 && doc['tiles_pass'] == 2)
+end
+
+# ── assert-phase6-ran.rb --min-parity-score gate ────────────────────────────
+FINAL = { 'mode' => 'strict', 'status' => 'PASS', 'charts_total' => 2, 'charts_pass' => 2,
+          'charts_fail' => 0, 'value_parity_score' => 0.70,
+          'per_tile_scores' => [{ 'chart' => 'Weak', 'status' => 'PASS', 'score' => 0.4 }] }
+
+Dir.mktmpdir do |d|
+  File.write(File.join(d, 'parity-final.json'), JSON.generate(FINAL))
+  below = system(RUBY, GATE, '--workdir', d, '--min-parity-score', '0.80', out: File::NULL, err: File::NULL)
+  ok('gate FAILS when score below threshold', below == false)
+  # gate 1 passes at 0.60; later gates may fail on missing files, so assert the
+  # gate-1 score line is printed rather than the overall exit.
+  out = `#{RUBY} #{GATE} --workdir #{d} --min-parity-score 0.60 2>&1`
+  ok('gate 1 OK line when score above threshold', out.include?('value-parity score=70.0% (>= 60.0% required)'))
+  # off by default: no score gating, no score line
+  out_off = `#{RUBY} #{GATE} --workdir #{d} 2>&1`
+  ok('score gate OFF by default (no false gating)', !out_off.include?('value-parity score='))
+end
+
+puts($fail.zero? ? "\nALL PASS" : "\n#{$fail} FAILED")
+exit($fail.zero? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-parity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-parity.rb
@@ -38,7 +38,9 @@ OptionParser.new do |p|
   p.on('--plan P')              { |v| opts[:plan] = v }
   p.on('--extract-mode')        {     opts[:mode] = :extract }
   p.on('--extract-tol TOL', Float) { |v| opts[:tol] = v }
+  p.on('--score-out P')         { |v| opts[:score_out] = v }
 end.parse!
+require 'time'
 abort('--plan required') unless opts[:plan]
 
 MONTH_NUM = {
@@ -107,6 +109,14 @@ def round_row(row)
   end
 end
 
+# Per-tile value-parity score in [0,1] (bead y9rd.2): tuple-set Jaccard —
+# matched cells / distinct cells across both sides. 1.0 = exact. Lets us turn
+# "75% parity" into a real, repeatable, gateable number instead of pass/fail only.
+def jaccard(exp_set, act_set)
+  union = (exp_set | act_set).size
+  union.zero? ? 1.0 : ((exp_set & act_set).size.to_f / union).round(4)
+end
+
 def strict_compare(exp, act)
   # Compare the FULL tuple width the plan carries (bead s6fo): 3-channel charts
   # (stacked color / pivot row+col+value / scatter dim+x+y) must compare every
@@ -114,7 +124,8 @@ def strict_compare(exp, act)
   width = [(exp.map(&:size) + act.map(&:size)).max || 2, 2].max
   exp_set = Set.new(exp.map { |r| r.first(width) })
   act_set = Set.new(act.map { |r| r.first(width) })
-  return { status: 'PASS', only_in_tableau: [], only_in_sigma: [] } if exp_set == act_set
+  counts = { n_expected: exp_set.size, n_actual: act_set.size, n_matched: (exp_set & act_set).size }
+  return { status: 'PASS', score: 1.0, only_in_tableau: [], only_in_sigma: [], **counts } if exp_set == act_set
 
   # Month-grain fallback — REPRESENTATION mismatches only: a monthly chart's
   # Tableau label ("January 2026" → "2026-01") vs Sigma's DateTrunc value
@@ -127,14 +138,16 @@ def strict_compare(exp, act)
      (day_form.call(exp_set) && month_form.call(act_set))
     to_month = ->(set) { Set.new(set.map { |r| [month_grain(r[0]), *r[1..]] }) }
     if to_month.call(exp_set) == to_month.call(act_set)
-      return { status: 'PASS', only_in_tableau: [], only_in_sigma: [],
-               notes: ['matched at month grain (label vs first-of-month representation)'] }
+      return { status: 'PASS', score: 1.0, only_in_tableau: [], only_in_sigma: [],
+               notes: ['matched at month grain (label vs first-of-month representation)'], **counts }
     end
   end
 
   { status: 'DIVERGE',
+    score: jaccard(exp_set, act_set),
     only_in_tableau: (exp_set - act_set).to_a,
-    only_in_sigma:   (act_set - exp_set).to_a }
+    only_in_sigma:   (act_set - exp_set).to_a,
+    **counts }
 end
 
 # Extract-mode: same row count + same dim set + same dim sort. Measure values
@@ -164,31 +177,39 @@ def extract_compare(exp, act, tol:)
     notes << "dim sort order differs (extract-mode flags only — not a failure)"
   end
 
-  # Wild-divergence check on measures (10x or more drift = probably a real bug,
-  # not just extract staleness)
-  if exp.size == act.size && exp_set == act_set
-    exp_h = exp.each_with_object({}) { |r, h| h[r[0]] = r[1] }
-    act_h = act.each_with_object({}) { |r, h| h[r[0]] = r[1] }
-    big_drifts = []
-    exp_h.each do |k, v|
-      a = act_h[k]
-      next if v.nil? || a.nil?
-      next unless v.is_a?(Numeric) && a.is_a?(Numeric)
-      denom = [v.abs.to_f, a.abs.to_f, 1.0].max
-      drift = (v - a).abs.to_f / denom
-      big_drifts << [k, v, a, drift] if drift > tol
-    end
-    if big_drifts.any?
-      notes << "#{big_drifts.size} measure value(s) drift > #{(tol * 100).to_i}% — review:"
-      big_drifts.first(3).each do |k, v, a, d|
-        notes << "    #{k.inspect} tableau=#{v} sigma=#{a} drift=#{(d * 100).round}%"
-      end
+  # Value fidelity over matched dims (bead y9rd.2 score): mean of max(0, 1-drift)
+  # across comparable numeric cells, capped at 1. Computed regardless of bucket
+  # alignment so the score reflects real value accuracy even when extract-mode
+  # leniently PASSes. big_drifts (> tol) still surfaced as review notes.
+  exp_h = exp.each_with_object({}) { |r, h| h[r[0]] = r[1] }
+  act_h = act.each_with_object({}) { |r, h| h[r[0]] = r[1] }
+  big_drifts = []
+  fidelities = []
+  exp_h.each do |k, v|
+    a = act_h[k]
+    next if v.nil? || a.nil?
+    next unless v.is_a?(Numeric) && a.is_a?(Numeric)
+    denom = [v.abs.to_f, a.abs.to_f, 1.0].max
+    drift = (v - a).abs.to_f / denom
+    fidelities << [0.0, 1.0 - drift].max
+    big_drifts << [k, v, a, drift] if drift > tol
+  end
+  if big_drifts.any? && exp.size == act.size && exp_set == act_set
+    notes << "#{big_drifts.size} measure value(s) drift > #{(tol * 100).to_i}% — review:"
+    big_drifts.first(3).each do |k, v, a, d|
+      notes << "    #{k.inspect} tableau=#{v} sigma=#{a} drift=#{(d * 100).round}%"
     end
   end
 
-  { status: status, notes: notes,
+  # Score = dim-set Jaccard × mean value fidelity (when comparable numerics exist).
+  dim_jac = jaccard(exp_set, act_set)
+  value_acc = fidelities.empty? ? 1.0 : (fidelities.sum / fidelities.size)
+  score = (dim_jac * value_acc).round(4)
+
+  { status: status, notes: notes, score: score,
     only_in_tableau: (exp_set - act_set).to_a,
-    only_in_sigma:   (act_set - exp_set).to_a }
+    only_in_sigma:   (act_set - exp_set).to_a,
+    n_expected: exp_set.size, n_actual: act_set.size, n_matched: (exp_set & act_set).size }
 end
 
 raw = JSON.parse(File.read(opts[:plan]))
@@ -221,7 +242,7 @@ end
 
 results.each do |r|
   tag = r[:extract] ? '[extract]' : '[strict] '
-  printf "%-7s  %s  %s\n", r[:status], tag, r[:chart]
+  printf "%-7s  %s  %s  (score %.0f%%)\n", r[:status], tag, r[:chart], (r[:score] || 0) * 100
   if r[:status] != 'PASS' || (r[:notes] && r[:notes].any?)
     Array(r[:notes]).each { |n| puts "    #{n}" }
     if r[:only_in_tableau].any? || r[:only_in_sigma].any?
@@ -232,6 +253,29 @@ results.each do |r|
 end
 
 failed = results.count { |r| r[:status] != 'PASS' }
+# Overall value-parity score (bead y9rd.2): mean per-tile score — the real,
+# repeatable number behind "N% parity". Separate from pass/fail (a chart can
+# DIVERGE yet score 0.9 if only one bucket is off) so trends are visible.
+overall = results.empty? ? 1.0 : (results.sum { |r| r[:score] || 0.0 } / results.size).round(4)
 puts '---'
 puts "#{results.size - failed}/#{results.size} pass" + (mode_forced ? '  (extract-mode)' : '')
+puts "value-parity score: #{(overall * 100).round(1)}%  (mean per-tile, #{results.size} tile(s))"
+
+if opts[:score_out]
+  score_doc = {
+    'ran_at'              => Time.now.utc.iso8601,
+    'mode'                => mode_forced ? 'extract' : 'strict',
+    'tiles_total'         => results.size,
+    'tiles_pass'          => results.size - failed,
+    'tiles_fail'          => failed,
+    'value_parity_score'  => overall,
+    'tiles'               => results.map { |r|
+      { 'chart' => r[:chart], 'status' => r[:status], 'extract' => r[:extract],
+        'score' => (r[:score] || 0.0),
+        'n_expected' => r[:n_expected], 'n_actual' => r[:n_actual], 'n_matched' => r[:n_matched] }
+    }
+  }
+  File.write(opts[:score_out], JSON.pretty_generate(score_doc))
+  warn "value-parity score written → #{opts[:score_out]}"
+end
 exit(failed.zero? ? 0 : 1)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -108,12 +108,13 @@ require 'optparse'
 require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
-         allow_missing_tiles: 0 }
+         allow_missing_tiles: 0, min_parity_score: 0.0 }
 OptionParser.new do |p|
   p.on('--tableau DIR')              { |v| opts[:tab] = v }
   p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
   p.on('--workbook-id ID')           { |v| opts[:wb] = v }
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
@@ -185,6 +186,26 @@ else
       warn "       Failing charts: #{fail_names.join(', ')}"
     end
     exit 2
+  end
+
+  # Value-parity SCORE gate (bead y9rd.2): the mean per-tile value-fidelity score
+  # is a finer signal than pass/fail — a tile can PASS the bucket check yet score
+  # low on value drift. When --min-parity-score is set, gate on the real number.
+  if opts[:min_parity_score] > 0.0
+    vps = summary['value_parity_score']
+    if vps.nil?
+      warn "[FAIL] --min-parity-score #{opts[:min_parity_score]} requested but parity-final.json has no value_parity_score."
+      warn "       Re-run phase6-parity.rb --finalize (it now writes the score via verify-parity --score-out)."
+      exit 2
+    end
+    if vps.to_f < opts[:min_parity_score]
+      warn "[FAIL] value-parity score=#{(vps.to_f * 100).round(1)}% < required #{(opts[:min_parity_score] * 100).round(1)}%"
+      low = (summary['per_tile_scores'] || []).select { |t| t['score'].to_f < opts[:min_parity_score] }
+                                              .sort_by { |t| t['score'].to_f }.first(5)
+      low.each { |t| warn format('       %-40s %.0f%% (%s)', t['chart'], t['score'].to_f * 100, t['status']) }
+      exit 2
+    end
+    puts "[OK] gate 1/7: value-parity score=#{(vps.to_f * 100).round(1)}% (>= #{(opts[:min_parity_score] * 100).round(1)}% required)"
   end
 
   if rate_gate_only && status != 'PASS'

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -108,12 +108,13 @@ require 'optparse'
 require 'rbconfig'
 
 opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
-         allow_missing_tiles: 0 }
+         allow_missing_tiles: 0, min_parity_score: 0.0 }
 OptionParser.new do |p|
   p.on('--tableau DIR')              { |v| opts[:tab] = v }
   p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
   p.on('--workbook-id ID')           { |v| opts[:wb] = v }
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
   p.on('--skip-column-check')        { opts[:skip_column] = true }
   p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
@@ -185,6 +186,26 @@ else
       warn "       Failing charts: #{fail_names.join(', ')}"
     end
     exit 2
+  end
+
+  # Value-parity SCORE gate (bead y9rd.2): the mean per-tile value-fidelity score
+  # is a finer signal than pass/fail — a tile can PASS the bucket check yet score
+  # low on value drift. When --min-parity-score is set, gate on the real number.
+  if opts[:min_parity_score] > 0.0
+    vps = summary['value_parity_score']
+    if vps.nil?
+      warn "[FAIL] --min-parity-score #{opts[:min_parity_score]} requested but parity-final.json has no value_parity_score."
+      warn "       Re-run phase6-parity.rb --finalize (it now writes the score via verify-parity --score-out)."
+      exit 2
+    end
+    if vps.to_f < opts[:min_parity_score]
+      warn "[FAIL] value-parity score=#{(vps.to_f * 100).round(1)}% < required #{(opts[:min_parity_score] * 100).round(1)}%"
+      low = (summary['per_tile_scores'] || []).select { |t| t['score'].to_f < opts[:min_parity_score] }
+                                              .sort_by { |t| t['score'].to_f }.first(5)
+      low.each { |t| warn format('       %-40s %.0f%% (%s)', t['chart'], t['score'].to_f * 100, t['status']) }
+      exit 2
+    end
+    puts "[OK] gate 1/7: value-parity score=#{(vps.to_f * 100).round(1)}% (>= #{(opts[:min_parity_score] * 100).round(1)}% required)"
   end
 
   if rate_gate_only && status != 'PASS'


### PR DESCRIPTION
## What

Phase 6 verified **pass/fail** only — "75% parity" was never a measured number. This makes it one.

- **`verify-parity.rb`**: every tile gets a **score ∈ [0,1]**.
  - strict mode = tuple-set Jaccard (matched cells / distinct cells)
  - extract mode = dim-set Jaccard × mean value fidelity (`max(0, 1-drift)` over comparable numeric cells)
  - overall = mean per-tile score; printed per tile + overall
  - new `--score-out parity-score.json` → `{value_parity_score, tiles:[{chart,status,score,n_expected,n_actual,n_matched}]}`
  - score is **separate from pass/fail** (a DIVERGE tile can still score 0.9), so trends are visible
- **`phase6-parity.rb`**: passes `--score-out`; folds `value_parity_score` + `per_tile_scores` into `parity-final.json`, plus a `tier_coverage` block from `coverage.json` (built/approximated/degraded/dropped). PASS/DIVERGE name regexes updated to strip the new `(score NN%)` suffix so the tile census stays clean.
- **`assert-phase6-ran.rb`** (shared canonical + 6 fanned-out copies): new `--min-parity-score F` gate-1 check. **OFF by default (0.0)** — zero impact on existing runs; lists lowest-scoring tiles on failure.
- **`test-parity-score.rb`**: offline unit test (10 assertions), registered in `corpus-check.yml`. No network/creds.

## Verification

```
PASS     [strict]   Exact      (score 100%)
DIVERGE  [strict]   HalfMatch  (score 50%)     # 2/4 Jaccard
PASS     [extract]  Drift      (score 95%)     # 9% drift, under tol
value-parity score: 81.8%  (mean per-tile, 3 tile(s))
```

`test-parity-score.rb`: 10/10. `check-shared` + `lint-skills` green. Score gate verified to fail below threshold (exit 2) and stay silent when off.

## Scope notes

`verify-parity`/`phase6-parity` are not manifest-managed (no shared canonical) → edits are tableau-scoped (this is a Tableau-epic bead). `assert-phase6-ran.rb` **is** shared → edited the canonical and ran `tools/sync-shared.rb`.

## Follow-up

Per-formula (column-level) scoring + cross-ref-depth in the tier report (y9rd.2 stretch) — left for a follow-up; this lands the core measured number + gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)