### PR TITLE
fix(tableau): don't leak ctl-param-<caption> for picker-driven params → control-lint clean (jwsf)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -102,6 +102,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-parity-score.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-aggregate-dimension.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-measure-picker.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1430,6 +1430,30 @@ def param_switch_for(*candidates)
   nil
 end
 
+# Normalize a parameter caption/name for dedup matching: strip Tableau's
+# "[Parameters].[X]" wrapping and bare brackets, then case-fold. (jwsf)
+def norm_param_caption(s)
+  s.to_s.gsub(/\A\[Parameters\]\.\[|\]\z|\A\[|\]\z/, '').strip.downcase
+end
+
+# Index the parameter captions that drive a WIRED measure-picker Switch, so the
+# auto-control loop can skip the redundant `ctl-param-<caption>` control (jwsf).
+# The converter usually puts the parameter CAPTION directly in `param_name`
+# ("Metric Picker"), but older paths put a GUID/key resolvable via
+# columns_by_guid; index EVERY form so the dedup fires regardless. Returns a
+# Set-like hash {normalized_caption => true}. Only pickers actually used on a
+# tile count (an un-wired picker doesn't suppress its parameter's control).
+def picker_param_caps_index(param_switches, used, columns_by_guid)
+  idx = {}
+  (param_switches || []).each do |sw|
+    next unless (used || []).include?(sw['control_id'])
+    [sw['param_name'], (columns_by_guid || {}).dig(sw['param_name'], 'caption')]
+      .compact.reject { |x| x.to_s.strip.empty? }
+      .each { |pc| idx[norm_param_caption(pc)] = true }
+  end
+  idx
+end
+
 # ---- Converter aggregate-derived dimensions (workbookPatterns kind:aggregate-
 # dimension; y9rd.13) ---------------------------------------------------------
 # The converter emits { kind:'aggregate-dimension', name (the calc CAPTION),
@@ -3647,12 +3671,13 @@ if opts[:auto_controls]
   # control emitted under the converter's controlId (ctl-parameter-<n>); don't ALSO
   # emit the legacy auto-param control (ctl-param-<caption>) for the same parameter
   # — that second control binds nothing and trips the control lint (n4pi.10).
-  picker_param_caps = {}
-  $param_switches.each do |sw|
-    next unless $param_switch_used.include?(sw['control_id'])
-    pc = (meta['columns_by_guid'] || {}).dig(sw['param_name'], 'caption')
-    picker_param_caps[pc.to_s.downcase] = true if pc && !pc.to_s.empty?
-  end
+  # Skip the redundant ctl-param-<caption> auto-control for any parameter that
+  # already drives a WIRED measure-picker Switch (jwsf: when paramName was already
+  # the caption, the old columns_by_guid-only lookup returned nil → the control
+  # leaked, got pruned as unreferenced, and its orphan control-scope record tripped
+  # control_lint "missing control"). picker_param_caps_index matches every caption
+  # form.
+  picker_param_caps = picker_param_caps_index($param_switches, $param_switch_used, meta['columns_by_guid'])
   # A parameter is typically declared once in the workbook metadata AND again in
   # every worksheet's datasource-dependencies that references it, so
   # meta['parameters'] commonly carries many duplicates of the same caption
@@ -3665,7 +3690,7 @@ if opts[:auto_controls]
     next if cap.empty?
     next if seen_param_caps[cap.downcase]
     seen_param_caps[cap.downcase] = true
-    if picker_param_caps[cap.downcase]
+    if picker_param_caps[norm_param_caption(cap)] || picker_param_caps[norm_param_caption(p['name'])]
       warnings << "parameter '#{cap}' drives a measure-picker Switch — control emitted under the converter controlId; skipping the redundant auto-param control"
       next
     end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-measure-picker.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-measure-picker.rb
@@ -19,7 +19,8 @@ SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
 # Pull the pure helper methods out of the script (which otherwise runs main) and
 # define them here. Order doesn't matter — they're resolved at call time.
 %w[map_column coerce_case_literal remap_param_branch
-   load_param_switches param_switch_for param_switch_inline].each do |fn|
+   load_param_switches param_switch_for param_switch_inline
+   norm_param_caption picker_param_caps_index].each do |fn|
   m = SRC.match(/^def #{fn}\b.*?\n^end$/m) or abort("could not extract #{fn} from build-charts-from-signals.rb")
   eval(m[0]) # rubocop:disable Security/Eval — test-only extraction of first-party code
 end
@@ -94,6 +95,26 @@ check(param_switch_inline(sw3, MMAP, CBG).nil?, 'window-function picker → nil 
 sw4 = { 'name' => 'P4', 'control_id' => 'ctl-parameter-5', 'param_name' => 'Parameter 5',
         'cases' => [{ 'when' => 'X', 'then' => '[Ghost A]' }, { 'when' => 'Y', 'then' => '[Ghost B]' }], 'else' => nil }
 check(param_switch_inline(sw4, MMAP, CBG).nil?, 'all branches unresolvable → nil (no empty Switch)', fails)
+
+# ---- 5. picker-param dedup index (jwsf) ----------------------------------------
+# The auto-control loop must skip the redundant ctl-param-<caption> control for a
+# parameter that already drives a WIRED picker — else the orphan control-scope
+# record trips control_lint "missing control". The jwsf failure: param_name WAS
+# the caption ("Metric Picker"), so the old columns_by_guid-only lookup returned
+# nil and the dedup never fired.
+check(norm_param_caption('[Parameters].[Metric Picker]') == 'metric picker', 'norm_param_caption strips [Parameters].[…] wrapping', fails)
+check(norm_param_caption('[Metric Picker]') == 'metric picker', 'norm_param_caption strips bare brackets', fails)
+sws = [{ 'control_id' => 'ctl-metric-picker', 'param_name' => 'Metric Picker' }]
+# jwsf case: param_name is already the caption, columns_by_guid has NO entry for it.
+idx = picker_param_caps_index(sws, ['ctl-metric-picker'], {})
+check(idx['metric picker'] == true, 'jwsf: dedup matches when param_name IS the caption (columns_by_guid miss)', fails)
+# GUID-keyed param_name still resolves via columns_by_guid (legacy path).
+idx2 = picker_param_caps_index([{ 'control_id' => 'ctl-x', 'param_name' => 'Parameter 7' }],
+                               ['ctl-x'], { 'Parameter 7' => { 'caption' => 'Region Picker' } })
+check(idx2['region picker'] == true, 'GUID-keyed param_name resolves caption via columns_by_guid', fails)
+# An UN-wired picker must NOT suppress its parameter's control.
+idx3 = picker_param_caps_index(sws, [], {})
+check(idx3.empty?, 'un-wired picker → no dedup (control still emitted)', fails)
 
 puts
 if fails.empty?


### PR DESCRIPTION
Fixes beads-sigma-jwsf — a pre-existing control-lint hard-FAIL surfaced by the DDMX testbed E2E.

## Symptom
`control_lint` failed `missing control: ctl-param-metric-picker` on any workbook whose parameter drives a measure-picker Switch.

## Root cause
The auto-control loop skips the redundant `ctl-param-<caption>` control when the parameter already drives a **wired** picker — but it indexed those params only via `columns_by_guid[param_name].caption`. The converter now puts the parameter **caption** directly in `param_name` (`"Metric Picker"`), so that lookup returned `nil`, the dedup never fired, and `ctl-param-metric-picker` got emitted → pruned as unreferenced (tiles reference the picker's `ctl-metric-picker`) → leaving an **orphan control-scope record** that tripped the lint.

## Fix
Extract two pure helpers and match through a normalizer:
- `norm_param_caption(s)` — strip `[Parameters].[…]` / bare-bracket wrapping, casefold
- `picker_param_caps_index(switches, used, columns_by_guid)` — index picker params by **every** caption form (raw `param_name` **and** the `columns_by_guid` caption)

The redundant control is now skipped at the source, so no orphan scope record.

## Verification
- Testbed E2E: **"control lint: clean"** (was a hard FAIL); control-scope carries only the real `ctl-metric-picker-crosstabs`.
- `test-param-measure-picker.rb` +5 assertions (incl. the jwsf `param_name == caption` case); **also wired that suite into `corpus-check.yml`** (it wasn't gated before).
- `lint-skills` + `check-shared` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)