### PR TITLE
python-entrypoint skills: Windows-safe child spawns + fix looker gate-8 render wiring

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
@@ -15,6 +15,13 @@ python3 scripts/migrate-looker.py --lookml-dir fixtures/skilltest-orders \
     [--name PREFIX] [--workdir /tmp/look-run]
 # live: --dashboard-id <id> instead of --dashboard (needs ~/.looker/looker.ini)
 ```
+> **Windows:** launch with the `py` launcher — `py -3 scripts/migrate-looker.py …` —
+> not a bare `python3`. A bare `python`/`python3` on Windows often resolves to the
+> Microsoft Store *App Execution Alias* stub, which silently does nothing. If you
+> see the command exit instantly with no output, disable those aliases (Settings →
+> Apps → Advanced app settings → App execution aliases) or use `py -3`. Child steps
+> the orchestrator spawns already reuse the running interpreter (`sys.executable`),
+> so only the first launch needs this.
 Runs everything below — parse → RLS gate (exit 10 on findings unless `--yes`) →
 convert (exit 3 + `--converted` resume when no local converter) → DM-reuse check
 (candidates PRINTED; default build-new, reuse only via `--reuse-dm <id>`) →

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -488,10 +488,10 @@ def main():
     hdr(1, TOTAL, "Parse")
     contract_path = os.path.join(wd, "contract.json")
     if offline:
-        run(["python3", os.path.join(HERE, "parse_lookml_dashboard.py"),
+        run([sys.executable, os.path.join(HERE, "parse_lookml_dashboard.py"),
              a.dashboard, "--out", contract_path])
     else:
-        run(["python3", os.path.join(HERE, "fetch_looker_dashboard.py"),
+        run([sys.executable, os.path.join(HERE, "fetch_looker_dashboard.py"),
              a.dashboard_id, contract_path])
     dash = json.load(open(contract_path))
     if isinstance(dash, list):
@@ -536,7 +536,7 @@ def main():
         scope_args += ["--scope-models", ",".join(dash_models)]
     if dash_explores:
         scope_args += ["--scope-explores", ",".join(dash_explores)]
-    p = subprocess.run(["python3", os.path.join(HERE, "detect_rls.py"), lookml_dir,
+    p = subprocess.run([sys.executable, os.path.join(HERE, "detect_rls.py"), lookml_dir,
                         "--json"] + scope_args, capture_output=True, text=True)
     findings, info_findings = [], []
     try:
@@ -703,7 +703,7 @@ console.error('stats:', JSON.stringify(res.stats));
     else:
         sig = os.path.join(wd, "dm-signature.json")
         match_out = os.path.join(wd, "dm-match.json")
-        run(["python3", os.path.join(HERE, "lookml-dm-signature.py"),
+        run([sys.executable, os.path.join(HERE, "lookml-dm-signature.py"),
              "--lookml-dir", lookml_dir, "--label", dash["title"], "--out", sig])
         # Auto-pick is OFF by default (POSTMORTEM 2026-06-18 #4): the gate fires on
         # TABLE coverage, not COLUMN coverage, so a DM that covers the tables but
@@ -736,7 +736,7 @@ console.error('stats:', JSON.stringify(res.stats));
 
     if a.dry_run:
         wb_spec = os.path.join(wd, "wb-spec.json")
-        run(["python3", os.path.join(HERE, "build_workbook.py"), contract_path,
+        run([sys.executable, os.path.join(HERE, "build_workbook.py"), contract_path,
              "--views", views_dir, "--out", wb_spec])
         print("\n================ RESULT (dry run) ================")
         print(f"artifacts   : {wd}  (contract, dm-spec/convert-request, wb-spec — no Sigma objects created)")
@@ -756,7 +756,7 @@ console.error('stats:', JSON.stringify(res.stats));
         swap_args = []
         for s in a.source_swap:
             swap_args += ["--source-swap", s]
-        rc, out = run(["python3", os.path.join(HERE, "post_dm.py"), dm_spec_path,
+        rc, out = run([sys.executable, os.path.join(HERE, "post_dm.py"), dm_spec_path,
                        "--folder-id", folder] + swap_args)
         m = re.search(r'dataModelId"?\s*[:=]\s*"?([0-9a-f-]{36})', out)
         if not m:
@@ -814,7 +814,7 @@ console.error('stats:', JSON.stringify(res.stats));
                for e in els], open(dm_els_path, "w"))
     # Use --flag=value for ids: Sigma-reassigned element ids can start with '-'
     # (e.g. "-BGy34L4Yj"), which argparse otherwise mis-reads as a flag.
-    run(["python3", os.path.join(HERE, "build_workbook.py"), contract_path,
+    run([sys.executable, os.path.join(HERE, "build_workbook.py"), contract_path,
          "--views", views_dir, f"--dm-id={dm}", f"--element-id={denorm['id']}",
          f"--dm-element-name={denorm_name}", f"--dm-elements={dm_els_path}",
          f"--folder-id={folder}", f"--out={wb_spec_path}"])
@@ -900,15 +900,18 @@ console.error('stats:', JSON.stringify(res.stats));
     content_pages = [pg for pg in (wspec.get("pages") or [])
                      if "data" not in str(pg.get("id")).lower()]
     rendered = 0
+    render_png = None  # first successful page PNG — wired to gate 8 (--sigma-render)
     for pg in content_pages:
         out = os.path.join(vqa, f"{pg['id']}.png")
-        rc, _ = run(["python3", os.path.join(HERE, "sigma-export-png.py"),
+        rc, _ = run([sys.executable, os.path.join(HERE, "sigma-export-png.py"),
                      "--workbook", wb, "--page", pg["id"], "--out", out,
                      "--w", "1800", "--h", "1000"],
                     env={"SIGMA_API_TOKEN": os.environ.get("SIGMA_API_TOKEN", "")},
                     check=False)
         if rc == 0:
             rendered += 1
+            if render_png is None and os.path.exists(out):
+                render_png = out
         else:
             print(f"   WARN: visual-QA render failed for page {pg['id']}")
     print(f"   rendered {rendered}/{len(content_pages)} full-page PNG(s) → {vqa}")
@@ -1014,8 +1017,15 @@ console.error('stats:', JSON.stringify(res.stats));
     json.dump(actuals, open(os.path.join(wd, "parity-actuals.json"), "w"), indent=2)
     rc, _ = run(["ruby", os.path.join(HERE, "phase6-parity-looker.rb"),
                  "--workdir", wd, "--finalize"], check=False)
-    grc, _ = run(["ruby", os.path.join(HERE, "assert-phase6-ran.rb"),
-                  "--workdir", wd, "--workbook-id", wb], check=False)
+    gate_cmd = ["ruby", os.path.join(HERE, "assert-phase6-ran.rb"),
+                "--workdir", wd, "--workbook-id", wb]
+    # Wire the Phase-4c render to gate 8 (visual render). We render to
+    # visual-qa/<pageId>.png, but the gate defaults to looking for
+    # <workdir>/sigma-render.png — without this the gate never finds the PNG and
+    # every migration fails gate 8 despite a clean render.
+    if render_png and os.path.exists(render_png):
+        gate_cmd += ["--sigma-render", render_png]
+    grc, _ = run(gate_cmd, check=False)
     summary = json.load(open(os.path.join(wd, "parity-final.json")))
 
     # ── Parity-RED triage (POSTMORTEM 2026-06-18 #4) ─────────────────────────

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/scout-validate.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/scout-validate.py
@@ -75,7 +75,7 @@ def build_escalation(a, err):
     except Exception:
         json.dump(payload, open(esc_path, "w"), indent=2)
     filer = os.path.join(os.path.dirname(os.path.abspath(__file__)), "escalate-gap.py")
-    cmd = ["python3", filer, "--skill", skill, "--category", "converter",
+    cmd = [sys.executable, filer, "--skill", skill, "--category", "converter",
            "--feature", a.feature, "--description", a.description or "",
            "--source-pattern", a.pattern or "", "--template-attempted", a.template or "",
            "--test-formula", a.formula, "--sigma-response", json.dumps(err)[:1500],

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/QUICKSTART.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/QUICKSTART.md
@@ -52,6 +52,11 @@ Duration: 2
 - **The same warehouse on both sides** — Sigma's connection must reach the
   database MicroStrategy queries. In-memory cubes migrate as their
   *underlying* warehouse tables.
+- **Windows:** run the scripts with the `py` launcher (`py -3 scripts/…py`), not a
+  bare `python3`. A bare `python`/`python3` on Windows often resolves to the
+  Microsoft Store *App Execution Alias* stub, which silently does nothing. Disable
+  those aliases (Settings → Apps → Advanced app settings → App execution aliases)
+  or use `py -3`. Child steps reuse the running interpreter (`sys.executable`).
 
 ## Assess the estate (optional, ~minutes)
 Duration: 5

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-validate.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/scout-validate.py
@@ -80,7 +80,7 @@ def build_escalation(a, err):
     except Exception:
         json.dump(payload, open(esc_path, "w"), indent=2)
     filer = os.path.join(os.path.dirname(os.path.abspath(__file__)), "escalate-gap.py")
-    cmd = ["python3", filer, "--skill", skill, "--category", "converter",
+    cmd = [sys.executable, filer, "--skill", skill, "--category", "converter",
            "--feature", a.feature, "--description", a.description or "",
            "--source-pattern", a.pattern or "", "--template-attempted", a.template or "",
            "--test-formula", a.formula, "--sigma-response", json.dumps(err)[:1500],

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
@@ -81,6 +81,11 @@ eval "$(scripts/sisense-auth.sh)"
 python3 scripts/discover.py --out ~/sisense-migration        # all cubes + dashboards
 python3 scripts/discover.py --out ~/sisense-migration --cube "Sample ECommerce"
 ```
+> **Windows:** run these with the `py` launcher (`py -3 scripts/…py`), not a bare
+> `python3`. A bare `python`/`python3` on Windows often resolves to the Microsoft
+> Store *App Execution Alias* stub, which silently does nothing. Disable those
+> aliases (Settings → Apps → Advanced app settings → App execution aliases) or use
+> `py -3`. Child steps reuse the running interpreter (`sys.executable`).
 Writes `~/sisense-migration/discovery/`: `elasticubes.json`,
 `model_<title>.json` (full schema export), `dashboards.json` (widgets inlined).
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/QUICKSTART.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/QUICKSTART.md
@@ -10,6 +10,13 @@ python3 scripts/migrate-thoughtspot.py --model <TS_MODEL_ID> [--liveboard <ID> .
     [--name PREFIX] [--workdir /tmp/ts-run]
 # offline: --model-tml fixtures/retail-analytics-model.tml --liveboard-tml fixtures/retail-analytics-liveboard.tml
 ```
+> **Windows:** launch with the `py` launcher — `py -3 scripts/migrate-thoughtspot.py …` —
+> not a bare `python3`. A bare `python`/`python3` on Windows often resolves to the
+> Microsoft Store *App Execution Alias* stub, which silently does nothing (the command
+> exits instantly with no output). Disable those aliases (Settings → Apps → Advanced
+> app settings → App execution aliases) or use `py -3`. Child steps the orchestrator
+> spawns already reuse the running interpreter (`sys.executable`), so only the first
+> launch needs this.
 Runs everything below — discover → DM-reuse check (candidates PRINTED; default
 build-new, reuse only via `--reuse-dm <id>`) → convert (exit 3 + `--converted`
 resume when no local converter build) → DM → workbooks → layout → **freshness

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
@@ -364,7 +364,7 @@ def main():
     else:
         sig = os.path.join(wd, "dm-signature.json")
         match_out = os.path.join(wd, "dm-match.json")
-        sig_cmd = ["python3", os.path.join(HERE, "ts-dm-signature.py"), "--tml",
+        sig_cmd = [sys.executable, os.path.join(HERE, "ts-dm-signature.py"), "--tml",
                    os.path.join(wd, "model.tml"), "--out", sig]
         if os.environ.get("TS_DB"):
             sig_cmd += ["--database", os.environ["TS_DB"]]
@@ -414,7 +414,7 @@ def main():
         print("==================================================")
         return 0
     resolve_folder()
-    mig_cmd = ["python3", os.path.join(HERE, "migrate.py"), "--workdir", wd]
+    mig_cmd = [sys.executable, os.path.join(HERE, "migrate.py"), "--workdir", wd]
     if a.model:
         mig_cmd += ["--model", a.model]
     if a.model_tml:

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/scout-validate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/scout-validate.py
@@ -77,7 +77,7 @@ def build_escalation(a, err):
     except Exception:
         json.dump(payload, open(esc_path, "w"), indent=2)
     filer = os.path.join(os.path.dirname(os.path.abspath(__file__)), "escalate-gap.py")
-    cmd = ["python3", filer, "--skill", skill, "--category", "converter",
+    cmd = [sys.executable, filer, "--skill", skill, "--category", "converter",
            "--feature", a.feature, "--description", a.description or "",
            "--source-pattern", a.pattern or "", "--template-attempted", a.template or "",
            "--test-formula", a.formula, "--sigma-response", json.dumps(err)[:1500],


### PR DESCRIPTION
Follow-up to **#220** (Ruby/Node Python resolver), covering the skills whose **entrypoint is Python** — looker / thoughtspot / microstrategy / sisense. A Ruby/JS resolver can't reach those; the Python-native fix is different.

## 1. Child spawns use `sys.executable`, not `"python3"`
When a Python entrypoint re-spawns Python (parse, RLS scan, dm-signature, `build_workbook`, PNG export, gap escalation), a bare `"python3"` can resolve to the Windows Store **App-Execution-Alias stub** and silently no-op. `sys.executable` is the interpreter **already running the parent** — by definition real, never the stub, and zero-heuristic. This matches the repo's existing idiom (tests, `thoughtspot migrate.py`).

Sites converted: `looker/migrate-looker.py` (8) + `scout-validate.py`; `thoughtspot/migrate-thoughtspot.py` (2) + `scout-validate.py`; `mstr/scout-validate.py`.

The **entrypoint launch itself** (`python3 migrate-X.py`) can't self-check — if it's the stub, the script never runs. That's a "how you invoke it" problem, so each skill's docs got a concise **Windows note** (`use py -3` / disable aliases).

## 2. Fix: looker gate-8 visual-render path mismatch (pre-existing bug, surfaced by the E2E)
`migrate-looker.py` renders the QA PNG to `visual-qa/<pageId>.png` but called `assert-phase6-ran.rb` **without** `--sigma-render`, while the gate defaults to `<workdir>/sigma-render.png`. Result: **every Looker migration failed gate 8** despite a clean render. Now threads the rendered PNG to the gate.

## End-to-end test (Looker, live)
`fixtures/skilltest-orders` → Sigma on `CSA.TJ`, full orchestrator:
- DM + workbook built; child-spawns (incl. PNG render) all ran via `sys.executable`
- **5/5 charts strict parity PASS** (live warehouse queries, exact 1.000× match)
- **All 8 hard gates GREEN, exit 0** (after recording the telemetry decision — the only non-green was the expected unattended telemetry-consent gate)
- Before the gate-8 fix: same run failed gate 8; after: passes
- Test workbooks + DMs **cleaned up**. Offline `--dry-run` green; `lint-skills` + `check-shared` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)