### PR TITLE
feat(gates): no silent gate bypass — every --skip-* waiver requires/records a reason

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -116,11 +116,14 @@ OptionParser.new do |p|
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
   p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
-  p.on('--skip-column-check')        { opts[:skip_column] = true }
-  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
-  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
-  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
-  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  # These five accept an OPTIONAL reason (kept backward-compatible: a bare flag
+  # still works). A skip with no reason is recorded as "NO REASON GIVEN" and
+  # logged loudly so a silent bypass can't hide — see record_waiver below.
+  p.on('--skip-column-check [REASON]')  { |v| opts[:skip_column] = v || true }
+  p.on('--skip-orphan-check [REASON]')  { |v| opts[:skip_orphan] = v || true }
+  p.on('--skip-layout-check [REASON]')  { |v| opts[:skip_layout] = v || true }
+  p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
+  p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
@@ -131,6 +134,20 @@ OptionParser.new do |p|
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
+
+# A waived gate must never pass SILENTLY. record_waiver prints a loud banner and
+# appends to <workdir>/waivers.json so the migration report (and any future
+# check) can see every gate that was bypassed and why. A bare skip (no reason)
+# is recorded as "NO REASON GIVEN" — visible, not invisible. (CoCo run wrapped
+# up GREEN after silently skipping checks — this makes that impossible.)
+waivers = []
+record_waiver = lambda do |flag, gate, reason|
+  r = (reason.is_a?(String) && !reason.strip.empty?) ? reason.strip : nil
+  waivers << { 'flag' => flag, 'gate' => gate, 'reason' => r }
+  puts "[SKIP] #{gate} WAIVED via #{flag}#{r ? " (#{r})" : ' — NO REASON GIVEN'}"
+  puts "       MUST be named in the migration report#{r ? '' : ' WITH a reason'}; this gate did NOT verify the workbook."
+  File.write(File.join(opts[:tab], 'waivers.json'), JSON.pretty_generate(waivers)) rescue nil
+end
 
 summary_path = File.join(opts[:tab], 'parity-final.json')
 
@@ -279,7 +296,7 @@ unless opts[:skip_orphan]
     puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/7: --skip-orphan-check"
+  record_waiver.call('--skip-orphan-check', 'gate 2 (orphan-workbook cleanup)', opts[:skip_orphan])
 end
 
 # ---------------------------------------------------------------------------
@@ -333,7 +350,7 @@ unless opts[:skip_column]
     end
   end
 else
-  puts "[SKIP] gate 3/7: --skip-column-check"
+  record_waiver.call('--skip-column-check', 'gate 3 (live column type=error scan)', opts[:skip_column])
 end
 
 # ---------------------------------------------------------------------------
@@ -439,7 +456,7 @@ unless opts[:skip_layout]
     end
   end
 else
-  puts "[SKIP] gate 4/7: --skip-layout-check"
+  record_waiver.call('--skip-layout-check', 'gate 4 (top-level layout applied)', opts[:skip_layout])
 end
 
 # ---------------------------------------------------------------------------
@@ -483,7 +500,7 @@ end
 # This gate mechanizes those checks on the LIVE spec.
 # ---------------------------------------------------------------------------
 if opts[:skip_lint]
-  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+  record_waiver.call('--skip-layout-lint', 'gate 6 (layout-quality lint)', opts[:skip_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?
@@ -549,7 +566,7 @@ end
 # (zero controls built from an interactive source = FAIL, the Qlik class).
 # ---------------------------------------------------------------------------
 if opts[:skip_control_lint]
-  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+  record_waiver.call('--skip-control-lint', 'gate 7 (control-wiring lint)', opts[:skip_control_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -116,11 +116,14 @@ OptionParser.new do |p|
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
   p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
-  p.on('--skip-column-check')        { opts[:skip_column] = true }
-  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
-  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
-  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
-  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  # These five accept an OPTIONAL reason (kept backward-compatible: a bare flag
+  # still works). A skip with no reason is recorded as "NO REASON GIVEN" and
+  # logged loudly so a silent bypass can't hide — see record_waiver below.
+  p.on('--skip-column-check [REASON]')  { |v| opts[:skip_column] = v || true }
+  p.on('--skip-orphan-check [REASON]')  { |v| opts[:skip_orphan] = v || true }
+  p.on('--skip-layout-check [REASON]')  { |v| opts[:skip_layout] = v || true }
+  p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
+  p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
@@ -131,6 +134,20 @@ OptionParser.new do |p|
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
+
+# A waived gate must never pass SILENTLY. record_waiver prints a loud banner and
+# appends to <workdir>/waivers.json so the migration report (and any future
+# check) can see every gate that was bypassed and why. A bare skip (no reason)
+# is recorded as "NO REASON GIVEN" — visible, not invisible. (CoCo run wrapped
+# up GREEN after silently skipping checks — this makes that impossible.)
+waivers = []
+record_waiver = lambda do |flag, gate, reason|
+  r = (reason.is_a?(String) && !reason.strip.empty?) ? reason.strip : nil
+  waivers << { 'flag' => flag, 'gate' => gate, 'reason' => r }
+  puts "[SKIP] #{gate} WAIVED via #{flag}#{r ? " (#{r})" : ' — NO REASON GIVEN'}"
+  puts "       MUST be named in the migration report#{r ? '' : ' WITH a reason'}; this gate did NOT verify the workbook."
+  File.write(File.join(opts[:tab], 'waivers.json'), JSON.pretty_generate(waivers)) rescue nil
+end
 
 summary_path = File.join(opts[:tab], 'parity-final.json')
 
@@ -279,7 +296,7 @@ unless opts[:skip_orphan]
     puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/7: --skip-orphan-check"
+  record_waiver.call('--skip-orphan-check', 'gate 2 (orphan-workbook cleanup)', opts[:skip_orphan])
 end
 
 # ---------------------------------------------------------------------------
@@ -333,7 +350,7 @@ unless opts[:skip_column]
     end
   end
 else
-  puts "[SKIP] gate 3/7: --skip-column-check"
+  record_waiver.call('--skip-column-check', 'gate 3 (live column type=error scan)', opts[:skip_column])
 end
 
 # ---------------------------------------------------------------------------
@@ -439,7 +456,7 @@ unless opts[:skip_layout]
     end
   end
 else
-  puts "[SKIP] gate 4/7: --skip-layout-check"
+  record_waiver.call('--skip-layout-check', 'gate 4 (top-level layout applied)', opts[:skip_layout])
 end
 
 # ---------------------------------------------------------------------------
@@ -483,7 +500,7 @@ end
 # This gate mechanizes those checks on the LIVE spec.
 # ---------------------------------------------------------------------------
 if opts[:skip_lint]
-  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+  record_waiver.call('--skip-layout-lint', 'gate 6 (layout-quality lint)', opts[:skip_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?
@@ -549,7 +566,7 @@ end
 # (zero controls built from an interactive source = FAIL, the Qlik class).
 # ---------------------------------------------------------------------------
 if opts[:skip_control_lint]
-  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+  record_waiver.call('--skip-control-lint', 'gate 7 (control-wiring lint)', opts[:skip_control_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -116,11 +116,14 @@ OptionParser.new do |p|
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
   p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
-  p.on('--skip-column-check')        { opts[:skip_column] = true }
-  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
-  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
-  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
-  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  # These five accept an OPTIONAL reason (kept backward-compatible: a bare flag
+  # still works). A skip with no reason is recorded as "NO REASON GIVEN" and
+  # logged loudly so a silent bypass can't hide — see record_waiver below.
+  p.on('--skip-column-check [REASON]')  { |v| opts[:skip_column] = v || true }
+  p.on('--skip-orphan-check [REASON]')  { |v| opts[:skip_orphan] = v || true }
+  p.on('--skip-layout-check [REASON]')  { |v| opts[:skip_layout] = v || true }
+  p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
+  p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
@@ -131,6 +134,20 @@ OptionParser.new do |p|
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
+
+# A waived gate must never pass SILENTLY. record_waiver prints a loud banner and
+# appends to <workdir>/waivers.json so the migration report (and any future
+# check) can see every gate that was bypassed and why. A bare skip (no reason)
+# is recorded as "NO REASON GIVEN" — visible, not invisible. (CoCo run wrapped
+# up GREEN after silently skipping checks — this makes that impossible.)
+waivers = []
+record_waiver = lambda do |flag, gate, reason|
+  r = (reason.is_a?(String) && !reason.strip.empty?) ? reason.strip : nil
+  waivers << { 'flag' => flag, 'gate' => gate, 'reason' => r }
+  puts "[SKIP] #{gate} WAIVED via #{flag}#{r ? " (#{r})" : ' — NO REASON GIVEN'}"
+  puts "       MUST be named in the migration report#{r ? '' : ' WITH a reason'}; this gate did NOT verify the workbook."
+  File.write(File.join(opts[:tab], 'waivers.json'), JSON.pretty_generate(waivers)) rescue nil
+end
 
 summary_path = File.join(opts[:tab], 'parity-final.json')
 
@@ -279,7 +296,7 @@ unless opts[:skip_orphan]
     puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/7: --skip-orphan-check"
+  record_waiver.call('--skip-orphan-check', 'gate 2 (orphan-workbook cleanup)', opts[:skip_orphan])
 end
 
 # ---------------------------------------------------------------------------
@@ -333,7 +350,7 @@ unless opts[:skip_column]
     end
   end
 else
-  puts "[SKIP] gate 3/7: --skip-column-check"
+  record_waiver.call('--skip-column-check', 'gate 3 (live column type=error scan)', opts[:skip_column])
 end
 
 # ---------------------------------------------------------------------------
@@ -439,7 +456,7 @@ unless opts[:skip_layout]
     end
   end
 else
-  puts "[SKIP] gate 4/7: --skip-layout-check"
+  record_waiver.call('--skip-layout-check', 'gate 4 (top-level layout applied)', opts[:skip_layout])
 end
 
 # ---------------------------------------------------------------------------
@@ -483,7 +500,7 @@ end
 # This gate mechanizes those checks on the LIVE spec.
 # ---------------------------------------------------------------------------
 if opts[:skip_lint]
-  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+  record_waiver.call('--skip-layout-lint', 'gate 6 (layout-quality lint)', opts[:skip_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?
@@ -549,7 +566,7 @@ end
 # (zero controls built from an interactive source = FAIL, the Qlik class).
 # ---------------------------------------------------------------------------
 if opts[:skip_control_lint]
-  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+  record_waiver.call('--skip-control-lint', 'gate 7 (control-wiring lint)', opts[:skip_control_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -116,11 +116,14 @@ OptionParser.new do |p|
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
   p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
-  p.on('--skip-column-check')        { opts[:skip_column] = true }
-  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
-  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
-  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
-  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  # These five accept an OPTIONAL reason (kept backward-compatible: a bare flag
+  # still works). A skip with no reason is recorded as "NO REASON GIVEN" and
+  # logged loudly so a silent bypass can't hide — see record_waiver below.
+  p.on('--skip-column-check [REASON]')  { |v| opts[:skip_column] = v || true }
+  p.on('--skip-orphan-check [REASON]')  { |v| opts[:skip_orphan] = v || true }
+  p.on('--skip-layout-check [REASON]')  { |v| opts[:skip_layout] = v || true }
+  p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
+  p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
@@ -131,6 +134,20 @@ OptionParser.new do |p|
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
+
+# A waived gate must never pass SILENTLY. record_waiver prints a loud banner and
+# appends to <workdir>/waivers.json so the migration report (and any future
+# check) can see every gate that was bypassed and why. A bare skip (no reason)
+# is recorded as "NO REASON GIVEN" — visible, not invisible. (CoCo run wrapped
+# up GREEN after silently skipping checks — this makes that impossible.)
+waivers = []
+record_waiver = lambda do |flag, gate, reason|
+  r = (reason.is_a?(String) && !reason.strip.empty?) ? reason.strip : nil
+  waivers << { 'flag' => flag, 'gate' => gate, 'reason' => r }
+  puts "[SKIP] #{gate} WAIVED via #{flag}#{r ? " (#{r})" : ' — NO REASON GIVEN'}"
+  puts "       MUST be named in the migration report#{r ? '' : ' WITH a reason'}; this gate did NOT verify the workbook."
+  File.write(File.join(opts[:tab], 'waivers.json'), JSON.pretty_generate(waivers)) rescue nil
+end
 
 summary_path = File.join(opts[:tab], 'parity-final.json')
 
@@ -279,7 +296,7 @@ unless opts[:skip_orphan]
     puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/7: --skip-orphan-check"
+  record_waiver.call('--skip-orphan-check', 'gate 2 (orphan-workbook cleanup)', opts[:skip_orphan])
 end
 
 # ---------------------------------------------------------------------------
@@ -333,7 +350,7 @@ unless opts[:skip_column]
     end
   end
 else
-  puts "[SKIP] gate 3/7: --skip-column-check"
+  record_waiver.call('--skip-column-check', 'gate 3 (live column type=error scan)', opts[:skip_column])
 end
 
 # ---------------------------------------------------------------------------
@@ -439,7 +456,7 @@ unless opts[:skip_layout]
     end
   end
 else
-  puts "[SKIP] gate 4/7: --skip-layout-check"
+  record_waiver.call('--skip-layout-check', 'gate 4 (top-level layout applied)', opts[:skip_layout])
 end
 
 # ---------------------------------------------------------------------------
@@ -483,7 +500,7 @@ end
 # This gate mechanizes those checks on the LIVE spec.
 # ---------------------------------------------------------------------------
 if opts[:skip_lint]
-  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+  record_waiver.call('--skip-layout-lint', 'gate 6 (layout-quality lint)', opts[:skip_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?
@@ -549,7 +566,7 @@ end
 # (zero controls built from an interactive source = FAIL, the Qlik class).
 # ---------------------------------------------------------------------------
 if opts[:skip_control_lint]
-  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+  record_waiver.call('--skip-control-lint', 'gate 7 (control-wiring lint)', opts[:skip_control_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -116,11 +116,14 @@ OptionParser.new do |p|
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
   p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
-  p.on('--skip-column-check')        { opts[:skip_column] = true }
-  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
-  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
-  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
-  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  # These five accept an OPTIONAL reason (kept backward-compatible: a bare flag
+  # still works). A skip with no reason is recorded as "NO REASON GIVEN" and
+  # logged loudly so a silent bypass can't hide — see record_waiver below.
+  p.on('--skip-column-check [REASON]')  { |v| opts[:skip_column] = v || true }
+  p.on('--skip-orphan-check [REASON]')  { |v| opts[:skip_orphan] = v || true }
+  p.on('--skip-layout-check [REASON]')  { |v| opts[:skip_layout] = v || true }
+  p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
+  p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
@@ -131,6 +134,20 @@ OptionParser.new do |p|
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
+
+# A waived gate must never pass SILENTLY. record_waiver prints a loud banner and
+# appends to <workdir>/waivers.json so the migration report (and any future
+# check) can see every gate that was bypassed and why. A bare skip (no reason)
+# is recorded as "NO REASON GIVEN" — visible, not invisible. (CoCo run wrapped
+# up GREEN after silently skipping checks — this makes that impossible.)
+waivers = []
+record_waiver = lambda do |flag, gate, reason|
+  r = (reason.is_a?(String) && !reason.strip.empty?) ? reason.strip : nil
+  waivers << { 'flag' => flag, 'gate' => gate, 'reason' => r }
+  puts "[SKIP] #{gate} WAIVED via #{flag}#{r ? " (#{r})" : ' — NO REASON GIVEN'}"
+  puts "       MUST be named in the migration report#{r ? '' : ' WITH a reason'}; this gate did NOT verify the workbook."
+  File.write(File.join(opts[:tab], 'waivers.json'), JSON.pretty_generate(waivers)) rescue nil
+end
 
 summary_path = File.join(opts[:tab], 'parity-final.json')
 
@@ -279,7 +296,7 @@ unless opts[:skip_orphan]
     puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/7: --skip-orphan-check"
+  record_waiver.call('--skip-orphan-check', 'gate 2 (orphan-workbook cleanup)', opts[:skip_orphan])
 end
 
 # ---------------------------------------------------------------------------
@@ -333,7 +350,7 @@ unless opts[:skip_column]
     end
   end
 else
-  puts "[SKIP] gate 3/7: --skip-column-check"
+  record_waiver.call('--skip-column-check', 'gate 3 (live column type=error scan)', opts[:skip_column])
 end
 
 # ---------------------------------------------------------------------------
@@ -439,7 +456,7 @@ unless opts[:skip_layout]
     end
   end
 else
-  puts "[SKIP] gate 4/7: --skip-layout-check"
+  record_waiver.call('--skip-layout-check', 'gate 4 (top-level layout applied)', opts[:skip_layout])
 end
 
 # ---------------------------------------------------------------------------
@@ -483,7 +500,7 @@ end
 # This gate mechanizes those checks on the LIVE spec.
 # ---------------------------------------------------------------------------
 if opts[:skip_lint]
-  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+  record_waiver.call('--skip-layout-lint', 'gate 6 (layout-quality lint)', opts[:skip_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?
@@ -549,7 +566,7 @@ end
 # (zero controls built from an interactive source = FAIL, the Qlik class).
 # ---------------------------------------------------------------------------
 if opts[:skip_control_lint]
-  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+  record_waiver.call('--skip-control-lint', 'gate 7 (control-wiring lint)', opts[:skip_control_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -116,11 +116,14 @@ OptionParser.new do |p|
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
   p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
-  p.on('--skip-column-check')        { opts[:skip_column] = true }
-  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
-  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
-  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
-  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  # These five accept an OPTIONAL reason (kept backward-compatible: a bare flag
+  # still works). A skip with no reason is recorded as "NO REASON GIVEN" and
+  # logged loudly so a silent bypass can't hide — see record_waiver below.
+  p.on('--skip-column-check [REASON]')  { |v| opts[:skip_column] = v || true }
+  p.on('--skip-orphan-check [REASON]')  { |v| opts[:skip_orphan] = v || true }
+  p.on('--skip-layout-check [REASON]')  { |v| opts[:skip_layout] = v || true }
+  p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
+  p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
@@ -131,6 +134,20 @@ OptionParser.new do |p|
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
+
+# A waived gate must never pass SILENTLY. record_waiver prints a loud banner and
+# appends to <workdir>/waivers.json so the migration report (and any future
+# check) can see every gate that was bypassed and why. A bare skip (no reason)
+# is recorded as "NO REASON GIVEN" — visible, not invisible. (CoCo run wrapped
+# up GREEN after silently skipping checks — this makes that impossible.)
+waivers = []
+record_waiver = lambda do |flag, gate, reason|
+  r = (reason.is_a?(String) && !reason.strip.empty?) ? reason.strip : nil
+  waivers << { 'flag' => flag, 'gate' => gate, 'reason' => r }
+  puts "[SKIP] #{gate} WAIVED via #{flag}#{r ? " (#{r})" : ' — NO REASON GIVEN'}"
+  puts "       MUST be named in the migration report#{r ? '' : ' WITH a reason'}; this gate did NOT verify the workbook."
+  File.write(File.join(opts[:tab], 'waivers.json'), JSON.pretty_generate(waivers)) rescue nil
+end
 
 summary_path = File.join(opts[:tab], 'parity-final.json')
 
@@ -279,7 +296,7 @@ unless opts[:skip_orphan]
     puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/7: --skip-orphan-check"
+  record_waiver.call('--skip-orphan-check', 'gate 2 (orphan-workbook cleanup)', opts[:skip_orphan])
 end
 
 # ---------------------------------------------------------------------------
@@ -333,7 +350,7 @@ unless opts[:skip_column]
     end
   end
 else
-  puts "[SKIP] gate 3/7: --skip-column-check"
+  record_waiver.call('--skip-column-check', 'gate 3 (live column type=error scan)', opts[:skip_column])
 end
 
 # ---------------------------------------------------------------------------
@@ -439,7 +456,7 @@ unless opts[:skip_layout]
     end
   end
 else
-  puts "[SKIP] gate 4/7: --skip-layout-check"
+  record_waiver.call('--skip-layout-check', 'gate 4 (top-level layout applied)', opts[:skip_layout])
 end
 
 # ---------------------------------------------------------------------------
@@ -483,7 +500,7 @@ end
 # This gate mechanizes those checks on the LIVE spec.
 # ---------------------------------------------------------------------------
 if opts[:skip_lint]
-  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+  record_waiver.call('--skip-layout-lint', 'gate 6 (layout-quality lint)', opts[:skip_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?
@@ -549,7 +566,7 @@ end
 # (zero controls built from an interactive source = FAIL, the Qlik class).
 # ---------------------------------------------------------------------------
 if opts[:skip_control_lint]
-  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+  record_waiver.call('--skip-control-lint', 'gate 7 (control-wiring lint)', opts[:skip_control_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -116,11 +116,14 @@ OptionParser.new do |p|
   p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
   p.on('--min-parity-score F', Float, 'gate 1: fail if value_parity_score (mean per-tile, parity-score.json) < F (0..1, default 0 = off)') { |v| opts[:min_parity_score] = v }
   p.on('--allow-extract')            { opts[:allow_extract] = true }
-  p.on('--skip-column-check')        { opts[:skip_column] = true }
-  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
-  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
-  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
-  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  # These five accept an OPTIONAL reason (kept backward-compatible: a bare flag
+  # still works). A skip with no reason is recorded as "NO REASON GIVEN" and
+  # logged loudly so a silent bypass can't hide — see record_waiver below.
+  p.on('--skip-column-check [REASON]')  { |v| opts[:skip_column] = v || true }
+  p.on('--skip-orphan-check [REASON]')  { |v| opts[:skip_orphan] = v || true }
+  p.on('--skip-layout-check [REASON]')  { |v| opts[:skip_layout] = v || true }
+  p.on('--skip-layout-lint [REASON]')   { |v| opts[:skip_lint] = v || true }
+  p.on('--skip-control-lint [REASON]')  { |v| opts[:skip_control_lint] = v || true }
   p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
   p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
   p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
@@ -131,6 +134,20 @@ OptionParser.new do |p|
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
 end.parse!
 abort('--workdir (or --tableau) required') unless opts[:tab]
+
+# A waived gate must never pass SILENTLY. record_waiver prints a loud banner and
+# appends to <workdir>/waivers.json so the migration report (and any future
+# check) can see every gate that was bypassed and why. A bare skip (no reason)
+# is recorded as "NO REASON GIVEN" — visible, not invisible. (CoCo run wrapped
+# up GREEN after silently skipping checks — this makes that impossible.)
+waivers = []
+record_waiver = lambda do |flag, gate, reason|
+  r = (reason.is_a?(String) && !reason.strip.empty?) ? reason.strip : nil
+  waivers << { 'flag' => flag, 'gate' => gate, 'reason' => r }
+  puts "[SKIP] #{gate} WAIVED via #{flag}#{r ? " (#{r})" : ' — NO REASON GIVEN'}"
+  puts "       MUST be named in the migration report#{r ? '' : ' WITH a reason'}; this gate did NOT verify the workbook."
+  File.write(File.join(opts[:tab], 'waivers.json'), JSON.pretty_generate(waivers)) rescue nil
+end
 
 summary_path = File.join(opts[:tab], 'parity-final.json')
 
@@ -279,7 +296,7 @@ unless opts[:skip_orphan]
     puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
   end
 else
-  puts "[SKIP] gate 2/7: --skip-orphan-check"
+  record_waiver.call('--skip-orphan-check', 'gate 2 (orphan-workbook cleanup)', opts[:skip_orphan])
 end
 
 # ---------------------------------------------------------------------------
@@ -333,7 +350,7 @@ unless opts[:skip_column]
     end
   end
 else
-  puts "[SKIP] gate 3/7: --skip-column-check"
+  record_waiver.call('--skip-column-check', 'gate 3 (live column type=error scan)', opts[:skip_column])
 end
 
 # ---------------------------------------------------------------------------
@@ -439,7 +456,7 @@ unless opts[:skip_layout]
     end
   end
 else
-  puts "[SKIP] gate 4/7: --skip-layout-check"
+  record_waiver.call('--skip-layout-check', 'gate 4 (top-level layout applied)', opts[:skip_layout])
 end
 
 # ---------------------------------------------------------------------------
@@ -483,7 +500,7 @@ end
 # This gate mechanizes those checks on the LIVE spec.
 # ---------------------------------------------------------------------------
 if opts[:skip_lint]
-  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+  record_waiver.call('--skip-layout-lint', 'gate 6 (layout-quality lint)', opts[:skip_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?
@@ -549,7 +566,7 @@ end
 # (zero controls built from an interactive source = FAIL, the Qlik class).
 # ---------------------------------------------------------------------------
 if opts[:skip_control_lint]
-  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+  record_waiver.call('--skip-control-lint', 'gate 7 (control-wiring lint)', opts[:skip_control_lint])
 else
   wb_id = opts[:wb]
   if wb_id.nil?


### PR DESCRIPTION
## Problem
The CoCo run wrapped up GREEN after silently skipping checks. In `assert-phase6-ran.rb` (the shared 8-gate hard gate across all converters), three escape hatches were **bare booleans** (`--skip-orphan-check`, `--skip-column-check`, `--skip-layout-check`) that printed at most a one-line ack; `--skip-layout-lint` / `--skip-control-lint` mentioned a reason but captured none. A silent bypass left no trace in the result.

## Fix
All five now accept an **optional** reason (backward-compatible — a bare flag still parses) and route through one `record_waiver` helper that:
- prints a **loud banner** — `WAIVED via <flag> (reason)` or `— NO REASON GIVEN`,
- records every waiver to **`<workdir>/waivers.json`** so the migration report (and any future check) can see exactly which gates were bypassed and why.

A bare skip is no longer invisible: it logs `NO REASON GIVEN — MUST be named in the report`.

## Shared-script discipline
Edited the **canonical** `shared/scripts/assert-phase6-ran.rb` and fanned out via `tools/sync-shared.rb` to all **6** converters (tableau/powerbi/qlik/quicksight/looker/thoughtspot). `check-shared.rb` + the gate-doc hook are green.

## Verified
On a fanned-out copy (thoughtspot): all five skips log loudly, `waivers.json` carries 5 entries, and the run still reaches `[OK] all gates pass`. `ruby -c` clean.

## Context / deferred
Part of the prose-vs-gate enforcement hardening (from the audit). Two larger items are **deferred to their own PRs** because they carry design forks I want your call on:
1. **Hard-require a recorded visual source-vs-target comparison** — gate 8 already verifies a non-blank PNG *exists*; making "a comparison was recorded" a hard fail would catch the "GREEN on parity numbers, never looked at the render" case, but would fail converters that don't yet write the `visual_checked` flag (blast radius → needs coordinated orchestrator updates).
2. **Turn destination / conversion-mode / DM-reuse / RLS asks into exit-10 OPEN-QUESTION stops** — per-orchestrator, in 3 languages, and must not break legitimate unattended/batch runs (`--yes` / `--answers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)