### PR TITLE
Vendor self-contained converters: Looker + ThoughtSpot + Cognos (zero-config, no clone/MCP)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -60,8 +60,11 @@ node scripts/migrate-cognos.mjs \
 `--folder` is optional: when omitted, the DM + workbook land in **your My
 Documents** (resolved automatically via `GET /v2/whoami`). To target a shared
 folder, look its id up first — `GET /v2/files?typeFilters=folder&limit=500`
-(match on `name`/`path`) — and pass `--folder <id>`. Converter deps install
-themselves on first run (`npm install` in `converter/`; needs Node ≥ 18 + npm).
+(match on `name`/`path`) — and pass `--folder <id>`. **The converter is zero-config:**
+a self-contained bundle ships in the skill at `converter/cli.mjs` and runs via plain
+`node` — no `npm install`, no `tsx`, no network, no MCP (needs only Node ≥ 18). Devs
+editing the TS source can rebuild it with `tools/vendor-converters.sh`; if the bundle
+is ever missing the orchestrator falls back to `tsx cli.ts` (one `npm install`).
 
 Chains every phase below in one process: module convert → DM-reuse scan
 (reuse-first: auto-reuses an existing DM covering all the report's source
@@ -161,8 +164,9 @@ windows are the workaround for session-replay auth, not a substitute for asking.
 ## Phase 1 — Convert the Data Module → Sigma data model
 
 ```bash
-cd converter && npm install
-node --import tsx/esm cli.ts ../path/to/module.json --connection <SIGMA_CONN> --database <DB> --schema <SCHEMA>
+# zero-config: the self-contained bundle runs via plain node (no npm install, no tsx)
+node converter/cli.mjs path/to/module.json --connection <SIGMA_CONN> --database <DB> --schema <SCHEMA>
+# (dev fallback, only if editing the TS source: cd converter && npm install && node --import tsx/esm cli.ts …)
 ```
 Emits the Sigma data-model JSON on stdout; stats + warnings on stderr. Read the
 warnings aloud to the user — they are the parts that need manual authoring

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/PROVENANCE.json
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/PROVENANCE.json
@@ -1,0 +1,6 @@
+{
+  "source": "in-skill converter/cli.ts (cognos.ts + cognos-report.ts + sigma-ids.ts)",
+  "bundler": "esbuild --bundle --format=esm --platform=node",
+  "vendored_modules": "cli.mjs",
+  "note": "Self-contained bundle of the skill's own pinned Cognos converter. Refresh with tools/vendor-converters.sh after editing converter/*.ts."
+}

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.mjs
@@ -1,0 +1,3437 @@
+#!/usr/bin/env node
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/util.js
+var require_util = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/util.js"(exports) {
+    "use strict";
+    var nameStartChar = ":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
+    var nameChar = nameStartChar + "\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
+    var nameRegexp = "[" + nameStartChar + "][" + nameChar + "]*";
+    var regexName = new RegExp("^" + nameRegexp + "$");
+    var getAllMatches = function(string, regex) {
+      const matches = [];
+      let match = regex.exec(string);
+      while (match) {
+        const allmatches = [];
+        allmatches.startIndex = regex.lastIndex - match[0].length;
+        const len = match.length;
+        for (let index = 0; index < len; index++) {
+          allmatches.push(match[index]);
+        }
+        matches.push(allmatches);
+        match = regex.exec(string);
+      }
+      return matches;
+    };
+    var isName = function(string) {
+      const match = regexName.exec(string);
+      return !(match === null || typeof match === "undefined");
+    };
+    exports.isExist = function(v) {
+      return typeof v !== "undefined";
+    };
+    exports.isEmptyObject = function(obj) {
+      return Object.keys(obj).length === 0;
+    };
+    exports.merge = function(target, a, arrayMode) {
+      if (a) {
+        const keys = Object.keys(a);
+        const len = keys.length;
+        for (let i = 0; i < len; i++) {
+          if (arrayMode === "strict") {
+            target[keys[i]] = [a[keys[i]]];
+          } else {
+            target[keys[i]] = a[keys[i]];
+          }
+        }
+      }
+    };
+    exports.getValue = function(v) {
+      if (exports.isExist(v)) {
+        return v;
+      } else {
+        return "";
+      }
+    };
+    var DANGEROUS_PROPERTY_NAMES = [
+      // '__proto__',
+      // 'constructor',
+      // 'prototype',
+      "hasOwnProperty",
+      "toString",
+      "valueOf",
+      "__defineGetter__",
+      "__defineSetter__",
+      "__lookupGetter__",
+      "__lookupSetter__"
+    ];
+    var criticalProperties = ["__proto__", "constructor", "prototype"];
+    exports.isName = isName;
+    exports.getAllMatches = getAllMatches;
+    exports.nameRegexp = nameRegexp;
+    exports.DANGEROUS_PROPERTY_NAMES = DANGEROUS_PROPERTY_NAMES;
+    exports.criticalProperties = criticalProperties;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/validator.js
+var require_validator = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/validator.js"(exports) {
+    "use strict";
+    var util = require_util();
+    var defaultOptions = {
+      allowBooleanAttributes: false,
+      //A tag can have attributes without any value
+      unpairedTags: []
+    };
+    exports.validate = function(xmlData, options) {
+      options = Object.assign({}, defaultOptions, options);
+      const tags = [];
+      let tagFound = false;
+      let reachedRoot = false;
+      if (xmlData[0] === "\uFEFF") {
+        xmlData = xmlData.substr(1);
+      }
+      for (let i = 0; i < xmlData.length; i++) {
+        if (xmlData[i] === "<" && xmlData[i + 1] === "?") {
+          i += 2;
+          i = readPI(xmlData, i);
+          if (i.err) return i;
+        } else if (xmlData[i] === "<") {
+          let tagStartPos = i;
+          i++;
+          if (xmlData[i] === "!") {
+            i = readCommentAndCDATA(xmlData, i);
+            continue;
+          } else {
+            let closingTag = false;
+            if (xmlData[i] === "/") {
+              closingTag = true;
+              i++;
+            }
+            let tagName = "";
+            for (; i < xmlData.length && xmlData[i] !== ">" && xmlData[i] !== " " && xmlData[i] !== "	" && xmlData[i] !== "\n" && xmlData[i] !== "\r"; i++) {
+              tagName += xmlData[i];
+            }
+            tagName = tagName.trim();
+            if (tagName[tagName.length - 1] === "/") {
+              tagName = tagName.substring(0, tagName.length - 1);
+              i--;
+            }
+            if (!validateTagName(tagName)) {
+              let msg;
+              if (tagName.trim().length === 0) {
+                msg = "Invalid space after '<'.";
+              } else {
+                msg = "Tag '" + tagName + "' is an invalid name.";
+              }
+              return getErrorObject("InvalidTag", msg, getLineNumberForPosition(xmlData, i));
+            }
+            const result = readAttributeStr(xmlData, i);
+            if (result === false) {
+              return getErrorObject("InvalidAttr", "Attributes for '" + tagName + "' have open quote.", getLineNumberForPosition(xmlData, i));
+            }
+            let attrStr = result.value;
+            i = result.index;
+            if (attrStr[attrStr.length - 1] === "/") {
+              const attrStrStart = i - attrStr.length;
+              attrStr = attrStr.substring(0, attrStr.length - 1);
+              const isValid = validateAttributeString(attrStr, options);
+              if (isValid === true) {
+                tagFound = true;
+              } else {
+                return getErrorObject(isValid.err.code, isValid.err.msg, getLineNumberForPosition(xmlData, attrStrStart + isValid.err.line));
+              }
+            } else if (closingTag) {
+              if (!result.tagClosed) {
+                return getErrorObject("InvalidTag", "Closing tag '" + tagName + "' doesn't have proper closing.", getLineNumberForPosition(xmlData, i));
+              } else if (attrStr.trim().length > 0) {
+                return getErrorObject("InvalidTag", "Closing tag '" + tagName + "' can't have attributes or invalid starting.", getLineNumberForPosition(xmlData, tagStartPos));
+              } else if (tags.length === 0) {
+                return getErrorObject("InvalidTag", "Closing tag '" + tagName + "' has not been opened.", getLineNumberForPosition(xmlData, tagStartPos));
+              } else {
+                const otg = tags.pop();
+                if (tagName !== otg.tagName) {
+                  let openPos = getLineNumberForPosition(xmlData, otg.tagStartPos);
+                  return getErrorObject(
+                    "InvalidTag",
+                    "Expected closing tag '" + otg.tagName + "' (opened in line " + openPos.line + ", col " + openPos.col + ") instead of closing tag '" + tagName + "'.",
+                    getLineNumberForPosition(xmlData, tagStartPos)
+                  );
+                }
+                if (tags.length == 0) {
+                  reachedRoot = true;
+                }
+              }
+            } else {
+              const isValid = validateAttributeString(attrStr, options);
+              if (isValid !== true) {
+                return getErrorObject(isValid.err.code, isValid.err.msg, getLineNumberForPosition(xmlData, i - attrStr.length + isValid.err.line));
+              }
+              if (reachedRoot === true) {
+                return getErrorObject("InvalidXml", "Multiple possible root nodes found.", getLineNumberForPosition(xmlData, i));
+              } else if (options.unpairedTags.indexOf(tagName) !== -1) {
+              } else {
+                tags.push({ tagName, tagStartPos });
+              }
+              tagFound = true;
+            }
+            for (i++; i < xmlData.length; i++) {
+              if (xmlData[i] === "<") {
+                if (xmlData[i + 1] === "!") {
+                  i++;
+                  i = readCommentAndCDATA(xmlData, i);
+                  continue;
+                } else if (xmlData[i + 1] === "?") {
+                  i = readPI(xmlData, ++i);
+                  if (i.err) return i;
+                } else {
+                  break;
+                }
+              } else if (xmlData[i] === "&") {
+                const afterAmp = validateAmpersand(xmlData, i);
+                if (afterAmp == -1)
+                  return getErrorObject("InvalidChar", "char '&' is not expected.", getLineNumberForPosition(xmlData, i));
+                i = afterAmp;
+              } else {
+                if (reachedRoot === true && !isWhiteSpace(xmlData[i])) {
+                  return getErrorObject("InvalidXml", "Extra text at the end", getLineNumberForPosition(xmlData, i));
+                }
+              }
+            }
+            if (xmlData[i] === "<") {
+              i--;
+            }
+          }
+        } else {
+          if (isWhiteSpace(xmlData[i])) {
+            continue;
+          }
+          return getErrorObject("InvalidChar", "char '" + xmlData[i] + "' is not expected.", getLineNumberForPosition(xmlData, i));
+        }
+      }
+      if (!tagFound) {
+        return getErrorObject("InvalidXml", "Start tag expected.", 1);
+      } else if (tags.length == 1) {
+        return getErrorObject("InvalidTag", "Unclosed tag '" + tags[0].tagName + "'.", getLineNumberForPosition(xmlData, tags[0].tagStartPos));
+      } else if (tags.length > 0) {
+        return getErrorObject("InvalidXml", "Invalid '" + JSON.stringify(tags.map((t) => t.tagName), null, 4).replace(/\r?\n/g, "") + "' found.", { line: 1, col: 1 });
+      }
+      return true;
+    };
+    function isWhiteSpace(char) {
+      return char === " " || char === "	" || char === "\n" || char === "\r";
+    }
+    function readPI(xmlData, i) {
+      const start = i;
+      for (; i < xmlData.length; i++) {
+        if (xmlData[i] == "?" || xmlData[i] == " ") {
+          const tagname = xmlData.substr(start, i - start);
+          if (i > 5 && tagname === "xml") {
+            return getErrorObject("InvalidXml", "XML declaration allowed only at the start of the document.", getLineNumberForPosition(xmlData, i));
+          } else if (xmlData[i] == "?" && xmlData[i + 1] == ">") {
+            i++;
+            break;
+          } else {
+            continue;
+          }
+        }
+      }
+      return i;
+    }
+    function readCommentAndCDATA(xmlData, i) {
+      if (xmlData.length > i + 5 && xmlData[i + 1] === "-" && xmlData[i + 2] === "-") {
+        for (i += 3; i < xmlData.length; i++) {
+          if (xmlData[i] === "-" && xmlData[i + 1] === "-" && xmlData[i + 2] === ">") {
+            i += 2;
+            break;
+          }
+        }
+      } else if (xmlData.length > i + 8 && xmlData[i + 1] === "D" && xmlData[i + 2] === "O" && xmlData[i + 3] === "C" && xmlData[i + 4] === "T" && xmlData[i + 5] === "Y" && xmlData[i + 6] === "P" && xmlData[i + 7] === "E") {
+        let angleBracketsCount = 1;
+        for (i += 8; i < xmlData.length; i++) {
+          if (xmlData[i] === "<") {
+            angleBracketsCount++;
+          } else if (xmlData[i] === ">") {
+            angleBracketsCount--;
+            if (angleBracketsCount === 0) {
+              break;
+            }
+          }
+        }
+      } else if (xmlData.length > i + 9 && xmlData[i + 1] === "[" && xmlData[i + 2] === "C" && xmlData[i + 3] === "D" && xmlData[i + 4] === "A" && xmlData[i + 5] === "T" && xmlData[i + 6] === "A" && xmlData[i + 7] === "[") {
+        for (i += 8; i < xmlData.length; i++) {
+          if (xmlData[i] === "]" && xmlData[i + 1] === "]" && xmlData[i + 2] === ">") {
+            i += 2;
+            break;
+          }
+        }
+      }
+      return i;
+    }
+    var doubleQuote = '"';
+    var singleQuote = "'";
+    function readAttributeStr(xmlData, i) {
+      let attrStr = "";
+      let startChar = "";
+      let tagClosed = false;
+      for (; i < xmlData.length; i++) {
+        if (xmlData[i] === doubleQuote || xmlData[i] === singleQuote) {
+          if (startChar === "") {
+            startChar = xmlData[i];
+          } else if (startChar !== xmlData[i]) {
+          } else {
+            startChar = "";
+          }
+        } else if (xmlData[i] === ">") {
+          if (startChar === "") {
+            tagClosed = true;
+            break;
+          }
+        }
+        attrStr += xmlData[i];
+      }
+      if (startChar !== "") {
+        return false;
+      }
+      return {
+        value: attrStr,
+        index: i,
+        tagClosed
+      };
+    }
+    var validAttrStrRegxp = new RegExp(`(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['"])(([\\s\\S])*?)\\5)?`, "g");
+    function validateAttributeString(attrStr, options) {
+      const matches = util.getAllMatches(attrStr, validAttrStrRegxp);
+      const attrNames = {};
+      for (let i = 0; i < matches.length; i++) {
+        if (matches[i][1].length === 0) {
+          return getErrorObject("InvalidAttr", "Attribute '" + matches[i][2] + "' has no space in starting.", getPositionFromMatch(matches[i]));
+        } else if (matches[i][3] !== void 0 && matches[i][4] === void 0) {
+          return getErrorObject("InvalidAttr", "Attribute '" + matches[i][2] + "' is without value.", getPositionFromMatch(matches[i]));
+        } else if (matches[i][3] === void 0 && !options.allowBooleanAttributes) {
+          return getErrorObject("InvalidAttr", "boolean attribute '" + matches[i][2] + "' is not allowed.", getPositionFromMatch(matches[i]));
+        }
+        const attrName = matches[i][2];
+        if (!validateAttrName(attrName)) {
+          return getErrorObject("InvalidAttr", "Attribute '" + attrName + "' is an invalid name.", getPositionFromMatch(matches[i]));
+        }
+        if (!attrNames.hasOwnProperty(attrName)) {
+          attrNames[attrName] = 1;
+        } else {
+          return getErrorObject("InvalidAttr", "Attribute '" + attrName + "' is repeated.", getPositionFromMatch(matches[i]));
+        }
+      }
+      return true;
+    }
+    function validateNumberAmpersand(xmlData, i) {
+      let re = /\d/;
+      if (xmlData[i] === "x") {
+        i++;
+        re = /[\da-fA-F]/;
+      }
+      for (; i < xmlData.length; i++) {
+        if (xmlData[i] === ";")
+          return i;
+        if (!xmlData[i].match(re))
+          break;
+      }
+      return -1;
+    }
+    function validateAmpersand(xmlData, i) {
+      i++;
+      if (xmlData[i] === ";")
+        return -1;
+      if (xmlData[i] === "#") {
+        i++;
+        return validateNumberAmpersand(xmlData, i);
+      }
+      let count = 0;
+      for (; i < xmlData.length; i++, count++) {
+        if (xmlData[i].match(/\w/) && count < 20)
+          continue;
+        if (xmlData[i] === ";")
+          break;
+        return -1;
+      }
+      return i;
+    }
+    function getErrorObject(code, message, lineNumber) {
+      return {
+        err: {
+          code,
+          msg: message,
+          line: lineNumber.line || lineNumber,
+          col: lineNumber.col
+        }
+      };
+    }
+    function validateAttrName(attrName) {
+      return util.isName(attrName);
+    }
+    function validateTagName(tagname) {
+      return util.isName(tagname);
+    }
+    function getLineNumberForPosition(xmlData, index) {
+      const lines = xmlData.substring(0, index).split(/\r?\n/);
+      return {
+        line: lines.length,
+        // column number is last line's length + 1, because column numbering starts at 1:
+        col: lines[lines.length - 1].length + 1
+      };
+    }
+    function getPositionFromMatch(match) {
+      return match.startIndex + match[1].length;
+    }
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
+var require_OptionsBuilder = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js"(exports) {
+    var { DANGEROUS_PROPERTY_NAMES, criticalProperties } = require_util();
+    var defaultOnDangerousProperty = (name) => {
+      if (DANGEROUS_PROPERTY_NAMES.includes(name)) {
+        return "__" + name;
+      }
+      return name;
+    };
+    var defaultOptions = {
+      preserveOrder: false,
+      attributeNamePrefix: "@_",
+      attributesGroupName: false,
+      textNodeName: "#text",
+      ignoreAttributes: true,
+      removeNSPrefix: false,
+      // remove NS from tag name or attribute name if true
+      allowBooleanAttributes: false,
+      //a tag can have attributes without any value
+      //ignoreRootElement : false,
+      parseTagValue: true,
+      parseAttributeValue: false,
+      trimValues: true,
+      //Trim string values of tag and attributes
+      cdataPropName: false,
+      numberParseOptions: {
+        hex: true,
+        leadingZeros: true,
+        eNotation: true
+      },
+      tagValueProcessor: function(tagName, val) {
+        return val;
+      },
+      attributeValueProcessor: function(attrName, val) {
+        return val;
+      },
+      stopNodes: [],
+      //nested tags will not be parsed even for errors
+      alwaysCreateTextNode: false,
+      isArray: () => false,
+      commentPropName: false,
+      unpairedTags: [],
+      processEntities: true,
+      htmlEntities: false,
+      ignoreDeclaration: false,
+      ignorePiTags: false,
+      transformTagName: false,
+      transformAttributeName: false,
+      updateTag: function(tagName, jPath, attrs) {
+        return tagName;
+      },
+      // skipEmptyListItem: false
+      captureMetaData: false,
+      maxNestedTags: 100,
+      strictReservedNames: true,
+      onDangerousProperty: defaultOnDangerousProperty
+    };
+    function validatePropertyName(propertyName, optionName) {
+      if (typeof propertyName !== "string") {
+        return;
+      }
+      const normalized = propertyName.toLowerCase();
+      if (DANGEROUS_PROPERTY_NAMES.some((dangerous) => normalized === dangerous.toLowerCase())) {
+        throw new Error(
+          `[SECURITY] Invalid ${optionName}: "${propertyName}" is a reserved JavaScript keyword that could cause prototype pollution`
+        );
+      }
+      if (criticalProperties.some((dangerous) => normalized === dangerous.toLowerCase())) {
+        throw new Error(
+          `[SECURITY] Invalid ${optionName}: "${propertyName}" is a reserved JavaScript keyword that could cause prototype pollution`
+        );
+      }
+    }
+    function normalizeProcessEntities(value) {
+      if (typeof value === "boolean") {
+        return {
+          enabled: value,
+          // true or false
+          maxEntitySize: 1e4,
+          maxExpansionDepth: 10,
+          maxTotalExpansions: 1e3,
+          maxExpandedLength: 1e5,
+          allowedTags: null,
+          tagFilter: null
+        };
+      }
+      if (typeof value === "object" && value !== null) {
+        return {
+          enabled: value.enabled !== false,
+          maxEntitySize: Math.max(1, value.maxEntitySize ?? 1e4),
+          maxExpansionDepth: Math.max(1, value.maxExpansionDepth ?? 1e4),
+          maxTotalExpansions: Math.max(1, value.maxTotalExpansions ?? Infinity),
+          maxExpandedLength: Math.max(1, value.maxExpandedLength ?? 1e5),
+          maxEntityCount: Math.max(1, value.maxEntityCount ?? 1e3),
+          allowedTags: value.allowedTags ?? null,
+          tagFilter: value.tagFilter ?? null
+        };
+      }
+      return normalizeProcessEntities(true);
+    }
+    var buildOptions = function(options) {
+      const built = Object.assign({}, defaultOptions, options);
+      const propertyNameOptions = [
+        { value: built.attributeNamePrefix, name: "attributeNamePrefix" },
+        { value: built.attributesGroupName, name: "attributesGroupName" },
+        { value: built.textNodeName, name: "textNodeName" },
+        { value: built.cdataPropName, name: "cdataPropName" },
+        { value: built.commentPropName, name: "commentPropName" }
+      ];
+      for (const { value, name } of propertyNameOptions) {
+        if (value) {
+          validatePropertyName(value, name);
+        }
+      }
+      if (built.onDangerousProperty === null) {
+        built.onDangerousProperty = defaultOnDangerousProperty;
+      }
+      built.processEntities = normalizeProcessEntities(built.processEntities);
+      return built;
+    };
+    exports.buildOptions = buildOptions;
+    exports.defaultOptions = defaultOptions;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
+var require_xmlNode = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js"(exports, module) {
+    "use strict";
+    var XmlNode = class {
+      constructor(tagname) {
+        this.tagname = tagname;
+        this.child = [];
+        this[":@"] = {};
+      }
+      add(key, val) {
+        if (key === "__proto__") key = "#__proto__";
+        this.child.push({ [key]: val });
+      }
+      addChild(node) {
+        if (node.tagname === "__proto__") node.tagname = "#__proto__";
+        if (node[":@"] && Object.keys(node[":@"]).length > 0) {
+          this.child.push({ [node.tagname]: node.child, [":@"]: node[":@"] });
+        } else {
+          this.child.push({ [node.tagname]: node.child });
+        }
+      }
+    };
+    module.exports = XmlNode;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
+var require_DocTypeReader = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js"(exports, module) {
+    var util = require_util();
+    var DocTypeReader = class {
+      constructor(options) {
+        this.suppressValidationErr = !options;
+        this.options = options || {};
+      }
+      readDocType(xmlData, i) {
+        const entities = /* @__PURE__ */ Object.create(null);
+        let entityCount = 0;
+        if (xmlData[i + 3] === "O" && xmlData[i + 4] === "C" && xmlData[i + 5] === "T" && xmlData[i + 6] === "Y" && xmlData[i + 7] === "P" && xmlData[i + 8] === "E") {
+          i = i + 9;
+          let angleBracketsCount = 1;
+          let hasBody = false, comment = false;
+          let exp = "";
+          for (; i < xmlData.length; i++) {
+            if (xmlData[i] === "<" && !comment) {
+              if (hasBody && hasSeq(xmlData, "!ENTITY", i)) {
+                i += 7;
+                let entityName, val;
+                [entityName, val, i] = this.readEntityExp(xmlData, i + 1, this.suppressValidationErr);
+                if (val.indexOf("&") === -1) {
+                  if (this.options.enabled !== false && this.options.maxEntityCount != null && entityCount >= this.options.maxEntityCount) {
+                    throw new Error(
+                      `Entity count (${entityCount + 1}) exceeds maximum allowed (${this.options.maxEntityCount})`
+                    );
+                  }
+                  const escaped = entityName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                  entities[entityName] = {
+                    regx: RegExp(`&${escaped};`, "g"),
+                    val
+                  };
+                  entityCount++;
+                }
+              } else if (hasBody && hasSeq(xmlData, "!ELEMENT", i)) {
+                i += 8;
+                const { index } = this.readElementExp(xmlData, i + 1);
+                i = index;
+              } else if (hasBody && hasSeq(xmlData, "!ATTLIST", i)) {
+                i += 8;
+              } else if (hasBody && hasSeq(xmlData, "!NOTATION", i)) {
+                i += 9;
+                const { index } = this.readNotationExp(xmlData, i + 1, this.suppressValidationErr);
+                i = index;
+              } else if (hasSeq(xmlData, "!--", i)) {
+                comment = true;
+              } else {
+                throw new Error(`Invalid DOCTYPE`);
+              }
+              angleBracketsCount++;
+              exp = "";
+            } else if (xmlData[i] === ">") {
+              if (comment) {
+                if (xmlData[i - 1] === "-" && xmlData[i - 2] === "-") {
+                  comment = false;
+                  angleBracketsCount--;
+                }
+              } else {
+                angleBracketsCount--;
+              }
+              if (angleBracketsCount === 0) {
+                break;
+              }
+            } else if (xmlData[i] === "[") {
+              hasBody = true;
+            } else {
+              exp += xmlData[i];
+            }
+          }
+          if (angleBracketsCount !== 0) {
+            throw new Error(`Unclosed DOCTYPE`);
+          }
+        } else {
+          throw new Error(`Invalid Tag instead of DOCTYPE`);
+        }
+        return { entities, i };
+      }
+      readEntityExp(xmlData, i) {
+        i = skipWhitespace(xmlData, i);
+        let entityName = "";
+        while (i < xmlData.length && !/\s/.test(xmlData[i]) && xmlData[i] !== '"' && xmlData[i] !== "'") {
+          entityName += xmlData[i];
+          i++;
+        }
+        validateEntityName(entityName);
+        i = skipWhitespace(xmlData, i);
+        if (!this.suppressValidationErr) {
+          if (xmlData.substring(i, i + 6).toUpperCase() === "SYSTEM") {
+            throw new Error("External entities are not supported");
+          } else if (xmlData[i] === "%") {
+            throw new Error("Parameter entities are not supported");
+          }
+        }
+        let entityValue = "";
+        [i, entityValue] = this.readIdentifierVal(xmlData, i, "entity");
+        if (this.options.enabled !== false && this.options.maxEntitySize != null && entityValue.length > this.options.maxEntitySize) {
+          throw new Error(
+            `Entity "${entityName}" size (${entityValue.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`
+          );
+        }
+        i--;
+        return [entityName, entityValue, i];
+      }
+      readNotationExp(xmlData, i) {
+        i = skipWhitespace(xmlData, i);
+        let notationName = "";
+        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+          notationName += xmlData[i];
+          i++;
+        }
+        !this.suppressValidationErr && validateEntityName(notationName);
+        i = skipWhitespace(xmlData, i);
+        const identifierType = xmlData.substring(i, i + 6).toUpperCase();
+        if (!this.suppressValidationErr && identifierType !== "SYSTEM" && identifierType !== "PUBLIC") {
+          throw new Error(`Expected SYSTEM or PUBLIC, found "${identifierType}"`);
+        }
+        i += identifierType.length;
+        i = skipWhitespace(xmlData, i);
+        let publicIdentifier = null;
+        let systemIdentifier = null;
+        if (identifierType === "PUBLIC") {
+          [i, publicIdentifier] = this.readIdentifierVal(xmlData, i, "publicIdentifier");
+          i = skipWhitespace(xmlData, i);
+          if (xmlData[i] === '"' || xmlData[i] === "'") {
+            [i, systemIdentifier] = this.readIdentifierVal(xmlData, i, "systemIdentifier");
+          }
+        } else if (identifierType === "SYSTEM") {
+          [i, systemIdentifier] = this.readIdentifierVal(xmlData, i, "systemIdentifier");
+          if (!this.suppressValidationErr && !systemIdentifier) {
+            throw new Error("Missing mandatory system identifier for SYSTEM notation");
+          }
+        }
+        return { notationName, publicIdentifier, systemIdentifier, index: --i };
+      }
+      readIdentifierVal(xmlData, i, type) {
+        let identifierVal = "";
+        const startChar = xmlData[i];
+        if (startChar !== '"' && startChar !== "'") {
+          throw new Error(`Expected quoted string, found "${startChar}"`);
+        }
+        i++;
+        while (i < xmlData.length && xmlData[i] !== startChar) {
+          identifierVal += xmlData[i];
+          i++;
+        }
+        if (xmlData[i] !== startChar) {
+          throw new Error(`Unterminated ${type} value`);
+        }
+        i++;
+        return [i, identifierVal];
+      }
+      readElementExp(xmlData, i) {
+        i = skipWhitespace(xmlData, i);
+        let elementName = "";
+        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+          elementName += xmlData[i];
+          i++;
+        }
+        if (!this.suppressValidationErr && !util.isName(elementName)) {
+          throw new Error(`Invalid element name: "${elementName}"`);
+        }
+        i = skipWhitespace(xmlData, i);
+        let contentModel = "";
+        if (xmlData[i] === "E" && hasSeq(xmlData, "MPTY", i)) {
+          i += 4;
+        } else if (xmlData[i] === "A" && hasSeq(xmlData, "NY", i)) {
+          i += 2;
+        } else if (xmlData[i] === "(") {
+          i++;
+          while (i < xmlData.length && xmlData[i] !== ")") {
+            contentModel += xmlData[i];
+            i++;
+          }
+          if (xmlData[i] !== ")") {
+            throw new Error("Unterminated content model");
+          }
+        } else if (!this.suppressValidationErr) {
+          throw new Error(`Invalid Element Expression, found "${xmlData[i]}"`);
+        }
+        return {
+          elementName,
+          contentModel: contentModel.trim(),
+          index: i
+        };
+      }
+      readAttlistExp(xmlData, i) {
+        i = skipWhitespace(xmlData, i);
+        let elementName = "";
+        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+          elementName += xmlData[i];
+          i++;
+        }
+        validateEntityName(elementName);
+        i = skipWhitespace(xmlData, i);
+        let attributeName = "";
+        while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+          attributeName += xmlData[i];
+          i++;
+        }
+        if (!validateEntityName(attributeName)) {
+          throw new Error(`Invalid attribute name: "${attributeName}"`);
+        }
+        i = skipWhitespace(xmlData, i);
+        let attributeType = "";
+        if (xmlData.substring(i, i + 8).toUpperCase() === "NOTATION") {
+          attributeType = "NOTATION";
+          i += 8;
+          i = skipWhitespace(xmlData, i);
+          if (xmlData[i] !== "(") {
+            throw new Error(`Expected '(', found "${xmlData[i]}"`);
+          }
+          i++;
+          let allowedNotations = [];
+          while (i < xmlData.length && xmlData[i] !== ")") {
+            let notation = "";
+            while (i < xmlData.length && xmlData[i] !== "|" && xmlData[i] !== ")") {
+              notation += xmlData[i];
+              i++;
+            }
+            notation = notation.trim();
+            if (!validateEntityName(notation)) {
+              throw new Error(`Invalid notation name: "${notation}"`);
+            }
+            allowedNotations.push(notation);
+            if (xmlData[i] === "|") {
+              i++;
+              i = skipWhitespace(xmlData, i);
+            }
+          }
+          if (xmlData[i] !== ")") {
+            throw new Error("Unterminated list of notations");
+          }
+          i++;
+          attributeType += " (" + allowedNotations.join("|") + ")";
+        } else {
+          while (i < xmlData.length && !/\s/.test(xmlData[i])) {
+            attributeType += xmlData[i];
+            i++;
+          }
+          const validTypes = ["CDATA", "ID", "IDREF", "IDREFS", "ENTITY", "ENTITIES", "NMTOKEN", "NMTOKENS"];
+          if (!this.suppressValidationErr && !validTypes.includes(attributeType.toUpperCase())) {
+            throw new Error(`Invalid attribute type: "${attributeType}"`);
+          }
+        }
+        i = skipWhitespace(xmlData, i);
+        let defaultValue = "";
+        if (xmlData.substring(i, i + 8).toUpperCase() === "#REQUIRED") {
+          defaultValue = "#REQUIRED";
+          i += 8;
+        } else if (xmlData.substring(i, i + 7).toUpperCase() === "#IMPLIED") {
+          defaultValue = "#IMPLIED";
+          i += 7;
+        } else {
+          [i, defaultValue] = this.readIdentifierVal(xmlData, i, "ATTLIST");
+        }
+        return {
+          elementName,
+          attributeName,
+          attributeType,
+          defaultValue,
+          index: i
+        };
+      }
+    };
+    var skipWhitespace = (data, index) => {
+      while (index < data.length && /\s/.test(data[index])) {
+        index++;
+      }
+      return index;
+    };
+    function hasSeq(data, seq, i) {
+      for (let j = 0; j < seq.length; j++) {
+        if (seq[j] !== data[i + j + 1]) return false;
+      }
+      return true;
+    }
+    function validateEntityName(name) {
+      if (util.isName(name))
+        return name;
+      else
+        throw new Error(`Invalid entity name ${name}`);
+    }
+    module.exports = DocTypeReader;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/strnum/strnum.js
+var require_strnum = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/strnum/strnum.js"(exports, module) {
+    var hexRegex = /^[-+]?0x[a-fA-F0-9]+$/;
+    var numRegex = /^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/;
+    var consider = {
+      hex: true,
+      // oct: false,
+      leadingZeros: true,
+      decimalPoint: ".",
+      eNotation: true
+      //skipLike: /regex/
+    };
+    function toNumber(str, options = {}) {
+      options = Object.assign({}, consider, options);
+      if (!str || typeof str !== "string") return str;
+      let trimmedStr = str.trim();
+      if (options.skipLike !== void 0 && options.skipLike.test(trimmedStr)) return str;
+      else if (str === "0") return 0;
+      else if (options.hex && hexRegex.test(trimmedStr)) {
+        return parse_int(trimmedStr, 16);
+      } else if (trimmedStr.search(/[eE]/) !== -1) {
+        const notation = trimmedStr.match(/^([-\+])?(0*)([0-9]*(\.[0-9]*)?[eE][-\+]?[0-9]+)$/);
+        if (notation) {
+          if (options.leadingZeros) {
+            trimmedStr = (notation[1] || "") + notation[3];
+          } else {
+            if (notation[2] === "0" && notation[3][0] === ".") {
+            } else {
+              return str;
+            }
+          }
+          return options.eNotation ? Number(trimmedStr) : str;
+        } else {
+          return str;
+        }
+      } else {
+        const match = numRegex.exec(trimmedStr);
+        if (match) {
+          const sign = match[1];
+          const leadingZeros = match[2];
+          let numTrimmedByZeros = trimZeros(match[3]);
+          if (!options.leadingZeros && leadingZeros.length > 0 && sign && trimmedStr[2] !== ".") return str;
+          else if (!options.leadingZeros && leadingZeros.length > 0 && !sign && trimmedStr[1] !== ".") return str;
+          else if (options.leadingZeros && leadingZeros === str) return 0;
+          else {
+            const num = Number(trimmedStr);
+            const numStr = "" + num;
+            if (numStr.search(/[eE]/) !== -1) {
+              if (options.eNotation) return num;
+              else return str;
+            } else if (trimmedStr.indexOf(".") !== -1) {
+              if (numStr === "0" && numTrimmedByZeros === "") return num;
+              else if (numStr === numTrimmedByZeros) return num;
+              else if (sign && numStr === "-" + numTrimmedByZeros) return num;
+              else return str;
+            }
+            if (leadingZeros) {
+              return numTrimmedByZeros === numStr || sign + numTrimmedByZeros === numStr ? num : str;
+            } else {
+              return trimmedStr === numStr || trimmedStr === sign + numStr ? num : str;
+            }
+          }
+        } else {
+          return str;
+        }
+      }
+    }
+    function trimZeros(numStr) {
+      if (numStr && numStr.indexOf(".") !== -1) {
+        numStr = numStr.replace(/0+$/, "");
+        if (numStr === ".") numStr = "0";
+        else if (numStr[0] === ".") numStr = "0" + numStr;
+        else if (numStr[numStr.length - 1] === ".") numStr = numStr.substr(0, numStr.length - 1);
+        return numStr;
+      }
+      return numStr;
+    }
+    function parse_int(numStr, base) {
+      if (parseInt) return parseInt(numStr, base);
+      else if (Number.parseInt) return Number.parseInt(numStr, base);
+      else if (window && window.parseInt) return window.parseInt(numStr, base);
+      else throw new Error("parseInt, Number.parseInt, window.parseInt are not supported");
+    }
+    module.exports = toNumber;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/ignoreAttributes.js
+var require_ignoreAttributes = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/ignoreAttributes.js"(exports, module) {
+    function getIgnoreAttributesFn(ignoreAttributes) {
+      if (typeof ignoreAttributes === "function") {
+        return ignoreAttributes;
+      }
+      if (Array.isArray(ignoreAttributes)) {
+        return (attrName) => {
+          for (const pattern of ignoreAttributes) {
+            if (typeof pattern === "string" && attrName === pattern) {
+              return true;
+            }
+            if (pattern instanceof RegExp && pattern.test(attrName)) {
+              return true;
+            }
+          }
+        };
+      }
+      return () => false;
+    }
+    module.exports = getIgnoreAttributesFn;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
+var require_OrderedObjParser = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js"(exports, module) {
+    "use strict";
+    var util = require_util();
+    var xmlNode = require_xmlNode();
+    var DocTypeReader = require_DocTypeReader();
+    var toNumber = require_strnum();
+    var getIgnoreAttributesFn = require_ignoreAttributes();
+    var OrderedObjParser = class {
+      constructor(options) {
+        this.options = options;
+        this.currentNode = null;
+        this.tagsNodeStack = [];
+        this.docTypeEntities = {};
+        this.lastEntities = {
+          "apos": { regex: /&(apos|#39|#x27);/g, val: "'" },
+          "gt": { regex: /&(gt|#62|#x3E);/g, val: ">" },
+          "lt": { regex: /&(lt|#60|#x3C);/g, val: "<" },
+          "quot": { regex: /&(quot|#34|#x22);/g, val: '"' }
+        };
+        this.ampEntity = { regex: /&(amp|#38|#x26);/g, val: "&" };
+        this.htmlEntities = {
+          "space": { regex: /&(nbsp|#160);/g, val: " " },
+          // "lt" : { regex: /&(lt|#60);/g, val: "<" },
+          // "gt" : { regex: /&(gt|#62);/g, val: ">" },
+          // "amp" : { regex: /&(amp|#38);/g, val: "&" },
+          // "quot" : { regex: /&(quot|#34);/g, val: "\"" },
+          // "apos" : { regex: /&(apos|#39);/g, val: "'" },
+          "cent": { regex: /&(cent|#162);/g, val: "\xA2" },
+          "pound": { regex: /&(pound|#163);/g, val: "\xA3" },
+          "yen": { regex: /&(yen|#165);/g, val: "\xA5" },
+          "euro": { regex: /&(euro|#8364);/g, val: "\u20AC" },
+          "copyright": { regex: /&(copy|#169);/g, val: "\xA9" },
+          "reg": { regex: /&(reg|#174);/g, val: "\xAE" },
+          "inr": { regex: /&(inr|#8377);/g, val: "\u20B9" },
+          "num_dec": { regex: /&#([0-9]{1,7});/g, val: (_, str) => fromCodePoint(str, 10, "&#") },
+          "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val: (_, str) => fromCodePoint(str, 16, "&#x") }
+        };
+        this.addExternalEntities = addExternalEntities;
+        this.parseXml = parseXml;
+        this.parseTextData = parseTextData;
+        this.resolveNameSpace = resolveNameSpace;
+        this.buildAttributesMap = buildAttributesMap;
+        this.isItStopNode = isItStopNode;
+        this.replaceEntitiesValue = replaceEntitiesValue;
+        this.readStopNodeData = readStopNodeData;
+        this.saveTextToParentTag = saveTextToParentTag;
+        this.addChild = addChild;
+        this.ignoreAttributesFn = getIgnoreAttributesFn(this.options.ignoreAttributes);
+        this.entityExpansionCount = 0;
+        this.currentExpandedLength = 0;
+        if (this.options.stopNodes && this.options.stopNodes.length > 0) {
+          this.stopNodesExact = /* @__PURE__ */ new Set();
+          this.stopNodesWildcard = /* @__PURE__ */ new Set();
+          for (let i = 0; i < this.options.stopNodes.length; i++) {
+            const stopNodeExp = this.options.stopNodes[i];
+            if (typeof stopNodeExp !== "string") continue;
+            if (stopNodeExp.startsWith("*.")) {
+              this.stopNodesWildcard.add(stopNodeExp.substring(2));
+            } else {
+              this.stopNodesExact.add(stopNodeExp);
+            }
+          }
+        }
+      }
+    };
+    function addExternalEntities(externalEntities) {
+      const entKeys = Object.keys(externalEntities);
+      for (let i = 0; i < entKeys.length; i++) {
+        const ent = entKeys[i];
+        const escaped = ent.replace(/[.\-+*:]/g, "\\.");
+        this.lastEntities[ent] = {
+          regex: new RegExp("&" + escaped + ";", "g"),
+          val: externalEntities[ent]
+        };
+      }
+    }
+    function parseTextData(val, tagName, jPath, dontTrim, hasAttributes, isLeafNode, escapeEntities) {
+      if (val !== void 0) {
+        if (this.options.trimValues && !dontTrim) {
+          val = val.trim();
+        }
+        if (val.length > 0) {
+          if (!escapeEntities) val = this.replaceEntitiesValue(val, tagName, jPath);
+          const newval = this.options.tagValueProcessor(tagName, val, jPath, hasAttributes, isLeafNode);
+          if (newval === null || newval === void 0) {
+            return val;
+          } else if (typeof newval !== typeof val || newval !== val) {
+            return newval;
+          } else if (this.options.trimValues) {
+            return parseValue(val, this.options.parseTagValue, this.options.numberParseOptions);
+          } else {
+            const trimmedVal = val.trim();
+            if (trimmedVal === val) {
+              return parseValue(val, this.options.parseTagValue, this.options.numberParseOptions);
+            } else {
+              return val;
+            }
+          }
+        }
+      }
+    }
+    function resolveNameSpace(tagname) {
+      if (this.options.removeNSPrefix) {
+        const tags = tagname.split(":");
+        const prefix = tagname.charAt(0) === "/" ? "/" : "";
+        if (tags[0] === "xmlns") {
+          return "";
+        }
+        if (tags.length === 2) {
+          tagname = prefix + tags[1];
+        }
+      }
+      return tagname;
+    }
+    var attrsRegx = new RegExp(`([^\\s=]+)\\s*(=\\s*(['"])([\\s\\S]*?)\\3)?`, "gm");
+    function buildAttributesMap(attrStr, jPath, tagName) {
+      if (this.options.ignoreAttributes !== true && typeof attrStr === "string") {
+        const matches = util.getAllMatches(attrStr, attrsRegx);
+        const len = matches.length;
+        const attrs = {};
+        for (let i = 0; i < len; i++) {
+          const attrName = this.resolveNameSpace(matches[i][1]);
+          if (this.ignoreAttributesFn(attrName, jPath)) {
+            continue;
+          }
+          let oldVal = matches[i][4];
+          let aName = this.options.attributeNamePrefix + attrName;
+          if (attrName.length) {
+            if (this.options.transformAttributeName) {
+              aName = this.options.transformAttributeName(aName);
+            }
+            aName = sanitizeName(aName, this.options);
+            if (oldVal !== void 0) {
+              if (this.options.trimValues) {
+                oldVal = oldVal.trim();
+              }
+              oldVal = this.replaceEntitiesValue(oldVal, tagName, jPath);
+              const newVal = this.options.attributeValueProcessor(attrName, oldVal, jPath);
+              if (newVal === null || newVal === void 0) {
+                attrs[aName] = oldVal;
+              } else if (typeof newVal !== typeof oldVal || newVal !== oldVal) {
+                attrs[aName] = newVal;
+              } else {
+                attrs[aName] = parseValue(
+                  oldVal,
+                  this.options.parseAttributeValue,
+                  this.options.numberParseOptions
+                );
+              }
+            } else if (this.options.allowBooleanAttributes) {
+              attrs[aName] = true;
+            }
+          }
+        }
+        if (!Object.keys(attrs).length) {
+          return;
+        }
+        if (this.options.attributesGroupName) {
+          const attrCollection = {};
+          attrCollection[this.options.attributesGroupName] = attrs;
+          return attrCollection;
+        }
+        return attrs;
+      }
+    }
+    var parseXml = function(xmlData) {
+      xmlData = xmlData.replace(/\r\n?/g, "\n");
+      const xmlObj = new xmlNode("!xml");
+      let currentNode = xmlObj;
+      let textData = "";
+      let jPath = "";
+      this.entityExpansionCount = 0;
+      this.currentExpandedLength = 0;
+      const docTypeReader = new DocTypeReader(this.options.processEntities);
+      for (let i = 0; i < xmlData.length; i++) {
+        const ch = xmlData[i];
+        if (ch === "<") {
+          if (xmlData[i + 1] === "/") {
+            const closeIndex = findClosingIndex(xmlData, ">", i, "Closing Tag is not closed.");
+            let tagName = xmlData.substring(i + 2, closeIndex).trim();
+            if (this.options.removeNSPrefix) {
+              const colonIndex = tagName.indexOf(":");
+              if (colonIndex !== -1) {
+                tagName = tagName.substr(colonIndex + 1);
+              }
+            }
+            if (this.options.transformTagName) {
+              tagName = this.options.transformTagName(tagName);
+            }
+            if (currentNode) {
+              textData = this.saveTextToParentTag(textData, currentNode, jPath);
+            }
+            const lastTagName = jPath.substring(jPath.lastIndexOf(".") + 1);
+            if (tagName && this.options.unpairedTags.indexOf(tagName) !== -1) {
+              throw new Error(`Unpaired tag can not be used as closing tag: </${tagName}>`);
+            }
+            let propIndex = 0;
+            if (lastTagName && this.options.unpairedTags.indexOf(lastTagName) !== -1) {
+              propIndex = jPath.lastIndexOf(".", jPath.lastIndexOf(".") - 1);
+              this.tagsNodeStack.pop();
+            } else {
+              propIndex = jPath.lastIndexOf(".");
+            }
+            jPath = jPath.substring(0, propIndex);
+            currentNode = this.tagsNodeStack.pop();
+            textData = "";
+            i = closeIndex;
+          } else if (xmlData[i + 1] === "?") {
+            let tagData = readTagExp(xmlData, i, false, "?>");
+            if (!tagData) throw new Error("Pi Tag is not closed.");
+            textData = this.saveTextToParentTag(textData, currentNode, jPath);
+            if (this.options.ignoreDeclaration && tagData.tagName === "?xml" || this.options.ignorePiTags) {
+            } else {
+              const childNode = new xmlNode(tagData.tagName);
+              childNode.add(this.options.textNodeName, "");
+              if (tagData.tagName !== tagData.tagExp && tagData.attrExpPresent) {
+                childNode[":@"] = this.buildAttributesMap(tagData.tagExp, jPath, tagData.tagName);
+              }
+              this.addChild(currentNode, childNode, jPath, i);
+            }
+            i = tagData.closeIndex + 1;
+          } else if (xmlData.substr(i + 1, 3) === "!--") {
+            const endIndex = findClosingIndex(xmlData, "-->", i + 4, "Comment is not closed.");
+            if (this.options.commentPropName) {
+              const comment = xmlData.substring(i + 4, endIndex - 2);
+              textData = this.saveTextToParentTag(textData, currentNode, jPath);
+              currentNode.add(this.options.commentPropName, [{ [this.options.textNodeName]: comment }]);
+            }
+            i = endIndex;
+          } else if (xmlData.substr(i + 1, 2) === "!D") {
+            const result = docTypeReader.readDocType(xmlData, i);
+            this.docTypeEntities = result.entities;
+            i = result.i;
+          } else if (xmlData.substr(i + 1, 2) === "![") {
+            const closeIndex = findClosingIndex(xmlData, "]]>", i, "CDATA is not closed.") - 2;
+            const tagExp = xmlData.substring(i + 9, closeIndex);
+            textData = this.saveTextToParentTag(textData, currentNode, jPath);
+            let val = this.parseTextData(tagExp, currentNode.tagname, jPath, true, false, true, true);
+            if (val == void 0) val = "";
+            if (this.options.cdataPropName) {
+              currentNode.add(this.options.cdataPropName, [{ [this.options.textNodeName]: tagExp }]);
+            } else {
+              currentNode.add(this.options.textNodeName, val);
+            }
+            i = closeIndex + 2;
+          } else {
+            let result = readTagExp(xmlData, i, this.options.removeNSPrefix);
+            let tagName = result.tagName;
+            const rawTagName = result.rawTagName;
+            let tagExp = result.tagExp;
+            let attrExpPresent = result.attrExpPresent;
+            let closeIndex = result.closeIndex;
+            if (this.options.transformTagName) {
+              const newTagName = this.options.transformTagName(tagName);
+              if (tagExp === tagName) {
+                tagExp = newTagName;
+              }
+              tagName = newTagName;
+            }
+            if (this.options.strictReservedNames && (tagName === this.options.commentPropName || tagName === this.options.cdataPropName || tagName === this.options.textNodeName || tagName === this.options.attributesGroupName)) {
+              throw new Error(`Invalid tag name: ${tagName}`);
+            }
+            if (currentNode && textData) {
+              if (currentNode.tagname !== "!xml") {
+                textData = this.saveTextToParentTag(textData, currentNode, jPath, false);
+              }
+            }
+            const lastTag = currentNode;
+            if (lastTag && this.options.unpairedTags.indexOf(lastTag.tagname) !== -1) {
+              currentNode = this.tagsNodeStack.pop();
+              jPath = jPath.substring(0, jPath.lastIndexOf("."));
+            }
+            if (tagName !== xmlObj.tagname) {
+              jPath += jPath ? "." + tagName : tagName;
+            }
+            const startIndex = i;
+            if (this.isItStopNode(this.stopNodesExact, this.stopNodesWildcard, jPath, tagName)) {
+              let tagContent = "";
+              if (tagExp.length > 0 && tagExp.lastIndexOf("/") === tagExp.length - 1) {
+                if (tagName[tagName.length - 1] === "/") {
+                  tagName = tagName.substr(0, tagName.length - 1);
+                  jPath = jPath.substr(0, jPath.length - 1);
+                  tagExp = tagName;
+                } else {
+                  tagExp = tagExp.substr(0, tagExp.length - 1);
+                }
+                i = result.closeIndex;
+              } else if (this.options.unpairedTags.indexOf(tagName) !== -1) {
+                i = result.closeIndex;
+              } else {
+                const result2 = this.readStopNodeData(xmlData, rawTagName, closeIndex + 1);
+                if (!result2) throw new Error(`Unexpected end of ${rawTagName}`);
+                i = result2.i;
+                tagContent = result2.tagContent;
+              }
+              const childNode = new xmlNode(tagName);
+              if (tagName !== tagExp && attrExpPresent) {
+                childNode[":@"] = this.buildAttributesMap(tagExp, jPath, tagName);
+              }
+              if (tagContent) {
+                tagContent = this.parseTextData(tagContent, tagName, jPath, true, attrExpPresent, true, true);
+              }
+              jPath = jPath.substr(0, jPath.lastIndexOf("."));
+              childNode.add(this.options.textNodeName, tagContent);
+              this.addChild(currentNode, childNode, jPath, startIndex);
+            } else {
+              if (tagExp.length > 0 && tagExp.lastIndexOf("/") === tagExp.length - 1) {
+                if (tagName[tagName.length - 1] === "/") {
+                  tagName = tagName.substr(0, tagName.length - 1);
+                  jPath = jPath.substr(0, jPath.length - 1);
+                  tagExp = tagName;
+                } else {
+                  tagExp = tagExp.substr(0, tagExp.length - 1);
+                }
+                if (this.options.transformTagName) {
+                  const newTagName = this.options.transformTagName(tagName);
+                  if (tagExp === tagName) {
+                    tagExp = newTagName;
+                  }
+                  tagName = newTagName;
+                }
+                const childNode = new xmlNode(tagName);
+                if (tagName !== tagExp && attrExpPresent) {
+                  childNode[":@"] = this.buildAttributesMap(tagExp, jPath, tagName);
+                }
+                this.addChild(currentNode, childNode, jPath, startIndex);
+                jPath = jPath.substr(0, jPath.lastIndexOf("."));
+              } else if (this.options.unpairedTags.indexOf(tagName) !== -1) {
+                const childNode = new xmlNode(tagName);
+                if (tagName !== tagExp && attrExpPresent) {
+                  childNode[":@"] = this.buildAttributesMap(tagExp, jPath);
+                }
+                this.addChild(currentNode, childNode, jPath, startIndex);
+                jPath = jPath.substr(0, jPath.lastIndexOf("."));
+                i = result.closeIndex;
+                continue;
+              } else {
+                const childNode = new xmlNode(tagName);
+                if (this.tagsNodeStack.length > this.options.maxNestedTags) {
+                  throw new Error("Maximum nested tags exceeded");
+                }
+                this.tagsNodeStack.push(currentNode);
+                if (tagName !== tagExp && attrExpPresent) {
+                  childNode[":@"] = this.buildAttributesMap(tagExp, jPath, tagName);
+                }
+                this.addChild(currentNode, childNode, jPath);
+                currentNode = childNode;
+              }
+              textData = "";
+              i = closeIndex;
+            }
+          }
+        } else {
+          textData += xmlData[i];
+        }
+      }
+      return xmlObj.child;
+    };
+    function addChild(currentNode, childNode, jPath, startIndex) {
+      if (!this.options.captureMetaData) startIndex = void 0;
+      const result = this.options.updateTag(childNode.tagname, jPath, childNode[":@"]);
+      if (result === false) {
+      } else if (typeof result === "string") {
+        childNode.tagname = result;
+        currentNode.addChild(childNode, startIndex);
+      } else {
+        currentNode.addChild(childNode, startIndex);
+      }
+    }
+    var replaceEntitiesValue = function(val, tagName, jPath) {
+      if (val.indexOf("&") === -1) {
+        return val;
+      }
+      const entityConfig = this.options.processEntities;
+      if (!entityConfig.enabled) {
+        return val;
+      }
+      if (entityConfig.allowedTags) {
+        if (!entityConfig.allowedTags.includes(tagName)) {
+          return val;
+        }
+      }
+      if (entityConfig.tagFilter) {
+        if (!entityConfig.tagFilter(tagName, jPath)) {
+          return val;
+        }
+      }
+      for (let entityName in this.docTypeEntities) {
+        const entity = this.docTypeEntities[entityName];
+        const matches = val.match(entity.regx);
+        if (matches) {
+          this.entityExpansionCount += matches.length;
+          if (entityConfig.maxTotalExpansions && this.entityExpansionCount > entityConfig.maxTotalExpansions) {
+            throw new Error(
+              `Entity expansion limit exceeded: ${this.entityExpansionCount} > ${entityConfig.maxTotalExpansions}`
+            );
+          }
+          const lengthBefore = val.length;
+          val = val.replace(entity.regx, entity.val);
+          if (entityConfig.maxExpandedLength) {
+            this.currentExpandedLength += val.length - lengthBefore;
+            if (this.currentExpandedLength > entityConfig.maxExpandedLength) {
+              throw new Error(
+                `Total expanded content size exceeded: ${this.currentExpandedLength} > ${entityConfig.maxExpandedLength}`
+              );
+            }
+          }
+        }
+      }
+      if (val.indexOf("&") === -1) return val;
+      for (const entityName of Object.keys(this.lastEntities)) {
+        const entity = this.lastEntities[entityName];
+        const matches = val.match(entity.regex);
+        if (matches) {
+          this.entityExpansionCount += matches.length;
+          if (entityConfig.maxTotalExpansions && this.entityExpansionCount > entityConfig.maxTotalExpansions) {
+            throw new Error(
+              `Entity expansion limit exceeded: ${this.entityExpansionCount} > ${entityConfig.maxTotalExpansions}`
+            );
+          }
+        }
+        val = val.replace(entity.regex, entity.val);
+      }
+      if (val.indexOf("&") === -1) return val;
+      if (this.options.htmlEntities) {
+        for (const entityName of Object.keys(this.htmlEntities)) {
+          const entity = this.htmlEntities[entityName];
+          const matches = val.match(entity.regex);
+          if (matches) {
+            this.entityExpansionCount += matches.length;
+            if (entityConfig.maxTotalExpansions && this.entityExpansionCount > entityConfig.maxTotalExpansions) {
+              throw new Error(
+                `Entity expansion limit exceeded: ${this.entityExpansionCount} > ${entityConfig.maxTotalExpansions}`
+              );
+            }
+          }
+          val = val.replace(entity.regex, entity.val);
+        }
+      }
+      val = val.replace(this.ampEntity.regex, this.ampEntity.val);
+      return val;
+    };
+    function saveTextToParentTag(textData, parentNode, jPath, isLeafNode) {
+      if (textData) {
+        if (isLeafNode === void 0) isLeafNode = parentNode.child.length === 0;
+        textData = this.parseTextData(
+          textData,
+          parentNode.tagname,
+          jPath,
+          false,
+          parentNode[":@"] ? Object.keys(parentNode[":@"]).length !== 0 : false,
+          isLeafNode
+        );
+        if (textData !== void 0 && textData !== "")
+          parentNode.add(this.options.textNodeName, textData);
+        textData = "";
+      }
+      return textData;
+    }
+    function isItStopNode(stopNodesExact, stopNodesWildcard, jPath, currentTagName) {
+      if (stopNodesWildcard && stopNodesWildcard.has(currentTagName)) return true;
+      if (stopNodesExact && stopNodesExact.has(jPath)) return true;
+      return false;
+    }
+    function tagExpWithClosingIndex(xmlData, i, closingChar = ">") {
+      let attrBoundary;
+      let tagExp = "";
+      for (let index = i; index < xmlData.length; index++) {
+        let ch = xmlData[index];
+        if (attrBoundary) {
+          if (ch === attrBoundary) attrBoundary = "";
+        } else if (ch === '"' || ch === "'") {
+          attrBoundary = ch;
+        } else if (ch === closingChar[0]) {
+          if (closingChar[1]) {
+            if (xmlData[index + 1] === closingChar[1]) {
+              return {
+                data: tagExp,
+                index
+              };
+            }
+          } else {
+            return {
+              data: tagExp,
+              index
+            };
+          }
+        } else if (ch === "	") {
+          ch = " ";
+        }
+        tagExp += ch;
+      }
+    }
+    function findClosingIndex(xmlData, str, i, errMsg) {
+      const closingIndex = xmlData.indexOf(str, i);
+      if (closingIndex === -1) {
+        throw new Error(errMsg);
+      } else {
+        return closingIndex + str.length - 1;
+      }
+    }
+    function readTagExp(xmlData, i, removeNSPrefix, closingChar = ">") {
+      const result = tagExpWithClosingIndex(xmlData, i + 1, closingChar);
+      if (!result) return;
+      let tagExp = result.data;
+      const closeIndex = result.index;
+      const separatorIndex = tagExp.search(/\s/);
+      let tagName = tagExp;
+      let attrExpPresent = true;
+      if (separatorIndex !== -1) {
+        tagName = tagExp.substring(0, separatorIndex);
+        tagExp = tagExp.substring(separatorIndex + 1).trimStart();
+      }
+      const rawTagName = tagName;
+      if (removeNSPrefix) {
+        const colonIndex = tagName.indexOf(":");
+        if (colonIndex !== -1) {
+          tagName = tagName.substr(colonIndex + 1);
+          attrExpPresent = tagName !== result.data.substr(colonIndex + 1);
+        }
+      }
+      return {
+        tagName,
+        tagExp,
+        closeIndex,
+        attrExpPresent,
+        rawTagName
+      };
+    }
+    function readStopNodeData(xmlData, tagName, i) {
+      const startIndex = i;
+      let openTagCount = 1;
+      for (; i < xmlData.length; i++) {
+        if (xmlData[i] === "<") {
+          if (xmlData[i + 1] === "/") {
+            const closeIndex = findClosingIndex(xmlData, ">", i, `${tagName} is not closed`);
+            let closeTagName = xmlData.substring(i + 2, closeIndex).trim();
+            if (closeTagName === tagName) {
+              openTagCount--;
+              if (openTagCount === 0) {
+                return {
+                  tagContent: xmlData.substring(startIndex, i),
+                  i: closeIndex
+                };
+              }
+            }
+            i = closeIndex;
+          } else if (xmlData[i + 1] === "?") {
+            const closeIndex = findClosingIndex(xmlData, "?>", i + 1, "StopNode is not closed.");
+            i = closeIndex;
+          } else if (xmlData.substr(i + 1, 3) === "!--") {
+            const closeIndex = findClosingIndex(xmlData, "-->", i + 3, "StopNode is not closed.");
+            i = closeIndex;
+          } else if (xmlData.substr(i + 1, 2) === "![") {
+            const closeIndex = findClosingIndex(xmlData, "]]>", i, "StopNode is not closed.") - 2;
+            i = closeIndex;
+          } else {
+            const tagData = readTagExp(xmlData, i, ">");
+            if (tagData) {
+              const openTagName = tagData && tagData.tagName;
+              if (openTagName === tagName && tagData.tagExp[tagData.tagExp.length - 1] !== "/") {
+                openTagCount++;
+              }
+              i = tagData.closeIndex;
+            }
+          }
+        }
+      }
+    }
+    function parseValue(val, shouldParse, options) {
+      if (shouldParse && typeof val === "string") {
+        const newval = val.trim();
+        if (newval === "true") return true;
+        else if (newval === "false") return false;
+        else return toNumber(val, options);
+      } else {
+        if (util.isExist(val)) {
+          return val;
+        } else {
+          return "";
+        }
+      }
+    }
+    function fromCodePoint(str, base, prefix) {
+      const codePoint = Number.parseInt(str, base);
+      if (codePoint >= 0 && codePoint <= 1114111) {
+        return String.fromCodePoint(codePoint);
+      } else {
+        return prefix + str + ";";
+      }
+    }
+    function sanitizeName(name, options) {
+      if (util.criticalProperties.includes(name)) {
+        throw new Error(`[SECURITY] Invalid name: "${name}" is a reserved JavaScript keyword that could cause prototype pollution`);
+      } else if (util.DANGEROUS_PROPERTY_NAMES.includes(name)) {
+        return options.onDangerousProperty(name);
+      }
+      return name;
+    }
+    module.exports = OrderedObjParser;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/node2json.js
+var require_node2json = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/node2json.js"(exports) {
+    "use strict";
+    function prettify(node, options) {
+      return compress(node, options);
+    }
+    function compress(arr3, options, jPath) {
+      let text;
+      const compressedObj = {};
+      for (let i = 0; i < arr3.length; i++) {
+        const tagObj = arr3[i];
+        const property = propName(tagObj);
+        let newJpath = "";
+        if (jPath === void 0) newJpath = property;
+        else newJpath = jPath + "." + property;
+        if (property === options.textNodeName) {
+          if (text === void 0) text = tagObj[property];
+          else text += "" + tagObj[property];
+        } else if (property === void 0) {
+          continue;
+        } else if (tagObj[property]) {
+          let val = compress(tagObj[property], options, newJpath);
+          const isLeaf = isLeafTag(val, options);
+          if (tagObj[":@"]) {
+            assignAttributes(val, tagObj[":@"], newJpath, options);
+          } else if (Object.keys(val).length === 1 && val[options.textNodeName] !== void 0 && !options.alwaysCreateTextNode) {
+            val = val[options.textNodeName];
+          } else if (Object.keys(val).length === 0) {
+            if (options.alwaysCreateTextNode) val[options.textNodeName] = "";
+            else val = "";
+          }
+          if (compressedObj[property] !== void 0 && compressedObj.hasOwnProperty(property)) {
+            if (!Array.isArray(compressedObj[property])) {
+              compressedObj[property] = [compressedObj[property]];
+            }
+            compressedObj[property].push(val);
+          } else {
+            if (options.isArray(property, newJpath, isLeaf)) {
+              compressedObj[property] = [val];
+            } else {
+              compressedObj[property] = val;
+            }
+          }
+        }
+      }
+      if (typeof text === "string") {
+        if (text.length > 0) compressedObj[options.textNodeName] = text;
+      } else if (text !== void 0) compressedObj[options.textNodeName] = text;
+      return compressedObj;
+    }
+    function propName(obj) {
+      const keys = Object.keys(obj);
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        if (key !== ":@") return key;
+      }
+    }
+    function assignAttributes(obj, attrMap, jpath, options) {
+      if (attrMap) {
+        const keys = Object.keys(attrMap);
+        const len = keys.length;
+        for (let i = 0; i < len; i++) {
+          const atrrName = keys[i];
+          if (options.isArray(atrrName, jpath + "." + atrrName, true, true)) {
+            obj[atrrName] = [attrMap[atrrName]];
+          } else {
+            obj[atrrName] = attrMap[atrrName];
+          }
+        }
+      }
+    }
+    function isLeafTag(obj, options) {
+      const { textNodeName } = options;
+      const propCount = Object.keys(obj).length;
+      if (propCount === 0) {
+        return true;
+      }
+      if (propCount === 1 && (obj[textNodeName] || typeof obj[textNodeName] === "boolean" || obj[textNodeName] === 0)) {
+        return true;
+      }
+      return false;
+    }
+    exports.prettify = prettify;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
+var require_XMLParser = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js"(exports, module) {
+    var { buildOptions } = require_OptionsBuilder();
+    var OrderedObjParser = require_OrderedObjParser();
+    var { prettify } = require_node2json();
+    var validator = require_validator();
+    var XMLParser2 = class {
+      constructor(options) {
+        this.externalEntities = {};
+        this.options = buildOptions(options);
+      }
+      /**
+       * Parse XML dats to JS object 
+       * @param {string|Buffer} xmlData 
+       * @param {boolean|Object} validationOption 
+       */
+      parse(xmlData, validationOption) {
+        if (typeof xmlData === "string") {
+        } else if (xmlData.toString) {
+          xmlData = xmlData.toString();
+        } else {
+          throw new Error("XML data is accepted in String or Bytes[] form.");
+        }
+        if (validationOption) {
+          if (validationOption === true) validationOption = {};
+          const result = validator.validate(xmlData, validationOption);
+          if (result !== true) {
+            throw Error(`${result.err.msg}:${result.err.line}:${result.err.col}`);
+          }
+        }
+        const orderedObjParser = new OrderedObjParser(this.options);
+        orderedObjParser.addExternalEntities(this.externalEntities);
+        const orderedResult = orderedObjParser.parseXml(xmlData);
+        if (this.options.preserveOrder || orderedResult === void 0) return orderedResult;
+        else return prettify(orderedResult, this.options);
+      }
+      /**
+       * Add Entity which is not by default supported by this library
+       * @param {string} key 
+       * @param {string} value 
+       */
+      addEntity(key, value) {
+        if (value.indexOf("&") !== -1) {
+          throw new Error("Entity value can't have '&'");
+        } else if (key.indexOf("&") !== -1 || key.indexOf(";") !== -1) {
+          throw new Error("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");
+        } else if (value === "&") {
+          throw new Error("An entity with value '&' is not permitted");
+        } else {
+          this.externalEntities[key] = value;
+        }
+      }
+    };
+    module.exports = XMLParser2;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js
+var require_orderedJs2Xml = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js"(exports, module) {
+    var EOL = "\n";
+    function toXml(jArray, options) {
+      let indentation = "";
+      if (options.format && options.indentBy.length > 0) {
+        indentation = EOL;
+      }
+      return arrToStr(jArray, options, "", indentation);
+    }
+    function arrToStr(arr3, options, jPath, indentation) {
+      let xmlStr = "";
+      let isPreviousElementTag = false;
+      if (!Array.isArray(arr3)) {
+        if (arr3 !== void 0 && arr3 !== null) {
+          let text = arr3.toString();
+          text = replaceEntitiesValue(text, options);
+          return text;
+        }
+        return "";
+      }
+      for (let i = 0; i < arr3.length; i++) {
+        const tagObj = arr3[i];
+        const tagName = propName(tagObj);
+        if (tagName === void 0) continue;
+        let newJPath = "";
+        if (jPath.length === 0) newJPath = tagName;
+        else newJPath = `${jPath}.${tagName}`;
+        if (tagName === options.textNodeName) {
+          let tagText = tagObj[tagName];
+          if (!isStopNode(newJPath, options)) {
+            tagText = options.tagValueProcessor(tagName, tagText);
+            tagText = replaceEntitiesValue(tagText, options);
+          }
+          if (isPreviousElementTag) {
+            xmlStr += indentation;
+          }
+          xmlStr += tagText;
+          isPreviousElementTag = false;
+          continue;
+        } else if (tagName === options.cdataPropName) {
+          if (isPreviousElementTag) {
+            xmlStr += indentation;
+          }
+          xmlStr += `<![CDATA[${tagObj[tagName][0][options.textNodeName]}]]>`;
+          isPreviousElementTag = false;
+          continue;
+        } else if (tagName === options.commentPropName) {
+          xmlStr += indentation + `<!--${tagObj[tagName][0][options.textNodeName]}-->`;
+          isPreviousElementTag = true;
+          continue;
+        } else if (tagName[0] === "?") {
+          const attStr2 = attr_to_str(tagObj[":@"], options);
+          const tempInd = tagName === "?xml" ? "" : indentation;
+          let piTextNodeName = tagObj[tagName][0][options.textNodeName];
+          piTextNodeName = piTextNodeName.length !== 0 ? " " + piTextNodeName : "";
+          xmlStr += tempInd + `<${tagName}${piTextNodeName}${attStr2}?>`;
+          isPreviousElementTag = true;
+          continue;
+        }
+        let newIdentation = indentation;
+        if (newIdentation !== "") {
+          newIdentation += options.indentBy;
+        }
+        const attStr = attr_to_str(tagObj[":@"], options);
+        const tagStart = indentation + `<${tagName}${attStr}`;
+        const tagValue = arrToStr(tagObj[tagName], options, newJPath, newIdentation);
+        if (options.unpairedTags.indexOf(tagName) !== -1) {
+          if (options.suppressUnpairedNode) xmlStr += tagStart + ">";
+          else xmlStr += tagStart + "/>";
+        } else if ((!tagValue || tagValue.length === 0) && options.suppressEmptyNode) {
+          xmlStr += tagStart + "/>";
+        } else if (tagValue && tagValue.endsWith(">")) {
+          xmlStr += tagStart + `>${tagValue}${indentation}</${tagName}>`;
+        } else {
+          xmlStr += tagStart + ">";
+          if (tagValue && indentation !== "" && (tagValue.includes("/>") || tagValue.includes("</"))) {
+            xmlStr += indentation + options.indentBy + tagValue + indentation;
+          } else {
+            xmlStr += tagValue;
+          }
+          xmlStr += `</${tagName}>`;
+        }
+        isPreviousElementTag = true;
+      }
+      return xmlStr;
+    }
+    function propName(obj) {
+      const keys = Object.keys(obj);
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        if (!Object.prototype.hasOwnProperty.call(obj, key)) continue;
+        if (key !== ":@") return key;
+      }
+    }
+    function attr_to_str(attrMap, options) {
+      let attrStr = "";
+      if (attrMap && !options.ignoreAttributes) {
+        for (let attr in attrMap) {
+          if (!Object.prototype.hasOwnProperty.call(attrMap, attr)) continue;
+          let attrVal = options.attributeValueProcessor(attr, attrMap[attr]);
+          attrVal = replaceEntitiesValue(attrVal, options);
+          if (attrVal === true && options.suppressBooleanAttributes) {
+            attrStr += ` ${attr.substr(options.attributeNamePrefix.length)}`;
+          } else {
+            attrStr += ` ${attr.substr(options.attributeNamePrefix.length)}="${attrVal}"`;
+          }
+        }
+      }
+      return attrStr;
+    }
+    function isStopNode(jPath, options) {
+      jPath = jPath.substr(0, jPath.length - options.textNodeName.length - 1);
+      let tagName = jPath.substr(jPath.lastIndexOf(".") + 1);
+      for (let index in options.stopNodes) {
+        if (options.stopNodes[index] === jPath || options.stopNodes[index] === "*." + tagName) return true;
+      }
+      return false;
+    }
+    function replaceEntitiesValue(textValue, options) {
+      if (textValue && textValue.length > 0 && options.processEntities) {
+        for (let i = 0; i < options.entities.length; i++) {
+          const entity = options.entities[i];
+          textValue = textValue.replace(entity.regex, entity.val);
+        }
+      }
+      return textValue;
+    }
+    module.exports = toXml;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js
+var require_json2xml = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js"(exports, module) {
+    "use strict";
+    var buildFromOrderedJs = require_orderedJs2Xml();
+    var getIgnoreAttributesFn = require_ignoreAttributes();
+    var defaultOptions = {
+      attributeNamePrefix: "@_",
+      attributesGroupName: false,
+      textNodeName: "#text",
+      ignoreAttributes: true,
+      cdataPropName: false,
+      format: false,
+      indentBy: "  ",
+      suppressEmptyNode: false,
+      suppressUnpairedNode: true,
+      suppressBooleanAttributes: true,
+      tagValueProcessor: function(key, a) {
+        return a;
+      },
+      attributeValueProcessor: function(attrName, a) {
+        return a;
+      },
+      preserveOrder: false,
+      commentPropName: false,
+      unpairedTags: [],
+      entities: [
+        { regex: new RegExp("&", "g"), val: "&amp;" },
+        //it must be on top
+        { regex: new RegExp(">", "g"), val: "&gt;" },
+        { regex: new RegExp("<", "g"), val: "&lt;" },
+        { regex: new RegExp("'", "g"), val: "&apos;" },
+        { regex: new RegExp('"', "g"), val: "&quot;" }
+      ],
+      processEntities: true,
+      stopNodes: [],
+      // transformTagName: false,
+      // transformAttributeName: false,
+      oneListGroup: false
+    };
+    function Builder(options) {
+      this.options = Object.assign({}, defaultOptions, options);
+      if (this.options.ignoreAttributes === true || this.options.attributesGroupName) {
+        this.isAttribute = function() {
+          return false;
+        };
+      } else {
+        this.ignoreAttributesFn = getIgnoreAttributesFn(this.options.ignoreAttributes);
+        this.attrPrefixLen = this.options.attributeNamePrefix.length;
+        this.isAttribute = isAttribute;
+      }
+      this.processTextOrObjNode = processTextOrObjNode;
+      if (this.options.format) {
+        this.indentate = indentate;
+        this.tagEndChar = ">\n";
+        this.newLine = "\n";
+      } else {
+        this.indentate = function() {
+          return "";
+        };
+        this.tagEndChar = ">";
+        this.newLine = "";
+      }
+    }
+    Builder.prototype.build = function(jObj) {
+      if (this.options.preserveOrder) {
+        return buildFromOrderedJs(jObj, this.options);
+      } else {
+        if (Array.isArray(jObj) && this.options.arrayNodeName && this.options.arrayNodeName.length > 1) {
+          jObj = {
+            [this.options.arrayNodeName]: jObj
+          };
+        }
+        return this.j2x(jObj, 0, []).val;
+      }
+    };
+    Builder.prototype.j2x = function(jObj, level, ajPath) {
+      let attrStr = "";
+      let val = "";
+      const jPath = ajPath.join(".");
+      for (let key in jObj) {
+        if (!Object.prototype.hasOwnProperty.call(jObj, key)) continue;
+        if (typeof jObj[key] === "undefined") {
+          if (this.isAttribute(key)) {
+            val += "";
+          }
+        } else if (jObj[key] === null) {
+          if (this.isAttribute(key)) {
+            val += "";
+          } else if (key === this.options.cdataPropName) {
+            val += "";
+          } else if (key[0] === "?") {
+            val += this.indentate(level) + "<" + key + "?" + this.tagEndChar;
+          } else {
+            val += this.indentate(level) + "<" + key + "/" + this.tagEndChar;
+          }
+        } else if (jObj[key] instanceof Date) {
+          val += this.buildTextValNode(jObj[key], key, "", level);
+        } else if (typeof jObj[key] !== "object") {
+          const attr = this.isAttribute(key);
+          if (attr && !this.ignoreAttributesFn(attr, jPath)) {
+            attrStr += this.buildAttrPairStr(attr, "" + jObj[key]);
+          } else if (!attr) {
+            if (key === this.options.textNodeName) {
+              let newval = this.options.tagValueProcessor(key, "" + jObj[key]);
+              val += this.replaceEntitiesValue(newval);
+            } else {
+              val += this.buildTextValNode(jObj[key], key, "", level);
+            }
+          }
+        } else if (Array.isArray(jObj[key])) {
+          const arrLen = jObj[key].length;
+          let listTagVal = "";
+          let listTagAttr = "";
+          for (let j = 0; j < arrLen; j++) {
+            const item = jObj[key][j];
+            if (typeof item === "undefined") {
+            } else if (item === null) {
+              if (key[0] === "?") val += this.indentate(level) + "<" + key + "?" + this.tagEndChar;
+              else val += this.indentate(level) + "<" + key + "/" + this.tagEndChar;
+            } else if (typeof item === "object") {
+              if (this.options.oneListGroup) {
+                const result = this.j2x(item, level + 1, ajPath.concat(key));
+                listTagVal += result.val;
+                if (this.options.attributesGroupName && item.hasOwnProperty(this.options.attributesGroupName)) {
+                  listTagAttr += result.attrStr;
+                }
+              } else {
+                listTagVal += this.processTextOrObjNode(item, key, level, ajPath);
+              }
+            } else {
+              if (this.options.oneListGroup) {
+                let textValue = this.options.tagValueProcessor(key, item);
+                textValue = this.replaceEntitiesValue(textValue);
+                listTagVal += textValue;
+              } else {
+                listTagVal += this.buildTextValNode(item, key, "", level);
+              }
+            }
+          }
+          if (this.options.oneListGroup) {
+            listTagVal = this.buildObjectNode(listTagVal, key, listTagAttr, level);
+          }
+          val += listTagVal;
+        } else {
+          if (this.options.attributesGroupName && key === this.options.attributesGroupName) {
+            const Ks = Object.keys(jObj[key]);
+            const L = Ks.length;
+            for (let j = 0; j < L; j++) {
+              attrStr += this.buildAttrPairStr(Ks[j], "" + jObj[key][Ks[j]]);
+            }
+          } else {
+            val += this.processTextOrObjNode(jObj[key], key, level, ajPath);
+          }
+        }
+      }
+      return { attrStr, val };
+    };
+    Builder.prototype.buildAttrPairStr = function(attrName, val) {
+      val = this.options.attributeValueProcessor(attrName, "" + val);
+      val = this.replaceEntitiesValue(val);
+      if (this.options.suppressBooleanAttributes && val === "true") {
+        return " " + attrName;
+      } else return " " + attrName + '="' + val + '"';
+    };
+    function processTextOrObjNode(object, key, level, ajPath) {
+      const result = this.j2x(object, level + 1, ajPath.concat(key));
+      if (object[this.options.textNodeName] !== void 0 && Object.keys(object).length === 1) {
+        return this.buildTextValNode(object[this.options.textNodeName], key, result.attrStr, level);
+      } else {
+        return this.buildObjectNode(result.val, key, result.attrStr, level);
+      }
+    }
+    Builder.prototype.buildObjectNode = function(val, key, attrStr, level) {
+      if (val === "") {
+        if (key[0] === "?") return this.indentate(level) + "<" + key + attrStr + "?" + this.tagEndChar;
+        else {
+          return this.indentate(level) + "<" + key + attrStr + this.closeTag(key) + this.tagEndChar;
+        }
+      } else {
+        let tagEndExp = "</" + key + this.tagEndChar;
+        let piClosingChar = "";
+        if (key[0] === "?") {
+          piClosingChar = "?";
+          tagEndExp = "";
+        }
+        if ((attrStr || attrStr === "") && val.indexOf("<") === -1) {
+          return this.indentate(level) + "<" + key + attrStr + piClosingChar + ">" + val + tagEndExp;
+        } else if (this.options.commentPropName !== false && key === this.options.commentPropName && piClosingChar.length === 0) {
+          return this.indentate(level) + `<!--${val}-->` + this.newLine;
+        } else {
+          return this.indentate(level) + "<" + key + attrStr + piClosingChar + this.tagEndChar + val + this.indentate(level) + tagEndExp;
+        }
+      }
+    };
+    Builder.prototype.closeTag = function(key) {
+      let closeTag = "";
+      if (this.options.unpairedTags.indexOf(key) !== -1) {
+        if (!this.options.suppressUnpairedNode) closeTag = "/";
+      } else if (this.options.suppressEmptyNode) {
+        closeTag = "/";
+      } else {
+        closeTag = `></${key}`;
+      }
+      return closeTag;
+    };
+    Builder.prototype.buildTextValNode = function(val, key, attrStr, level) {
+      if (this.options.cdataPropName !== false && key === this.options.cdataPropName) {
+        return this.indentate(level) + `<![CDATA[${val}]]>` + this.newLine;
+      } else if (this.options.commentPropName !== false && key === this.options.commentPropName) {
+        return this.indentate(level) + `<!--${val}-->` + this.newLine;
+      } else if (key[0] === "?") {
+        return this.indentate(level) + "<" + key + attrStr + "?" + this.tagEndChar;
+      } else {
+        let textValue = this.options.tagValueProcessor(key, val);
+        textValue = this.replaceEntitiesValue(textValue);
+        if (textValue === "") {
+          return this.indentate(level) + "<" + key + attrStr + this.closeTag(key) + this.tagEndChar;
+        } else {
+          return this.indentate(level) + "<" + key + attrStr + ">" + textValue + "</" + key + this.tagEndChar;
+        }
+      }
+    };
+    Builder.prototype.replaceEntitiesValue = function(textValue) {
+      if (textValue && textValue.length > 0 && this.options.processEntities) {
+        for (let i = 0; i < this.options.entities.length; i++) {
+          const entity = this.options.entities[i];
+          textValue = textValue.replace(entity.regex, entity.val);
+        }
+      }
+      return textValue;
+    };
+    function indentate(level) {
+      return this.options.indentBy.repeat(level);
+    }
+    function isAttribute(name) {
+      if (name.startsWith(this.options.attributeNamePrefix) && name !== this.options.textNodeName) {
+        return name.substr(this.attrPrefixLen);
+      } else {
+        return false;
+      }
+    }
+    module.exports = Builder;
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/fxp.js
+var require_fxp = __commonJS({
+  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/fxp.js"(exports, module) {
+    "use strict";
+    var validator = require_validator();
+    var XMLParser2 = require_XMLParser();
+    var XMLBuilder = require_json2xml();
+    module.exports = {
+      XMLParser: XMLParser2,
+      XMLValidator: validator,
+      XMLBuilder
+    };
+  }
+});
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.ts
+import { readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/sigma-ids.ts
+var SIGMA_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+var _usedIds = /* @__PURE__ */ new Set();
+var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "but",
+  "or",
+  "for",
+  "nor",
+  "so",
+  "yet",
+  "at",
+  "by",
+  "in",
+  "of",
+  "on",
+  "to",
+  "up",
+  "as",
+  "into",
+  "via",
+  "per"
+]);
+function resetIds() {
+  _usedIds.clear();
+}
+function sigmaShortId(len = 10) {
+  let id;
+  do {
+    id = Array.from(
+      { length: len },
+      () => SIGMA_CHARS[Math.floor(Math.random() * SIGMA_CHARS.length)]
+    ).join("");
+  } while (_usedIds.has(id));
+  _usedIds.add(id);
+  return id;
+}
+function sigmaDisplayName(s) {
+  const normalized = (s || "").replace(/([a-z])([A-Z])/g, "$1_$2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2").replace(/([A-Za-z])([0-9])/g, "$1_$2").replace(/([0-9])([A-Za-z])/g, "$1_$2");
+  const words = normalized.toLowerCase().split(/[_\s]+/).filter(Boolean);
+  return words.map(
+    (w, i) => i === 0 || !SIGMA_LOWERCASE_WORDS.has(w) ? w.charAt(0).toUpperCase() + w.slice(1) : w
+  ).join(" ");
+}
+function formatFromMask(mask) {
+  if (!mask || typeof mask !== "string") return null;
+  const s = mask.trim();
+  if (!s || /general|date|time|@|yy|dd/i.test(s)) return null;
+  const decM = s.match(/\.([0#]+)/);
+  const decimals = decM ? decM[1].length : 0;
+  const isPercent = /%/.test(s);
+  const isCurrency = /[$£€¥]/.test(s);
+  if (isPercent) return { kind: "number", formatString: `,.${decimals}%` };
+  if (isCurrency) return { kind: "number", formatString: `$,.${decimals}f`, currencySymbol: "$" };
+  if (/[0#]/.test(s)) return { kind: "number", formatString: `,.${decimals}f` };
+  return null;
+}
+function inferSigmaFormat(formula, displayName, sourceMask) {
+  const fromMask = formatFromMask(sourceMask);
+  if (fromMask) return fromMask;
+  if (!formula) return null;
+  const f = formula.trim();
+  const n = (displayName || "").toLowerCase();
+  const alreadyPctScale = /\*\s*100\b/.test(f);
+  if (alreadyPctScale && /\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n)) {
+    return { kind: "number", formatString: ",.2f", suffix: "%" };
+  }
+  const currencyWord = /\b(revenue|sales|profit|cost|spend|amount|discounts?|price|value|aov|arpu)\b/;
+  const ratio = f.match(/^([A-Za-z]+)\s*\(([^)]*)\)\s*\/\s*([A-Za-z]+)\s*\(([^)]*)\)$/);
+  if (ratio) {
+    const [, numFn, numArg, denFn, denArg] = ratio;
+    const isCount = (fn) => /^Count/i.test(fn);
+    const numIsCurrency = currencyWord.test(numArg.toLowerCase());
+    const nameSaysPct = /\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n);
+    if (nameSaysPct || isCount(numFn) && isCount(denFn)) {
+      return { kind: "number", formatString: ",.2%" };
+    }
+    if (numIsCurrency) {
+      return { kind: "number", formatString: "$,.2f", currencySymbol: "$" };
+    }
+    return { kind: "number", formatString: ",.2f" };
+  }
+  if (/\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n)) {
+    return { kind: "number", formatString: ",.2%" };
+  }
+  if (currencyWord.test(n)) {
+    return { kind: "number", formatString: "$,.2f", currencySymbol: "$" };
+  }
+  if (/^Count(?:Distinct|If|DistinctIf)?\s*\(/.test(f)) {
+    return { kind: "number", formatString: ",.0f" };
+  }
+  return null;
+}
+var DATA_MODEL_SCHEMA_SUMMARY = `
+Sigma Data Model JSON top-level structure:
+{
+  "name": "Model Name",
+  "pages": [{ "id": "pageId", "name": "Page 1", "elements": [...] }]
+}
+
+Element types: warehouse-table, custom-sql (kind:"sql"), join, union, control.
+Columns: { "id": "inode-xxx/COL", "formula": "[TABLE/Display Name]" }
+Calculated columns: { "id": "shortId", "formula": "[Price] - [Cost]", "name": "Profit" }
+Metrics: { "id": "shortId", "formula": "Sum([Revenue])", "name": "Total Revenue" }
+Relationships: { "id": "shortId", "targetElementId": "...", "keys": [{ "sourceColumnId": "...", "targetColumnId": "..." }] }
+
+Cross-element Reference (accessing related dimension columns via relationships):
+  [SOURCE_TABLE/REL_NAME/Column Display Name]
+  REL_NAME is the relationship's "name" field (= target table name uppercase by convention).
+  Example: DateDiff("day", [ORDER_FACT/PROMO_DIM/Start Date], [ORDER_FACT/PROMO_DIM/End Date])
+  \u26A0 The dash-link form [SRC/FK_COL - link/Field] does NOT work via the API \u2014 use REL_NAME.
+
+Conditional Aggregate Syntax:
+  CountIf(condition) \u2014 condition only, NO field argument
+  SumIf(field, condition) \u2014 FIELD FIRST, condition second
+  AvgIf/MaxIf/MinIf/CountDistinctIf \u2014 all FIELD FIRST
+  For booleans: always use [Column] = True, never bare [Column]
+
+Groupings (for LOD / different aggregation levels):
+  "groupings": [{ "id": "gId", "groupBy": ["colId1"], "calculations": ["calcId1"] }]
+  Array order = nesting hierarchy. Use child elements for LOD patterns.
+`.trim();
+function buildDerivedElements(elements) {
+  const derived = [];
+  for (const srcEl of elements) {
+    if (!srcEl.relationships?.length) continue;
+    if (srcEl.source?.kind !== "warehouse-table") continue;
+    const srcPath = srcEl.source.path || [];
+    const srcTableName = srcPath[srcPath.length - 1] || "";
+    const baseName = srcEl.name || srcTableName;
+    const derivedName = `${srcEl.name || sigmaDisplayName(srcTableName)} View`;
+    const viewCols = [];
+    const viewOrder = [];
+    for (const col of srcEl.columns || []) {
+      if (!col.formula || col.formula.startsWith("/*")) continue;
+      const fm = col.formula.match(/^\[([^\/\]]+)\/([^\]]+)\]$/);
+      if (!fm) continue;
+      const dispName = fm[2];
+      if (dispName.includes("/")) continue;
+      const cId = sigmaShortId();
+      viewCols.push({ id: cId, formula: `[${baseName}/${dispName}]` });
+      viewOrder.push(cId);
+    }
+    for (const rel of srcEl.relationships) {
+      if (!rel.name) continue;
+      const tgtEl = elements.find((e) => e.id === rel.targetElementId);
+      if (!tgtEl || tgtEl.source?.kind !== "warehouse-table") continue;
+      for (const col of tgtEl.columns || []) {
+        if (!col.formula || col.formula.startsWith("/*")) continue;
+        const fm = col.formula.match(/^\[([^\]]+)\]$/);
+        if (!fm) continue;
+        const inner = fm[1];
+        const s = inner.indexOf("/");
+        const dispName = s >= 0 ? inner.slice(s + 1) : inner;
+        if (dispName.includes("/")) continue;
+        const cId = sigmaShortId();
+        viewCols.push({ id: cId, formula: `[${baseName}/${rel.name}/${dispName}]` });
+        viewOrder.push(cId);
+      }
+    }
+    if (viewCols.length > 0) {
+      derived.push({
+        id: sigmaShortId(),
+        kind: "table",
+        name: derivedName,
+        source: { kind: "table", elementId: srcEl.id },
+        columns: viewCols,
+        order: viewOrder
+      });
+    }
+  }
+  return derived;
+}
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos.ts
+function applyLearnedRules(expr, rules) {
+  let s = expr || "";
+  for (const r of rules || []) {
+    try {
+      s = s.replace(new RegExp(r.pattern, r.flags || "gi"), r.template);
+    } catch {
+    }
+  }
+  return s;
+}
+var arr = (x) => Array.isArray(x) ? x : x == null ? [] : [x];
+var lc = (s) => String(s ?? "").toLowerCase();
+function normalizeCognosDataModule(input) {
+  const root = typeof input === "string" ? JSON.parse(input) : input;
+  const name = root.label || root.identifier || root.name || "Cognos Data Module";
+  const querySubjects = [];
+  const qsList = arr(root.querySubject || root.querySubjects || root.module?.querySubject);
+  for (const qs of qsList) {
+    const identifier = qs.identifier || qs.idForExpression || qs.label || "QUERY_SUBJECT";
+    let table = identifier, database, schema;
+    const ref0 = arr(qs.ref)[0];
+    if (typeof ref0 === "string" && ref0.includes(".")) {
+      table = ref0.split(".").slice(1).join(".");
+    } else {
+      const tableRef = arr(qs.definition?.dbQuery?.tableRef)[0] || qs.sourceTable || qs.table;
+      const src = tableRef?.sourceTable || tableRef || {};
+      table = src.name || (typeof tableRef === "string" ? tableRef : identifier);
+      database = src.catalog || src.database || qs.catalog;
+      schema = src.schema || qs.schema;
+    }
+    const items = [];
+    for (const raw of arr(qs.item || qs.items)) {
+      const qi = raw.queryItem || raw.calculation || raw.measure;
+      if (!qi || !(qi.identifier || qi.label)) continue;
+      const ident = qi.identifier || qi.label;
+      const expr = qi.expression;
+      const isCalc = !!raw.calculation || expr != null && !isPlainColumn(expr, identifier);
+      items.push({
+        identifier: ident,
+        label: qi.label,
+        expression: expr,
+        datatype: qi.datatype || qi.highlevelDatatype,
+        usage: lc(qi.usage),
+        aggregate: lc(qi.regularAggregate || qi.aggregate || qi.aggregateFunction),
+        isCalculation: isCalc
+      });
+    }
+    querySubjects.push({ identifier, label: qs.label, database, schema, table, items });
+  }
+  const relationships = [];
+  for (const rel of arr(root.relationship || root.relationships)) {
+    const links = arr(rel.link);
+    const left = qsKey(rel.left?.ref || links[0]?.ref || rel.left);
+    const right = qsKey(rel.right?.ref || links[1]?.ref || rel.right);
+    if (!left || !right) continue;
+    const colLink = links.find((l) => l && (l.leftRef || l.rightRef));
+    relationships.push({
+      left,
+      right,
+      leftKey: colLink?.leftRef,
+      rightKey: colLink?.rightRef,
+      leftCard: lc(rel.left?.maxcard),
+      rightCard: lc(rel.right?.maxcard),
+      expression: rel.expression || rel.linkExpression,
+      cardinality: rel.cardinality
+    });
+  }
+  const securityFilters = [];
+  const pushSec = (sf, subject) => {
+    if (!sf || typeof sf !== "object") return;
+    const groups = arr(sf.securityObject || sf.member || sf.members || sf.appliesTo).map((g) => typeof g === "string" ? g : g?.searchPath || g?.ref || g?.identifier).filter(Boolean);
+    securityFilters.push({
+      type: "data-module-security-filter",
+      subject,
+      name: sf.label || sf.identifier,
+      expression: sf.expression || sf.filterDefinition || sf.embeddedFilter?.expression,
+      ...groups.length ? { groups } : {}
+    });
+  };
+  for (const sf of arr(root.securityFilter || root.securityFilters)) pushSec(sf);
+  for (const qs of qsList) {
+    for (const sf of arr(qs.securityFilter || qs.securityFilters)) pushSec(sf, qs.identifier || qs.label);
+  }
+  for (const fl of arr(root.filter || root.filters)) {
+    if (fl && (lc(fl.classifier).includes("security") || arr(fl.propertyOverride).some((p) => lc(p).includes("security")))) pushSec(fl);
+  }
+  return { name, querySubjects, relationships, securityFilters };
+}
+function qsKey(ref) {
+  const parts = String(ref).replace(/[[\]]/g, "").split(".");
+  return parts[parts.length - 1].trim();
+}
+function isPlainColumn(expr, subjectId) {
+  const e = (expr || "").trim();
+  if (/^[A-Za-z_][\w ]*$/.test(e)) return true;
+  const m = e.replace(/[[\]\s]/g, "").match(/^([\w]+)\.([\w]+)$/);
+  return !!m && m[1].toUpperCase() === subjectId.toUpperCase();
+}
+function convertCognosIR(model, options = {}) {
+  resetIds();
+  const { connectionId = "<CONNECTION_ID>", database: dbOverride = "", schema: schOverride = "", modelName } = options;
+  const warnings = [];
+  const ctxByKey = /* @__PURE__ */ new Map();
+  for (const qs of model.querySubjects) {
+    const key = qs.identifier.toUpperCase();
+    const path = [];
+    const db = dbOverride || qs.database || "";
+    const sch = schOverride || qs.schema || "";
+    if (db) path.push(db);
+    if (sch) path.push(sch);
+    const tableTail = (qs.table || qs.identifier).toUpperCase();
+    path.push(tableTail);
+    const element = {
+      id: sigmaShortId(),
+      kind: "table",
+      name: sigmaDisplayName(qs.identifier),
+      source: { connectionId, kind: "warehouse-table", path },
+      columns: [],
+      order: []
+    };
+    ctxByKey.set(key, { element, columns: [], metrics: [], order: [], colIdByName: /* @__PURE__ */ new Map(), tableTail });
+  }
+  const ensureRawCol = (ctx, _tableKey, ident, hidden = false) => {
+    const disp = sigmaDisplayName(ident);
+    const existing = ctx.colIdByName.get(disp);
+    if (existing) return existing;
+    const id = sigmaShortId();
+    const col = { id, formula: `[${ctx.tableTail}/${disp}]` };
+    if (hidden) col.hidden = true;
+    ctx.columns.push(col);
+    ctx.order.push(id);
+    ctx.colIdByName.set(disp, id);
+    return id;
+  };
+  for (const qs of model.querySubjects) {
+    const key = qs.identifier.toUpperCase();
+    const ctx = ctxByKey.get(key);
+    for (const item of qs.items) {
+      const dispName = sigmaDisplayName(item.label || item.identifier);
+      const isMeasure = !item.isCalculation && (item.usage === "fact" || item.usage === "measure") && item.aggregate && item.aggregate !== "none";
+      if (item.isCalculation && item.expression) {
+        const { formula, warnings: w } = translateCognosExpr(applyLearnedRules(item.expression, options.learnedRules), qs, ensureRawCol, ctx);
+        w.forEach((x) => warnings.push(`"${qs.identifier}.${item.identifier}": ${x}`));
+        if (/\b(Sum|Avg|Count|Min|Max|.*Over)\(/.test(formula)) {
+          const m = { id: sigmaShortId(), name: dispName, formula };
+          const fmt = inferSigmaFormat(formula, dispName);
+          if (fmt) m.format = fmt;
+          ctx.metrics.push(m);
+        } else {
+          const id = sigmaShortId();
+          ctx.columns.push({ id, name: dispName, formula });
+          ctx.order.push(id);
+        }
+      } else if (isMeasure) {
+        ensureRawCol(ctx, key, item.identifier);
+        const agg = aggFn(item.aggregate, `[${sigmaDisplayName(item.identifier)}]`);
+        const m = { id: sigmaShortId(), name: dispName, formula: agg };
+        const fmt = inferSigmaFormat(agg, dispName);
+        if (fmt) m.format = fmt;
+        ctx.metrics.push(m);
+      } else {
+        const physDisp = sigmaDisplayName(item.identifier);
+        const existing = ctx.colIdByName.get(physDisp);
+        if (existing) {
+          if (dispName !== physDisp) {
+          }
+          continue;
+        }
+        const id = sigmaShortId();
+        const col = { id, formula: `[${ctx.tableTail}/${physDisp}]` };
+        if (dispName !== physDisp) col.name = dispName;
+        ctx.columns.push(col);
+        ctx.order.push(id);
+        ctx.colIdByName.set(physDisp, id);
+      }
+    }
+  }
+  for (const rel of model.relationships) {
+    let leftTable = rel.left, rightTable = rel.right, leftCol = rel.leftKey, rightCol = rel.rightKey;
+    if (!leftCol || !rightCol) {
+      const parsed = parseJoinExpr(rel.expression);
+      if (!parsed) {
+        warnings.push(`Relationship ${rel.left}\u2192${rel.right}: no join columns and expression "${trunc(rel.expression)}" not a simple equi-join \u2014 add manually in Sigma.`);
+        continue;
+      }
+      ({ leftTable, leftCol, rightTable, rightCol } = parsed);
+    }
+    const rightIsMany = /many|\bn\b|\*/.test(rel.rightCard || "");
+    const leftIsMany = /many|\bn\b|\*/.test(rel.leftCard || "");
+    if (rightIsMany && !leftIsMany) {
+      [leftTable, leftCol, rightTable, rightCol] = [rightTable, rightCol, leftTable, leftCol];
+    }
+    const srcKey = leftTable.toUpperCase(), tgtKey = rightTable.toUpperCase();
+    const srcCtx = ctxByKey.get(srcKey), tgtCtx = ctxByKey.get(tgtKey);
+    if (!srcCtx || !tgtCtx) {
+      warnings.push(`Relationship ${srcKey}\u2192${tgtKey}: a query subject is missing \u2014 relationship skipped.`);
+      continue;
+    }
+    const srcColId = ensureRawCol(srcCtx, srcKey, leftCol, true);
+    const tgtColId = ensureRawCol(tgtCtx, tgtKey, rightCol, true);
+    (srcCtx.element.relationships ||= []).push({
+      id: sigmaShortId(),
+      targetElementId: tgtCtx.element.id,
+      keys: [{ sourceColumnId: srcColId, targetColumnId: tgtColId }],
+      name: tgtKey
+    });
+  }
+  const elements = [];
+  for (const ctx of ctxByKey.values()) {
+    ctx.element.columns = ctx.columns;
+    ctx.element.order = ctx.order;
+    if (ctx.metrics.length) ctx.element.metrics = ctx.metrics;
+    elements.push(ctx.element);
+  }
+  for (const de of buildDerivedElements(elements)) elements.push(de);
+  const stats = {
+    querySubjects: model.querySubjects.length,
+    elements: elements.length,
+    columns: elements.reduce((n, e) => n + (e.columns?.length || 0), 0),
+    metrics: elements.reduce((n, e) => n + (e.metrics?.length || 0), 0),
+    relationships: elements.reduce((n, e) => n + (e.relationships?.length || 0), 0)
+  };
+  const security2 = (model.securityFilters || []).map((sf) => ({ ...sf }));
+  if (security2.length) {
+    warnings.push(`SECURITY: ${security2.length} data-module security filter(s) detected \u2014 NOT ported into the model spec. Run the skill's RLS flow (scripts/apply_sigma_rls.py) after posting the model; skipping leaves ALL rows visible to everyone.`);
+  }
+  return {
+    model: { name: modelName || model.name, schemaVersion: 1, pages: [{ id: sigmaShortId(), name: "Page 1", elements }] },
+    warnings,
+    stats,
+    ...security2.length ? { security: security2 } : {}
+  };
+}
+function convertCognosToSigma(input, options = {}) {
+  return convertCognosIR(normalizeCognosDataModule(input), options);
+}
+var AGG_MAP = {
+  total: "Sum",
+  sum: "Sum",
+  average: "Avg",
+  avg: "Avg",
+  count: "Count",
+  "count distinct": "CountDistinct",
+  maximum: "Max",
+  max: "Max",
+  minimum: "Min",
+  min: "Min"
+};
+var OVER_MAP = { total: "SumOver", sum: "SumOver", average: "AvgOver", count: "CountOver", maximum: "MaxOver", minimum: "MinOver" };
+function aggFn(agg, inner) {
+  const fn = AGG_MAP[agg] || "Sum";
+  return `${fn}(${inner})`;
+}
+function translateCognosExpr(expr, qs, ensureRawCol, ctx) {
+  const warnings = [];
+  let f = (expr || "").trim();
+  for (const bad of ["running-total", "running-count", "running-average", "running-difference", "moving-total", "moving-average", "rank", "percentile", "quantile", "tertile"]) {
+    if (new RegExp(`\\b${bad}\\b`, "i").test(f)) warnings.push(`uses Cognos "${bad}" (window/running calc) \u2014 no clean single-column Sigma analog; needs manual authoring (window function).`);
+  }
+  f = f.replace(/\[[^\]]+\](?:\.\[[^\]]+\])*/g, (ref) => {
+    const segs = ref.split(".").map((s) => s.replace(/[[\]]/g, "").trim());
+    const item = segs[segs.length - 1];
+    return `[${sigmaDisplayName(item)}]`;
+  });
+  f = translateCaseExpr(f);
+  const identMap = /* @__PURE__ */ new Map();
+  for (const it of qs.items || []) identMap.set(it.identifier.toLowerCase(), sigmaDisplayName(it.label || it.identifier));
+  if (identMap.size) {
+    const pfx = ctx && ctx.tableTail ? `${ctx.tableTail}/` : "";
+    f = f.replace(/\[[^\]]*\]|[^[\]]+/g, (seg) => seg.startsWith("[") ? seg : seg.replace(/\b([A-Za-z_][A-Za-z0-9_]*)\b(?!\s*\()/g, (w) => {
+      const d = identMap.get(w.toLowerCase());
+      return d ? `[${pfx}${d}]` : w;
+    }));
+  }
+  if (/\bcase\b[\s\S]*\bwhen\b/i.test(f)) warnings.push("a CASE expression could not be fully translated (nested or non-standard) \u2014 review/author manually.");
+  f = f.replace(
+    /\b(total|sum|average|count|maximum|minimum)\s*\(\s*([^()]*?)\s+for\s+([^()]*)\)/gi,
+    (_m, fn, inner, scope) => {
+      const over = OVER_MAP[lc(fn)] || "SumOver";
+      const dims = scope.split(",").map((s) => s.trim()).join(", ");
+      return `${over}(${inner.trim()}, ${dims})`;
+    }
+  );
+  f = f.replace(/\b(total|sum|average|count|maximum|minimum)\s*\(/gi, (_m, fn) => `${AGG_MAP[lc(fn)] || "Sum"}(`);
+  let guard = 0;
+  while (/\bif\s*\(/i.test(f) && guard++ < 25) {
+    f = f.replace(
+      /\bif\s*\(([^()]*(?:\([^()]*\)[^()]*)*)\)\s*then\s*\(([^()]*(?:\([^()]*\)[^()]*)*)\)\s*else\s*/i,
+      (_m, cond, thenv) => `If(${cond.trim()}, ${thenv.trim()}, `
+    );
+    if (!/\bif\s*\(/i.test(f)) break;
+  }
+  const opens = (f.match(/If\(/g) || []).length;
+  const closes = (f.match(/\)/g) || []).length - (f.match(/\(/g) || []).length + opens;
+  if (opens > 0 && closes < opens) f = f + ")".repeat(opens - Math.max(0, closes));
+  f = f.replace(/_add_days\s*\(([^,]+),\s*([^)]+)\)/gi, (_m, d, n) => `DateAdd("day", ${n.trim()}, ${d.trim()})`);
+  f = f.replace(/_add_months\s*\(([^,]+),\s*([^)]+)\)/gi, (_m, d, n) => `DateAdd("month", ${n.trim()}, ${d.trim()})`);
+  f = f.replace(/_add_years\s*\(([^,]+),\s*([^)]+)\)/gi, (_m, d, n) => `DateAdd("year", ${n.trim()}, ${d.trim()})`);
+  f = f.replace(/_days_between\s*\(([^,]+),\s*([^)]+)\)/gi, (_m, a, b) => `DateDiff("day", ${b.trim()}, ${a.trim()})`);
+  f = f.replace(/\bextract\s*\(\s*(year|month|day)\s*,\s*([^)]+)\)/gi, (_m, part, d) => `DatePart("${lc(part)}", ${d.trim()})`);
+  f = f.replace(/\bsubstring\s*\(/gi, "Mid(").replace(/\bsubstr\s*\(/gi, "Mid(").replace(/\bupper\s*\(/gi, "Upper(").replace(/\blower\s*\(/gi, "Lower(").replace(/\btrim\s*\(/gi, "Trim(");
+  f = f.replace(
+    /\bsubstitute\s*\(\s*([^,]+?)\s*,\s*([^,]+?)\s*,\s*([^)]+?)\s*\)/gi,
+    (_m, p, r, s) => `RegexpReplace(${s.trim()}, ${p.trim()}, ${r.trim()})`
+  );
+  const castRepl = (_m, x, ty) => /char|text|string|varchar/i.test(ty) ? `Text(${x.trim()})` : x.trim();
+  f = f.replace(/\bcast\s*\(\s*([^,()]+?)\s+as\s+(\w+)[^)]*\)/gi, castRepl);
+  f = f.replace(/\bcast\s*\(\s*([^,()]+?)\s*,\s*(\w+)[^)]*\)/gi, castRepl);
+  f = f.replace(/\b(?:n?varchar|char)\s*\(\s*([^,)]+?)(?:\s*,\s*\d+)?\s*\)/gi, (_m, x) => `Text(${x.trim()})`);
+  f = f.replace(/\b(?:decimal|double|float|number)\s*\(\s*([^,)]+?)(?:\s*,[^)]*)?\)/gi, (_m, x) => x.trim());
+  f = f.replace(/\|\|/g, "&");
+  f = f.replace(/\bcoalesce\s*\(/gi, "Coalesce(");
+  f = f.replace(/\babs\s*\(/gi, "Abs(").replace(/\bround\s*\(/gi, "Round(").replace(/\bfloor\s*\(/gi, "Floor(").replace(/\bceiling\s*\(/gi, "Ceiling(").replace(/\bsqrt\s*\(/gi, "Sqrt(").replace(/\bln\s*\(/gi, "Ln(").replace(/\bmod\s*\(/gi, "Mod(").replace(/\bpower\s*\(/gi, "Power(");
+  f = f.replace(/'([^']*)'/g, '"$1"');
+  const known = /\b(If|Switch|Sum|Avg|Count|CountDistinct|Min|Max|SumOver|AvgOver|CountOver|MinOver|MaxOver|DateAdd|DateDiff|DatePart|Mid|Upper|Lower|Trim|Coalesce|Text|RegexpReplace|Replace|Abs|Round|Floor|Ceiling|Sqrt|Ln|Mod|Power)\b/;
+  for (const m of f.matchAll(/\b([a-z][a-z0-9_-]*)\s*\(/gi)) {
+    if (!known.test(m[1]) && !/^(and|or|not|in|like|between|then|else|end|case|when)$/i.test(m[1])) {
+      warnings.push(`function "${m[1]}()" has no confirmed Sigma mapping \u2014 review/translate manually.`);
+    }
+  }
+  return { formula: f, warnings };
+}
+function translateCaseExpr(s) {
+  let guard = 0;
+  while (/\bcase\b/i.test(s) && guard++ < 25) {
+    const m = s.match(/\bcase\b([\s\S]*?)\bend\b/i);
+    if (!m || m.index == null) break;
+    const repl = convertCaseBody(m[1]);
+    if (repl == null) break;
+    s = s.slice(0, m.index) + repl + s.slice(m.index + m[0].length);
+  }
+  return s;
+}
+function convertCaseBody(body) {
+  const em = body.match(/\belse\b([\s\S]*)$/i);
+  const elseVal = em ? em[1].trim() : "Null";
+  const head = em ? body.slice(0, em.index) : body;
+  const fw = head.search(/\bwhen\b/i);
+  if (fw < 0) return null;
+  const selector = head.slice(0, fw).trim();
+  const clauses = head.slice(fw).split(/\bwhen\b/i).map((c) => c.trim()).filter(Boolean);
+  const pairs = [];
+  for (const cl of clauses) {
+    const tm = cl.match(/^([\s\S]*?)\bthen\b([\s\S]*)$/i);
+    if (!tm) return null;
+    pairs.push([tm[1].trim(), tm[2].trim()]);
+  }
+  if (!pairs.length) return null;
+  if (selector) return `Switch(${[selector, ...pairs.flatMap((p) => [p[0], p[1]]), elseVal].join(", ")})`;
+  let out = elseVal;
+  for (let i = pairs.length - 1; i >= 0; i--) out = `If(${pairs[i][0]}, ${pairs[i][1]}, ${out})`;
+  return out;
+}
+function parseJoinExpr(expr) {
+  if (!expr) return null;
+  const e = expr.replace(/[[\]]/g, "");
+  const m = e.match(/([\w]+)\.([\w]+)\s*=\s*([\w]+)\.([\w]+)/);
+  if (!m) return null;
+  if (/\band\b|\bor\b/i.test(e)) return null;
+  return { leftTable: m[1].trim(), leftCol: m[2].trim(), rightTable: m[3].trim(), rightCol: m[4].trim() };
+}
+var trunc = (s, n = 80) => s && s.length > n ? s.slice(0, n) + "\u2026" : s || "";
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
+var import_fast_xml_parser = __toESM(require_fxp(), 1);
+var xmlParser = new import_fast_xml_parser.XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  trimValues: true,
+  isArray: (n) => [
+    "query",
+    "dataItem",
+    "list",
+    "page",
+    "detailFilter",
+    "summaryFilter",
+    "dataItemValue",
+    "dataItemLabel",
+    "listColumn",
+    "reportPage",
+    "crosstab",
+    "crosstabNode",
+    "crosstabNodeMember",
+    "vizControl",
+    "vcDataSet",
+    "vcSlotData",
+    "vcSlotDsColumn",
+    "reportDataStore"
+  ].includes(n)
+});
+var arr2 = (v) => Array.isArray(v) ? v : v == null ? [] : [v];
+var txt = (v) => v == null ? "" : typeof v === "object" ? v["#text"] ?? "" : String(v);
+function findAll(node, tag, out = []) {
+  if (node && typeof node === "object") {
+    for (const [k, v] of Object.entries(node)) {
+      if (k === tag) arr2(v).forEach((x) => out.push(x));
+      arr2(v).forEach((x) => x && typeof x === "object" && findAll(x, tag, out));
+    }
+  }
+  return out;
+}
+function convertCognosReportToSigma(xml2, options = {}) {
+  resetIds();
+  const warnings = [];
+  const parsed = xmlParser.parse(xml2);
+  const report = parsed.report || parsed;
+  const reportName = txt(report.reportName) || options.workbookName || "Cognos Report";
+  const queries = /* @__PURE__ */ new Map();
+  for (const q of findAll(report.queries || report, "query")) {
+    const name = q["@_name"] || "query";
+    const items = /* @__PURE__ */ new Map();
+    let subject = "";
+    for (const di of findAll(q, "dataItem")) {
+      const dn = di["@_name"];
+      if (!dn) continue;
+      const expr = txt(di.expression);
+      const dataType = findAll(di, "XMLAttribute").find((x) => x["@_name"] === "RS_dataType")?.["@_value"];
+      items.set(dn, { name: dn, expression: expr, aggregate: di["@_aggregate"], dataType });
+      const m = expr.match(/\[[^\]]+\]\.\[[^\]]+\]\.\[([^\]]+)\]\.\[[^\]]+\]/);
+      if (m && !subject) subject = m[1];
+    }
+    const filters = findAll(q, "detailFilter").map((f) => txt(f.filterExpression || f.expression)).filter(Boolean);
+    queries.set(name, { name, subject, items, filters });
+  }
+  const prompts = /* @__PURE__ */ new Map();
+  for (const sv of findAll(report, "selectValue")) {
+    const p = sv["@_parameter"];
+    if (!p) continue;
+    const meta = prompts.get(p) || { options: [], valueRefs: {} };
+    for (const o of findAll(sv, "selectOption")) {
+      const v = o["@_useValue"];
+      if (v && !meta.options.includes(v)) meta.options.push(v);
+    }
+    const d = txt(findAll(sv, "defaultSimpleSelection")[0]);
+    if (d && meta.def == null) meta.def = d;
+    prompts.set(p, meta);
+  }
+  for (const cc of findAll(report, "customControl")) {
+    try {
+      const cfg = JSON.parse(txt(cc.configuration));
+      const p = cfg?.["Parameter"];
+      if (p && cfg["Button label"] && cfg["Button value"]) {
+        const meta = prompts.get(p) || { options: [], valueRefs: {} };
+        meta.valueRefs[cfg["Button label"]] = String(cfg["Button value"]);
+        if (!meta.options.includes(cfg["Button label"])) meta.options.push(cfg["Button label"]);
+        prompts.set(p, meta);
+      }
+    } catch {
+    }
+  }
+  const controls = /* @__PURE__ */ new Map();
+  const registerPrompt = (p) => {
+    if (controls.has(p)) return;
+    const meta = prompts.get(p);
+    const ctrl = {
+      id: sigmaShortId(),
+      kind: "control",
+      controlId: p,
+      name: sigmaDisplayName(p),
+      controlType: "segmented",
+      source: { kind: "manual", valueType: "text", values: [...meta?.options || []], labels: (meta?.options || []).map(() => null) },
+      value: meta?.def ?? meta?.options?.[0] ?? null
+    };
+    if (!meta?.options?.length) {
+      warnings.push(`prompt '${p}': no <selectValue> options found in the report \u2014 emitted an empty segmented control; add its values in Sigma.`);
+    }
+    controls.set(p, ctrl);
+  };
+  const translateModelRef = (ref) => ref.replace(/\[[^\]]+\]\.\[[^\]]+\]\.\[([^\]]+)\]\.\[([^\]]+)\]/g, (_m, subj, col) => `[${sigmaDisplayName(subj)}/${sigmaDisplayName(col)}]`).replace(/\[([^\]/]+)\]\.\[([^\]]+)\]/g, (_m, subj, col) => `[${sigmaDisplayName(subj)}/${sigmaDisplayName(col)}]`);
+  const translate = (expr, q) => {
+    const warns = [];
+    let f = (expr || "").trim();
+    if (f.startsWith("#") || /#\s*sql\s*\(|'token'/.test(f)) {
+      const norm = (s) => s.replace(/[\s'"]+/g, "");
+      const mA = f.match(/^#\s*prompt\(\s*'([^']+)'\s*,\s*'token'\s*(?:,\s*'([^']*)')?\s*\)\s*#$/s);
+      if (mA) {
+        const [, p, defRef] = mA;
+        registerPrompt(p);
+        const meta = prompts.get(p);
+        const defaultFormula = defRef ? translateModelRef(defRef) : void 0;
+        const defaultOption = defRef && meta ? Object.keys(meta.valueRefs).find((k) => norm(meta.valueRefs[k]) === norm(defRef)) : void 0;
+        const branches = [];
+        for (const opt2 of meta?.options || []) {
+          if (opt2 === defaultOption) continue;
+          let refFormula = meta.valueRefs[opt2] ? translateModelRef(meta.valueRefs[opt2]) : void 0;
+          if (!refFormula) {
+            const di = q.items.get(opt2) || [...q.items.values()].find((d) => d.name.toLowerCase() === opt2.toLowerCase());
+            if (di && !di.expression.trim().startsWith("#")) refFormula = translateModelRef(di.expression.trim());
+          }
+          if (refFormula) branches.push(`"${opt2}", ${refFormula}`);
+          else warns.push(`prompt '${p}' option "${opt2}" could not be mapped to a model column \u2014 left out of the Switch; add the branch manually.`);
+        }
+        if (defaultFormula && branches.length) {
+          return { formula: `Switch([${p}], ${branches.join(", ")}, ${defaultFormula})`, warns };
+        }
+        if (defaultFormula) {
+          warns.push(`prompt '${p}': no swap options resolved \u2014 emitted only the macro's default column.`);
+          return { formula: defaultFormula, warns };
+        }
+      }
+      const mB = f.match(/^#\s*'([^']*)'\s*\+\s*prompt\(\s*'([^']+)'\s*,\s*'token'\s*\)\s*\+\s*'([^']*)'\s*#$/s);
+      if (mB) {
+        const [, pre, p, suf] = mB;
+        registerPrompt(p);
+        const meta = prompts.get(p);
+        if (meta?.options?.length) {
+          const def = meta.def && meta.options.includes(meta.def) ? meta.def : meta.options[meta.options.length - 1];
+          const branches = meta.options.filter((o) => o !== def).map((o) => `"${o}", ${translateModelRef(pre + o + suf)}`);
+          const defaultFormula = translateModelRef(pre + def + suf);
+          return { formula: branches.length ? `Switch([${p}], ${branches.join(", ")}, ${defaultFormula})` : defaultFormula, warns };
+        }
+        warns.push(`dataItem builds a column ref from prompt '${p}' but the report carries no option list for it \u2014 emitted a placeholder.`);
+        return { formula: `/* MACRO \u2014 manual: ${f.slice(0, 60)} */`, warns };
+      }
+      const promptName = (f.match(/prompt\(\s*'([^']+)'/) || [])[1];
+      if (promptName) registerPrompt(promptName);
+      warns.push(`dataItem uses a Cognos macro (#\u2026#${promptName ? `, prompt '${promptName}'` : ""}) that builds the column/SQL at runtime \u2014 model it in Sigma as a control + Switch([Control], \u2026). Emitted a placeholder.`);
+      return { formula: promptName ? `Switch([${promptName}] /* map prompt tokens to columns */)` : `/* MACRO \u2014 manual: ${f.slice(0, 60)} */`, warns };
+    }
+    f = f.replace(
+      /\[[^\]]+\]\.\[[^\]]+\]\.\[([^\]]+)\]\.\[([^\]]+)\]/g,
+      (_m, subj, col) => `[${sigmaDisplayName(subj)}/${sigmaDisplayName(col)}]`
+    );
+    f = f.replace(/\[([^\]]+)\]\.\[([^\]]+)\]/g, (_m, subj, col) => `[${sigmaDisplayName(subj)}/${sigmaDisplayName(col)}]`);
+    f = f.replace(/\[([^\]\/]+)\]/g, (whole, nm) => q.items.has(nm) ? `[${sigmaDisplayName(nm)}]` : whole);
+    f = f.replace(/prompt\(\s*'([^']+)'[^)]*\)/g, (_m, p) => {
+      registerPrompt(p);
+      return `[${p}]`;
+    });
+    const dsl = translateCognosExpr(
+      f,
+      { identifier: q.subject || "Q", items: [] },
+      () => "",
+      {}
+    );
+    dsl.warnings.forEach((w) => warns.push(w));
+    return { formula: dsl.formula, warns };
+  };
+  const formatFromNode = (node) => {
+    const cf = findAll(node, "currencyFormat")[0];
+    const pf = findAll(node, "percentFormat")[0];
+    const nf = findAll(node, "numberFormat")[0];
+    const dec = (x, d) => x?.["@_decimalSize"] != null ? Number(x["@_decimalSize"]) : d;
+    const scaled = (x) => x?.["@_scale"] != null || /[KMB]/.test(String(x?.["@_pattern"] || ""));
+    if (cf) return { kind: "number", formatString: scaled(cf) ? `$,.${dec(cf, 1) + 2}s` : `$,.${dec(cf, 2)}f` };
+    if (pf) return { kind: "number", formatString: `,.${dec(pf, 0)}%` };
+    if (nf) return { kind: "number", formatString: scaled(nf) ? `$,.${dec(nf, 1) + 2}s` : `,.${dec(nf, 2)}f` };
+    return void 0;
+  };
+  const pages = [];
+  const reportPages = findAll(report.layouts || report, "reportPage").concat(findAll(report.layouts || report, "page"));
+  const lists = findAll(report, "list");
+  const pageEls = [];
+  const dmSource = (q) => ({ kind: "data-model", dataModelId: options.dataModelId || "<DM_ID \u2014 wire after posting the data model>", elementId: q.subject ? sigmaDisplayName(q.subject) : "<element>" });
+  const ensureFilterCol = (el, q, itemName) => {
+    const di = q.items.get(itemName);
+    if (!di) return void 0;
+    const want = sigmaDisplayName(di.name);
+    const existing = (el.columns || []).find((c) => c.name === want);
+    if (existing) return existing.id;
+    const { formula, warns } = translate(di.expression, q);
+    warns.forEach((w) => warnings.push(`"${q.name}.${itemName}": ${w}`));
+    const id = sigmaShortId();
+    (el.columns ||= []).push({ id, name: want, formula, hidden: true });
+    return id;
+  };
+  const applyQueryFilters = (el, q) => {
+    for (const fx of q.filters) {
+      const m = fx.match(/^\s*\[([^\]]+)\]\s+(in)\s*\(([^)]*)\)\s*$/i) || fx.match(/^\s*\[([^\]]+)\]\s*(=)\s*(.+?)\s*$/);
+      const fail = (why) => warnings.push(`filter "${fx.slice(0, 80)}" on query "${q.name}": ${why} \u2014 re-create as a Sigma element/page filter.`);
+      if (!m) {
+        fail("not a simple =/in filter");
+        continue;
+      }
+      const [, nm, op, rhs] = m;
+      if (!q.items.has(nm)) {
+        fail(`[${nm}] is not a dataItem in the query`);
+        continue;
+      }
+      const colId = ensureFilterCol(el, q, nm);
+      if (!colId) {
+        fail("filter column could not be added");
+        continue;
+      }
+      const col = el.columns.find((c) => c.id === colId);
+      const textCol = /^Text\(/.test(col.formula);
+      const lit = (s) => {
+        const t = s.trim().replace(/^['"](.*)['"]$/, "$1");
+        return t !== "" && /^-?[\d.]+$/.test(t) && !Number.isNaN(Number(t)) && !textCol ? Number(t) : t;
+      };
+      const prompt = rhs.trim().match(/^\?(\w+)\?$/);
+      if (prompt && op === "=") {
+        const p = prompt[1];
+        registerPrompt(p);
+        const boolId = sigmaShortId();
+        el.columns.push({ id: boolId, name: `${col.name} = ${p}`, formula: `[${col.name}] = [${p}]`, hidden: true });
+        (el.filters ||= []).push({ id: sigmaShortId(), columnId: boolId, kind: "list", mode: "include", values: [true] });
+      } else if (op.toLowerCase() === "in") {
+        const values = rhs.split(",").map((s) => lit(s)).filter((v) => v !== "");
+        (el.filters ||= []).push({ id: sigmaShortId(), columnId: colId, kind: "list", mode: "include", values });
+      } else if (rhs.trim().startsWith("?")) {
+        fail("unsupported prompt comparison");
+      } else {
+        (el.filters ||= []).push({ id: sigmaShortId(), columnId: colId, kind: "list", mode: "include", values: [lit(rhs)] });
+      }
+    }
+  };
+  for (const sg of findAll(report, "singleton")) {
+    const qName = sg["@_refQuery"];
+    const q = queries.get(qName);
+    if (!q) {
+      warnings.push(`<singleton> "${sg["@_name"]}" refQuery="${qName}" has no matching query \u2014 skipped.`);
+      continue;
+    }
+    const ref = findAll(sg, "dataItemValue").map((d) => d["@_refDataItem"]).find(Boolean);
+    const di = ref ? q.items.get(ref) : void 0;
+    if (!di) {
+      warnings.push(`<singleton> "${sg["@_name"]}" has no resolvable dataItem ("${ref}") \u2014 skipped.`);
+      continue;
+    }
+    const cols = [];
+    const idByName = /* @__PURE__ */ new Map();
+    const addKpiCol = (nm) => {
+      if (idByName.has(nm)) return idByName.get(nm);
+      const d = q.items.get(nm);
+      if (!d) return void 0;
+      for (const sm of d.expression.matchAll(/\[([^\]/.]+)\]/g)) {
+        if (sm[1] !== nm && q.items.has(sm[1])) addKpiCol(sm[1]);
+      }
+      const { formula, warns } = translate(d.expression, q);
+      warns.forEach((w) => warnings.push(`"${qName}.${nm}": ${w}`));
+      const referencesSibling = [...q.items.keys()].some((k) => k !== nm && formula.toLowerCase().includes(`[${sigmaDisplayName(k).toLowerCase()}]`));
+      const hasAgg = /\b(Sum|Avg|Min|Max|Count|CountDistinct|Median)\s*\(/.test(formula);
+      const id = sigmaShortId();
+      cols.push({ id, name: sigmaDisplayName(nm), formula: referencesSibling || hasAgg ? formula : `Sum(${formula})` });
+      idByName.set(nm, id);
+      return id;
+    };
+    const valId = addKpiCol(ref);
+    const fmt = formatFromNode(sg);
+    if (fmt) cols.find((c) => c.id === valId).format = fmt;
+    if (findAll(sg, "conditionalStyleRef").length) {
+      warnings.push(`singleton "${sg["@_name"]}" (${ref}) uses conditional styling (e.g. up/down KPI icons) \u2014 not portable to a Sigma kpi-chart spec; the VALUE is preserved, re-create the icon rule manually.`);
+    }
+    const el = {
+      id: sigmaShortId(),
+      kind: "kpi-chart",
+      name: di.name,
+      source: dmSource(q),
+      columns: cols,
+      order: cols.map((c) => c.id),
+      value: { columnId: valId }
+    };
+    applyQueryFilters(el, q);
+    pageEls.push(el);
+  }
+  for (const L of lists) {
+    const qName = L["@_refQuery"];
+    const q = queries.get(qName);
+    if (!q) {
+      warnings.push(`<list> refQuery="${qName}" has no matching query \u2014 skipped.`);
+      continue;
+    }
+    const colRefs = findAll(L, "dataItemValue").map((d) => d["@_refDataItem"]).filter(Boolean);
+    const refs = colRefs.length ? colRefs : [...q.items.keys()];
+    const columns = [];
+    const AGG = { total: "Sum", summary: "Sum", aggregate: "Sum", calculated: "Sum", average: "Avg", count: "Count", maximum: "Max", minimum: "Min" };
+    const isMeasureItem = (d) => !!d.aggregate && d.aggregate !== "none";
+    const grouped = refs.some((r) => {
+      const d = q.items.get(r);
+      return d && isMeasureItem(d);
+    }) && refs.some((r) => {
+      const d = q.items.get(r);
+      return d && !isMeasureItem(d);
+    });
+    const dimIds = [];
+    const measureIds = [];
+    const footerRefs = [];
+    for (const r of refs) {
+      const di = q.items.get(r);
+      if (!di) {
+        const m = r.match(/^(Total|Summary|Aggregate|Average|Count|Maximum|Minimum)\((.+?)\)\d*$/i);
+        if (m && q.items.get(m[2])) {
+          if (grouped) {
+            footerRefs.push(r);
+            continue;
+          }
+          columns.push({ id: sigmaShortId(), name: sigmaDisplayName(r), formula: `${AGG[m[1].toLowerCase()]}([${sigmaDisplayName(m[2])}])` });
+          continue;
+        }
+        warnings.push(`list column "${r}" not found in query "${qName}" \u2014 skipped.`);
+        continue;
+      }
+      const { formula, warns } = translate(di.expression, q);
+      warns.forEach((w) => warnings.push(`"${qName}.${r}": ${w}`));
+      const id = sigmaShortId();
+      if (grouped && isMeasureItem(di)) {
+        const fn = AGG[di.aggregate.toLowerCase()] || "Sum";
+        columns.push({ id, name: sigmaDisplayName(di.name), formula: /^\s*(Sum|Avg|Min|Max|Count|CountDistinct)\s*\(/.test(formula) ? formula : `${fn}(${formula})` });
+        measureIds.push(id);
+      } else {
+        columns.push({ id, name: sigmaDisplayName(di.name), formula });
+        if (grouped) dimIds.push(id);
+      }
+    }
+    if (footerRefs.length) {
+      warnings.push(`list "${qName}": footer total(s) ${footerRefs.join(", ")} \u2014 the grouped Sigma table already aggregates per group; add a grand-total via the table's totals UI (a duplicate Sum column would double-aggregate).`);
+    }
+    for (const si of findAll(L, "sortItem")) {
+      if (si["@_refDataItem"]) warnings.push(`list "${qName}" sorts by "${si["@_refDataItem"]}" (${si["@_sortOrder"] || "ascending"}) \u2014 table sort isn't part of the Sigma workbook spec; apply the sort in the UI.`);
+    }
+    const condRefs = [...new Set(findAll(L, "conditionalStyleRef").map((c) => c["@_refConditionalStyle"]).filter(Boolean))];
+    if (condRefs.length) warnings.push(`list "${qName}" uses conditional style(s) ${condRefs.map((r) => `"${r}"`).join(", ")} \u2014 threshold-driven formats/styles aren't portable to the Sigma spec; set a column format (e.g. $,.3s) or conditional formatting in the UI.`);
+    const el = {
+      id: sigmaShortId(),
+      kind: "table",
+      name: `${q.subject ? sigmaDisplayName(q.subject) + " \u2014 " : ""}${qName}`,
+      source: dmSource(q),
+      columns,
+      order: columns.map((c) => c.id)
+    };
+    if (grouped && dimIds.length && measureIds.length) {
+      el.groupings = [{ id: sigmaShortId(), groupBy: dimIds, calculations: measureIds }];
+    }
+    applyQueryFilters(el, q);
+    pageEls.push(el);
+  }
+  const isTotal = (r) => /^(Total|Summary|Aggregate|Average|Count|Maximum|Minimum)\(/i.test(r || "");
+  for (const X of findAll(report, "crosstab")) {
+    const qName = X["@_refQuery"];
+    const q = queries.get(qName);
+    if (!q) {
+      warnings.push(`<crosstab> refQuery="${qName}" has no matching query \u2014 skipped.`);
+      continue;
+    }
+    const edge = (subtree) => [...new Set(findAll(subtree || {}, "crosstabNodeMember").map((m) => m["@_refDataItem"]).filter((r) => r && !isTotal(r)))];
+    const rowRefs = edge(X.crosstabRows);
+    const colRefs = edge(X.crosstabColumns);
+    let measRefs = [...new Set(findAll(X.crosstabCorner || {}, "dataItemLabel").map((d) => d["@_refDataItem"]).filter((r) => r && !isTotal(r)))];
+    if (!measRefs.length) measRefs = [...q.items.keys()].filter((k) => !rowRefs.includes(k) && !colRefs.includes(k) && !isTotal(k));
+    const cols = [];
+    const mk = (ref, agg) => {
+      const di = q.items.get(ref);
+      if (!di) {
+        warnings.push(`crosstab "${qName}" member "${ref}" not in query \u2014 skipped.`);
+        return null;
+      }
+      const { formula, warns } = translate(di.expression, q);
+      warns.forEach((w) => warnings.push(`"${qName}.${ref}": ${w}`));
+      const id = sigmaShortId();
+      cols.push({ id, name: sigmaDisplayName(di.name), formula: agg ? `Sum(${formula})` : formula });
+      return { id };
+    };
+    const rowsBy = rowRefs.map((r) => mk(r, false)).filter(Boolean);
+    const columnsBy = colRefs.map((c) => mk(c, false)).filter(Boolean);
+    const values = measRefs.map((m) => mk(m, true)).filter(Boolean).map((o) => o.id);
+    if (!values.length || !rowsBy.length && !columnsBy.length) warnings.push(`crosstab "${qName}" missing a measure or both edges \u2014 review the pivot.`);
+    const el = {
+      id: sigmaShortId(),
+      kind: "pivot-table",
+      name: `${q.subject ? sigmaDisplayName(q.subject) + " \u2014 " : ""}${qName} (crosstab)`,
+      source: dmSource(q),
+      columns: cols,
+      order: cols.map((c) => c.id),
+      rowsBy,
+      columnsBy,
+      values
+    };
+    applyQueryFilters(el, q);
+    pageEls.push(el);
+  }
+  const dsToQuery = /* @__PURE__ */ new Map();
+  for (const ds of findAll(report, "reportDataStore")) {
+    const nm = ds["@_name"];
+    const rq = findAll(ds, "dsV5ListQuery").map((x) => x["@_refQuery"]).find(Boolean);
+    if (nm && rq) dsToQuery.set(nm, rq);
+  }
+  const ROLLUP_AGG = { total: "Sum", sum: "Sum", average: "Avg", avg: "Avg", count: "Count", countdistinct: "CountDistinct", maximum: "Max", minimum: "Min" };
+  const VIZ_KIND = {
+    "com.ibm.vis.clusteredbar": "bar-chart",
+    "com.ibm.vis.stackedbar": "bar-chart",
+    "com.ibm.vis.clusteredcolumn": "bar-chart",
+    "com.ibm.vis.stackedcolumn": "bar-chart",
+    "com.ibm.vis.line": "line-chart",
+    "com.ibm.vis.spline": "line-chart",
+    "com.ibm.vis.area": "area-chart",
+    "com.ibm.vis.stackedarea": "area-chart",
+    "com.ibm.vis.pie": "pie-chart",
+    "com.ibm.vis.donut": "donut-chart",
+    "com.ibm.vis.clusteredcombination": "combo-chart",
+    "com.ibm.vis.stackedcombination": "combo-chart",
+    "com.ibm.vis.bubble": "scatter-chart",
+    "com.ibm.vis.scatter": "scatter-chart"
+  };
+  const VIZ_NOANALOG = {
+    "com.ibm.vis.network": "network diagram",
+    "com.ibm.vis.wordcloud": "word cloud",
+    "com.ibm.vis.packedbubble": "packed bubble",
+    "com.ibm.vis.treemap": "treemap"
+  };
+  const isMapViz = (t) => /tiledmap|choropleth|\bmap\b/.test(t);
+  const chartSource = dmSource;
+  const COGNOS_SCHEME = {
+    // sequential (single-hue ramps)
+    blue: ["#deebf7", "#9ecae1", "#3182bd"],
+    blues: ["#deebf7", "#9ecae1", "#3182bd"],
+    green: ["#e5f5e0", "#a1d99b", "#31a354"],
+    greens: ["#e5f5e0", "#a1d99b", "#31a354"],
+    orange: ["#fee6ce", "#fdae6b", "#e6550d"],
+    oranges: ["#fee6ce", "#fdae6b", "#e6550d"],
+    red: ["#fee0d2", "#fc9272", "#de2d26"],
+    reds: ["#fee0d2", "#fc9272", "#de2d26"],
+    purple: ["#efedf5", "#bcbddc", "#756bb1"],
+    heat: ["#ffffcc", "#fd8d3c", "#bd0026"],
+    sequential: ["#ffffcc", "#fd8d3c", "#bd0026"],
+    // diverging
+    diverging: ["#a50026", "#f46d43", "#fee090", "#74add1", "#313695"],
+    redblue: ["#a50026", "#f46d43", "#fee090", "#74add1", "#313695"],
+    redgreen: ["#d73027", "#fee08b", "#1a9850"]
+  };
+  const SEQ_DEFAULT = COGNOS_SCHEME.sequential;
+  const schemeFromSignal = (sig) => {
+    const key = String(sig || "").toLowerCase().replace(/[^a-z]/g, "");
+    for (const k of Object.keys(COGNOS_SCHEME)) if (key.includes(k)) return [...COGNOS_SCHEME[k]];
+    return [...SEQ_DEFAULT];
+  };
+  const vizColorSignal = (V) => {
+    for (const pv of findAll(V, "vizPropertyValues")) {
+      for (const [, v] of Object.entries(pv)) {
+        for (const p of arr2(v)) {
+          const nm = String(p?.["@_name"] || "");
+          if (/palette|colou?r.?scheme|colou?rmodel/i.test(nm)) {
+            const val = txt(p);
+            if (val) return val;
+          }
+        }
+      }
+    }
+    const pal = findAll(V, "vcSlotData").map((s) => s["@_refPaletteDefinition"] || s["@_refPalette"]).find(Boolean) || V["@_refPaletteDefinition"] || V["@_refPalette"];
+    return pal ? String(pal) : void 0;
+  };
+  const buildRefMarks = (V, q, vizName) => {
+    const nodes = [...findAll(V, "baseline"), ...findAll(V, "vizBaseline")];
+    const out = [];
+    for (const b of nodes) {
+      if (String(b["@_visible"] ?? b["@_show"] ?? "true").toLowerCase() === "false") continue;
+      const onX = /^(category|categories|x|item|itemaxis)$/i.test(String(b["@_refAxis"] || b["@_axis"] || ""));
+      const axis = onX ? "axis" : "series";
+      let formula = "";
+      const di = b["@_refDataItem"] ? q.items.get(b["@_refDataItem"]) : void 0;
+      if (di) {
+        const { formula: f, warns } = translate(di.expression, q);
+        warns.forEach((w) => warnings.push(`"${vizName}.baseline ${b["@_refDataItem"]}": ${w}`));
+        formula = /^\s*(Sum|Avg|Min|Max|Count|CountDistinct|Median)\s*\(/.test(f) ? f : `Avg(${f})`;
+      } else {
+        const v = b["@_value"] ?? b["@_position"] ?? txt(b.value) ?? txt(b);
+        if (v != null && String(v).trim() !== "" && /^-?[\d.]+$/.test(String(v).trim())) formula = String(v).trim();
+      }
+      if (!formula) {
+        warnings.push(`chart "${vizName}": a reference line / baseline had no static value or data-item measure \u2014 skipped (re-add it in the workbook).`);
+        continue;
+      }
+      const rm = {
+        type: "line",
+        axis,
+        value: { type: "formula", formula },
+        line: { color: String(b["@_color"] || b["@_lineColor"] || "#ef4444"), width: 2 }
+      };
+      const label = b["@_label"] || b["@_text"] || (di ? sigmaDisplayName(di.name) : void 0);
+      if (label) rm.label = { visibility: "shown", text: String(label) };
+      out.push(rm);
+    }
+    return out;
+  };
+  for (const V of findAll(report, "vizControl")) {
+    const vizType = String(V["@_type"] || "").toLowerCase();
+    const vizName = V["@_name"] || "Chart";
+    const dsName = findAll(V, "vcDataSet").map((d) => d["@_refDataStore"]).find(Boolean);
+    const qName = dsName ? dsToQuery.get(dsName) : void 0;
+    const q = qName ? queries.get(qName) : void 0;
+    if (!q) {
+      warnings.push(`<vizControl> "${vizName}" (${vizType}): no resolvable query (dataStore "${dsName}") \u2014 chart skipped.`);
+      continue;
+    }
+    const slot = (id) => {
+      const out = [];
+      for (const sd of findAll(V, "vcSlotData")) {
+        if (String(sd["@_idSlot"] || "").toLowerCase() !== id) continue;
+        for (const c of findAll(sd, "vcSlotDsColumn")) if (c["@_refDsColumn"]) {
+          out.push({ ref: c["@_refDsColumn"], rollup: c["@_rollupMethod"], sort: c["@_dsSort"], format: formatFromNode(c) });
+        }
+      }
+      return out;
+    };
+    const cols = [];
+    const seen = /* @__PURE__ */ new Map();
+    const addCol = (e, measure, categorical = false) => {
+      if (!e) return void 0;
+      const di = q.items.get(e.ref);
+      if (!di) {
+        warnings.push(`chart "${vizName}" column "${e.ref}" not in query "${qName}" \u2014 skipped.`);
+        return void 0;
+      }
+      const nm = sigmaDisplayName(di.name);
+      if (seen.has(nm)) return seen.get(nm);
+      let { formula, warns } = translate(di.expression, q);
+      warns.forEach((w) => warnings.push(`"${vizName}.${e.ref}": ${w}`));
+      if (categorical && !measure && (di.dataType === "1" || di.dataType === "2")) formula = `Text(${formula})`;
+      const id = sigmaShortId();
+      const fn = measure ? ROLLUP_AGG[String(e.rollup || "").toLowerCase()] || "Sum" : "";
+      const col = { id, name: nm, formula: measure ? `${fn}(${formula})` : formula };
+      if (e.format) col.format = e.format;
+      cols.push(col);
+      seen.set(nm, id);
+      return id;
+    };
+    const cats = slot("categories"), series = slot("series"), vals = slot("values");
+    const sizes = slot("size"), xs = slot("x"), ys = slot("y"), colorSlot = slot("color");
+    const kind = VIZ_KIND[vizType];
+    if (isMapViz(vizType)) {
+      const lat = slot("latlonglocations.latitude")[0] || slot("latitude")[0];
+      const lon = slot("latlonglocations.longitude")[0] || slot("longitude")[0];
+      const region = slot("locations")[0] || slot("location")[0];
+      if (lat && lon) {
+        const latId = addCol(lat, false), lonId = addCol(lon, false);
+        const sizeId = addCol(slot("latlongsize")[0] || sizes[0], true);
+        const colorId = addCol(slot("latlongcolor")[0] || colorSlot[0], true);
+        const el2 = { id: sigmaShortId(), kind: "point-map", name: vizName, source: chartSource(q), columns: cols, order: [] };
+        if (latId) el2.latitude = { id: latId };
+        if (lonId) el2.longitude = { id: lonId };
+        if (sizeId) el2.size = { id: sizeId };
+        if (colorId) el2.color = { by: "scale", column: colorId };
+        el2.order = cols.map((c) => c.id);
+        if (!cols.length) {
+          warnings.push(`<vizControl> map "${vizName}" had no resolvable lat/long columns \u2014 skipped.`);
+          continue;
+        }
+        applyQueryFilters(el2, q);
+        pageEls.push(el2);
+      } else if (region) {
+        const regId = addCol(region, false);
+        const colorId = addCol(slot("locationcolor")[0] || colorSlot[0] || slot("locationheight")[0], true);
+        if (!regId) {
+          warnings.push(`<vizControl> map "${vizName}" had no resolvable location column \u2014 skipped.`);
+          continue;
+        }
+        const el2 = { id: sigmaShortId(), kind: "region-map", name: vizName, source: chartSource(q), columns: cols, order: cols.map((c) => c.id), region: { id: regId, regionType: "country" } };
+        if (colorId) el2.color = { by: "scale", column: colorId };
+        warnings.push(`chart "${vizName}" \u2192 region-map: defaulted regionType to "country" \u2014 set it to match your data (country / us-state / us-county / us-zipcode / us-cbsa / us-postal-place / ca-province).`);
+        applyQueryFilters(el2, q);
+        pageEls.push(el2);
+      } else {
+        for (const c of findAll(V, "vcSlotDsColumn")) if (c["@_refDsColumn"]) addCol({ ref: c["@_refDsColumn"], rollup: c["@_rollupMethod"] }, !!c["@_rollupMethod"]);
+        if (!cols.length) {
+          warnings.push(`<vizControl> map "${vizName}" (${vizType}) had no resolvable columns \u2014 skipped.`);
+          continue;
+        }
+        warnings.push(`chart "${vizName}" is a Cognos map (${vizType}) with no lat/long or named-location slot \u2014 emitted its data as a table; add geographic columns + a map in the workbook.`);
+        const fb = { id: sigmaShortId(), kind: "table", name: `${vizName} (was map)`, source: chartSource(q), columns: cols, order: cols.map((c) => c.id) };
+        applyQueryFilters(fb, q);
+        pageEls.push(fb);
+      }
+      continue;
+    }
+    if (!kind) {
+      const label = VIZ_NOANALOG[vizType] || vizType.replace("com.ibm.vis.", "");
+      for (const c of findAll(V, "vcSlotDsColumn")) if (c["@_refDsColumn"]) addCol({ ref: c["@_refDsColumn"], rollup: c["@_rollupMethod"] }, !!c["@_rollupMethod"]);
+      if (!cols.length) {
+        warnings.push(`<vizControl> "${vizName}" (${vizType}) had no resolvable columns \u2014 skipped.`);
+        continue;
+      }
+      warnings.push(`chart "${vizName}" is a Cognos ${label} (${vizType}) \u2014 Sigma has no native equivalent; emitted its data as a table. Re-pick a Sigma chart in the workbook.`);
+      const fb = { id: sigmaShortId(), kind: "table", name: `${vizName} (was ${label})`, source: chartSource(q), columns: cols, order: cols.map((c) => c.id) };
+      applyQueryFilters(fb, q);
+      pageEls.push(fb);
+      continue;
+    }
+    const el = { id: sigmaShortId(), kind, name: vizName, source: chartSource(q), columns: [], order: [] };
+    if (kind === "pie-chart" || kind === "donut-chart") {
+      const colorId = addCol(cats[0] || colorSlot[0], false);
+      const valId = addCol(vals[0] || sizes[0], true);
+      if (colorId) el.color = { id: colorId };
+      if (valId) el.value = { id: valId };
+    } else if (kind === "scatter-chart") {
+      const dimSlot = series[0] || colorSlot[0];
+      const xId = addCol(xs[0] || cats[0], true);
+      const yId = addCol(ys[0] || vals[0] || sizes[0], true);
+      const dId = dimSlot ? addCol(dimSlot, false) : void 0;
+      const szId = sizes[0] && sizes[0] !== (ys[0] || vals[0]) ? addCol(sizes[0], true) : void 0;
+      if (xId && yId && dId) {
+        const grpId = sigmaShortId();
+        const srcName = `${vizName} (scatter source)`;
+        const src = {
+          id: sigmaShortId(),
+          kind: "table",
+          name: srcName,
+          source: chartSource(q),
+          columns: cols,
+          order: cols.map((c) => c.id),
+          groupings: [{ id: grpId, groupBy: [dId], calculations: szId ? [xId, yId, szId] : [xId, yId] }],
+          visibleAsSource: false
+        };
+        applyQueryFilters(src, q);
+        const byId = new Map(cols.map((c) => [c.id, c]));
+        const raw = (srcColId) => {
+          const sc = byId.get(srcColId);
+          return { id: sigmaShortId(), name: sc.name, formula: `[${srcName}/${sc.name}]` };
+        };
+        const sDim = raw(dId), sX = raw(xId), sY = raw(yId);
+        const scols = [sDim, sX, sY];
+        el.source = { kind: "table", elementId: src.id, groupingId: grpId };
+        el.xAxis = { columnId: sX.id };
+        el.yAxis = { columnIds: [sY.id] };
+        el.color = { by: "category", column: sDim.id };
+        if (szId) {
+          const sSz = raw(szId);
+          scols.push(sSz);
+          el.size = { id: sSz.id };
+        }
+        el.columns = scols;
+        el.order = scols.map((c) => c.id);
+        const sRefMarks2 = buildRefMarks(V, q, vizName);
+        if (sRefMarks2.length) el.refMarks = sRefMarks2;
+        pageEls.push(src);
+        pageEls.push(el);
+        continue;
+      }
+      if (xId) el.xAxis = { columnId: xId };
+      if (yId) el.yAxis = { columnIds: [yId] };
+      if (dId) el.color = { by: "category", column: dId };
+      const sRefMarks = buildRefMarks(V, q, vizName);
+      if (sRefMarks.length) el.refMarks = sRefMarks;
+    } else {
+      const xId = addCol(cats[0], false, true);
+      if (xId) {
+        el.xAxis = { columnId: xId };
+        if (cats[0]?.sort) el.xAxis.sort = { by: xId, direction: /desc/i.test(cats[0].sort) ? "descending" : "ascending" };
+      }
+      if (cats.length > 1) {
+        warnings.push(`chart "${vizName}": Cognos used ${cats.length} category levels; Sigma x-axis takes one \u2014 bound the first, kept the rest as columns.`);
+        cats.slice(1).forEach((c) => addCol(c, false, true));
+      }
+      const yIds = [...vals, ...sizes].map((v) => addCol(v, true)).filter(Boolean);
+      if (yIds.length) el.yAxis = { columnIds: yIds };
+      else warnings.push(`chart "${vizName}" (${kind}) resolved no measure for the value axis \u2014 add a measure in the workbook.`);
+      const colorE = colorSlot[0];
+      const colorIsMeasure = !series[0] && !!colorE && !!colorE.rollup && !!q.items.get(colorE.ref);
+      if (colorIsMeasure) {
+        const baseId = addCol(colorE, true);
+        const base = cols.find((c) => c.id === baseId);
+        if (base) {
+          const dupId = sigmaShortId();
+          const dup = { id: dupId, name: `${base.name} (color)`, formula: base.formula };
+          if (base.format) dup.format = base.format;
+          cols.push(dup);
+          el.color = { by: "scale", column: dupId, scheme: schemeFromSignal(vizColorSignal(V)) };
+        }
+      } else {
+        const cId = addCol(series[0] || colorE, false);
+        if (cId) el.color = { by: "category", column: cId };
+      }
+      const refMarks = buildRefMarks(V, q, vizName);
+      if (refMarks.length) el.refMarks = refMarks;
+      if (kind === "bar-chart") {
+        el.stacking = /stacked/.test(vizType) ? "stacked" : "none";
+        if (/\bbar\b/.test(vizType) && !/column/.test(vizType)) el.orientation = "horizontal";
+      }
+      if (kind === "combo-chart" && yIds.length > 1) warnings.push(`chart "${vizName}" \u2192 combo-chart: all measures placed on the primary axis as the same mark \u2014 set per-series shape / secondary axis in the workbook.`);
+    }
+    el.columns = cols;
+    el.order = cols.map((c) => c.id);
+    if (!cols.length) {
+      warnings.push(`<vizControl> "${vizName}" (${vizType}) had no resolvable slot columns \u2014 skipped.`);
+      continue;
+    }
+    applyQueryFilters(el, q);
+    pageEls.push(el);
+  }
+  const controlEls = [...controls.values()];
+  pages.push({ id: sigmaShortId(), name: reportPages[0]?.["@_name"] || "Report", elements: [...controlEls, ...pageEls] });
+  for (const fnode of findAll(report, "summaryFilter")) {
+    const fexpr = txt(fnode.filterExpression || fnode.expression);
+    if (fexpr) warnings.push(`summary filter: "${fexpr.slice(0, 80)}" \u2014 post-aggregation filter; re-create as a Sigma filter on the aggregated column.`);
+  }
+  const stats = {
+    queries: queries.size,
+    tables: pageEls.filter((e) => e.kind === "table").length,
+    pivots: pageEls.filter((e) => e.kind === "pivot-table").length,
+    kpis: pageEls.filter((e) => e.kind === "kpi-chart").length,
+    charts: pageEls.filter((e) => e.kind.endsWith("-chart") && e.kind !== "kpi-chart").length,
+    maps: pageEls.filter((e) => e.kind.endsWith("-map")).length,
+    columns: pageEls.reduce((n, e) => n + (e.columns?.length || 0), 0),
+    filters: pageEls.reduce((n, e) => n + (e.filters?.length || 0), 0),
+    controls: controls.size,
+    refMarks: pageEls.reduce((n, e) => n + (e.refMarks?.length || 0), 0),
+    scaleColors: pageEls.filter((e) => e.color?.by === "scale").length
+  };
+  return {
+    workbook: { name: reportName, schemaVersion: 1, pages, controls: controlEls },
+    warnings,
+    stats
+  };
+}
+
+// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.ts
+function loadLearnedRules() {
+  try {
+    const p = join(homedir(), ".cognos-to-sigma", "learned-rules.json");
+    const rules = JSON.parse(readFileSync(p, "utf8"));
+    const arr3 = Array.isArray(rules) ? rules : rules.rules || [];
+    if (arr3.length) console.error(`[learned-rules] applying ${arr3.length} customer rule(s) from ${p}`);
+    return arr3;
+  } catch {
+    return [];
+  }
+}
+var args = process.argv.slice(2);
+var file = args.find((a) => !a.startsWith("--"));
+var opt = (k, d = "") => {
+  const i = args.indexOf("--" + k);
+  return i >= 0 ? args[i + 1] : d;
+};
+if (!file) {
+  console.error("usage: cli.ts <module.json|report.xml> [--connection X --database DB --schema S --dm ID]");
+  process.exit(1);
+}
+var xml = readFileSync(file, "utf8");
+var isReport = file.endsWith(".xml") || xml.trimStart().startsWith("<");
+var res = isReport ? convertCognosReportToSigma(xml, { dataModelId: opt("dm", "<DM_ID>") }) : convertCognosToSigma(xml, { connectionId: opt("connection", "<CONNECTION_ID>"), database: opt("database"), schema: opt("schema"), learnedRules: loadLearnedRules() });
+var payload = isReport ? res.workbook : res.model;
+process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+console.error(`
+[${isReport ? "report\u2192workbook" : "module\u2192data-model"}] stats: ${JSON.stringify(res.stats)}`);
+var security = res.security;
+if (security?.length) {
+  const out = opt("security-out", "security.json");
+  writeFileSync(out, JSON.stringify(security, null, 2));
+  console.error(`SECURITY: ${security.length} rule(s) detected \u2192 ${out} \u2014 run scripts/apply_sigma_rls.py after posting the model (see SKILL.md "Security").`);
+}
+if (res.warnings.length) {
+  console.error(`warnings (${res.warnings.length}) \u2014 translated where possible, flagged where not:`);
+  res.warnings.forEach((w) => console.error("  ! " + w));
+}

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
@@ -293,25 +293,33 @@ if (opt.resume) {
 // Phase 1 — Convert the Data Module → Sigma DM spec (converter/cli.ts).
 // ---------------------------------------------------------------------------
 hdr(1, 'Convert data module');
-// One-time converter-deps preflight (bead eqom): node_modules existing is NOT
-// enough — the converter shells `node --import tsx/esm`, so require the tsx
-// binary specifically and fail with a clear, actionable error (not a cryptic
-// ERR_MODULE_NOT_FOUND three phases in).
-if (!existsSync(join(CONV, 'node_modules', '.bin', 'tsx'))) {
-  line('converter deps missing — running npm install (once)…');
-  const inst = run('npm', ['install', '--silent'], { cwd: CONV, allowFail: true });
-  if (inst.status !== 0 || !existsSync(join(CONV, 'node_modules', '.bin', 'tsx'))) {
-    die(`converter dependencies could not be installed automatically.\n` +
-        `  Run manually:  cd ${CONV} && npm install\n` +
-        `  (requires Node >= 18 and npm on PATH; the converter runs via tsx)`);
+// Converter resolution — ZERO-config by default. The converter ships as a
+// self-contained ESM bundle (converter/cli.mjs) run by plain `node`: no npm
+// install, no tsx, no network, no MCP. Only if the bundle is absent (a dev
+// editing the TS source) do we fall back to `node --import tsx/esm cli.ts`,
+// installing tsx once. Rebuild the bundle with tools/vendor-converters.sh.
+const cliBundle = join(CONV, 'cli.mjs');
+let cliCmd, cliPre;
+if (existsSync(cliBundle)) {
+  cliCmd = cliBundle; cliPre = [];
+} else {
+  if (!existsSync(join(CONV, 'node_modules', '.bin', 'tsx'))) {
+    line('converter bundle (cli.mjs) missing and tsx deps absent — running npm install (once)…');
+    const inst = run('npm', ['install', '--silent'], { cwd: CONV, allowFail: true });
+    if (inst.status !== 0 || !existsSync(join(CONV, 'node_modules', '.bin', 'tsx'))) {
+      die(`converter bundle missing and dependencies could not be installed.\n` +
+          `  Rebuild the bundle:  tools/vendor-converters.sh  (commits converter/cli.mjs)\n` +
+          `  or run manually:     cd ${CONV} && npm install   (dev tsx fallback)`);
+    }
   }
+  cliCmd = join(CONV, 'cli.ts'); cliPre = ['--import', 'tsx/esm'];
 }
 const modulePath = resolve(opt.module);
 const reportPath = resolve(opt.report);
 const db = opt.database || 'CSA';
 const schema = opt.schema || 'TJ';
 const securityPath = join(WORK, 'security.json');
-const conv = spawnSync('node', ['--import', 'tsx/esm', join(CONV, 'cli.ts'), modulePath,
+const conv = spawnSync('node', [...cliPre, cliCmd, modulePath,
   '--connection', opt.connection, '--database', db, '--schema', schema,
   '--security-out', securityPath],
   { encoding: 'utf8', cwd: CONV, maxBuffer: 64 * 1024 * 1024 });
@@ -465,7 +473,7 @@ if (opt['dry-run']) {
   hdr(3, 'Build data model');
   line(`DRY RUN: DM spec → ${dmPath} (no POST)`);
   hdr(4, 'Convert report');
-  const rconv = spawnSync('node', ['--import', 'tsx/esm', join(CONV, 'cli.ts'), reportPath, '--dm', 'DRY-RUN'],
+  const rconv = spawnSync('node', [...cliPre, cliCmd, reportPath, '--dm', 'DRY-RUN'],
     { encoding: 'utf8', cwd: CONV, maxBuffer: 64 * 1024 * 1024 });
   if (rconv.status !== 0) die(`report converter failed:\n${rconv.stderr}`);
   writeFileSync(join(WORK, 'wb.json'), rconv.stdout);
@@ -504,7 +512,7 @@ writeFileSync(statePath, JSON.stringify(state, null, 2));
 // Phase 4 — Convert the report → workbook spec, remap to the real DM ids.
 // ---------------------------------------------------------------------------
 hdr(4, 'Convert report + remap');
-const rconv = spawnSync('node', ['--import', 'tsx/esm', join(CONV, 'cli.ts'), reportPath, '--dm', dmId],
+const rconv = spawnSync('node', [...cliPre, cliCmd, reportPath, '--dm', dmId],
   { encoding: 'utf8', cwd: CONV, maxBuffer: 64 * 1024 * 1024 });
 if (rconv.status !== 0) die(`report converter failed:\n${rconv.stderr}`);
 const wbSpec = JSON.parse(rconv.stdout);

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -108,11 +108,16 @@ python3 scripts/migrate-looker.py --lookml-dir /path/to/lookml \
   project (Looker only serves raw LookML in the dev workspace); without it the
   command fails loud and tells you to clone the Git repo and use `--lookml-dir`.
   `scripts/looker_project.py` is the standalone helper (`pull` / `connection`).
-- **Converter paths:** `CONVERTER_SRC` (patched `src/lookml.ts` via tsx) or
-  `CONVERTER_PATH` (`build/lookml.js`) — both auto-located; with neither, the
-  command writes `<workdir>/convert-request.json` (the exact
-  `convert_lookml_to_sigma` MCP arguments) and exits 3 — call the tool, save its
-  JSON, re-run with `--converted <file>` (mirrors thoughtspot's exit-3 design).
+- **Converter — zero-config, local, no MCP.** A self-contained converter bundle
+  ships in the skill at `converter/lookml.mjs` and is the default: conversion runs
+  locally via `node` with no clone, no `npm install`, no network, no MCP. A dev's
+  own build still wins when set — `CONVERTER_SRC` (`src/lookml.ts` via tsx) or
+  `CONVERTER_PATH` (`build/lookml.js`), both auto-located. Refresh the vendored
+  bundle with `tools/vendor-converters.sh` (see `converter/PROVENANCE.json`). Only
+  if the bundle is missing AND no build is found does the command fall back to the
+  MCP path: it writes `<workdir>/convert-request.json` (the exact
+  `convert_lookml_to_sigma` arguments) and exits 3 — call the tool, save its JSON,
+  re-run with `--converted <file>`.
 - **Parity is fully scripted** (the Phase-4 gate below): ACTUAL = Sigma CSV
   export per chart; EXPECTED = a Looker inline query (live) or a
   SOURCE-LookML-derived re-aggregation of the master's warehouse rows (offline —

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/converter/PROVENANCE.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/converter/PROVENANCE.json
@@ -1,0 +1,8 @@
+{
+  "source_repo": "twells89/sigma-data-model-mcp",
+  "source_commit": "867c669",
+  "source_commit_date": "2026-06-22",
+  "bundler": "esbuild --bundle --format=esm --platform=node",
+  "vendored_modules": "lookml.mjs",
+  "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/converter/lookml.mjs
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/converter/lookml.mjs
@@ -1,0 +1,2133 @@
+// ../../../Users/tjwells/sigma-data-model-mcp/build/sigma-ids.js
+var SIGMA_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+var _usedIds = /* @__PURE__ */ new Set();
+var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "but",
+  "or",
+  "for",
+  "nor",
+  "so",
+  "yet",
+  "at",
+  "by",
+  "in",
+  "of",
+  "on",
+  "to",
+  "up",
+  "as",
+  "into",
+  "via",
+  "per"
+]);
+function resetIds() {
+  _usedIds.clear();
+}
+function sigmaShortId(len = 10) {
+  let id;
+  do {
+    id = Array.from({ length: len }, () => SIGMA_CHARS[Math.floor(Math.random() * SIGMA_CHARS.length)]).join("");
+  } while (_usedIds.has(id));
+  _usedIds.add(id);
+  return id;
+}
+function sigmaInodeId(identifier) {
+  return `inode-${sigmaShortId(22)}/${identifier.toUpperCase()}`;
+}
+function sigmaDisplayName(s) {
+  const normalized = (s || "").replace(/([a-z])([A-Z])/g, "$1_$2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2").replace(/([A-Za-z])([0-9])/g, "$1_$2").replace(/([0-9])([A-Za-z])/g, "$1_$2");
+  const words = normalized.toLowerCase().split(/[_\s]+/).filter(Boolean);
+  return words.map((w, i) => i === 0 || !SIGMA_LOWERCASE_WORDS.has(w) ? w.charAt(0).toUpperCase() + w.slice(1) : w).join(" ");
+}
+var DATA_MODEL_SCHEMA_SUMMARY = `
+Sigma Data Model JSON top-level structure:
+{
+  "name": "Model Name",
+  "pages": [{ "id": "pageId", "name": "Page 1", "elements": [...] }]
+}
+
+Element types: warehouse-table, custom-sql (kind:"sql"), join, union, control.
+Columns: { "id": "inode-xxx/COL", "formula": "[TABLE/Display Name]" }
+Calculated columns: { "id": "shortId", "formula": "[Price] - [Cost]", "name": "Profit" }
+Metrics: { "id": "shortId", "formula": "Sum([Revenue])", "name": "Total Revenue" }
+Relationships: { "id": "shortId", "targetElementId": "...", "keys": [{ "sourceColumnId": "...", "targetColumnId": "..." }] }
+
+Cross-element Reference (accessing related dimension columns via relationships):
+  [SOURCE_TABLE/REL_NAME/Column Display Name]
+  REL_NAME is the relationship's "name" field (= target table name uppercase by convention).
+  Example: DateDiff("day", [ORDER_FACT/PROMO_DIM/Start Date], [ORDER_FACT/PROMO_DIM/End Date])
+  \u26A0 The dash-link form [SRC/FK_COL - link/Field] does NOT work via the API \u2014 use REL_NAME.
+
+Conditional Aggregate Syntax:
+  CountIf(condition) \u2014 condition only, NO field argument
+  SumIf(field, condition) \u2014 FIELD FIRST, condition second
+  AvgIf/MaxIf/MinIf/CountDistinctIf \u2014 all FIELD FIRST
+  For booleans: always use [Column] = True, never bare [Column]
+
+Groupings (for LOD / different aggregation levels):
+  "groupings": [{ "id": "gId", "groupBy": ["colId1"], "calculations": ["calcId1"] }]
+  Array order = nesting hierarchy. Use child elements for LOD patterns.
+`.trim();
+function _securityElementName(el) {
+  if (el?.name)
+    return el.name;
+  const path = el?.source?.path;
+  return path && path.length ? String(path[path.length - 1]) : void 0;
+}
+function makeRlsSecurity(opts) {
+  const attrs = [...opts.formula.matchAll(/CurrentUserAttributeText\(\s*"([^"]+)"/g)].map((m) => m[1]);
+  const teams = [...opts.formula.matchAll(/CurrentUserInTeam\(\s*"([^"]+)"/g)].map((m) => m[1]);
+  const usesEmail = /\bCurrentUserEmail\(/.test(opts.formula);
+  const provision = [
+    attrs.length ? `provision/assign Sigma user attribute(s): ${[...new Set(attrs)].join(", ")}` : "",
+    teams.length ? `create Sigma team(s) + membership: ${[...new Set(teams)].join(", ")}` : "",
+    usesEmail && !attrs.length && !teams.length ? "uses CurrentUserEmail() \u2014 no provisioning needed" : ""
+  ].filter(Boolean).join("; ");
+  return {
+    kind: "rls",
+    source: opts.source,
+    elementId: opts.element.id,
+    elementName: _securityElementName(opts.element),
+    rls: {
+      name: opts.name,
+      formula: opts.formula,
+      userAttributes: attrs.length ? [...new Set(attrs)] : void 0,
+      teams: teams.length ? [...new Set(teams)] : void 0,
+      usesCurrentUserEmail: usesEmail || void 0
+    },
+    note: `Fail-closed RLS (boolean calc + element filter, only True rows). ${provision || "review"}. The skill provisions then applies \u2014 the converter does NOT inject it.`
+  };
+}
+
+// ../../../Users/tjwells/sigma-data-model-mcp/build/formulas.js
+function lookColRef(identifier) {
+  return `[${sigmaDisplayName(identifier)}]`;
+}
+var UNSUPPORTED_SIGMA_SQL = [
+  { pattern: /\bFLATTEN\s*\(/i, name: "FLATTEN" },
+  { pattern: /\bLATERAL\b/i, name: "LATERAL" },
+  { pattern: /\bQUALIFY\b/i, name: "QUALIFY" },
+  { pattern: /\bPIVOT\s*\(/i, name: "PIVOT" },
+  { pattern: /\bUNPIVOT\s*\(/i, name: "UNPIVOT" },
+  { pattern: /\bGENERATOR\s*\(/i, name: "GENERATOR" },
+  { pattern: /\bTABLESAMPLE\b/i, name: "TABLESAMPLE" },
+  { pattern: /\bOBJECT_CONSTRUCT\s*\(/i, name: "OBJECT_CONSTRUCT" },
+  { pattern: /\bARRAY_CONSTRUCT\s*\(/i, name: "ARRAY_CONSTRUCT" }
+];
+function detectUnsupportedSigmaFunction(formula) {
+  for (const { pattern, name } of UNSUPPORTED_SIGMA_SQL) {
+    if (pattern.test(formula))
+      return name;
+  }
+  return null;
+}
+function lookIsComplexSql(sql) {
+  if (!sql)
+    return false;
+  const cleaned = sql.replace(/\$\{TABLE\}\./gi, "").replace(/\$\{[^}]+\}/g, "X").trim();
+  if (/^(?:CAST|SAFE_CAST|TRY_CAST)\s*\(\s*"?[A-Za-z_][A-Za-z0-9_]*"?\s+AS\s+\w[\w_]*\s*\)$/i.test(cleaned))
+    return false;
+  if (/^[A-Za-z_][A-Za-z0-9_]*\s*\(/.test(cleaned))
+    return true;
+  if (/^CASE\b/i.test(cleaned))
+    return true;
+  if (/\bIN\s*\(/i.test(cleaned))
+    return true;
+  if (cleaned.includes("||"))
+    return true;
+  if (/[=<>!+\-*\/%]/.test(cleaned.replace(/'[^']*'/g, "")))
+    return true;
+  return false;
+}
+var LOOK_FUNC_MAP = {
+  "MONTH": "Month",
+  "YEAR": "Year",
+  "DAY": "Day",
+  "HOUR": "Hour",
+  "MINUTE": "Minute",
+  "SECOND": "Second",
+  "QUARTER": "Quarter",
+  "WEEK": "WeekOfYear",
+  "WEEKDAY": "Weekday",
+  "DATE_TRUNC": "DateTrunc",
+  "DATEADD": "DateAdd",
+  "DATEDIFF": "DateDiff",
+  "COALESCE": "Coalesce",
+  "NVL": "Coalesce",
+  "NULLIF": "Nullif",
+  "ROUND": "Round",
+  "FLOOR": "Floor",
+  "CEILING": "Ceiling",
+  "ABS": "Abs",
+  "UPPER": "Upper",
+  "LOWER": "Lower",
+  "TRIM": "Trim",
+  "LENGTH": "Length",
+  "SUBSTR": "Substring",
+  "SUBSTRING": "Substring",
+  "CONCAT": "Concat",
+  "CURRENT_DATE": "Today()",
+  "GETDATE": "Now()",
+  "IFF": "If",
+  "IIF": "If",
+  "DECODE": "Switch",
+  "ISNULL": "IsNull",
+  "IFNULL": "Coalesce",
+  "TO_DATE": "ToDate",
+  "TO_NUMBER": "ToNumber",
+  "TO_VARCHAR": "Text"
+};
+function lookConvertCase(expr) {
+  const body = expr.replace(/^CASE\s*/i, "").replace(/\s*END\s*$/i, "").trim();
+  const branches = [];
+  const parts = body.split(/\bWHEN\b/i).filter(Boolean);
+  let elseVal = null;
+  for (const part of parts) {
+    const elseMatch = part.match(/^([\s\S]+?)\s+THEN\s+([\s\S]+?)(?:\s+ELSE\s+([\s\S]+))?$/i);
+    if (!elseMatch) {
+      const e = part.match(/\bELSE\s+([\s\S]+)$/i);
+      if (e && !elseVal)
+        elseVal = e[1].trim();
+      continue;
+    }
+    const cond = elseMatch[1].trim();
+    let val = elseMatch[2].trim();
+    const elseInVal = val.match(/^([\s\S]+?)\s+ELSE\s+([\s\S]+)$/i);
+    if (elseInVal) {
+      val = elseInVal[1].trim();
+      if (!elseVal)
+        elseVal = elseInVal[2].trim();
+    }
+    branches.push({ cond, val });
+  }
+  const topElse = body.match(/\bELSE\s+([\s\S]+)$/i);
+  if (topElse && !elseVal)
+    elseVal = topElse[1].trim();
+  if (branches.length === 0)
+    return null;
+  const convertVal = (v) => {
+    v = v.trim();
+    if (/^'[^']*'$/.test(v))
+      return v;
+    if (/^-?\d+(\.\d+)?$/.test(v))
+      return v;
+    return lookConvertExpression(v);
+  };
+  let result = elseVal ? convertVal(elseVal) : "null";
+  for (let i = branches.length - 1; i >= 0; i--) {
+    const sigmaCond = lookConvertExpression(branches[i].cond);
+    const sigmaVal = convertVal(branches[i].val);
+    result = `If(${sigmaCond}, ${sigmaVal}, ${result})`;
+  }
+  return result;
+}
+function lookConvertMathExpr(expr) {
+  expr = expr.replace(/NULLIF\s*\(([A-Z_][A-Z0-9_]*)\s*,\s*([^)]+)\)/gi, (_, col, val) => `If(${lookColRef(col)} = ${val.trim()}, null, ${lookColRef(col)})`);
+  return lookConvertExpression(expr);
+}
+function lookConvertExpression(expr) {
+  expr = expr.replace(/\b([A-Z_][A-Z0-9_]*)\s*(?=\()/gi, (match, fn) => {
+    const upper = fn.toUpperCase();
+    return LOOK_FUNC_MAP[upper] || fn.charAt(0).toUpperCase() + fn.slice(1).toLowerCase();
+  });
+  expr = expr.replace(/(\[[^\]]+\]|[\w\]\)]+(?:\([^)]*\))?)\s+IN\s*\(([^)]+)\)/gi, (_, lhs, list) => {
+    return `In(${lhs}, ${list})`;
+  });
+  expr = expr.replace(/\b([A-Z_][A-Z0-9_]*)\b(?!\s*\()/g, (match) => {
+    if (/^(AND|OR|NOT|NULL|IS|IN|BETWEEN|LIKE|THEN|ELSE|END|WHEN|CASE|TRUE|FALSE)$/i.test(match))
+      return match;
+    if (/^\d+$/.test(match))
+      return match;
+    return lookColRef(match);
+  });
+  return expr.trim();
+}
+function lookSqlToSigmaRules(sql) {
+  let expr = sql.replace(/\$\{TABLE\}\./gi, "").replace(/\$\{[^.}]+\.([^}]+)\}/g, (_, f) => f.toUpperCase()).replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, n) => n.toUpperCase()).replace(/[\r\n]+\s*/g, " ").trim();
+  {
+    const m = expr.match(/^([A-Z_][A-Z0-9_]*)\s*=\s*(\d+)$/i);
+    if (m)
+      return `${lookColRef(m[1])} = ${m[2]}`;
+  }
+  {
+    const m = expr.match(/^([A-Z_][A-Z0-9_]*)\s+IN\s*\(([^)]+)\)$/i);
+    if (m) {
+      const col = lookColRef(m[1]);
+      const vals = m[2].split(",").map((v) => {
+        v = v.trim();
+        if (/^'[^']*'$/.test(v))
+          return `"${v.slice(1, -1)}"`;
+        return v;
+      });
+      return `In(${col}, ${vals.join(", ")})`;
+    }
+  }
+  {
+    const m = expr.match(/^(\[[^\]]+\])\s*(>=|<=|!=|<>|>|<|=)\s*(-?\d+(?:\.\d+)?)$/i);
+    if (m)
+      return `${m[1]} ${m[2] === "<>" ? "!=" : m[2]} ${m[3]}`;
+  }
+  {
+    const m = expr.match(/^(\[[^\]]+\])\s+IN\s*\(([^)]+)\)$/i);
+    if (m) {
+      const vals = m[2].split(",").map((v) => {
+        v = v.trim();
+        if (/^'[^']*'$/.test(v))
+          return `"${v.slice(1, -1)}"`;
+        return v;
+      });
+      return `In(${m[1]}, ${vals.join(", ")})`;
+    }
+  }
+  if (/^ROUND\s*\(/i.test(expr)) {
+    const inner = expr.replace(/^ROUND\s*\(/i, "").replace(/\)\s*$/, "");
+    const lastComma = inner.lastIndexOf(",");
+    if (lastComma >= 0) {
+      const mathExpr = inner.slice(0, lastComma).trim();
+      const decimals = inner.slice(lastComma + 1).trim();
+      const converted = lookConvertMathExpr(mathExpr);
+      return `Round(${converted}, ${decimals})`;
+    }
+  }
+  {
+    const m = expr.match(/^DATEDIFF\s*\(\s*'([^']+)'\s*,\s*([A-Z_][A-Z0-9_]*)\s*,\s*([A-Z_][A-Z0-9_]*)\s*\)$/i);
+    if (m)
+      return `DateDiff("${m[1]}", ${lookColRef(m[2])}, ${lookColRef(m[3])})`;
+  }
+  if (/^CASE\b/i.test(expr)) {
+    return lookConvertCase(expr);
+  }
+  if (/^[A-Z_][A-Z0-9_]*\s*[+\-*\/]/.test(expr) || /NULLIF/i.test(expr)) {
+    return lookConvertMathExpr(expr);
+  }
+  if (expr.includes("||")) {
+    const parts = expr.split("||").map((p) => {
+      p = p.trim();
+      if (/^'[^']*'$/.test(p))
+        return `"${p.slice(1, -1)}"`;
+      if (/^\[[^\]]+\]$/.test(p))
+        return `Text(${p})`;
+      if (/^[A-Z_][A-Z0-9_]*$/i.test(p))
+        return `Text(${lookColRef(p)})`;
+      return null;
+    });
+    if (parts.length > 1 && parts.every((p) => p !== null))
+      return `Concat(${parts.join(", ")})`;
+  }
+  return null;
+}
+var _TC_COL = "(\\[[^\\]]+\\]|[A-Za-z_][A-Za-z0-9_]*)";
+var _TC_AGG = "(SUM|AVG|MIN|MAX|COUNT|COUNTD|MEDIAN|STDEV|VAR)";
+var _TC_AGG_EXPR = `${_TC_AGG}\\s*\\(\\s*${_TC_COL}\\s*\\)`;
+function lookStripSql(sql) {
+  if (!sql)
+    return "";
+  sql = sql.replace(/\$\{TABLE\}\./gi, "").trim();
+  sql = sql.replace(/\$\{[^.}]+\.([^}]+)\}/g, "$1");
+  sql = sql.replace(/`/g, "");
+  sql = sql.replace(/\[([A-Za-z_][A-Za-z0-9_\s]*)\]/g, "$1");
+  sql = sql.replace(/::\w[\w_]*/g, "");
+  const castMatch = sql.match(/^(?:SAFE_CAST|TRY_CAST|CAST)\s*\(\s*("?[A-Za-z_][A-Za-z0-9_]*"?)\s+AS\s+\w[\w_]*\s*\)$/i);
+  if (castMatch)
+    sql = castMatch[1];
+  sql = sql.replace(/"/g, "").trim();
+  const m = sql.match(/^([A-Za-z_][A-Za-z0-9_]*)/);
+  return m ? m[1] : sql;
+}
+function lookSigmaMetric(measureType, colName) {
+  const dn = sigmaDisplayName(colName);
+  const map = {
+    sum: `Sum([${dn}])`,
+    count: `CountIf(IsNotNull([${dn}]))`,
+    count_distinct: `CountDistinct([${dn}])`,
+    average: `Avg([${dn}])`,
+    max: `Max([${dn}])`,
+    min: `Min([${dn}])`,
+    list: `ListAgg([${dn}])`,
+    sum_distinct: `Sum(Distinct [${dn}])`,
+    average_distinct: `Avg(Distinct [${dn}])`,
+    median: `Median([${dn}])`,
+    number: `[${dn}]`,
+    yesno: `CountIf([${dn}])`
+  };
+  return map[(measureType || "").toLowerCase()] || `CountIf(IsNotNull([${dn}]))`;
+}
+
+// ../../../Users/tjwells/sigma-data-model-mcp/build/lookml.js
+function lookmlNamedFormat(name) {
+  const n = name.trim().toLowerCase();
+  const CUR = { usd: "$", gbp: "\xA3", eur: "\u20AC", cad: "$", aud: "$" };
+  let m = n.match(/^(usd|gbp|eur|cad|aud)(?:_(\d+))?$/);
+  if (m) {
+    const sym = CUR[m[1]];
+    const dec = m[2] != null ? Number(m[2]) : 2;
+    return { kind: "number", formatString: `${sym},.${dec}f`, currencySymbol: sym };
+  }
+  m = n.match(/^percent(?:_(\d+))?$/);
+  if (m) {
+    const dec = m[1] != null ? Number(m[1]) : 0;
+    return { kind: "number", formatString: `,.${dec}%` };
+  }
+  m = n.match(/^decimal(?:_(\d+))?$/);
+  if (m) {
+    const dec = m[1] != null ? Number(m[1]) : 0;
+    return { kind: "number", formatString: `,.${dec}f` };
+  }
+  if (n === "id")
+    return { kind: "number", formatString: ",.0f" };
+  return null;
+}
+function lookmlCustomFormat(mask) {
+  if (typeof mask !== "string")
+    return null;
+  const raw = mask.trim();
+  if (!raw)
+    return null;
+  if (/general|date|time|@|yyyy|mmm|\bdd\b/i.test(raw))
+    return null;
+  const decM = raw.match(/\.([0#]+)/);
+  const decimals = decM ? decM[1].length : 0;
+  const isPercent = /%/.test(raw);
+  const curM = raw.match(/[$£€¥]/);
+  const sufM = raw.match(/\\?["']\s*([KMB])\s*\\?["']/i);
+  const suffix = sufM ? sufM[1].toUpperCase() : void 0;
+  const SYM = { "$": "$", "\xA3": "\xA3", "\u20AC": "\u20AC", "\xA5": "\xA5" };
+  if (isPercent) {
+    const fmt = { kind: "number", formatString: `,.${decimals}%` };
+    if (suffix)
+      fmt.suffix = suffix;
+    return fmt;
+  }
+  if (curM) {
+    const sym = SYM[curM[0]] || "$";
+    const fmt = { kind: "number", formatString: `${sym},.${decimals}f`, currencySymbol: sym };
+    if (suffix)
+      fmt.suffix = suffix;
+    return fmt;
+  }
+  if (/[0#]/.test(raw)) {
+    const fmt = { kind: "number", formatString: `,.${decimals}f` };
+    if (suffix)
+      fmt.suffix = suffix;
+    return fmt;
+  }
+  return null;
+}
+function snowflakeNumericMaskFormat(mask) {
+  if (typeof mask !== "string")
+    return null;
+  const m = mask.trim().replace(/^FM/i, "");
+  if (!m || !/^[\s$£€¥90,.]+$/.test(m))
+    return null;
+  const decM = m.match(/\.([90]+)/);
+  const decimals = decM ? decM[1].length : 0;
+  const curM = m.match(/[$£€¥]/);
+  const sep = m.includes(",") ? "," : "";
+  if (curM)
+    return { kind: "number", formatString: `${curM[0]}${sep}.${decimals}f`, currencySymbol: curM[0] };
+  if (/[90]/.test(m))
+    return { kind: "number", formatString: `${sep}.${decimals}f` };
+  return null;
+}
+function lookmlFieldFormat(field, warnings) {
+  if (!field || typeof field !== "object")
+    return void 0;
+  const named = field.value_format_name;
+  if (typeof named === "string" && named.trim()) {
+    const f = lookmlNamedFormat(named);
+    if (f)
+      return f;
+    warnings.push(`\u26A0 "${field._name}": value_format_name "${named}" has no Sigma mapping \u2014 set the column format manually.`);
+    return void 0;
+  }
+  const custom = field.value_format;
+  if (typeof custom === "string" && custom.trim()) {
+    const f = lookmlCustomFormat(custom);
+    if (f)
+      return f;
+    warnings.push(`\u26A0 "${field._name}": value_format "${custom}" could not be translated \u2014 set the column format manually.`);
+    return void 0;
+  }
+  return void 0;
+}
+function restoreSqlPlaceholders(obj, map) {
+  if (!obj || typeof obj !== "object")
+    return;
+  for (const key of Object.keys(obj)) {
+    const v = obj[key];
+    if (typeof v === "string" && map[v] !== void 0) {
+      obj[key] = map[v];
+    } else if (typeof v === "object") {
+      restoreSqlPlaceholders(v, map);
+    }
+  }
+}
+function parseLookML(text) {
+  text = (() => {
+    let out = "";
+    let inStr = false;
+    for (let i = 0; i < text.length; i++) {
+      const ch = text[i];
+      if (inStr) {
+        out += ch;
+        if (ch === "\\" && i + 1 < text.length) {
+          out += text[++i];
+          continue;
+        }
+        if (ch === '"')
+          inStr = false;
+        continue;
+      }
+      if (ch === '"') {
+        inStr = true;
+        out += ch;
+        continue;
+      }
+      if (ch === "#") {
+        while (i < text.length && text[i] !== "\n")
+          i++;
+        if (i < text.length)
+          out += "\n";
+        continue;
+      }
+      out += ch;
+    }
+    return out;
+  })();
+  const sqlPlaceholders = {};
+  let phIdx = 0;
+  text = text.replace(/\b(sql_trigger_value|sql_table_name|sql_where|sql_start|sql_end|sql_on|html|sql)\s*:([\s\S]*?);;/g, (match, keyName, sqlContent) => {
+    const key = `__SQLPH${phIdx++}__`;
+    sqlPlaceholders[key] = sqlContent.trim();
+    return `${keyName}: "${key}" ;;`;
+  });
+  const tokens = [];
+  const re = /;;;?|\$\{[^}]*\}|[\[\]{}]|"(?:[^"\\]|\\.)*"|[^\s\[\]{}:;,"]+|:/g;
+  let m;
+  while ((m = re.exec(text)) !== null)
+    tokens.push(m[0]);
+  let pos = 0;
+  const peek = (n) => tokens[pos + (n || 0)];
+  const consume = () => tokens[pos++];
+  const NAMED_BLOCK_KEYS = /* @__PURE__ */ new Set([
+    "dimension",
+    "measure",
+    "dimension_group",
+    "filter",
+    "parameter",
+    "join",
+    "set",
+    "link",
+    "action",
+    "form_param",
+    "option",
+    // Native Derived Table (NDT): `explore_source: <explore> { column ... }`
+    "explore_source",
+    "column",
+    "derived_column"
+  ]);
+  const SQL_KEYS = /* @__PURE__ */ new Set([
+    "sql",
+    "sql_on",
+    "sql_where",
+    "sql_table_name",
+    "sql_trigger_value",
+    "html",
+    "label_from_parameter",
+    "sql_start",
+    "sql_end"
+  ]);
+  function parseBlock() {
+    const obj = {};
+    while (pos < tokens.length) {
+      const t = peek();
+      if (t === "}") {
+        consume();
+        break;
+      }
+      if (t === void 0)
+        break;
+      const key = consume();
+      if (peek() !== ":")
+        continue;
+      consume();
+      const a0 = peek();
+      const a1 = peek(1);
+      if (SQL_KEYS.has(key)) {
+        const parts = [];
+        while (pos < tokens.length && peek() !== ";;" && peek() !== ";;;" && peek() !== "}") {
+          parts.push(consume());
+        }
+        if (peek() === ";;" || peek() === ";;;")
+          consume();
+        let val = parts.join(" ").trim();
+        if (val.startsWith('"') && val.endsWith('"'))
+          val = val.slice(1, -1);
+        obj[key] = val;
+      } else if (NAMED_BLOCK_KEYS.has(key) && a0 && a0 !== "{" && a1 === "{") {
+        const name = consume().replace(/"/g, "");
+        consume();
+        const child = parseBlock();
+        child._name = name;
+        if (obj[key] !== void 0) {
+          if (!Array.isArray(obj[key]))
+            obj[key] = [obj[key]];
+          obj[key].push(child);
+        } else {
+          obj[key] = [child];
+        }
+      } else if (a0 === "{") {
+        consume();
+        const child = parseBlock();
+        if (obj[key] !== void 0) {
+          if (!Array.isArray(obj[key]))
+            obj[key] = [obj[key]];
+          obj[key].push(child);
+        } else {
+          obj[key] = child;
+        }
+      } else if (a0 === ";;" || a0 === ";;;") {
+        consume();
+        obj[key] = "";
+      } else if (a0 === "[") {
+        consume();
+        const items = [];
+        while (pos < tokens.length && peek() !== "]") {
+          const t1 = consume();
+          if (t1 === void 0)
+            break;
+          if (peek() === ":") {
+            consume();
+            let val = consume() || "";
+            if (val.startsWith('"') && val.endsWith('"'))
+              val = val.slice(1, -1);
+            items.push({ field: t1.replace(/"/g, ""), value: val });
+          } else {
+            let val = t1;
+            if (val.startsWith('"') && val.endsWith('"'))
+              val = val.slice(1, -1);
+            items.push(val);
+          }
+        }
+        if (peek() === "]")
+          consume();
+        if (peek() === ";;" || peek() === ";;;")
+          consume();
+        obj[key] = items;
+      } else {
+        let val = consume() || "";
+        if (val.startsWith('"') && val.endsWith('"'))
+          val = val.slice(1, -1);
+        if (peek() === ";;" || peek() === ";;;")
+          consume();
+        obj[key] = val;
+      }
+    }
+    return obj;
+  }
+  const result = { views: [], explores: [], connection: null, label: null, includes: [] };
+  while (pos < tokens.length) {
+    const keyword = consume();
+    if (!keyword)
+      continue;
+    if ((keyword === "view" || keyword === "explore") && peek() === ":") {
+      consume();
+      const name = (consume() || "").replace(/"/g, "");
+      if (peek() === "{") {
+        consume();
+        const block = parseBlock();
+        block._name = name;
+        result[keyword + "s"].push(block);
+      }
+    } else if (keyword === "connection" && peek() === ":") {
+      consume();
+      result.connection = (consume() || "").replace(/"/g, "");
+    } else if (keyword === "label" && peek() === ":") {
+      consume();
+      result.label = (consume() || "").replace(/"/g, "");
+    } else if (keyword === "include" && peek() === ":") {
+      consume();
+      result.includes.push((consume() || "").replace(/"/g, ""));
+    } else if (peek() === ":") {
+      consume();
+      if (peek() === "{") {
+        consume();
+        parseBlock();
+      } else {
+        consume();
+        if (peek() === ";;" || peek() === ";;;")
+          consume();
+      }
+    }
+  }
+  restoreSqlPlaceholders(result, sqlPlaceholders);
+  return result;
+}
+var PDT_SQL_PREFIX = "__PDT_SQL__:";
+function buildSqlTableNameMap(views) {
+  const map = {};
+  for (const [name, view] of Object.entries(views)) {
+    if (!view)
+      continue;
+    if (view.derived_table) {
+      const sql = (view.derived_table.sql || "").replace(/;;\s*$/, "").trim();
+      map[name] = PDT_SQL_PREFIX + sql;
+    } else if (view.sql_table_name) {
+      map[name] = view.sql_table_name.trim();
+    }
+  }
+  let changed = true;
+  for (let i = 0; i < 20 && changed; i++) {
+    changed = false;
+    for (const name of Object.keys(map)) {
+      const val = map[name];
+      if (!val.includes("${"))
+        continue;
+      const next = val.replace(/\$\{(\w+)\.SQL_TABLE_NAME\}/gi, (_m, ref) => {
+        const refVal = map[ref];
+        if (refVal !== void 0 && !refVal.includes("${") && !refVal.startsWith(PDT_SQL_PREFIX))
+          return refVal;
+        return _m;
+      });
+      if (next !== val) {
+        map[name] = next;
+        changed = true;
+      }
+    }
+  }
+  return map;
+}
+function splitLeadingSqlComments(sql) {
+  const m = sql.match(/^(?:\s*--[^\n]*\n|\s+)*/);
+  const head = m ? m[0] : "";
+  return { head, rest: sql.slice(head.length) };
+}
+function isCteFragment(sql) {
+  return splitLeadingSqlComments(sql).rest.startsWith(",");
+}
+function resolveSqlTableNameRefs(sql, map, warnings, contextViewName) {
+  const ctes = [];
+  const cteOk = /* @__PURE__ */ new Set();
+  const cteSeen = /* @__PURE__ */ new Set();
+  const warnedOnce = /* @__PURE__ */ new Set();
+  const stack = /* @__PURE__ */ new Set();
+  const scratchTable = (ref) => `LOOKER_SCRATCH.${String(ref).toUpperCase()}`;
+  const placeholder = (ref) => `${scratchTable(ref)} /* unresolved Looker view: ${ref} */`;
+  function resolveBody(body2) {
+    return body2.replace(/\$\{(\w+)\.SQL_TABLE_NAME\}/gi, (_m, ref) => {
+      const val = map[ref];
+      if (val === void 0) {
+        if (!warnedOnce.has(ref)) {
+          warnedOnce.add(ref);
+          warnings.push(`\u{1F536} UNRESOLVED VIEW "${ref}": view "${contextViewName}" references \${${ref}.SQL_TABLE_NAME} but "${ref}" is not in the provided files. Emitted placeholder table ${scratchTable(ref)} \u2014 this SQL will NOT run until you either (a) re-run the conversion with ${ref}.view.lkml included so its SQL is inlined as a CTE, or (b) replace the placeholder with the real warehouse table behind that view (its Looker scratch-schema PDT or underlying source table).`);
+        }
+        return placeholder(ref);
+      }
+      if (val.startsWith(PDT_SQL_PREFIX)) {
+        if (stack.has(ref)) {
+          if (!warnedOnce.has(ref)) {
+            warnedOnce.add(ref);
+            warnings.push(`\u26A0 View "${contextViewName}": circular \${${ref}.SQL_TABLE_NAME} reference chain \u2014 emitted placeholder table ${scratchTable(ref)}; break the cycle manually (this is the pattern Looker customers inline as CTEs).`);
+          }
+          return placeholder(ref);
+        }
+        if (!cteSeen.has(ref)) {
+          cteSeen.add(ref);
+          stack.add(ref);
+          let depSql = val.slice(PDT_SQL_PREFIX.length);
+          depSql = resolveBody(depSql);
+          stack.delete(ref);
+          if (isCteFragment(depSql)) {
+            warnings.push(`\u{1F536} View "${contextViewName}": \${${ref}.SQL_TABLE_NAME} resolves to a derived table whose SQL is itself a CTE-continuation fragment (starts with ", <name> AS ("), so it cannot be wrapped in a CTE. Emitted placeholder table ${scratchTable(ref)} \u2014 include that view's own upstream view files, or replace the placeholder manually.`);
+          } else {
+            ctes.push({ name: ref, sql: depSql });
+            cteOk.add(ref);
+          }
+        }
+        return cteOk.has(ref) ? ref : placeholder(ref);
+      }
+      if (val.includes("${")) {
+        if (!warnedOnce.has(ref)) {
+          warnedOnce.add(ref);
+          warnings.push(`\u{1F536} View "${contextViewName}": \${${ref}.SQL_TABLE_NAME} could not be fully resolved (missing link in the reference chain) \u2014 emitted placeholder table ${scratchTable(ref)}. Provide the missing view file(s) and re-run.`);
+        }
+        return placeholder(ref);
+      }
+      return val;
+    });
+  }
+  let body = resolveBody(sql);
+  if (ctes.length) {
+    const prelude = "WITH " + ctes.map((c) => `${c.name} AS (
+${c.sql}
+)`).join(",\n");
+    const { head, rest } = splitLeadingSqlComments(body);
+    if (rest.startsWith(",")) {
+      body = head + prelude + "\n" + rest;
+      warnings.push(`\u2139 View "${contextViewName}": inlined ${ctes.length} referenced derived view(s) as CTE(s) \u2014 ${ctes.map((c) => c.name).join(", ")} \u2014 completing the view's CTE-continuation fragment.`);
+    } else if (/^WITH\b/i.test(rest)) {
+      body = head + prelude + ",\n" + rest.replace(/^WITH\b\s*/i, "");
+      warnings.push(`\u2139 View "${contextViewName}": inlined ${ctes.length} referenced derived view(s) as CTE(s) \u2014 ${ctes.map((c) => c.name).join(", ")} \u2014 merged into the view's existing WITH clause.`);
+    } else {
+      body = head + prelude + "\n" + rest;
+      warnings.push(`\u2139 View "${contextViewName}": inlined ${ctes.length} referenced derived view(s) as CTE(s) \u2014 ${ctes.map((c) => c.name).join(", ")}.`);
+    }
+  }
+  return body;
+}
+function lookExtractPath(view, sqlTableNameMap) {
+  let raw = (view.sql_table_name || view.from || "").trim().replace(/`/g, "");
+  if (!raw)
+    return [];
+  if (sqlTableNameMap && raw.includes("${")) {
+    raw = raw.replace(/\$\{(\w+)\.SQL_TABLE_NAME\}/gi, (_m, ref) => {
+      const val = sqlTableNameMap[ref];
+      if (val && !val.startsWith(PDT_SQL_PREFIX) && !val.includes("${"))
+        return val;
+      return _m;
+    });
+  }
+  if (raw.includes("${"))
+    return [];
+  return raw.split(".").map((p) => p.trim().toUpperCase()).filter(Boolean);
+}
+function lookFindColId(elementResult, colName) {
+  if (!elementResult)
+    return null;
+  const upper = (colName || "").toUpperCase();
+  return elementResult.colIdMap[upper] || null;
+}
+function lookParseFilterExpr(expr, columnId) {
+  expr = (expr || "").trim();
+  if (/^NULL$/i.test(expr))
+    return { id: sigmaShortId(), columnId, kind: "list", mode: "include", values: [null] };
+  if (/^NOT\s+NULL$/i.test(expr))
+    return { id: sigmaShortId(), columnId, kind: "list", mode: "exclude", values: [null] };
+  if (/^\d+\s+(second|minute|hour|day|week|month|quarter|year)s?$/i.test(expr))
+    return null;
+  if (/^(this|last|next|current)\s+/i.test(expr))
+    return null;
+  if (/^\d{4}[\/\-]\d{2}/.test(expr))
+    return null;
+  if (/^[><!]=?/.test(expr))
+    return null;
+  if (/^[\[(]/.test(expr))
+    return null;
+  if (expr.startsWith("-")) {
+    const vals2 = expr.slice(1).split(/\s*,\s*-?\s*/).map((v) => v.replace(/^"|"$/g, "").trim()).filter(Boolean);
+    return { id: sigmaShortId(), columnId, kind: "list", mode: "exclude", values: vals2 };
+  }
+  const vals = expr.split(",").map((v) => v.replace(/^"|"$/g, "").trim()).filter(Boolean);
+  if (vals.length > 0)
+    return { id: sigmaShortId(), columnId, kind: "list", mode: "include", values: vals };
+  return null;
+}
+function resolveNdtToSql(ndtViewName, explSource, ctx, warnings) {
+  const exploreName = explSource._name || "";
+  const explore = ctx.explores[exploreName];
+  if (!explore) {
+    warnings.push(`\u26A0 View "${ndtViewName}" is a Native Derived Table on explore "${exploreName}", which was not found in the provided files. Rebuild it as a Sigma data element (aggregate the source element) after import.`);
+    return { sql: "", resolved: false };
+  }
+  const baseViewName = explore.from || exploreName;
+  const baseView = ctx.views[baseViewName];
+  if (!baseView || baseView.derived_table) {
+    warnings.push(`\u26A0 View "${ndtViewName}" (NDT on explore "${exploreName}"): base view "${baseViewName}" is not a simple warehouse table \u2014 cannot auto-generate SQL. Rebuild as a Sigma data element after import.`);
+    return { sql: "", resolved: false };
+  }
+  const basePath = lookExtractPath(baseView);
+  if (!basePath.length) {
+    warnings.push(`\u26A0 View "${ndtViewName}" (NDT on explore "${exploreName}"): could not resolve base table for view "${baseViewName}". Rebuild as a Sigma data element after import.`);
+    return { sql: "", resolved: false };
+  }
+  const fromTable = basePath.join(".");
+  const dimMap = /* @__PURE__ */ new Map();
+  const dims = baseView.dimension ? Array.isArray(baseView.dimension) ? baseView.dimension : [baseView.dimension] : [];
+  for (const d of dims) {
+    if (!d._name || !d.sql)
+      continue;
+    const expr = d.sql.replace(/\$\{TABLE\}\s*\.\s*/gi, "").replace(/;;\s*$/, "").trim();
+    if (/\$\{/.test(expr))
+      continue;
+    dimMap.set(d._name.toLowerCase(), expr);
+  }
+  const measureMap = /* @__PURE__ */ new Map();
+  const measures = baseView.measure ? Array.isArray(baseView.measure) ? baseView.measure : [baseView.measure] : [];
+  for (const ms of measures) {
+    if (!ms._name)
+      continue;
+    const t = (ms.type || "").toLowerCase();
+    const aggFn = { sum: "SUM", average: "AVG", avg: "AVG", min: "MIN", max: "MAX", count: "COUNT", count_distinct: "COUNT", median: "MEDIAN" };
+    if (!aggFn[t])
+      continue;
+    let col = "*";
+    if (ms.sql) {
+      const e = ms.sql.replace(/\$\{TABLE\}\s*\.\s*/gi, "").replace(/;;\s*$/, "").trim();
+      if (/\$\{(\w+)\}/.test(e)) {
+        const refName = e.match(/\$\{(\w+)\}/)[1].toLowerCase();
+        col = dimMap.get(refName) || "*";
+        if (col === "*")
+          continue;
+      } else
+        col = e;
+    } else if (t !== "count")
+      continue;
+    const distinct = t === "count_distinct" ? "DISTINCT " : "";
+    measureMap.set(ms._name.toLowerCase(), { agg: aggFn[t], col: distinct + col });
+  }
+  const cols = explSource.column ? Array.isArray(explSource.column) ? explSource.column : [explSource.column] : [];
+  const selectParts = [];
+  const groupByExprs = [];
+  let hasMeasure = false;
+  let unresolved = false;
+  for (const c of cols) {
+    const outName = c._name || "";
+    const fieldRef = (c.field || c._name || "").trim();
+    const fieldName = (fieldRef.includes(".") ? fieldRef.split(".").pop() : fieldRef).toLowerCase();
+    const alias = outName ? ` AS "${outName.toUpperCase()}"` : "";
+    if (measureMap.has(fieldName)) {
+      const m = measureMap.get(fieldName);
+      selectParts.push(`${m.agg}(${m.col})${alias}`);
+      hasMeasure = true;
+    } else if (dimMap.has(fieldName)) {
+      const expr = dimMap.get(fieldName);
+      selectParts.push(`${expr}${alias}`);
+      groupByExprs.push(expr);
+    } else {
+      unresolved = true;
+      break;
+    }
+  }
+  if (unresolved || selectParts.length === 0) {
+    warnings.push(`\u26A0 View "${ndtViewName}" (NDT on explore "${exploreName}"): one or more selected columns reference fields that could not be resolved on the base view (joined/derived fields are not supported here). Rebuild this NDT as a Sigma data element that aggregates the "${sigmaDisplayName(exploreName)}" element after import.`);
+    return { sql: "", resolved: false };
+  }
+  let sql = `SELECT
+  ${selectParts.join(",\n  ")}
+FROM ${fromTable}`;
+  if (hasMeasure && groupByExprs.length) {
+    sql += `
+GROUP BY ${groupByExprs.join(", ")}`;
+  }
+  warnings.push(`\u2139 View "${ndtViewName}" \u2192 Native Derived Table on explore "${exploreName}" was translated to a Custom SQL element (aggregation pushed to ${fromTable}). Review the generated SQL and consider rebuilding it as a native Sigma data element for full editability.`);
+  return { sql, resolved: true };
+}
+function lookResolveLiquidIf(sql, paramDefaults) {
+  if (!/\{%-?\s*if\b/i.test(sql))
+    return { sql, resolved: false };
+  const ifCount = (sql.match(/\{%-?\s*if\b/gi) || []).length;
+  if (ifCount !== 1)
+    return { sql, resolved: false };
+  const m = sql.match(/\{%-?\s*if\b([\s\S]*?)\{%-?\s*endif\s*-?%\}/i);
+  if (!m)
+    return { sql, resolved: false };
+  const before = sql.slice(0, m.index);
+  const after = sql.slice((m.index || 0) + m[0].length);
+  const body = "{% if" + m[1];
+  const parts = body.split(/\{%-?\s*(?:els?if|elsif|if|else)\b/i);
+  const markers = body.match(/\{%-?\s*(elsif|else if|else|if)\b([^%]*?)-?%\}/gi) || [];
+  const branches = [];
+  let rest = body;
+  for (let i = 0; i < markers.length; i++) {
+    const marker = markers[i];
+    const start = rest.indexOf(marker);
+    const bodyStart = start + marker.length;
+    const nextMarker = markers[i + 1];
+    const bodyEnd = nextMarker ? rest.indexOf(nextMarker, bodyStart) : rest.length;
+    const text = rest.slice(bodyStart, bodyEnd).trim();
+    const isElse = /\{%-?\s*else\s*-?%\}/i.test(marker);
+    const cond = isElse ? null : marker.replace(/\{%-?\s*(elsif|else if|if)\b/i, "").replace(/-?%\}/i, "").trim();
+    branches.push({ cond, text });
+  }
+  const evalCond = (cond) => {
+    const cm = cond.match(/([A-Za-z_][A-Za-z0-9_.]*?)(?:\._parameter_value)?\s*(==|!=)\s*['"]?([^'"]*)['"]?\s*$/);
+    if (!cm)
+      return false;
+    const pname = cm[1].split(".").pop().toLowerCase();
+    const op = cm[2];
+    const want = cm[3].trim();
+    const dv = paramDefaults.get(pname);
+    if (dv === void 0)
+      return false;
+    return op === "==" ? dv === want : dv !== want;
+  };
+  let chosen = branches.find((b) => b.cond !== null && evalCond(b.cond));
+  if (!chosen)
+    chosen = branches.find((b) => b.cond === null);
+  if (!chosen)
+    chosen = branches[0];
+  if (!chosen)
+    return { sql, resolved: false };
+  const out = (before + " " + chosen.text + " " + after).replace(/\s+/g, " ").trim();
+  if (/\{%/.test(out))
+    return { sql, resolved: false };
+  return { sql: out, resolved: true };
+}
+function lookResolveParamSubst(sql, paramDefaults) {
+  let changed = false;
+  const out = sql.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (full, name) => {
+    const dv = paramDefaults.get(name.toLowerCase());
+    if (dv !== void 0) {
+      changed = true;
+      return dv;
+    }
+    return full;
+  });
+  return { sql: out, resolved: changed };
+}
+function lookConvertView(viewName, view, connectionId, warnings, sqlTableNameMap, ndtContext) {
+  if (!view) {
+    warnings.push(`\u26A0 View "${viewName}" not found \u2014 element will have no columns`);
+    const id = sigmaShortId();
+    return {
+      element: { id, kind: "table", source: { connectionId: connectionId || "<CONNECTION_ID>", kind: "warehouse-table", path: [viewName.toUpperCase()] }, columns: [], order: [] },
+      elementId: id,
+      colIdMap: {}
+    };
+  }
+  const elementId = sigmaShortId();
+  let tableName, element;
+  if (view.derived_table !== void 0) {
+    let rawSql = (view.derived_table.sql || "").replace(/;;\s*$/, "").trim();
+    const explSource = Array.isArray(view.derived_table.explore_source) ? view.derived_table.explore_source[0] : view.derived_table.explore_source;
+    if (!rawSql && explSource !== void 0 && ndtContext) {
+      const ndt = resolveNdtToSql(viewName, explSource, ndtContext, warnings);
+      if (ndt.resolved)
+        rawSql = ndt.sql;
+    } else if (!rawSql && explSource !== void 0) {
+      warnings.push(`\u26A0 View "${viewName}" is a Native Derived Table (explore_source) but explore context was unavailable \u2014 rebuild it as a Sigma data element after import.`);
+    }
+    if (/\{%\s*incrementcondition\s*%\}/i.test(rawSql)) {
+      rawSql = rawSql.replace(/\{%\s*incrementcondition\s*%\}([\s\S]*?)\{%\s*endincrementcondition\s*%\}/gi, (_m, inner) => `1=1 /* Looker incremental condition on ${inner.trim()} \u2014 full scan in Sigma */`);
+      warnings.push(`\u{1F536} View "${viewName}": incremental-PDT {% incrementcondition %} was replaced with 1=1 \u2014 Sigma always runs the full SQL. Enable scheduled materialization on this element (Materialization tab in the Sigma UI, or via the API) to keep refreshes warehouse-side; the migration skill can hand off to the materialization flow.`);
+    }
+    if (sqlTableNameMap && rawSql.includes("${")) {
+      rawSql = resolveSqlTableNameRefs(rawSql, sqlTableNameMap, warnings, viewName);
+    }
+    if (rawSql && isCteFragment(rawSql)) {
+      const { head, rest } = splitLeadingSqlComments(rawSql);
+      rawSql = head + "WITH " + rest.slice(1);
+      warnings.push(`\u2139 View "${viewName}": derived SQL was a CTE-continuation fragment (leading ","), expecting Looker to prepend inlined PDT CTEs. Prepended WITH so it parses standalone \u2014 verify the first CTE no longer depends on a missing upstream CTE.`);
+    }
+    const PERSIST_HINTS = ["datagroup_trigger", "persist_for", "sql_trigger_value"];
+    const dt = view.derived_table;
+    for (const prop of PERSIST_HINTS) {
+      if (dt[prop] !== void 0) {
+        const val = typeof dt[prop] === "string" ? dt[prop] : "";
+        warnings.push(`\u2139 View "${viewName}": PDT persistence hint "${prop}"${val ? ` (${val})` : ""} maps to Sigma scheduled materialization. Configure a materialization schedule on this data model (Materialization tab in the Sigma UI, or via the API) to get the equivalent refresh cadence.`);
+      }
+    }
+    if (dt.increment_key !== void 0) {
+      const off = dt.increment_offset !== void 0 ? `, increment_offset: ${dt.increment_offset}` : "";
+      warnings.push(`\u{1F536} View "${viewName}": incremental PDT (increment_key: "${dt.increment_key}"${off}) has no Sigma equivalent \u2014 the converted element re-computes its full SQL on each refresh. Recommend Sigma scheduled materialization on this element (Materialization tab / API; the migration skill can hand off to the materialization flow).`);
+    } else if (dt.increment_offset !== void 0) {
+      warnings.push(`\u2139 View "${viewName}": increment_offset is set without increment_key \u2014 ignored.`);
+    }
+    const PDT_SKIP_PROPS = ["distribution", "sortkeys", "persist_with", "cluster_keys", "partition_keys"];
+    for (const prop of PDT_SKIP_PROPS) {
+      if (dt[prop] !== void 0) {
+        warnings.push(`\u2139 View "${viewName}": PDT property "${prop}" is a warehouse-specific materialization hint and is not converted \u2014 configure this in your warehouse or Sigma dataset settings.`);
+      }
+    }
+    tableName = "Custom SQL";
+    element = {
+      id: elementId,
+      kind: "table",
+      // Explicit display name: without it Sigma falls back to "Custom SQL" for
+      // every sql element, making [Element/Column] refs ambiguous and breaking
+      // the orchestrators' name-based element lookup on readback.
+      name: view.label || sigmaDisplayName(viewName),
+      source: {
+        connectionId: connectionId || "<CONNECTION_ID>",
+        statement: rawSql || "",
+        kind: "sql"
+      },
+      columns: [],
+      metrics: [],
+      order: []
+    };
+    if (rawSql)
+      warnings.push(`\u2139 View "${viewName}" \u2192 Custom SQL element. Review the SQL before saving.`);
+    else
+      warnings.push(`\u26A0 View "${viewName}" derived_table has no sql \u2014 SQL statement left blank. Add SQL manually in the JSON before saving.`);
+  } else {
+    const path = lookExtractPath(view, sqlTableNameMap);
+    tableName = (path[path.length - 1] || viewName).toUpperCase();
+    element = {
+      id: elementId,
+      kind: "table",
+      name: view.label || sigmaDisplayName(viewName),
+      source: {
+        connectionId: connectionId || "<CONNECTION_ID>",
+        kind: "warehouse-table",
+        path: path.length > 0 ? path : [viewName.toUpperCase()]
+      },
+      columns: [],
+      metrics: [],
+      order: []
+    };
+  }
+  const colIdMap = {};
+  const isCustomSql = tableName === "Custom SQL";
+  const colLabel = (physCol) => isCustomSql ? physCol : sigmaDisplayName(physCol);
+  const makeColId = (physCol) => isCustomSql ? sigmaShortId() : sigmaInodeId(physCol);
+  const viewSqls = JSON.stringify(view);
+  if (/\{%-?\s*(if|unless|for|assign|capture)\b/i.test(viewSqls)) {
+    warnings.push(`\u2139 View "${viewName}": contains Liquid templating ({% if %} blocks). Parameter-driven dimensions are resolved to their DEFAULT branch (see per-dimension \u{1F536} notes); any unresolved Liquid is skipped \u2014 review in Sigma.`);
+  }
+  const yesnoExprMap = /* @__PURE__ */ new Map();
+  const fieldDisplayMap = /* @__PURE__ */ new Map();
+  const dimPhysColMap = /* @__PURE__ */ new Map();
+  {
+    const allDims = view.dimension ? Array.isArray(view.dimension) ? view.dimension : [view.dimension] : [];
+    allDims.forEach((yd) => {
+      if (!yd._name)
+        return;
+      const lname = yd._name.toLowerCase();
+      if ((yd.type || "").toLowerCase() === "yesno" && yd.sql) {
+        const expr = yd.sql.replace(/\$\{TABLE\}\s*\.\s*/gi, "").replace(/\$\{[^.}]+\.([^}]+)\}/g, (_, f) => f.toUpperCase()).replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, n) => n.toUpperCase()).trim();
+        yesnoExprMap.set(lname, expr);
+      } else {
+        let displayName;
+        if (yd.sql && !lookIsComplexSql(yd.sql)) {
+          const stripped = lookStripSql(yd.sql) || yd._name;
+          const physCol = stripped.split(".").pop().replace(/"/g, "").toUpperCase();
+          displayName = colLabel(physCol);
+          dimPhysColMap.set(lname, physCol);
+        } else {
+          displayName = yd.label || sigmaDisplayName(yd._name);
+        }
+        fieldDisplayMap.set(lname, displayName);
+      }
+    });
+  }
+  const physColDisplays = /* @__PURE__ */ new Set();
+  {
+    const allDims = view.dimension ? Array.isArray(view.dimension) ? view.dimension : [view.dimension] : [];
+    const allGroups = view.dimension_group ? Array.isArray(view.dimension_group) ? view.dimension_group : [view.dimension_group] : [];
+    const scan = (sql) => {
+      const re = /\$\{TABLE\}\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)/gi;
+      let m;
+      while ((m = re.exec(sql || "")) !== null)
+        physColDisplays.add(colLabel(m[1].toUpperCase()));
+    };
+    allDims.forEach((d) => {
+      scan(d.sql);
+      if (d.case)
+        JSON.stringify(d.case).replace(/\$\{TABLE\}\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)/gi, (_, c) => {
+          physColDisplays.add(colLabel(c.toUpperCase()));
+          return "";
+        });
+    });
+    allGroups.forEach((g) => {
+      scan(g.sql);
+      scan(g.sql_start);
+      scan(g.sql_end);
+    });
+  }
+  function qualifyPhysRefs(formula) {
+    return formula.replace(/\[([^\]\/]+)\]/g, (m, disp) => physColDisplays.has(disp) ? `[${tableName}/${disp}]` : m);
+  }
+  function expandFieldRefs(sql) {
+    if (!yesnoExprMap.size && !fieldDisplayMap.size)
+      return sql;
+    return sql.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (match, n) => {
+      const lname = n.toLowerCase();
+      const yesnoExpr = yesnoExprMap.get(lname);
+      if (yesnoExpr !== void 0)
+        return `(${yesnoExpr})`;
+      const displayName = fieldDisplayMap.get(lname);
+      if (displayName !== void 0)
+        return `[${displayName}]`;
+      return match;
+    });
+  }
+  const paramDefaults = /* @__PURE__ */ new Map();
+  {
+    const params = view.parameter ? Array.isArray(view.parameter) ? view.parameter : [view.parameter] : [];
+    for (const p of params) {
+      if (p && p._name && p.default_value != null && p.default_value !== "") {
+        paramDefaults.set(p._name.toLowerCase(), String(p.default_value));
+      }
+    }
+  }
+  const dims = view.dimension ? Array.isArray(view.dimension) ? view.dimension : [view.dimension] : [];
+  for (const d of dims) {
+    if (!d._name)
+      continue;
+    const colName = d._name.toUpperCase();
+    const dFormat = lookmlFieldFormat(d, warnings);
+    if (d.sql && /\{%-?\s*if\b/i.test(d.sql)) {
+      const liq = lookResolveLiquidIf(d.sql, paramDefaults);
+      if (liq.resolved) {
+        d.sql = liq.sql;
+        warnings.push(`\u{1F536} "${d._name}": Liquid {% if %} field-picker resolved to the parameter DEFAULT branch (\u2192 ${liq.sql.replace(/\s+/g, " ").trim().slice(0, 60)}). To reproduce the dynamic dropdown, add a Sigma parameter control and a Switch()/If() over its value.`);
+      }
+    }
+    if (d.sql && !/\$\{TABLE\}/i.test(d.sql)) {
+      const sub = lookResolveParamSubst(d.sql, paramDefaults);
+      if (sub.resolved) {
+        d.sql = sub.sql;
+        warnings.push(`\u{1F536} "${d._name}": LookML parameter \${...} substituted with its DEFAULT value (\u2192 ${sub.sql.replace(/\s+/g, " ").trim().slice(0, 60)}). To reproduce the dynamic behavior, add a Sigma parameter control.`);
+      }
+    }
+    if (d.case && typeof d.case === "object") {
+      const whens = Array.isArray(d.case.when) ? d.case.when : d.case.when ? [d.case.when] : [];
+      const toCond = (sql) => lookConvertExpression((sql || "").replace(/\$\{TABLE\}\./gi, "").replace(/\$\{[^.}]+\.([^}]+)\}/g, "$1").replace(/[\r\n]+\s*/g, " ").trim());
+      let formula = d.case.else != null ? `"${String(d.case.else)}"` : "Null";
+      for (let i = whens.length - 1; i >= 0; i--) {
+        const w = whens[i];
+        if (typeof w !== "object" || !w.sql)
+          continue;
+        formula = `If(${qualifyPhysRefs(toCond(w.sql))}, "${String(w.label ?? w._name ?? "")}", ${formula})`;
+      }
+      const caseColId = sigmaShortId();
+      colIdMap[colName] = caseColId;
+      element.columns.push({ id: caseColId, formula, name: d.label || sigmaDisplayName(d._name) });
+      element.order.push(caseColId);
+      warnings.push(`\u2705 "${d._name}" (case) \u2192 ${formula.slice(0, 70)}`);
+      continue;
+    }
+    if ((d.type || "").toLowerCase() === "tier" && Array.isArray(d.tiers) && d.tiers.length) {
+      const tiers = d.tiers.map((t) => Number(t)).filter((n) => !Number.isNaN(n));
+      if (tiers.length) {
+        const physCol = (lookStripSql(d.sql) || colName).split(".").pop().replace(/"/g, "").toUpperCase();
+        const ref = `[${tableName}/${colLabel(physCol)}]`;
+        const allInt = tiers.every((t) => Number.isInteger(t));
+        const lbl = (lo, hi) => allInt ? `${lo} to ${hi - 1}` : `${lo} to ${hi}`;
+        let formula = `"${tiers[tiers.length - 1]} or Above"`;
+        for (let i = tiers.length - 2; i >= 0; i--) {
+          formula = `If(${ref} < ${tiers[i + 1]}, "${lbl(tiers[i], tiers[i + 1])}", ${formula})`;
+        }
+        formula = `If(${ref} < ${tiers[0]}, "Below ${tiers[0]}", ${formula})`;
+        const tierColId = sigmaShortId();
+        colIdMap[colName] = tierColId;
+        element.columns.push({ id: tierColId, formula, name: d.label || sigmaDisplayName(d._name) });
+        element.order.push(tierColId);
+        const style = (d.style || "classic").toLowerCase();
+        if (style !== "integer")
+          warnings.push(`\u2139 "${d._name}" (tier, style: ${style}) \u2192 If() buckets emitted with integer-style labels ("lo to hi-1"); verify the labels match Looker's ${style} style and adjust if needed.`);
+        else
+          warnings.push(`\u2705 "${d._name}" (tier) \u2192 ${formula.slice(0, 70)}\u2026`);
+        continue;
+      }
+    }
+    if (/\$\{[^.}]+\}/.test(d.sql || "") && !/\$\{TABLE\}/i.test(d.sql || "")) {
+      warnings.push(`\u26A0 "${d._name}": uses LookML parameter substitution \u2014 skipped. Add this dimension manually after configuring parameters in Sigma.`);
+      continue;
+    }
+    if (lookIsComplexSql(d.sql)) {
+      const cleanedSql = (d.sql || "").replace(/\$\{TABLE\}\./gi, "").replace(/\$\{[^.}]+\.([^}]+)\}/g, "$1").trim();
+      const boolMatch = cleanedSql.match(/^([A-Z_][A-Z0-9_]*)\s*=\s*(\d+)$/i);
+      if (boolMatch) {
+        const physicalCol2 = boolMatch[1].toUpperCase();
+        const val = boolMatch[2];
+        let physColId = colIdMap[physicalCol2];
+        if (!physColId) {
+          physColId = makeColId(physicalCol2);
+          colIdMap[physicalCol2] = physColId;
+          element.columns.push({ id: physColId, formula: `[${tableName}/${colLabel(physicalCol2)}]` });
+          element.order.push(physColId);
+        }
+        const calcId = sigmaShortId();
+        colIdMap[colName] = calcId;
+        const baseName = d.label || sigmaDisplayName(d._name);
+        const displayName = baseName + " (T-F)";
+        element.columns.push({ id: calcId, formula: `[${tableName}/${colLabel(physicalCol2)}] = ${val}`, name: displayName });
+        element.order.push(calcId);
+        continue;
+      }
+      const unsupported = detectUnsupportedSigmaFunction(d.sql || "");
+      if (unsupported) {
+        warnings.push(`\u26A0 "${d._name}": skipped \u2014 contains ${unsupported}() which has no Sigma equivalent. Add this column manually in the Sigma UI.`);
+        continue;
+      }
+      const colId2 = sigmaShortId();
+      colIdMap[colName] = colId2;
+      const expandedSql = expandFieldRefs(d.sql || "");
+      let sigmaFormula = lookSqlToSigmaRules(expandedSql);
+      if (!sigmaFormula) {
+        const stripped = expandedSql.replace(/\$\{TABLE\}\./gi, "").replace(/\$\{[^.}]+\.([^}]+)\}/g, (_, f) => f.toUpperCase()).replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, n) => n.toUpperCase()).replace(/[\r\n]+\s*/g, " ").trim();
+        if (/^[A-Za-z_][A-Za-z0-9_]*\s*\(/.test(stripped)) {
+          sigmaFormula = lookConvertExpression(stripped);
+        }
+      }
+      if (sigmaFormula) {
+        sigmaFormula = qualifyPhysRefs(sigmaFormula);
+        element.columns.push({ id: colId2, formula: sigmaFormula, name: d.label || sigmaDisplayName(d._name), ...dFormat ? { format: dFormat } : {} });
+        element.order.push(colId2);
+        warnings.push(`\u2139 "${d._name}" \u2192 calculated column: ${sigmaFormula}`);
+      } else {
+        element.columns.push({ id: colId2, formula: `[${tableName}/${sigmaDisplayName(colName)}]`, name: d.label || sigmaDisplayName(d._name), ...dFormat ? { format: dFormat } : {} });
+        element.order.push(colId2);
+        warnings.push(`\u26A0 "${d._name}": could not auto-convert. Edit formula manually.`);
+      }
+      continue;
+    }
+    const sqlCol = lookStripSql(d.sql) || colName;
+    const physicalCol = sqlCol.split(".").pop().replace(/"/g, "").toUpperCase();
+    if (colIdMap[physicalCol]) {
+      colIdMap[colName] = colIdMap[physicalCol];
+      continue;
+    }
+    const colId = makeColId(physicalCol);
+    colIdMap[colName] = colId;
+    colIdMap[physicalCol] = colId;
+    if (isCustomSql) {
+      element.columns.push({ id: colId, formula: `[${tableName}/${colLabel(physicalCol)}]`, name: d.label || sigmaDisplayName(d._name), ...dFormat ? { format: dFormat } : {} });
+    } else {
+      element.columns.push({ id: colId, formula: `[${tableName}/${colLabel(physicalCol)}]`, ...dFormat ? { format: dFormat } : {} });
+    }
+    element.order.push(colId);
+  }
+  const TIMEFRAME_MAP = {
+    raw: { suffix: "Raw", formula: (ref) => ref },
+    time: { suffix: "Time", formula: (ref) => ref },
+    date: { suffix: "Date", formula: (ref) => `DateTrunc("day", ${ref})` },
+    week: { suffix: "Week", formula: (ref) => `DateTrunc("week", ${ref})` },
+    month: { suffix: "Month", formula: (ref) => `DateTrunc("month", ${ref})` },
+    quarter: { suffix: "Quarter", formula: (ref) => `DateTrunc("quarter", ${ref})` },
+    year: { suffix: "Year", formula: (ref) => `DateTrunc("year", ${ref})` }
+  };
+  const DEFAULT_TIMEFRAMES = ["raw", "time", "date", "week", "month", "quarter", "year"];
+  const dimGroups = view.dimension_group ? Array.isArray(view.dimension_group) ? view.dimension_group : [view.dimension_group] : [];
+  dimGroups.forEach((dg) => {
+    if (!dg._name)
+      return;
+    const colName = dg._name.toUpperCase();
+    const dgType = (dg.type || "time").toLowerCase();
+    if (dgType === "duration") {
+      if (!dg.sql_start || !dg.sql_end) {
+        warnings.push(`\u26A0 Duration group "${dg._name}": missing sql_start/sql_end \u2014 skipped.`);
+        return;
+      }
+      const normStart = (dg.sql_start || "").replace(/\$\{TABLE\}\s*\.\s*/gi, "").trim();
+      const normEnd = (dg.sql_end || "").replace(/\$\{TABLE\}\s*\.\s*/gi, "").trim();
+      const startCol = (normStart.match(/^([A-Za-z_][A-Za-z0-9_]*)/) || ["", ""])[1].toUpperCase() || lookStripSql(dg.sql_start).split(".").pop().replace(/"/g, "").toUpperCase();
+      const endCol = (normEnd.match(/^([A-Za-z_][A-Za-z0-9_]*)/) || ["", ""])[1].toUpperCase() || lookStripSql(dg.sql_end).split(".").pop().replace(/"/g, "").toUpperCase();
+      for (const pc of [startCol, endCol]) {
+        if (pc && !colIdMap[pc]) {
+          const cid = makeColId(pc);
+          colIdMap[pc] = cid;
+          element.columns.push({ id: cid, formula: `[${tableName}/${colLabel(pc)}]` });
+          element.order.push(cid);
+        }
+      }
+      const startRef = `[${tableName}/${colLabel(startCol)}]`;
+      const endRef = `[${tableName}/${colLabel(endCol)}]`;
+      const DG_DURATION = {
+        second: "second",
+        minute: "minute",
+        hour: "hour",
+        day: "day",
+        week: "week",
+        month: "month",
+        quarter: "quarter",
+        year: "year"
+      };
+      const intervals = Array.isArray(dg.intervals) ? dg.intervals.map((i) => String(i).toLowerCase()) : ["day"];
+      const folderItems2 = [];
+      intervals.forEach((interval) => {
+        const prec = DG_DURATION[interval];
+        if (!prec)
+          return;
+        const durColId = sigmaShortId();
+        const durColName = `${colName}_${interval.toUpperCase()}S`;
+        colIdMap[durColName] = durColId;
+        element.columns.push({
+          id: durColId,
+          formula: `DateDiff("${prec}", ${startRef}, ${endRef})`,
+          name: sigmaDisplayName(durColName)
+        });
+        element.order.push(durColId);
+        folderItems2.push(durColId);
+      });
+      if (folderItems2.length > 0) {
+        if (!element.folders)
+          element.folders = [];
+        element.folders.push({
+          id: sigmaShortId(),
+          name: sigmaDisplayName(dg._name),
+          items: folderItems2
+        });
+      }
+      return;
+    }
+    if (/\$\{[^.}]+\}/.test(dg.sql || "") && !/\$\{TABLE\}/i.test(dg.sql || "")) {
+      warnings.push(`\u26A0 "${dg._name}": uses LookML parameter substitution \u2014 skipped. Add this dimension manually after configuring parameters in Sigma.`);
+      return;
+    }
+    if (lookIsComplexSql(dg.sql)) {
+      warnings.push(`\u26A0 Dimension group "${dg._name}": complex expression \u2014 skipped.`);
+      return;
+    }
+    const sqlCol = lookStripSql(dg.sql) || colName;
+    const physicalCol = sqlCol.split(".").pop().replace(/"/g, "").toUpperCase();
+    const rawTimeframes = dg.timeframes ? (Array.isArray(dg.timeframes) ? dg.timeframes : [dg.timeframes]).map((t) => (t.field || t).toLowerCase()) : DEFAULT_TIMEFRAMES;
+    const timeframes = rawTimeframes.filter((t) => TIMEFRAME_MAP[t]);
+    const displayBase = sigmaDisplayName(dg._name);
+    const colRef = `[${tableName}/${colLabel(physicalCol)}]`;
+    dimPhysColMap.set(dg._name.toLowerCase(), physicalCol);
+    rawTimeframes.forEach((tf) => dimPhysColMap.set(`${dg._name}_${tf}`.toLowerCase(), physicalCol));
+    const existingId = colIdMap[physicalCol];
+    const rawColId = existingId || makeColId(physicalCol);
+    colIdMap[colName] = rawColId;
+    colIdMap[physicalCol] = rawColId;
+    if (timeframes.length <= 1) {
+      if (timeframes[0])
+        colIdMap[`${colName}_${timeframes[0].toUpperCase()}`] = rawColId;
+      if (!existingId) {
+        element.columns.push({ id: rawColId, formula: colRef });
+        element.order.push(rawColId);
+      }
+      return;
+    }
+    const folderItems = [];
+    let rawEmitted = !!existingId;
+    timeframes.forEach((tf) => {
+      const { suffix, formula } = TIMEFRAME_MAP[tf];
+      const tfFormula = formula(colRef);
+      const tfName = `${displayBase} ${suffix}`;
+      if (tf === "raw" || tf === "time") {
+        if (!rawEmitted) {
+          colIdMap[`${colName}_${tf.toUpperCase()}`] = rawColId;
+          element.columns.push({ id: rawColId, formula: colRef, name: tfName });
+          folderItems.push(rawColId);
+          rawEmitted = true;
+        } else {
+          const dupId = sigmaShortId();
+          colIdMap[`${colName}_${tf.toUpperCase()}`] = dupId;
+          element.columns.push({ id: dupId, formula: colRef, name: tfName });
+          folderItems.push(dupId);
+          element.order.push(dupId);
+        }
+      } else {
+        const tfId = sigmaShortId();
+        colIdMap[`${colName}_${tf.toUpperCase()}`] = tfId;
+        element.columns.push({ id: tfId, formula: tfFormula, name: tfName });
+        folderItems.push(tfId);
+        element.order.push(tfId);
+      }
+    });
+    if (!rawEmitted) {
+      element.columns.push({ id: rawColId, formula: colRef, name: `${displayBase} Raw` });
+      folderItems.push(rawColId);
+      rawEmitted = true;
+    }
+    if (!element.folders)
+      element.folders = [];
+    element.folders.push({ id: sigmaShortId(), name: displayBase, items: folderItems });
+    if (!existingId)
+      element.order.push(rawColId);
+  });
+  const measures = view.measure ? Array.isArray(view.measure) ? view.measure : [view.measure] : [];
+  const CALC_COL_MEASURE_TYPES = /* @__PURE__ */ new Set(["running_total", "percent_of_total"]);
+  const measurePhysCol = (ms) => {
+    const resolved = (ms.sql || "").replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (m, r) => dimPhysColMap.get(r.toLowerCase()) ?? m);
+    const sc = lookStripSql(resolved) || (ms._name || "").toUpperCase();
+    return sc.split(".").pop().replace(/"/g, "").toUpperCase();
+  };
+  const filterCondition = (ms) => {
+    const fl = Array.isArray(ms.filters) ? ms.filters : ms.filters ? [ms.filters] : [];
+    const conds = [];
+    for (const f of fl) {
+      if (typeof f !== "object" || !f)
+        continue;
+      const ff = f.field || f._name, fv = f.value;
+      if (!ff || fv == null)
+        continue;
+      const dn = colLabel(ff.replace(/^.*\./, "").toUpperCase());
+      if (fv === "yes" || fv === "true")
+        conds.push(`[${dn}] = True`);
+      else if (fv === "no" || fv === "false")
+        conds.push(`[${dn}] = False`);
+      else
+        conds.push(`[${dn}] = "${fv}"`);
+    }
+    if (!conds.length)
+      return null;
+    return conds.length === 1 ? conds[0] : conds.map((c) => `(${c})`).join(" And ");
+  };
+  const simpleMeasureFormula = (ms) => {
+    const t = (ms.type || "count").toLowerCase();
+    const dn = colLabel(measurePhysCol(ms));
+    const cond = filterCondition(ms);
+    if (cond) {
+      const m = {
+        sum: `SumIf([${dn}], ${cond})`,
+        count: `CountIf(${cond})`,
+        count_distinct: `CountDistinctIf([${dn}], ${cond})`,
+        average: `AvgIf([${dn}], ${cond})`,
+        max: `MaxIf([${dn}], ${cond})`,
+        min: `MinIf([${dn}], ${cond})`
+      };
+      return m[t] || `SumIf([${dn}], ${cond})`;
+    }
+    if (t === "count")
+      return "Count()";
+    if (t === "count_distinct")
+      return `CountDistinct([${dn}])`;
+    if (t === "percentile")
+      return `Percentile([${dn}], ${(Number(ms.percentile) || 50) / 100})`;
+    if (["sum", "average", "median", "min", "max", "average_distinct", "sum_distinct", "list"].includes(t))
+      return lookSigmaMetric(t, measurePhysCol(ms));
+    return null;
+  };
+  const measureSigmaFormula = /* @__PURE__ */ new Map();
+  measures.forEach((ms) => {
+    if (!ms._name)
+      return;
+    const f = simpleMeasureFormula(ms);
+    if (f)
+      measureSigmaFormula.set(ms._name.toLowerCase(), f);
+  });
+  measures.forEach((ms) => {
+    if (!ms._name)
+      return;
+    const msName = ms._name.toUpperCase();
+    const resolvedMsSql = (ms.sql || "").replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (match, refName) => dimPhysColMap.get(refName.toLowerCase()) ?? match);
+    const sqlCol = lookStripSql(resolvedMsSql) || msName;
+    const physicalCol = sqlCol.split(".").pop().replace(/"/g, "").toUpperCase() || msName.replace(/"/g, "");
+    const msType = (ms.type || "count").toLowerCase();
+    const msLabel = ms.label || sigmaDisplayName(msName);
+    const msFormat = lookmlFieldFormat(ms, warnings) ?? (msType === "percent_of_total" ? { kind: "number", formatString: ",.1%" } : void 0);
+    {
+      const tcm = resolvedMsSql.trim().replace(/;;\s*$/, "").match(/^TO_(?:CHAR|VARCHAR)\s*\(\s*(SUM|AVG|MIN|MAX|MEDIAN|COUNT)\s*\(\s*(?:\$\{TABLE\}\s*\.\s*)?("?[A-Za-z_][A-Za-z0-9_]*"?)\s*\)\s*,\s*'([^']+)'\s*\)$/i);
+      const tcFmt = tcm ? snowflakeNumericMaskFormat(tcm[3]) : null;
+      if (tcm && tcFmt) {
+        const fnMap = { sum: "Sum", avg: "Avg", min: "Min", max: "Max", median: "Median", count: "Count" };
+        const pc = tcm[2].replace(/"/g, "").toUpperCase();
+        if (!colIdMap[pc]) {
+          const colId = makeColId(pc);
+          colIdMap[pc] = colId;
+          element.columns.push({ id: colId, formula: `[${tableName}/${colLabel(pc)}]` });
+          element.order.push(colId);
+        }
+        const formula = `${fnMap[tcm[1].toLowerCase()]}([${colLabel(pc)}])`;
+        element.metrics.push({ id: sigmaShortId(), formula, name: msLabel, format: msFormat ?? tcFmt });
+        warnings.push(`\u2705 "${ms._name}" (TO_CHAR display mask) \u2192 ${formula} + Sigma column format "${(msFormat ?? tcFmt).formatString}" \u2014 value stays numeric, display matches the mask`);
+        return;
+      }
+    }
+    if (["date", "datetime", "date_time", "time"].includes(msType)) {
+      const am = resolvedMsSql.trim().replace(/;;\s*$/, "").match(/^(MAX|MIN)\s*\(\s*(?:\$\{TABLE\}\s*\.\s*)?("?[A-Za-z_][A-Za-z0-9_]*"?)\s*\)$/i);
+      if (am) {
+        const fn = am[1].toUpperCase() === "MAX" ? "Max" : "Min";
+        const pc = am[2].replace(/"/g, "").toUpperCase();
+        if (!colIdMap[pc]) {
+          const colId = makeColId(pc);
+          colIdMap[pc] = colId;
+          element.columns.push({ id: colId, formula: `[${tableName}/${colLabel(pc)}]` });
+          element.order.push(colId);
+        }
+        element.metrics.push({ id: sigmaShortId(), formula: `${fn}([${colLabel(pc)}])`, name: msLabel, ...msFormat ? { format: msFormat } : {} });
+        warnings.push(`\u2705 "${ms._name}" (${msType}) \u2192 ${fn}([${colLabel(pc)}])`);
+      } else {
+        warnings.push(`\u26A0 "${ms._name}": measure type "${msType}" with sql "${(ms.sql || "").trim().replace(/\s+/g, " ").slice(0, 80)}" could not be translated \u2014 add this metric manually in Sigma.`);
+      }
+      return;
+    }
+    if (CALC_COL_MEASURE_TYPES.has(msType)) {
+      if (!colIdMap[physicalCol]) {
+        const colId = makeColId(physicalCol);
+        colIdMap[physicalCol] = colId;
+        element.columns.push({ id: colId, formula: `[${tableName}/${colLabel(physicalCol)}]` });
+        element.order.push(colId);
+      }
+      const dn = colLabel(physicalCol);
+      const calcId = sigmaShortId();
+      if (msType === "running_total") {
+        element.columns.push({ id: calcId, formula: `CumulativeSum([${dn}])`, name: msLabel, ...msFormat ? { format: msFormat } : {} });
+        warnings.push(`\u2705 "${ms._name}" (running_total) \u2192 CumulativeSum([${dn}])`);
+      } else {
+        element.columns.push({ id: calcId, formula: `Sum([${dn}]) / GrandTotal(Sum([${dn}]))`, name: msLabel, ...msFormat ? { format: msFormat } : {} });
+        warnings.push(`\u2705 "${ms._name}" (percent_of_total) \u2192 Sum/GrandTotal`);
+      }
+      element.order.push(calcId);
+      return;
+    }
+    const measureRefs = [...(ms.sql || "").matchAll(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g)].map((mm) => mm[1].toLowerCase());
+    const refsOtherMeasure = measureRefs.some((r) => measureSigmaFormula.has(r));
+    const isComputed = !ms.filters && (refsOtherMeasure || msType === "number" && ms.sql && lookIsComplexSql(ms.sql));
+    if (isComputed) {
+      let expr = ms.sql || "";
+      expr = expr.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (m, r) => {
+        const mf = measureSigmaFormula.get(r.toLowerCase());
+        if (mf)
+          return `(${mf})`;
+        const phys = dimPhysColMap.get(r.toLowerCase());
+        return phys ? `[${colLabel(phys.toUpperCase())}]` : m;
+      });
+      expr = expr.replace(/\bNULLIF\s*\(/gi, "NullIf(").replace(/\b(COALESCE|NVL|IFNULL)\s*\(/gi, "Coalesce(").replace(/\b(IFF|IIF)\s*\(/gi, "If(");
+      const RAW_FN = /\b(TO_CHAR|TO_VARCHAR|TO_NUMBER|TO_DATE|LISTAGG|DECODE)\s*\(/i;
+      const hasRawFn = RAW_FN.test(expr);
+      const hasConcatOp = /\|\|/.test(expr);
+      const hasCast = /::\s*\w+/.test(expr);
+      const hasCase = /\bCASE\b[\s\S]*\bWHEN\b/i.test(expr);
+      if (hasRawFn || hasConcatOp || hasCast || hasCase) {
+        let viaRules = null;
+        if (hasCase && !hasRawFn && !hasConcatOp && !hasCast) {
+          viaRules = lookSqlToSigmaRules(expr.replace(/--[^\n]*/g, ""));
+          if (viaRules && /\b(CASE|WHEN|THEN)\b|\|\||::\s*\w/i.test(viaRules))
+            viaRules = null;
+        }
+        if (viaRules) {
+          element.metrics.push({ id: sigmaShortId(), formula: viaRules.trim(), name: msLabel, ...msFormat ? { format: msFormat } : {} });
+          warnings.push(`\u2705 "${ms._name}" (computed CASE) \u2192 ${viaRules.trim().slice(0, 70)}`);
+          return;
+        }
+        const fragMatch = expr.match(/\b(?:TO_CHAR|TO_VARCHAR|TO_NUMBER|TO_DATE|LISTAGG|DECODE)\s*\([^()]*(?:\([^()]*\)[^()]*)*\)/i);
+        const frag = (fragMatch ? fragMatch[0] : expr.replace(/--[^\n]*/g, " ").replace(/\s+/g, " ").trim().slice(0, 110)).trim();
+        const hint = /TO_CHAR|TO_VARCHAR/i.test(expr) ? " TO_CHAR display masks have no Sigma formula equivalent \u2014 keep the underlying numeric metric and apply a Sigma column format instead." : " Recreate this metric manually in Sigma.";
+        warnings.push(`\u26A0 "${ms._name}": measure could not be translated \u2014 untranslatable fragment: ${frag}${hint}`);
+        return;
+      }
+      element.metrics.push({ id: sigmaShortId(), formula: expr.trim(), name: msLabel, ...msFormat ? { format: msFormat } : {} });
+      warnings.push(`\u2705 "${ms._name}" (computed) \u2192 ${expr.trim().slice(0, 70)}`);
+      return;
+    }
+    if (ms.filters && (Array.isArray(ms.filters) ? ms.filters.length : false)) {
+      const filters = Array.isArray(ms.filters) ? ms.filters : [];
+      const conditions = [];
+      for (const f of filters) {
+        if (typeof f !== "object" || !f)
+          continue;
+        const fField = f.field || f._name;
+        const fVal = f.value;
+        if (fField && fVal) {
+          const cleanField = fField.replace(/^.*\./, "").toUpperCase();
+          const dn = colLabel(cleanField);
+          if (!colIdMap[cleanField]) {
+            const colId = makeColId(cleanField);
+            colIdMap[cleanField] = colId;
+            element.columns.push({ id: colId, formula: `[${tableName}/${dn}]` });
+            element.order.push(colId);
+          }
+          if (fVal === "yes" || fVal === "true")
+            conditions.push(`[${dn}] = True`);
+          else if (fVal === "no" || fVal === "false")
+            conditions.push(`[${dn}] = False`);
+          else
+            conditions.push(`[${dn}] = "${fVal}"`);
+        }
+      }
+      if (conditions.length > 0) {
+        const condition = conditions.length === 1 ? conditions[0] : conditions.map((c) => `(${c})`).join(" And ");
+        if (msType !== "count" && !colIdMap[physicalCol]) {
+          const colId = makeColId(physicalCol);
+          colIdMap[physicalCol] = colId;
+          element.columns.push({ id: colId, formula: `[${tableName}/${colLabel(physicalCol)}]` });
+          element.order.push(colId);
+        }
+        const dn = colLabel(physicalCol);
+        const condAggMap = {
+          sum: `SumIf([${dn}], ${condition})`,
+          count: `CountIf(${condition})`,
+          count_distinct: `CountDistinctIf([${dn}], ${condition})`,
+          average: `AvgIf([${dn}], ${condition})`,
+          max: `MaxIf([${dn}], ${condition})`,
+          min: `MinIf([${dn}], ${condition})`
+        };
+        const formula = condAggMap[msType] || `SumIf([${dn}], ${condition})`;
+        element.metrics.push({ id: sigmaShortId(), formula, name: msLabel, ...msFormat ? { format: msFormat } : {} });
+        warnings.push(`\u2705 Filtered "${ms._name}" \u2192 ${formula.slice(0, 60)}`);
+        return;
+      }
+      warnings.push(`\u26A0 "${ms._name}": filters not parsed \u2014 metric created without filter`);
+    }
+    if (msType === "count") {
+      element.metrics.push({ id: sigmaShortId(), formula: "Count()", name: msLabel, ...msFormat ? { format: msFormat } : {} });
+    } else if (msType === "count_distinct") {
+      const cdCol = physicalCol && physicalCol !== msName ? physicalCol : msName;
+      if (!colIdMap[cdCol]) {
+        const colId = makeColId(cdCol);
+        colIdMap[cdCol] = colId;
+        element.columns.push({ id: colId, formula: `[${tableName}/${colLabel(cdCol)}]` });
+        element.order.push(colId);
+      }
+      element.metrics.push({ id: sigmaShortId(), formula: `CountDistinct([${colLabel(cdCol)}])`, name: msLabel, ...msFormat ? { format: msFormat } : {} });
+    } else {
+      const FN_HEADS = /* @__PURE__ */ new Set(["MAX", "MIN", "SUM", "AVG", "COUNT", "CASE", "CAST", "COALESCE", "NULLIF", "IFF", "TO_CHAR", "TO_NUMBER", "TO_DATE", "ROUND", "ABS", "CONCAT"]);
+      if (/\$\{(?!TABLE\})[^.}]+\}/.test(resolvedMsSql) || ms.sql && FN_HEADS.has(physicalCol) && /\(/.test(ms.sql)) {
+        warnings.push(`\u26A0 "${ms._name}": measure sql "${(ms.sql || "").trim().replace(/\s+/g, " ").slice(0, 80)}" could not be resolved to a column \u2014 add this metric manually in Sigma.`);
+        return;
+      }
+      if (!colIdMap[physicalCol]) {
+        const colId = makeColId(physicalCol);
+        colIdMap[physicalCol] = colId;
+        element.columns.push({ id: colId, formula: `[${tableName}/${colLabel(physicalCol)}]` });
+        element.order.push(colId);
+      }
+      const dn = colLabel(physicalCol);
+      const formula = msType === "percentile" ? `Percentile([${dn}], ${(Number(ms.percentile) || 50) / 100})` : lookSigmaMetric(msType, physicalCol);
+      element.metrics.push({ id: sigmaShortId(), formula, name: msLabel, ...msFormat ? { format: msFormat } : {} });
+    }
+  });
+  if (element.metrics.length === 0)
+    delete element.metrics;
+  return { element, elementId, colIdMap };
+}
+function convertLookMLToSigma(files, options = {}) {
+  resetIds();
+  const { connectionId = "", joinStrategy = "auto" } = options;
+  const views = {};
+  const explores = {};
+  const warnings = [];
+  const security = [];
+  for (const file of files) {
+    const isModel = file.name.endsWith(".model.lkml") || file.name.includes(".model.");
+    try {
+      const parsed = parseLookML(file.content);
+      if (isModel) {
+        parsed.explores.forEach((ex) => {
+          explores[ex._name] = ex;
+        });
+      }
+      parsed.views.forEach((v) => {
+        views[v._name] = v;
+      });
+      if (parsed.includes.length > 0) {
+        warnings.push(`\u2139 "${file.name}": contains include: directive(s) \u2014 ${parsed.includes.join(", ")} \u2014 cross-file resolution is not supported. Pass all referenced view files explicitly.`);
+      }
+    } catch (e) {
+      throw new Error(`Parse error in ${file.name}: ${e.message}`);
+    }
+  }
+  let exploreName = options.exploreName;
+  const exploreNames = Object.keys(explores);
+  if (exploreNames.length === 0) {
+    const viewNames = Object.keys(views);
+    if (viewNames.length === 0) {
+      throw new Error("No views or explores found in the LookML files.");
+    }
+    const targets = exploreName && views[exploreName] ? [exploreName] : viewNames;
+    warnings.push(`\u2139 No explore/model file provided \u2014 converted ${targets.length} standalone view element(s). Joins and explore settings live in the .model.lkml; include it to carry relationships.`);
+    const sqlTableNameMapVO = buildSqlTableNameMap(views);
+    const ndtCtx = { views, explores };
+    const allElements2 = targets.map((v) => lookConvertView(v, views[v], connectionId, warnings, sqlTableNameMapVO, ndtCtx).element);
+    if (!connectionId)
+      warnings.unshift("\u26A0 Connection ID not set \u2014 update in JSON before saving to Sigma");
+    const model = {
+      name: targets.length === 1 ? sigmaDisplayName(targets[0]) : "LookML Views",
+      schemaVersion: 1,
+      pages: [{ id: sigmaShortId(), name: "Page 1", elements: allElements2 }]
+    };
+    return {
+      model,
+      warnings,
+      ...security.length ? { security } : {},
+      stats: {
+        views: viewNames.length,
+        explores: 0,
+        elements: allElements2.length,
+        columns: allElements2.reduce((s, e) => s + (e.columns?.length || 0), 0),
+        metrics: allElements2.reduce((s, e) => s + (e.metrics?.length || 0), 0),
+        relationships: 0
+      }
+    };
+  }
+  if (!exploreName) {
+    if (exploreNames.length === 1)
+      exploreName = exploreNames[0];
+    else
+      throw new Error(`Multiple explores found: ${exploreNames.join(", ")}. Specify exploreName.`);
+  }
+  const explore = explores[exploreName];
+  if (!explore)
+    throw new Error(`Explore "${exploreName}" not found. Available: ${exploreNames.join(", ")}`);
+  const sqlTableNameMap = buildSqlTableNameMap(views);
+  const strategy = joinStrategy;
+  const baseViewName = explore.from || exploreName;
+  const baseAlias = exploreName;
+  const isBaseView = (name) => name === baseAlias || name === baseViewName;
+  const joinDefs = [];
+  const joinsRaw = explore.join ? Array.isArray(explore.join) ? explore.join : [explore.join] : [];
+  joinsRaw.forEach((j) => {
+    const alias = j._name || j.join;
+    const viewName = j.from || alias;
+    const rel = (j.relationship || "many_to_one").toLowerCase();
+    const jType = (j.type || "left_outer").toLowerCase().replace("_join", "").replace(" ", "_");
+    const sqlOn = j.sql_on || "";
+    const keyMatch = sqlOn.match(/\$\{(\w+)\.(\w+)\}\s*=\s*\$\{(\w+)\.(\w+)\}/);
+    const keys = keyMatch ? [{
+      leftView: keyMatch[1],
+      leftCol: keyMatch[2].toUpperCase(),
+      rightView: keyMatch[3],
+      rightCol: keyMatch[4].toUpperCase()
+    }] : [];
+    if (!keyMatch && sqlOn) {
+      const isRangeJoin = /\$\{[^}]+\}\s*[><!]|[><!]=?\s*\$\{/.test(sqlOn);
+      if (isRangeJoin) {
+        warnings.push(`\u26A0 Join "${alias}": uses range-based sql_on (>=, <=, >, <) which cannot be expressed as a Sigma relationship. Recreate this as a filtered join or custom SQL after import.`);
+      } else {
+        warnings.push(`\u26A0 Join "${alias}": complex sql_on could not be parsed automatically \u2014 add join keys manually in Sigma's ERD view`);
+      }
+    }
+    joinDefs.push({ alias, viewName, rel, joinType: jType, keys });
+  });
+  const needsPhysical = (j) => {
+    if (strategy === "joins")
+      return true;
+    if (strategy === "relationships")
+      return false;
+    return j.rel === "one_to_many" || j.joinType === "full_outer";
+  };
+  const relJoins = joinDefs.filter((j) => !needsPhysical(j));
+  const elementMap = {};
+  const physViewMap = {};
+  const ndtContext = { views, explores };
+  const baseResult = lookConvertView(baseViewName, views[baseViewName], connectionId, warnings, sqlTableNameMap, ndtContext);
+  elementMap[baseAlias] = baseResult;
+  physViewMap[baseViewName] = baseResult;
+  if (baseAlias !== baseViewName)
+    elementMap[baseViewName] = baseResult;
+  for (const j of joinDefs) {
+    if (!physViewMap[j.viewName]) {
+      const res = lookConvertView(j.viewName, views[j.viewName], connectionId, warnings, sqlTableNameMap, ndtContext);
+      physViewMap[j.viewName] = res;
+    }
+    elementMap[j.alias] = physViewMap[j.viewName];
+    if (!elementMap[j.viewName])
+      elementMap[j.viewName] = physViewMap[j.viewName];
+  }
+  const usedTargetCols = /* @__PURE__ */ new Set();
+  relJoins.forEach((j) => {
+    const targetRes = elementMap[j.alias] || elementMap[j.viewName];
+    if (!targetRes) {
+      warnings.push(`\u26A0 Relationship "${j.alias}": target not found`);
+      return;
+    }
+    const isTargetView = (name) => name === j.alias || name === j.viewName;
+    j.keys.forEach((k) => {
+      let srcView, srcCol, tgtCol;
+      if (isTargetView(k.rightView)) {
+        srcView = k.leftView;
+        srcCol = k.leftCol;
+        tgtCol = k.rightCol;
+      } else if (isTargetView(k.leftView)) {
+        srcView = k.rightView;
+        srcCol = k.rightCol;
+        tgtCol = k.leftCol;
+      } else {
+        warnings.push(`\u26A0 Relationship "${j.alias}": sql_on does not reference the joined view directly \u2014 wired from the base element; verify keys in Sigma.`);
+        const baseIsLeft = isBaseView(k.leftView);
+        srcView = baseAlias;
+        srcCol = baseIsLeft ? k.leftCol : k.rightCol;
+        tgtCol = baseIsLeft ? k.rightCol : k.leftCol;
+      }
+      const srcRes = elementMap[srcView];
+      if (!srcRes) {
+        warnings.push(`\u26A0 Relationship "${j.alias}": source view "${srcView}" not found in the explore \u2014 skipped`);
+        return;
+      }
+      const srcColId = lookFindColId(srcRes, srcCol);
+      const tgtColId = lookFindColId(targetRes, tgtCol);
+      if (!srcColId || !tgtColId) {
+        warnings.push(`\u26A0 Relationship "${j.alias}": could not resolve column IDs for keys (${k.leftCol} / ${k.rightCol})`);
+        return;
+      }
+      const pairKey = `${targetRes.elementId}|${tgtColId}`;
+      if (usedTargetCols.has(pairKey)) {
+        warnings.push(`\u2139 Role-playing join "${j.alias}" shares a physical table \u2014 add manually in Sigma.`);
+        return;
+      }
+      usedTargetCols.add(pairKey);
+      let relType = "N:1";
+      if (j.rel === "one_to_one")
+        relType = "1:1";
+      else if (j.rel === "many_to_many") {
+        relType = "N:1";
+        warnings.push(`\u26A0 Relationship "${j.alias}": LookML relationship is many_to_many, which Sigma does not support natively. Mapped to the closest type (N:1) \u2014 verify cardinality and introduce a bridge/junction table if the join can fan out on both sides (otherwise aggregates may double-count).`);
+      }
+      const srcEl = srcRes.element;
+      if (!srcEl.relationships)
+        srcEl.relationships = [];
+      srcEl.relationships.push({
+        id: sigmaShortId(),
+        targetElementId: targetRes.elementId,
+        keys: [{ sourceColumnId: srcColId, targetColumnId: tgtColId }],
+        name: j.alias,
+        relationshipType: relType
+      });
+    });
+  });
+  const seenIds = /* @__PURE__ */ new Set();
+  let allElements = Object.values(physViewMap).filter((r) => {
+    if (seenIds.has(r.elementId))
+      return false;
+    seenIds.add(r.elementId);
+    return true;
+  }).map((r) => r.element);
+  allElements.sort((a, b) => {
+    const aHasRel = !!(a.relationships && a.relationships.length > 0);
+    const bHasRel = !!(b.relationships && b.relationships.length > 0);
+    if (aHasRel === bHasRel)
+      return 0;
+    return aHasRel ? 1 : -1;
+  });
+  const accessFilters = explore.access_filter ? Array.isArray(explore.access_filter) ? explore.access_filter : [explore.access_filter] : [];
+  for (const af of accessFilters) {
+    const field = af.field || "(unspecified field)";
+    const ua = af.user_attribute || "(unspecified user_attribute)";
+    const dotIdx = field.lastIndexOf(".");
+    const viewPart = dotIdx >= 0 ? field.slice(0, dotIdx) : baseViewName;
+    const fieldPart = (dotIdx >= 0 ? field.slice(dotIdx + 1) : field).toUpperCase();
+    const targetRes = elementMap[viewPart] || elementMap[baseAlias];
+    const colId = targetRes ? lookFindColId(targetRes, fieldPart) : null;
+    if (!targetRes || !colId) {
+      warnings.push(`\u26A0 Explore "${exploreName}": access_filter restricts "${field}" by user_attribute "${ua}" (row-level security), but column "${field}" was not found in the converted model \u2014 re-apply this RLS rule manually in Sigma (boolean calc column CurrentUserAttributeText("${ua}") = [<field>] + an element filter keeping only True).`);
+      continue;
+    }
+    const targetEl = targetRes.element;
+    const ownerCol = (targetEl.columns || []).find((c) => c.id === colId);
+    let dispName = ownerCol?.name;
+    if (!dispName && ownerCol?.formula) {
+      const fm = String(ownerCol.formula).match(/^\[(?:[^\]\/]+\/)?([^\]]+)\]$/);
+      if (fm)
+        dispName = fm[1];
+    }
+    if (!dispName)
+      dispName = sigmaDisplayName(fieldPart);
+    security.push(makeRlsSecurity({
+      source: `Looker access_filter (explore "${exploreName}")`,
+      element: targetEl,
+      name: `RLS: ${dispName}`,
+      formula: `CurrentUserAttributeText("${ua}") = [${dispName}]`
+    }));
+    warnings.push(`\u{1F510} Explore "${exploreName}": access_filter "${field}" by user_attribute "${ua}" \u2192 row-level security DETECTED (reported in result.security, not injected). The migration skill provisions/reuses the Sigma user attribute "${ua}" and applies the RLS calc + filter.`);
+  }
+  const alwaysFilterItems = explore.always_filter?.filters ? Array.isArray(explore.always_filter.filters) ? explore.always_filter.filters : [explore.always_filter.filters] : [];
+  for (const af of alwaysFilterItems) {
+    const fieldRef = af.field || "";
+    const expr = (af.value || "").trim();
+    if (!fieldRef || !expr)
+      continue;
+    const dotIdx = fieldRef.lastIndexOf(".");
+    const viewPart = dotIdx >= 0 ? fieldRef.slice(0, dotIdx) : baseViewName;
+    const fieldPart = (dotIdx >= 0 ? fieldRef.slice(dotIdx + 1) : fieldRef).toUpperCase();
+    const targetRes = elementMap[viewPart] || elementMap[baseAlias];
+    if (!targetRes) {
+      warnings.push(`\u26A0 always_filter "${fieldRef}": view "${viewPart}" not found \u2014 filter skipped`);
+      continue;
+    }
+    const colId = lookFindColId(targetRes, fieldPart) || lookFindColId(targetRes, fieldPart.replace(/_(?:RAW|TIME|DATE|WEEK|MONTH|QUARTER|YEAR)$/, ""));
+    if (!colId) {
+      warnings.push(`\u26A0 always_filter "${fieldRef}": column "${fieldPart}" not found in element \u2014 filter skipped`);
+      continue;
+    }
+    const sigmaFilter = lookParseFilterExpr(expr, colId);
+    if (!sigmaFilter) {
+      warnings.push(`\u26A0 always_filter "${fieldRef}" = "${expr}": date/range expression cannot be auto-converted \u2014 add filter manually in Sigma`);
+      continue;
+    }
+    const targetEl = targetRes.element;
+    if (!targetEl.filters)
+      targetEl.filters = [];
+    targetEl.filters.push(sigmaFilter);
+    warnings.push(`\u2705 always_filter "${fieldRef}" = "${expr}" \u2192 element list filter added`);
+  }
+  if (!connectionId)
+    warnings.unshift("\u26A0 Connection ID not set \u2014 update in JSON before saving to Sigma");
+  const crossElCalcsByElId = {};
+  for (const el of allElements) {
+    if (el.source?.kind !== "warehouse-table")
+      continue;
+    if (!el.relationships?.length)
+      continue;
+    const localNames = /* @__PURE__ */ new Set();
+    for (const c of el.columns || []) {
+      if (!c.formula)
+        continue;
+      const m = c.formula.match(/^\[[^\]\/]+\/([^\]]+)\]$/);
+      if (m)
+        localNames.add(m[1].toUpperCase());
+      if (c.name)
+        localNames.add(c.name.toUpperCase());
+    }
+    const crossEl = [];
+    const keep = [];
+    for (const c of el.columns || []) {
+      if (!c.name || !c.formula) {
+        keep.push(c);
+        continue;
+      }
+      if (/^\[[^\]\/]+\/[^\]]+\]$/.test(c.formula)) {
+        keep.push(c);
+        continue;
+      }
+      const refs = c.formula.match(/\[([^\]\/]+)\]/g) || [];
+      const hasCross = refs.some((ref) => {
+        const n = ref.replace(/^\[|\]$/g, "");
+        return !/^(true|false|null)$/i.test(n) && !localNames.has(n.toUpperCase());
+      });
+      if (hasCross) {
+        const oi = (el.order || []).indexOf(c.id);
+        if (oi >= 0)
+          el.order.splice(oi, 1);
+        crossEl.push(c);
+      } else {
+        keep.push(c);
+      }
+    }
+    el.columns = keep;
+    if (crossEl.length)
+      crossElCalcsByElId[el.id] = crossEl;
+  }
+  const derivedElements = buildDerivedElements(allElements);
+  allElements = [...allElements, ...derivedElements];
+  const placedSrcElIds = {};
+  for (const de of derivedElements) {
+    if (de.source?.kind !== "table" || !de.source.elementId)
+      continue;
+    const srcElId = de.source.elementId;
+    const calcs = crossElCalcsByElId[srcElId];
+    if (!calcs?.length)
+      continue;
+    const srcEl = allElements.find((e) => e.id === srcElId);
+    if (!srcEl)
+      continue;
+    const srcPath = (srcEl.source?.kind === "warehouse-table" ? srcEl.source.path : []) || [];
+    const srcBaseName = srcEl.name || (srcPath.length ? srcPath[srcPath.length - 1] : "");
+    const relatedNameMap = {};
+    if (srcEl && srcEl.relationships && srcBaseName) {
+      for (const rel of srcEl.relationships || []) {
+        if (!rel.name)
+          continue;
+        const tgtEl = allElements.find((e) => e.id === rel.targetElementId);
+        if (!tgtEl || tgtEl.source?.kind !== "warehouse-table")
+          continue;
+        for (const tc of tgtEl.columns || []) {
+          if (!tc.formula || tc.formula.startsWith("/*"))
+            continue;
+          const fm = tc.formula.match(/^\[([^\]]+)\]$/);
+          if (!fm)
+            continue;
+          const inner = fm[1];
+          const s = inner.lastIndexOf("/");
+          const dispName = s >= 0 ? inner.slice(s + 1) : inner;
+          if (!(dispName in relatedNameMap)) {
+            relatedNameMap[dispName] = `${srcBaseName}/${rel.name}/${dispName}`;
+          }
+        }
+      }
+    }
+    for (const c of calcs) {
+      if (c.formula && Object.keys(relatedNameMap).length) {
+        c.formula = c.formula.replace(/\[([^\]\/]+)\]/g, (match, refName) => {
+          const rewritten = relatedNameMap[refName];
+          return rewritten ? `[${rewritten}]` : match;
+        });
+      }
+      de.columns.push(c);
+      de.order.push(c.id);
+    }
+    warnings.push(`\u2139 ${calcs.length} calc col(s) moved to derived "${de.name}" (cross-element refs)`);
+    placedSrcElIds[srcElId] = true;
+  }
+  for (const elId of Object.keys(crossElCalcsByElId)) {
+    if (placedSrcElIds[elId])
+      continue;
+    for (const c of crossElCalcsByElId[elId]) {
+      warnings.push(`\u26A0 "${c.name}" cross-element refs but no derived element \u2014 column dropped`);
+    }
+  }
+  const sigmaModel = {
+    name: sigmaDisplayName(exploreName),
+    schemaVersion: 1,
+    pages: [{ id: sigmaShortId(), name: "Page 1", elements: allElements }]
+  };
+  const totalCols = allElements.reduce((s, e) => s + (e.columns?.length || 0), 0);
+  const totalMetrics = allElements.reduce((s, e) => s + (e.metrics?.length || 0), 0);
+  const totalRels = allElements.reduce((s, e) => s + (e.relationships?.length || 0), 0);
+  return {
+    model: sigmaModel,
+    warnings,
+    ...security.length ? { security } : {},
+    stats: {
+      views: Object.keys(views).length,
+      explores: Object.keys(explores).length,
+      elements: allElements.length,
+      columns: totalCols,
+      metrics: totalMetrics,
+      relationships: totalRels
+    }
+  };
+}
+function buildDerivedElements(elements) {
+  const derived = [];
+  for (const srcEl of elements) {
+    if (!srcEl.relationships?.length)
+      continue;
+    if (srcEl.source?.kind !== "warehouse-table")
+      continue;
+    const srcPath = srcEl.source.path;
+    const srcTableName = srcPath[srcPath.length - 1];
+    const baseName = srcEl.name || srcTableName;
+    const viewCols = [];
+    const viewOrder = [];
+    for (const col of srcEl.columns ?? []) {
+      if (!col.formula || col.formula.startsWith("/*"))
+        continue;
+      const cId = sigmaShortId();
+      if (col.name) {
+        if (String(col.name).includes("/"))
+          continue;
+        viewCols.push({ id: cId, formula: `[${baseName}/${col.name}]` });
+        viewOrder.push(cId);
+        continue;
+      }
+      const fm = col.formula.match(/^\[([^\/\]]+)\/([^\]]+)\]$/);
+      viewCols.push({ id: cId, formula: fm ? `[${baseName}/${fm[2]}]` : col.formula });
+      viewOrder.push(cId);
+    }
+    for (const rel of srcEl.relationships ?? []) {
+      if (!rel.name)
+        continue;
+      const tgtEl = elements.find((e) => e.id === rel.targetElementId);
+      if (!tgtEl || tgtEl.source?.kind !== "warehouse-table" && tgtEl.source?.kind !== "sql")
+        continue;
+      const tgtKeyIds = new Set((rel.keys ?? []).map((k) => k.targetColumnId));
+      for (const col of tgtEl.columns ?? []) {
+        if (tgtKeyIds.has(col.id))
+          continue;
+        if (!col.formula || col.formula.startsWith("/*"))
+          continue;
+        let dispName;
+        if (col.name) {
+          dispName = col.name;
+        } else {
+          const fm = col.formula.match(/^\[([^\]]+)\]$/);
+          if (!fm)
+            continue;
+          const inner = fm[1];
+          const slashIdx = inner.lastIndexOf("/");
+          dispName = slashIdx >= 0 ? inner.slice(slashIdx + 1) : inner;
+        }
+        const cId = sigmaShortId();
+        viewCols.push({ id: cId, formula: `[${baseName}/${rel.name}/${dispName}]` });
+        viewOrder.push(cId);
+      }
+    }
+    if (viewCols.length > 0) {
+      derived.push({
+        id: sigmaShortId(),
+        kind: "table",
+        // " View" suffix matches sigma-ids.ts buildDerivedElements — without it
+        // the derived element collides with the (now-named) source element.
+        name: `${srcEl.name ?? sigmaDisplayName(srcTableName)} View`,
+        source: { kind: "table", elementId: srcEl.id },
+        columns: viewCols,
+        order: viewOrder
+      });
+    }
+  }
+  return derived;
+}
+export {
+  convertLookMLToSigma,
+  parseLookML
+};

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -595,6 +595,14 @@ def main():
         build = os.environ.get("CONVERTER_PATH") or next(
             (os.path.join(h, "build", "lookml.js") for h in CONVERTER_HOMES
              if os.path.exists(os.path.join(h, "build", "lookml.js"))), None)
+        # Zero-config fallback: the converter is VENDORED in the skill as a
+        # self-contained ESM bundle (converter/lookml.mjs) — no clone, no MCP, no
+        # network. A dev's CONVERTER_SRC/CONVERTER_PATH (or a CONVERTER_HOMES
+        # checkout) still wins above; this is the guaranteed floor so conversion
+        # runs locally out of the box. Imported by the same `build` node shim below.
+        vendored = os.path.join(HERE, "..", "converter", "lookml.mjs")
+        if not src and not build and os.path.exists(vendored):
+            build = vendored
         if src or build:
             print(f"   converter: {src or build}")
             warn_converter_skew(src or build)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -119,15 +119,17 @@ prefix applied to BOTH the data model and every workbook; workbooks and pages
 are named after the Liveboard's **display name** (resolved from its TML, never
 the UUID).
 
-**Converter paths** (no unvendored build required):
-- `CONVERTER_PATH` set (a local `sigma-data-model-mcp` `build/thoughtspot.js`)
-  → fully scripted one-shot via `convert_model.mjs`.
-- `CONVERTER_PATH` unset → **MCP fallback**: migrate.py writes
-  `<workdir>/model.tml` + `<workdir>/convert-request.json` (the exact
-  `mcp__sigma-data-model__convert_thoughtspot_to_sigma` arguments), prints the
-  instructions, and exits 3. Call the MCP tool, save its JSON output to
-  `<workdir>/converted.json`, and re-run the same command with
-  `--converted <workdir>/converted.json` to continue the pipeline.
+**Converter — zero-config, local, no MCP.** A self-contained converter bundle
+ships in the skill at `converter/thoughtspot.mjs` and is the default: conversion
+runs locally via `node` with no clone, no `npm install`, no network, no MCP.
+`CONVERTER_PATH` defaults to it; a dev's own `build/thoughtspot.js` still wins when
+set. Refresh the bundle with `tools/vendor-converters.sh` (see
+`converter/PROVENANCE.json`). Only if the bundle is missing AND `CONVERTER_PATH` is
+unset does migrate.py fall back to the **MCP path**: it writes `<workdir>/model.tml`
++ `<workdir>/convert-request.json` (the exact
+`mcp__sigma-data-model__convert_thoughtspot_to_sigma` arguments) and exits 3 — call
+the tool, save its JSON to `<workdir>/converted.json`, and re-run with
+`--converted <workdir>/converted.json`.
 
 **Offline mode** (no live ThoughtSpot needed): `--model-tml <file>` +
 `--liveboard-tml <file>` read exported TML from disk — `fixtures/` ships a real

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/converter/PROVENANCE.json
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/converter/PROVENANCE.json
@@ -1,0 +1,8 @@
+{
+  "source_repo": "twells89/sigma-data-model-mcp",
+  "source_commit": "867c669",
+  "source_commit_date": "2026-06-22",
+  "bundler": "esbuild --bundle --format=esm --platform=node",
+  "vendored_modules": "thoughtspot.mjs",
+  "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."
+}

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/converter/thoughtspot.mjs
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/converter/thoughtspot.mjs
@@ -1,0 +1,3658 @@
+// ../../../Users/tjwells/sigma-data-model-mcp/node_modules/js-yaml/dist/js-yaml.mjs
+function isNothing(subject) {
+  return typeof subject === "undefined" || subject === null;
+}
+function isObject(subject) {
+  return typeof subject === "object" && subject !== null;
+}
+function toArray(sequence) {
+  if (Array.isArray(sequence)) return sequence;
+  else if (isNothing(sequence)) return [];
+  return [sequence];
+}
+function extend(target, source) {
+  var index, length, key, sourceKeys;
+  if (source) {
+    sourceKeys = Object.keys(source);
+    for (index = 0, length = sourceKeys.length; index < length; index += 1) {
+      key = sourceKeys[index];
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
+function repeat(string, count) {
+  var result = "", cycle;
+  for (cycle = 0; cycle < count; cycle += 1) {
+    result += string;
+  }
+  return result;
+}
+function isNegativeZero(number) {
+  return number === 0 && Number.NEGATIVE_INFINITY === 1 / number;
+}
+var isNothing_1 = isNothing;
+var isObject_1 = isObject;
+var toArray_1 = toArray;
+var repeat_1 = repeat;
+var isNegativeZero_1 = isNegativeZero;
+var extend_1 = extend;
+var common = {
+  isNothing: isNothing_1,
+  isObject: isObject_1,
+  toArray: toArray_1,
+  repeat: repeat_1,
+  isNegativeZero: isNegativeZero_1,
+  extend: extend_1
+};
+function formatError(exception2, compact) {
+  var where = "", message = exception2.reason || "(unknown reason)";
+  if (!exception2.mark) return message;
+  if (exception2.mark.name) {
+    where += 'in "' + exception2.mark.name + '" ';
+  }
+  where += "(" + (exception2.mark.line + 1) + ":" + (exception2.mark.column + 1) + ")";
+  if (!compact && exception2.mark.snippet) {
+    where += "\n\n" + exception2.mark.snippet;
+  }
+  return message + " " + where;
+}
+function YAMLException$1(reason, mark) {
+  Error.call(this);
+  this.name = "YAMLException";
+  this.reason = reason;
+  this.mark = mark;
+  this.message = formatError(this, false);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  } else {
+    this.stack = new Error().stack || "";
+  }
+}
+YAMLException$1.prototype = Object.create(Error.prototype);
+YAMLException$1.prototype.constructor = YAMLException$1;
+YAMLException$1.prototype.toString = function toString(compact) {
+  return this.name + ": " + formatError(this, compact);
+};
+var exception = YAMLException$1;
+function getLine(buffer, lineStart, lineEnd, position, maxLineLength) {
+  var head = "";
+  var tail = "";
+  var maxHalfLength = Math.floor(maxLineLength / 2) - 1;
+  if (position - lineStart > maxHalfLength) {
+    head = " ... ";
+    lineStart = position - maxHalfLength + head.length;
+  }
+  if (lineEnd - position > maxHalfLength) {
+    tail = " ...";
+    lineEnd = position + maxHalfLength - tail.length;
+  }
+  return {
+    str: head + buffer.slice(lineStart, lineEnd).replace(/\t/g, "\u2192") + tail,
+    pos: position - lineStart + head.length
+    // relative position
+  };
+}
+function padStart(string, max) {
+  return common.repeat(" ", max - string.length) + string;
+}
+function makeSnippet(mark, options) {
+  options = Object.create(options || null);
+  if (!mark.buffer) return null;
+  if (!options.maxLength) options.maxLength = 79;
+  if (typeof options.indent !== "number") options.indent = 1;
+  if (typeof options.linesBefore !== "number") options.linesBefore = 3;
+  if (typeof options.linesAfter !== "number") options.linesAfter = 2;
+  var re = /\r?\n|\r|\0/g;
+  var lineStarts = [0];
+  var lineEnds = [];
+  var match;
+  var foundLineNo = -1;
+  while (match = re.exec(mark.buffer)) {
+    lineEnds.push(match.index);
+    lineStarts.push(match.index + match[0].length);
+    if (mark.position <= match.index && foundLineNo < 0) {
+      foundLineNo = lineStarts.length - 2;
+    }
+  }
+  if (foundLineNo < 0) foundLineNo = lineStarts.length - 1;
+  var result = "", i, line;
+  var lineNoLength = Math.min(mark.line + options.linesAfter, lineEnds.length).toString().length;
+  var maxLineLength = options.maxLength - (options.indent + lineNoLength + 3);
+  for (i = 1; i <= options.linesBefore; i++) {
+    if (foundLineNo - i < 0) break;
+    line = getLine(
+      mark.buffer,
+      lineStarts[foundLineNo - i],
+      lineEnds[foundLineNo - i],
+      mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo - i]),
+      maxLineLength
+    );
+    result = common.repeat(" ", options.indent) + padStart((mark.line - i + 1).toString(), lineNoLength) + " | " + line.str + "\n" + result;
+  }
+  line = getLine(mark.buffer, lineStarts[foundLineNo], lineEnds[foundLineNo], mark.position, maxLineLength);
+  result += common.repeat(" ", options.indent) + padStart((mark.line + 1).toString(), lineNoLength) + " | " + line.str + "\n";
+  result += common.repeat("-", options.indent + lineNoLength + 3 + line.pos) + "^\n";
+  for (i = 1; i <= options.linesAfter; i++) {
+    if (foundLineNo + i >= lineEnds.length) break;
+    line = getLine(
+      mark.buffer,
+      lineStarts[foundLineNo + i],
+      lineEnds[foundLineNo + i],
+      mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo + i]),
+      maxLineLength
+    );
+    result += common.repeat(" ", options.indent) + padStart((mark.line + i + 1).toString(), lineNoLength) + " | " + line.str + "\n";
+  }
+  return result.replace(/\n$/, "");
+}
+var snippet = makeSnippet;
+var TYPE_CONSTRUCTOR_OPTIONS = [
+  "kind",
+  "multi",
+  "resolve",
+  "construct",
+  "instanceOf",
+  "predicate",
+  "represent",
+  "representName",
+  "defaultStyle",
+  "styleAliases"
+];
+var YAML_NODE_KINDS = [
+  "scalar",
+  "sequence",
+  "mapping"
+];
+function compileStyleAliases(map2) {
+  var result = {};
+  if (map2 !== null) {
+    Object.keys(map2).forEach(function(style) {
+      map2[style].forEach(function(alias) {
+        result[String(alias)] = style;
+      });
+    });
+  }
+  return result;
+}
+function Type$1(tag, options) {
+  options = options || {};
+  Object.keys(options).forEach(function(name) {
+    if (TYPE_CONSTRUCTOR_OPTIONS.indexOf(name) === -1) {
+      throw new exception('Unknown option "' + name + '" is met in definition of "' + tag + '" YAML type.');
+    }
+  });
+  this.options = options;
+  this.tag = tag;
+  this.kind = options["kind"] || null;
+  this.resolve = options["resolve"] || function() {
+    return true;
+  };
+  this.construct = options["construct"] || function(data) {
+    return data;
+  };
+  this.instanceOf = options["instanceOf"] || null;
+  this.predicate = options["predicate"] || null;
+  this.represent = options["represent"] || null;
+  this.representName = options["representName"] || null;
+  this.defaultStyle = options["defaultStyle"] || null;
+  this.multi = options["multi"] || false;
+  this.styleAliases = compileStyleAliases(options["styleAliases"] || null);
+  if (YAML_NODE_KINDS.indexOf(this.kind) === -1) {
+    throw new exception('Unknown kind "' + this.kind + '" is specified for "' + tag + '" YAML type.');
+  }
+}
+var type = Type$1;
+function compileList(schema2, name) {
+  var result = [];
+  schema2[name].forEach(function(currentType) {
+    var newIndex = result.length;
+    result.forEach(function(previousType, previousIndex) {
+      if (previousType.tag === currentType.tag && previousType.kind === currentType.kind && previousType.multi === currentType.multi) {
+        newIndex = previousIndex;
+      }
+    });
+    result[newIndex] = currentType;
+  });
+  return result;
+}
+function compileMap() {
+  var result = {
+    scalar: {},
+    sequence: {},
+    mapping: {},
+    fallback: {},
+    multi: {
+      scalar: [],
+      sequence: [],
+      mapping: [],
+      fallback: []
+    }
+  }, index, length;
+  function collectType(type2) {
+    if (type2.multi) {
+      result.multi[type2.kind].push(type2);
+      result.multi["fallback"].push(type2);
+    } else {
+      result[type2.kind][type2.tag] = result["fallback"][type2.tag] = type2;
+    }
+  }
+  for (index = 0, length = arguments.length; index < length; index += 1) {
+    arguments[index].forEach(collectType);
+  }
+  return result;
+}
+function Schema$1(definition) {
+  return this.extend(definition);
+}
+Schema$1.prototype.extend = function extend2(definition) {
+  var implicit = [];
+  var explicit = [];
+  if (definition instanceof type) {
+    explicit.push(definition);
+  } else if (Array.isArray(definition)) {
+    explicit = explicit.concat(definition);
+  } else if (definition && (Array.isArray(definition.implicit) || Array.isArray(definition.explicit))) {
+    if (definition.implicit) implicit = implicit.concat(definition.implicit);
+    if (definition.explicit) explicit = explicit.concat(definition.explicit);
+  } else {
+    throw new exception("Schema.extend argument should be a Type, [ Type ], or a schema definition ({ implicit: [...], explicit: [...] })");
+  }
+  implicit.forEach(function(type$1) {
+    if (!(type$1 instanceof type)) {
+      throw new exception("Specified list of YAML types (or a single Type object) contains a non-Type object.");
+    }
+    if (type$1.loadKind && type$1.loadKind !== "scalar") {
+      throw new exception("There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.");
+    }
+    if (type$1.multi) {
+      throw new exception("There is a multi type in the implicit list of a schema. Multi tags can only be listed as explicit.");
+    }
+  });
+  explicit.forEach(function(type$1) {
+    if (!(type$1 instanceof type)) {
+      throw new exception("Specified list of YAML types (or a single Type object) contains a non-Type object.");
+    }
+  });
+  var result = Object.create(Schema$1.prototype);
+  result.implicit = (this.implicit || []).concat(implicit);
+  result.explicit = (this.explicit || []).concat(explicit);
+  result.compiledImplicit = compileList(result, "implicit");
+  result.compiledExplicit = compileList(result, "explicit");
+  result.compiledTypeMap = compileMap(result.compiledImplicit, result.compiledExplicit);
+  return result;
+};
+var schema = Schema$1;
+var str = new type("tag:yaml.org,2002:str", {
+  kind: "scalar",
+  construct: function(data) {
+    return data !== null ? data : "";
+  }
+});
+var seq = new type("tag:yaml.org,2002:seq", {
+  kind: "sequence",
+  construct: function(data) {
+    return data !== null ? data : [];
+  }
+});
+var map = new type("tag:yaml.org,2002:map", {
+  kind: "mapping",
+  construct: function(data) {
+    return data !== null ? data : {};
+  }
+});
+var failsafe = new schema({
+  explicit: [
+    str,
+    seq,
+    map
+  ]
+});
+function resolveYamlNull(data) {
+  if (data === null) return true;
+  var max = data.length;
+  return max === 1 && data === "~" || max === 4 && (data === "null" || data === "Null" || data === "NULL");
+}
+function constructYamlNull() {
+  return null;
+}
+function isNull(object) {
+  return object === null;
+}
+var _null = new type("tag:yaml.org,2002:null", {
+  kind: "scalar",
+  resolve: resolveYamlNull,
+  construct: constructYamlNull,
+  predicate: isNull,
+  represent: {
+    canonical: function() {
+      return "~";
+    },
+    lowercase: function() {
+      return "null";
+    },
+    uppercase: function() {
+      return "NULL";
+    },
+    camelcase: function() {
+      return "Null";
+    },
+    empty: function() {
+      return "";
+    }
+  },
+  defaultStyle: "lowercase"
+});
+function resolveYamlBoolean(data) {
+  if (data === null) return false;
+  var max = data.length;
+  return max === 4 && (data === "true" || data === "True" || data === "TRUE") || max === 5 && (data === "false" || data === "False" || data === "FALSE");
+}
+function constructYamlBoolean(data) {
+  return data === "true" || data === "True" || data === "TRUE";
+}
+function isBoolean(object) {
+  return Object.prototype.toString.call(object) === "[object Boolean]";
+}
+var bool = new type("tag:yaml.org,2002:bool", {
+  kind: "scalar",
+  resolve: resolveYamlBoolean,
+  construct: constructYamlBoolean,
+  predicate: isBoolean,
+  represent: {
+    lowercase: function(object) {
+      return object ? "true" : "false";
+    },
+    uppercase: function(object) {
+      return object ? "TRUE" : "FALSE";
+    },
+    camelcase: function(object) {
+      return object ? "True" : "False";
+    }
+  },
+  defaultStyle: "lowercase"
+});
+function isHexCode(c) {
+  return 48 <= c && c <= 57 || 65 <= c && c <= 70 || 97 <= c && c <= 102;
+}
+function isOctCode(c) {
+  return 48 <= c && c <= 55;
+}
+function isDecCode(c) {
+  return 48 <= c && c <= 57;
+}
+function resolveYamlInteger(data) {
+  if (data === null) return false;
+  var max = data.length, index = 0, hasDigits = false, ch;
+  if (!max) return false;
+  ch = data[index];
+  if (ch === "-" || ch === "+") {
+    ch = data[++index];
+  }
+  if (ch === "0") {
+    if (index + 1 === max) return true;
+    ch = data[++index];
+    if (ch === "b") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_") continue;
+        if (ch !== "0" && ch !== "1") return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+    if (ch === "x") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_") continue;
+        if (!isHexCode(data.charCodeAt(index))) return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+    if (ch === "o") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_") continue;
+        if (!isOctCode(data.charCodeAt(index))) return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+  }
+  if (ch === "_") return false;
+  for (; index < max; index++) {
+    ch = data[index];
+    if (ch === "_") continue;
+    if (!isDecCode(data.charCodeAt(index))) {
+      return false;
+    }
+    hasDigits = true;
+  }
+  if (!hasDigits || ch === "_") return false;
+  return true;
+}
+function constructYamlInteger(data) {
+  var value = data, sign = 1, ch;
+  if (value.indexOf("_") !== -1) {
+    value = value.replace(/_/g, "");
+  }
+  ch = value[0];
+  if (ch === "-" || ch === "+") {
+    if (ch === "-") sign = -1;
+    value = value.slice(1);
+    ch = value[0];
+  }
+  if (value === "0") return 0;
+  if (ch === "0") {
+    if (value[1] === "b") return sign * parseInt(value.slice(2), 2);
+    if (value[1] === "x") return sign * parseInt(value.slice(2), 16);
+    if (value[1] === "o") return sign * parseInt(value.slice(2), 8);
+  }
+  return sign * parseInt(value, 10);
+}
+function isInteger(object) {
+  return Object.prototype.toString.call(object) === "[object Number]" && (object % 1 === 0 && !common.isNegativeZero(object));
+}
+var int = new type("tag:yaml.org,2002:int", {
+  kind: "scalar",
+  resolve: resolveYamlInteger,
+  construct: constructYamlInteger,
+  predicate: isInteger,
+  represent: {
+    binary: function(obj) {
+      return obj >= 0 ? "0b" + obj.toString(2) : "-0b" + obj.toString(2).slice(1);
+    },
+    octal: function(obj) {
+      return obj >= 0 ? "0o" + obj.toString(8) : "-0o" + obj.toString(8).slice(1);
+    },
+    decimal: function(obj) {
+      return obj.toString(10);
+    },
+    /* eslint-disable max-len */
+    hexadecimal: function(obj) {
+      return obj >= 0 ? "0x" + obj.toString(16).toUpperCase() : "-0x" + obj.toString(16).toUpperCase().slice(1);
+    }
+  },
+  defaultStyle: "decimal",
+  styleAliases: {
+    binary: [2, "bin"],
+    octal: [8, "oct"],
+    decimal: [10, "dec"],
+    hexadecimal: [16, "hex"]
+  }
+});
+var YAML_FLOAT_PATTERN = new RegExp(
+  // 2.5e4, 2.5 and integers
+  "^(?:[-+]?(?:[0-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$"
+);
+function resolveYamlFloat(data) {
+  if (data === null) return false;
+  if (!YAML_FLOAT_PATTERN.test(data) || // Quick hack to not allow integers end with `_`
+  // Probably should update regexp & check speed
+  data[data.length - 1] === "_") {
+    return false;
+  }
+  return true;
+}
+function constructYamlFloat(data) {
+  var value, sign;
+  value = data.replace(/_/g, "").toLowerCase();
+  sign = value[0] === "-" ? -1 : 1;
+  if ("+-".indexOf(value[0]) >= 0) {
+    value = value.slice(1);
+  }
+  if (value === ".inf") {
+    return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+  } else if (value === ".nan") {
+    return NaN;
+  }
+  return sign * parseFloat(value, 10);
+}
+var SCIENTIFIC_WITHOUT_DOT = /^[-+]?[0-9]+e/;
+function representYamlFloat(object, style) {
+  var res;
+  if (isNaN(object)) {
+    switch (style) {
+      case "lowercase":
+        return ".nan";
+      case "uppercase":
+        return ".NAN";
+      case "camelcase":
+        return ".NaN";
+    }
+  } else if (Number.POSITIVE_INFINITY === object) {
+    switch (style) {
+      case "lowercase":
+        return ".inf";
+      case "uppercase":
+        return ".INF";
+      case "camelcase":
+        return ".Inf";
+    }
+  } else if (Number.NEGATIVE_INFINITY === object) {
+    switch (style) {
+      case "lowercase":
+        return "-.inf";
+      case "uppercase":
+        return "-.INF";
+      case "camelcase":
+        return "-.Inf";
+    }
+  } else if (common.isNegativeZero(object)) {
+    return "-0.0";
+  }
+  res = object.toString(10);
+  return SCIENTIFIC_WITHOUT_DOT.test(res) ? res.replace("e", ".e") : res;
+}
+function isFloat(object) {
+  return Object.prototype.toString.call(object) === "[object Number]" && (object % 1 !== 0 || common.isNegativeZero(object));
+}
+var float = new type("tag:yaml.org,2002:float", {
+  kind: "scalar",
+  resolve: resolveYamlFloat,
+  construct: constructYamlFloat,
+  predicate: isFloat,
+  represent: representYamlFloat,
+  defaultStyle: "lowercase"
+});
+var json = failsafe.extend({
+  implicit: [
+    _null,
+    bool,
+    int,
+    float
+  ]
+});
+var core = json;
+var YAML_DATE_REGEXP = new RegExp(
+  "^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"
+);
+var YAML_TIMESTAMP_REGEXP = new RegExp(
+  "^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$"
+);
+function resolveYamlTimestamp(data) {
+  if (data === null) return false;
+  if (YAML_DATE_REGEXP.exec(data) !== null) return true;
+  if (YAML_TIMESTAMP_REGEXP.exec(data) !== null) return true;
+  return false;
+}
+function constructYamlTimestamp(data) {
+  var match, year, month, day, hour, minute, second, fraction = 0, delta = null, tz_hour, tz_minute, date;
+  match = YAML_DATE_REGEXP.exec(data);
+  if (match === null) match = YAML_TIMESTAMP_REGEXP.exec(data);
+  if (match === null) throw new Error("Date resolve error");
+  year = +match[1];
+  month = +match[2] - 1;
+  day = +match[3];
+  if (!match[4]) {
+    return new Date(Date.UTC(year, month, day));
+  }
+  hour = +match[4];
+  minute = +match[5];
+  second = +match[6];
+  if (match[7]) {
+    fraction = match[7].slice(0, 3);
+    while (fraction.length < 3) {
+      fraction += "0";
+    }
+    fraction = +fraction;
+  }
+  if (match[9]) {
+    tz_hour = +match[10];
+    tz_minute = +(match[11] || 0);
+    delta = (tz_hour * 60 + tz_minute) * 6e4;
+    if (match[9] === "-") delta = -delta;
+  }
+  date = new Date(Date.UTC(year, month, day, hour, minute, second, fraction));
+  if (delta) date.setTime(date.getTime() - delta);
+  return date;
+}
+function representYamlTimestamp(object) {
+  return object.toISOString();
+}
+var timestamp = new type("tag:yaml.org,2002:timestamp", {
+  kind: "scalar",
+  resolve: resolveYamlTimestamp,
+  construct: constructYamlTimestamp,
+  instanceOf: Date,
+  represent: representYamlTimestamp
+});
+function resolveYamlMerge(data) {
+  return data === "<<" || data === null;
+}
+var merge = new type("tag:yaml.org,2002:merge", {
+  kind: "scalar",
+  resolve: resolveYamlMerge
+});
+var BASE64_MAP = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r";
+function resolveYamlBinary(data) {
+  if (data === null) return false;
+  var code, idx, bitlen = 0, max = data.length, map2 = BASE64_MAP;
+  for (idx = 0; idx < max; idx++) {
+    code = map2.indexOf(data.charAt(idx));
+    if (code > 64) continue;
+    if (code < 0) return false;
+    bitlen += 6;
+  }
+  return bitlen % 8 === 0;
+}
+function constructYamlBinary(data) {
+  var idx, tailbits, input = data.replace(/[\r\n=]/g, ""), max = input.length, map2 = BASE64_MAP, bits = 0, result = [];
+  for (idx = 0; idx < max; idx++) {
+    if (idx % 4 === 0 && idx) {
+      result.push(bits >> 16 & 255);
+      result.push(bits >> 8 & 255);
+      result.push(bits & 255);
+    }
+    bits = bits << 6 | map2.indexOf(input.charAt(idx));
+  }
+  tailbits = max % 4 * 6;
+  if (tailbits === 0) {
+    result.push(bits >> 16 & 255);
+    result.push(bits >> 8 & 255);
+    result.push(bits & 255);
+  } else if (tailbits === 18) {
+    result.push(bits >> 10 & 255);
+    result.push(bits >> 2 & 255);
+  } else if (tailbits === 12) {
+    result.push(bits >> 4 & 255);
+  }
+  return new Uint8Array(result);
+}
+function representYamlBinary(object) {
+  var result = "", bits = 0, idx, tail, max = object.length, map2 = BASE64_MAP;
+  for (idx = 0; idx < max; idx++) {
+    if (idx % 3 === 0 && idx) {
+      result += map2[bits >> 18 & 63];
+      result += map2[bits >> 12 & 63];
+      result += map2[bits >> 6 & 63];
+      result += map2[bits & 63];
+    }
+    bits = (bits << 8) + object[idx];
+  }
+  tail = max % 3;
+  if (tail === 0) {
+    result += map2[bits >> 18 & 63];
+    result += map2[bits >> 12 & 63];
+    result += map2[bits >> 6 & 63];
+    result += map2[bits & 63];
+  } else if (tail === 2) {
+    result += map2[bits >> 10 & 63];
+    result += map2[bits >> 4 & 63];
+    result += map2[bits << 2 & 63];
+    result += map2[64];
+  } else if (tail === 1) {
+    result += map2[bits >> 2 & 63];
+    result += map2[bits << 4 & 63];
+    result += map2[64];
+    result += map2[64];
+  }
+  return result;
+}
+function isBinary(obj) {
+  return Object.prototype.toString.call(obj) === "[object Uint8Array]";
+}
+var binary = new type("tag:yaml.org,2002:binary", {
+  kind: "scalar",
+  resolve: resolveYamlBinary,
+  construct: constructYamlBinary,
+  predicate: isBinary,
+  represent: representYamlBinary
+});
+var _hasOwnProperty$3 = Object.prototype.hasOwnProperty;
+var _toString$2 = Object.prototype.toString;
+function resolveYamlOmap(data) {
+  if (data === null) return true;
+  var objectKeys = [], index, length, pair, pairKey, pairHasKey, object = data;
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+    pairHasKey = false;
+    if (_toString$2.call(pair) !== "[object Object]") return false;
+    for (pairKey in pair) {
+      if (_hasOwnProperty$3.call(pair, pairKey)) {
+        if (!pairHasKey) pairHasKey = true;
+        else return false;
+      }
+    }
+    if (!pairHasKey) return false;
+    if (objectKeys.indexOf(pairKey) === -1) objectKeys.push(pairKey);
+    else return false;
+  }
+  return true;
+}
+function constructYamlOmap(data) {
+  return data !== null ? data : [];
+}
+var omap = new type("tag:yaml.org,2002:omap", {
+  kind: "sequence",
+  resolve: resolveYamlOmap,
+  construct: constructYamlOmap
+});
+var _toString$1 = Object.prototype.toString;
+function resolveYamlPairs(data) {
+  if (data === null) return true;
+  var index, length, pair, keys, result, object = data;
+  result = new Array(object.length);
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+    if (_toString$1.call(pair) !== "[object Object]") return false;
+    keys = Object.keys(pair);
+    if (keys.length !== 1) return false;
+    result[index] = [keys[0], pair[keys[0]]];
+  }
+  return true;
+}
+function constructYamlPairs(data) {
+  if (data === null) return [];
+  var index, length, pair, keys, result, object = data;
+  result = new Array(object.length);
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+    keys = Object.keys(pair);
+    result[index] = [keys[0], pair[keys[0]]];
+  }
+  return result;
+}
+var pairs = new type("tag:yaml.org,2002:pairs", {
+  kind: "sequence",
+  resolve: resolveYamlPairs,
+  construct: constructYamlPairs
+});
+var _hasOwnProperty$2 = Object.prototype.hasOwnProperty;
+function resolveYamlSet(data) {
+  if (data === null) return true;
+  var key, object = data;
+  for (key in object) {
+    if (_hasOwnProperty$2.call(object, key)) {
+      if (object[key] !== null) return false;
+    }
+  }
+  return true;
+}
+function constructYamlSet(data) {
+  return data !== null ? data : {};
+}
+var set = new type("tag:yaml.org,2002:set", {
+  kind: "mapping",
+  resolve: resolveYamlSet,
+  construct: constructYamlSet
+});
+var _default = core.extend({
+  implicit: [
+    timestamp,
+    merge
+  ],
+  explicit: [
+    binary,
+    omap,
+    pairs,
+    set
+  ]
+});
+var _hasOwnProperty$1 = Object.prototype.hasOwnProperty;
+var CONTEXT_FLOW_IN = 1;
+var CONTEXT_FLOW_OUT = 2;
+var CONTEXT_BLOCK_IN = 3;
+var CONTEXT_BLOCK_OUT = 4;
+var CHOMPING_CLIP = 1;
+var CHOMPING_STRIP = 2;
+var CHOMPING_KEEP = 3;
+var PATTERN_NON_PRINTABLE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
+var PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
+var PATTERN_FLOW_INDICATORS = /[,\[\]\{\}]/;
+var PATTERN_TAG_HANDLE = /^(?:!|!!|![a-z\-]+!)$/i;
+var PATTERN_TAG_URI = /^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;
+function _class(obj) {
+  return Object.prototype.toString.call(obj);
+}
+function is_EOL(c) {
+  return c === 10 || c === 13;
+}
+function is_WHITE_SPACE(c) {
+  return c === 9 || c === 32;
+}
+function is_WS_OR_EOL(c) {
+  return c === 9 || c === 32 || c === 10 || c === 13;
+}
+function is_FLOW_INDICATOR(c) {
+  return c === 44 || c === 91 || c === 93 || c === 123 || c === 125;
+}
+function fromHexCode(c) {
+  var lc;
+  if (48 <= c && c <= 57) {
+    return c - 48;
+  }
+  lc = c | 32;
+  if (97 <= lc && lc <= 102) {
+    return lc - 97 + 10;
+  }
+  return -1;
+}
+function escapedHexLen(c) {
+  if (c === 120) {
+    return 2;
+  }
+  if (c === 117) {
+    return 4;
+  }
+  if (c === 85) {
+    return 8;
+  }
+  return 0;
+}
+function fromDecimalCode(c) {
+  if (48 <= c && c <= 57) {
+    return c - 48;
+  }
+  return -1;
+}
+function simpleEscapeSequence(c) {
+  return c === 48 ? "\0" : c === 97 ? "\x07" : c === 98 ? "\b" : c === 116 ? "	" : c === 9 ? "	" : c === 110 ? "\n" : c === 118 ? "\v" : c === 102 ? "\f" : c === 114 ? "\r" : c === 101 ? "\x1B" : c === 32 ? " " : c === 34 ? '"' : c === 47 ? "/" : c === 92 ? "\\" : c === 78 ? "\x85" : c === 95 ? "\xA0" : c === 76 ? "\u2028" : c === 80 ? "\u2029" : "";
+}
+function charFromCodepoint(c) {
+  if (c <= 65535) {
+    return String.fromCharCode(c);
+  }
+  return String.fromCharCode(
+    (c - 65536 >> 10) + 55296,
+    (c - 65536 & 1023) + 56320
+  );
+}
+function setProperty(object, key, value) {
+  if (key === "__proto__") {
+    Object.defineProperty(object, key, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value
+    });
+  } else {
+    object[key] = value;
+  }
+}
+var simpleEscapeCheck = new Array(256);
+var simpleEscapeMap = new Array(256);
+for (i = 0; i < 256; i++) {
+  simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
+  simpleEscapeMap[i] = simpleEscapeSequence(i);
+}
+var i;
+function State$1(input, options) {
+  this.input = input;
+  this.filename = options["filename"] || null;
+  this.schema = options["schema"] || _default;
+  this.onWarning = options["onWarning"] || null;
+  this.legacy = options["legacy"] || false;
+  this.json = options["json"] || false;
+  this.listener = options["listener"] || null;
+  this.implicitTypes = this.schema.compiledImplicit;
+  this.typeMap = this.schema.compiledTypeMap;
+  this.length = input.length;
+  this.position = 0;
+  this.line = 0;
+  this.lineStart = 0;
+  this.lineIndent = 0;
+  this.firstTabInLine = -1;
+  this.documents = [];
+}
+function generateError(state, message) {
+  var mark = {
+    name: state.filename,
+    buffer: state.input.slice(0, -1),
+    // omit trailing \0
+    position: state.position,
+    line: state.line,
+    column: state.position - state.lineStart
+  };
+  mark.snippet = snippet(mark);
+  return new exception(message, mark);
+}
+function throwError(state, message) {
+  throw generateError(state, message);
+}
+function throwWarning(state, message) {
+  if (state.onWarning) {
+    state.onWarning.call(null, generateError(state, message));
+  }
+}
+var directiveHandlers = {
+  YAML: function handleYamlDirective(state, name, args) {
+    var match, major, minor;
+    if (state.version !== null) {
+      throwError(state, "duplication of %YAML directive");
+    }
+    if (args.length !== 1) {
+      throwError(state, "YAML directive accepts exactly one argument");
+    }
+    match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
+    if (match === null) {
+      throwError(state, "ill-formed argument of the YAML directive");
+    }
+    major = parseInt(match[1], 10);
+    minor = parseInt(match[2], 10);
+    if (major !== 1) {
+      throwError(state, "unacceptable YAML version of the document");
+    }
+    state.version = args[0];
+    state.checkLineBreaks = minor < 2;
+    if (minor !== 1 && minor !== 2) {
+      throwWarning(state, "unsupported YAML version of the document");
+    }
+  },
+  TAG: function handleTagDirective(state, name, args) {
+    var handle, prefix;
+    if (args.length !== 2) {
+      throwError(state, "TAG directive accepts exactly two arguments");
+    }
+    handle = args[0];
+    prefix = args[1];
+    if (!PATTERN_TAG_HANDLE.test(handle)) {
+      throwError(state, "ill-formed tag handle (first argument) of the TAG directive");
+    }
+    if (_hasOwnProperty$1.call(state.tagMap, handle)) {
+      throwError(state, 'there is a previously declared suffix for "' + handle + '" tag handle');
+    }
+    if (!PATTERN_TAG_URI.test(prefix)) {
+      throwError(state, "ill-formed tag prefix (second argument) of the TAG directive");
+    }
+    try {
+      prefix = decodeURIComponent(prefix);
+    } catch (err) {
+      throwError(state, "tag prefix is malformed: " + prefix);
+    }
+    state.tagMap[handle] = prefix;
+  }
+};
+function captureSegment(state, start, end, checkJson) {
+  var _position, _length, _character, _result;
+  if (start < end) {
+    _result = state.input.slice(start, end);
+    if (checkJson) {
+      for (_position = 0, _length = _result.length; _position < _length; _position += 1) {
+        _character = _result.charCodeAt(_position);
+        if (!(_character === 9 || 32 <= _character && _character <= 1114111)) {
+          throwError(state, "expected valid JSON character");
+        }
+      }
+    } else if (PATTERN_NON_PRINTABLE.test(_result)) {
+      throwError(state, "the stream contains non-printable characters");
+    }
+    state.result += _result;
+  }
+}
+function mergeMappings(state, destination, source, overridableKeys) {
+  var sourceKeys, key, index, quantity;
+  if (!common.isObject(source)) {
+    throwError(state, "cannot merge mappings; the provided source object is unacceptable");
+  }
+  sourceKeys = Object.keys(source);
+  for (index = 0, quantity = sourceKeys.length; index < quantity; index += 1) {
+    key = sourceKeys[index];
+    if (!_hasOwnProperty$1.call(destination, key)) {
+      setProperty(destination, key, source[key]);
+      overridableKeys[key] = true;
+    }
+  }
+}
+function storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, startLine, startLineStart, startPos) {
+  var index, quantity;
+  if (Array.isArray(keyNode)) {
+    keyNode = Array.prototype.slice.call(keyNode);
+    for (index = 0, quantity = keyNode.length; index < quantity; index += 1) {
+      if (Array.isArray(keyNode[index])) {
+        throwError(state, "nested arrays are not supported inside keys");
+      }
+      if (typeof keyNode === "object" && _class(keyNode[index]) === "[object Object]") {
+        keyNode[index] = "[object Object]";
+      }
+    }
+  }
+  if (typeof keyNode === "object" && _class(keyNode) === "[object Object]") {
+    keyNode = "[object Object]";
+  }
+  keyNode = String(keyNode);
+  if (_result === null) {
+    _result = {};
+  }
+  if (keyTag === "tag:yaml.org,2002:merge") {
+    if (Array.isArray(valueNode)) {
+      for (index = 0, quantity = valueNode.length; index < quantity; index += 1) {
+        mergeMappings(state, _result, valueNode[index], overridableKeys);
+      }
+    } else {
+      mergeMappings(state, _result, valueNode, overridableKeys);
+    }
+  } else {
+    if (!state.json && !_hasOwnProperty$1.call(overridableKeys, keyNode) && _hasOwnProperty$1.call(_result, keyNode)) {
+      state.line = startLine || state.line;
+      state.lineStart = startLineStart || state.lineStart;
+      state.position = startPos || state.position;
+      throwError(state, "duplicated mapping key");
+    }
+    setProperty(_result, keyNode, valueNode);
+    delete overridableKeys[keyNode];
+  }
+  return _result;
+}
+function readLineBreak(state) {
+  var ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch === 10) {
+    state.position++;
+  } else if (ch === 13) {
+    state.position++;
+    if (state.input.charCodeAt(state.position) === 10) {
+      state.position++;
+    }
+  } else {
+    throwError(state, "a line break is expected");
+  }
+  state.line += 1;
+  state.lineStart = state.position;
+  state.firstTabInLine = -1;
+}
+function skipSeparationSpace(state, allowComments, checkIndent) {
+  var lineBreaks = 0, ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    while (is_WHITE_SPACE(ch)) {
+      if (ch === 9 && state.firstTabInLine === -1) {
+        state.firstTabInLine = state.position;
+      }
+      ch = state.input.charCodeAt(++state.position);
+    }
+    if (allowComments && ch === 35) {
+      do {
+        ch = state.input.charCodeAt(++state.position);
+      } while (ch !== 10 && ch !== 13 && ch !== 0);
+    }
+    if (is_EOL(ch)) {
+      readLineBreak(state);
+      ch = state.input.charCodeAt(state.position);
+      lineBreaks++;
+      state.lineIndent = 0;
+      while (ch === 32) {
+        state.lineIndent++;
+        ch = state.input.charCodeAt(++state.position);
+      }
+    } else {
+      break;
+    }
+  }
+  if (checkIndent !== -1 && lineBreaks !== 0 && state.lineIndent < checkIndent) {
+    throwWarning(state, "deficient indentation");
+  }
+  return lineBreaks;
+}
+function testDocumentSeparator(state) {
+  var _position = state.position, ch;
+  ch = state.input.charCodeAt(_position);
+  if ((ch === 45 || ch === 46) && ch === state.input.charCodeAt(_position + 1) && ch === state.input.charCodeAt(_position + 2)) {
+    _position += 3;
+    ch = state.input.charCodeAt(_position);
+    if (ch === 0 || is_WS_OR_EOL(ch)) {
+      return true;
+    }
+  }
+  return false;
+}
+function writeFoldedLines(state, count) {
+  if (count === 1) {
+    state.result += " ";
+  } else if (count > 1) {
+    state.result += common.repeat("\n", count - 1);
+  }
+}
+function readPlainScalar(state, nodeIndent, withinFlowCollection) {
+  var preceding, following, captureStart, captureEnd, hasPendingContent, _line, _lineStart, _lineIndent, _kind = state.kind, _result = state.result, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (is_WS_OR_EOL(ch) || is_FLOW_INDICATOR(ch) || ch === 35 || ch === 38 || ch === 42 || ch === 33 || ch === 124 || ch === 62 || ch === 39 || ch === 34 || ch === 37 || ch === 64 || ch === 96) {
+    return false;
+  }
+  if (ch === 63 || ch === 45) {
+    following = state.input.charCodeAt(state.position + 1);
+    if (is_WS_OR_EOL(following) || withinFlowCollection && is_FLOW_INDICATOR(following)) {
+      return false;
+    }
+  }
+  state.kind = "scalar";
+  state.result = "";
+  captureStart = captureEnd = state.position;
+  hasPendingContent = false;
+  while (ch !== 0) {
+    if (ch === 58) {
+      following = state.input.charCodeAt(state.position + 1);
+      if (is_WS_OR_EOL(following) || withinFlowCollection && is_FLOW_INDICATOR(following)) {
+        break;
+      }
+    } else if (ch === 35) {
+      preceding = state.input.charCodeAt(state.position - 1);
+      if (is_WS_OR_EOL(preceding)) {
+        break;
+      }
+    } else if (state.position === state.lineStart && testDocumentSeparator(state) || withinFlowCollection && is_FLOW_INDICATOR(ch)) {
+      break;
+    } else if (is_EOL(ch)) {
+      _line = state.line;
+      _lineStart = state.lineStart;
+      _lineIndent = state.lineIndent;
+      skipSeparationSpace(state, false, -1);
+      if (state.lineIndent >= nodeIndent) {
+        hasPendingContent = true;
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      } else {
+        state.position = captureEnd;
+        state.line = _line;
+        state.lineStart = _lineStart;
+        state.lineIndent = _lineIndent;
+        break;
+      }
+    }
+    if (hasPendingContent) {
+      captureSegment(state, captureStart, captureEnd, false);
+      writeFoldedLines(state, state.line - _line);
+      captureStart = captureEnd = state.position;
+      hasPendingContent = false;
+    }
+    if (!is_WHITE_SPACE(ch)) {
+      captureEnd = state.position + 1;
+    }
+    ch = state.input.charCodeAt(++state.position);
+  }
+  captureSegment(state, captureStart, captureEnd, false);
+  if (state.result) {
+    return true;
+  }
+  state.kind = _kind;
+  state.result = _result;
+  return false;
+}
+function readSingleQuotedScalar(state, nodeIndent) {
+  var ch, captureStart, captureEnd;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 39) {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  state.position++;
+  captureStart = captureEnd = state.position;
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 39) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+      if (ch === 39) {
+        captureStart = state.position;
+        state.position++;
+        captureEnd = state.position;
+      } else {
+        return true;
+      }
+    } else if (is_EOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      throwError(state, "unexpected end of the document within a single quoted scalar");
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+  throwError(state, "unexpected end of the stream within a single quoted scalar");
+}
+function readDoubleQuotedScalar(state, nodeIndent) {
+  var captureStart, captureEnd, hexLength, hexResult, tmp, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 34) {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  state.position++;
+  captureStart = captureEnd = state.position;
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 34) {
+      captureSegment(state, captureStart, state.position, true);
+      state.position++;
+      return true;
+    } else if (ch === 92) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+      if (is_EOL(ch)) {
+        skipSeparationSpace(state, false, nodeIndent);
+      } else if (ch < 256 && simpleEscapeCheck[ch]) {
+        state.result += simpleEscapeMap[ch];
+        state.position++;
+      } else if ((tmp = escapedHexLen(ch)) > 0) {
+        hexLength = tmp;
+        hexResult = 0;
+        for (; hexLength > 0; hexLength--) {
+          ch = state.input.charCodeAt(++state.position);
+          if ((tmp = fromHexCode(ch)) >= 0) {
+            hexResult = (hexResult << 4) + tmp;
+          } else {
+            throwError(state, "expected hexadecimal character");
+          }
+        }
+        state.result += charFromCodepoint(hexResult);
+        state.position++;
+      } else {
+        throwError(state, "unknown escape sequence");
+      }
+      captureStart = captureEnd = state.position;
+    } else if (is_EOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      throwError(state, "unexpected end of the document within a double quoted scalar");
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+  throwError(state, "unexpected end of the stream within a double quoted scalar");
+}
+function readFlowCollection(state, nodeIndent) {
+  var readNext = true, _line, _lineStart, _pos, _tag = state.tag, _result, _anchor = state.anchor, following, terminator, isPair, isExplicitPair, isMapping, overridableKeys = /* @__PURE__ */ Object.create(null), keyNode, keyTag, valueNode, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch === 91) {
+    terminator = 93;
+    isMapping = false;
+    _result = [];
+  } else if (ch === 123) {
+    terminator = 125;
+    isMapping = true;
+    _result = {};
+  } else {
+    return false;
+  }
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+  ch = state.input.charCodeAt(++state.position);
+  while (ch !== 0) {
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if (ch === terminator) {
+      state.position++;
+      state.tag = _tag;
+      state.anchor = _anchor;
+      state.kind = isMapping ? "mapping" : "sequence";
+      state.result = _result;
+      return true;
+    } else if (!readNext) {
+      throwError(state, "missed comma between flow collection entries");
+    } else if (ch === 44) {
+      throwError(state, "expected the node content, but found ','");
+    }
+    keyTag = keyNode = valueNode = null;
+    isPair = isExplicitPair = false;
+    if (ch === 63) {
+      following = state.input.charCodeAt(state.position + 1);
+      if (is_WS_OR_EOL(following)) {
+        isPair = isExplicitPair = true;
+        state.position++;
+        skipSeparationSpace(state, true, nodeIndent);
+      }
+    }
+    _line = state.line;
+    _lineStart = state.lineStart;
+    _pos = state.position;
+    composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+    keyTag = state.tag;
+    keyNode = state.result;
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if ((isExplicitPair || state.line === _line) && ch === 58) {
+      isPair = true;
+      ch = state.input.charCodeAt(++state.position);
+      skipSeparationSpace(state, true, nodeIndent);
+      composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+      valueNode = state.result;
+    }
+    if (isMapping) {
+      storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos);
+    } else if (isPair) {
+      _result.push(storeMappingPair(state, null, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos));
+    } else {
+      _result.push(keyNode);
+    }
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if (ch === 44) {
+      readNext = true;
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      readNext = false;
+    }
+  }
+  throwError(state, "unexpected end of the stream within a flow collection");
+}
+function readBlockScalar(state, nodeIndent) {
+  var captureStart, folding, chomping = CHOMPING_CLIP, didReadContent = false, detectedIndent = false, textIndent = nodeIndent, emptyLines = 0, atMoreIndented = false, tmp, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch === 124) {
+    folding = false;
+  } else if (ch === 62) {
+    folding = true;
+  } else {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  while (ch !== 0) {
+    ch = state.input.charCodeAt(++state.position);
+    if (ch === 43 || ch === 45) {
+      if (CHOMPING_CLIP === chomping) {
+        chomping = ch === 43 ? CHOMPING_KEEP : CHOMPING_STRIP;
+      } else {
+        throwError(state, "repeat of a chomping mode identifier");
+      }
+    } else if ((tmp = fromDecimalCode(ch)) >= 0) {
+      if (tmp === 0) {
+        throwError(state, "bad explicit indentation width of a block scalar; it cannot be less than one");
+      } else if (!detectedIndent) {
+        textIndent = nodeIndent + tmp - 1;
+        detectedIndent = true;
+      } else {
+        throwError(state, "repeat of an indentation width identifier");
+      }
+    } else {
+      break;
+    }
+  }
+  if (is_WHITE_SPACE(ch)) {
+    do {
+      ch = state.input.charCodeAt(++state.position);
+    } while (is_WHITE_SPACE(ch));
+    if (ch === 35) {
+      do {
+        ch = state.input.charCodeAt(++state.position);
+      } while (!is_EOL(ch) && ch !== 0);
+    }
+  }
+  while (ch !== 0) {
+    readLineBreak(state);
+    state.lineIndent = 0;
+    ch = state.input.charCodeAt(state.position);
+    while ((!detectedIndent || state.lineIndent < textIndent) && ch === 32) {
+      state.lineIndent++;
+      ch = state.input.charCodeAt(++state.position);
+    }
+    if (!detectedIndent && state.lineIndent > textIndent) {
+      textIndent = state.lineIndent;
+    }
+    if (is_EOL(ch)) {
+      emptyLines++;
+      continue;
+    }
+    if (state.lineIndent < textIndent) {
+      if (chomping === CHOMPING_KEEP) {
+        state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
+      } else if (chomping === CHOMPING_CLIP) {
+        if (didReadContent) {
+          state.result += "\n";
+        }
+      }
+      break;
+    }
+    if (folding) {
+      if (is_WHITE_SPACE(ch)) {
+        atMoreIndented = true;
+        state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
+      } else if (atMoreIndented) {
+        atMoreIndented = false;
+        state.result += common.repeat("\n", emptyLines + 1);
+      } else if (emptyLines === 0) {
+        if (didReadContent) {
+          state.result += " ";
+        }
+      } else {
+        state.result += common.repeat("\n", emptyLines);
+      }
+    } else {
+      state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
+    }
+    didReadContent = true;
+    detectedIndent = true;
+    emptyLines = 0;
+    captureStart = state.position;
+    while (!is_EOL(ch) && ch !== 0) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+    captureSegment(state, captureStart, state.position, false);
+  }
+  return true;
+}
+function readBlockSequence(state, nodeIndent) {
+  var _line, _tag = state.tag, _anchor = state.anchor, _result = [], following, detected = false, ch;
+  if (state.firstTabInLine !== -1) return false;
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+  ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    if (state.firstTabInLine !== -1) {
+      state.position = state.firstTabInLine;
+      throwError(state, "tab characters must not be used in indentation");
+    }
+    if (ch !== 45) {
+      break;
+    }
+    following = state.input.charCodeAt(state.position + 1);
+    if (!is_WS_OR_EOL(following)) {
+      break;
+    }
+    detected = true;
+    state.position++;
+    if (skipSeparationSpace(state, true, -1)) {
+      if (state.lineIndent <= nodeIndent) {
+        _result.push(null);
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      }
+    }
+    _line = state.line;
+    composeNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
+    _result.push(state.result);
+    skipSeparationSpace(state, true, -1);
+    ch = state.input.charCodeAt(state.position);
+    if ((state.line === _line || state.lineIndent > nodeIndent) && ch !== 0) {
+      throwError(state, "bad indentation of a sequence entry");
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+  if (detected) {
+    state.tag = _tag;
+    state.anchor = _anchor;
+    state.kind = "sequence";
+    state.result = _result;
+    return true;
+  }
+  return false;
+}
+function readBlockMapping(state, nodeIndent, flowIndent) {
+  var following, allowCompact, _line, _keyLine, _keyLineStart, _keyPos, _tag = state.tag, _anchor = state.anchor, _result = {}, overridableKeys = /* @__PURE__ */ Object.create(null), keyTag = null, keyNode = null, valueNode = null, atExplicitKey = false, detected = false, ch;
+  if (state.firstTabInLine !== -1) return false;
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+  ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    if (!atExplicitKey && state.firstTabInLine !== -1) {
+      state.position = state.firstTabInLine;
+      throwError(state, "tab characters must not be used in indentation");
+    }
+    following = state.input.charCodeAt(state.position + 1);
+    _line = state.line;
+    if ((ch === 63 || ch === 58) && is_WS_OR_EOL(following)) {
+      if (ch === 63) {
+        if (atExplicitKey) {
+          storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+          keyTag = keyNode = valueNode = null;
+        }
+        detected = true;
+        atExplicitKey = true;
+        allowCompact = true;
+      } else if (atExplicitKey) {
+        atExplicitKey = false;
+        allowCompact = true;
+      } else {
+        throwError(state, "incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line");
+      }
+      state.position += 1;
+      ch = following;
+    } else {
+      _keyLine = state.line;
+      _keyLineStart = state.lineStart;
+      _keyPos = state.position;
+      if (!composeNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) {
+        break;
+      }
+      if (state.line === _line) {
+        ch = state.input.charCodeAt(state.position);
+        while (is_WHITE_SPACE(ch)) {
+          ch = state.input.charCodeAt(++state.position);
+        }
+        if (ch === 58) {
+          ch = state.input.charCodeAt(++state.position);
+          if (!is_WS_OR_EOL(ch)) {
+            throwError(state, "a whitespace character is expected after the key-value separator within a block mapping");
+          }
+          if (atExplicitKey) {
+            storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+            keyTag = keyNode = valueNode = null;
+          }
+          detected = true;
+          atExplicitKey = false;
+          allowCompact = false;
+          keyTag = state.tag;
+          keyNode = state.result;
+        } else if (detected) {
+          throwError(state, "can not read an implicit mapping pair; a colon is missed");
+        } else {
+          state.tag = _tag;
+          state.anchor = _anchor;
+          return true;
+        }
+      } else if (detected) {
+        throwError(state, "can not read a block mapping entry; a multiline key may not be an implicit key");
+      } else {
+        state.tag = _tag;
+        state.anchor = _anchor;
+        return true;
+      }
+    }
+    if (state.line === _line || state.lineIndent > nodeIndent) {
+      if (atExplicitKey) {
+        _keyLine = state.line;
+        _keyLineStart = state.lineStart;
+        _keyPos = state.position;
+      }
+      if (composeNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, allowCompact)) {
+        if (atExplicitKey) {
+          keyNode = state.result;
+        } else {
+          valueNode = state.result;
+        }
+      }
+      if (!atExplicitKey) {
+        storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _keyLine, _keyLineStart, _keyPos);
+        keyTag = keyNode = valueNode = null;
+      }
+      skipSeparationSpace(state, true, -1);
+      ch = state.input.charCodeAt(state.position);
+    }
+    if ((state.line === _line || state.lineIndent > nodeIndent) && ch !== 0) {
+      throwError(state, "bad indentation of a mapping entry");
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+  if (atExplicitKey) {
+    storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+  }
+  if (detected) {
+    state.tag = _tag;
+    state.anchor = _anchor;
+    state.kind = "mapping";
+    state.result = _result;
+  }
+  return detected;
+}
+function readTagProperty(state) {
+  var _position, isVerbatim = false, isNamed = false, tagHandle, tagName, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 33) return false;
+  if (state.tag !== null) {
+    throwError(state, "duplication of a tag property");
+  }
+  ch = state.input.charCodeAt(++state.position);
+  if (ch === 60) {
+    isVerbatim = true;
+    ch = state.input.charCodeAt(++state.position);
+  } else if (ch === 33) {
+    isNamed = true;
+    tagHandle = "!!";
+    ch = state.input.charCodeAt(++state.position);
+  } else {
+    tagHandle = "!";
+  }
+  _position = state.position;
+  if (isVerbatim) {
+    do {
+      ch = state.input.charCodeAt(++state.position);
+    } while (ch !== 0 && ch !== 62);
+    if (state.position < state.length) {
+      tagName = state.input.slice(_position, state.position);
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      throwError(state, "unexpected end of the stream within a verbatim tag");
+    }
+  } else {
+    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+      if (ch === 33) {
+        if (!isNamed) {
+          tagHandle = state.input.slice(_position - 1, state.position + 1);
+          if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
+            throwError(state, "named tag handle cannot contain such characters");
+          }
+          isNamed = true;
+          _position = state.position + 1;
+        } else {
+          throwError(state, "tag suffix cannot contain exclamation marks");
+        }
+      }
+      ch = state.input.charCodeAt(++state.position);
+    }
+    tagName = state.input.slice(_position, state.position);
+    if (PATTERN_FLOW_INDICATORS.test(tagName)) {
+      throwError(state, "tag suffix cannot contain flow indicator characters");
+    }
+  }
+  if (tagName && !PATTERN_TAG_URI.test(tagName)) {
+    throwError(state, "tag name cannot contain such characters: " + tagName);
+  }
+  try {
+    tagName = decodeURIComponent(tagName);
+  } catch (err) {
+    throwError(state, "tag name is malformed: " + tagName);
+  }
+  if (isVerbatim) {
+    state.tag = tagName;
+  } else if (_hasOwnProperty$1.call(state.tagMap, tagHandle)) {
+    state.tag = state.tagMap[tagHandle] + tagName;
+  } else if (tagHandle === "!") {
+    state.tag = "!" + tagName;
+  } else if (tagHandle === "!!") {
+    state.tag = "tag:yaml.org,2002:" + tagName;
+  } else {
+    throwError(state, 'undeclared tag handle "' + tagHandle + '"');
+  }
+  return true;
+}
+function readAnchorProperty(state) {
+  var _position, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 38) return false;
+  if (state.anchor !== null) {
+    throwError(state, "duplication of an anchor property");
+  }
+  ch = state.input.charCodeAt(++state.position);
+  _position = state.position;
+  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+  if (state.position === _position) {
+    throwError(state, "name of an anchor node must contain at least one character");
+  }
+  state.anchor = state.input.slice(_position, state.position);
+  return true;
+}
+function readAlias(state) {
+  var _position, alias, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 42) return false;
+  ch = state.input.charCodeAt(++state.position);
+  _position = state.position;
+  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+  if (state.position === _position) {
+    throwError(state, "name of an alias node must contain at least one character");
+  }
+  alias = state.input.slice(_position, state.position);
+  if (!_hasOwnProperty$1.call(state.anchorMap, alias)) {
+    throwError(state, 'unidentified alias "' + alias + '"');
+  }
+  state.result = state.anchorMap[alias];
+  skipSeparationSpace(state, true, -1);
+  return true;
+}
+function composeNode(state, parentIndent, nodeContext, allowToSeek, allowCompact) {
+  var allowBlockStyles, allowBlockScalars, allowBlockCollections, indentStatus = 1, atNewLine = false, hasContent = false, typeIndex, typeQuantity, typeList, type2, flowIndent, blockIndent;
+  if (state.listener !== null) {
+    state.listener("open", state);
+  }
+  state.tag = null;
+  state.anchor = null;
+  state.kind = null;
+  state.result = null;
+  allowBlockStyles = allowBlockScalars = allowBlockCollections = CONTEXT_BLOCK_OUT === nodeContext || CONTEXT_BLOCK_IN === nodeContext;
+  if (allowToSeek) {
+    if (skipSeparationSpace(state, true, -1)) {
+      atNewLine = true;
+      if (state.lineIndent > parentIndent) {
+        indentStatus = 1;
+      } else if (state.lineIndent === parentIndent) {
+        indentStatus = 0;
+      } else if (state.lineIndent < parentIndent) {
+        indentStatus = -1;
+      }
+    }
+  }
+  if (indentStatus === 1) {
+    while (readTagProperty(state) || readAnchorProperty(state)) {
+      if (skipSeparationSpace(state, true, -1)) {
+        atNewLine = true;
+        allowBlockCollections = allowBlockStyles;
+        if (state.lineIndent > parentIndent) {
+          indentStatus = 1;
+        } else if (state.lineIndent === parentIndent) {
+          indentStatus = 0;
+        } else if (state.lineIndent < parentIndent) {
+          indentStatus = -1;
+        }
+      } else {
+        allowBlockCollections = false;
+      }
+    }
+  }
+  if (allowBlockCollections) {
+    allowBlockCollections = atNewLine || allowCompact;
+  }
+  if (indentStatus === 1 || CONTEXT_BLOCK_OUT === nodeContext) {
+    if (CONTEXT_FLOW_IN === nodeContext || CONTEXT_FLOW_OUT === nodeContext) {
+      flowIndent = parentIndent;
+    } else {
+      flowIndent = parentIndent + 1;
+    }
+    blockIndent = state.position - state.lineStart;
+    if (indentStatus === 1) {
+      if (allowBlockCollections && (readBlockSequence(state, blockIndent) || readBlockMapping(state, blockIndent, flowIndent)) || readFlowCollection(state, flowIndent)) {
+        hasContent = true;
+      } else {
+        if (allowBlockScalars && readBlockScalar(state, flowIndent) || readSingleQuotedScalar(state, flowIndent) || readDoubleQuotedScalar(state, flowIndent)) {
+          hasContent = true;
+        } else if (readAlias(state)) {
+          hasContent = true;
+          if (state.tag !== null || state.anchor !== null) {
+            throwError(state, "alias node should not have any properties");
+          }
+        } else if (readPlainScalar(state, flowIndent, CONTEXT_FLOW_IN === nodeContext)) {
+          hasContent = true;
+          if (state.tag === null) {
+            state.tag = "?";
+          }
+        }
+        if (state.anchor !== null) {
+          state.anchorMap[state.anchor] = state.result;
+        }
+      }
+    } else if (indentStatus === 0) {
+      hasContent = allowBlockCollections && readBlockSequence(state, blockIndent);
+    }
+  }
+  if (state.tag === null) {
+    if (state.anchor !== null) {
+      state.anchorMap[state.anchor] = state.result;
+    }
+  } else if (state.tag === "?") {
+    if (state.result !== null && state.kind !== "scalar") {
+      throwError(state, 'unacceptable node kind for !<?> tag; it should be "scalar", not "' + state.kind + '"');
+    }
+    for (typeIndex = 0, typeQuantity = state.implicitTypes.length; typeIndex < typeQuantity; typeIndex += 1) {
+      type2 = state.implicitTypes[typeIndex];
+      if (type2.resolve(state.result)) {
+        state.result = type2.construct(state.result);
+        state.tag = type2.tag;
+        if (state.anchor !== null) {
+          state.anchorMap[state.anchor] = state.result;
+        }
+        break;
+      }
+    }
+  } else if (state.tag !== "!") {
+    if (_hasOwnProperty$1.call(state.typeMap[state.kind || "fallback"], state.tag)) {
+      type2 = state.typeMap[state.kind || "fallback"][state.tag];
+    } else {
+      type2 = null;
+      typeList = state.typeMap.multi[state.kind || "fallback"];
+      for (typeIndex = 0, typeQuantity = typeList.length; typeIndex < typeQuantity; typeIndex += 1) {
+        if (state.tag.slice(0, typeList[typeIndex].tag.length) === typeList[typeIndex].tag) {
+          type2 = typeList[typeIndex];
+          break;
+        }
+      }
+    }
+    if (!type2) {
+      throwError(state, "unknown tag !<" + state.tag + ">");
+    }
+    if (state.result !== null && type2.kind !== state.kind) {
+      throwError(state, "unacceptable node kind for !<" + state.tag + '> tag; it should be "' + type2.kind + '", not "' + state.kind + '"');
+    }
+    if (!type2.resolve(state.result, state.tag)) {
+      throwError(state, "cannot resolve a node with !<" + state.tag + "> explicit tag");
+    } else {
+      state.result = type2.construct(state.result, state.tag);
+      if (state.anchor !== null) {
+        state.anchorMap[state.anchor] = state.result;
+      }
+    }
+  }
+  if (state.listener !== null) {
+    state.listener("close", state);
+  }
+  return state.tag !== null || state.anchor !== null || hasContent;
+}
+function readDocument(state) {
+  var documentStart = state.position, _position, directiveName, directiveArgs, hasDirectives = false, ch;
+  state.version = null;
+  state.checkLineBreaks = state.legacy;
+  state.tagMap = /* @__PURE__ */ Object.create(null);
+  state.anchorMap = /* @__PURE__ */ Object.create(null);
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    skipSeparationSpace(state, true, -1);
+    ch = state.input.charCodeAt(state.position);
+    if (state.lineIndent > 0 || ch !== 37) {
+      break;
+    }
+    hasDirectives = true;
+    ch = state.input.charCodeAt(++state.position);
+    _position = state.position;
+    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+    directiveName = state.input.slice(_position, state.position);
+    directiveArgs = [];
+    if (directiveName.length < 1) {
+      throwError(state, "directive name must not be less than one character in length");
+    }
+    while (ch !== 0) {
+      while (is_WHITE_SPACE(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+      if (ch === 35) {
+        do {
+          ch = state.input.charCodeAt(++state.position);
+        } while (ch !== 0 && !is_EOL(ch));
+        break;
+      }
+      if (is_EOL(ch)) break;
+      _position = state.position;
+      while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+      directiveArgs.push(state.input.slice(_position, state.position));
+    }
+    if (ch !== 0) readLineBreak(state);
+    if (_hasOwnProperty$1.call(directiveHandlers, directiveName)) {
+      directiveHandlers[directiveName](state, directiveName, directiveArgs);
+    } else {
+      throwWarning(state, 'unknown document directive "' + directiveName + '"');
+    }
+  }
+  skipSeparationSpace(state, true, -1);
+  if (state.lineIndent === 0 && state.input.charCodeAt(state.position) === 45 && state.input.charCodeAt(state.position + 1) === 45 && state.input.charCodeAt(state.position + 2) === 45) {
+    state.position += 3;
+    skipSeparationSpace(state, true, -1);
+  } else if (hasDirectives) {
+    throwError(state, "directives end mark is expected");
+  }
+  composeNode(state, state.lineIndent - 1, CONTEXT_BLOCK_OUT, false, true);
+  skipSeparationSpace(state, true, -1);
+  if (state.checkLineBreaks && PATTERN_NON_ASCII_LINE_BREAKS.test(state.input.slice(documentStart, state.position))) {
+    throwWarning(state, "non-ASCII line breaks are interpreted as content");
+  }
+  state.documents.push(state.result);
+  if (state.position === state.lineStart && testDocumentSeparator(state)) {
+    if (state.input.charCodeAt(state.position) === 46) {
+      state.position += 3;
+      skipSeparationSpace(state, true, -1);
+    }
+    return;
+  }
+  if (state.position < state.length - 1) {
+    throwError(state, "end of the stream or a document separator is expected");
+  } else {
+    return;
+  }
+}
+function loadDocuments(input, options) {
+  input = String(input);
+  options = options || {};
+  if (input.length !== 0) {
+    if (input.charCodeAt(input.length - 1) !== 10 && input.charCodeAt(input.length - 1) !== 13) {
+      input += "\n";
+    }
+    if (input.charCodeAt(0) === 65279) {
+      input = input.slice(1);
+    }
+  }
+  var state = new State$1(input, options);
+  var nullpos = input.indexOf("\0");
+  if (nullpos !== -1) {
+    state.position = nullpos;
+    throwError(state, "null byte is not allowed in input");
+  }
+  state.input += "\0";
+  while (state.input.charCodeAt(state.position) === 32) {
+    state.lineIndent += 1;
+    state.position += 1;
+  }
+  while (state.position < state.length - 1) {
+    readDocument(state);
+  }
+  return state.documents;
+}
+function loadAll$1(input, iterator, options) {
+  if (iterator !== null && typeof iterator === "object" && typeof options === "undefined") {
+    options = iterator;
+    iterator = null;
+  }
+  var documents = loadDocuments(input, options);
+  if (typeof iterator !== "function") {
+    return documents;
+  }
+  for (var index = 0, length = documents.length; index < length; index += 1) {
+    iterator(documents[index]);
+  }
+}
+function load$1(input, options) {
+  var documents = loadDocuments(input, options);
+  if (documents.length === 0) {
+    return void 0;
+  } else if (documents.length === 1) {
+    return documents[0];
+  }
+  throw new exception("expected a single document in the stream, but found more");
+}
+var loadAll_1 = loadAll$1;
+var load_1 = load$1;
+var loader = {
+  loadAll: loadAll_1,
+  load: load_1
+};
+var _toString = Object.prototype.toString;
+var _hasOwnProperty = Object.prototype.hasOwnProperty;
+var CHAR_BOM = 65279;
+var CHAR_TAB = 9;
+var CHAR_LINE_FEED = 10;
+var CHAR_CARRIAGE_RETURN = 13;
+var CHAR_SPACE = 32;
+var CHAR_EXCLAMATION = 33;
+var CHAR_DOUBLE_QUOTE = 34;
+var CHAR_SHARP = 35;
+var CHAR_PERCENT = 37;
+var CHAR_AMPERSAND = 38;
+var CHAR_SINGLE_QUOTE = 39;
+var CHAR_ASTERISK = 42;
+var CHAR_COMMA = 44;
+var CHAR_MINUS = 45;
+var CHAR_COLON = 58;
+var CHAR_EQUALS = 61;
+var CHAR_GREATER_THAN = 62;
+var CHAR_QUESTION = 63;
+var CHAR_COMMERCIAL_AT = 64;
+var CHAR_LEFT_SQUARE_BRACKET = 91;
+var CHAR_RIGHT_SQUARE_BRACKET = 93;
+var CHAR_GRAVE_ACCENT = 96;
+var CHAR_LEFT_CURLY_BRACKET = 123;
+var CHAR_VERTICAL_LINE = 124;
+var CHAR_RIGHT_CURLY_BRACKET = 125;
+var ESCAPE_SEQUENCES = {};
+ESCAPE_SEQUENCES[0] = "\\0";
+ESCAPE_SEQUENCES[7] = "\\a";
+ESCAPE_SEQUENCES[8] = "\\b";
+ESCAPE_SEQUENCES[9] = "\\t";
+ESCAPE_SEQUENCES[10] = "\\n";
+ESCAPE_SEQUENCES[11] = "\\v";
+ESCAPE_SEQUENCES[12] = "\\f";
+ESCAPE_SEQUENCES[13] = "\\r";
+ESCAPE_SEQUENCES[27] = "\\e";
+ESCAPE_SEQUENCES[34] = '\\"';
+ESCAPE_SEQUENCES[92] = "\\\\";
+ESCAPE_SEQUENCES[133] = "\\N";
+ESCAPE_SEQUENCES[160] = "\\_";
+ESCAPE_SEQUENCES[8232] = "\\L";
+ESCAPE_SEQUENCES[8233] = "\\P";
+var DEPRECATED_BOOLEANS_SYNTAX = [
+  "y",
+  "Y",
+  "yes",
+  "Yes",
+  "YES",
+  "on",
+  "On",
+  "ON",
+  "n",
+  "N",
+  "no",
+  "No",
+  "NO",
+  "off",
+  "Off",
+  "OFF"
+];
+var DEPRECATED_BASE60_SYNTAX = /^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/;
+function compileStyleMap(schema2, map2) {
+  var result, keys, index, length, tag, style, type2;
+  if (map2 === null) return {};
+  result = {};
+  keys = Object.keys(map2);
+  for (index = 0, length = keys.length; index < length; index += 1) {
+    tag = keys[index];
+    style = String(map2[tag]);
+    if (tag.slice(0, 2) === "!!") {
+      tag = "tag:yaml.org,2002:" + tag.slice(2);
+    }
+    type2 = schema2.compiledTypeMap["fallback"][tag];
+    if (type2 && _hasOwnProperty.call(type2.styleAliases, style)) {
+      style = type2.styleAliases[style];
+    }
+    result[tag] = style;
+  }
+  return result;
+}
+function encodeHex(character) {
+  var string, handle, length;
+  string = character.toString(16).toUpperCase();
+  if (character <= 255) {
+    handle = "x";
+    length = 2;
+  } else if (character <= 65535) {
+    handle = "u";
+    length = 4;
+  } else if (character <= 4294967295) {
+    handle = "U";
+    length = 8;
+  } else {
+    throw new exception("code point within a string may not be greater than 0xFFFFFFFF");
+  }
+  return "\\" + handle + common.repeat("0", length - string.length) + string;
+}
+var QUOTING_TYPE_SINGLE = 1;
+var QUOTING_TYPE_DOUBLE = 2;
+function State(options) {
+  this.schema = options["schema"] || _default;
+  this.indent = Math.max(1, options["indent"] || 2);
+  this.noArrayIndent = options["noArrayIndent"] || false;
+  this.skipInvalid = options["skipInvalid"] || false;
+  this.flowLevel = common.isNothing(options["flowLevel"]) ? -1 : options["flowLevel"];
+  this.styleMap = compileStyleMap(this.schema, options["styles"] || null);
+  this.sortKeys = options["sortKeys"] || false;
+  this.lineWidth = options["lineWidth"] || 80;
+  this.noRefs = options["noRefs"] || false;
+  this.noCompatMode = options["noCompatMode"] || false;
+  this.condenseFlow = options["condenseFlow"] || false;
+  this.quotingType = options["quotingType"] === '"' ? QUOTING_TYPE_DOUBLE : QUOTING_TYPE_SINGLE;
+  this.forceQuotes = options["forceQuotes"] || false;
+  this.replacer = typeof options["replacer"] === "function" ? options["replacer"] : null;
+  this.implicitTypes = this.schema.compiledImplicit;
+  this.explicitTypes = this.schema.compiledExplicit;
+  this.tag = null;
+  this.result = "";
+  this.duplicates = [];
+  this.usedDuplicates = null;
+}
+function indentString(string, spaces) {
+  var ind = common.repeat(" ", spaces), position = 0, next = -1, result = "", line, length = string.length;
+  while (position < length) {
+    next = string.indexOf("\n", position);
+    if (next === -1) {
+      line = string.slice(position);
+      position = length;
+    } else {
+      line = string.slice(position, next + 1);
+      position = next + 1;
+    }
+    if (line.length && line !== "\n") result += ind;
+    result += line;
+  }
+  return result;
+}
+function generateNextLine(state, level) {
+  return "\n" + common.repeat(" ", state.indent * level);
+}
+function testImplicitResolving(state, str2) {
+  var index, length, type2;
+  for (index = 0, length = state.implicitTypes.length; index < length; index += 1) {
+    type2 = state.implicitTypes[index];
+    if (type2.resolve(str2)) {
+      return true;
+    }
+  }
+  return false;
+}
+function isWhitespace(c) {
+  return c === CHAR_SPACE || c === CHAR_TAB;
+}
+function isPrintable(c) {
+  return 32 <= c && c <= 126 || 161 <= c && c <= 55295 && c !== 8232 && c !== 8233 || 57344 <= c && c <= 65533 && c !== CHAR_BOM || 65536 <= c && c <= 1114111;
+}
+function isNsCharOrWhitespace(c) {
+  return isPrintable(c) && c !== CHAR_BOM && c !== CHAR_CARRIAGE_RETURN && c !== CHAR_LINE_FEED;
+}
+function isPlainSafe(c, prev, inblock) {
+  var cIsNsCharOrWhitespace = isNsCharOrWhitespace(c);
+  var cIsNsChar = cIsNsCharOrWhitespace && !isWhitespace(c);
+  return (
+    // ns-plain-safe
+    (inblock ? (
+      // c = flow-in
+      cIsNsCharOrWhitespace
+    ) : cIsNsCharOrWhitespace && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET) && c !== CHAR_SHARP && !(prev === CHAR_COLON && !cIsNsChar) || isNsCharOrWhitespace(prev) && !isWhitespace(prev) && c === CHAR_SHARP || prev === CHAR_COLON && cIsNsChar
+  );
+}
+function isPlainSafeFirst(c) {
+  return isPrintable(c) && c !== CHAR_BOM && !isWhitespace(c) && c !== CHAR_MINUS && c !== CHAR_QUESTION && c !== CHAR_COLON && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET && c !== CHAR_SHARP && c !== CHAR_AMPERSAND && c !== CHAR_ASTERISK && c !== CHAR_EXCLAMATION && c !== CHAR_VERTICAL_LINE && c !== CHAR_EQUALS && c !== CHAR_GREATER_THAN && c !== CHAR_SINGLE_QUOTE && c !== CHAR_DOUBLE_QUOTE && c !== CHAR_PERCENT && c !== CHAR_COMMERCIAL_AT && c !== CHAR_GRAVE_ACCENT;
+}
+function isPlainSafeLast(c) {
+  return !isWhitespace(c) && c !== CHAR_COLON;
+}
+function codePointAt(string, pos) {
+  var first = string.charCodeAt(pos), second;
+  if (first >= 55296 && first <= 56319 && pos + 1 < string.length) {
+    second = string.charCodeAt(pos + 1);
+    if (second >= 56320 && second <= 57343) {
+      return (first - 55296) * 1024 + second - 56320 + 65536;
+    }
+  }
+  return first;
+}
+function needIndentIndicator(string) {
+  var leadingSpaceRe = /^\n* /;
+  return leadingSpaceRe.test(string);
+}
+var STYLE_PLAIN = 1;
+var STYLE_SINGLE = 2;
+var STYLE_LITERAL = 3;
+var STYLE_FOLDED = 4;
+var STYLE_DOUBLE = 5;
+function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType, quotingType, forceQuotes, inblock) {
+  var i;
+  var char = 0;
+  var prevChar = null;
+  var hasLineBreak = false;
+  var hasFoldableLine = false;
+  var shouldTrackWidth = lineWidth !== -1;
+  var previousLineBreak = -1;
+  var plain = isPlainSafeFirst(codePointAt(string, 0)) && isPlainSafeLast(codePointAt(string, string.length - 1));
+  if (singleLineOnly || forceQuotes) {
+    for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+      char = codePointAt(string, i);
+      if (!isPrintable(char)) {
+        return STYLE_DOUBLE;
+      }
+      plain = plain && isPlainSafe(char, prevChar, inblock);
+      prevChar = char;
+    }
+  } else {
+    for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+      char = codePointAt(string, i);
+      if (char === CHAR_LINE_FEED) {
+        hasLineBreak = true;
+        if (shouldTrackWidth) {
+          hasFoldableLine = hasFoldableLine || // Foldable line = too long, and not more-indented.
+          i - previousLineBreak - 1 > lineWidth && string[previousLineBreak + 1] !== " ";
+          previousLineBreak = i;
+        }
+      } else if (!isPrintable(char)) {
+        return STYLE_DOUBLE;
+      }
+      plain = plain && isPlainSafe(char, prevChar, inblock);
+      prevChar = char;
+    }
+    hasFoldableLine = hasFoldableLine || shouldTrackWidth && (i - previousLineBreak - 1 > lineWidth && string[previousLineBreak + 1] !== " ");
+  }
+  if (!hasLineBreak && !hasFoldableLine) {
+    if (plain && !forceQuotes && !testAmbiguousType(string)) {
+      return STYLE_PLAIN;
+    }
+    return quotingType === QUOTING_TYPE_DOUBLE ? STYLE_DOUBLE : STYLE_SINGLE;
+  }
+  if (indentPerLevel > 9 && needIndentIndicator(string)) {
+    return STYLE_DOUBLE;
+  }
+  if (!forceQuotes) {
+    return hasFoldableLine ? STYLE_FOLDED : STYLE_LITERAL;
+  }
+  return quotingType === QUOTING_TYPE_DOUBLE ? STYLE_DOUBLE : STYLE_SINGLE;
+}
+function writeScalar(state, string, level, iskey, inblock) {
+  state.dump = (function() {
+    if (string.length === 0) {
+      return state.quotingType === QUOTING_TYPE_DOUBLE ? '""' : "''";
+    }
+    if (!state.noCompatMode) {
+      if (DEPRECATED_BOOLEANS_SYNTAX.indexOf(string) !== -1 || DEPRECATED_BASE60_SYNTAX.test(string)) {
+        return state.quotingType === QUOTING_TYPE_DOUBLE ? '"' + string + '"' : "'" + string + "'";
+      }
+    }
+    var indent = state.indent * Math.max(1, level);
+    var lineWidth = state.lineWidth === -1 ? -1 : Math.max(Math.min(state.lineWidth, 40), state.lineWidth - indent);
+    var singleLineOnly = iskey || state.flowLevel > -1 && level >= state.flowLevel;
+    function testAmbiguity(string2) {
+      return testImplicitResolving(state, string2);
+    }
+    switch (chooseScalarStyle(
+      string,
+      singleLineOnly,
+      state.indent,
+      lineWidth,
+      testAmbiguity,
+      state.quotingType,
+      state.forceQuotes && !iskey,
+      inblock
+    )) {
+      case STYLE_PLAIN:
+        return string;
+      case STYLE_SINGLE:
+        return "'" + string.replace(/'/g, "''") + "'";
+      case STYLE_LITERAL:
+        return "|" + blockHeader(string, state.indent) + dropEndingNewline(indentString(string, indent));
+      case STYLE_FOLDED:
+        return ">" + blockHeader(string, state.indent) + dropEndingNewline(indentString(foldString(string, lineWidth), indent));
+      case STYLE_DOUBLE:
+        return '"' + escapeString(string) + '"';
+      default:
+        throw new exception("impossible error: invalid scalar style");
+    }
+  })();
+}
+function blockHeader(string, indentPerLevel) {
+  var indentIndicator = needIndentIndicator(string) ? String(indentPerLevel) : "";
+  var clip = string[string.length - 1] === "\n";
+  var keep = clip && (string[string.length - 2] === "\n" || string === "\n");
+  var chomp = keep ? "+" : clip ? "" : "-";
+  return indentIndicator + chomp + "\n";
+}
+function dropEndingNewline(string) {
+  return string[string.length - 1] === "\n" ? string.slice(0, -1) : string;
+}
+function foldString(string, width) {
+  var lineRe = /(\n+)([^\n]*)/g;
+  var result = (function() {
+    var nextLF = string.indexOf("\n");
+    nextLF = nextLF !== -1 ? nextLF : string.length;
+    lineRe.lastIndex = nextLF;
+    return foldLine(string.slice(0, nextLF), width);
+  })();
+  var prevMoreIndented = string[0] === "\n" || string[0] === " ";
+  var moreIndented;
+  var match;
+  while (match = lineRe.exec(string)) {
+    var prefix = match[1], line = match[2];
+    moreIndented = line[0] === " ";
+    result += prefix + (!prevMoreIndented && !moreIndented && line !== "" ? "\n" : "") + foldLine(line, width);
+    prevMoreIndented = moreIndented;
+  }
+  return result;
+}
+function foldLine(line, width) {
+  if (line === "" || line[0] === " ") return line;
+  var breakRe = / [^ ]/g;
+  var match;
+  var start = 0, end, curr = 0, next = 0;
+  var result = "";
+  while (match = breakRe.exec(line)) {
+    next = match.index;
+    if (next - start > width) {
+      end = curr > start ? curr : next;
+      result += "\n" + line.slice(start, end);
+      start = end + 1;
+    }
+    curr = next;
+  }
+  result += "\n";
+  if (line.length - start > width && curr > start) {
+    result += line.slice(start, curr) + "\n" + line.slice(curr + 1);
+  } else {
+    result += line.slice(start);
+  }
+  return result.slice(1);
+}
+function escapeString(string) {
+  var result = "";
+  var char = 0;
+  var escapeSeq;
+  for (var i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+    char = codePointAt(string, i);
+    escapeSeq = ESCAPE_SEQUENCES[char];
+    if (!escapeSeq && isPrintable(char)) {
+      result += string[i];
+      if (char >= 65536) result += string[i + 1];
+    } else {
+      result += escapeSeq || encodeHex(char);
+    }
+  }
+  return result;
+}
+function writeFlowSequence(state, level, object) {
+  var _result = "", _tag = state.tag, index, length, value;
+  for (index = 0, length = object.length; index < length; index += 1) {
+    value = object[index];
+    if (state.replacer) {
+      value = state.replacer.call(object, String(index), value);
+    }
+    if (writeNode(state, level, value, false, false) || typeof value === "undefined" && writeNode(state, level, null, false, false)) {
+      if (_result !== "") _result += "," + (!state.condenseFlow ? " " : "");
+      _result += state.dump;
+    }
+  }
+  state.tag = _tag;
+  state.dump = "[" + _result + "]";
+}
+function writeBlockSequence(state, level, object, compact) {
+  var _result = "", _tag = state.tag, index, length, value;
+  for (index = 0, length = object.length; index < length; index += 1) {
+    value = object[index];
+    if (state.replacer) {
+      value = state.replacer.call(object, String(index), value);
+    }
+    if (writeNode(state, level + 1, value, true, true, false, true) || typeof value === "undefined" && writeNode(state, level + 1, null, true, true, false, true)) {
+      if (!compact || _result !== "") {
+        _result += generateNextLine(state, level);
+      }
+      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+        _result += "-";
+      } else {
+        _result += "- ";
+      }
+      _result += state.dump;
+    }
+  }
+  state.tag = _tag;
+  state.dump = _result || "[]";
+}
+function writeFlowMapping(state, level, object) {
+  var _result = "", _tag = state.tag, objectKeyList = Object.keys(object), index, length, objectKey, objectValue, pairBuffer;
+  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+    pairBuffer = "";
+    if (_result !== "") pairBuffer += ", ";
+    if (state.condenseFlow) pairBuffer += '"';
+    objectKey = objectKeyList[index];
+    objectValue = object[objectKey];
+    if (state.replacer) {
+      objectValue = state.replacer.call(object, objectKey, objectValue);
+    }
+    if (!writeNode(state, level, objectKey, false, false)) {
+      continue;
+    }
+    if (state.dump.length > 1024) pairBuffer += "? ";
+    pairBuffer += state.dump + (state.condenseFlow ? '"' : "") + ":" + (state.condenseFlow ? "" : " ");
+    if (!writeNode(state, level, objectValue, false, false)) {
+      continue;
+    }
+    pairBuffer += state.dump;
+    _result += pairBuffer;
+  }
+  state.tag = _tag;
+  state.dump = "{" + _result + "}";
+}
+function writeBlockMapping(state, level, object, compact) {
+  var _result = "", _tag = state.tag, objectKeyList = Object.keys(object), index, length, objectKey, objectValue, explicitPair, pairBuffer;
+  if (state.sortKeys === true) {
+    objectKeyList.sort();
+  } else if (typeof state.sortKeys === "function") {
+    objectKeyList.sort(state.sortKeys);
+  } else if (state.sortKeys) {
+    throw new exception("sortKeys must be a boolean or a function");
+  }
+  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+    pairBuffer = "";
+    if (!compact || _result !== "") {
+      pairBuffer += generateNextLine(state, level);
+    }
+    objectKey = objectKeyList[index];
+    objectValue = object[objectKey];
+    if (state.replacer) {
+      objectValue = state.replacer.call(object, objectKey, objectValue);
+    }
+    if (!writeNode(state, level + 1, objectKey, true, true, true)) {
+      continue;
+    }
+    explicitPair = state.tag !== null && state.tag !== "?" || state.dump && state.dump.length > 1024;
+    if (explicitPair) {
+      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+        pairBuffer += "?";
+      } else {
+        pairBuffer += "? ";
+      }
+    }
+    pairBuffer += state.dump;
+    if (explicitPair) {
+      pairBuffer += generateNextLine(state, level);
+    }
+    if (!writeNode(state, level + 1, objectValue, true, explicitPair)) {
+      continue;
+    }
+    if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+      pairBuffer += ":";
+    } else {
+      pairBuffer += ": ";
+    }
+    pairBuffer += state.dump;
+    _result += pairBuffer;
+  }
+  state.tag = _tag;
+  state.dump = _result || "{}";
+}
+function detectType(state, object, explicit) {
+  var _result, typeList, index, length, type2, style;
+  typeList = explicit ? state.explicitTypes : state.implicitTypes;
+  for (index = 0, length = typeList.length; index < length; index += 1) {
+    type2 = typeList[index];
+    if ((type2.instanceOf || type2.predicate) && (!type2.instanceOf || typeof object === "object" && object instanceof type2.instanceOf) && (!type2.predicate || type2.predicate(object))) {
+      if (explicit) {
+        if (type2.multi && type2.representName) {
+          state.tag = type2.representName(object);
+        } else {
+          state.tag = type2.tag;
+        }
+      } else {
+        state.tag = "?";
+      }
+      if (type2.represent) {
+        style = state.styleMap[type2.tag] || type2.defaultStyle;
+        if (_toString.call(type2.represent) === "[object Function]") {
+          _result = type2.represent(object, style);
+        } else if (_hasOwnProperty.call(type2.represent, style)) {
+          _result = type2.represent[style](object, style);
+        } else {
+          throw new exception("!<" + type2.tag + '> tag resolver accepts not "' + style + '" style');
+        }
+        state.dump = _result;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+function writeNode(state, level, object, block, compact, iskey, isblockseq) {
+  state.tag = null;
+  state.dump = object;
+  if (!detectType(state, object, false)) {
+    detectType(state, object, true);
+  }
+  var type2 = _toString.call(state.dump);
+  var inblock = block;
+  var tagStr;
+  if (block) {
+    block = state.flowLevel < 0 || state.flowLevel > level;
+  }
+  var objectOrArray = type2 === "[object Object]" || type2 === "[object Array]", duplicateIndex, duplicate;
+  if (objectOrArray) {
+    duplicateIndex = state.duplicates.indexOf(object);
+    duplicate = duplicateIndex !== -1;
+  }
+  if (state.tag !== null && state.tag !== "?" || duplicate || state.indent !== 2 && level > 0) {
+    compact = false;
+  }
+  if (duplicate && state.usedDuplicates[duplicateIndex]) {
+    state.dump = "*ref_" + duplicateIndex;
+  } else {
+    if (objectOrArray && duplicate && !state.usedDuplicates[duplicateIndex]) {
+      state.usedDuplicates[duplicateIndex] = true;
+    }
+    if (type2 === "[object Object]") {
+      if (block && Object.keys(state.dump).length !== 0) {
+        writeBlockMapping(state, level, state.dump, compact);
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + state.dump;
+        }
+      } else {
+        writeFlowMapping(state, level, state.dump);
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + " " + state.dump;
+        }
+      }
+    } else if (type2 === "[object Array]") {
+      if (block && state.dump.length !== 0) {
+        if (state.noArrayIndent && !isblockseq && level > 0) {
+          writeBlockSequence(state, level - 1, state.dump, compact);
+        } else {
+          writeBlockSequence(state, level, state.dump, compact);
+        }
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + state.dump;
+        }
+      } else {
+        writeFlowSequence(state, level, state.dump);
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + " " + state.dump;
+        }
+      }
+    } else if (type2 === "[object String]") {
+      if (state.tag !== "?") {
+        writeScalar(state, state.dump, level, iskey, inblock);
+      }
+    } else if (type2 === "[object Undefined]") {
+      return false;
+    } else {
+      if (state.skipInvalid) return false;
+      throw new exception("unacceptable kind of an object to dump " + type2);
+    }
+    if (state.tag !== null && state.tag !== "?") {
+      tagStr = encodeURI(
+        state.tag[0] === "!" ? state.tag.slice(1) : state.tag
+      ).replace(/!/g, "%21");
+      if (state.tag[0] === "!") {
+        tagStr = "!" + tagStr;
+      } else if (tagStr.slice(0, 18) === "tag:yaml.org,2002:") {
+        tagStr = "!!" + tagStr.slice(18);
+      } else {
+        tagStr = "!<" + tagStr + ">";
+      }
+      state.dump = tagStr + " " + state.dump;
+    }
+  }
+  return true;
+}
+function getDuplicateReferences(object, state) {
+  var objects = [], duplicatesIndexes = [], index, length;
+  inspectNode(object, objects, duplicatesIndexes);
+  for (index = 0, length = duplicatesIndexes.length; index < length; index += 1) {
+    state.duplicates.push(objects[duplicatesIndexes[index]]);
+  }
+  state.usedDuplicates = new Array(length);
+}
+function inspectNode(object, objects, duplicatesIndexes) {
+  var objectKeyList, index, length;
+  if (object !== null && typeof object === "object") {
+    index = objects.indexOf(object);
+    if (index !== -1) {
+      if (duplicatesIndexes.indexOf(index) === -1) {
+        duplicatesIndexes.push(index);
+      }
+    } else {
+      objects.push(object);
+      if (Array.isArray(object)) {
+        for (index = 0, length = object.length; index < length; index += 1) {
+          inspectNode(object[index], objects, duplicatesIndexes);
+        }
+      } else {
+        objectKeyList = Object.keys(object);
+        for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+          inspectNode(object[objectKeyList[index]], objects, duplicatesIndexes);
+        }
+      }
+    }
+  }
+}
+function dump$1(input, options) {
+  options = options || {};
+  var state = new State(options);
+  if (!state.noRefs) getDuplicateReferences(input, state);
+  var value = input;
+  if (state.replacer) {
+    value = state.replacer.call({ "": value }, "", value);
+  }
+  if (writeNode(state, 0, value, true, true)) return state.dump + "\n";
+  return "";
+}
+var dump_1 = dump$1;
+var dumper = {
+  dump: dump_1
+};
+function renamed(from, to) {
+  return function() {
+    throw new Error("Function yaml." + from + " is removed in js-yaml 4. Use yaml." + to + " instead, which is now safe by default.");
+  };
+}
+var Type = type;
+var Schema = schema;
+var FAILSAFE_SCHEMA = failsafe;
+var JSON_SCHEMA = json;
+var CORE_SCHEMA = core;
+var DEFAULT_SCHEMA = _default;
+var load = loader.load;
+var loadAll = loader.loadAll;
+var dump = dumper.dump;
+var YAMLException = exception;
+var types = {
+  binary,
+  float,
+  map,
+  null: _null,
+  pairs,
+  set,
+  timestamp,
+  bool,
+  int,
+  merge,
+  omap,
+  seq,
+  str
+};
+var safeLoad = renamed("safeLoad", "load");
+var safeLoadAll = renamed("safeLoadAll", "loadAll");
+var safeDump = renamed("safeDump", "dump");
+var jsYaml = {
+  Type,
+  Schema,
+  FAILSAFE_SCHEMA,
+  JSON_SCHEMA,
+  CORE_SCHEMA,
+  DEFAULT_SCHEMA,
+  load,
+  loadAll,
+  dump,
+  YAMLException,
+  types,
+  safeLoad,
+  safeLoadAll,
+  safeDump
+};
+
+// ../../../Users/tjwells/sigma-data-model-mcp/build/sigma-ids.js
+var SIGMA_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+var _usedIds = /* @__PURE__ */ new Set();
+var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "but",
+  "or",
+  "for",
+  "nor",
+  "so",
+  "yet",
+  "at",
+  "by",
+  "in",
+  "of",
+  "on",
+  "to",
+  "up",
+  "as",
+  "into",
+  "via",
+  "per"
+]);
+function resetIds() {
+  _usedIds.clear();
+}
+function sigmaShortId(len = 10) {
+  let id;
+  do {
+    id = Array.from({ length: len }, () => SIGMA_CHARS[Math.floor(Math.random() * SIGMA_CHARS.length)]).join("");
+  } while (_usedIds.has(id));
+  _usedIds.add(id);
+  return id;
+}
+function sigmaInodeId(identifier) {
+  return `inode-${sigmaShortId(22)}/${identifier.toUpperCase()}`;
+}
+function sigmaDisplayName(s) {
+  const normalized = (s || "").replace(/([a-z])([A-Z])/g, "$1_$2").replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2").replace(/([A-Za-z])([0-9])/g, "$1_$2").replace(/([0-9])([A-Za-z])/g, "$1_$2");
+  const words = normalized.toLowerCase().split(/[_\s]+/).filter(Boolean);
+  return words.map((w, i) => i === 0 || !SIGMA_LOWERCASE_WORDS.has(w) ? w.charAt(0).toUpperCase() + w.slice(1) : w).join(" ");
+}
+function sigmaColFormula(tableName, identifier) {
+  return `[${tableName}/${sigmaDisplayName(identifier)}]`;
+}
+function formatFromMask(mask) {
+  if (!mask || typeof mask !== "string")
+    return null;
+  const s = mask.trim();
+  if (!s || /general|date|time|@|yy|dd/i.test(s))
+    return null;
+  const decM = s.match(/\.([0#]+)/);
+  const decimals = decM ? decM[1].length : 0;
+  const isPercent = /%/.test(s);
+  const isCurrency = /[$£€¥]/.test(s);
+  if (isPercent)
+    return { kind: "number", formatString: `,.${decimals}%` };
+  if (isCurrency)
+    return { kind: "number", formatString: `$,.${decimals}f`, currencySymbol: "$" };
+  if (/[0#]/.test(s))
+    return { kind: "number", formatString: `,.${decimals}f` };
+  return null;
+}
+function inferSigmaFormat(formula, displayName, sourceMask) {
+  const fromMask = formatFromMask(sourceMask);
+  if (fromMask)
+    return fromMask;
+  if (!formula)
+    return null;
+  const f = formula.trim();
+  const n = (displayName || "").toLowerCase();
+  const alreadyPctScale = /\*\s*100\b/.test(f);
+  if (alreadyPctScale && /\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n)) {
+    return { kind: "number", formatString: ",.2f", suffix: "%" };
+  }
+  const currencyWord = /\b(revenue|sales|profit|cost|spend|amount|discounts?|price|value|aov|arpu)\b/;
+  const ratio = f.match(/^([A-Za-z]+)\s*\(([^)]*)\)\s*\/\s*([A-Za-z]+)\s*\(([^)]*)\)$/);
+  if (ratio) {
+    const [, numFn, numArg, denFn, denArg] = ratio;
+    const isCount = (fn) => /^Count/i.test(fn);
+    const numIsCurrency = currencyWord.test(numArg.toLowerCase());
+    const nameSaysPct = /\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n);
+    if (nameSaysPct || isCount(numFn) && isCount(denFn)) {
+      return { kind: "number", formatString: ",.2%" };
+    }
+    if (numIsCurrency) {
+      return { kind: "number", formatString: "$,.2f", currencySymbol: "$" };
+    }
+    return { kind: "number", formatString: ",.2f" };
+  }
+  if (/\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n)) {
+    return { kind: "number", formatString: ",.2%" };
+  }
+  if (currencyWord.test(n)) {
+    return { kind: "number", formatString: "$,.2f", currencySymbol: "$" };
+  }
+  if (/^Count(?:Distinct|If|DistinctIf)?\s*\(/.test(f)) {
+    return { kind: "number", formatString: ",.0f" };
+  }
+  return null;
+}
+var DATA_MODEL_SCHEMA_SUMMARY = `
+Sigma Data Model JSON top-level structure:
+{
+  "name": "Model Name",
+  "pages": [{ "id": "pageId", "name": "Page 1", "elements": [...] }]
+}
+
+Element types: warehouse-table, custom-sql (kind:"sql"), join, union, control.
+Columns: { "id": "inode-xxx/COL", "formula": "[TABLE/Display Name]" }
+Calculated columns: { "id": "shortId", "formula": "[Price] - [Cost]", "name": "Profit" }
+Metrics: { "id": "shortId", "formula": "Sum([Revenue])", "name": "Total Revenue" }
+Relationships: { "id": "shortId", "targetElementId": "...", "keys": [{ "sourceColumnId": "...", "targetColumnId": "..." }] }
+
+Cross-element Reference (accessing related dimension columns via relationships):
+  [SOURCE_TABLE/REL_NAME/Column Display Name]
+  REL_NAME is the relationship's "name" field (= target table name uppercase by convention).
+  Example: DateDiff("day", [ORDER_FACT/PROMO_DIM/Start Date], [ORDER_FACT/PROMO_DIM/End Date])
+  \u26A0 The dash-link form [SRC/FK_COL - link/Field] does NOT work via the API \u2014 use REL_NAME.
+
+Conditional Aggregate Syntax:
+  CountIf(condition) \u2014 condition only, NO field argument
+  SumIf(field, condition) \u2014 FIELD FIRST, condition second
+  AvgIf/MaxIf/MinIf/CountDistinctIf \u2014 all FIELD FIRST
+  For booleans: always use [Column] = True, never bare [Column]
+
+Groupings (for LOD / different aggregation levels):
+  "groupings": [{ "id": "gId", "groupBy": ["colId1"], "calculations": ["calcId1"] }]
+  Array order = nesting hierarchy. Use child elements for LOD patterns.
+`.trim();
+function _securityElementName(el) {
+  if (el?.name)
+    return el.name;
+  const path = el?.source?.path;
+  return path && path.length ? String(path[path.length - 1]) : void 0;
+}
+function makeRlsSecurity(opts) {
+  const attrs = [...opts.formula.matchAll(/CurrentUserAttributeText\(\s*"([^"]+)"/g)].map((m) => m[1]);
+  const teams = [...opts.formula.matchAll(/CurrentUserInTeam\(\s*"([^"]+)"/g)].map((m) => m[1]);
+  const usesEmail = /\bCurrentUserEmail\(/.test(opts.formula);
+  const provision = [
+    attrs.length ? `provision/assign Sigma user attribute(s): ${[...new Set(attrs)].join(", ")}` : "",
+    teams.length ? `create Sigma team(s) + membership: ${[...new Set(teams)].join(", ")}` : "",
+    usesEmail && !attrs.length && !teams.length ? "uses CurrentUserEmail() \u2014 no provisioning needed" : ""
+  ].filter(Boolean).join("; ");
+  return {
+    kind: "rls",
+    source: opts.source,
+    elementId: opts.element.id,
+    elementName: _securityElementName(opts.element),
+    rls: {
+      name: opts.name,
+      formula: opts.formula,
+      userAttributes: attrs.length ? [...new Set(attrs)] : void 0,
+      teams: teams.length ? [...new Set(teams)] : void 0,
+      usesCurrentUserEmail: usesEmail || void 0
+    },
+    note: `Fail-closed RLS (boolean calc + element filter, only True rows). ${provision || "review"}. The skill provisions then applies \u2014 the converter does NOT inject it.`
+  };
+}
+function buildDerivedElements(elements) {
+  const derived = [];
+  for (const srcEl of elements) {
+    if (!srcEl.relationships?.length)
+      continue;
+    if (srcEl.source?.kind !== "warehouse-table")
+      continue;
+    const srcPath = srcEl.source.path || [];
+    const srcTableName = srcPath[srcPath.length - 1] || "";
+    const baseName = srcEl.name || srcTableName;
+    const derivedName = `${srcEl.name || sigmaDisplayName(srcTableName)} View`;
+    const viewCols = [];
+    const viewOrder = [];
+    for (const col of srcEl.columns || []) {
+      if (!col.formula || col.formula.startsWith("/*"))
+        continue;
+      let dispName;
+      const fm = col.formula.match(/^\[([^\/\]]+)\/([^\]]+)\]$/);
+      if (fm)
+        dispName = fm[2];
+      else if (col.name)
+        dispName = String(col.name);
+      if (!dispName)
+        continue;
+      if (dispName.includes("/"))
+        continue;
+      const cId = sigmaShortId();
+      viewCols.push({ id: cId, formula: `[${baseName}/${dispName}]` });
+      viewOrder.push(cId);
+    }
+    for (const rel of srcEl.relationships) {
+      if (!rel.name)
+        continue;
+      const tgtEl = elements.find((e) => e.id === rel.targetElementId);
+      if (!tgtEl || tgtEl.source?.kind !== "warehouse-table" && tgtEl.source?.kind !== "sql")
+        continue;
+      const tgtKeyIds = new Set((rel.keys || []).map((k) => k.targetColumnId));
+      for (const col of tgtEl.columns || []) {
+        if (tgtKeyIds.has(col.id))
+          continue;
+        if (!col.formula || col.formula.startsWith("/*"))
+          continue;
+        let dispName;
+        if (col.name) {
+          dispName = String(col.name);
+        } else {
+          const fm = col.formula.match(/^\[([^\]]+)\]$/);
+          if (fm) {
+            const inner = fm[1];
+            const s = inner.indexOf("/");
+            dispName = s >= 0 ? inner.slice(s + 1) : inner;
+          }
+        }
+        if (!dispName)
+          continue;
+        if (dispName.includes("/"))
+          continue;
+        const cId = sigmaShortId();
+        viewCols.push({ id: cId, formula: `[${baseName}/${rel.name}/${dispName}]` });
+        viewOrder.push(cId);
+      }
+    }
+    if (viewCols.length > 0) {
+      derived.push({
+        id: sigmaShortId(),
+        kind: "table",
+        name: derivedName,
+        source: { kind: "table", elementId: srcEl.id },
+        columns: viewCols,
+        order: viewOrder
+      });
+    }
+  }
+  return derived;
+}
+
+// ../../../Users/tjwells/sigma-data-model-mcp/build/thoughtspot.js
+function convertThoughtSpotToSigma(yamlText, options = {}) {
+  resetIds();
+  const { connectionId, database: dbOverride, schema: schOverride } = options;
+  const warnings = [];
+  const security = [];
+  let tml;
+  try {
+    tml = jsYaml.load(yamlText);
+  } catch (e) {
+    throw new Error("YAML parse error: " + e.message);
+  }
+  if (!tml || typeof tml !== "object")
+    throw new Error("Empty or invalid TML");
+  const ws = tml.worksheet || tml.model || tml;
+  const modelName = ws.name || "ThoughtSpot Model";
+  const tablesMeta = {};
+  for (const t of ws.tables || []) {
+    tablesMeta[t.name] = { db: t.db || dbOverride || "", schema: t.schema || schOverride || "" };
+  }
+  for (const mt of ws.model_tables || []) {
+    if (mt?.name && !tablesMeta[mt.name]) {
+      tablesMeta[mt.name] = { db: dbOverride || "", schema: schOverride || "" };
+    }
+  }
+  const colType = (c) => (c.type || c.properties?.column_type || "").toUpperCase();
+  const colAgg = (c) => (c.aggregation || c.properties?.aggregation || "SUM").toUpperCase();
+  const tablePathMap = {};
+  for (const tp of ws.table_paths || []) {
+    tablePathMap[tp.id] = tp.table;
+  }
+  if (Object.keys(tablePathMap).length === 0) {
+    for (const n of Object.keys(tablesMeta))
+      tablePathMap[n] = n;
+  }
+  const formulaMap = {};
+  for (const f of ws.formulas || []) {
+    formulaMap[f.id || f.name] = f.expr || f.expression || "";
+  }
+  const colsByTable = {};
+  const formulaCols = [];
+  for (const col of ws.worksheet_columns || ws.columns || []) {
+    const colId = col.column_id || col.id || "";
+    const sepIdx = colId.indexOf("::");
+    if (sepIdx !== -1) {
+      const alias = colId.slice(0, sepIdx);
+      const physCol = colId.slice(sepIdx + 2);
+      const tableName = tablePathMap[alias] || alias;
+      if (!colsByTable[tableName])
+        colsByTable[tableName] = [];
+      colsByTable[tableName].push({ col, physCol, tableName });
+    } else if (colId && formulaMap[colId]) {
+      formulaCols.push({ col, formulaExpr: formulaMap[colId] });
+    } else if (col.formula_id && formulaMap[col.formula_id]) {
+      formulaCols.push({ col, formulaExpr: formulaMap[col.formula_id] });
+    } else {
+      warnings.push(`Column "${col.name || colId}" has no resolvable source \u2014 skipped`);
+    }
+  }
+  const refRe = /\[([^\]:]+)::([^\]]+)\]/g;
+  const referenced = [];
+  const collectRefs = (s) => {
+    let m;
+    while (m = refRe.exec(s || ""))
+      referenced.push([m[1], m[2]]);
+  };
+  for (const j of ws.joins || [])
+    collectRefs(j.on || "");
+  for (const mt of ws.model_tables || [])
+    for (const j of mt.joins || [])
+      collectRefs(j.on || "");
+  for (const expr of Object.values(formulaMap))
+    collectRefs(expr);
+  const collectRlsRefs = (h) => {
+    const raw = h?.rls_rules ?? h?.rls_rule;
+    const rules = Array.isArray(raw) ? raw : raw?.rules || (raw ? [raw] : []);
+    for (const r of rules)
+      collectRefs(String(r?.expr || ""));
+  };
+  collectRlsRefs(ws);
+  for (const mt of ws.model_tables || [])
+    collectRlsRefs(mt);
+  for (const t of ws.tables || [])
+    collectRlsRefs(t);
+  for (const [alias, physCol] of referenced) {
+    const tableName = tablePathMap[alias] || alias;
+    if (!tablesMeta[tableName] && !colsByTable[tableName])
+      continue;
+    const existing = colsByTable[tableName] ||= [];
+    if (!existing.some((e) => e.physCol.toUpperCase() === physCol.toUpperCase())) {
+      existing.push({ col: { column_id: `${tableName}::${physCol}`, name: sigmaDisplayName(physCol) }, physCol, tableName });
+    }
+  }
+  const allTableNames = Array.from(/* @__PURE__ */ new Set([
+    ...Object.keys(colsByTable),
+    ...Object.keys(tablesMeta)
+  ]));
+  if (allTableNames.length === 0) {
+    warnings.push("No tables found in TML \u2014 check table_paths and tables sections");
+  }
+  const pageId = sigmaShortId();
+  const elements = [];
+  const elementByTable = {};
+  const colAggByDisp = {};
+  for (const tableName of allTableNames) {
+    const meta = tablesMeta[tableName] || { db: "", schema: "" };
+    const db = dbOverride || meta.db || "";
+    const sch = schOverride || meta.schema || "";
+    const elemId = sigmaShortId();
+    const columns = [];
+    const metrics = [];
+    const colOrder = [];
+    const colPhysIdMap = {};
+    for (const { col, physCol } of colsByTable[tableName] || []) {
+      const dispName = col.name || sigmaDisplayName(physCol);
+      const isMeasure = colType(col) === "MEASURE";
+      const isDate = colType(col) === "DATE";
+      let colId;
+      let colObj;
+      if (isDate) {
+        colId = sigmaShortId();
+        colObj = {
+          id: colId,
+          formula: `DateTrunc("day", ${sigmaColFormula(tableName, physCol)})`,
+          name: dispName
+        };
+      } else {
+        colId = sigmaInodeId(physCol);
+        colObj = { id: colId, formula: sigmaColFormula(tableName, physCol) };
+      }
+      colPhysIdMap[physCol.toUpperCase()] = colId;
+      columns.push(colObj);
+      colOrder.push(colId);
+      if (isMeasure) {
+        const agg = colAgg(col);
+        const aggMap = {
+          SUM: "Sum",
+          COUNT: "Count",
+          COUNT_DISTINCT: "CountDistinct",
+          AVERAGE: "Avg",
+          AVG: "Avg",
+          MAX: "Max",
+          MIN: "Min",
+          STD_DEVIATION: "StdDev",
+          VARIANCE: "Variance"
+        };
+        const sigmaAgg = aggMap[agg] || "Sum";
+        const colDisplayName = sigmaDisplayName(physCol);
+        colAggByDisp[colDisplayName.toUpperCase()] = sigmaAgg;
+        colAggByDisp[dispName.toUpperCase()] = sigmaAgg;
+        const formula = `${sigmaAgg}([${colDisplayName}])`;
+        let fmt = inferSigmaFormat(formula, dispName);
+        if (fmt?.formatString === ",.2%")
+          fmt = { kind: "number", formatString: ",.2f", suffix: "%" };
+        const metric = { id: sigmaShortId(), name: dispName, formula };
+        if (fmt)
+          metric.format = fmt;
+        metrics.push(metric);
+      }
+    }
+    const element = {
+      id: elemId,
+      kind: "table",
+      name: sigmaDisplayName(tableName),
+      source: {
+        connectionId,
+        kind: "warehouse-table",
+        path: [db, sch, tableName].filter(Boolean)
+      },
+      columns,
+      metrics,
+      order: colOrder,
+      relationships: [],
+      _colPhysIdMap: colPhysIdMap
+    };
+    elements.push(element);
+    elementByTable[tableName] = element;
+  }
+  const dispNameToElId = {};
+  for (const el of elements) {
+    for (const c of el.columns || []) {
+      const fm = c.formula?.match(/^\[([^\/\]]+)\/([^\]]+)\]$/);
+      if (fm) {
+        const disp = sigmaDisplayName(fm[2]);
+        if (!dispNameToElId[disp.toUpperCase()])
+          dispNameToElId[disp.toUpperCase()] = el.id;
+      } else if (c.name) {
+        if (!dispNameToElId[c.name.toUpperCase()])
+          dispNameToElId[c.name.toUpperCase()] = el.id;
+      }
+    }
+  }
+  const sameElCalcsByElId = {};
+  const crossElCalcsByElId = {};
+  const pendingWindowCalcs = [];
+  let tmlJoins = Array.isArray(ws.joins) ? ws.joins : [];
+  if (tmlJoins.length === 0 && Array.isArray(ws.model_tables)) {
+    for (const mt of ws.model_tables) {
+      for (const j of mt.joins || []) {
+        tmlJoins.push({ name: j.name || `${mt.name}_to_${j.with}`, on: j.on, type: j.type });
+      }
+    }
+  }
+  const joinOnRe = /\[([^\]:]+)::([^\]]+)\]\s*=\s*\[([^\]:]+)::([^\]]+)\]/;
+  for (const join of tmlJoins) {
+    const onStr = join.on || "";
+    const m = joinOnRe.exec(onStr);
+    if (!m) {
+      warnings.push(`Join "${join.name || "?"}": could not parse ON clause \u2014 "${onStr}"`);
+      continue;
+    }
+    const [, lAlias, lCol, rAlias, rCol] = m;
+    const lTable = tablePathMap[lAlias] || lAlias;
+    const rTable = tablePathMap[rAlias] || rAlias;
+    const lEl = elementByTable[lTable];
+    const rEl = elementByTable[rTable];
+    if (!lEl || !rEl) {
+      warnings.push(`Join "${join.name}": element not found for "${lTable}" or "${rTable}"`);
+      continue;
+    }
+    const srcColId = (lEl._colPhysIdMap || {})[lCol.toUpperCase()] || null;
+    const tgtColId = (rEl._colPhysIdMap || {})[rCol.toUpperCase()] || null;
+    if (!srcColId || !tgtColId) {
+      warnings.push(`Join "${join.name}": join key columns not found \u2014 "${lCol}" / "${rCol}"`);
+      continue;
+    }
+    const tsTgtPath = rEl.source && rEl.source.path;
+    const tsRelName = (tsTgtPath ? tsTgtPath[tsTgtPath.length - 1] : rTable).toUpperCase();
+    lEl.relationships.push({
+      id: sigmaShortId(),
+      targetElementId: rEl.id,
+      keys: [{ sourceColumnId: srcColId, targetColumnId: tgtColId }],
+      name: tsRelName,
+      relationshipType: "N:1"
+    });
+  }
+  if (tmlJoins.length === 0 && allTableNames.length > 1) {
+    warnings.push("No joins defined in TML \u2014 relationships will need to be configured manually in Sigma");
+  }
+  if (formulaCols.length > 0 && elements.length > 0) {
+    for (const { col, formulaExpr } of formulaCols) {
+      const dispName = col.name || "Calculated";
+      if (TS_WINDOW_FN_RE.test(formulaExpr)) {
+        pendingWindowCalcs.push({ dispName, formulaExpr, call: tsParseWindowCall(formulaExpr) });
+        continue;
+      }
+      const sigmaFormula = tsFormulaToSigma(formulaExpr, elementByTable);
+      const refs = sigmaFormula.match(/\[([^\]\/]+)\]/g) || [];
+      const refElIds = /* @__PURE__ */ new Set();
+      for (const ref of refs) {
+        const inner = ref.replace(/^\[|\]$/g, "");
+        const elId = dispNameToElId[inner.toUpperCase()];
+        if (elId)
+          refElIds.add(elId);
+      }
+      let hostElId;
+      if (refElIds.size === 0) {
+        hostElId = elements[0].id;
+      } else if (refElIds.size === 1) {
+        hostElId = Array.from(refElIds)[0];
+      } else {
+        const candidates = Array.from(refElIds);
+        const withRels = candidates.find((id) => {
+          const el = elements.find((e) => e.id === id);
+          return el?.relationships?.length > 0;
+        });
+        hostElId = withRels || candidates[0];
+      }
+      const pending = { col, formulaExpr, sigmaFormula, dispName };
+      if (refElIds.size > 1) {
+        (crossElCalcsByElId[hostElId] ||= []).push(pending);
+      } else {
+        (sameElCalcsByElId[hostElId] ||= []).push(pending);
+      }
+    }
+  }
+  for (const elId of Object.keys(sameElCalcsByElId)) {
+    const hostEl = elements.find((e) => e.id === elId);
+    if (!hostEl)
+      continue;
+    for (const p of sameElCalcsByElId[elId]) {
+      let fmt = inferSigmaFormat(p.sigmaFormula, p.dispName);
+      if (fmt?.formatString === ",.2%")
+        fmt = { kind: "number", formatString: ",.2f", suffix: "%" };
+      if (tsIsAggregateFormula(p.formulaExpr)) {
+        const metric = { id: sigmaShortId(), name: p.dispName, formula: p.sigmaFormula };
+        if (fmt)
+          metric.format = fmt;
+        (hostEl.metrics ||= []).push(metric);
+      } else {
+        const colObj = { id: sigmaShortId(), name: p.dispName, formula: p.sigmaFormula };
+        if (fmt)
+          colObj.format = fmt;
+        hostEl.columns.push(colObj);
+      }
+    }
+  }
+  for (const el of elements) {
+    delete el._colPhysIdMap;
+  }
+  const derivedEls = buildDerivedElements(elements);
+  for (const de of derivedEls)
+    elements.push(de);
+  tsEmitWindowElements(pendingWindowCalcs, elements, derivedEls, dispNameToElId, colAggByDisp, warnings);
+  for (const elId of Object.keys(crossElCalcsByElId)) {
+    const calcs = crossElCalcsByElId[elId];
+    if (!calcs?.length)
+      continue;
+    const srcEl = elements.find((e) => e.id === elId);
+    if (!srcEl)
+      continue;
+    const de = derivedEls.find((d) => d.source?.elementId === elId);
+    const srcBaseName = srcEl.name || srcEl.source?.path?.[srcEl.source.path.length - 1] || "";
+    const relatedNameMap = {};
+    if (srcBaseName && srcEl.relationships?.length) {
+      for (const rel of srcEl.relationships || []) {
+        if (!rel.name)
+          continue;
+        const tgtEl = elements.find((e) => e.id === rel.targetElementId);
+        if (!tgtEl || tgtEl.source?.kind !== "warehouse-table")
+          continue;
+        for (const tc of tgtEl.columns || []) {
+          if (!tc.formula || tc.formula.startsWith("/*"))
+            continue;
+          const fm = tc.formula.match(/^\[([^\]]+)\]$/);
+          if (!fm)
+            continue;
+          const inner = fm[1];
+          const s = inner.lastIndexOf("/");
+          const dispName = s >= 0 ? inner.slice(s + 1) : inner;
+          if (!(dispName in relatedNameMap)) {
+            relatedNameMap[dispName] = `${srcBaseName}/${rel.name}/${dispName}`;
+          }
+        }
+      }
+    }
+    const placeOn = de || srcEl;
+    for (const p of calcs) {
+      let formula = p.sigmaFormula;
+      if (Object.keys(relatedNameMap).length) {
+        formula = formula.replace(/\[([^\]\/]+)\]/g, (match, refName) => {
+          const rewritten = relatedNameMap[refName];
+          return rewritten ? `[${rewritten}]` : match;
+        });
+      }
+      const colId = sigmaShortId();
+      let fmt = inferSigmaFormat(formula, p.dispName);
+      if (fmt?.formatString === ",.2%")
+        fmt = { kind: "number", formatString: ",.2f", suffix: "%" };
+      const colObj = { id: colId, name: p.dispName, formula };
+      if (fmt)
+        colObj.format = fmt;
+      placeOn.columns.push(colObj);
+      if (placeOn.order)
+        placeOn.order.push(colId);
+    }
+    if (!de) {
+      warnings.push(`\u26A0 ${calcs.length} cross-element calc(s) had no derived view for "${srcBaseName}" \u2014 placed on source element with bare refs (may error)`);
+    }
+  }
+  const tsRlsByTable = {};
+  const collectRls = (tableName, holder) => {
+    const raw = holder?.rls_rules ?? holder?.rls_rule;
+    const rules = Array.isArray(raw) ? raw : raw?.rules || (raw ? [raw] : []);
+    if (rules.length)
+      (tsRlsByTable[tableName] ??= []).push(...rules);
+  };
+  collectRls(ws.model_tables?.[0]?.name || ws.tables?.[0]?.name || Object.keys(elementByTable)[0] || "", ws);
+  for (const mt of ws.model_tables || [])
+    collectRls(mt.name, mt);
+  for (const t of ws.tables || [])
+    collectRls(t.name, t);
+  for (const [tableName, rules] of Object.entries(tsRlsByTable)) {
+    const el = elementByTable[tableName];
+    if (!el || !rules.length)
+      continue;
+    const conds = rules.map((r) => tsRlsExprToSigma(String(r.expr || ""), elementByTable)).filter(Boolean);
+    if (!conds.length)
+      continue;
+    const formula = conds.length === 1 ? conds[0] : conds.map((c) => `(${c})`).join(" or ");
+    security.push(makeRlsSecurity({ source: `ThoughtSpot rls_rules (table "${tableName}", ${rules.length} rule${rules.length > 1 ? "s OR-combined" : ""})`, element: el, name: "RLS", formula }));
+    warnings.push(`\u{1F510} ThoughtSpot RLS on "${tableName}" (${rules.length} rule${rules.length > 1 ? "s, OR-combined" : ""}) \u2192 row-level security DETECTED (reported in result.security, not injected). The migration skill provisions the referenced teams/attributes and applies the RLS calc + filter.`);
+  }
+  const stats = {
+    elements: elements.length,
+    columns: elements.reduce((n, e) => n + (e.columns?.length || 0), 0),
+    metrics: elements.reduce((n, e) => n + (e.metrics?.length || 0), 0),
+    relationships: elements.reduce((n, e) => n + (e.relationships?.length || 0), 0)
+  };
+  return {
+    model: { name: modelName, schemaVersion: 1, pages: [{ id: pageId, name: "Page 1", elements }] },
+    warnings,
+    ...security.length ? { security } : {},
+    stats
+  };
+}
+function tsIsAggregateFormula(expr) {
+  return /\b(sum|count|count_distinct|unique_count|count_not_null|average|avg|max|min|median|std_deviation|stddev|variance|cumulative_sum|running_total|sum_if|count_if|average_if|max_if|min_if|unique_count_if)\s*\(/i.test(expr || "");
+}
+function tsRlsExprToSigma(expr, elementByTable) {
+  if (!expr?.trim())
+    return "";
+  let e = expr.trim();
+  e = e.replace(/'([^']*)'/g, '"$1"');
+  e = e.replace(/\[([^\]]+)\]\s*(?:=|in)\s*ts_groups/gi, "CurrentUserInTeam([$1])");
+  e = e.replace(/ts_groups\s*(?:=|in)\s*\[([^\]]+)\]/gi, "CurrentUserInTeam([$1])");
+  e = e.replace(/\bts_username\b/gi, "CurrentUserEmail()");
+  return tsFormulaToSigma(e, elementByTable).trim();
+}
+function tsFormulaToSigma(expr, _elementByTable) {
+  if (!expr)
+    return "";
+  let s = expr;
+  s = s.replace(/'([^']*)'/g, '"$1"');
+  s = s.replace(/\[([^\]:]+)::([^\]]+)\]/g, (_, _tbl, col) => `[${sigmaDisplayName(col.trim())}]`);
+  s = tsConvertIfThenElse(s);
+  s = s.replace(/(\[[^\]]+\]|\w+)\s+in\s*\{([^}]+)\}/gi, (_, col, vals) => {
+    const vlist = vals.split(",").map((v) => v.trim()).join(", ");
+    const colRef = col.startsWith("[") ? col : `[${sigmaDisplayName(col.trim())}]`;
+    return `In(${colRef}, ${vlist})`;
+  });
+  s = s.replace(/\bunique[\s_]+count\s*\(/gi, "count_distinct(");
+  const tsAggMap = {
+    sum: "Sum",
+    count: "Count",
+    count_distinct: "CountDistinct",
+    average: "Avg",
+    avg: "Avg",
+    max: "Max",
+    min: "Min",
+    median: "Median",
+    std_deviation: "StdDev",
+    variance: "Variance",
+    count_not_null: "CountDistinct",
+    cumulative_sum: "CumulativeSum"
+  };
+  s = s.replace(/\b(sum|count_distinct|count_not_null|count|average|avg|max|min|median|std_deviation|variance|cumulative_sum)\s*\(([^)]+)\)/gi, (_, fn, arg) => {
+    const sigmaFn = tsAggMap[fn.toLowerCase()] || fn;
+    return `${sigmaFn}(${tsWrapColumnRefs(arg.trim())})`;
+  });
+  s = tsRewriteSafeDivide(s);
+  s = tsRewriteCondAgg(s, "sum_if", "SumIf");
+  s = tsRewriteCondAgg(s, "unique_count_if", "CountDistinctIf");
+  s = tsRewriteCondAgg(s, "average_if", "AvgIf");
+  s = tsRewriteCondAgg(s, "max_if", "MaxIf");
+  s = tsRewriteCondAgg(s, "min_if", "MinIf");
+  s = s.replace(/\bcount_if\s*\(/gi, "CountIf(");
+  s = s.replace(/\bstart_of_week\s*\(/gi, 'DateTrunc("week", ');
+  s = s.replace(/\bstart_of_month\s*\(/gi, 'DateTrunc("month", ');
+  s = s.replace(/\bstart_of_quarter\s*\(/gi, 'DateTrunc("quarter", ');
+  s = s.replace(/\bstart_of_year\s*\(/gi, 'DateTrunc("year", ');
+  s = s.replace(/\bstart_of_day\s*\(/gi, 'DateTrunc("day", ');
+  s = s.replace(/\bmonth_number\s*\(/gi, "Month(");
+  s = s.replace(/\bquarter_number\s*\(/gi, "Quarter(");
+  s = s.replace(/\b(?:day_number_of_week|day_of_week)\s*\(/gi, "Weekday(");
+  s = s.replace(/\bday_of_month\s*\(/gi, "Day(");
+  s = s.replace(/\byear\s*\(/gi, "Year(");
+  s = s.replace(/\bmonth\s*\(/gi, "Month(");
+  s = s.replace(/\bday\s*\(/gi, "Day(");
+  s = s.replace(/\bhour\s*\(/gi, "Hour(");
+  s = s.replace(/\bpow(?:er)?\s*\(/gi, "Power(");
+  s = s.replace(/\bsqrt\s*\(/gi, "Sqrt(");
+  s = s.replace(/\babs\s*\(/gi, "Abs(");
+  s = s.replace(/\bround\s*\(/gi, "Round(");
+  s = s.replace(/\bexp\s*\(/gi, "Exp(");
+  s = s.replace(/\bln\s*\(/gi, "Ln(");
+  s = s.replace(/\blog10\s*\(/gi, "Log10(");
+  s = s.replace(/\bceil\s*\(/gi, "Ceiling(");
+  s = s.replace(/\bfloor\s*\(/gi, "Floor(");
+  s = s.replace(/\bmod\s*\(/gi, "Mod(");
+  s = s.replace(/\bconcat\s*\(/gi, "Concat(");
+  s = s.replace(/\bsubstr(?:ing)?\s*\(/gi, "Mid(");
+  s = s.replace(/\bstrlen\s*\(/gi, "Len(");
+  s = s.replace(/\bupper\s*\(/gi, "Upper(");
+  s = s.replace(/\blower\s*\(/gi, "Lower(");
+  s = s.replace(/\bltrim\s*\(/gi, "Ltrim(");
+  s = s.replace(/\brtrim\s*\(/gi, "Rtrim(");
+  s = s.replace(/\btrim\s*\(/gi, "Trim(");
+  s = s.replace(/\breplace\s*\(/gi, "Replace(");
+  s = s.replace(/\bifnull\s*\(/gi, "Coalesce(");
+  s = s.replace(/\bcoalesce\s*\(/gi, "Coalesce(");
+  s = s.replace(/\bisnull\s*\(/gi, "IsNull(");
+  s = s.replace(/\bnot\s*\(/gi, "Not(");
+  s = s.replace(/\btoday\s*\(\s*\)/gi, "Today()");
+  s = s.replace(/\bdate_diff\s*\(/gi, "DateDiff(");
+  s = s.replace(/\bdatediff\s*\(/gi, "DateDiff(");
+  s = tsWrapColumnRefs(s);
+  return s;
+}
+function tsRewriteCondAgg(s, tsFn, sigmaFn) {
+  let out = "";
+  let i = 0;
+  const re = new RegExp(`\\b${tsFn}\\s*\\(`, "gi");
+  let m;
+  while ((m = re.exec(s)) !== null) {
+    out += s.slice(i, m.index);
+    let depth = 1, j = re.lastIndex, commaIdx = -1;
+    while (j < s.length && depth > 0) {
+      const ch = s[j];
+      if (ch === "(")
+        depth++;
+      else if (ch === ")") {
+        depth--;
+        if (depth === 0)
+          break;
+      } else if (ch === "," && depth === 1 && commaIdx === -1)
+        commaIdx = j;
+      j++;
+    }
+    if (depth !== 0 || commaIdx === -1) {
+      out += m[0];
+      i = re.lastIndex;
+      continue;
+    }
+    const cond = s.slice(re.lastIndex, commaIdx).trim();
+    const measure = s.slice(commaIdx + 1, j).trim();
+    out += `${sigmaFn}(${measure}, ${cond})`;
+    i = j + 1;
+    re.lastIndex = i;
+  }
+  out += s.slice(i);
+  return out;
+}
+function tsRewriteSafeDivide(s) {
+  let out = "";
+  let i = 0;
+  const re = /\bsafe_divide\s*\(/gi;
+  let m;
+  while ((m = re.exec(s)) !== null) {
+    out += s.slice(i, m.index);
+    let depth = 1;
+    let j = re.lastIndex;
+    let commaIdx = -1;
+    while (j < s.length && depth > 0) {
+      const ch = s[j];
+      if (ch === "(")
+        depth++;
+      else if (ch === ")") {
+        depth--;
+        if (depth === 0)
+          break;
+      } else if (ch === "," && depth === 1 && commaIdx === -1)
+        commaIdx = j;
+      j++;
+    }
+    if (depth !== 0 || commaIdx === -1) {
+      out += m[0];
+      i = re.lastIndex;
+      continue;
+    }
+    const a = s.slice(re.lastIndex, commaIdx).trim();
+    const b = s.slice(commaIdx + 1, j).trim();
+    out += `If(IsNull(${b}) or ${b} = 0, null, ${a} / ${b})`;
+    i = j + 1;
+    re.lastIndex = i;
+  }
+  out += s.slice(i);
+  return out;
+}
+function tsConvertIfThenElse(s) {
+  let maxPasses = 10;
+  const re = /\bif\s*\(([^)]+)\)\s*then\s+(.+?)\s+else\s+/g;
+  while (re.test(s) && maxPasses-- > 0) {
+    re.lastIndex = 0;
+    s = s.replace(/\bif\s*\(([^)]+)\)\s*then\s+(.+?)\s+else\s+(.+?)(?=\s*(?:$|\bif\b))/g, (_, cond, thenV, elseV) => `If(${cond}, ${thenV}, ${elseV})`);
+  }
+  return s;
+}
+function tsWrapColumnRefs(expr) {
+  const saved = [];
+  let s = expr.replace(/\[[^\]]*\]/g, (m) => {
+    saved.push(m);
+    return `${saved.length - 1}`;
+  }).replace(/"[^"]*"/g, (m) => {
+    saved.push(m);
+    return `${saved.length - 1}`;
+  });
+  const skip = /^(if|then|else|and|or|not|in|null|true|false|today|IsNull|If|In|List|Sum|Count|Avg|Max|Min|CountDistinct|StdDev|Variance|DateDiff|Today|CumulativeSum|Not)$/;
+  s = s.replace(/\b([A-Z_][A-Z0-9_]*)\b(?!\s*\()/gi, (match, ident) => {
+    if (skip.test(ident))
+      return match;
+    return `[${sigmaDisplayName(ident)}]`;
+  });
+  return s.replace(/\x02(\d+)\x03/g, (_, i) => saved[+i]);
+}
+var TS_WINDOW_SIGMA = {
+  cumulative_sum: "CumulativeSum",
+  running_total: "CumulativeSum",
+  running_sum: "CumulativeSum",
+  cumulative_average: "CumulativeAvg",
+  cumulative_avg: "CumulativeAvg",
+  cumulative_max: "CumulativeMax",
+  cumulative_min: "CumulativeMin",
+  running_count: "CumulativeCount",
+  moving_average: "MovingAvg",
+  moving_avg: "MovingAvg",
+  moving_sum: "MovingSum",
+  moving_max: "MovingMax",
+  moving_min: "MovingMin",
+  rank: "Rank",
+  rank_desc: "Rank",
+  lead: "Lead",
+  lag: "Lag",
+  first: "First",
+  first_value: "First",
+  last: "Last",
+  last_value: "Last"
+};
+var TS_WINDOW_FN_RE = new RegExp(`\\b(${Object.keys(TS_WINDOW_SIGMA).sort((a, b) => b.length - a.length).join("|")})\\s*\\(`, "i");
+function tsParseWindowCall(expr) {
+  const t = (expr || "").trim();
+  const m = t.match(/^([a-z_]+)\s*\(/i);
+  if (!m || !(m[1].toLowerCase() in TS_WINDOW_SIGMA))
+    return null;
+  let depth = 1, j = m[0].length, cur = "";
+  const args = [];
+  for (; j < t.length; j++) {
+    const ch = t[j];
+    if (ch === "(")
+      depth++;
+    else if (ch === ")") {
+      depth--;
+      if (depth === 0)
+        break;
+    }
+    if (ch === "," && depth === 1) {
+      args.push(cur.trim());
+      cur = "";
+      continue;
+    }
+    cur += ch;
+  }
+  if (depth !== 0 || j !== t.length - 1)
+    return null;
+  if (cur.trim())
+    args.push(cur.trim());
+  return { fn: m[1].toLowerCase(), args };
+}
+function tsEmitWindowElements(pend, elements, derivedEls, dispNameToElId, colAggByDisp, warnings) {
+  if (!pend.length || !elements.length)
+    return;
+  const refsOf = (sig) => (sig.match(/\[([^\]\/]+)\]/g) || []).map((r) => r.slice(1, -1));
+  const hostColDisp = (c) => {
+    if (c.name)
+      return c.name;
+    const fm = (c.formula || "").match(/^\[([^\/\]]+)\/([^\]]+)\]$/);
+    return fm ? sigmaDisplayName(fm[2]) : "";
+  };
+  for (const p of pend) {
+    const flagOnly = (host2, reason) => {
+      const colId = sigmaShortId();
+      host2.columns.push({
+        id: colId,
+        name: p.dispName,
+        formula: "Null",
+        description: `ThoughtSpot window function (re-author as a grouped-element calc in Sigma \u2014 window functions error in DM calc columns): ${p.formulaExpr}`
+      });
+      if (host2.order)
+        host2.order.push(colId);
+      warnings.push(`\u26A0 "${p.dispName}": ${reason} Left as a flagged Null column on "${host2.name}" with the original expression in its description \u2014 re-author as a calc in a grouped workbook element.`);
+    };
+    const allRefs = refsOf(tsFormulaToSigma(p.formulaExpr, {}));
+    const hostElId = allRefs.map((r) => dispNameToElId[r.toUpperCase()]).find(Boolean) || elements[0].id;
+    const host = elements.find((e) => e.id === hostElId) || elements[0];
+    if (!p.call || !p.call.args.length) {
+      flagOnly(host, "window function is embedded in a larger expression (or has no arguments), which can't be decomposed into a single grouped element.");
+      continue;
+    }
+    const fn = p.call.fn;
+    const sigmaFn = TS_WINDOW_SIGMA[fn];
+    const rawMeasure = p.call.args[0];
+    const measureSigma = tsFormulaToSigma(rawMeasure, {});
+    const nums = [];
+    const dimSigs = [];
+    for (const a of p.call.args.slice(1)) {
+      if (/^-?\d+$/.test(a.trim()))
+        nums.push(a.trim());
+      else
+        dimSigs.push(tsFormulaToSigma(a, {}));
+    }
+    const offHost = [...refsOf(measureSigma), ...dimSigs.flatMap(refsOf)].filter((r) => {
+      const id = dispNameToElId[r.toUpperCase()];
+      return id && id !== host.id;
+    });
+    let parent = host;
+    let crossRel = null;
+    if (offHost.length) {
+      const view = derivedEls.find((d) => d.source?.elementId === host.id);
+      const rels = host.relationships || [];
+      crossRel = {};
+      let ok = !!view;
+      for (const r of new Set(offHost)) {
+        const tgtId = dispNameToElId[r.toUpperCase()];
+        const rel = rels.find((rr) => rr.targetElementId === tgtId && rr.name);
+        if (!rel) {
+          ok = false;
+          break;
+        }
+        crossRel[r] = `${r} (${rel.name})`;
+      }
+      if (!ok) {
+        flagOnly(host, "window function references columns across elements with no derived join view to host the grouped calc.");
+        continue;
+      }
+      parent = view;
+    }
+    const parentName = parent.name;
+    const qualify = (sig) => sig.replace(/\[([^\]\/]+)\]/g, (mch, ref) => {
+      const disp = crossRel && crossRel[ref] ? crossRel[ref] : ref;
+      return `[${parentName}/${disp}]`;
+    });
+    let dims = [];
+    for (let i = 0; i < dimSigs.length; i++) {
+      const sig = dimSigs[i];
+      const bare = sig.match(/^\[([^\]\/]+)\]$/);
+      if (bare) {
+        const disp = bare[1];
+        dims.push({ name: disp, formula: qualify(sig) });
+      } else {
+        dims.push({ name: `${p.dispName} Key ${i + 1}`, formula: qualify(sig) });
+      }
+    }
+    if (!dims.length) {
+      const hostCols = host.columns || [];
+      const dateCol = hostCols.find((c) => typeof c.formula === "string" && c.formula.startsWith("DateTrunc("));
+      const fallback = dateCol || hostCols.find((c) => hostColDisp(c) && c.formula !== "Null");
+      if (!fallback) {
+        flagOnly(host, `${fn}() has no ordering dimension and "${host.name}" has no usable column to group by.`);
+        continue;
+      }
+      const disp = hostColDisp(fallback);
+      dims.push({ name: disp, formula: qualify(`[${disp}]`) });
+      warnings.push(`\u2139 "${p.dispName}": ${fn}() had no explicit dimension \u2014 grouped by "${disp}" (host's ${dateCol ? "date" : "first"} column). Adjust the grouping in Sigma if a different grain is wanted.`);
+    }
+    let valFormula;
+    let valName;
+    const bareMeasure = measureSigma.match(/^\[([^\]\/]+)\]$/);
+    if (tsIsAggregateFormula(rawMeasure)) {
+      valFormula = qualify(measureSigma);
+      valName = `${p.dispName} Base`;
+    } else if (bareMeasure) {
+      valName = bareMeasure[1];
+      const agg = colAggByDisp[valName.toUpperCase()] || "Sum";
+      valFormula = `${agg}(${qualify(measureSigma)})`;
+    } else {
+      valFormula = `Sum(${qualify(measureSigma)})`;
+      valName = `${p.dispName} Base`;
+    }
+    let winFormula;
+    if (sigmaFn === "Rank") {
+      winFormula = `Rank([${valName}], "${fn === "rank_desc" ? "desc" : "asc"}")`;
+    } else if (sigmaFn === "Lead" || sigmaFn === "Lag") {
+      winFormula = `${sigmaFn}([${valName}], ${nums[0] || "1"})`;
+    } else if (sigmaFn.startsWith("Moving")) {
+      winFormula = `${sigmaFn}([${valName}], ${nums[0] || "1"}${nums.length > 1 ? `, ${nums[1]}` : ""})`;
+    } else {
+      winFormula = `${sigmaFn}([${valName}])`;
+    }
+    const dimCols = dims.map((d) => ({ id: sigmaShortId(), formula: d.formula, name: d.name }));
+    const vId = sigmaShortId();
+    const wId = sigmaShortId();
+    const cols = [
+      ...dimCols,
+      { id: vId, formula: valFormula, name: valName },
+      { id: wId, formula: winFormula, name: p.dispName }
+    ];
+    elements.push({
+      id: sigmaShortId(),
+      kind: "table",
+      name: p.dispName,
+      source: { kind: "table", elementId: parent.id },
+      columns: cols,
+      order: cols.map((c) => c.id),
+      groupings: [{ id: sigmaShortId(), groupBy: dimCols.map((c) => c.id), calculations: [vId, wId] }]
+    });
+    const flagId = sigmaShortId();
+    host.columns.push({
+      id: flagId,
+      name: p.dispName,
+      formula: "Null",
+      description: `ThoughtSpot window function \u2014 auto-built as grouped element "${p.dispName}" in this data model (window functions error in DM calc columns): ${p.formulaExpr}`
+    });
+    if (host.order)
+      host.order.push(flagId);
+    warnings.push(`\u2139 "${p.dispName}": ${fn}() \u2192 grouped ${sigmaFn} element "${p.dispName}" on "${parentName}" (group by ${dims.map((d) => `"${d.name}"`).join(", ")}). The column on "${host.name}" is a flagged Null placeholder pointing at it.`);
+  }
+}
+export {
+  convertThoughtSpotToSigma
+};
+/*! Bundled license information:
+
+js-yaml/dist/js-yaml.mjs:
+  (*! js-yaml 4.1.1 https://github.com/nodeca/js-yaml @license MIT *)
+*/

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/convert_model.mjs
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/convert_model.mjs
@@ -2,9 +2,15 @@
 // Convert a ThoughtSpot model TML file to a Sigma data-model spec (JSON to stdout).
 // Usage: node convert_model.mjs <model.tml>
 //   env: SIGMA_CONNECTION_ID, TS_DB, TS_SCHEMA, CONVERTER_PATH (build/thoughtspot.js)
-import { readFileSync } from 'fs';
-const CONV = process.env.CONVERTER_PATH;  // path to sigma-data-model-mcp build/thoughtspot.js
-if (!CONV) { console.error('set CONVERTER_PATH (sigma-data-model-mcp build/thoughtspot.js), or call the convert_thoughtspot_to_sigma MCP tool and pass its JSON to the build step'); process.exit(2); }
+import { readFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+// Converter resolution: explicit CONVERTER_PATH (a dev's fresher build) wins;
+// otherwise the self-contained bundle vendored in the skill (no clone, no MCP).
+const HERE = dirname(fileURLToPath(import.meta.url));
+const VENDORED = join(HERE, '..', 'converter', 'thoughtspot.mjs');
+const CONV = process.env.CONVERTER_PATH || (existsSync(VENDORED) ? VENDORED : null);
+if (!CONV) { console.error('no converter: set CONVERTER_PATH (sigma-data-model-mcp build/thoughtspot.js) or restore the vendored converter/thoughtspot.mjs'); process.exit(2); }
 const { convertThoughtSpotToSigma } = await import(CONV);
 const tml = readFileSync(process.argv[2], 'utf8');
 const r = convertThoughtSpotToSigma(tml, {

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
@@ -60,6 +60,14 @@ import yaml, ts_common
 import migrate  # the per-phase pipeline (sigma() REST helper reused)
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+# Zero-config converter: a self-contained ESM bundle ships in the skill at
+# converter/thoughtspot.mjs (no clone, no npm, no network, no MCP). Default
+# CONVERTER_PATH to it so local conversion is the out-of-the-box path; an explicit
+# CONVERTER_PATH (a dev's fresher build) still wins. Inherited by migrate.py +
+# convert_model.mjs, which gate local-vs-MCP on this var.
+_VENDORED_CONV = os.path.join(HERE, "..", "converter", "thoughtspot.mjs")
+if not os.environ.get("CONVERTER_PATH") and os.path.exists(_VENDORED_CONV):
+    os.environ["CONVERTER_PATH"] = _VENDORED_CONV
 T0 = time.time()
 
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate.py
@@ -41,6 +41,12 @@ import yaml, ts_common, apply_layouts, scout_gate
 yaml.SafeLoader.add_constructor("tag:yaml.org,2002:value", lambda l, n: l.construct_scalar(n))
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+# Zero-config converter: default CONVERTER_PATH to the vendored bundle shipped in
+# the skill (converter/thoughtspot.mjs) so the local one-shot path runs out of the
+# box — no clone, no MCP. An explicit CONVERTER_PATH still wins. (See convert_model.)
+_VENDORED_CONV = os.path.join(HERE, "..", "converter", "thoughtspot.mjs")
+if not os.environ.get("CONVERTER_PATH") and os.path.exists(_VENDORED_CONV):
+    os.environ["CONVERTER_PATH"] = _VENDORED_CONV
 _SSL = ssl._create_unverified_context()
 MCP_TOOL = "mcp__sigma-data-model__convert_thoughtspot_to_sigma"
 

--- a/tools/vendor-converters.sh
+++ b/tools/vendor-converters.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# vendor-converters.sh — the ONE consistent way to refresh the committed,
+# zero-config converters that ship inside every migration skill.
+#
+# Each converter in sigma-data-model-mcp (convert<Tool>ToSigma) is bundled by
+# esbuild into a single self-contained ESM file committed at
+#   plugins/<skill>/skills/<skill>/converter/<module>.mjs
+# so conversion runs locally via `node` with NO clone, NO npm install, NO network,
+# and NO MCP. A developer's own checkout still wins via the per-skill env override;
+# the vendored bundle is only the guaranteed floor.
+#
+#   tools/vendor-converters.sh [/path/to/sigma-data-model-mcp] [converter ...]
+#
+#   # all converters from ~/sigma-data-model-mcp:
+#   tools/vendor-converters.sh
+#   # a subset from an explicit checkout:
+#   tools/vendor-converters.sh ~/sigma-data-model-mcp lookml thoughtspot cognos
+#
+# Re-run after the converter repo changes (see memory: "mcp-sync") and commit the
+# bundles. Requires a sigma-data-model-mcp checkout with esbuild installed (devDep).
+# Portable to macOS bash 3.2 (no associative arrays).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="${1:-$HOME/sigma-data-model-mcp}"; [ $# -gt 0 ] && shift || true
+
+# module (in build/) -> skill plugin dir under plugins/ that owns it.
+skill_for() {
+  case "$1" in
+    tableau) echo tableau-to-sigma ;;
+    lookml) echo looker-to-sigma ;;
+    thoughtspot) echo thoughtspot-to-sigma ;;
+    qlik) echo qlik-to-sigma ;;
+    powerbi) echo powerbi-to-sigma ;;
+    quicksight) echo quicksight-to-sigma ;;
+    cognos|cognos-report) echo cognos-to-sigma ;;
+    *) echo "" ;;
+  esac
+}
+
+WANT=("$@"); [ ${#WANT[@]} -eq 0 ] && WANT=(tableau lookml thoughtspot qlik powerbi quicksight cognos)
+
+[ -d "$SRC" ] || { echo "FATAL: converter source not found: $SRC"; exit 1; }
+ESBUILD="$SRC/node_modules/.bin/esbuild"
+[ -x "$ESBUILD" ] || { echo "FATAL: esbuild not at $ESBUILD — run 'npm install' in $SRC"; exit 1; }
+
+# build the converter repo if its artifacts are missing
+if ! ls "$SRC"/build/*.js >/dev/null 2>&1; then
+  echo "→ building converter repo (npm run build)"
+  ( cd "$SRC" && { npm ci --silent || npm install --silent; } && npm run build --silent )
+fi
+
+SHA="$(git -C "$SRC" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+DATE="$(git -C "$SRC" log -1 --format=%cd --date=short 2>/dev/null || echo unknown)"
+STAMPED_DIRS=""
+
+for mod in "${WANT[@]}"; do
+  skill="$(skill_for "$mod")"
+  [ -n "$skill" ] || { echo "WARN: unknown converter '$mod' — skipping"; continue; }
+  dest="$ROOT/plugins/$skill/skills/$skill/converter"
+  mkdir -p "$dest"
+
+  # Cognos is special: its converter is vendored as TS source IN the skill
+  # (converter/cli.ts → cognos.ts/cognos-report.ts), not in sigma-data-model-mcp.
+  # Bundle that pinned CLI into a self-contained converter/cli.mjs (npm install in
+  # the skill's converter/ once for fast-xml-parser; node_modules stays gitignored).
+  if [ "$mod" = "cognos" ]; then
+    entry="$dest/cli.ts"
+    out="$dest/cli.mjs"
+    [ -f "$entry" ] || { echo "FATAL: $entry missing (cognos vendors its own TS converter)"; exit 1; }
+    [ -d "$dest/node_modules/fast-xml-parser" ] || ( cd "$dest" && npm install --silent )
+    "$ESBUILD" "$entry" --bundle --format=esm --platform=node --outfile="$out" >/dev/null
+    echo "✓ $skill/converter/cli.mjs  ($(du -h "$out" | cut -f1))  [bundled from in-skill cli.ts]"
+    # cognos provenance tracks the in-repo TS source, not the mcp commit.
+    cat > "$dest/PROVENANCE.json" <<EOF
+{
+  "source": "in-skill converter/cli.ts (cognos.ts + cognos-report.ts + sigma-ids.ts)",
+  "bundler": "esbuild --bundle --format=esm --platform=node",
+  "vendored_modules": "cli.mjs",
+  "note": "Self-contained bundle of the skill's own pinned Cognos converter. Refresh with tools/vendor-converters.sh after editing converter/*.ts."
+}
+EOF
+    continue
+  fi
+
+  entry="$SRC/build/$mod.js"
+  [ -f "$entry" ] || { echo "FATAL: $entry missing (build the converter repo first)"; exit 1; }
+  out="$dest/$mod.mjs"
+  "$ESBUILD" "$entry" --bundle --format=esm --platform=node --outfile="$out" >/dev/null
+  # sanity: the bundle must export a convert<Tool>ToSigma symbol
+  node --input-type=module -e "
+    import * as m from '$out';
+    const fn = Object.keys(m).find(k => /^convert.*ToSigma\$/.test(k));
+    if (!fn) { console.error('FATAL: $out exports no convert*ToSigma'); process.exit(1); }
+  "
+  echo "✓ $skill/converter/$mod.mjs  ($(du -h "$out" | cut -f1))"
+  case "$STAMPED_DIRS" in *"|$dest|"*) : ;; *) STAMPED_DIRS="$STAMPED_DIRS|$dest|" ;; esac
+done
+
+# one PROVENANCE.json per touched skill converter dir
+echo "$STAMPED_DIRS" | tr '|' '\n' | grep -v '^$' | sort -u | while read -r dest; do
+  [ -d "$dest" ] || continue
+  mods=$(ls "$dest"/*.mjs 2>/dev/null | xargs -n1 basename | paste -sd, -)
+  cat > "$dest/PROVENANCE.json" <<EOF
+{
+  "source_repo": "twells89/sigma-data-model-mcp",
+  "source_commit": "$SHA",
+  "source_commit_date": "$DATE",
+  "bundler": "esbuild --bundle --format=esm --platform=node",
+  "vendored_modules": "$mods",
+  "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."
+}
+EOF
+done
+
+echo "Done — source $SHA ($DATE). Commit the converter/ diffs."


### PR DESCRIPTION
**Group A** of making *every* converter self-contained — the consistent process you asked for. Conversion now runs locally via `node` with **no clone, no `npm install`, no network, no MCP**. Mirrors the Tableau vendoring (#220).

## Shared process
`tools/vendor-converters.sh` — the **one** way to refresh all skills' converters: esbuild-bundles each into a committed, self-contained `converter/*.mjs` + `PROVENANCE.json`. Bundles from `sigma-data-model-mcp` for most; **Cognos** bundles its own pinned `converter/cli.ts`. (Portable to macOS bash 3.2.)

## Per skill
| Skill | Change | MCP/clone now |
|---|---|---|
| **Looker** | ships `converter/lookml.mjs`; `migrate-looker.py` auto-uses it as the zero-config floor | dev `CONVERTER_SRC/PATH` still win; MCP exit-3 only if bundle absent |
| **ThoughtSpot** | ships `converter/thoughtspot.mjs`; `CONVERTER_PATH` defaults to it across `migrate-thoughtspot.py` / `migrate.py` / `convert_model.mjs` | MCP fallback kept |
| **Cognos** | bundles its own `cli.ts` → `converter/cli.mjs`; `migrate-cognos.mjs` runs it via plain `node` | falls back to `tsx cli.ts` (+ one `npm install`) only if bundle missing — removes the **mandatory** npm bootstrap |

MCP/hosted stays everywhere as an explicit last-resort fallback (per the agreed design), never the default.

## Testing (offline fixtures; no live tenant needed where possible)
- **Looker** — full **live** migration via the vendored bundle (clone hidden via empty `HOME` to force it): DM + workbook built, **5/5 charts strict parity PASS**. Test objects cleaned up. (Gate-8 visual-render FAIL here is the pre-existing path bug fixed in #221, which isn't on this branch — functionally the bundle's output posts + parity-passes.)
- **ThoughtSpot** — dry-run converts via the vendored bundle (7 elements).
- **Cognos** — orchestrator Phase-1 converts via `cli.mjs` with **zero npm/tsx**; both module→DM (25 elements) and report→workbook (6 KPIs / 3 charts) verified directly.
- `lint-skills` + `check-shared` green; all scripts AST/syntax-clean.

## Follow-ups
- **PR B** — Qlik / PowerBI / QuickSight (PowerBI/QuickSight need a new local node path; today they only emit an MCP instruction).
- Once **#220** merges, fold Tableau's per-skill `vendor-converter.sh` into `tools/vendor-converters.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)