### PR TITLE
feat(tableau): route the manual/agent path back through the gated spine

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -68,8 +68,26 @@ ruby scripts/migrate-tableau.rb --workbook "<name>" \
 > `.twb` contents (schema/SQL/formulas) off-box. The **hosted** converter
 > (`https://sigma-data-model-mcp.onrender.com/mcp`) is used **only** with explicit consent
 > (`--converter hosted` or `SIGMA_CONVERTER_ALLOW_HOSTED=1`) because it uploads the `.twb`
-> to a third-party server. With neither, pass 1 STOPS and prints both options — it never
+> to a third-party server. With neither, pass 1 STOPS and prints the options — it never
 > falls back to hosted on its own. See QUICKSTART "the data-model converter backend".
+>
+> **No converter available? Re-enter the GATED spine — do NOT hand-drive raw POSTs.**
+> When no backend is configured, the fallback is *not* "build everything by hand and POST
+> it yourself" (that skips preflight/control lint, Phase-6 parity, and the
+> `assert-phase6-ran` hard gate — the exact way a workbook ships with missing controls and
+> an unverified parity claim). Instead author the specs *once* and let the scripts run them:
+> 1. Get the **DM spec** — call the `sigma-data-model` MCP's `convert_tableau_to_sigma` on
+>    the `.twb` if it's available to you, else author it by hand (see `sigma-data-models`).
+> 2. Author the **workbook spec** (see the companion `sigma-workbooks` skill). Reference the
+>    data model with placeholders the orchestrator binds to the live readback ids:
+>    `"__DM_ID__"` (top-level `dataModelId`) and `"__DM_ELEMENT__:<ElementName>"` per element
+>    (the fact element is `"__DM_ELEMENT__:__FACT__"`). An unresolved element ref aborts loudly.
+> 3. Write `dm-spec.json` + `wb-spec.json` into the workdir and re-run the orchestrator with
+>    `--dm-spec <path> --wb-spec <path>` (fresh build) — or, when the DM is **already posted**
+>    (exit 4 workbook-layer handoff), `--reuse-dm <dataModelId> --wb-spec <path>`. Either way
+>    the spec runs through validate → post-and-readback (preflight/control lint + column guard)
+>    → layout → parity, and stops at exit 12 to collect actuals + `--finalize`. **A conversion
+>    is not done until `assert-phase6-ran.rb` exits 0**, on this path too.
 
 > **Parity is EXACT for warehouse-backed migrations — never blame "drift."** Sigma
 > queries the **same warehouse** the Tableau source reads, so a value gap is a real
@@ -92,7 +110,7 @@ stop/gate fires exactly as in the serial flow. A `PHASE TIMINGS` summary line
 prints at every terminal exit so the speedup stays visible. Exit codes: `10` = OPEN QUESTIONS
 (re-run with `--yes`/`--answers`), `11` = ❌-unhandled gap-scan features (close via
 gap-scout or `--force`), `12` = pass 1 done, parity PENDING (collect mcp-v2 actuals,
-then `--finalize`), `4` = DM posted but the workbook layer needs the agent path,
+then `--finalize`), `4` = DM posted but the workbook layer needs an agent-authored spec — re-enter the gated spine with `--reuse-dm <id> --wb-spec <path>` (never hand-POST),
 `3` = a gate failed, `14` = migration GREEN + Phase E proposals pending
 acceptance, `0` = ALL gates green (only reachable via `--finalize`).
 DM-reuse is **reuse-first** — auto-reuses an existing DM that covers all the
@@ -950,6 +968,20 @@ Prefer a **workbook-level control filtering the master table** — every chart t
 > **A relative-date filter that "rolls forward" in Tableau** ("this year", "last 30 days", "year to date") must be translated as a relative `date-range` control (`mode: "current"`, `unit: ...`) — not a fixed start/end date. Hard-coding `startDate`/`endDate` freezes the filter to today's date and breaks tomorrow.
 
 > **Phase 6 will not catch a missed filter on its own.** Data parity in Phase 6 compares Sigma rows to Tableau rows for the dimensions you query — if your Sigma chart includes extra rows the CSV never had, the comparison only flags missing rows from Tableau, not extra rows in Sigma. Always sanity-check distinct values and date ranges side-by-side before declaring parity.
+
+> **Element-level filters DO work on viz elements — verify them the right way.** A boolean
+> `filters: [{columnId, kind:"list", mode:"include", values:[true]}]` on a `bar-chart` /
+> `kpi-chart` is enforced in the render AND round-trips intact on `GET /v2/workbooks/{id}/spec`
+> (live-verified 2026-06-29 on `tj-wells-1989`: a not-null filter cut 731→397 on both kinds,
+> confirmed via element CSV export and rendered PNG). So if a filter *looks* like it "doesn't
+> work," do NOT assume the API silently dropped it — the cause is almost always a `columnId`
+> that doesn't resolve to a real column on that element, which `validate-spec.rb` / `control_lint.rb`
+> catch on the gated path. **Validate filter behavior via the element's CSV export or a rendered
+> PNG — NOT via a base-grain `mcp__sigma-mcp-v2__query` against the connection**, which reads the
+> underlying table and is blind to element-level `filters`, `groupings`, and sort (use MCP only
+> for raw-data spot-checks and explicit-`GROUP BY` aggregation checks). A helper-table element
+> carrying the filter (chart sources the helper) also works, but is NOT required for simple
+> boolean/not-null slices — reserve it for the LOD/grain cases above.
 
 ---
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -954,4 +954,42 @@ module MechanicalSpecs
     spec['folderId'] = folder_id if folder_id
     spec
   end
+
+  # Bind an agent-authored (--wb-spec) workbook spec to the LIVE data model. The
+  # agent authors the JSON before the DM is posted, so it can't know the real ids;
+  # it uses two placeholders, substituted here against the readback:
+  #   "__DM_ID__"               → the posted dataModelId (anywhere a string value)
+  #   "__DM_ELEMENT__:<Name>"   → the readback element id whose name == <Name>
+  #                               (case-insensitive); the fact element is also
+  #                               reachable as "__DM_ELEMENT__:__FACT__".
+  # An unresolved "__DM_ELEMENT__:<Name>" aborts loudly (same no-silent-misbind
+  # contract as the mechanical grain-helper resolver in migrate-tableau.rb) — a
+  # chart bound to a non-existent element would otherwise render blank.
+  def bind_manual_wb_spec(node, dm_id:, fact_eid:, dm_els: [])
+    by_name = {}
+    (dm_els || []).each { |e| by_name[e['name'].to_s.strip.downcase] = e['id'] }
+    walk = lambda do |n|
+      case n
+      when Hash  then n.transform_values { |v| walk.call(v) }
+      when Array then n.map { |v| walk.call(v) }
+      when String
+        if n == '__DM_ID__'
+          dm_id
+        elsif n.start_with?('__DM_ELEMENT__:')
+          want = n.split(':', 2).last.to_s.strip
+          if want == '__FACT__'
+            fact_eid
+          else
+            by_name[want.downcase] ||
+              raise("--wb-spec references DM element '#{want}' but the posted data model has no element by that name " \
+                    "(have: #{by_name.keys.join(', ')})")
+          end
+        else
+          n
+        end
+      else n
+      end
+    end
+    walk.call(node)
+  end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -98,6 +98,17 @@ OptionParser.new do |o|
   o.on('--db NAME')          { |v| opts[:db]      = v }
   o.on('--schema NAME')      { |v| opts[:schema]  = v }
   o.on('--specs PATH')       { |v| opts[:specs]   = File.expand_path(v) }
+  # Agent-authored JSON specs — the manual path's re-entry into the GATED spine.
+  # When the mechanical converter backend is unavailable, the agent authors the DM
+  # (and optionally the workbook) spec as JSON and re-runs with these flags, instead
+  # of hand-driving raw POSTs that skip preflight/control lint + Phase-6 + the hard
+  # gate. The JSON is wrapped into the same `Specs` contract the .rb override uses,
+  # so POST → lint → layout → parity → assert-phase6-ran all run unchanged.
+  # The workbook JSON may reference the data model via the placeholder idiom
+  # "__DM_ID__" (top-level dataModelId) and "__DM_ELEMENT__:<ElementName>"
+  # (per-element source) — both are substituted against the live readback ids.
+  o.on('--dm-spec PATH')     { |v| opts[:dm_spec] = File.expand_path(v) }
+  o.on('--wb-spec PATH')     { |v| opts[:wb_spec] = File.expand_path(v) }
   o.on('--out DIR')          { |v| opts[:out]     = File.expand_path(v) }
   o.on('--answers JSON')     { |v| opts[:answers] = v }
   o.on('--yes')              {     opts[:yes]     = true }
@@ -584,6 +595,51 @@ if specs_path && File.exist?(specs_path)
   end
 end
 
+# Agent-authored JSON specs (--dm-spec / --wb-spec). The manual path's re-entry
+# into the GATED spine: instead of hand-driving raw POSTs (which skip preflight/
+# control lint, Phase 6 parity, and the assert-phase6-ran hard gate), the agent
+# drops JSON specs and re-runs. We wrap them into the same `Specs` contract the
+# .rb override uses, so the DOWNSTREAM flow (validate → post-and-readback →
+# layout → parity → assert) is byte-for-byte identical to the hand-authored-.rb
+# path. `wb_spec` returns the raw JSON; live-id binding happens at the workbook
+# assembly step (where dm_id / fact_eid / the DM readback elements are known).
+if opts[:dm_spec] || opts[:wb_spec]
+  # The workbook spec is always agent-authored on this path.
+  abort 'FATAL: --wb-spec is required for the agent-authored manual path ' \
+        '(pair it with --dm-spec for a fresh build, or --reuse-dm for an existing model).' \
+    unless opts[:wb_spec]
+  # The DATA-MODEL source is exactly one of: --dm-spec (build it fresh) OR
+  # --reuse-dm (attach to a model already in the org — the exit-4 re-entry, where
+  # the DM is already posted). Both/neither is ambiguous.
+  dm_sources = (opts[:dm_spec] ? 1 : 0) + (opts[:reuse_dm] ? 1 : 0)
+  abort 'FATAL: provide the data model via EITHER --dm-spec <json> (fresh build) OR ' \
+        '--reuse-dm <id> (attach to an existing model) — not both, not neither.' \
+    unless dm_sources == 1
+  abort "FATAL: --wb-spec #{opts[:wb_spec]} not found" unless File.exist?(opts[:wb_spec])
+  begin
+    wb_json = JSON.parse(File.read(opts[:wb_spec]))
+    dm_json = opts[:dm_spec] ? JSON.parse(File.read(opts[:dm_spec])) : nil
+  rescue JSON::ParserError => e
+    abort "FATAL: --dm-spec/--wb-spec is not valid JSON: #{e.message}"
+  rescue Errno::ENOENT => e
+    abort "FATAL: #{e.message}"
+  end
+  abort 'FATAL: --dm-spec JSON is not a page-bearing data-model spec (no top-level "pages" array)' \
+    if dm_json && !(dm_json.is_a?(Hash) && dm_json['pages'].is_a?(Array))
+  abort 'FATAL: --wb-spec JSON is not a page-bearing workbook spec (no top-level "pages" array)' \
+    unless wb_json.is_a?(Hash) && wb_json['pages'].is_a?(Array)
+  Object.const_set(:Specs, Module.new do
+    # nil on the --reuse-dm path: the DM is read back from the API, never rebuilt
+    # from this module (so dm_spec is only consulted on the fresh --dm-spec path).
+    define_singleton_method(:dm_spec) { dm_json }
+    # Raw passthrough — live-id binding (the __DM_ID__/__DM_ELEMENT__ placeholders)
+    # is applied at the assembly step where the readback ids exist.
+    define_singleton_method(:wb_spec) { |_dm_id, _fact_eid| wb_json }
+  end)
+  have_specs = true
+  line "spec generator: agent-authored JSON specs (#{opts[:dm_spec] ? "--dm-spec #{opts[:dm_spec]}" : "--reuse-dm #{opts[:reuse_dm]}"}, --wb-spec #{opts[:wb_spec]}) — routing through the gated spine"
+end
+
 # Mechanical converter run (the default). Requires the .twb (parse-twb-layout
 # already gated on have_twb above) and a converter backend — local build by
 # default, hosted MCP only on explicit consent (see backend resolution below).
@@ -624,13 +680,38 @@ if mechanical
     sleep 0.1 until lane_done.call # reap the background lane before aborting
     print_lane_log.call
     abort <<~MSG
-      FATAL: no local Tableau→Sigma converter, and hosted conversion was not consented to.
-      The .twb holds customer schema/SQL/formulas, so this skill will NOT upload it to the
-      hosted converter without explicit consent. Choose one:
-        • LOCAL (no data egress): set TABLEAU_MCP_BUILD to a local build/tableau.js (or run the
-          sigma-data-model MCP locally), then re-run. See QUICKSTART "Converter backend".
-        • HOSTED (uploads the .twb to sigma-data-model-mcp.onrender.com): re-run with
-          --converter hosted (or SIGMA_CONVERTER_ALLOW_HOSTED=1) to consent.
+      ==================== CONVERTER STOP (no backend) ====================
+      No mechanical Tableau→Sigma converter is configured, and hosted conversion was not
+      consented to. The .twb holds customer schema/SQL/formulas, so this skill will NOT
+      upload it to the hosted converter without explicit consent.
+
+      DO NOT hand-drive raw POSTs from here — that path skips preflight/control lint, the
+      Phase-6 parity check, and the assert-phase6-ran hard gate (the exact regression that
+      ships a workbook with missing controls and an unverified parity claim). Instead pick
+      one of the three options below; the spec you produce re-enters the SAME gated spine.
+
+        1. LOCAL converter (no data egress, RECOMMENDED): set TABLEAU_MCP_BUILD to a local
+           build/tableau.js (or run the sigma-data-model MCP locally), then re-run this command
+           verbatim. The mechanical path takes over. See QUICKSTART "Converter backend".
+
+        2. AGENT-AUTHORED SPECS (when no local build is available): produce the specs once,
+           then re-enter the gated spine — DO NOT POST them yourself:
+             • If the sigma-data-model MCP is available to you, call convert_tableau_to_sigma
+               on this .twb to get the DM spec; author the matching workbook spec (use the
+               companion sigma-workbooks skill). Reference the data model via the placeholders
+               "__DM_ID__" and "__DM_ELEMENT__:<ElementName>" (fact = "__DM_ELEMENT__:__FACT__").
+             • Write #{WORK}/dm-spec.json and #{WORK}/wb-spec.json, then re-run:
+                 ruby scripts/migrate-tableau.rb <same flags> \\
+                   --dm-spec #{WORK}/dm-spec.json --wb-spec #{WORK}/wb-spec.json
+             • This runs validate → post-and-readback (preflight/control lint + column guard)
+               → layout → parity, and STOPS at exit 12 for you to collect actuals + --finalize.
+
+        3. HOSTED converter (uploads the .twb to sigma-data-model-mcp.onrender.com): re-run with
+           --converter hosted (or SIGMA_CONVERTER_ALLOW_HOSTED=1) to consent.
+
+      A conversion is NOT done until `scripts/assert-phase6-ran.rb` exits 0 — that is a hard
+      gate, not a guideline, on every path above.
+      =====================================================================
     MSG
   end
   conv = MechanicalSpecs.run_converter(
@@ -1464,6 +1545,14 @@ if mechanical
     folder_id: opts[:folder])
 else
   spec = Specs.wb_spec(dm_id, fact_eid)
+  # Agent-authored JSON path: bind the DM placeholders ("__DM_ID__" and
+  # "__DM_ELEMENT__:<name>") in the workbook spec to the live readback ids now
+  # that the data model is posted. A reference to a non-existent element aborts
+  # loudly (same contract as the mechanical grain-helper resolver), so the manual
+  # path can't silently misbind a chart source.
+  spec = MechanicalSpecs.bind_manual_wb_spec(
+    spec, dm_id: dm_id, fact_eid: fact_eid,
+    dm_els: (defined?(dm_els) && dm_els) || []) if opts[:wb_spec]
   spec['name'] = display_wb_name if opts[:name]
   spec['folderId'] = opts[:folder] if opts[:folder]
   layout_xml = (Specs.respond_to?(:layout_xml) ? Specs.layout_xml : nil)
@@ -1567,9 +1656,16 @@ rescue WorkbookBuildError => e
   puts "      Speed Category'), translate its Tableau formula (see calc-fields.json) to"
   puts '      a Sigma formula over master columns and re-run this exact command with:'
   puts "        --master-col '<Name>=<Sigma formula>'   (repeatable)"
-  puts '   2. Otherwise fall back to the agent path: rebuild the workbook via the'
-  puts "      skill's agent-authored flow (see SKILL.md) against this DM."
-  puts '   The data model is posted and ready to attach either way.'
+  puts '   2. Otherwise author the workbook spec yourself and RE-ENTER THE GATED SPINE —'
+  puts '      do NOT hand-POST it (that skips control lint + Phase-6 + the hard gate):'
+  puts "        • Author #{WORK}/wb-spec.json against the posted DM (dataModelId=#{dm_id});"
+  puts '          reference elements via "__DM_ID__" / "__DM_ELEMENT__:<Name>"'
+  puts '          (fact = "__DM_ELEMENT__:__FACT__"). See the sigma-workbooks skill.'
+  puts '        • Re-run this exact command adding (REUSE the posted DM — do not rebuild it):'
+  puts "            --reuse-dm #{dm_id} --wb-spec #{WORK}/wb-spec.json"
+  puts '          (attaches to the existing DM; the workbook re-POST is re-gated).'
+  puts '   The data model is posted and ready to attach either way. A conversion is NOT done'
+  puts '   until scripts/assert-phase6-ran.rb exits 0 — that hard gate applies on both paths.'
   mark('phase4-workbook')
   phase_summary
   exit 4

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-manual-spec-ingestion.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-manual-spec-ingestion.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Unit test for the manual-path JSON-spec ingestion binding (MechanicalSpecs.
+# bind_manual_wb_spec) — proves the agent-authored --wb-spec placeholders bind to
+# the live readback ids, and that an unresolved DM-element ref aborts loudly
+# (no silent misbind). See migrate-tableau.rb --dm-spec/--wb-spec.
+require 'json'
+require_relative 'mechanical-specs'
+
+failures = 0
+def check(desc, ok)
+  puts "#{ok ? 'ok  ' : 'FAIL'} - #{desc}"
+  ok
+end
+
+dm_els = [
+  { 'name' => 'Order Fact View', 'id' => 'el-fact-123' },
+  { 'name' => 'Customer Dim',    'id' => 'el-cust-456' }
+]
+
+wb = {
+  'name' => 'Manual WB',
+  'pages' => [
+    { 'id' => 'p1', 'name' => 'Dash', 'elements' => [
+      { 'id' => 'k1', 'kind' => 'kpi-chart',
+        'source' => { 'kind' => 'data-model', 'dataModelId' => '__DM_ID__', 'elementId' => '__DM_ELEMENT__:__FACT__' } },
+      { 'id' => 't1', 'kind' => 'table',
+        'source' => { 'kind' => 'data-model', 'dataModelId' => '__DM_ID__', 'elementId' => '__DM_ELEMENT__:Customer Dim' } }
+    ] }
+  ]
+}
+
+bound = MechanicalSpecs.bind_manual_wb_spec(wb, dm_id: 'dm-789', fact_eid: 'el-fact-123', dm_els: dm_els)
+els = bound['pages'][0]['elements']
+failures += 1 unless check('__DM_ID__ → live dataModelId', els[0]['source']['dataModelId'] == 'dm-789')
+failures += 1 unless check('__DM_ELEMENT__:__FACT__ → fact_eid', els[0]['source']['elementId'] == 'el-fact-123')
+failures += 1 unless check('__DM_ELEMENT__:<name> → readback id (case-insensitive)', els[1]['source']['elementId'] == 'el-cust-456')
+failures += 1 unless check('input spec is not mutated in place', wb['pages'][0]['elements'][0]['source']['dataModelId'] == '__DM_ID__')
+
+# Unresolved element reference must raise (loud, no silent misbind).
+raised = begin
+  MechanicalSpecs.bind_manual_wb_spec(
+    { 'pages' => [{ 'elements' => [{ 'source' => { 'elementId' => '__DM_ELEMENT__:No Such Element' } }] }] },
+    dm_id: 'dm-789', fact_eid: 'el-fact-123', dm_els: dm_els)
+  false
+rescue RuntimeError => e
+  e.message.include?('No Such Element')
+end
+failures += 1 unless check('unresolved __DM_ELEMENT__ raises with the missing name', raised)
+
+# A spec with no placeholders is returned unchanged.
+plain = { 'pages' => [{ 'elements' => [{ 'source' => { 'elementId' => 'literal-id' } }] }] }
+failures += 1 unless check('non-placeholder values pass through untouched',
+                           MechanicalSpecs.bind_manual_wb_spec(plain, dm_id: 'x', fact_eid: 'y', dm_els: dm_els) == plain)
+
+puts(failures.zero? ? "\nALL PASS" : "\n#{failures} FAILURE(S)")
+exit(failures.zero? ? 0 : 1)


### PR DESCRIPTION
## Problem

The EDNA / CQ-Funnel migration in CoCo shipped a workbook with **missing controls, an unverified parity claim, and no telemetry prompt** — all on HTTP 200. Root cause: with no converter backend configured, the orchestrator STOPS and the agent hand-authors raw POSTs **off the gated spine**, so `preflight_lint` / `control_lint` / Phase-6 parity / `assert-phase6-ran` (incl. **gate 10 telemetry consent**) never run. The gates are only "hard" when a *script* chains them; prose "MUST" instructions get rationalized past by an autonomous agent (and CoCo got hit hardest because the backend gap forced it onto the prose-only path).

## Fix

`migrate-tableau.rb` accepts agent-authored JSON specs and **re-enters the same gated spine**:

```
--dm-spec <json> --wb-spec <json>     # fresh build
--reuse-dm <id>  --wb-spec <json>     # exit-4 handoff (DM already posted)
```

The JSON is wrapped into the existing `Specs` contract, so `validate → post-and-readback (preflight/control lint + column guard) → layout → parity → assert-phase6-ran (incl. telemetry)` all run unchanged. Workbook specs bind to the live DM via placeholders `__DM_ID__` / `__DM_ELEMENT__:<Name>` / `__DM_ELEMENT__:__FACT__`, resolved by new `MechanicalSpecs.bind_manual_wb_spec` — an unresolved element ref **aborts loudly** (no silent misbind).

Both STOP blocks (converter-missing, exit-4 workbook handoff) rewritten to print the exact gated re-entry instead of "switch to the manual agent path", each ending with the **"not done until `assert-phase6-ran.rb` exits 0"** banner. SKILL.md documents the contract.

## Also

Documents the **live-verified** (tj-wells-1989, 2026-06-29) filter behavior, **debunking the postmortem's headline claim**: element-level `values:[true]` filters on bar/kpi **are enforced** (731→397, CSV + PNG) and **round-trip on GET**. So no filter-lint rule was added (it would regress the converter's own `IsNotNull(...)` output); the doc instead says a filter that looks inert = an unresolved `columnId` the gated lints catch, and to validate via element export/PNG not base-grain MCP.

## Testing

- **E2E live** (tj-wells-1989): `bind_manual_wb_spec` resolved against a real DM readback and the bound spec POSTed cleanly; test objects cleaned up.
- New unit test `test-manual-spec-ingestion.rb` (placeholder binding, case-insensitivity, no-mutation, loud-abort).
- `ruby -c` clean; `check-shared.rb` + the gate-documentation pre-commit hook green.

## Postmortem triage (CQ-Funnel)

- recs **A** (local validator) / **E** (incremental build) — already exist; the gap was running them → this PR.
- rec **G** ("detect param-CASE, defer to manual") — **rejected**: would regress the converter's existing CASE→`Switch` translator.
- rec **F** (patterns dir) — point at `sigma-workbooks` instead of forking.

## Follow-ups (not in this PR)

- **Converter bundle**: vendor a prebuilt `tableau.js` so `TABLEAU_MCP_BUILD` auto-resolves (zero-config local-first) → makes the gated path the default and the manual path rare.
- Pivot-table element-filter retest (bar/kpi verified here; pivot still per the older "drop" finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)