### PR TITLE
feat(tableau): per-formula parity scoring + tier-report enrichment (y9rd.14)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/phase6-parity.rb
@@ -286,9 +286,69 @@ if File.exist?(score_out_path)
   end
 end
 coverage_path = opts[:coverage] || File.join(opts[:tab], 'coverage.json')
+cov_unresolved = []
 if File.exist?(coverage_path)
   cov = JSON.parse(File.read(coverage_path)) rescue nil
-  summary['tier_coverage'] = cov['summary'] if cov.is_a?(Hash) && cov['summary']
+  if cov.is_a?(Hash)
+    summary['tier_coverage'] = cov['summary'] if cov['summary']
+    cov_unresolved = cov['unresolved'] || []
+    # Tier report enrichment (bead y9rd.14): the summary counts alone don't say
+    # WHICH tier or WHY. Add a distribution (by severity + source kind) and the
+    # full dropped-with-root-cause list so a reviewer sees exactly what was lost.
+    if cov_unresolved.any?
+      summary['tier_distribution'] = {
+        'by_severity'    => cov_unresolved.group_by { |u| u['severity'] }.transform_values(&:size),
+        'by_source_type' => cov_unresolved.group_by { |u| u['source_type'] }.transform_values(&:size)
+      }
+      summary['excluded_with_root_cause'] = cov_unresolved
+        .select { |u| u['severity'] == 'dropped' }
+        .map { |u| u.select { |k, _| %w[visual source_type sigma_kind detail action recoverable].include?(k) } }
+    end
+  end
+end
+
+# Cross-ref DEPTH (bead y9rd.14): how deep the nested-LOD calc chains run — a
+# proxy for calc-on-calc complexity. The build emits a <chart-specs>-lod-chains.json
+# sidecar (decompose_nested_fixed, innermost-first); each chain's length is its
+# depth. Best-effort: glob the tableau dir, omit the block when no chains exist.
+lod_files = Dir.glob(File.join(opts[:tab], '*-lod-chains.json'))
+chains = lod_files.flat_map { |f| (JSON.parse(File.read(f)) rescue []) }.select { |c| c.is_a?(Hash) }
+if chains.any?
+  depths = chains.map { |c| (c['chain'] || []).size }.reject(&:zero?)
+  if depths.any?
+    by_depth = depths.group_by(&:itself).transform_keys(&:to_s).transform_values(&:size)
+    summary['cross_ref_depth'] = { 'max_depth' => depths.max, 'chains' => depths.size, 'by_depth' => by_depth }
+  end
+end
+
+# Per-FORMULA "coverage answer" artifact (bead y9rd.14, ThoughtSpot idea): one
+# record per scored column (did this formula migrate + at what fidelity) PLUS the
+# dropped items (migrated:false + root cause). Flattens per-tile per-column scores
+# (from parity-score.json, now carrying `columns`) and joins the coverage drops.
+formula_coverage = []
+if defined?(score_doc) && score_doc
+  (score_doc['tiles'] || []).each do |t|
+    (t['columns'] || []).each do |c|
+      formula_coverage << {
+        'chart' => t['chart'], 'column_id' => c['column_id'], 'kind' => c['kind'],
+        'migrated' => true, 'fidelity' => c['score'],
+        'coverage_status' => ((c['score'] || 0) >= 0.999 ? 'exact' : 'diverged')
+      }
+    end
+  end
+end
+cov_unresolved.select { |u| u['severity'] == 'dropped' }.each do |u|
+  formula_coverage << {
+    'chart' => u['visual'], 'column_id' => nil, 'kind' => u['source_type'],
+    'migrated' => false, 'fidelity' => nil, 'coverage_status' => 'dropped', 'detail' => u['detail']
+  }
+end
+unless formula_coverage.empty?
+  fc_path = File.join(opts[:tab], 'parity-formula-coverage.json')
+  File.write(fc_path, JSON.pretty_generate(formula_coverage))
+  n_drop = formula_coverage.count { |f| !f['migrated'] }
+  n_div  = formula_coverage.count { |f| f['coverage_status'] == 'diverged' }
+  warn "wrote #{fc_path} (#{formula_coverage.size} formula record(s): #{n_div} diverged, #{n_drop} dropped)"
 end
 
 File.write(summary_path, JSON.pretty_generate(summary))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-score.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-score.rb
@@ -39,6 +39,16 @@ Dir.mktmpdir do |d|
      (tiles['Drift']['score'] - 0.9545).abs < 0.01 && tiles['Drift']['status'] == 'PASS')
   ok('overall = mean per-tile (~0.818)', (doc['value_parity_score'] - 0.8182).abs < 0.001)
   ok('tiles_total/pass counts', doc['tiles_total'] == 3 && doc['tiles_pass'] == 2)
+
+  # per-column (per-formula) scores — bead y9rd.14
+  ok('per-column scores present (2 cols)', tiles['Exact']['columns'].is_a?(Array) && tiles['Exact']['columns'].size == 2)
+  ok('exact: both columns score 1.0', tiles['Exact']['columns'].all? { |c| c['score'] == 1.0 })
+  hm = tiles['HalfMatch']['columns']
+  ok('half-match dim col (idx0, kind=dim) scores 0.5', hm[0]['score'] == 0.5 && hm[0]['kind'] == 'dim')
+  ok('half-match measure col (idx1, kind=measure) scores 0.5 (key 0.5 × value 1.0)',
+     hm[1]['score'] == 0.5 && hm[1]['kind'] == 'measure')
+  dr = tiles['Drift']['columns']
+  ok('drift measure col reflects the 9% drift (~0.95)', (dr[1]['score'] - 0.9545).abs < 0.01)
 end
 
 # ── assert-phase6-ran.rb --min-parity-score gate ────────────────────────────

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-parity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-parity.rb
@@ -212,6 +212,42 @@ def extract_compare(exp, act, tol:)
     n_expected: exp_set.size, n_actual: act_set.size, n_matched: (exp_set & act_set).size }
 end
 
+# Per-COLUMN (per-formula) value scoring (y9rd.14): project the row tuples to each
+# column position and score it independently, so a 3-channel / multi-measure tile
+# reports WHICH column diverged (the per-formula "coverage answer"), not just one
+# blended tile score. Column 0 is the key/dim → distinct-value-set Jaccard. A
+# numeric column i>0 is a measure → key-set Jaccard × mean value fidelity keyed on
+# the row's dim (col 0), matching extract_compare. A non-numeric column i>0 falls
+# back to set Jaccard. `cols` = the plan's sigma_columns (ids in row order).
+def per_column_scores(exp, act, cols)
+  width = [(exp.map(&:size) + act.map(&:size)).max || 0, 0].max
+  return [] if width.zero?
+  (0...width).map do |i|
+    exp_vals = exp.map { |r| r[i] }
+    act_vals = act.map { |r| r[i] }
+    present  = (exp_vals + act_vals).compact
+    numeric  = i.positive? && present.any? && present.all? { |v| v.is_a?(Numeric) }
+    if numeric
+      exp_h = exp.each_with_object({}) { |r, h| h[r[0]] = r[i] }
+      act_h = act.each_with_object({}) { |r, h| h[r[0]] = r[i] }
+      fids = []
+      exp_h.each do |k, v|
+        a = act_h[k]
+        next if v.nil? || a.nil?
+        denom = [v.abs.to_f, a.abs.to_f, 1.0].max
+        fids << [0.0, 1.0 - (v - a).abs.to_f / denom].max
+      end
+      key_jac = jaccard(Set.new(exp_h.keys), Set.new(act_h.keys))
+      val_acc = fids.empty? ? (key_jac.zero? ? 0.0 : 1.0) : (fids.sum / fids.size)
+      score = (key_jac * val_acc).round(4)
+    else
+      score = jaccard(Set.new(exp_vals), Set.new(act_vals))
+    end
+    { 'index' => i, 'column_id' => (cols && cols[i]), 'kind' => (numeric ? 'measure' : 'dim'),
+      'score' => score, 'n_expected' => exp_vals.compact.uniq.size, 'n_actual' => act_vals.compact.uniq.size }
+  end
+end
+
 raw = JSON.parse(File.read(opts[:plan]))
 default_extract = false
 if raw.is_a?(Hash) && raw['charts']
@@ -237,7 +273,8 @@ results = plan.map do |p|
                  end
 
   result = this_extract ? extract_compare(exp, act, tol: opts[:tol]) : strict_compare(exp, act)
-  result.merge(chart: p['chart'], extract: this_extract)
+  result.merge(chart: p['chart'], extract: this_extract,
+               columns: per_column_scores(exp, act, p['sigma_columns']))
 end
 
 results.each do |r|
@@ -248,6 +285,11 @@ results.each do |r|
     if r[:only_in_tableau].any? || r[:only_in_sigma].any?
       puts "    Tableau-only: #{r[:only_in_tableau].inspect[0..200]}"
       puts "    Sigma-only:   #{r[:only_in_sigma].inspect[0..200]}"
+    end
+    # Point at the weakest column (per-formula coverage answer, y9rd.14).
+    weak = (r[:columns] || []).reject { |c| (c['score'] || 1.0) >= 0.999 }.min_by { |c| c['score'] }
+    if weak
+      puts "    weakest column: ##{weak['index']} #{weak['column_id'] || '(unnamed)'} (#{weak['kind']}) score #{(weak['score'] * 100).round}%"
     end
   end
 end
@@ -272,7 +314,9 @@ if opts[:score_out]
     'tiles'               => results.map { |r|
       { 'chart' => r[:chart], 'status' => r[:status], 'extract' => r[:extract],
         'score' => (r[:score] || 0.0),
-        'n_expected' => r[:n_expected], 'n_actual' => r[:n_actual], 'n_matched' => r[:n_matched] }
+        'n_expected' => r[:n_expected], 'n_actual' => r[:n_actual], 'n_matched' => r[:n_matched],
+        # per-column (per-formula) scores (y9rd.14) — which column carried the divergence
+        'columns' => (r[:columns] || []) }
     }
   }
   File.write(opts[:score_out], JSON.pretty_generate(score_doc))


### PR DESCRIPTION
P3 stretch on the y9rd.2 value-parity scorer (bead beads-sigma-y9rd.14, under epic y9rd).

## 1. Per-column (per-formula) value scoring — `verify-parity.rb`
A tile's single blended score didn't say *which* channel diverged. `per_column_scores()` projects the row tuples to each column position:
- col 0 (key/dim) → distinct-value-set Jaccard
- numeric col i>0 (measure) → key-set Jaccard × mean value fidelity keyed on the row's dim (mirrors `extract_compare`)
- non-numeric col i>0 → set Jaccard

Each `parity-score.json` tile now carries `columns:[{index, column_id, kind, score, n_expected, n_actual}]`; the console prints the weakest column for diverging tiles.

## 2. Tier-report enrichment — `phase6-parity.rb`
Folds from `coverage.json`:
- `tier_distribution` (by_severity + by_source_type)
- `excluded_with_root_cause` (dropped items + detail/action/recoverable)
- `cross_ref_depth` (max + distribution of nested-LOD chain depths from the `*-lod-chains.json` sidecar — calc-on-calc complexity proxy; best-effort)

## 3. Per-formula coverage-answer artifact (ThoughtSpot idea)
New `parity-formula-coverage.json`: one record per scored column (migrated + fidelity + exact/diverged) plus dropped items (migrated:false + root cause).

## Tests / gates
- `test-parity-score.rb` extended with 5 per-column assertions (in `corpus-check.yml`); all pass.
- Enrichment expressions shape-validated offline.
- `lint-skills` + `check-shared` clean.

Completes the last open child of the DDMX epic (y9rd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)