### PR TITLE
feat(tableau): auto-discover a local converter build (+ fetch-script)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 # Generated at vendor/release time by tools/stamp-version.rb (do not commit)
 shared/lib/VERSION
 plugins/*/skills/*/scripts/lib/VERSION
+
+# vendored local converter build (fetched on demand by fetch-converter.sh; never committed — drifts)
+plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/vendor/

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/dev/fetch-converter.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/dev/fetch-converter.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# fetch-converter.sh — get a LOCAL Tableau→Sigma converter build with one command,
+# for the no-egress mechanical path when you don't already have the sigma-data-model
+# MCP checked out elsewhere.
+#
+# It clones (or updates) the converter repo into a GITIGNORED vendor/ dir under the
+# skill and builds it. migrate-tableau.rb then auto-discovers vendor/sigma-data-model-mcp/
+# build/tableau.js (see the auto-discover block) — no TABLEAU_MCP_BUILD needed.
+#
+# We deliberately do NOT commit the build artifact: the converter is actively
+# developed and not self-contained (build/tableau.js imports siblings), so a vendored
+# snapshot would silently drift. Re-run this script to refresh.
+#
+#   ./scripts/dev/fetch-converter.sh            # clone/update + build (default branch)
+#   ./scripts/dev/fetch-converter.sh <ref>      # build a specific branch/tag/sha
+#
+# Requires: git + node/npm on PATH.
+set -euo pipefail
+
+REPO="${SIGMA_CONVERTER_REPO:-https://github.com/twells89/sigma-data-model-mcp.git}"
+REF="${1:-}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # the skill's scripts/ dir
+DEST="$HERE/vendor/sigma-data-model-mcp"
+
+command -v git  >/dev/null || { echo "FATAL: git not on PATH"; exit 1; }
+command -v npm  >/dev/null || { echo "FATAL: npm/node not on PATH — the local converter needs Node"; exit 1; }
+
+if [ -d "$DEST/.git" ]; then
+  echo "→ updating existing checkout at $DEST"
+  git -C "$DEST" fetch --quiet origin
+  if [ -n "$REF" ]; then git -C "$DEST" checkout --quiet "$REF"; git -C "$DEST" pull --quiet --ff-only origin "$REF" 2>/dev/null || true
+  else git -C "$DEST" pull --quiet --ff-only; fi
+else
+  echo "→ cloning $REPO → $DEST"
+  mkdir -p "$(dirname "$DEST")"
+  git clone --quiet "$REPO" "$DEST"
+  [ -n "$REF" ] && git -C "$DEST" checkout --quiet "$REF"
+fi
+
+echo "→ installing deps + building (npm ci && npm run build)"
+( cd "$DEST" && { npm ci --silent || npm install --silent; } && npm run build --silent )
+
+BUILD="$DEST/build/tableau.js"
+if [ -f "$BUILD" ]; then
+  echo ""
+  echo "✓ local converter ready: $BUILD"
+  echo "  migrate-tableau.rb will auto-discover it (no TABLEAU_MCP_BUILD needed)."
+  echo "  built from $(git -C "$DEST" rev-parse --short HEAD) ($(git -C "$DEST" rev-parse --abbrev-ref HEAD))"
+else
+  echo "FATAL: build did not produce $BUILD — check the npm build output above"; exit 1
+fi

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -670,6 +670,24 @@ if mechanical
     line "WARN: TABLEAU_MCP_BUILD=#{mcp_build} does not exist — ignoring"
     mcp_build = nil
   end
+  # Auto-discover a LOCAL converter build when TABLEAU_MCP_BUILD is unset, so
+  # anyone who has the sigma-data-model MCP checked out (or ran scripts/dev/
+  # fetch-converter.sh) gets the no-egress local path with ZERO config — the
+  # mechanical path becomes the default instead of dropping to the manual STOP.
+  # First hit wins; purely filesystem (never the network), so a miss just falls
+  # through to the consent/STOP logic below. Set TABLEAU_MCP_BUILD to override.
+  if mcp_build.nil?
+    auto = [
+      (ENV['SIGMA_DATA_MODEL_MCP'] && File.join(ENV['SIGMA_DATA_MODEL_MCP'], 'build', 'tableau.js')),
+      File.join(HERE, 'vendor', 'sigma-data-model-mcp', 'build', 'tableau.js'), # fetch-converter.sh target (gitignored)
+      File.expand_path('~/sigma-data-model-mcp/build/tableau.js'),
+      File.expand_path('~/Desktop/sigma-data-model-mcp/build/tableau.js')
+    ].compact.find { |p| File.exist?(p) }
+    if auto
+      mcp_build = auto
+      line "converter: auto-discovered LOCAL build #{auto} (no data leaves this machine; set TABLEAU_MCP_BUILD to override)"
+    end
+  end
   allow_hosted = opts[:converter] == 'hosted' || ENV['SIGMA_CONVERTER_ALLOW_HOSTED'] == '1'
   if mcp_build
     line "converter: LOCAL build #{mcp_build} (no data leaves this machine)"


### PR DESCRIPTION
(Re-opened as a fresh PR — the original #215 was auto-closed when its stacked base branch was deleted on merge of #214. Now targets main; #214 is already merged.)

## Why
#214 makes the *manual* path safe. This makes the *mechanical* (local, no-egress) path the **default**, so we rarely fall onto the manual path — directly addressing the no-converter-backend STOP the CoCo run hit.

## What
- **Auto-discover**: when `TABLEAU_MCP_BUILD` is unset, `migrate-tableau.rb` probes standard filesystem locations (`SIGMA_DATA_MODEL_MCP`, the gitignored skill-local `vendor/`, `~/sigma-data-model-mcp`, `~/Desktop/...`) and uses the first build found. Filesystem-only (never network); a miss falls through to the existing consent/STOP logic. Logged loudly; `TABLEAU_MCP_BUILD` overrides.
- **`scripts/dev/fetch-converter.sh`**: one command to clone+build the converter into a **gitignored** `vendor/` dir, which auto-discover then picks up.

## Why not commit a prebuilt bundle
The converter is actively developed and **not self-contained** (`build/tableau.js` imports siblings; 1.5M/39 files). A committed snapshot would silently drift. Fetch-on-demand avoids a stale artifact.

## Verified
Auto-discover resolves the real `~/sigma-data-model-mcp/build/tableau.js`; the LOCAL `run_converter` shim (`convertTableauToSigma` → `{model,warnings}`) yields 4 elements/53 cols from the `lod_test` fixture. `ruby -c`/`bash -n` clean; hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)