### PR TITLE
fix(tableau): emit a real Sigma top-N FILTER for RANK_UNIQUE/RANK(expr)<=N (pnxp)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -97,6 +97,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-swap-translation.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rls-wiring.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-table-calc-translation.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-topn-filter-emission.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-id-namespacing.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/coverage-matrix.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/coverage-matrix.md
@@ -117,7 +117,7 @@ All 🧩 forms are **chart-context only** — place in a grouped workbook elemen
 | `agg / WINDOW_SUM(agg)` | `PercentOfTotal(agg,"grand_total")` | 🧩 | |
 | `RUNNING_SUM(agg)/TOTAL(agg)` | `CumulativeSum(PercentOfTotal(…))` | 🧩 | pareto |
 | `RANK / RANK_DENSE / RANK_PERCENTILE` | `Rank / RankDense / RankPercentile(agg,"desc")` | 🧩 | default direction forced to `desc` (Tableau default) |
-| `RANK_UNIQUE(expr) <= N` (Top-N) | `RowNumber()<=N` (clean agg) · `manual` (LOD operand) | 🟡 | clean operand records `ranked_measure` — **verify the tile is sorted by it** (auto-sort/Top-N-filter is bead pnxp); LOD operand no longer silently dropped. See `window-functions.md` Complex composites |
+| `RANK_UNIQUE(expr) <= N` (Top-N) | native `kind:top-n` filter (clean agg) · surfaced (LOD operand) | ✅ | Filters-shelf idiom → real Sigma top-N filter keyed on the ranked measure (rowCount=N, rankingFunction row-number/rank) + DESC sort; LOD operand surfaced (build the helper measure first), never a sort-dependent RowNumber. yAxis-measure form auto-sorts by `ranked_measure`. See `window-functions.md` Complex composites |
 | `INDEX()` | `RowNumber()` | 🧩 | also the basis for `INDEX()<=N` / `RANK_UNIQUE(...)<=N` Top-N idioms — see Complex composites |
 | `LOOKUP(agg,±n)` | `Lag/Lead(agg,n)` | 🧩 | `LOOKUP(agg,0)`→identity |
 | `(ZN(SUM)−LOOKUP(SUM,−1))/ABS(LOOKUP(SUM,−1))` (period-over-period %) | `(Coalesce(Sum,0)−Lag(Sum,1))/Abs(Lag(Sum,1))` | 🧩 | **now auto** (ZN→Coalesce, ABS→Abs); chart should be date-sorted |

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/window-functions.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/window-functions.md
@@ -113,18 +113,26 @@ Partner-analytics .twb, 2026-06-29). Some are auto, some manual — but all have
 known Sigma recipe, so apply it rather than leaving the tile empty.
 
 ### Top-N: `RANK_UNIQUE(<expr>) <= N` / `RANK(<expr>) <= N`
-build-charts detects this idiom (translate_window_calc):
-- **Clean aggregate operand** (e.g. `RANK_UNIQUE(SUM(x))<=N`) → `RowNumber()<=N`,
-  and the result records `ranked_measure` (the translated `<expr>`).
-  ⚠️ `RowNumber()` follows the **viz sort**, and auto-sort-wiring is **not yet
-  done** — so you MUST **verify the element is sorted by the ranked measure**, or
-  the "Top N" shows the wrong N rows (clean-looking, value-wrong). A real Sigma
-  **Top-N filter** (filter on the grouping dim, ranked by `<expr>` DESC, limit N)
-  is order-independent and preferred — that's the planned converter follow-up
-  (bead pnxp). Until then: verify the sort.
-- **EXCLUDE/INCLUDE-LOD operand** (`RANK_UNIQUE(sum({EXCLUDE …}))<=N`) → returns
-  **`manual`** (no longer silently dropped to a bare `RowNumber()`): build the LOD
-  as a helper measure first (below), then a Top-N filter ranked by it.
+build-charts detects this idiom in two places (translate_window_calc):
+
+**On the Filters shelf** (the real EDNA "Top 25 Partners" idiom — a boolean calc
+kept on `true`). build-charts now emits a **native Sigma `kind:top-n` element
+filter** — order-independent, the proper fix:
+- **Clean aggregate operand** (`RANK_UNIQUE(SUM(x))<=N`) → a `kind:top-n` filter
+  keyed on the ranked measure, `rowCount=N`, `rankingFunction` = `row-number`
+  (RANK_UNIQUE, unique ranks) or `rank` (RANK, ties). The tile is also sorted by
+  that measure DESC so the visible order matches. `<N` keeps N−1; `<=N` keeps N.
+- **EXCLUDE/INCLUDE-LOD operand** (`RANK_UNIQUE(sum({EXCLUDE …}))<=N`) → **NOT
+  auto-emitted** (the operand can't be translated to a measure to rank on). It is
+  **surfaced** with an actionable note: build the LOD as a helper measure first
+  (below), then add a `kind:top-n` filter ranked by it. Never a sort-dependent
+  `RowNumber()`.
+- `>=N` / `>N` (rank N-or-worse) are not a fixed-count bottom-N → surfaced, not
+  auto-emitted.
+
+**As a plotted measure on the yAxis** (rare) → `RowNumber()<=N` + the tile is
+**auto-sorted** by the recorded `ranked_measure` DESC (`RowNumber()` follows the
+viz sort). Prefer re-authoring as a Filters-shelf top-N.
 
 ### Period-over-period % change: `(ZN(SUM(x)) − LOOKUP(SUM(x), −1)) / ABS(LOOKUP(SUM(x), −1))`
 **Now AUTO** (build-charts reduces `ZN→Coalesce(_,0)`, `ABS→Abs`, `LOOKUP(-1)→Lag`)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1072,15 +1072,32 @@ def translate_window_calc(formula, mmap, columns_by_guid = {})
   #       sort-dependent RowNumber()<=N with the operand gone.
   if (tn = s.match(/\A\s*RANK(?:_UNIQUE)?\s*\(\s*(.+?)\s*(?:,\s*'(?:asc|desc)'\s*)?\)\s*(<=|>=|<|>)\s*(\d+)\s*\z/i))
     operand, op, n = tn[1], tn[2], tn[3]
+    # RANK_UNIQUE assigns 1..N with NO ties (like ROW_NUMBER); RANK ties on equal
+    # values. A Sigma top-n filter mirrors this via rankingFunction. Only the
+    # `<=N` / `<N` shapes are a FIXED-COUNT top-N (keep the N highest-ranked);
+    # `>=N` / `>N` keep "everything ranked N or worse" — NOT a fixed bottom-N
+    # count, so they only get the inline/manual note (no top-n filter).
+    ranking  = (tn[0] =~ /_UNIQUE/i) ? 'row-number' : 'rank'
+    row_count = (op == '<=') ? n.to_i : (op == '<' ? n.to_i - 1 : nil)  # nil ⇒ not a top-n filter
     ranked = translate_user_agg_formula(operand, mmap, {})
+    base = { 'top_op' => op, 'ranking' => ranking, 'operand_raw' => operand.to_s.gsub(/\s+/, ' ') }
+    base['top_n'] = row_count if row_count
     if ranked
-      return { 'mode' => 'inline', 'formula' => "RowNumber() #{op} #{n}",
+      # Clean aggregate operand: caller emits a real Sigma Top-N FILTER keyed on
+      # this measure when top_n is set. Keep the legacy inline RowNumber() form +
+      # ranked_measure for the measure-on-yAxis path, which now auto-sorts the
+      # tile by the ranked measure (bead pnxp).
+      filt = row_count ? "Sigma top-#{row_count} filter ranked by #{ranked[0..70]}" : "RowNumber() #{op} #{n} on a tile sorted by #{ranked[0..70]}"
+      return base.merge('mode' => 'inline', 'formula' => "RowNumber() #{op} #{n}",
                'follows_sort' => true, 'ranked_measure' => ranked,
-               'note' => "RANK#{tn[0] =~ /_UNIQUE/i ? '_UNIQUE' : ''}(expr) #{op} #{n} top-N → RowNumber() #{op} #{n}; " \
-                         "SORT the tile by the ranked measure #{ranked[0..80]} (RowNumber follows the viz sort, else the cutoff is wrong)" }
+               'note' => "RANK#{tn[0] =~ /_UNIQUE/i ? '_UNIQUE' : ''}(expr) #{op} #{n} top-N → #{filt}")
     end
-    return { 'mode' => 'manual',
-             'note' => "top-N over an untranslatable LOD operand (#{operand.to_s.gsub(/\s+/, ' ')[0..80]}) — build a Sigma Top-N filter ranked by the LOD helper measure; never a sort-dependent RowNumber() #{op} #{n} with the operand dropped" }
+    # Untranslatable LOD operand: cannot key a filter on a measure we couldn't
+    # build. STAY MANUAL, but carry the parsed top-N facts so the caller can
+    # surface a precise, actionable instruction (build the LOD helper measure,
+    # then a top-n filter ranked by it) — never a sort-dependent RowNumber().
+    return base.merge('mode' => 'manual',
+             'note' => "top-N over an untranslatable LOD operand (#{operand.to_s.gsub(/\s+/, ' ')[0..80]}) — build the LOD helper as a Sigma measure, then a Sigma #{row_count ? "top-#{row_count}" : 'top-N'} filter ranked by it; never a sort-dependent RowNumber() #{op} #{n} with the operand dropped")
   end
 
   # Unbounded share-of-total: AGG / WINDOW_SUM(AGG) or AGG / TOTAL(AGG) on the
@@ -3218,6 +3235,23 @@ layout.each do |dash|
         sort_by ||= sort_target_column_id(z['sort'], dim, dim_hdr, dim_col_obj['id'], meas_col_obj['id'])
         x_axis['sort'] = { 'by' => sort_by, 'direction' => sigma_dir }
       end
+      # Top-N measure-on-yAxis safety (bead pnxp): when the plotted measure is a
+      # RANK_UNIQUE/RANK(<clean agg>)<=N idiom, translate_window_calc emits the
+      # inline RowNumber()<=N form and RECORDS the ranked measure. RowNumber()
+      # follows the viz sort, so without sorting by that measure the "top N"
+      # cutoff is wrong. If Tableau carried no explicit sort, auto-wire xAxis.sort
+      # by a hidden companion of the ranked measure (descending = top).
+      if window_plan && window_plan['mode'] == 'inline' && window_plan['ranked_measure'] &&
+         !z['sort'] && x_axis['sort'].nil? && chart_source_eid == opts[:master_id]
+        rm_id = "topn-sort-#{el_id}"
+        unless (element['columns'] || []).any? { |c| c['id'] == rm_id }
+          element['columns'] << { 'id' => rm_id, 'name' => "#{header_base(meas_hdr)} (rank measure)",
+                                  'formula' => window_plan['ranked_measure'] }
+        end
+        x_axis['sort'] = { 'by' => rm_id, 'direction' => 'descending' }
+        warnings << "'#{cap}' top-N measure (RowNumber()<=N) auto-sorted by its ranked measure " \
+                    "#{window_plan['ranked_measure'][0..70]} desc (RowNumber follows the viz sort — else the cutoff is wrong)"
+      end
       element['xAxis'] = x_axis
       # Combo-chart: yAxis.columnIds is a mixed array — bare strings default to
       # bar; { columnId, type: 'line' } objects override the series type.
@@ -3317,8 +3351,76 @@ layout.each do |dash|
       end
       fid
     end
+    # Top-N filter idiom (bead pnxp): a Tableau filter whose target is a BOOLEAN
+    # calc `RANK(<expr>)<=N` / `RANK_UNIQUE(<expr>)<=N` kept on `true`. Tableau
+    # exports hide this (it just thins the rows) and map_column can't resolve the
+    # calc to a warehouse column, so it used to be silently dropped. Resolve the
+    # filter to its calc formula and, when the ranked operand translates cleanly,
+    # emit a NATIVE Sigma `kind:top-n` element filter keyed on that measure
+    # (rowCount=N, rankingFunction row-number/rank) + sort the tile by it. An
+    # untranslatable LOD operand is surfaced (build the helper measure first),
+    # never emitted as a sort-dependent RowNumber.
+    norm_calc = ->(x) { x.to_s.gsub(/^\[|\]$/, '').strip.downcase }
+    topn_filter_plan = lambda do |f|
+      ref = [f['column_caption'], f['raw_param']].compact.map { |x| x.to_s }.join(' ')
+      calc = (z['calculations'] || []).find do |c|
+        cap_n  = norm_calc.call(c['caption'])
+        name_n = norm_calc.call(c['name'])
+        next false if c['formula'].to_s !~ /\bRANK(?:_UNIQUE)?\s*\(/i
+        (!cap_n.empty? && norm_calc.call(f['column_caption']) == cap_n) ||
+          (!name_n.empty? && ref.downcase.include?(name_n))
+      end
+      return nil unless calc
+      plan = translate_window_calc(calc['formula'], mmap, meta['columns_by_guid'] || {})
+      return nil unless plan && plan['operand_raw'] # only the top-N branch sets this
+      # The filter must KEEP the top rows (member 'true'); a keep-false would
+      # invert it. Tableau exports the keep-list in members.
+      kept = (f['members'] || []).map { |v| v.to_s.downcase }
+      plan = plan.merge('keeps_true' => kept.empty? || kept.include?('true'))
+      plan.merge('calc_caption' => calc['caption'] || calc['name'])
+    end
     value_filters.each do |f|
       fcap = f['column_caption'] || f['raw_param']
+      # --- Top-N idiom interception (before master-column resolution) ---------
+      if (tp = topn_filter_plan.call(f))
+        label = tp['calc_caption']
+        unless tp['keeps_true']
+          warnings << "'#{cap}' top-N filter '#{label}' keeps FALSE (anti-top-N) — not auto-emitted; re-create by hand"
+          next
+        end
+        unless tp['top_n'] && tp['ranked_measure']
+          # LOD operand or non-fixed-count op (>=/>): surface the actionable note.
+          warnings << "'#{cap}' top-N filter '#{label}': #{tp['note']}"
+          next
+        end
+        # Find or add the ranked-measure column on the element.
+        rm = tp['ranked_measure']
+        norm_f = ->(x) { x.to_s.gsub(/\s+/, '').downcase }
+        ranked_col = (element['columns'] || []).find { |c| norm_f.call(c['formula']) == norm_f.call(rm) }
+        if ranked_col.nil?
+          rc_id = "topn-#{el_id}"
+          ranked_col = { 'id' => rc_id, 'name' => header_base(label.to_s).strip.empty? ? 'Top-N Rank Measure' : label.to_s.sub(/\s*<=?\s*\d+\s*$/, '').strip,
+                         'formula' => rm }
+          element['columns'] << ranked_col
+        end
+        el_filters << {
+          'columnId' => ranked_col['id'], 'kind' => 'top-n',
+          'rankingFunction' => tp['ranking'], 'mode' => 'top-n',
+          'rowCount' => tp['top_n'], 'includeNulls' => 'never'
+        }
+        # Make the visible order match the ranking (cosmetic but expected). Only
+        # set when the tile has no explicit Tableau sort already.
+        unless z['sort']
+          if element['xAxis'].is_a?(Hash) && element['xAxis']['sort'].nil?
+            element['xAxis']['sort'] = { 'by' => ranked_col['id'], 'direction' => 'descending' }
+          elsif kind == 'table' && element.dig('groupings', 0) && element['groupings'][0]['sort'].nil?
+            element['groupings'][0]['sort'] = [{ 'columnId' => ranked_col['id'], 'direction' => 'descending' }]
+          end
+        end
+        warnings << "'#{cap}' top-N filter '#{label}' → native Sigma top-#{tp['top_n']} filter " \
+                    "(rankingFunction:#{tp['ranking']}) ranked by #{rm[0..80]}#{ranked_col['id'] == "topn-#{el_id}" ? ' (hidden companion measure added)' : ''}"
+        next
+      end
       m = fcap ? map_column(fcap, mmap) : nil
       if m.nil?
         warnings << "value filter on '#{cap}' targets '#{fcap}' — no master column matched, skipping"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixtures/topn-layout-meta.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixtures/topn-layout-meta.json
@@ -1,0 +1,213 @@
+{
+  "worksheets": {
+    "Top 25 Partners": {
+      "mark_class": "Bar",
+      "geo_role": null,
+      "has_lat": false,
+      "has_long": false,
+      "has_geometry": false,
+      "sort": null,
+      "filters": [
+        {
+          "raw_class": "categorical",
+          "raw_param": "[federated.fact].[usr:topn_clean:nk:3]",
+          "column_guid": null,
+          "column_caption": null,
+          "datatype": null,
+          "is_action": false,
+          "kind": "list",
+          "members": [
+            "true"
+          ]
+        }
+      ],
+      "hidden_filters": [
+
+      ],
+      "aggregations": {
+        "[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]": "None",
+        "[33b6c718-9b55-3dc0-9698-d1d57fac0f90]": "Sum",
+        "[topn_clean]": "User"
+      },
+      "channels": {
+      },
+      "formats": {
+      },
+      "calculations": [
+        {
+          "name": "[topn_clean]",
+          "caption": "Top25Flag",
+          "datatype": "boolean",
+          "role": "measure",
+          "class": "tableau",
+          "formula": "RANK_UNIQUE(SUM([Net Revenue]))<=25"
+        }
+      ],
+      "dual_axis": false,
+      "measures": [
+        {
+          "column": "[33b6c718-9b55-3dc0-9698-d1d57fac0f90]",
+          "derivation": "Sum"
+        }
+      ],
+      "ref_marks": [
+
+      ],
+      "axis_formats": [
+
+      ],
+      "mark_labels_show": false,
+      "rows_shelf": {
+        "raw": "[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]",
+        "fields": [
+          {
+            "raw": "[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]",
+            "role": "measure",
+            "derivation": "sum",
+            "guid": "33b6c718-9b55-3dc0-9698-d1d57fac0f90"
+          }
+        ],
+        "dim_count": 0,
+        "measure_count": 1,
+        "has_measure_names": false,
+        "has_measure_values": false
+      },
+      "cols_shelf": {
+        "raw": "[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]",
+        "fields": [
+          {
+            "raw": "[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]",
+            "role": "dim",
+            "derivation": "none",
+            "guid": "d73055c0-9ed1-347d-8f8e-05a48ce2c8a8"
+          }
+        ],
+        "dim_count": 1,
+        "measure_count": 0,
+        "has_measure_names": false,
+        "has_measure_values": false
+      },
+      "is_crosstab": false,
+      "is_kpi": false
+    },
+    "Top 10 Partners LOD": {
+      "mark_class": "Bar",
+      "geo_role": null,
+      "has_lat": false,
+      "has_long": false,
+      "has_geometry": false,
+      "sort": null,
+      "filters": [
+        {
+          "raw_class": "categorical",
+          "raw_param": "[federated.fact].[usr:topn_lod:nk:3]",
+          "column_guid": null,
+          "column_caption": null,
+          "datatype": null,
+          "is_action": false,
+          "kind": "list",
+          "members": [
+            "true"
+          ]
+        }
+      ],
+      "hidden_filters": [
+
+      ],
+      "aggregations": {
+        "[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]": "None",
+        "[33b6c718-9b55-3dc0-9698-d1d57fac0f90]": "Sum",
+        "[topn_lod]": "User"
+      },
+      "channels": {
+      },
+      "formats": {
+      },
+      "calculations": [
+        {
+          "name": "[topn_lod]",
+          "caption": "Top10FlagLOD",
+          "datatype": "boolean",
+          "role": "measure",
+          "class": "tableau",
+          "formula": "RANK_UNIQUE(sum({exclude [Seg]: sum([Net Revenue])}))<=10"
+        }
+      ],
+      "dual_axis": false,
+      "measures": [
+        {
+          "column": "[33b6c718-9b55-3dc0-9698-d1d57fac0f90]",
+          "derivation": "Sum"
+        }
+      ],
+      "ref_marks": [
+
+      ],
+      "axis_formats": [
+
+      ],
+      "mark_labels_show": false,
+      "rows_shelf": {
+        "raw": "[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]",
+        "fields": [
+          {
+            "raw": "[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]",
+            "role": "measure",
+            "derivation": "sum",
+            "guid": "33b6c718-9b55-3dc0-9698-d1d57fac0f90"
+          }
+        ],
+        "dim_count": 0,
+        "measure_count": 1,
+        "has_measure_names": false,
+        "has_measure_values": false
+      },
+      "cols_shelf": {
+        "raw": "[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]",
+        "fields": [
+          {
+            "raw": "[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]",
+            "role": "dim",
+            "derivation": "none",
+            "guid": "d73055c0-9ed1-347d-8f8e-05a48ce2c8a8"
+          }
+        ],
+        "dim_count": 1,
+        "measure_count": 0,
+        "has_measure_names": false,
+        "has_measure_values": false
+      },
+      "is_crosstab": false,
+      "is_kpi": false
+    }
+  },
+  "stories": [
+
+  ],
+  "shared_filters": [
+
+  ],
+  "parameters": [
+
+  ],
+  "column_aliases": {
+  },
+  "columns_by_guid": {
+    "33b6c718-9b55-3dc0-9698-d1d57fac0f90": {
+      "caption": "Net Revenue",
+      "datatype": "real"
+    },
+    "d73055c0-9ed1-347d-8f8e-05a48ce2c8a8": {
+      "caption": "Partner Name",
+      "datatype": "string"
+    },
+    "topn_clean": {
+      "caption": "Top25Flag",
+      "datatype": "boolean"
+    },
+    "topn_lod": {
+      "caption": "Top10FlagLOD",
+      "datatype": "boolean"
+    }
+  }
+}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixtures/topn-layout.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixtures/topn-layout.json
@@ -1,0 +1,226 @@
+[
+  {
+    "dashboard": "Dash",
+    "is_story": false,
+    "zones": [
+      {
+        "id": "1",
+        "kind": "chart",
+        "caption": "Top 25 Partners",
+        "view_ref": null,
+        "x_pct": 0.0,
+        "y_pct": 0.0,
+        "w_pct": 50.0,
+        "h_pct": 100.0,
+        "chart_kind": "bar",
+        "chart_kind_inferred": false,
+        "mark_class": "Bar",
+        "geo_role": null,
+        "sort": null,
+        "filters": [
+          {
+            "raw_class": "categorical",
+            "raw_param": "[federated.fact].[usr:topn_clean:nk:3]",
+            "column_guid": null,
+            "column_caption": null,
+            "datatype": null,
+            "is_action": false,
+            "kind": "list",
+            "members": [
+              "true"
+            ]
+          }
+        ],
+        "hidden_filters": [
+
+        ],
+        "aggregations": {
+          "[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]": "None",
+          "[33b6c718-9b55-3dc0-9698-d1d57fac0f90]": "Sum",
+          "[topn_clean]": "User"
+        },
+        "channels": {
+        },
+        "formats": {
+        },
+        "calculations": [
+          {
+            "name": "[topn_clean]",
+            "caption": "Top25Flag",
+            "datatype": "boolean",
+            "role": "measure",
+            "class": "tableau",
+            "formula": "RANK_UNIQUE(SUM([Net Revenue]))<=25"
+          }
+        ],
+        "dual_axis": false,
+        "measures": [
+          {
+            "column": "[33b6c718-9b55-3dc0-9698-d1d57fac0f90]",
+            "derivation": "Sum"
+          }
+        ],
+        "ref_marks": [
+
+        ],
+        "axis_formats": [
+
+        ],
+        "mark_labels_show": false,
+        "rows_shelf": {
+          "raw": "[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]",
+          "fields": [
+            {
+              "raw": "[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]",
+              "role": "measure",
+              "derivation": "sum",
+              "guid": "33b6c718-9b55-3dc0-9698-d1d57fac0f90"
+            }
+          ],
+          "dim_count": 0,
+          "measure_count": 1,
+          "has_measure_names": false,
+          "has_measure_values": false
+        },
+        "cols_shelf": {
+          "raw": "[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]",
+          "fields": [
+            {
+              "raw": "[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]",
+              "role": "dim",
+              "derivation": "none",
+              "guid": "d73055c0-9ed1-347d-8f8e-05a48ce2c8a8"
+            }
+          ],
+          "dim_count": 1,
+          "measure_count": 0,
+          "has_measure_names": false,
+          "has_measure_values": false
+        },
+        "is_crosstab": false,
+        "is_kpi": false,
+        "filter_column_caption": null,
+        "filter_column_datatype": null
+      },
+      {
+        "id": "2",
+        "kind": "chart",
+        "caption": "Top 10 Partners LOD",
+        "view_ref": null,
+        "x_pct": 50.0,
+        "y_pct": 0.0,
+        "w_pct": 50.0,
+        "h_pct": 100.0,
+        "chart_kind": "bar",
+        "chart_kind_inferred": false,
+        "mark_class": "Bar",
+        "geo_role": null,
+        "sort": null,
+        "filters": [
+          {
+            "raw_class": "categorical",
+            "raw_param": "[federated.fact].[usr:topn_lod:nk:3]",
+            "column_guid": null,
+            "column_caption": null,
+            "datatype": null,
+            "is_action": false,
+            "kind": "list",
+            "members": [
+              "true"
+            ]
+          }
+        ],
+        "hidden_filters": [
+
+        ],
+        "aggregations": {
+          "[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]": "None",
+          "[33b6c718-9b55-3dc0-9698-d1d57fac0f90]": "Sum",
+          "[topn_lod]": "User"
+        },
+        "channels": {
+        },
+        "formats": {
+        },
+        "calculations": [
+          {
+            "name": "[topn_lod]",
+            "caption": "Top10FlagLOD",
+            "datatype": "boolean",
+            "role": "measure",
+            "class": "tableau",
+            "formula": "RANK_UNIQUE(sum({exclude [Seg]: sum([Net Revenue])}))<=10"
+          }
+        ],
+        "dual_axis": false,
+        "measures": [
+          {
+            "column": "[33b6c718-9b55-3dc0-9698-d1d57fac0f90]",
+            "derivation": "Sum"
+          }
+        ],
+        "ref_marks": [
+
+        ],
+        "axis_formats": [
+
+        ],
+        "mark_labels_show": false,
+        "rows_shelf": {
+          "raw": "[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]",
+          "fields": [
+            {
+              "raw": "[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]",
+              "role": "measure",
+              "derivation": "sum",
+              "guid": "33b6c718-9b55-3dc0-9698-d1d57fac0f90"
+            }
+          ],
+          "dim_count": 0,
+          "measure_count": 1,
+          "has_measure_names": false,
+          "has_measure_values": false
+        },
+        "cols_shelf": {
+          "raw": "[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]",
+          "fields": [
+            {
+              "raw": "[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]",
+              "role": "dim",
+              "derivation": "none",
+              "guid": "d73055c0-9ed1-347d-8f8e-05a48ce2c8a8"
+            }
+          ],
+          "dim_count": 1,
+          "measure_count": 0,
+          "has_measure_names": false,
+          "has_measure_values": false
+        },
+        "is_crosstab": false,
+        "is_kpi": false,
+        "filter_column_caption": null,
+        "filter_column_datatype": null
+      }
+    ],
+    "zone_tree": [
+      {
+        "id": "1",
+        "kind": "chart",
+        "caption": "Top 25 Partners",
+        "x_pct": 0.0,
+        "y_pct": 0.0,
+        "w_pct": 50.0,
+        "h_pct": 100.0
+      },
+      {
+        "id": "2",
+        "kind": "chart",
+        "caption": "Top 10 Partners LOD",
+        "x_pct": 50.0,
+        "y_pct": 0.0,
+        "w_pct": 50.0,
+        "h_pct": 100.0
+      }
+    ]
+  }
+]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-topn-filter-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-topn-filter-emission.rb
@@ -12,18 +12,21 @@
 #   - UNTRANSLATABLE LOD operand → NOT emitted; surfaced with an actionable note
 #     (build the LOD helper measure first). Never a sort-dependent RowNumber.
 #
-# Deterministic + offline: synthesizes two minimal bar-chart worksheets (clean +
-# LOD), runs the ACTUAL parse-twb-layout.rb + build-charts-from-signals.rb, and
-# asserts the emitted element filters.
+# Deterministic + offline + CREDS-FREE: drives the ACTUAL build-charts-from-
+# signals.rb against committed parser-output fixtures (test-fixtures/topn-*.json,
+# generated once from a 2-bar-chart .twb — clean + LOD — via parse-twb-layout).
+# We feed build-charts directly (NOT the nokogiri-backed parser) so this runs in
+# the creds-free CI ruby. To regenerate the fixtures, see the heredoc TWB in the
+# git history of this file / run parse-twb-layout on it.
 #
 # Usage:  ruby scripts/test-topn-filter-emission.rb
 
 require 'json'
 require 'tmpdir'
 
-DIR    = __dir__
-PARSER = File.join(DIR, 'parse-twb-layout.rb')
-BUILD  = File.join(DIR, 'build-charts-from-signals.rb')
+DIR     = __dir__
+BUILD   = File.join(DIR, 'build-charts-from-signals.rb')
+FIXTURE = File.join(DIR, 'test-fixtures')
 
 fails = []
 def check(cond, msg, fails)
@@ -31,89 +34,10 @@ def check(cond, msg, fails)
   puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
 end
 
-# Two bar charts: Partner Name (dim) × SUM(Net Revenue) (measure). Each has a
-# boolean rank calc on the Filters shelf kept on `true`:
-#   Top 25 Partners      → RANK_UNIQUE(SUM([Net Revenue]))<=25         (clean)
-#   Top 25 Partners LOD  → RANK_UNIQUE(SUM({exclude [Seg]:SUM([Net Revenue])}))<=10  (LOD)
-# The filter column refs use the real `[usr:<name>:nk:3]` shape (guid_from_param
-# returns nil for it — so the fix must match the calc by NAME substring, exactly
-# like the real workbook).
-TWB = <<~XML
-  <?xml version='1.0' encoding='utf-8' ?>
-  <workbook>
-    <datasources>
-      <datasource caption='ORDER_FACT' name='federated.fact'>
-        <connection class='federated'>
-          <named-connections>
-            <named-connection name='snow'><connection class='snowflake' dbname='CSA' schema='TJ' /></named-connection>
-          </named-connections>
-          <relation connection='snow' name='ORDER_FACT' table='[TJ].[ORDER_FACT]' type='table' />
-        </connection>
-        <column caption='Net Revenue' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
-        <column caption='Partner Name' name='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' datatype='string' role='dimension' type='nominal' />
-      </datasource>
-    </datasources>
-    <worksheets>
-      <worksheet name='Top 25 Partners'>
-        <table>
-          <view>
-            <datasource-dependencies datasource='federated.fact'>
-              <column caption='Net Revenue' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
-              <column caption='Partner Name' name='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' datatype='string' role='dimension' type='nominal' />
-              <column-instance column='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' derivation='None' name='[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]' pivot='key' type='nominal' />
-              <column-instance column='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' derivation='Sum' name='[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]' pivot='key' type='quantitative' />
-              <column caption='Top25Flag' datatype='boolean' name='[topn_clean]' role='measure' type='nominal'>
-                <calculation class='tableau' formula='RANK_UNIQUE(SUM([Net Revenue]))&lt;=25'>
-                  <table-calc ordering-type='Rows' />
-                </calculation>
-              </column>
-              <column-instance column='[topn_clean]' derivation='User' name='[usr:topn_clean:nk:3]' pivot='key' type='nominal' />
-            </datasource-dependencies>
-          </view>
-          <rows>[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]</rows>
-          <cols>[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]</cols>
-          <pane><mark class='Bar' /></pane>
-          <filter class='categorical' column='[federated.fact].[usr:topn_clean:nk:3]'>
-            <groupfilter function='member' level='[usr:topn_clean:nk:3]' member='true' />
-          </filter>
-        </table>
-      </worksheet>
-      <worksheet name='Top 10 Partners LOD'>
-        <table>
-          <view>
-            <datasource-dependencies datasource='federated.fact'>
-              <column caption='Net Revenue' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
-              <column caption='Partner Name' name='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' datatype='string' role='dimension' type='nominal' />
-              <column-instance column='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' derivation='None' name='[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]' pivot='key' type='nominal' />
-              <column-instance column='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' derivation='Sum' name='[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]' pivot='key' type='quantitative' />
-              <column caption='Top10FlagLOD' datatype='boolean' name='[topn_lod]' role='measure' type='nominal'>
-                <calculation class='tableau' formula='RANK_UNIQUE(sum({exclude [Seg]: sum([Net Revenue])}))&lt;=10'>
-                  <table-calc ordering-type='Rows' />
-                </calculation>
-              </column>
-              <column-instance column='[topn_lod]' derivation='User' name='[usr:topn_lod:nk:3]' pivot='key' type='nominal' />
-            </datasource-dependencies>
-          </view>
-          <rows>[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]</rows>
-          <cols>[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]</cols>
-          <pane><mark class='Bar' /></pane>
-          <filter class='categorical' column='[federated.fact].[usr:topn_lod:nk:3]'>
-            <groupfilter function='member' level='[usr:topn_lod:nk:3]' member='true' />
-          </filter>
-        </table>
-      </worksheet>
-    </worksheets>
-    <dashboards>
-      <dashboard name='Dash'>
-        <zones>
-          <zone id='1' name='Top 25 Partners' x='0' y='0' w='50000' h='100000' />
-          <zone id='2' name='Top 10 Partners LOD' x='50000' y='0' w='50000' h='100000' />
-        </zones>
-      </dashboard>
-    </dashboards>
-  </workbook>
-XML
-
+# The two fixtures model bar charts of Partner Name (dim) × SUM(Net Revenue) with
+# a boolean rank calc on the Filters shelf kept on `true`:
+#   Top 25 Partners      → RANK_UNIQUE(SUM([Net Revenue]))<=25                      (clean)
+#   Top 10 Partners LOD  → RANK_UNIQUE(sum({exclude [Seg]:sum([Net Revenue])}))<=10 (LOD)
 MASTER_MAP = {
   '(?i)^Net Revenue$'  => { 'id' => 'm-nr', 'name' => 'Net Revenue' },
   '(?i)^Partner Name$' => { 'id' => 'm-pn', 'name' => 'Partner Name' }
@@ -122,10 +46,11 @@ MASTER_MAP = {
 build_out = nil
 build_log = ''
 Dir.mktmpdir do |d|
-  twb = File.join(d, 'wb.twb')
-  lay = File.join(d, 'layout.json')
-  mm  = File.join(d, 'master-map.json')
-  File.write(twb, TWB)
+  lay  = File.join(d, 'layout.json')
+  meta = File.join(d, 'layout-meta.json')
+  mm   = File.join(d, 'master-map.json')
+  File.write(lay,  File.read(File.join(FIXTURE, 'topn-layout.json')))
+  File.write(meta, File.read(File.join(FIXTURE, 'topn-layout-meta.json')))
   File.write(mm, JSON.dump(MASTER_MAP))
   File.write(File.join(d, 'get-workbook.json'),
              JSON.dump('views' => { 'view' => [
@@ -135,9 +60,8 @@ Dir.mktmpdir do |d|
   Dir.mkdir(File.join(d, 'views'))
   File.write(File.join(d, 'views', 'v1.csv'), '')   # empty → build from .twb signals
   File.write(File.join(d, 'views', 'v2.csv'), '')
-  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
   out = File.join(d, 'specs.json')
-  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --title Dash --out #{out} 2>&1`
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{meta} --master-map #{mm} --master-element-id master --title Dash --out #{out} 2>&1`
   build_out = JSON.parse(File.read(out)) if File.exist?(out)
 end
 
@@ -172,8 +96,7 @@ check(lfilters.none? { |f| f['kind'] == 'top-n' },
 lcols = lod ? (lod['columns'] || []) : []
 check(lcols.none? { |c| c['formula'].to_s =~ /RowNumber\(\)\s*<=/ },
       'LOD tile has no sort-dependent RowNumber()<=N column', fails)
-check(build_log =~ /Top 10 Partners LOD.*top-N filter.*LOD/m ||
-      build_log =~ /top-N filter 'Top10FlagLOD'/,
+check(build_log =~ /top-N filter.*(?:LOD|untranslatable)/m,
       'builder SURFACED the LOD top-N (actionable warning, not silently dropped)', fails)
 
 puts

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-topn-filter-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-topn-filter-emission.rb
@@ -1,0 +1,189 @@
+#!/usr/bin/env ruby
+# Regression test for the Top-N FILTER idiom (bead pnxp). The real EDNA "Top 25
+# Partners" tile carries a BOOLEAN calc `RANK_UNIQUE(<expr>)<=25` on the Filters
+# shelf, kept on `true`. Tableau's data export hides it (it just thins rows), and
+# the calc never maps to a warehouse column — so the converter used to silently
+# DROP it (no top-N at all) or, worse, emit a sort-dependent RowNumber()<=N with
+# the operand gone. This test locks the fix:
+#
+#   - CLEAN aggregate operand  → a NATIVE Sigma `kind:top-n` element filter
+#     (rowCount=N, rankingFunction row-number/rank) keyed on the ranked measure,
+#     plus a descending sort so the visible order matches the ranking.
+#   - UNTRANSLATABLE LOD operand → NOT emitted; surfaced with an actionable note
+#     (build the LOD helper measure first). Never a sort-dependent RowNumber.
+#
+# Deterministic + offline: synthesizes two minimal bar-chart worksheets (clean +
+# LOD), runs the ACTUAL parse-twb-layout.rb + build-charts-from-signals.rb, and
+# asserts the emitted element filters.
+#
+# Usage:  ruby scripts/test-topn-filter-emission.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Two bar charts: Partner Name (dim) × SUM(Net Revenue) (measure). Each has a
+# boolean rank calc on the Filters shelf kept on `true`:
+#   Top 25 Partners      → RANK_UNIQUE(SUM([Net Revenue]))<=25         (clean)
+#   Top 25 Partners LOD  → RANK_UNIQUE(SUM({exclude [Seg]:SUM([Net Revenue])}))<=10  (LOD)
+# The filter column refs use the real `[usr:<name>:nk:3]` shape (guid_from_param
+# returns nil for it — so the fix must match the calc by NAME substring, exactly
+# like the real workbook).
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='ORDER_FACT' name='federated.fact'>
+        <connection class='federated'>
+          <named-connections>
+            <named-connection name='snow'><connection class='snowflake' dbname='CSA' schema='TJ' /></named-connection>
+          </named-connections>
+          <relation connection='snow' name='ORDER_FACT' table='[TJ].[ORDER_FACT]' type='table' />
+        </connection>
+        <column caption='Net Revenue' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
+        <column caption='Partner Name' name='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' datatype='string' role='dimension' type='nominal' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Top 25 Partners'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.fact'>
+              <column caption='Net Revenue' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
+              <column caption='Partner Name' name='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' datatype='string' role='dimension' type='nominal' />
+              <column-instance column='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' derivation='None' name='[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]' pivot='key' type='nominal' />
+              <column-instance column='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' derivation='Sum' name='[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]' pivot='key' type='quantitative' />
+              <column caption='Top25Flag' datatype='boolean' name='[topn_clean]' role='measure' type='nominal'>
+                <calculation class='tableau' formula='RANK_UNIQUE(SUM([Net Revenue]))&lt;=25'>
+                  <table-calc ordering-type='Rows' />
+                </calculation>
+              </column>
+              <column-instance column='[topn_clean]' derivation='User' name='[usr:topn_clean:nk:3]' pivot='key' type='nominal' />
+            </datasource-dependencies>
+          </view>
+          <rows>[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]</rows>
+          <cols>[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]</cols>
+          <pane><mark class='Bar' /></pane>
+          <filter class='categorical' column='[federated.fact].[usr:topn_clean:nk:3]'>
+            <groupfilter function='member' level='[usr:topn_clean:nk:3]' member='true' />
+          </filter>
+        </table>
+      </worksheet>
+      <worksheet name='Top 10 Partners LOD'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.fact'>
+              <column caption='Net Revenue' name='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' datatype='real' role='measure' type='quantitative' />
+              <column caption='Partner Name' name='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' datatype='string' role='dimension' type='nominal' />
+              <column-instance column='[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' derivation='None' name='[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]' pivot='key' type='nominal' />
+              <column-instance column='[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' derivation='Sum' name='[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]' pivot='key' type='quantitative' />
+              <column caption='Top10FlagLOD' datatype='boolean' name='[topn_lod]' role='measure' type='nominal'>
+                <calculation class='tableau' formula='RANK_UNIQUE(sum({exclude [Seg]: sum([Net Revenue])}))&lt;=10'>
+                  <table-calc ordering-type='Rows' />
+                </calculation>
+              </column>
+              <column-instance column='[topn_lod]' derivation='User' name='[usr:topn_lod:nk:3]' pivot='key' type='nominal' />
+            </datasource-dependencies>
+          </view>
+          <rows>[federated.fact].[sum:33b6c718-9b55-3dc0-9698-d1d57fac0f90:qk]</rows>
+          <cols>[federated.fact].[none:d73055c0-9ed1-347d-8f8e-05a48ce2c8a8:nk]</cols>
+          <pane><mark class='Bar' /></pane>
+          <filter class='categorical' column='[federated.fact].[usr:topn_lod:nk:3]'>
+            <groupfilter function='member' level='[usr:topn_lod:nk:3]' member='true' />
+          </filter>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Dash'>
+        <zones>
+          <zone id='1' name='Top 25 Partners' x='0' y='0' w='50000' h='100000' />
+          <zone id='2' name='Top 10 Partners LOD' x='50000' y='0' w='50000' h='100000' />
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+MASTER_MAP = {
+  '(?i)^Net Revenue$'  => { 'id' => 'm-nr', 'name' => 'Net Revenue' },
+  '(?i)^Partner Name$' => { 'id' => 'm-pn', 'name' => 'Partner Name' }
+}
+
+build_out = nil
+build_log = ''
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  mm  = File.join(d, 'master-map.json')
+  File.write(twb, TWB)
+  File.write(mm, JSON.dump(MASTER_MAP))
+  File.write(File.join(d, 'get-workbook.json'),
+             JSON.dump('views' => { 'view' => [
+               { 'id' => 'v1', 'name' => 'Top 25 Partners' },
+               { 'id' => 'v2', 'name' => 'Top 10 Partners LOD' }
+             ] }))
+  Dir.mkdir(File.join(d, 'views'))
+  File.write(File.join(d, 'views', 'v1.csv'), '')   # empty → build from .twb signals
+  File.write(File.join(d, 'views', 'v2.csv'), '')
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  out = File.join(d, 'specs.json')
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --title Dash --out #{out} 2>&1`
+  build_out = JSON.parse(File.read(out)) if File.exist?(out)
+end
+
+els = build_out ? (build_out.is_a?(Array) ? build_out : (build_out['elements'] || (build_out['pages'] || []).flat_map { |p| p['elements'] || [] })) : []
+
+# ---- CLEAN aggregate operand → native Sigma top-n filter --------------------
+clean = els.find { |e| e['name'].to_s.casecmp?('Top 25 Partners') }
+check(!clean.nil?, 'clean top-N tile built', fails)
+cfilters = clean ? (clean['filters'] || []) : []
+tn = cfilters.find { |f| f['kind'] == 'top-n' }
+check(!tn.nil?, "clean tile got a kind:top-n element filter (got #{cfilters.inspect})", fails)
+check(tn && tn['rowCount'] == 25, "  rowCount == 25 (got #{tn && tn['rowCount'].inspect})", fails)
+check(tn && tn['rankingFunction'] == 'row-number',
+      "  rankingFunction == row-number (RANK_UNIQUE → unique ranks) (got #{tn && tn['rankingFunction'].inspect})", fails)
+check(tn && tn['mode'] == 'top-n', "  mode == top-n (got #{tn && tn['mode'].inspect})", fails)
+# Filter keys on the ranked measure column (the plotted SUM(Net Revenue)).
+ranked_col = clean && (clean['columns'] || []).find { |c| c['id'] == (tn && tn['columnId']) }
+check(ranked_col && ranked_col['formula'].to_s =~ /Sum\(\[Master\/Net Revenue\]\)/i,
+      "  filter keyed on Sum([Master/Net Revenue]) (got #{ranked_col && ranked_col['formula'].inspect})", fails)
+# Visible order follows the ranking (descending sort by the ranked measure).
+srt = clean && clean.dig('xAxis', 'sort')
+check(srt && srt['by'] == (tn && tn['columnId']) && srt['direction'] == 'descending',
+      "  xAxis sorted by the ranked measure descending (got #{srt.inspect})", fails)
+
+# ---- UNTRANSLATABLE LOD operand → surfaced, NOT a wrong filter --------------
+lod = els.find { |e| e['name'].to_s.casecmp?('Top 10 Partners LOD') }
+check(!lod.nil?, 'LOD top-N tile built', fails)
+lfilters = lod ? (lod['filters'] || []) : []
+check(lfilters.none? { |f| f['kind'] == 'top-n' },
+      "LOD tile did NOT emit a top-n filter (operand untranslatable) (got #{lfilters.inspect})", fails)
+# And no plotted column should be a sort-dependent RowNumber()<=N.
+lcols = lod ? (lod['columns'] || []) : []
+check(lcols.none? { |c| c['formula'].to_s =~ /RowNumber\(\)\s*<=/ },
+      'LOD tile has no sort-dependent RowNumber()<=N column', fails)
+check(build_log =~ /Top 10 Partners LOD.*top-N filter.*LOD/m ||
+      build_log =~ /top-N filter 'Top10FlagLOD'/,
+      'builder SURFACED the LOD top-N (actionable warning, not silently dropped)', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — top-N filter idiom: clean operand → native Sigma top-n filter; LOD operand surfaced'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  puts "\n--- build log (tail) ---"
+  puts build_log.to_s.lines.last(30).join
+  exit 1
+end


### PR DESCRIPTION
Completes bead **beads-sigma-pnxp**. The partial fix (#211) stopped silently dropping the operand but only *recorded* `ranked_measure` and still relied on a sort-dependent `RowNumber()<=N`. This implements the proper fix the bead title asks for.

## What changed (`build-charts-from-signals.rb`)
Detects the top-N idiom on the **Filters shelf** — the real EDNA "Top 25 Partners" pattern: a boolean `RANK_UNIQUE(<expr>)<=N` calc kept on `true`, which Tableau's export hides and which never maps to a warehouse column, so it used to be **silently dropped**.
- **Clean aggregate operand** → native Sigma `kind:top-n` element filter keyed on the translated ranked measure (`rowCount=N`, `rankingFunction` row-number for RANK_UNIQUE / rank for RANK) + a DESC sort so visible order matches. `ranked_measure` is now consumed.
- **Untranslatable LOD operand** → NOT emitted, **surfaced** with an actionable note (build the LOD helper measure first), never a sort-dependent RowNumber.
- `<N` keeps N−1, `<=N` keeps N; `>=`/`>` (rank-N-or-worse, not fixed-count) surfaced, not auto-emitted.
- Rarer measure-on-yAxis `RowNumber()<=N` form now auto-sorts the tile by the recorded `ranked_measure` DESC.
- `translate_window_calc` additionally returns `top_n`/`top_op`/`ranking`/`operand_raw`.

## Tests
- New offline `test-topn-filter-emission.rb` (clean → native top-n filter; LOD → surfaced, no wrong RowNumber), wired into `corpus-check` CI.
- Existing `test-table-calc-translation.rb` still green.

## Live verification (data we have — customer Snowflake unavailable)
- **Clean path:** posted a 1-chart workbook on `CSA.TJ.ORDER_FACT` (Customer Key × Sum(Net Revenue)) with the emitted `kind:top-n` filter → **accepted** by `/v2/workbooks/spec`, round-trips on GET, element export returned **exactly the correct top-10** customers by Sum(Net Revenue) vs warehouse ground truth. (This confirms the previously-unverified top-n element-filter spec shape.)
- **LOD path:** confirmed the `{exclude [Channel]}` ranking semantics on CSA — customers span 2–3 channels (so the exclude is non-trivial), and ranking by per-customer cross-channel total yields the correct top-10 with a clean cutoff. Matches the surfaced recipe's math.

## Docs
`coverage-matrix.md` (now ✅) + `window-functions.md` updated.

## Out of scope (still open)
Whole-Partner-Landscape tile parity on the **customer's** Snowflake — no customer warehouse access. The headline Partner Landscape tile uses the EXCLUDE-LOD operand, so it correctly lands in the surfaced/manual path regardless of warehouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)