### PR TITLE
Windows-safe environment doctor + setup ref in every skill

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-assessment/refs/environment.md
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -13,6 +13,10 @@ user-invocable: true
 
 # Cognos → Sigma migration
 
+> **Windows / first run — run the environment doctor before anything else:**
+> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+
 ## Preflight the workbook spec before POST (mandatory)
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/environment.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/refs/environment.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
@@ -17,6 +17,10 @@ user-invocable: true
 
 # GoodData → Sigma
 
+> **Windows / first run — run the environment doctor before anything else:**
+> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+
 > **Status: LIVE-VALIDATED — exact parity, data model + workbook.**
 > Proven end-to-end on a GoodData Cloud trial → Sigma (both on Snowflake): a
 > workspace (LDM + MAQL metrics + insights + dashboard) migrated to a Sigma data

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/environment.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/looker-to-sigma/skills/looker-assessment/refs/environment.md
+++ b/plugins/looker-to-sigma/skills/looker-assessment/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -14,6 +14,10 @@ user-invocable: true
 
 # Looker → Sigma Conversion
 
+> **Windows / first run — run the environment doctor before anything else:**
+> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+
 ## Preflight the workbook spec before POST (mandatory)
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/environment.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/refs/environment.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -13,6 +13,10 @@ user-invocable: true
 
 # MicroStrategy → Sigma migration
 
+> **Windows / first run — run the environment doctor before anything else:**
+> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+
 ## Preflight the workbook spec before POST (mandatory)
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/environment.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/environment.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # Power BI → Sigma
 
+> **Windows / first run — run the environment doctor before anything else:**
+> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+
 ## Preflight the workbook spec before POST (mandatory)
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/environment.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/refs/environment.md
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -12,6 +12,10 @@ user-invocable: true
 
 # Qlik → Sigma Conversion
 
+> **Windows / first run — run the environment doctor before anything else:**
+> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+
 ## Preflight the workbook spec before POST (mandatory)
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/environment.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/environment.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # QuickSight → Sigma
 
+> **Windows / first run — run the environment doctor before anything else:**
+> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+
 ## Preflight the workbook spec before POST (mandatory)
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/environment.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/refs/environment.md
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/sigma-authoring/skills/sigma-workbooks/refs/environment.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/refs/environment.md
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
@@ -17,6 +17,10 @@ user-invocable: true
 
 # Sisense → Sigma migration
 
+> **Windows / first run — run the environment doctor before anything else:**
+> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+
 Convert a **Sisense** data model + dashboards into a Sigma **data model** +
 **workbook**. Pull the model schema export and the widget definitions over REST,
 translate JAQL / widget types / filters, emit the specs, then **verify parity**

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/environment.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/refs/environment.md
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -11,6 +11,10 @@ user-invocable: true
 
 # Tableau → Sigma Conversion
 
+> **Windows / first run — run the environment doctor before anything else:**
+> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+
 Convert a Tableau datasource into a Sigma data model, then build a Sigma workbook
 that mirrors the Tableau dashboard layout as closely as possible.
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/environment.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/environment.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 
 # ThoughtSpot → Sigma migration
 
+> **Windows / first run — run the environment doctor before anything else:**
+> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+
 ## Preflight the workbook spec before POST (mandatory)
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/environment.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -356,6 +356,7 @@
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh",
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh",
+        "plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh",
         "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh",
         "plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh",
@@ -382,6 +383,7 @@
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1",
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1",
+        "plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1",
         "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1",
         "plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1",
@@ -408,6 +410,7 @@
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-assessment/refs/environment.md",
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/environment.md",
+        "plugins/gooddata-to-sigma/skills/gooddata-assessment/refs/environment.md",
         "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/environment.md",
         "plugins/looker-to-sigma/skills/looker-assessment/refs/environment.md",
         "plugins/looker-to-sigma/skills/looker-to-sigma/refs/environment.md",

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -339,6 +339,84 @@
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-build-parity-plan.rb",
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-build-parity-plan.rb"
       ]
+    },
+    {
+      "canonical": "shared/scripts/doctor.sh",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh",
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh",
+        "plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh",
+        "plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh",
+        "plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh",
+        "plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh",
+        "plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh",
+        "plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh",
+        "plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh",
+        "plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh"
+      ]
+    },
+    {
+      "canonical": "shared/scripts/doctor.ps1",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1",
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1",
+        "plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1",
+        "plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1",
+        "plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1",
+        "plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1",
+        "plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1",
+        "plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1",
+        "plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1",
+        "plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1"
+      ]
+    },
+    {
+      "canonical": "shared/refs/environment.md",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-assessment/refs/environment.md",
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/environment.md",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/environment.md",
+        "plugins/looker-to-sigma/skills/looker-assessment/refs/environment.md",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/refs/environment.md",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-assessment/refs/environment.md",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/environment.md",
+        "plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/environment.md",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/environment.md",
+        "plugins/qlik-to-sigma/skills/qlik-assessment/refs/environment.md",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/environment.md",
+        "plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/environment.md",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/environment.md",
+        "plugins/sigma-authoring/skills/custom-sql-to-data-model/refs/environment.md",
+        "plugins/sigma-authoring/skills/sigma-workbooks/refs/environment.md",
+        "plugins/sisense-to-sigma/skills/sisense-assessment/refs/environment.md",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/environment.md",
+        "plugins/tableau-to-sigma/skills/tableau-assessment/refs/environment.md",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/environment.md",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/environment.md",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/environment.md"
+      ]
     }
   ]
 }

--- a/shared/refs/environment.md
+++ b/shared/refs/environment.md
@@ -1,0 +1,47 @@
+# Environment & Windows setup
+
+**Run the doctor first.** Before discovery/conversion, run the environment preflight —
+it reports what's installed and prints the exact fix for anything missing, so you
+don't trial-and-error the setup:
+
+- macOS / Linux / **Git Bash**: `bash scripts/doctor.sh`
+- **Windows PowerShell**: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+
+Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has the fix).
+
+## Required runtimes
+| Tool | Used by | Notes |
+|---|---|---|
+| **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
+| **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
+
+## Windows footguns (and fixes)
+
+1. **Python "Store stub."** A bare `python` / `python3` on Windows usually resolves to
+   the Microsoft Store *App Execution Alias* — a stub that silently does nothing when
+   run non-interactively (commands "hang or exit with no output"). Fixes:
+   - Install Python from **python.org** (tick *Add Python to PATH*) and launch with the
+     **`py -3`** launcher, **or**
+   - Disable the stub: *Settings → Apps → Advanced app settings → App execution aliases*
+     → turn **OFF** `python.exe` / `python3.exe`.
+   - The skills' scripts are already hardened: Ruby/Node spawns resolve a real Python
+     (skipping the stub), and Python entrypoints re-spawn via `sys.executable`. The
+     stub only blocks the **first** `python ...` launch — so use `py -3 scripts/<x>.py`.
+
+2. **No `bash`.** The Sigma token step (`eval "$(scripts/get-token.sh)"`) is a bash
+   script. Install **Git for Windows** (ships Git Bash) and run the `*.sh` helpers from
+   Git Bash (or via WSL). cmd/PowerShell alone can't run them.
+
+3. **CRLF line endings.** If `git config core.autocrlf` is `true`, checkout can rewrite
+   the shipped `.sh`/`.rb`/`.py` to CRLF and break shebangs (`\r: command not found`).
+   Set `git config --global core.autocrlf input` and re-checkout.
+
+4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
+   *Add Ruby to PATH*, reopen the shell.
+
+> The converters themselves need **no clone, no `npm install`, no network, no MCP** —
+> each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on
+> Windows the only setup is: a real Python (`py -3`), Ruby on PATH, Node, and a bash
+> for the token step. The doctor checks all four.

--- a/shared/scripts/doctor.ps1
+++ b/shared/scripts/doctor.ps1
@@ -1,0 +1,90 @@
+# doctor.ps1 — environment preflight for the migration skills on Windows.
+# Run this FIRST in PowerShell: it reports what's installed, flags the known
+# Windows footguns (the Python "Store stub" and a missing bash), and prints the
+# exact fix for each — so neither you nor the agent has to trial-and-error setup.
+#
+#   powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1
+#
+# Exits 0 when all REQUIRED tools are present; 1 when something required is
+# missing. (macOS / Linux / Git-Bash users: run scripts/doctor.sh instead.)
+#
+# REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
+# sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+
+$script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
+
+Write-Host "Environment doctor - host: windows (PowerShell)`n"
+
+# --- ruby ------------------------------------------------------------------
+$ruby = Get-Command ruby -ErrorAction SilentlyContinue
+if ($ruby) { Ok "ruby - $((& ruby -e 'print RUBY_VERSION' 2>$null))" }
+else { Bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen PowerShell." }
+
+# --- python (reject the Microsoft Store App-Execution-Alias stub) ----------
+# Detect by PATH first: the stub lives under ...\WindowsApps\. We check py -3,
+# then python / python3, and accept the first whose interpreter is NOT in
+# WindowsApps. (We avoid invoking a WindowsApps stub, which can pop the Store.)
+function Test-RealPython($exe, $pre) {
+  $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+  if (-not $cmd) { return $null }
+  # `py` is the launcher (always real); for python/python3 inspect the source path.
+  if ($exe -ne 'py' -and $cmd.Source -and $cmd.Source.ToLower().Contains('windowsapps')) { return $null }
+  try {
+    $argsv = @(); if ($pre) { $argsv += $pre }
+    $ver = (& $exe @argsv --version 2>&1 | Out-String).Trim()
+    if ($ver -notmatch 'Python\s+\d') { return $null }
+    $where = (& $exe @argsv -c 'import sys;print(sys.executable)' 2>&1 | Out-String).Trim()
+    if ($where.ToLower().Contains('windowsapps')) { return $null }
+    return "$ver  ($where)"
+  } catch { return $null }
+}
+$py = Test-RealPython 'py' '-3'
+if ($py) { Ok "python - $py  [launcher: py -3]" }
+else {
+  $py = Test-RealPython 'python' $null
+  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { Ok "python - $py" }
+  else {
+    Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
+        "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- node ------------------------------------------------------------------
+$node = Get-Command node -ErrorAction SilentlyContinue
+if ($node) { Ok "node - $((& node --version 2>$null))" }
+else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+
+# --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+  Ok "bash - $($bash.Source) (run the *.sh helpers like get-token.sh from Git Bash, or 'bash scripts/get-token.sh')"
+} else {
+  $wsl = Get-Command wsl -ErrorAction SilentlyContinue
+  if ($wsl) { Warn "no native bash, but WSL is present" "Run the *.sh helpers via WSL, or install Git for Windows (Git Bash) for a native bash." }
+  else { Bad "no bash found - get-token.sh / *-auth.sh (Sigma token minting) cannot run" `
+             "Install Git for Windows (https://git-scm.com/download/win) - it ships Git Bash - then run the *.sh helpers from Git Bash." }
+}
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+$crlf = (& git config --get core.autocrlf 2>$null)
+if ($crlf -eq 'true') {
+  Warn "git core.autocrlf=true - may rewrite shipped .sh/.rb/.py to CRLF and break them under bash" `
+       "git config --global core.autocrlf input  (then re-clone / re-checkout)."
+} else { Ok "git core.autocrlf=$(if ($crlf) {$crlf} else {'unset'}) (won't CRLF-mangle scripts)" }
+
+# --- Sigma credentials (informational) -------------------------------------
+$envFile = Join-Path $env:USERPROFILE ".sigma-migration\env"
+if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
+  Ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+} else {
+  Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
+}
+
+Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
+if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }
+Write-Host "Fix the [X] item(s) above, then re-run: powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1"
+exit 1

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# doctor.sh — environment preflight for the migration skills (macOS / Linux /
+# Windows Git-Bash). Run this FIRST: it reports exactly what's installed, flags
+# the known footguns (esp. the Windows Python "Store stub" and a missing bash),
+# and prints the precise fix for each — so neither you nor the agent has to
+# trial-and-error the environment.
+#
+#   bash scripts/doctor.sh
+#
+# Exit 0 when all REQUIRED tools are present; 1 when something required is
+# missing (each failure prints a remediation line). Windows users without a
+# bash at all should run scripts/doctor.ps1 in PowerShell instead.
+#
+# REQUIRED, by skill family:
+#   - ruby   : the *-to-sigma orchestrators (tableau/qlik/powerbi/quicksight, …)
+#   - python3: looker/thoughtspot/microstrategy/sisense entrypoints + discovery
+#   - node   : the vendored converters (converter/*.mjs) and *.mjs build steps
+#   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
+set -u
+
+PASS=0; FAIL=0; WARN=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*) OS=windows-bash ;;
+  Darwin) OS=macos ;; Linux) OS=linux ;; *) OS=unknown ;;
+esac
+echo "Environment doctor — host: $OS"
+echo
+
+# --- ruby ------------------------------------------------------------------
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby — $(ruby -e 'print RUBY_VERSION' 2>/dev/null)"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "ruby not found" "Install RubyInstaller (https://rubyinstaller.org), tick 'Add Ruby to PATH', reopen the shell."
+  else
+    bad "ruby not found" "macOS: 'brew install ruby'  •  Linux: 'apt-get install ruby' (or your package manager)."
+  fi
+fi
+
+# --- python (real interpreter, NOT the Windows Store alias stub) -----------
+# Probe py -3 (Windows launcher) first, then python3/python. Reject any that
+# resolves under WindowsApps — the App-Execution-Alias stub that silently no-ops.
+py_real() {
+  local exe="$1"; shift
+  command -v "$exe" >/dev/null 2>&1 || return 1
+  local ver; ver="$("$exe" "$@" --version 2>&1)" || return 1
+  case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
+  local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
+  case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
+  PY_DESC="$ver  ($where)"; return 0
+}
+if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
+elif py_real python3; then ok "python — $PY_DESC  [python3]"
+elif py_real python ; then ok "python — $PY_DESC  [python]"
+else
+  if [ "$OS" = "windows-bash" ]; then
+    bad "no real Python (the 'python'/'python3' you have is likely the Microsoft Store alias stub)" \
+        "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
+  else
+    bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- node (vendored converters are ESM run via node) -----------------------
+if command -v node >/dev/null 2>&1; then
+  ok "node — $(node --version 2>/dev/null)"
+else
+  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+fi
+
+# --- bash (token minting + *.sh helpers) -----------------------------------
+# We're running under bash, so it exists here. The note matters for Windows
+# users who might otherwise try to run get-token.sh from cmd/PowerShell.
+if [ "$OS" = "windows-bash" ]; then
+  ok "bash available (Git Bash / MSYS) — run the *.sh helpers (get-token.sh) from THIS shell"
+else
+  ok "bash available"
+fi
+
+# --- git autocrlf (CRLF mangles shebangs + bash scripts) -------------------
+CRLF="$(git config --get core.autocrlf 2>/dev/null || true)"
+if [ "$CRLF" = "true" ]; then
+  warn "git core.autocrlf=true — may rewrite shipped .sh/.rb/.py to CRLF and break shebangs" \
+       "Re-clone with: git config --global core.autocrlf input   (or set 'false' for this repo, then re-checkout)."
+else
+  ok "git core.autocrlf=${CRLF:-unset} (won't CRLF-mangle scripts)"
+fi
+
+# --- CRLF actually present in a shipped shell script? ----------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$HERE/get-token.sh"
+if [ -f "$GT" ] && grep -q $'\r' "$GT" 2>/dev/null; then
+  bad "get-token.sh has CRLF line endings — bash will fail with '\\r: command not found'" \
+      "Fix: 'sed -i \$'s/\\r\$//' scripts/*.sh' (or set core.autocrlf=input and re-checkout)."
+fi
+
+# --- Sigma credentials (informational) -------------------------------------
+if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n "${SIGMA_CLIENT_ID:-}" ]; then
+  ok "Sigma credentials present (env or ~/.sigma-migration/env)"
+else
+  warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
+fi
+
+echo
+echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."
+[ "$FAIL" -eq 0 ] && { echo "Environment looks good — proceed."; exit 0; }
+echo "Fix the ✗ item(s) above, then re-run: bash scripts/doctor.sh"
+exit 1


### PR DESCRIPTION
The highest-leverage Windows helper: a **one-command preflight** so neither the customer nor the agent has to trial-and-error environment setup (the recurring Windows pain around Python and Ruby). Run it first; it tells you exactly what's wrong and how to fix it.

## What's added
- **`scripts/doctor.sh`** (macOS / Linux / Git Bash) + **`scripts/doctor.ps1`** (Windows PowerShell) — check **Ruby / Python / Node / bash** presence + versions, detect the **Microsoft Store Python "alias stub"** (reuses the PyResolve heuristic; the `.ps1` inspects the command's *source path* for `WindowsApps` **before** executing, so it never triggers the Store), warn on `git autocrlf=true` + CRLF in shipped `.sh`, and report Sigma creds. Every failure prints the exact fix; exit 1 when a required tool is missing.
- **`refs/environment.md`** — the remediation knowledge baked in (required runtimes per skill family + the 4 Windows footguns and fixes), so the agent reads it instead of re-deriving.
- Fanned into **all 21 skills** via the manifest + `sync-shared`; a one-line **pointer at the top of the 9 converter `SKILL.md` runbooks** tells the agent to run the doctor first.

## Why
Earlier PRs hardened the *code paths* (PyResolve, `sys.executable`, vendored converters). This makes the environment itself **self-diagnosing** — the agent runs one command and gets structured readiness + fixes, instead of reverse-engineering failures live.

## Testing
- `doctor.sh` runs clean on macOS (6/6 ok, exit 0); `lint-skills` + `check-shared` green (248 shared copies in sync).
- **Caveat:** no Windows box (or `pwsh`) available here — `doctor.ps1` logic was reviewed but **not run on Windows**. Validate it on a real Windows machine before relying on it. `doctor.sh` is fully exercised.

## Not included (deferred, per discussion)
PowerShell shims for the `*.sh` auth scripts (so the `bash` dependency isn't a hard wall) — the doctor currently *detects + guides* on missing bash rather than replacing it. Worth doing if customers actually hit the bash gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)