### PR TITLE
looker-to-sigma: reuse-relational-DM hardening — docs + mechanical guards (visibility / layer rel-refs / JSON dot-notation / fan-out)

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -145,6 +145,7 @@ python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
 | `scripts/convert_dm.mjs` | **Phase 2:** run `convertLookMLToSigma` against a directory of `.lkml` files for one explore → a Sigma DM spec JSON + `…-warnings.json` sidecar. A `.model.lkml` is optional — with none it converts **view-only** (each view → standalone element; pass the WHOLE directory so cross-view `${view.SQL_TABLE_NAME}` refs resolve — see `refs/layered-lookml.md`). Bypasses the deployed MCP build (see the converter-build gotcha below). Env: `LOOKML_DIR`, `CONVERTER_SRC`; args `<exploreName> <out.json>`. |
 | `scripts/lookml-dm-signature.py` | **Phase 2.5:** LookML view files → DM-reuse signature (`{warehouse_tables, referenced_columns, measures}`) for `find-or-pick-dm.rb`. Pure, no network. |
 | `scripts/find-or-pick-dm.rb` | **Phase 2.5:** scan existing Sigma DMs and recommend reuse (score = 0.7·column + 0.2·table + 0.1·metric overlap; `--auto-pick` with tie-window safety). Shared vendor-neutral copy (canonical: tableau-to-sigma; needs `scripts/lib/sigma_rest.rb`). Non-destructive. |
+| `scripts/shape-preflight.rb` | **Phase 2.5 (reuse gate):** before wiring a workbook to a REUSED DM element, mechanically check the three things a spec POST won't: (1) the element is not `visibleAsSource:false` (hidden → unusable as a source), (2) needed columns resolve on it, (3) every relationship it reaches columns through is 1:1 (non-unique target key → silent fan-out). Visibility/coverage hard-fail (exit 2); fan-out is surfaced with the exact Sigma-MCP uniqueness query per relationship — run it and feed back via `--fanout-results` (or `--ack-fanout`). Non-destructive; needs `scripts/lib/sigma_rest.rb`. `migrate-looker.py` auto-runs it on `--reuse-dm`. |
 | `scripts/post_dm.py` | **Phase 2:** POST a DM spec to `/v2/dataModels/spec` (auto-finds a writable folder, swaps in the full connection UUID). Env: `SIGMA_API_TOKEN`, `SIGMA_BASE_URL`, `SIGMA_CONNECTION_ID`; args `<spec.json>`. |
 | `scripts/build_workbook.py` | **Phase 3:** dashboard contract + the explore's view `.lkml` files → a Sigma `/v2/workbooks/spec` body (hidden Data page + master table, one element per tile, controls from filters, newspaper→24-col layout XML). Generates locally; does **not** POST. Handles ratio measures, joined-col `Field (alias)` naming, table calcs, pivot-flatten + warn. Layout: a top control bar (row 0), a full-width strip of **tall** KPI tiles (height ≥ 6 so titles render), then the remaining tiles shifted down. |
 | `scripts/looker-render-dashboard.py` | **Phase 4 (visual QA — SOURCE side):** render a LIVE Looker dashboard to PNG via the Looker render API (`POST /render_tasks/dashboards/{id}/png` → poll `GET /render_tasks/{task_id}` until `success` → `GET .../results`). Pairs with `sigma-export-png.py` for source-vs-migrated side-by-side. Reuses `looker_api.py` `~/.looker/looker.ini` auth. `python3 looker-render-dashboard.py <dashboard_id> [out.png] [--w 1200 --h 1600]`. |
@@ -483,8 +484,10 @@ bash -c 'eval "$(scripts/get-token.sh)" && \
 referenced_columns (dimension/measure names), measures}` straight from the LookML view
 files — the same files you fed `convert_dm.mjs`. Decision:
 - **Score ≥ 0.6** → **ASK the user** reuse-vs-new: surface the candidate name, matched
-  cols (N/M), and the inherited-extras warning from `dm-match.json`. If they reuse, run a
-  **shape preflight** first — read the candidate DM's spec back and confirm:
+  cols (N/M), and the inherited-extras warning from `dm-match.json`. If they reuse, run the
+  **shape preflight** first — `ruby scripts/shape-preflight.rb --dm-id <id> --element "<element
+  you'll wire to>" --needed-columns "<dashboard cols>" --out /tmp/<name>/shape-preflight.json`
+  (exit 2 = unsafe). It mechanically confirms:
   1. every column the dashboards reference resolves on the element you'll wire to (no
      `type=error` columns; fact vs separate-dim location);
   2. **the element is usable as a source** — i.e. it is NOT `visibleAsSource: false`. The

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -484,12 +484,24 @@ referenced_columns (dimension/measure names), measures}` straight from the LookM
 files — the same files you fed `convert_dm.mjs`. Decision:
 - **Score ≥ 0.6** → **ASK the user** reuse-vs-new: surface the candidate name, matched
   cols (N/M), and the inherited-extras warning from `dm-match.json`. If they reuse, run a
-  **shape preflight** first — read the candidate DM's spec back and confirm every column
-  the dashboards reference resolves on the element you'll wire to (no `type=error`
-  columns; fact vs separate-dim location) — then **skip 2c/2d** and point Phase 3's
-  workbook masters at the matched `recommended_dm_id` + its element ids. With
-  `--auto-pick` a clear winner (no tie within 0.05) skips the prompt — still WARN about
-  inherited columns/RLS/metrics.
+  **shape preflight** first — read the candidate DM's spec back and confirm:
+  1. every column the dashboards reference resolves on the element you'll wire to (no
+     `type=error` columns; fact vs separate-dim location);
+  2. **the element is usable as a source** — i.e. it is NOT `visibleAsSource: false`. The
+     flag **defaults to `true` and is omitted from the spec when true**, so absence = visible
+     and you only act when you literally see `"visibleAsSource": false`. A hidden element
+     builds fine via the API but **users can't pick it as a source in the workbook UI** —
+     wire to a visible sibling, or `PUT` the DM spec setting `visibleAsSource: true`, before
+     proceeding (verified live 2026-06-29);
+  3. **how related columns are exposed** — if the columns you need live on a *separate*
+     element reached by a `relationships[]` entry (a reused relational DM, NOT a flat denorm
+     element), note the relationship's exact `name`; Phase 3 will reference them as
+     `[<element>/<RelationshipName>/<col>]` (see 3b). Confirm the join is 1:1 on its key — a
+     non-unique target key silently fans out (see the fan-out troubleshooting row).
+
+  Then **skip 2c/2d** and point Phase 3's workbook masters at the matched
+  `recommended_dm_id` + its element ids. With `--auto-pick` a clear winner (no tie within
+  0.05) skips the prompt — still WARN about inherited columns/RLS/metrics.
 - **Score < 0.6** → POST new (2c) and TELL the user no reusable DM was found.
 
 ### 2c. POST the data model
@@ -605,6 +617,30 @@ Newspaper layout math (a single arithmetic transform, no spatial heuristic):
 - **Joined-view columns** in the denorm DM element are named `<Field> (<joinAlias>)` (Sigma
   disambiguates cross-element lookup cols) — master/tile refs must include the suffix, e.g.
   `[Order Fact/Region (customer_dim)]`.
+- **Cross-element relationship refs (reused relational DMs) — the form is LAYER-DEPENDENT.**
+  When the converter builds the DM it flattens joined columns into one denorm element, so the
+  workbook only ever does `[<element>/<col>]`. But when you **reuse an existing DM** whose
+  element reaches other columns through a `relationships[]` entry (instead of a flat denorm),
+  the ref form differs by where you write it (all verified live 2026-06-29):
+    - **In a workbook formula** (master/tile/chart column) → `[<SourceElement>/<RelationshipName>/<col display>]`
+      — uses the **relationship's `name`**. e.g. `[Plugs Fact/Plugs to Customer/Cust Region]` ✅.
+    - **In a DM calc column** → `[<TargetElementName>/<col display>]` (or `Lookup([<TargetElementName>/<col>], <localKey>, [<TargetElementName>/<key>])`)
+      — uses the **target element's name**, NOT the relationship name. e.g. `[Customer Dim/Cust Region]` ✅.
+    - **Both layers reject the raw warehouse/staging table name** (e.g. `STG_…`/`D_CUSTOMER`)
+      → the column resolves as `type=error`. The relationship `name` is whatever the DM author
+      set (often a phrase like `"Plugs to Customer"`, **not** the table name) — read it from the
+      DM spec's `relationships[].name`; don't guess it from the table. Two-segment guesses like
+      `[<RelationshipName>/<col>]` hard-reject the whole spec POST ("dependency not found").
+- **VARIANT / JSON columns — extract with DOT NOTATION, not a function.** Sigma has **no**
+  `JsonExtractText()` / `CallVariant()` / `Variant()`-extraction function (those error the
+  column — don't trial-and-error them). To pull a value out of a JSON/VARIANT column, write a
+  **dot-notation** formula and wrap it in `Text()` to land a typed column:
+  `Text([Cust Json].AGE_GROUP)`, nested `Text([Cust Json].LOYALTY_EXTRA.LOYALTY_TIER)`, array
+  `Text([Cart Details].cart[0])` (0-based). Best practice is to extract **upstream in the DM**
+  (the extracted column then flows into the workbook as a normal column — verified live
+  2026-06-29); the UI equivalent is the column menu's **Extract columns…**. So a JSON field is
+  migratable — surface it as a dot-notation column, don't leave it as raw JSON and don't block
+  on it. (`Variant()`/`Json()` exist only to *cast* a column's type, not to extract.)
 - **Table calcs** → workbook formula columns: `running_total` → `CumulativeSum`,
   `pct_of_total`/`sum()` → `GrandTotal`, `offset(…,-1)` → `Lag`. (`build_workbook.py` translates
   these; `dynamic_fields` arrives JSON-parsed from discovery.)
@@ -793,6 +829,9 @@ declaring Phase 4 green.
 | LookML model 404s on query right after deploy | Model not registered | `POST /lookml_models {name, project_name, allowed_db_connection_names}` |
 | `PUT /projects/{id}` 404 when setting git remote | Wrong verb | Use `PATCH /projects/{id}` |
 | Looker dev-workspace mutation has no effect | The calls ran in separate processes/sessions (the bearer cache is per-process; a 401 re-login also starts a NEW session that resets the workspace to production) | Do the whole dev flow in ONE process — `looker_api.py`'s cached token keeps one session, so `PATCH /session {workspace_id: dev}` sticks for subsequent `call()`s; re-PATCH after any forced re-login |
+| Reused DM element builds via API but users can't select it as a source in the workbook UI | The element is `visibleAsSource: false` (hidden); the API doesn't enforce visibility on build | Wire to a visible sibling, or `PUT` the DM spec setting `visibleAsSource: true`. NB the flag defaults true and is **omitted when true** — only `"visibleAsSource": false` in the spec means hidden. Catch it in the Phase 2.5 shape preflight |
+| Related-element column resolves as `type=error` | Referenced the raw warehouse/staging table name, or used the wrong layer's form | **Workbook** formula → `[<element>/<RelationshipName>/<col>]` (relationship name); **DM** calc → `[<TargetElementName>/<col>]` or `Lookup(…)`. Read the exact name from `relationships[].name` — never the table name (see 3b) |
+| Reused relationship returns 2+ matches per row / inflated KPI & chart totals | The relationship key is incomplete (e.g. fact related to a dim on a non-unique attribute, or missing a 2nd key like Region) so it fans out — a non-unique target key multiplies fact rows silently (e.g. relating on a 5-value Region column vs a 4,972-row dim ≈ 994× inflation) | Relate on the dim's true primary key (or add the missing key to make the join 1:1) in the DM — manual. A single-key fan-out produces **wrong** aggregates with no error; flag it, don't ship |
 
 ---
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -777,6 +777,32 @@ console.error('stats:', JSON.stringify(res.stats));
     print(f"   DM {dm} · denorm '{denorm_name}' ({denorm['id']}, "
           f"{len(denorm.get('columns') or [])} cols) · {len(els)} element(s)")
 
+    # ── Phase 4a.5 — shape preflight (REUSE only) ────────────────────────────
+    # Mechanical reuse gate for the failure modes a spec POST won't catch and that
+    # otherwise ship silently: a hidden (visibleAsSource:false) element, missing
+    # columns, and relationship FAN-OUT. Only meaningful when reusing a DM we did
+    # NOT just build (a freshly-converted DM's elements are visible and 1:1 by
+    # construction). The orchestrator can't run ad-hoc SQL, so fan-out relationships
+    # are SURFACED with the exact Sigma-MCP query (--ack-fanout); visibility hard-fails.
+    # The agent path (SKILL.md Phase 2.5) runs the emitted queries to confirm 1:1.
+    if a.reuse_dm:
+        pf_out = os.path.join(wd, "shape-preflight.json")
+        rc_pf, _ = run(["ruby", os.path.join(HERE, "shape-preflight.rb"),
+                        "--dm-id", dm, "--element", denorm_name,
+                        "--ack-fanout", "--out", pf_out], check=False)
+        try:
+            pf = json.load(open(pf_out))
+            for r in pf.get("relationships", []):
+                q = (r.get("uniqueness_query") or {}).get("sql")
+                print(f"   ↳ verify 1:1 (reuse): relationship '{r['name']}' → "
+                      f"'{r.get('target_element')}' — run via Sigma MCP query: {q}")
+        except Exception:
+            pass
+        if rc_pf == 2:
+            sys.exit("FATAL: shape-preflight failed (hidden element / missing columns on the "
+                     "reuse element) — see shape-preflight.json. Wire to a visible element or fix "
+                     "coverage before reusing.")
+
     # ── Phase 4b — Build + POST the workbook (layout XML inline) ─────────────
     hdr(4, TOTAL, "Build workbook (4b)")
     wb_spec_path = os.path.join(wd, "wb-spec.json")

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/shape-preflight.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/shape-preflight.rb
@@ -1,0 +1,139 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# shape-preflight.rb — Phase 2.5 reuse gate. BEFORE wiring a workbook to an
+# EXISTING (reused) data model element, mechanically check the three failure
+# modes that a spec POST will NOT catch and that otherwise ship silently
+# (verified live 2026-06-29; see SKILL.md Phase 2.5 + §3b):
+#
+#   1. VISIBILITY — the element you wire to must be usable as a source. An element
+#      with "visibleAsSource": false builds fine via the API but users can't pick
+#      it as a source in the workbook UI. The flag DEFAULTS true and is OMITTED
+#      when true, so only a literal `false` means hidden.
+#   2. COLUMN COVERAGE — every dashboard-referenced column must resolve on that
+#      element (present by name; relationship-reached columns are reported so you
+#      know they come via a relationship, not directly).
+#   3. FAN-OUT — every relationship the element reaches columns through must be
+#      1:1 on its key. A non-unique target key multiplies fact rows and silently
+#      inflates every aggregate. The public REST API has no ad-hoc SQL endpoint,
+#      so this script EMITS the exact uniqueness query per relationship (run it
+#      via the Sigma MCP `query` tool) and BLOCKS until you feed results back via
+#      --fanout-results (or acknowledge with --ack-fanout).
+#
+# Usage:
+#   ruby scripts/shape-preflight.rb --dm-id <id> --element <name-or-id> \
+#     [--needed-columns "Col A,Col B,..."] \
+#     [--fanout-results <file.json>]   # {"<relName>": {"n": <count>, "d": <distinct>}}
+#     [--ack-fanout]                    # bypass the fan-out block (records the ack)
+#     --out <dir>/shape-preflight.json
+#
+# Exit: 0 = PASS (safe to reuse this element).
+#       2 = FAIL (hidden element / missing columns / unverified or fanning-out relationship).
+#       1 = bad invocation.
+
+require 'json'
+require 'yaml'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--dm-id ID')            { |v| opts[:dm] = v }
+  p.on('--element NAME_OR_ID')  { |v| opts[:el] = v }
+  p.on('--needed-columns LIST') { |v| opts[:cols] = v }
+  p.on('--fanout-results PATH') { |v| opts[:fanout] = v }
+  p.on('--ack-fanout')          { |_| opts[:ack] = true }
+  p.on('--out PATH')            { |v| opts[:out] = v }
+end.parse!
+%i[dm el out].each { |k| abort "missing --#{k.to_s.tr('_', '-')}" unless opts[k] }
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+# GET spec — usually JSON, but tolerate YAML defensively.
+raw = Sigma.request(:get, "/v2/dataModels/#{opts[:dm]}/spec", accept: 'application/json')
+spec = raw.is_a?(String) ? (JSON.parse(raw) rescue YAML.safe_load(raw, permitted_classes: [Date, Time])) : raw
+
+elements = (spec['elements'] || (spec['pages'] || []).flat_map { |pg| pg['elements'] || [] })
+abort "no elements in DM #{opts[:dm]}" if elements.empty?
+
+el_by_id   = elements.each_with_object({}) { |e, h| h[e['id']] = e }
+el_by_name = elements.each_with_object({}) { |e, h| h[e['name'].to_s.downcase] = e }
+target = el_by_id[opts[:el]] || el_by_name[opts[:el].to_s.downcase]
+unless target
+  names = elements.map { |e| "#{e['name']} (#{e['id']})" }.join(', ')
+  abort "element '#{opts[:el]}' not found in DM. Available: #{names}"
+end
+
+norm = ->(s) { s.to_s.downcase.gsub(/[^a-z0-9]/, '') }
+fails = []
+
+# ---- Check 1: visibility -------------------------------------------------
+hidden = (target['visibleAsSource'] == false)
+hidden_siblings = elements.select { |e| e['visibleAsSource'] == false }.map { |e| e['name'] }
+if hidden
+  fails << "element '#{target['name']}' is visibleAsSource:false (hidden) — it will build via the " \
+           "API but users can't pick it as a source. Wire to a visible sibling, or PUT the DM spec " \
+           "setting visibleAsSource:true on this element."
+end
+
+# ---- Check 2: column coverage -------------------------------------------
+target_col_names = (target['columns'] || []).map { |c| c['name'] }.compact
+target_col_norms = target_col_names.map(&norm)
+needed = (opts[:cols] || '').split(',').map(&:strip).reject(&:empty?)
+missing = needed.reject { |n| target_col_norms.include?(norm.call(n)) }
+unless missing.empty?
+  fails << "columns absent from element '#{target['name']}': #{missing.join(', ')}. They may live " \
+           "on a related element (reach them via [#{target['name']}/<RelationshipName>/<col>] in the " \
+           "workbook) or be genuinely missing — confirm before wiring."
+end
+
+# ---- Check 3: fan-out ----------------------------------------------------
+fanout_results = opts[:fanout] ? JSON.parse(File.read(opts[:fanout])) : {}
+rels = (target['relationships'] || []).map do |r|
+  tgt = el_by_id[r['targetElementId']]
+  tgt_path = tgt && (tgt['source'] || {})['path']
+  tgt_table = tgt_path.is_a?(Array) ? tgt_path.join('.') : tgt_path
+  key = (r['keys'] || []).first || {}
+  rname = r['name'] || r['id']
+  # Emit the uniqueness query in Sigma-MCP form (column id == live spec id).
+  sql = %(SELECT COUNT(*) AS n, COUNT(DISTINCT "#{key['targetColumnId']}") AS d ) +
+        %(FROM "datamodel"."#{r['targetElementId']}")
+  res = fanout_results[rname]
+  verdict =
+    if res && res['n'] && res['d']
+      res['d'].to_i == res['n'].to_i ? :ok : :fanout
+    else
+      :unverified
+    end
+  if verdict == :fanout
+    fails << "relationship '#{rname}' FANS OUT: target '#{tgt && tgt['name']}' has #{res['n']} rows " \
+             "but only #{res['d']} distinct join-key values — every reached column inflates aggregates " \
+             "~#{(res['n'].to_f / [res['d'].to_i, 1].max).round(1)}x. Relate on the dim's true unique key."
+  elsif verdict == :unverified && !opts[:ack]
+    fails << "relationship '#{rname}' → '#{tgt && tgt['name']}' not verified 1:1. Run via Sigma MCP query " \
+             "(dataModelId=#{opts[:dm]}): #{sql}  — then pass --fanout-results (or --ack-fanout to skip)."
+  end
+  {
+    'name' => rname, 'target_element' => (tgt && tgt['name']), 'target_table' => tgt_table,
+    'source_column_id' => key['sourceColumnId'], 'target_column_id' => key['targetColumnId'],
+    'uniqueness_query' => { 'dataModelId' => opts[:dm], 'sql' => sql },
+    'verdict' => verdict.to_s
+  }
+end
+
+status = fails.empty? ? 'PASS' : 'FAIL'
+result = {
+  'dm_id' => opts[:dm],
+  'element' => { 'id' => target['id'], 'name' => target['name'],
+                 'visibleAsSource' => target.fetch('visibleAsSource', true) },
+  'hidden_elements' => hidden_siblings,
+  'needed_columns' => { 'resolved' => (needed - missing), 'missing' => missing },
+  'relationships' => rels,
+  'failures' => fails,
+  'status' => status
+}
+File.write(opts[:out], JSON.pretty_generate(result))
+
+warn "shape-preflight: DM #{opts[:dm]} element '#{target['name']}' → #{status}"
+fails.each { |f| warn "  FAIL  #{f}" }
+warn "  → #{opts[:out]}"
+exit(status == 'PASS' ? 0 : 2)


### PR DESCRIPTION
## Why
Migration feedback from **Look #2088 (CRM Sync History)** — a Look migrated by reusing a pre-existing relational DM — surfaced 4 friction points that cost ~3 iterations: an unknowingly-hidden DM element, wrong cross-element relationship ref syntax, failed JSON extraction, and a silent join fan-out. The skill covered none of them. Every claim below was verified live against `tj-wells-1989` (2026-06-29) — and that testing corrected two of my initial drafts.

## 1. Docs (SKILL.md)
- **Phase 2.5 shape preflight** now checks the reuse candidate is usable as a source (`visibleAsSource` not `false`) + how related columns are exposed.
- **§3b — cross-element relationship refs are LAYER-DEPENDENT** (verified):
  - workbook formula → `[<element>/<RelationshipName>/<col>]` (relationship name)
  - DM calc column → `[<TargetElementName>/<col>]` or `Lookup(…)` (target element name)
  - raw warehouse/staging table name → `type=error` in **both**; read the exact name from `relationships[].name`.
- **§3b — VARIANT/JSON extraction** via **dot notation** `Text([Col].field.subfield)` (the functions `JsonExtractText`/`CallVariant` don't exist). Corrects a backwards first draft.
- **Troubleshooting** — hidden source element, wrong-layer relationship ref, silent fan-out rows.

## 2. Mechanical guards (code)
- **`scripts/shape-preflight.rb`** (new) — before wiring a workbook to a REUSED DM element, mechanically checks: (1) element not `visibleAsSource:false`, (2) needed columns resolve, (3) each relationship is 1:1. The public REST API has no ad-hoc SQL endpoint, so it emits the exact Sigma-MCP uniqueness query per relationship and blocks until verified (`--fanout-results` / `--ack-fanout`). Exit 2 on hidden/missing/confirmed-fan-out.
- **`migrate-looker.py`** auto-runs the preflight on `--reuse-dm` (hard-gates visibility/coverage; surfaces fan-out queries — the orchestrator can't run ad-hoc SQL; the agent path runs them).

## Verification (live, 2026-06-29)
- `visibleAsSource`: confirmed real (DM-spec resource) — boolean, **default true, omitted when true**, round-trips `false` when hidden.
- Built throwaway DM + workbook and read back resolved column types: **JSON dot notation → `text`** ✅ (first "no JSON support" draft was backwards); **relationship ref form is layer-inverted** (a second test reconciled it vs an older memory: the DM-calc triple form fails even when the rel name = the table name).
- **Guard tested standalone** against a fixture DM: hidden element → FAIL; relationship on a 5-distinct-value key vs a 4,972-row dim → fan-out FAIL **~994×**; unique key → ok; missing column flagged.
- **Guard tested in-flow**: cold `migrate-looker.py --reuse-dm` run on the offline `skilltest-orders` fixture → preflight **PASS**, reuse build **33/33 columns resolve, 5/5 strict parity**. Build-new cold run also 5/5 strict. (Gate 8 visual-PNG unmet only because the render step wasn't fed — orthogonal to this change.)
- All test DMs/workbooks deleted; no orphans.