### PR TITLE
Vendor gooddata-to-sigma as a first-class plugin (parity with siblings)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -133,6 +133,21 @@
         "migration",
         "bi"
       ]
+    },
+    {
+      "name": "gooddata-to-sigma",
+      "source": "./plugins/gooddata-to-sigma",
+      "description": "GoodData Cloud / GoodData.CN → Sigma — the declarative workspace layout (LDM + analytics model) → Sigma data model + workbook (datasets/attributes/facts/references → DM; MAQL metrics → Sigma formulas; insights → charts/KPIs/pivots; dashboards → pages + layout), with parity verification and opt-in user-data-filter RLS. Flags compute-only MAQL and exotic widgets rather than mis-converting. Bundles gooddata-to-sigma + gooddata-assessment.",
+      "category": "migration",
+      "keywords": [
+        "gooddata",
+        "gooddata-cloud",
+        "gooddata-cn",
+        "maql",
+        "ldm",
+        "migration",
+        "bi"
+      ]
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ reading the relevant `SKILL.md` and executing its scripts.
 | Scope/assess a MicroStrategy (Strategy One) instance | `microstrategy-assessment` | `plugins/microstrategy-to-sigma/skills/microstrategy-assessment/` |
 | Convert a Sisense (ElastiCube / Live model + dashboards) → Sigma | `sisense-to-sigma` | `plugins/sisense-to-sigma/skills/sisense-to-sigma/` |
 | Scope/assess a Sisense instance | `sisense-assessment` | `plugins/sisense-to-sigma/skills/sisense-assessment/` |
+| Convert a GoodData Cloud / .CN workspace (LDM + MAQL + insights + dashboards) → Sigma | `gooddata-to-sigma` | `plugins/gooddata-to-sigma/skills/gooddata-to-sigma/` |
+| Scope/assess a GoodData workspace | `gooddata-assessment` | `plugins/gooddata-to-sigma/skills/gooddata-assessment/` |
 | Land a Tableau published-datasource/extract in Snowflake or Databricks | `tableau-vds-to-cdw` | `plugins/tableau-to-sigma/skills/tableau-vds-to-cdw/` |
 
 Assessments are read-only (never write to the source or post to Sigma); run one

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ shared `~/.sigma-migration/env` under any agent.
 /plugin install looker-to-sigma@sigma-migration-skills
 /plugin install microstrategy-to-sigma@sigma-migration-skills
 /plugin install sisense-to-sigma@sigma-migration-skills
+/plugin install gooddata-to-sigma@sigma-migration-skills
 ```
 
 **Other agents (Cursor, Cortex Code, …)** — clone the repo and point your agent at the
@@ -59,6 +60,7 @@ and the skill drives discovery → translation → build → parity.
 | [`looker-to-sigma`](plugins/looker-to-sigma/) | Looker | `looker-to-sigma`, `looker-assessment` |
 | [`microstrategy-to-sigma`](plugins/microstrategy-to-sigma/) | MicroStrategy (Strategy One) | `microstrategy-to-sigma`, `microstrategy-assessment` |
 | [`sisense-to-sigma`](plugins/sisense-to-sigma/) | Sisense (ElastiCube / Live) | `sisense-to-sigma`, `sisense-assessment` |
+| [`gooddata-to-sigma`](plugins/gooddata-to-sigma/) | GoodData Cloud / .CN | `gooddata-to-sigma`, `gooddata-assessment` |
 
 In Claude Code, installed skills are namespaced — e.g. `/powerbi-to-sigma:powerbi-assessment`.
 

--- a/corpus/gooddata/orders-workspace/MANIFEST.md
+++ b/corpus/gooddata/orders-workspace/MANIFEST.md
@@ -1,0 +1,54 @@
+# gooddata / orders-workspace
+
+The `test_workspace_orders.json` fixture from the gooddata-to-sigma plugin
+(referenced, not duplicated) — a GoodData Cloud declarative workspace layout
+(LDM + analytics model): an ORDER_FACT dataset + CUSTOMER_DIM with a dataset
+reference, 5 MAQL metrics that map cleanly, and one `BY ALL` context metric
+that must be flagged rather than mis-converted.
+
+## Converter
+
+The **in-repo converter** (not MCP), from the plugin's scripts/ dir. Runs
+offline — the warehouse path (`--db`/`--schema`) and Sigma ids are placeholders
+for the regression golden:
+
+```
+cd plugins/gooddata-to-sigma/skills/gooddata-to-sigma
+python3 scripts/convert.py --workspace fixtures/test_workspace_orders.json \
+  --connection-id inode-CONN0000 --db DEMO_DB --schema PUBLIC \
+  --folder-id inode-FOLDER00 --out model.json --flags flags.json
+```
+
+The golden wraps the emitted DM spec as `{sigmaDataModel, warnings}` (the
+flagged metrics become the `warnings` list) to mirror the MCP converters' shape.
+
+## Features exercised
+
+- LDM datasets → table elements (dim-before-fact); attributes/facts → columns
+- dataset `reference` → relationship (CUSTOMER_DIM, many side = ORDER_FACT)
+- MAQL metrics → DM metrics via `maql.py` (SUM/COUNT/ratio, recursive inlining)
+- "flag, never fake": `BY ALL` context metric → 1 warning (no DM-metric equiv)
+
+## Expectations
+
+```json
+{
+  "artifacts": [
+    {"path": "../../../plugins/gooddata-to-sigma/skills/gooddata-to-sigma/fixtures/test_workspace_orders.json", "format": "json"},
+    {"path": "../../../plugins/gooddata-to-sigma/skills/gooddata-to-sigma/fixtures/expected_flags.json", "format": "json"}
+  ],
+  "goldens": {
+    "data-model.json": {
+      "pages": 1,
+      "elements": 2,
+      "columns": 19,
+      "metrics": 5,
+      "relationships": 1,
+      "warnings": 1,
+      "element_names": ["CUSTOMER_DIM", "ORDER_FACT"],
+      "metric_names": ["Avg Order Value", "Gross Revenue", "Net Profit", "Net Revenue", "Order Count"],
+      "relationship_names": ["CUSTOMER_DIM"]
+    }
+  }
+}
+```

--- a/corpus/gooddata/orders-workspace/golden/data-model.json
+++ b/corpus/gooddata/orders-workspace/golden/data-model.json
@@ -1,0 +1,191 @@
+{
+  "sigmaDataModel": {
+    "name": "GoodData Migration",
+    "schemaVersion": 1,
+    "folderId": "inode-FOLDER00",
+    "pages": [
+      {
+        "id": "p1",
+        "name": "Model",
+        "elements": [
+          {
+            "id": "el_customer",
+            "name": "CUSTOMER_DIM",
+            "kind": "table",
+            "source": {
+              "kind": "warehouse-table",
+              "connectionId": "inode-CONN0000",
+              "path": [
+                "DEMO_DB",
+                "PUBLIC",
+                "CUSTOMER_DIM"
+              ]
+            },
+            "columns": [
+              {
+                "id": "c_acquisition_channel",
+                "name": "Acquisition Channel",
+                "formula": "[CUSTOMER_DIM/ACQUISITION_CHANNEL]"
+              },
+              {
+                "id": "c_customer",
+                "name": "Customer Key",
+                "formula": "[CUSTOMER_DIM/CUSTOMER_KEY]"
+              },
+              {
+                "id": "c_customer_segment",
+                "name": "Customer Segment",
+                "formula": "[CUSTOMER_DIM/CUSTOMER_SEGMENT]"
+              },
+              {
+                "id": "c_loyalty_tier",
+                "name": "Loyalty Tier",
+                "formula": "[CUSTOMER_DIM/LOYALTY_TIER]"
+              },
+              {
+                "id": "c_region",
+                "name": "Region",
+                "formula": "[CUSTOMER_DIM/REGION]"
+              },
+              {
+                "id": "c_lifetime_order_count",
+                "name": "Lifetime Order Count",
+                "formula": "[CUSTOMER_DIM/LIFETIME_ORDER_COUNT]"
+              },
+              {
+                "id": "c_lifetime_revenue",
+                "name": "Lifetime Revenue",
+                "formula": "[CUSTOMER_DIM/LIFETIME_REVENUE]"
+              }
+            ]
+          },
+          {
+            "id": "el_order",
+            "name": "ORDER_FACT",
+            "kind": "table",
+            "source": {
+              "kind": "warehouse-table",
+              "connectionId": "inode-CONN0000",
+              "path": [
+                "DEMO_DB",
+                "PUBLIC",
+                "ORDER_FACT"
+              ]
+            },
+            "columns": [
+              {
+                "id": "c_order_channel",
+                "name": "Order Channel",
+                "formula": "[ORDER_FACT/ORDER_CHANNEL]"
+              },
+              {
+                "id": "c_order_id",
+                "name": "Order Id",
+                "formula": "[ORDER_FACT/ORDER_ID]"
+              },
+              {
+                "id": "c_order_line",
+                "name": "Order Line",
+                "formula": "[ORDER_FACT/ORDER_LINE]"
+              },
+              {
+                "id": "c_order_status",
+                "name": "Order Status",
+                "formula": "[ORDER_FACT/ORDER_STATUS]"
+              },
+              {
+                "id": "c_ship_method",
+                "name": "Ship Method",
+                "formula": "[ORDER_FACT/SHIP_METHOD]"
+              },
+              {
+                "id": "c_gross_profit",
+                "name": "Gross Profit",
+                "formula": "[ORDER_FACT/GROSS_PROFIT]"
+              },
+              {
+                "id": "c_gross_revenue",
+                "name": "Gross Revenue",
+                "formula": "[ORDER_FACT/GROSS_REVENUE]"
+              },
+              {
+                "id": "c_net_profit",
+                "name": "Net Profit",
+                "formula": "[ORDER_FACT/NET_PROFIT]"
+              },
+              {
+                "id": "c_net_revenue",
+                "name": "Net Revenue",
+                "formula": "[ORDER_FACT/NET_REVENUE]"
+              },
+              {
+                "id": "c_quantity_ordered",
+                "name": "Quantity Ordered",
+                "formula": "[ORDER_FACT/QUANTITY_ORDERED]"
+              },
+              {
+                "id": "c_unit_price",
+                "name": "Unit Price",
+                "formula": "[ORDER_FACT/UNIT_PRICE]"
+              },
+              {
+                "id": "fk_CUSTOMER_KEY",
+                "name": "Customer Key",
+                "formula": "[ORDER_FACT/CUSTOMER_KEY]"
+              }
+            ],
+            "relationships": [
+              {
+                "id": "rel_order_customer",
+                "name": "CUSTOMER_DIM",
+                "targetElementId": "el_customer",
+                "keys": [
+                  {
+                    "sourceColumnId": "fk_CUSTOMER_KEY",
+                    "targetColumnId": "c_customer"
+                  }
+                ]
+              }
+            ],
+            "metrics": [
+              {
+                "id": "m_m_avg_order_value",
+                "name": "Avg Order Value",
+                "formula": "[Net Revenue] / [Order Count]"
+              },
+              {
+                "id": "m_m_gross_revenue",
+                "name": "Gross Revenue",
+                "formula": "Sum([Gross Revenue])"
+              },
+              {
+                "id": "m_m_net_profit",
+                "name": "Net Profit",
+                "formula": "Sum([Net Profit])"
+              },
+              {
+                "id": "m_m_net_revenue",
+                "name": "Net Revenue",
+                "formula": "Sum([Net Revenue])"
+              },
+              {
+                "id": "m_m_order_count",
+                "name": "Order Count",
+                "formula": "CountDistinct([Order Id])"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "warnings": [
+    {
+      "metric": "m_pct_rev_region",
+      "title": "% Revenue (of all regions)",
+      "category": "CONTEXT",
+      "maql": "SELECT {metric/m_net_revenue} / (SELECT {metric/m_net_revenue} BY ALL {attribute/region})",
+      "reason": "context aggregation 'BY ALL' \u2192 Sigma workbook grouping / Level-scoped aggregate (workbook-level, not a DM metric)"
+    }
+  ]
+}

--- a/docs/phase-schema.md
+++ b/docs/phase-schema.md
@@ -76,6 +76,24 @@ mapping:
 | C9 Security/RLS | Phase 1.5 — RLS scan (opt-in: `detect_rls.py` + `apply_sigma_rls.py`) |
 | C10 Enhance | — (defer to `sigma-workbooks`) |
 
+### gooddata-to-sigma
+
+GoodData Cloud / .CN uses "Phase" numbering (it joined after the table was
+set). Its local mapping:
+
+| Canonical | gooddata-to-sigma |
+|---|---|
+| C1 Assess | Phase 0 — Assess (gooddata-assessment skill) + Phase 1b gap-scout (`scan_gaps.py`, MAQL coverage) |
+| C2 Discover | Phase 1 — Discover (`discover.py`, declarative layout export: LDM + analytics model) |
+| C3 Reuse-check | Phase 1c — Reuse check (`find-or-pick-dm.rb`) before POSTing a new DM |
+| C4 Convert | Phase 2 — Data model (`convert.py`; MAQL metrics → Sigma formulas via `maql.py`) |
+| C5 Post-DM gate | Phase 2 — POST `/v2/dataModels/spec` + read back server-assigned ids (hard gate) |
+| C6 Build workbook | Phase 3 — Workbook (`build_workbook.py`: insights → charts/KPIs/pivots) |
+| C7 Layout | within Phase 3 — apply the dashboard grid layout as the LAST write |
+| C8 Parity hard gate | Phase 4 — Parity vs the same warehouse |
+| C9 Security/RLS | Phase 6 — RLS (user data filters → Sigma user attributes; detect always, apply opt-in) |
+| C10 Enhance | Phase 6 — theme registry + final visual-QA (defer idioms to `sigma-workbooks`) |
+
 Notes:
 
 - **Looker runs the RLS gate early** (before building, C9 ahead of C4) by

--- a/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/gooddata-to-sigma/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "gooddata-to-sigma",
+  "displayName": "GoodData → Sigma",
+  "version": "1.0.0",
+  "description": "Migrate GoodData Cloud / GoodData.CN workspaces to Sigma — the declarative workspace layout (LDM + analytics model) → Sigma data model + workbook. Exports the full workspace via the declarative REST API (logicalModel + analyticsModel), maps datasets/attributes/facts/references to a Sigma data model, translates MAQL metrics to Sigma formulas, maps insights (visualizationObjects) to workbook charts/KPIs/pivots and analytical dashboards to workbook pages + layout, ports user data filters (RLS) to Sigma user attributes, and verifies parity against the same warehouse. Honors the sibling converters' 'flag, never fake' contract: MAQL constructs with no clean Sigma equivalent, GoodData-compute-only metrics, and unsupported widgets are surfaced as loud flags rather than silently mis-converted. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
+  "author": { "name": "Thomas Wells" },
+  "license": "MIT",
+  "keywords": ["gooddata", "gooddata-cloud", "gooddata-cn", "maql", "ldm", "sigma", "migration", "bi", "converter", "assessment"],
+  "skills": "./skills/"
+}

--- a/plugins/gooddata-to-sigma/README.md
+++ b/plugins/gooddata-to-sigma/README.md
@@ -1,0 +1,70 @@
+# gooddata-to-sigma
+
+Claude Code plugin for migrating **GoodData Cloud** / **GoodData.CN** to
+**Sigma**, in the same format and phase structure as the
+[sigma-migration-skills](https://github.com/twells89/sigma-migration-skills)
+converters (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight, Cognos,
+MicroStrategy, SSRS). Built standalone so it can graduate into that
+marketplace's `plugins/`.
+
+## Status: LIVE-VALIDATED — exact parity (data model + workbook)
+
+Proven end-to-end on a GoodData Cloud trial → Sigma, both on Snowflake: a
+workspace (LDM + 6 MAQL metrics + 5 insights + a dashboard) migrated to a Sigma
+**data model** (5/6 metrics translated, exact parity — Net Revenue 117,040.63,
+Orders 696, AOV 168.16; the `BY ALL` share metric correctly **flagged**) and a
+Sigma **workbook** (KPIs + bar charts; the by-region breakdown exact via the
+migrated relationship). MAQL coverage on that workspace: 5 AUTO / 1 CONTEXT / 0
+unhandled. Remaining: live FOR-PREVIOUS date-intel (translator routes it to a
+workbook DateLookback; not yet exercised on a live date dimension).
+
+The migration design is grounded in a verified read of GoodData's current
+public docs (June 2026). The spike findings live in
+[`skills/gooddata-to-sigma/refs/`](skills/gooddata-to-sigma/refs/):
+
+- [`gooddata-api.md`](skills/gooddata-to-sigma/refs/gooddata-api.md) — the
+  declarative REST API (workspace layout export), auth, and the LDM + analytics
+  model JSON structure.
+- [`maql-mapping.md`](skills/gooddata-to-sigma/refs/maql-mapping.md) — MAQL
+  metric grammar → Sigma formula mapping, and the constructs we expect to flag.
+- [`viz-type-mapping.md`](skills/gooddata-to-sigma/refs/viz-type-mapping.md) —
+  insight (`visualizationObject`) bucket/`visualizationUrl` → Sigma element.
+- [`design-notes.md`](skills/gooddata-to-sigma/refs/design-notes.md) —
+  end-to-end architecture, parity strategy, RLS, risks, and build order.
+
+`scripts/discover.py` is a functional declarative-export client (auth +
+workspace layout pull) but has **not been run against a live workspace yet** —
+the first build step is a GoodData Cloud trial signup to validate auth +
+discovery, then a real fixture, exactly as the ThoughtSpot / Sisense skills were
+bootstrapped.
+
+## Why GoodData is tractable
+
+Unlike screen-scraped sources, GoodData exposes the **entire workspace
+declaratively**: one `GET /api/v1/layout/workspaces/{id}` returns the logical
+data model *and* the analytics model (metrics, insights, dashboards) as JSON.
+GoodData Cloud computes on a customer warehouse (Snowflake / BigQuery /
+Redshift / …) via a data-source mapping, so Sigma can point at the **same
+warehouse** for exact parity — the same playbook as every other converter.
+
+## The two skills
+
+- **`gooddata-to-sigma`** — the converter: discover → data model → workbook →
+  parity. Translates what maps cleanly (datasets, references, most MAQL,
+  standard insights, dashboard layout, user data filters) and **flags** what
+  doesn't (compute-engine-only metrics, exotic MAQL context, unsupported
+  widgets) rather than emitting wrong logic.
+- **`gooddata-assessment`** — read-only estate inventory + migration-readiness
+  readout (workspace/metric/insight/dashboard counts, MAQL-complexity histogram,
+  per-dashboard AUTO / HINT / MANUAL / UNHANDLED scoring against the converter's
+  coverage).
+
+## Scope
+
+GoodData **Cloud / .CN first** (clean declarative API, `/api/v1`). Legacy
+**GoodData Platform** (the `/gdc/md/{project}` "classic" API, MUF user filters)
+is a documented fast-follow, not the initial target — see `design-notes.md`.
+
+## License
+
+MIT.

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/PRIVACY.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/PRIVACY.md
@@ -1,0 +1,13 @@
+# Privacy
+
+`gooddata-assessment` is **read-only** and **local**. It calls the GoodData
+declarative layout API (`GET /api/v1/layout/...`) with the user's own API token
+to read workspace metadata — dataset / metric / insight / dashboard definitions
+— and computes counts and complexity tags on the local machine.
+
+- No workspace data (warehouse rows / query results) is read or transmitted.
+- Nothing is written back to GoodData.
+- No definitions or credentials are sent anywhere except to the user's own
+  GoodData host. Output (the readout) stays local.
+- The API token is read from the environment / `~/.gooddata_env` and is never
+  logged.

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/SKILL.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: gooddata-assessment
+description: >-
+  Take inventory of a GoodData Cloud / GoodData.CN estate and produce a
+  migration-readiness readout — workspace, dataset, metric, insight, and
+  dashboard counts; a MAQL-complexity histogram (which metrics use BY / WITHIN /
+  BY ALL / FOR time transforms); an insight visualization-type mix; and per-
+  dashboard AUTO / HINT / MANUAL / UNHANDLED tags scored against the
+  gooddata-to-sigma converter's actual coverage. Use when a user wants to scope
+  a GoodData→Sigma migration, audit estate sprawl, or pick which dashboards to
+  convert first. Read-only, all-free pre-scoping over the declarative workspace
+  export.
+user-invocable: true
+---
+
+# GoodData assessment
+
+Read-only migration-readiness readout for a GoodData Cloud / .CN estate. Pulls
+the declarative layout (no writes) and scores it against what
+`gooddata-to-sigma` can actually convert.
+
+> Status: working + live-validated. `scripts/assess.py` reuses the converter's
+> own MAQL translator for honest coverage scoring (no guessing) and tags each
+> dashboard AUTO / HINT / MANUAL / UNHANDLED.
+
+## What it reports
+
+- **Inventory** — workspaces, datasets, metrics, insights, dashboards.
+- **MAQL complexity** — histogram of metrics by construct (plain agg / `WHERE` /
+  `BY`-`WITHIN`-`BY ALL` context / `FOR` time transforms / ranking), since
+  context + time intel are the conversion-risk drivers (`maql-mapping.md`).
+- **Visualization mix** — insight `visualizationUrl` histogram, with each type
+  tagged against `viz-type-mapping.md` (auto-mappable vs flagged).
+- **Per-dashboard tag** — AUTO (fully mappable), HINT (minor manual), MANUAL
+  (context MAQL / RLS review), UNHANDLED (exotic widgets / compute-only metrics).
+- **Shortlist** — value/cost-ranked migration order.
+
+## Usage
+
+```bash
+eval "$(../gooddata-to-sigma/scripts/get-token.sh)"
+python3 scripts/assess.py --workspace <id>     # or --all
+```
+
+Usage telemetry (per-dashboard view counts) is the universal weak spot — it is
+not in the declarative model; note it as a manual input if needed.

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/assess.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/assess.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""assess.py — GoodData estate migration-readiness readout (read-only).
+
+Pulls the declarative workspace layout (no writes) and scores it against what
+gooddata-to-sigma actually converts: MAQL coverage by category (reusing the
+converter's own translator), insight visualization-type mix, and a per-dashboard
+AUTO / HINT / MANUAL tag. Honest scoring — uses the real translator, not guesses.
+
+Usage:
+  eval "$(../gooddata-to-sigma/scripts/get-token.sh)"
+  python3 assess.py --workspace <id>            # or --all
+"""
+import argparse, json, os, ssl, sys, urllib.request, urllib.error
+
+# reuse the converter's MAQL translator for honest scoring
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "..", "gooddata-to-sigma", "scripts"))
+from maql import translate  # noqa: E402
+
+_CTX = ssl.create_default_context()
+if os.environ.get("GOODDATA_TLS_VERIFY") != "1":
+    _CTX.check_hostname = False; _CTX.verify_mode = ssl.CERT_NONE
+
+AUTO_VIZ = {"local:headline", "local:table", "local:pivot", "local:column", "local:bar",
+            "local:line", "local:area", "local:pie", "local:donut", "local:combo",
+            "local:combo2", "local:scatter", "local:bubble"}
+
+
+def api(path):
+    host = os.environ["GOODDATA_HOST"].rstrip("/")
+    req = urllib.request.Request(host + path, headers={
+        "Authorization": f"Bearer {os.environ['GOODDATA_TOKEN']}", "Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=60, context=_CTX) as r:
+        return json.load(r)
+
+
+def assess(ws):
+    layout = api(f"/api/v1/layout/workspaces/{ws}?exclude=ACTIVITY_INFO")
+    ldm = layout.get("ldm", {}) or {}; an = layout.get("analytics", {}) or {}
+    syms = {"fact": {}, "attribute": {}, "metric": {}}
+    for d in ldm.get("datasets", []):
+        for at in d.get("attributes", []): syms["attribute"][at["id"]] = at.get("title") or at["id"]
+        for f in d.get("facts", []): syms["fact"][f["id"]] = f.get("title") or f["id"]
+    for m in an.get("metrics", []): syms["metric"][m["id"]] = m.get("title") or m["id"]
+
+    metrics = an.get("metrics", []); insights = an.get("visualizationObjects", []); dashboards = an.get("analyticalDashboards", [])
+    cats = {}
+    for m in metrics:
+        c = translate((m.get("content") or {}).get("maql", ""), syms).get("category", "UNHANDLED")
+        cats[c] = cats.get(c, 0) + 1
+    viz = {}; insights_by = {i["id"]: i for i in insights}
+    for i in insights:
+        u = i["content"].get("visualizationUrl", "?"); viz[u] = viz.get(u, 0) + 1
+    flagged_viz = sum(v for k, v in viz.items() if k not in AUTO_VIZ)
+
+    print(f"\n=== {ws} ===")
+    print(f"  datasets {len(ldm.get('datasets', []))} | metrics {len(metrics)} | insights {len(insights)} | dashboards {len(dashboards)}")
+    print(f"  MAQL coverage: {cats}")
+    print(f"  insight types: {viz}  (non-auto: {flagged_viz})")
+    # per-dashboard tag
+    for d in dashboards:
+        iids = [it.get("widget", {}).get("insight", {}).get("identifier", {}).get("id")
+                for s in d["content"].get("layout", {}).get("sections", []) for it in s.get("items", [])]
+        urls = [insights_by[i]["content"].get("visualizationUrl") for i in iids if i in insights_by]
+        bad_viz = [u for u in urls if u not in AUTO_VIZ]
+        tag = "UNHANDLED" if (cats.get("UNHANDLED") or bad_viz) else \
+              "MANUAL" if (cats.get("CONTEXT") or cats.get("TIME_INTEL")) else \
+              "HINT" if flagged_viz else "AUTO"
+        print(f"  dashboard '{d.get('title')}': {len(iids)} widgets -> {tag}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workspace", default=os.environ.get("GOODDATA_WORKSPACE"))
+    ap.add_argument("--all", action="store_true")
+    a = ap.parse_args()
+    if a.all:
+        for w in api("/api/v1/entities/workspaces").get("data", []):
+            assess(w["id"])
+    elif a.workspace:
+        assess(a.workspace)
+    else:
+        sys.exit("--workspace <id> or --all required")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/dup-dashboards.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/QUICKSTART.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/QUICKSTART.md
@@ -1,0 +1,38 @@
+# gooddata-to-sigma — quickstart
+
+## 1. Credentials
+
+Create a GoodData API token (GoodData UI → personal access tokens, or the
+organization API). Then either export or drop a `~/.gooddata_env`:
+
+```bash
+export GOODDATA_HOST='https://<org>.cloud.gooddata.com'
+export GOODDATA_TOKEN='<api-token>'
+export GOODDATA_WORKSPACE='<workspace-id>'   # optional default
+```
+
+## 2. Discover (validate auth first)
+
+```bash
+cd skills/gooddata-to-sigma/scripts
+eval "$(./get-token.sh)"
+python3 discover.py --list                       # list workspaces
+python3 discover.py --workspace <id>             # → workspace_layout.json + summary
+```
+
+The summary prints dataset/metric/insight/dashboard counts, a MAQL-keyword
+histogram (sizes the translation effort), and an insight-type histogram.
+
+## 3. Sigma side
+
+Set up Sigma API credentials via the **sigma-api** skill, then follow the phases
+in `SKILL.md`. Data-model authoring uses **sigma-data-models**; workbook
+authoring uses **sigma-workbooks**. Parity runs against the same warehouse
+GoodData reads.
+
+## Status
+
+Spike + scaffold only. The converter (LDM→DM mapper, MAQL translator,
+insight/dashboard→workbook builder, parity scripts) is **not built yet** — see
+`refs/design-notes.md` for the build order. First milestone: a live trial
+workspace through Phase 1.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: gooddata-to-sigma
+description: >-
+  Migrate GoodData Cloud / GoodData.CN workspaces to Sigma. Use when the user
+  has a GoodData workspace — datasets, MAQL metrics, insights, and analytical
+  dashboards — and wants to recreate it in Sigma. Exports the workspace via the
+  declarative layout API (logicalModel + analyticsModel), maps the LDM
+  (datasets / attributes / facts / references) to a Sigma data model, translates
+  MAQL metrics to Sigma formulas, maps insights to workbook charts/KPIs/pivots
+  and dashboards to pages + layout, ports user data filters (RLS) to Sigma user
+  attributes, and verifies parity against the same warehouse. Translates what
+  maps cleanly and flags what doesn't (compute-engine-only metrics, exotic MAQL
+  context, unsupported widgets) instead of emitting wrong logic. Legacy GoodData
+  Platform (/gdc/md classic) is out of scope for now — Cloud / .CN only.
+user-invocable: true
+---
+
+# GoodData → Sigma
+
+> **Status: LIVE-VALIDATED — exact parity, data model + workbook.**
+> Proven end-to-end on a GoodData Cloud trial → Sigma (both on Snowflake): a
+> workspace (LDM + MAQL metrics + insights + dashboard) migrated to a Sigma data
+> model + workbook with **exact parity** on metrics and the relationship-backed
+> by-region breakdown; the `BY ALL` share metric was correctly flagged. Build
+> order, risks, and remaining work (live FOR-PREVIOUS date-intel) are in
+> `refs/design-notes.md`. Still: **never claim a specific conversion works until
+> it passes live parity for that workspace.**
+
+Recreate a GoodData workspace in Sigma, in the same phase structure as the
+sibling converters (Tableau, Power BI, Qlik, Cognos, MicroStrategy, SSRS, …).
+This skill defers all workbook-spec authoring to the **sigma-workbooks** skill
+and all data-model authoring to **sigma-data-models**.
+
+## Read these first
+
+- `refs/gooddata-api.md` — declarative export API, auth, LDM + analytics shape.
+- `refs/maql-mapping.md` — MAQL → Sigma formula contract (the hard part).
+- `refs/viz-type-mapping.md` — insight + dashboard → Sigma element mapping.
+- `refs/design-notes.md` — full architecture, parity, RLS, risks, build order.
+
+## Phases
+
+**Phase 0 — Assess.** Run the `gooddata-assessment` skill for an inventory +
+readiness readout before committing to a conversion.
+
+**Phase 1 — Discover.** `eval "$(scripts/get-token.sh)"` then
+`python3 scripts/discover.py --workspace <id>` → `workspace_layout.json`
+(full LDM + analytics model). Confirm counts and the MAQL-keyword / insight-type
+histograms it prints.
+
+**Phase 1b — Gap-scout (measure MAQL coverage first).**
+`python3 scripts/scan_gaps.py --workspace gd_workspace.json` reports coverage by
+category — AUTO (data-model metric), TIME_INTEL (→ workbook DateLookback),
+CONTEXT (→ workbook grouping/Level), UNHANDLED (logged to learned-rules). Run
+this before converting so coverage is known, not assumed.
+
+**Phase 1c — Reuse check (avoid DM sprawl).** Before creating a new data model,
+**reuse-check**: look for an existing Sigma DM with the same signature (same
+connection + tables) and reuse/pick it (`find-or-pick-dm`) rather than POSTing a
+duplicate. Only build a fresh DM when no match exists.
+
+**Phase 2 — Data model.** `scripts/convert.py` maps LDM datasets → Sigma
+warehouse-table elements (dim-before-fact; recover the path from the data-source
+db/schema so parity runs on the same warehouse), attributes/facts → columns,
+references → relationships, MAQL metrics → DM metrics (via `maql.py`); flagged
+metrics go to `flags.json`. POST the emitted spec to `/v2/dataModels/spec`
+(needs top-level `schemaVersion` + `folderId`), then **read back** the created
+DM (`GET /v2/dataModels/{id}/spec`) to capture the real, server-assigned
+element/column ids — a hard gate before any workbook work (POST reassigns ids).
+```
+python3 scripts/convert.py --workspace gd_workspace.json \
+  --connection-id <sigma-conn-uuid> --db <DB> --schema <SCHEMA> \
+  --folder-id <sigma-folder> --out dm_spec.json --flags flags.json
+```
+
+**Phase 3 — Workbook.** `scripts/build_workbook.py` maps insights →
+kpi-chart/bar-chart (each sourcing the migrated DM fact element; charts
+auto-aggregate by axis), recursively inlines metric MAQL into measure formulas,
+and resolves a related-dataset `view` attribute to a cross-element reference
+`[FACT/REL_NAME/Dim]` (exercises the migrated relationship). POST to
+`/v2/workbooks/spec`. Defers chart/layout/theming idioms to **sigma-workbooks**.
+```
+python3 scripts/build_workbook.py --workspace gd_workspace.json \
+  --data-model-id <dm-uuid> --fact-element <elId> --fact-name <TABLE> \
+  --rel-name <REL_NAME> --fact-dataset <ds-id> --folder-id <folder> --out wb_spec.json
+```
+Apply the dashboard grid **layout as the LAST write** (after all elements exist;
+a bare spec PUT wipes layout) — match GoodData's section/widget arrangement.
+
+**Phase 4 — Parity.** Query the migrated DM/workbook elements vs the **same
+warehouse** truth. NOTE: sigma-mcp-v2 `metric('<id>', t)` returns "Missing
+Metric" (a known MCP bug) — parity-query the columns/formulas directly instead.
+
+**Phase 5 — Repoint.** Finalize workbook element sources onto the built DM —
+never skip.
+
+**Phase 6 — RLS + enhance.** Port user data filters → Sigma user attributes via
+the consolidated RLS gate; apply theme via the theme registry; final visual-QA.
+
+## Contract: flag, never fake
+
+Surface — never silently mis-convert — these (log to gap-scout / learned-rules,
+opt-in escalate):
+- MAQL with no clean warehouse equivalent (FlexQuery / compute-only).
+- `BY` / `BY ALL` / `WITHIN` context that can't be reconstructed from insight grain.
+- Exotic visualizations (funnel / sankey / waterfall / treemap …) → flagged table.
+- `sql`-backed datasets and anything the MAQL parser tags `UNHANDLED`.
+
+## Scope
+
+GoodData **Cloud / .CN** (`/api/v1` declarative API). Legacy **Platform**
+(`/gdc/md/{project}`, classic MAQL, MUF) is a documented fast-follow — see
+`design-notes.md` — not built.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/fixtures/expected_flags.json
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/fixtures/expected_flags.json
@@ -1,0 +1,8 @@
+[
+  {
+    "metric": "m_pct_rev_region",
+    "title": "% Revenue (of all regions)",
+    "maql": "SELECT {metric/m_net_revenue} / (SELECT {metric/m_net_revenue} BY ALL {attribute/region})",
+    "reason": "MAQL context/time keyword 'BY ALL' has no pure data-model-metric equivalent (workbook-level); flagged"
+  }
+]

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/fixtures/test_workspace_orders.json
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/fixtures/test_workspace_orders.json
@@ -1,0 +1,360 @@
+{
+  "analytics": {
+    "analyticalDashboardExtensions": [],
+    "analyticalDashboards": [],
+    "attributeHierarchies": [],
+    "dashboardPlugins": [],
+    "exportDefinitions": [],
+    "filterContexts": [],
+    "memoryItems": [],
+    "metrics": [
+      {
+        "content": {
+          "format": "$#,##0.00",
+          "maql": "SELECT {metric/m_net_revenue} / {metric/m_order_count}"
+        },
+        "id": "m_avg_order_value",
+        "title": "Avg Order Value"
+      },
+      {
+        "content": {
+          "format": "$#,##0",
+          "maql": "SELECT SUM({fact/gross_revenue})"
+        },
+        "id": "m_gross_revenue",
+        "title": "Gross Revenue"
+      },
+      {
+        "content": {
+          "format": "$#,##0",
+          "maql": "SELECT SUM({fact/net_profit})"
+        },
+        "id": "m_net_profit",
+        "title": "Net Profit"
+      },
+      {
+        "content": {
+          "format": "$#,##0",
+          "maql": "SELECT SUM({fact/net_revenue})"
+        },
+        "id": "m_net_revenue",
+        "title": "Net Revenue"
+      },
+      {
+        "content": {
+          "format": "#,##0",
+          "maql": "SELECT COUNT({attribute/order_id})"
+        },
+        "id": "m_order_count",
+        "title": "Order Count"
+      },
+      {
+        "content": {
+          "format": "#,##0.0%",
+          "maql": "SELECT {metric/m_net_revenue} / (SELECT {metric/m_net_revenue} BY ALL {attribute/region})"
+        },
+        "id": "m_pct_rev_region",
+        "title": "% Revenue (of all regions)"
+      }
+    ],
+    "parameters": [],
+    "visualizationObjects": []
+  },
+  "ldm": {
+    "datasets": [
+      {
+        "aggregatedFacts": [],
+        "attributes": [
+          {
+            "description": "",
+            "id": "acquisition_channel",
+            "labels": [
+              {
+                "description": "",
+                "id": "acquisition_channel.name",
+                "sourceColumn": "ACQUISITION_CHANNEL",
+                "sourceColumnDataType": "STRING",
+                "title": "Acquisition Channel",
+                "valueType": "TEXT"
+              }
+            ],
+            "sourceColumn": "ACQUISITION_CHANNEL",
+            "sourceColumnDataType": "STRING",
+            "title": "Acquisition Channel"
+          },
+          {
+            "description": "",
+            "id": "customer",
+            "labels": [
+              {
+                "description": "",
+                "id": "customer.name",
+                "sourceColumn": "CUSTOMER_KEY",
+                "sourceColumnDataType": "INT",
+                "title": "Customer Key",
+                "valueType": "TEXT"
+              }
+            ],
+            "sourceColumn": "CUSTOMER_KEY",
+            "sourceColumnDataType": "INT",
+            "title": "Customer Key"
+          },
+          {
+            "description": "",
+            "id": "customer_segment",
+            "labels": [
+              {
+                "description": "",
+                "id": "customer_segment.name",
+                "sourceColumn": "CUSTOMER_SEGMENT",
+                "sourceColumnDataType": "STRING",
+                "title": "Customer Segment",
+                "valueType": "TEXT"
+              }
+            ],
+            "sourceColumn": "CUSTOMER_SEGMENT",
+            "sourceColumnDataType": "STRING",
+            "title": "Customer Segment"
+          },
+          {
+            "description": "",
+            "id": "loyalty_tier",
+            "labels": [
+              {
+                "description": "",
+                "id": "loyalty_tier.name",
+                "sourceColumn": "LOYALTY_TIER",
+                "sourceColumnDataType": "STRING",
+                "title": "Loyalty Tier",
+                "valueType": "TEXT"
+              }
+            ],
+            "sourceColumn": "LOYALTY_TIER",
+            "sourceColumnDataType": "STRING",
+            "title": "Loyalty Tier"
+          },
+          {
+            "description": "",
+            "id": "region",
+            "labels": [
+              {
+                "description": "",
+                "id": "region.name",
+                "sourceColumn": "REGION",
+                "sourceColumnDataType": "STRING",
+                "title": "Region",
+                "valueType": "TEXT"
+              }
+            ],
+            "sourceColumn": "REGION",
+            "sourceColumnDataType": "STRING",
+            "title": "Region"
+          }
+        ],
+        "dataSourceTableId": {
+          "dataSourceId": "csa-tj-snowflake",
+          "id": "CUSTOMER_DIM",
+          "type": "dataSource"
+        },
+        "description": "",
+        "facts": [
+          {
+            "description": "",
+            "id": "lifetime_order_count",
+            "sourceColumn": "LIFETIME_ORDER_COUNT",
+            "sourceColumnDataType": "NUMERIC",
+            "title": "Lifetime Order Count"
+          },
+          {
+            "description": "",
+            "id": "lifetime_revenue",
+            "sourceColumn": "LIFETIME_REVENUE",
+            "sourceColumnDataType": "NUMERIC",
+            "title": "Lifetime Revenue"
+          }
+        ],
+        "grain": [
+          {
+            "id": "customer",
+            "type": "attribute"
+          }
+        ],
+        "id": "customer",
+        "references": [],
+        "title": "Customer"
+      },
+      {
+        "aggregatedFacts": [],
+        "attributes": [
+          {
+            "description": "",
+            "id": "order_channel",
+            "labels": [
+              {
+                "description": "",
+                "id": "order_channel.name",
+                "sourceColumn": "ORDER_CHANNEL",
+                "sourceColumnDataType": "STRING",
+                "title": "Order Channel",
+                "valueType": "TEXT"
+              }
+            ],
+            "sourceColumn": "ORDER_CHANNEL",
+            "sourceColumnDataType": "STRING",
+            "title": "Order Channel"
+          },
+          {
+            "description": "",
+            "id": "order_id",
+            "labels": [
+              {
+                "description": "",
+                "id": "order_id.name",
+                "sourceColumn": "ORDER_ID",
+                "sourceColumnDataType": "STRING",
+                "title": "Order Id",
+                "valueType": "TEXT"
+              }
+            ],
+            "sourceColumn": "ORDER_ID",
+            "sourceColumnDataType": "STRING",
+            "title": "Order Id"
+          },
+          {
+            "description": "",
+            "id": "order_line",
+            "labels": [
+              {
+                "description": "",
+                "id": "order_line.name",
+                "sourceColumn": "ORDER_LINE",
+                "sourceColumnDataType": "INT",
+                "title": "Order Line",
+                "valueType": "TEXT"
+              }
+            ],
+            "sourceColumn": "ORDER_LINE",
+            "sourceColumnDataType": "INT",
+            "title": "Order Line"
+          },
+          {
+            "description": "",
+            "id": "order_status",
+            "labels": [
+              {
+                "description": "",
+                "id": "order_status.name",
+                "sourceColumn": "ORDER_STATUS",
+                "sourceColumnDataType": "STRING",
+                "title": "Order Status",
+                "valueType": "TEXT"
+              }
+            ],
+            "sourceColumn": "ORDER_STATUS",
+            "sourceColumnDataType": "STRING",
+            "title": "Order Status"
+          },
+          {
+            "description": "",
+            "id": "ship_method",
+            "labels": [
+              {
+                "description": "",
+                "id": "ship_method.name",
+                "sourceColumn": "SHIP_METHOD",
+                "sourceColumnDataType": "STRING",
+                "title": "Ship Method",
+                "valueType": "TEXT"
+              }
+            ],
+            "sourceColumn": "SHIP_METHOD",
+            "sourceColumnDataType": "STRING",
+            "title": "Ship Method"
+          }
+        ],
+        "dataSourceTableId": {
+          "dataSourceId": "csa-tj-snowflake",
+          "id": "ORDER_FACT",
+          "type": "dataSource"
+        },
+        "description": "",
+        "facts": [
+          {
+            "description": "",
+            "id": "gross_profit",
+            "sourceColumn": "GROSS_PROFIT",
+            "sourceColumnDataType": "NUMERIC",
+            "title": "Gross Profit"
+          },
+          {
+            "description": "",
+            "id": "gross_revenue",
+            "sourceColumn": "GROSS_REVENUE",
+            "sourceColumnDataType": "NUMERIC",
+            "title": "Gross Revenue"
+          },
+          {
+            "description": "",
+            "id": "net_profit",
+            "sourceColumn": "NET_PROFIT",
+            "sourceColumnDataType": "NUMERIC",
+            "title": "Net Profit"
+          },
+          {
+            "description": "",
+            "id": "net_revenue",
+            "sourceColumn": "NET_REVENUE",
+            "sourceColumnDataType": "NUMERIC",
+            "title": "Net Revenue"
+          },
+          {
+            "description": "",
+            "id": "quantity_ordered",
+            "sourceColumn": "QUANTITY_ORDERED",
+            "sourceColumnDataType": "NUMERIC",
+            "title": "Quantity Ordered"
+          },
+          {
+            "description": "",
+            "id": "unit_price",
+            "sourceColumn": "UNIT_PRICE",
+            "sourceColumnDataType": "NUMERIC",
+            "title": "Unit Price"
+          }
+        ],
+        "grain": [
+          {
+            "id": "order_id",
+            "type": "attribute"
+          },
+          {
+            "id": "order_line",
+            "type": "attribute"
+          }
+        ],
+        "id": "order",
+        "references": [
+          {
+            "identifier": {
+              "id": "customer",
+              "type": "dataset"
+            },
+            "multivalue": false,
+            "sources": [
+              {
+                "column": "CUSTOMER_KEY",
+                "dataType": "INT",
+                "target": {
+                  "id": "customer",
+                  "type": "attribute"
+                }
+              }
+            ]
+          }
+        ],
+        "title": "Order"
+      }
+    ],
+    "dateInstances": []
+  }
+}

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/design-notes.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/design-notes.md
@@ -1,0 +1,164 @@
+# gooddata-to-sigma — architecture, parity, risks, build order
+
+## Pipeline (mirrors the sibling converters)
+
+```
+Phase 0  Assess        gooddata-assessment: inventory + readiness readout
+Phase 1  Discover      discover.py → GET /api/v1/layout/workspaces/{id} → workspace_layout.json
+Phase 2  Data model    LDM datasets/attributes/facts/references → Sigma DM
+                        MAQL metrics → Sigma DM metrics/formulas (maql-mapping.md)
+                        recover warehouse path from dataSource → same connection for parity
+Phase 3  Workbook      insights → elements, dashboards → pages + layout (viz-type-mapping.md)
+                        filterContext → controls; defer chart authoring to sigma-workbooks
+Phase 4  Parity        post-and-readback + assert-parity vs the SAME warehouse
+Phase 5  Repoint        finalize workbook sources onto the built DM (never skip)
+Phase 6  Enhance/QA    mandatory visual-QA PNG gate; theme via theme-registry
+```
+
+## What's new code vs reused
+
+**New** (this repo): GoodData declarative client (`discover.py`), LDM→DM mapper,
+**MAQL translator** (the hard part), insight/dashboard→workbook signal builder,
+the assessment scanner.
+
+**Reused** (from sigma-migration-skills/shared + sigma-workbooks): the workbook
+spec authoring (sigma-workbooks), `find-or-pick-dm`, `build-charts-from-signals`,
+layout `decollide_bands` + visual-QA gate, `gap-scout` / `learned-rules` /
+`escalate-gap`, the RLS detect→ask→provision→emit gate, the theme registry, and
+the `convert_*_to_sigma_formula` plumbing the MAQL translator extends.
+
+Also: a `convert_gooddata_to_sigma` MCP converter + browser mirror, kept in sync
+(per the cross-converter convention).
+
+## RLS — user data filters (UDF)
+
+GoodData **User Data Filters** restrict rows per user via a `maql` predicate +
+user assignments (the Cloud equivalent of legacy MUF). Maps to the established
+Sigma pattern: detect UDFs → map the predicate attribute to a Sigma
+**user attribute** → emit a DM filter `CurrentUserAttributeText("x") = [Col]` →
+one consolidated gate, opt-in/out, never silent. Workspace Data Filters
+(multi-tenant child-workspace column filter) → a single user-attribute filter on
+the tenant column.
+
+## Date dimensions & FOR PREVIOUS — LIVE-VALIDATED, exact parity (all via API)
+
+**Closed 2026-06-22, entirely via the API (no UI).** GoodData date dimension +
+`FOR PREVIOUS` metric built through the declarative/entity APIs; migrated to a
+Sigma monthly-trend element whose `DateLookback` prior-month column matches the
+Snowflake monthly baseline **exactly** (2024-02 prev = 2,947.38 = Jan, etc.).
+
+Cracked recipe:
+- **Date reference shape** (the blocker): a dataset links a date dimension via a
+  normal `references` entry with `identifier.type: "dataset"` (pointing at the
+  dateInstance id) and a DATE source column whose **`sources[].target.type` is
+  `"date"`** (NOT `"dateInstance"` — that was the 400). `dateInstances[]` defines
+  the dimension (`granularities: DAY/WEEK/MONTH/QUARTER/YEAR`). Put the date ref
+  on the dataset that owns a DATE column (here `DATE_DIM.FULL_DATE`); bridge the
+  fact via a normal `order→DATE_DIM` reference on the INT key.
+- **MAQL time metric:** `SELECT {metric/m_net_revenue} FOR PREVIOUS({label/order_date.month})`.
+- **Converter (`convert.py`):** skip date references when building Sigma
+  *relationships* (target.type=="date") — the date column is just a plain column
+  (the FK-column pass already surfaces `FULL_DATE` as a column, reachable from
+  the fact via the `DATE_DIM` relationship).
+- **Sigma output:** date-grouped element (`DateTrunc("month", [FACT/DATE_DIM/Full Date])`)
+  with `DateLookback(Sum([FACT/Net Revenue]), [Month], 1, "month")` for prior month.
+  **`build_workbook` now AUTO-emits this** for any `FOR PREVIOUS/NEXT` metric —
+  date-grouped table (`DateTrunc`) + `DateLookback(base, [Period], n, unit)` —
+  validated at exact prior-month parity (no hand-authoring).
+
+Original findings (for reference):
+
+- **GoodData date dimensions are "Date datasets" = `dateInstances`** in the LDM.
+  `granularities` enum (validated): `MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER,
+  YEAR, MINUTE_OF_HOUR, HOUR_OF_DAY, DAY_OF_WEEK, DAY_OF_MONTH, DAY_OF_QUARTER,
+  DAY_OF_YEAR, WEEK_OF_YEAR, MONTH_OF_YEAR, QUARTER_OF_YEAR, FISCAL_MONTH,
+  FISCAL_QUARTER, FISCAL_YEAR` (NOT `WEEK_SUN_SAT`).
+- **A date link is NOT a normal `references` entry.** A `references[].identifier.type`
+  only accepts `dataset` (rejects `dateInstance`). Auto-generated models link a
+  date dimension by a **column-naming convention** (`d__date`, with a granularity
+  suffix like `d__date__day`), so the manual declarative date-reference shape
+  still needs to be harvested from a real workspace that has one (build a date
+  dim in the UI once, GET the LDM) — same harvest-from-example tactic used for
+  plugins/themes elsewhere.
+- **`ORDER_FACT` exposes only INT date keys** (`ORDER_DATE_KEY` YYYYMMDD, no DATE
+  column). Two ways to get a DATE: a SQL-backed dataset that casts it, or join
+  `CSA.TJ.DATE_DIM` (has `FULL_DATE` DATE + `DATE_KEY`).
+- **Converter work to add:** `dateInstance` → a Sigma date column (parse YYYYMMDD
+  via the date DSL, or use the joined `FULL_DATE`); `FOR PREVIOUS` →
+  `DateLookback(<measure>, "month", -1)` in a date-grouped workbook element
+  (build_workbook addition). Parity target: prior-period net revenue vs Snowflake.
+
+## Dashboard layout (implemented)
+
+`build_workbook` emits one Sigma page per GoodData dashboard and a top-level
+`layout` XML built from the dashboard's own grid: each `layout.sections[]` → a row
+band, each widget's `size.xl.gridWidth` (GoodData 12-col) → a Sigma 24-col span
+(×2), KPIs short / charts+tables taller. Applied as the LAST write (a bare spec
+stacks every element full-width). Non-dashboard auto-elements (e.g. the FOR
+PREVIOUS trend) go on an "Other" page. Rendered result: KPI strip + 2-up charts,
+structurally faithful to the source dashboard. (Pixel side-by-side pending — the
+GoodData trial visual-export API 500'd; layout is derived from the dashboard spec
+so it mirrors by construction.)
+
+## Parity strategy
+
+GoodData Cloud computes on the customer warehouse, so the same-warehouse parity
+play works. Caveats to prove out live:
+- **FlexQuery / compute-only metrics** may have no clean SQL equivalent — flag,
+  don't fake; confirm which MAQL constructs round-trip to warehouse SQL.
+- Apply dashboard `filterContext` when checking insight totals.
+- `sql`-backed datasets → **warehouse-table on the FROM table** (implemented).
+  Sigma's spec API can't resolve columns on a `kind:"sql"` source (it would have to
+  RUN the query to discover output columns — the known custom-SQL-via-spec
+  limitation), so convert.py maps a SQL dataset to a warehouse-table on its parsed,
+  db-qualified FROM table. SQL-derived alias columns (a synthetic grain key) are
+  translated to Sigma formulas (`||`→`&`, `CAST(x AS VARCHAR)`→`Text(x)`, bare
+  idents→`[TABLE/col]`, quote-aware); passthrough columns map straight through;
+  anything untranslatable is flagged. Composite-key facts need this (GoodData
+  requires a single-attribute grain → a synthetic key in SQL).
+
+## References — two GoodData shapes (both handled)
+
+convert.py reads BOTH `references[]` shapes: legacy `sources:[{column,target:{id,type}}]`
+(incl. dateInstance links via `target.type=="date"`) AND current GoodData Cloud
+`sourceColumns:["FK_COL"]` whose target is the **referenced dataset's grain**
+attribute. References whose target isn't a dataset (a dateInstance/date-dimension
+link) are skipped — the date column stays a plain column. A fresh convert rebuilds
+relationships under either shape (they were silently lost when only `sources` was read).
+
+## Dashboard date filter → a Sigma control (not baked predicates)
+
+A dashboard's relative date filter (`filterContext`) becomes ONE Sigma `date-range`
+control over a **hidden master detail table** that every KPI/chart/pivot sources;
+the filter propagates down the source lineage to all elements — including the pivot,
+which can't honor a direct element filter (the "filter the SOURCE, not the pivot"
+path around the pivot-filter-drop bug). GoodData relative `{month, from 0, to 0}` →
+`mode:current, unit:month` ("this month"); `from==to==-n` → `mode:last`. The master's
+date column is parsed from the YYYYMMDD key with `MakeDate(y,m,d)` (NOT `Date()` —
+that fails the export). Keeps the migrated dashboard interactive, mirroring GoodData.
+
+## Risks (ranked)
+
+1. **MAQL coverage** — `BY` / `BY ALL` / `WITHIN` context + `FOR` time intel.
+   Build gap-scout first so coverage is measured, not assumed.
+2. **Compute-engine-only metrics** — no warehouse equivalent → flag set.
+3. **Cloud vs classic Platform** API divergence — Cloud first; classic deferred.
+4. **Dashboard layout fidelity** — responsive grid, not pixels; map to Sigma grid.
+5. **Exotic visualizations** (funnel/sankey/waterfall/treemap) → flagged tables.
+
+## Build order
+
+1. **Trial + live discovery** — GoodData Cloud trial, validate token auth +
+   `GET /layout/workspaces/{id}`, dump a real workspace as the fixture
+   (ThoughtSpot/Sisense bootstrap pattern).
+2. LDM→DM mapper + plain-MAQL translator → first live DM with parity.
+3. Insights→workbook (headline/table/bar/line first) → first live workbook.
+4. MAQL context + time intel (gap-scout-driven).
+5. Dashboards→layout, filterContext→controls, UDF→RLS.
+6. Assessment skill readout; then graduate into sigma-migration-skills/plugins/.
+
+## Scope note
+
+GoodData **Cloud / .CN** only for v0.1. Legacy **GoodData Platform**
+(`/gdc/md/{project}`, classic MAQL dialect, MUF) is a separate extraction client
+— documented fast-follow, not built.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/gooddata-api.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/gooddata-api.md
@@ -1,0 +1,104 @@
+# GoodData Cloud / .CN — extraction API (research spike, verified June 2026)
+
+> Source of truth: GoodData Cloud public docs (declarative interface, API
+> reference) + `gooddata-sdk`. Endpoints below verified from docs; **not yet
+> exercised against a live workspace** — the first build step validates them on
+> a trial.
+
+## Products & which API
+
+| Product | API | Targeted? |
+|---|---|---|
+| **GoodData Cloud** (SaaS) | `/api/v1` REST + declarative layout | ✅ primary |
+| **GoodData.CN** (containerized) | same `/api/v1` + declarative layout | ✅ same code path |
+| **GoodData Platform** (classic / "bear", `/gdc/md/{project}`) | different REST, MUF user filters | ⏳ fast-follow only |
+
+Cloud and .CN share the API and the declarative model, so one client covers
+both. Classic Platform is a separate extraction client — deferred.
+
+## Auth
+
+Bearer **API token** (personal access token created in the GoodData UI /
+organization API). Every call:
+
+```
+Authorization: Bearer <API_TOKEN>
+```
+
+Base URL is the org host, e.g. `https://<org>.cloud.gooddata.com`. The
+`gooddata-sdk` (Python) wraps all of this — `GoodDataSdk.create(host, token)`.
+
+## The win: declarative workspace export
+
+One call returns the **entire workspace** — LDM *and* analytics — as JSON:
+
+```
+GET  {HOST}/api/v1/layout/workspaces/{workspaceId}              # full
+GET  {HOST}/api/v1/layout/workspaces/{workspaceId}/logicalModel # LDM only
+GET  {HOST}/api/v1/layout/workspaces/{workspaceId}/analyticsModel# analytics only
+GET  {HOST}/api/v1/layout/workspaces                            # all workspaces
+```
+
+Add `?exclude=ACTIVITY_INFO` to drop author/editor metadata. (Declarative API
+is GET/PUT, all-in-one document; the Entity API — `/api/v1/entities/...` — is
+the per-object alternative if we ever need finer reads.)
+
+### Top-level shape
+
+```jsonc
+{
+  "ldm": {
+    "datasets": [ /* dataset: id, title, attributes[], facts[], references[],
+                     dataSourceTableId / sql, grain, primaryKey */ ],
+    "dateInstances": [ /* date dimensions + granularities */ ]
+  },
+  "analytics": {
+    "metrics":              [ /* { id, title, content: { maql, format } } */ ],
+    "visualizationObjects": [ /* insights — see viz-type-mapping.md */ ],
+    "analyticalDashboards": [ /* layout: sections -> items -> widget; filterContext */ ],
+    "filterContexts":       [ /* saved filter state referenced by dashboards */ ]
+  }
+}
+```
+
+### LDM building blocks (`ldm.datasets[]`)
+
+- **dataset** — maps to one warehouse table via `dataSourceTableId` (or inline
+  `sql`). This recovers the Sigma source path (DB/schema/table) — same idea as
+  recovering the warehouse FQN in the other converters.
+- **attribute** — a dimension; has one or more **labels** (display forms); the
+  default label is the dimension column, alternates are extra columns.
+- **fact** — a numeric, aggregatable column.
+- **reference** — FK from one dataset to another (and to date instances) →
+  Sigma **relationship**.
+- **dateInstance** — a date dimension exposing granularities (day/week/month/
+  quarter/year) → Sigma date column + truncations.
+
+### Data source
+
+The workspace's `dataSource` (separate `/api/v1/entities/dataSources/...`)
+holds the warehouse type + connection. We recover the physical table path from
+the dataset mapping and point the Sigma DM at the **same** connection for parity.
+
+## Object id references
+
+Everywhere in MAQL and insights, objects are referenced by typed id:
+`{fact/<id>}`, `{metric/<id>}`, `{label/<id>}`, `{attribute/<id>}`. The
+declarative export carries these ids, so cross-references resolve without name
+matching.
+
+## Not in the API (expected weak spots)
+
+- **Usage telemetry** — like every other tool, per-insight/dashboard view
+  counts are not in the declarative model; if needed, pull from audit logs
+  separately. (Universal assessment weak spot.)
+- **Pixel layout fidelity** — dashboard layout is a responsive section/grid, not
+  absolute coordinates; map to Sigma's grid, don't chase pixels.
+
+## Open items to confirm live (first build step)
+
+1. Exact `dataset.dataSourceTableId` → warehouse `[DB, SCHEMA, TABLE]` shape.
+2. Whether `sql`-backed datasets (custom SQL) appear inline → Sigma Custom-SQL
+   element vs warehouse-table source.
+3. `metrics[].content.format` string → Sigma number format mapping.
+4. UDF (user data filter) export location + MAQL shape (see design-notes RLS).

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/layout-visual-qa.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/layout-visual-qa.md
@@ -1,0 +1,173 @@
+# Layout Visual QA — mandatory render-and-inspect gate
+
+Shared across all `*-to-sigma` migration plugins. A workbook that POSTs cleanly (HTTP 200)
+and passes numeric/CSV parity can still be **wrong** — overlapping tiles, clipped titles, dead
+zones, orphaned filters, a render that looks nothing like the source, or a layout that reads as
+generic AI-templated output. The export API renders exactly what a user sees, so the only
+reliable check is to **render each page to PNG and actually read the image** before declaring the
+migration done.
+
+> **The rule that triggered this gate:** Sigma's grid layout has **no z-order**. Source tools
+> with floating/absolute canvases (Qlik's associative listboxes & filterpanes, Power BI free-form
+> visuals, QuickSight FreeForm, Tableau floating zones) routinely place a **filter/legend/listbox
+> on top of a chart**. Preserving those coordinates 1:1 makes the two elements render *stacked on
+> the same cell*. The build scripts now resolve this deterministically (controls lifted to their
+> own band; `decollide_bands` tiles any remaining 2-D overlap edge-to-edge) — but novel layouts
+> can still slip through, which is why this human/agent visual gate is mandatory.
+
+## Mandatory loop (run after the workbook is POSTed, before you call it done)
+
+1. **Render the FULL Sigma page** (the whole dashboard, one image — not per-element) at a
+   realistic width:
+   `python3 scripts/sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/<page>.png --w 1600`
+   (Contract: `POST /v2/workbooks/{id}/export` → poll `/v2/query/{q}/download`. Plugins that ship
+   their own renderer — `export-chart-png.rb`, `compare.py` — use the same contract.)
+1b. **Render the FULL SOURCE dashboard** as ONE image and compare full-dashboard ↔ full-dashboard:
+   Tableau MCP `get-view-image` on the **dashboard view** (not each worksheet); Power BI page
+   export; MicroStrategy `export-dossier-pdf.py`; the equivalent source export each plugin
+   captures in discovery. Place the two full images side by side. **Compare dashboard-to-dashboard,
+   never element-by-element** — per-element screenshots (e.g. `export-chart-png.rb`) miss
+   layout/relationship defects (overlaps, dead zones, a control stranded outside its chart, wrong
+   relative sizing) and are NOT a substitute for the full-page comparison. Use per-element PNGs
+   only as a drill-down after a full-page mismatch.
+2. **Read both full PNGs** and check the Sigma render against the source AND the three rubrics
+   below (source-fidelity → structural → design-quality, in that order).
+3. **Fix** any failure (re-band, resize, move a control into its chart's container, shorten a
+   map title) by editing the spec — for large multi-page workbooks use
+   `sigma-skills/sigma-workbooks/scripts/wb-rep.rb` (pull → edit element files → push) — then
+   **re-render and re-read**.
+4. **Loop until the render passes inspection.** Declare the migration done on a *clean render*,
+   never on an HTTP 200.
+
+## 1. Source-fidelity parity (run BEFORE the quality rubrics)
+
+Clean ≠ faithful. A workbook can be perfectly laid out and still look nothing like the dashboard
+it migrated. This check compares the render against the **source's own appearance**, captured as a
+full-page source export in discovery (Tableau dashboard image, Power BI page export, MicroStrategy
+`source_dossier.pdf`, etc.). Put the Sigma page PNG and the source page side-by-side and verify,
+page-for-page:
+
+- [ ] **Same element set** — every viz on the source page exists on the Sigma page (none dropped, none invented).
+- [ ] **Same arrangement** — relative position holds (a 3-column source stays 3-column; KPIs that sit under a chart stay under it). Pixel-exact isn't required; the *grouping and reading order* are.
+- [ ] **Matching chart KIND** — source KPI → Sigma `kpi-chart` (not a 1-row table); source horizontal bar → horizontal bar; microchart/indicator → the closest Sigma equivalent (conditional-formatted table / data bars), not a generic bar. The source's declared `visualizationType` (`kpi`, `microcharts`, `combo_chart`, `grid`, …) is the spec to match.
+- [ ] **KPI shows the source's VALUE** — confirm the big number equals what the source card shows (often a latest-period stat, not a windowed Sum). A KPI that's structurally a KPI but shows the wrong metric FAILS.
+- [ ] **Controls / selector panels present** — source filter panels, attribute/metric selectors, and chapter filters have Sigma equivalents (controls or an inherited base filter). An interactive source page rebuilt as a static grid FAILS.
+- [ ] **Branding bands** — header strips, logos, greeting/title bands present, OR explicitly descoped *with the user* and recorded.
+
+A render that diverges on any unchecked box is a FAIL even when row parity is green — fix the spec
+and re-compare. **Known spec ceilings** (don't loop on them — note them as editor follow-ups): KPI
+sparklines and comparison/delta badges are UI-only (`sigma-workbooks` `kpis.md`); source-tool
+chrome (theme toggles, native nav) has no spec equivalent. When the user scopes styling down
+("layout + metrics, skip branding"), record exactly what was descoped in the final summary — never
+drop it silently.
+
+## 2. Structural rubric (read the PNG against every item)
+
+- [ ] **No overlaps / no stacking.** No two elements occupy the same cell; no filter, legend, or
+      listbox sits on top of a chart or KPI. (This is the #1 failure for floating-canvas sources.)
+- [ ] **No dead zones.** The page title never shares a band with a chart; bands are stacked edge
+      to edge; no giant empty tile (usually an over-tall table — size to content).
+- [ ] **Controls placed correctly.** A global filter sits in a top control band; a control scoped
+      to one chart lives *inside that chart's container*, never floating loose on the page.
+- [ ] **No clipped titles/values.** KPI bands are ≥ 5 grid rows (titles hide below that); side
+      charts are ≥ 6 columns wide (narrower truncates the title); table tiles show all rows
+      without cutting off the summary bar.
+- [ ] **Trend/comparison KPIs are tall enough to show the spark.** A KPI stacks title → value →
+      comparison → sparkline and drops the lower items first when short, so a KPI carrying a
+      sparkline or delta needs ~8+ grid rows (~240px), not 5. If you built a sparkline but the
+      render shows only the number, grow the tile's `gridRow` span and re-export before concluding
+      it failed — a too-short tile makes a real spark look missing.
+- [ ] **Even heights.** Charts in one band share an inner row span; sibling chart bands match.
+- [ ] **Right chart kind & formatting.** The rendered viz matches the source (no silently-dropped
+      log scale, data labels, `$`/`%` formats, or palette).
+
+## 3. Design-quality rubric (read AFTER the structural pass)
+
+> **Fidelity wins ties.** These checks make a *faithful* migration also look intentional rather
+> than generically AI-templated. They are tie-breakers for the converter's own **defaults** — never
+> a license to override the source. If the source dashboard deliberately uses equal-width tiles, a
+> flat KPI strip, or centered text, **keep it**; the source-fidelity rubric (§1) outranks polish.
+> Apply a design fix only where the converter picked a default and the source didn't dictate
+> otherwise. (Derived from the AI design anti-patterns catalog.)
+
+- [ ] **Focal point exists.** The page's signature element — the source's hero viz, or the primary
+      KPI — reads as the most important thing (larger span or stronger position), not one cell in a
+      uniform grid. *AI tell: every tile the same size and visual weight; "generic dashboard."*
+- [ ] **Proportion follows priority.** Two tiles share a row at equal width only when they're true
+      peers (a KPI strip, a real side-by-side comparison). A primary chart outweighs a supporting
+      one; a 50/50 split of unequal-priority content reads as indecisive. *AI tell: automatic
+      equal-width rows.*
+- [ ] **Pages don't all open the same way.** In a multi-page workbook, not every page leads with an
+      identical KPI band — each page opens with the thing it's actually for. *AI tell: every screen
+      starts with the same metric strip; feels templated.*
+- [ ] **Grid breaks where purpose changes.** Section layout shifts when the content's job shifts,
+      instead of repeating one 2–3-chart row down the whole page. *AI tell: "spreadsheet of cards."*
+- [ ] **Accent color is reserved, not sprayed.** Background tint / accent lives on the header band
+      and meaningful emphasis (state, the hero KPI) — not a pale wash on every container. When every
+      surface gets a touch of accent, nothing stands out. *AI tell: decorative accent overuse.*
+- [ ] **Status colors are tuned, not raw defaults.** Conditional-format / KPI semantic colors fit
+      the palette while preserving meaning; not unmodified saturated red/green badge defaults. *AI
+      tell: oversaturated framework-default status colors.*
+- [ ] **Typographic hierarchy.** Header → section title → KPI value → label form a clear scale (size,
+      weight, contrast); not every heading and number competing at the same visual volume. *AI tell:
+      flat typography; "feels like a form, not an application."*
+- [ ] **Alignment is intentional.** Left for text, natural for numbers; centering reserved for
+      genuine moments of emphasis, not applied to every section. *AI tell: centered text everywhere;
+      every section reads like a landing page.*
+- [ ] **Containers are for bands, not decoration.** No chart wrapped in its own card *inside* a band
+      container (card-in-card flattens hierarchy). Separate content levels with spacing, type, and
+      dividers before adding another container. *AI tell: nested cards.*
+- [ ] **Tables use the presentation style.** `table` / `pivot-table` elements carry
+      `tableStyle: {preset: presentation}` (roomier than the dense `spreadsheet` default) unless the
+      source is a true data grid; any source in-cell **data bars** are carried over (`dataBars`).
+
+## Building clean in the first place (so the gate rarely fails)
+
+Group every page into horizontal **band containers** — never a flat list of `<LayoutElement>`s:
+header band → control band → KPI band → chart rows → detail row. Verified container contract:
+
+- Spec side: a `kind: container` placeholder element per band.
+- Layout side: a `<GridContainer>` (NOT `<LayoutElement type="grid">`, which silently drops
+  children); child `gridRow`/`gridColumn` are **container-relative** (restart at 1);
+  `gridTemplateRows="auto"`; every `elementId` must match a real spec element (mismatch =
+  silent drop); GET before a layout PUT (POST reassigns ids; PUT preserves them).
+
+| Band | Container span | Children |
+|---|---|---|
+| Header | rows `1 / 4`, style `#0F172A` + `round` | full-width title text, inner `1 / 25` |
+| Control row | 3 rows | controls side-by-side, inner row `1 / 4` |
+| KPI row | ≥ 5 rows (≥ 8 if KPIs carry a sparkline/comparison) | N KPIs side-by-side, equal col spans (true peers → equal is correct here) |
+| Chart row | 11–12 rows | 2–3 charts side-by-side, identical inner row span, each ≥ 6 cols |
+| Detail table | content + summary (~4 rows + ~0.7/row) | never a fixed 20 (dead space) |
+
+**Design defaults that keep the render off the anti-pattern list** (apply only where the source
+doesn't dictate otherwise — §3 fidelity caveat):
+
+- **Give the hero its weight.** When a page has one signature viz (the source's largest/top viz, or
+  the primary trend), span it wider than its neighbors instead of forcing it into an equal split.
+  Equal col spans are right for a KPI strip and true comparisons — not for everything.
+- **Vary multi-page openings.** Don't auto-prepend an identical KPI band to every page; lead each
+  page with its own primary content.
+- **Reserve the accent.** Tint the header band and the hero KPI, not every container. Default the
+  rest to the neutral surface.
+- **Let type carry hierarchy.** Header title > section titles > KPI values > labels — don't flatten
+  everything to one size.
+
+**Table style — default to `presentation`.** Set `tableStyle: {preset: presentation}` on every
+`table` / `pivot-table` element (roomier rows, lighter grid lines — matches how most source BI tools
+present tables and reads better than Sigma's dense `spreadsheet` default). Keep `spreadsheet` only when
+the source is explicitly a dense data grid. This is spec-authorable and round-trips but is **frequently
+dropped** in migrations — set it deliberately. While you're styling the table, carry over any source
+in-cell bars with `conditionalFormats: [{type: dataBars, columnIds: [<aggregate col id>], scheme: ["#a4dfc0","#4caf7d"]}]`
+(also spec-authorable, also commonly dropped). See sigma-workbooks `tables.md` for the full field set.
+
+## Known render caveats (not fixable via spec — keep titles short, drop redundant legends)
+
+- **point-map / region-map**: the element `name` and legend render *overlaid on the map canvas*;
+  a long title collides with legend chips. No legend/title-position knob in the OpenAPI.
+- KPI titles hide below ~5 grid rows. Container style knobs that round-trip: backgroundColor,
+  borderRadius, borderColor, borderWidth, padding (`borderColor/Width` incompatible with
+  `padding: none`).
+
+_Base patterns verified 2026-06-10 on tj-wells-1989 (workbooks bc24d476, 3e23b761, 9733fcd9)
+against a known-good native layout (Chart Zoo Enhanced v4, 39a8f826)._

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/maql-mapping.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/maql-mapping.md
@@ -1,0 +1,72 @@
+# MAQL → Sigma formula mapping (research spike, verified June 2026)
+
+MAQL (Multidimensional Analytical Query Language) is GoodData's metric language
+and the **single biggest engineering surface** of this migration — the
+DAX-time-intel / LookML-measure class of risk. This doc is the translation
+contract; the converter rides the existing `convert_*_to_sigma_formula`
+plumbing plus a MAQL parser, and logs anything unmapped via gap-scout
+(flag, never fake).
+
+## Grammar essentials
+
+A metric is always `SELECT <expr>` returning a number. Objects are referenced
+by typed id:
+
+| MAQL | Means |
+|---|---|
+| `{fact/revenue}` | a fact (row-level numeric) |
+| `{metric/gross_profit}` | another metric (nestable) |
+| `{label/region}` / `{attribute/region}` | a dimension / its label |
+| `# ...` | comment |
+
+## Mapping table
+
+| MAQL construct | Example | Sigma |
+|---|---|---|
+| Aggregation of a fact | `SELECT SUM({fact/qty})` | `Sum([Dataset/Qty])` |
+| Other aggregations | `AVG/MIN/MAX/MEDIAN/COUNT` | `Avg/Min/Max/Median/Count` |
+| Row-level arithmetic in agg | `SELECT SUM({fact/qty}*{fact/price})` | `Sum([Qty]*[Price])` |
+| Metric reference (nesting) | `SELECT {metric/revenue} - {metric/cost}` | reference the other DM metrics: `[Revenue] - [Cost]` |
+| Filtered metric | `SELECT {metric/rev} WHERE {label/color}="red"` | `SumIf` / conditional aggregate, or a filtered DM metric |
+| Ratio | `SELECT {metric/rev} / {metric/rev} BY ALL {attr/region}` | share-of-total → windowed agg / Level-style total |
+| **`BY` context** | `SELECT SUM({fact/rev}) BY {attr/region}` | controls aggregation grain → Sigma grouping / `Level`-scoped aggregate |
+| **`BY ALL`** | `SELECT SUM({fact/rev}) BY ALL {attr/region}` | ignore that dimension → grand-total / `Total()`-style window |
+| **`WITHIN`** | `... WITHIN {attr/category}` | partition aggregate → windowed agg partitioned by the attribute |
+| Ranking | `TOP(n)` / `BOTTOM(n)`, rank filters | Sigma top-N element filter or `Rank()` |
+| **Time: prior period** | `SELECT {metric/rev} FOR PREVIOUS({date.month})` | `DateLookback` in a date-grouped element (proven PBI time-intel approach) |
+| `FOR PREVIOUS(x, n)` | n periods ago | `DateLookback(..., n, "month")` |
+| `FOR NEXT` | forward shift | forward `DateLookback` (negative offset) |
+| Period-over-period | derived from the two above | current vs `DateLookback` ratio in a date-grouped tile |
+
+## Context keywords are the crux
+
+`BY` / `BY ALL` / `WITHIN` redefine the aggregation grain independent of the
+report's grouping — Sigma has no 1:1 keyword. They map to a **combination of
+element grouping + windowed/Level-scoped aggregates**, and the right target
+depends on the consuming insight's buckets. This is exactly the EDNA-class
+"context-dependent aggregation" trap; expect iteration and lean on parity
+(not structure) to confirm.
+
+## Flag, never fake — expected UNHANDLED set
+
+Surface these as loud flags instead of guessing:
+
+- Metrics whose computation has **no clean warehouse-SQL equivalent** (GoodData
+  FlexQuery / extensible-analytics-only behavior).
+- Deeply nested `BY/WITHIN` stacks where the grain can't be reconstructed from
+  the insight context alone.
+- `FOR` time transforms on non-standard / fiscal date dimensions until the date
+  dimension mapping is confirmed live.
+- Anything the parser doesn't recognize → `UNHANDLED` + the raw MAQL, logged to
+  learned-rules and (opt-in) escalated as a gap issue.
+
+## Build order for the translator
+
+1. Plain aggregations + arithmetic + metric nesting (covers the majority).
+2. `WHERE` filters → conditional aggregates.
+3. `BY` / `BY ALL` / `WITHIN` context (the hard third).
+4. `FOR PREVIOUS/NEXT` time intel (reuse DateLookback recipe).
+5. Ranking / ratios.
+
+Measure coverage with gap-scout from day one — same discipline as the calc-gap
+closure rounds on the other converters.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/viz-type-mapping.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/viz-type-mapping.md
@@ -1,0 +1,70 @@
+# Insight & dashboard → Sigma element mapping (research spike, June 2026)
+
+## Insights = `visualizationObject`
+
+Each insight has:
+- `visualizationUrl` — the chart type, a `local:<type>` token.
+- `buckets[]` — each with a `localIdentifier` (`measures`, `view`, `stack`,
+  `segment`, `secondary_measures`, `trend`, …) and `items[]` (measures =
+  metric/fact refs with their own `localIdentifier` + aggregation; attributes =
+  dimension refs).
+- `filters[]` — measure-value / attribute / ranking / date filters (outside the
+  buckets).
+- `sorts` and `properties` (display config).
+
+Bucket → Sigma channel is the same idea as Cognos `vizControl` slot → axis:
+`measures`→values, `view`→category/x-axis, `stack`/`segment`→color/series.
+
+## `visualizationUrl` → Sigma element
+
+| `local:` type | Sigma element | Notes |
+|---|---|---|
+| `headline` | `kpi-chart` | one (or two, with secondary) measures; **set `name: ' '`** when a label sits above it (see sigma-workbooks) |
+| `table` | `table` | aggregated → carry `groupings` |
+| `pivot` (`table` w/ rows+cols) | `pivot-table` | `rowsBy` / `columnsBy` / `values` |
+| `column` | `bar-chart` | vertical (orientation omitted) |
+| `bar` | `bar-chart` | `orientation: horizontal` |
+| `line` | `line-chart` | `view`→x, `trend`/`segment`→series |
+| `area` | `area-chart` | stacking from bucket config |
+| `combo` / `combo2` | `combo-chart` | measures split across `yAxis` / `yAxis2` |
+| `pie` | `pie-chart` | |
+| `donut` | `donut-chart` | distinct hole-value column (avoid the collision bug) |
+| `scatter` | `scatter` | x/y measures |
+| `bubble` | `scatter` w/ size | |
+| `heatmap` | heatmap / pivot w/ conditional format | |
+| `treemap` | flag → table | no clean Sigma equivalent yet |
+| `geo` / `pushpin` | region-map / point-map | maps reference |
+| `funnel` / `pyramid` / `sankey` / `dependencywheel` / `waterfall` / `repeater` | **flag → table** | surfaced as UNHANDLED, not faked |
+
+Chart authoring defers entirely to the **sigma-workbooks** skill (channels,
+formula qualification, layout, the `name: ' '` KPI-title rule, theming). Reuse
+the shared `build-charts-from-signals` + `decollide_bands` + the mandatory
+visual-QA gate.
+
+## Dashboards = `analyticalDashboard`
+
+```jsonc
+{
+  "layout": {
+    "sections": [
+      { "items": [ { "size": {...}, "widget": { /* insight ref | kpi | richText */ } } ] }
+    ]
+  },
+  "filterContext": { /* attribute/date filters applied dashboard-wide */ }
+}
+```
+
+- `layout.sections[].items[].widget` → place each referenced insight as a
+  workbook element; `size` (responsive grid width) → Sigma grid columns in the
+  page `layout` XML.
+- `richText` widgets → `text` elements.
+- `filterContext` → Sigma **controls**, scoped to the pages that reference them
+  (avoid the over-broad-control trap).
+- `ignoreDashboardFilters` on a widget → that element opts out of the control.
+
+## Parity
+
+Each insight is a query; verify its aggregated result against the same
+warehouse (post-and-readback + assert-parity), exactly like the other
+converters. Dashboard filter context must be applied when checking, or totals
+won't match.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/build_workbook.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/build_workbook.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""build_workbook.py — GoodData insights + dashboard → Sigma workbook spec.
+
+Binds to the already-migrated Sigma data model (the DM convert.py produced).
+A hidden **master detail table** sources the DM fact element at row grain; every
+KPI/chart/pivot sources the master. A dashboard's relative date filter becomes a
+single Sigma **date-range control** that filters the master's date column — the
+filter then propagates down the source lineage to every element (KPIs, charts,
+AND the pivot, which can't honor a direct element filter). This mirrors GoodData,
+where the dashboard `filterContext` is one control over all widgets, and keeps
+the result interactive rather than baking the predicate into each measure.
+
+Measures are resolved by recursively inlining the metric MAQL down to fact
+aggregates; refs are then rewritten to the master's columns ([Data/Col]). A
+`view`/`trend` attribute on a *related* dataset resolves to a master column fed
+by the cross-element reference [FACT/REL/Dim].
+
+Usage:
+  python3 build_workbook.py --workspace gd_workspace.json \
+     --data-model-id <uuid> --fact-element <elId> --fact-name ORDER_FACT \
+     --rel-name EL_CUSTOMER --fact-dataset order --folder-id <uuid> --out wb_spec.json
+"""
+import argparse, json, re, sys, os
+
+AGG = {"SUM": "Sum", "AVG": "Avg", "MIN": "Min", "MAX": "Max", "MEDIAN": "Median"}
+MASTER_ID = "master_detail"
+MASTER_NAME = "Data"            # downstream refs resolve as [Data/Column]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workspace", required=True)
+    ap.add_argument("--data-model-id", required=True)
+    ap.add_argument("--fact-element", required=True)
+    ap.add_argument("--fact-name", required=True)
+    ap.add_argument("--rel-name", required=True)
+    ap.add_argument("--fact-dataset", required=True)
+    ap.add_argument("--folder-id", required=True)
+    ap.add_argument("--dashboard", default=None, help="migrate only this dashboard id (+ its filterContext)")
+    ap.add_argument("--out", default="wb_spec.json")
+    a = ap.parse_args()
+    P = a.fact_name  # element-name prefix for the master's own (DM-sourced) formulas
+
+    layout = json.load(open(a.workspace)); ldm = layout["ldm"]; an = layout["analytics"]
+    # symbol tables
+    attr = {}; fact = {}; metric_maql = {}
+    for d in ldm["datasets"]:
+        for at in d.get("attributes", []): attr[at["id"]] = {"title": at["title"], "ds": d["id"]}
+        for f in d.get("facts", []): fact[f["id"]] = {"title": f["title"], "ds": d["id"]}
+    metric_fmt = {}
+    for m in an.get("metrics", []):
+        metric_maql[m["id"]] = (m.get("content") or {}).get("maql", "")
+        metric_fmt[m["id"]] = (m.get("content") or {}).get("format")
+    ds_table = {d["id"]: d["dataSourceTableId"]["id"] for d in ldm["datasets"] if d.get("dataSourceTableId")}
+
+    # GoodData number format -> Sigma formatString (kind:number). Best-effort mapping.
+    def gd_fmt(g):
+        if not g:
+            return None
+        dec = 0
+        if "." in g:
+            dec = len(g.split(".", 1)[1].split("%")[0].rstrip("0")) or len(g.split(".", 1)[1].split("%")[0])
+        cur = "$" if "$" in g else ("€" if "€" in g else "")
+        if "%" in g:
+            return {"kind": "number", "formatString": f",.{dec}%"}
+        return {"kind": "number", "formatString": f"{cur},.{dec}f"}
+
+    # the fact's own YYYYMMDD date-key column on the DM fact element (robust — no
+    # dependency on the export's relationship `sources`, which GoodData can drop)
+    fds = next((d for d in ldm["datasets"] if d["id"] == a.fact_dataset), None)
+    mk = re.search(r"(\w*DATE_KEY)\b", json.dumps(fds or {}), re.I)
+    dkey = f"[{P}/{mk.group(1).replace('_', ' ').title()}]" if mk else None
+
+    # --dashboard scoping
+    _wid = lambda it: (((it.get("widget") or {}).get("insight") or {}).get("identifier") or {}).get("id")
+    target_iids = None
+    if a.dashboard:
+        dash = next((d for d in an.get("analyticalDashboards", []) if d["id"] == a.dashboard), None)
+        if dash:
+            target_iids = {_wid(it) for sec in dash["content"].get("layout", {}).get("sections", [])
+                           for it in sec.get("items", []) if _wid(it)}
+
+    # a dashboard's relative date filter -> a Sigma date-range control spec.
+    # "this month" == {relative, granularity month, from 0, to 0} -> mode current.
+    def detect_filter(dash):
+        ref = (dash["content"].get("filterContextRef") or {}).get("identifier", {}).get("id")
+        fc = next((f for f in an.get("filterContexts", []) if f["id"] == ref), None)
+        if not fc:
+            return None
+        for fl in fc["content"].get("filters", []):
+            df = fl.get("dateFilter")
+            if df and df.get("type") == "relative":
+                g = (df.get("granularity") or "").lower()
+                unit = next((u for u in ("year", "quarter", "month", "week", "day") if u in g), None)
+                if not unit:
+                    continue
+                if df.get("from") == 0 and df.get("to") == 0:
+                    return {"mode": "current", "unit": unit}
+                n = -int(df.get("from"))                      # from==to==-n => last n (current+offset)
+                if df.get("from") == df.get("to") and n > 0:
+                    return {"mode": "last", "value": n, "unit": unit, "includeToday": False}
+        return None
+
+    # master column accumulator (built after element scan so we know which dims are used)
+    needed_xdims = set()   # attribute ids on related datasets that elements reference
+
+    def dim_ref(attr_id):
+        a_ = attr[attr_id]
+        if a_["ds"] != a.fact_dataset:
+            needed_xdims.add(attr_id)
+        return f"[{MASTER_NAME}/{a_['title']}]"
+
+    # recursively resolve a metric's MAQL to a Sigma aggregate over the DM fact element
+    def resolve(maql):
+        body = re.sub(r"^\s*SELECT\s+", "", " ".join(maql.split()), flags=re.I).strip()
+        if re.search(r"BY ALL|WITHIN|\bFOR \b", body, re.I):
+            return None  # flagged context/time
+        out = re.sub(r"COUNT\(\s*\{attribute/([^}]+)\}\s*\)",
+                     lambda m: f"CountDistinct([{P}/{attr[m.group(1)]['title']}])", body, flags=re.I)
+        out = re.sub(r"\{fact/([^}]+)\}", lambda m: f"[{P}/{fact[m.group(1)]['title']}]", out)
+        out = re.sub(r"(SUM|AVG|MIN|MAX|MEDIAN)\(([^()]*)\)",
+                     lambda m: f"{AGG[m.group(1).upper()]}({m.group(2)})", out, flags=re.I)
+        out = re.sub(r"\{metric/([^}]+)\}", lambda m: f"({resolve(metric_maql[m.group(1)])})", out)
+        return out
+
+    # rewrite a DM-fact-element formula ([FACT/Col] or [FACT/REL/Dim]) onto the master ([Data/Col])
+    def to_master(formula):
+        if formula is None:
+            return None
+        return re.sub(rf"\[{re.escape(P)}/(?:[^/\]]+/)?([^\]]+)\]", rf"[{MASTER_NAME}/\1]", formula)
+
+    insights = {i["id"]: i for i in an["visualizationObjects"]}
+    CHART = {"local:bar": "bar-chart", "local:column": "bar-chart", "local:line": "line-chart",
+             "local:area": "area-chart", "local:donut": "donut-chart", "local:pie": "pie-chart"}
+    FLAGGED = {"local:funnel", "local:pyramid", "local:sankey", "local:dependencywheel",
+               "local:waterfall", "local:treemap", "local:repeater", "local:bullet"}
+    SRC_DM = {"kind": "data-model", "dataModelId": a.data_model_id, "elementId": a.fact_element}
+    SRC_M = {"kind": "table", "elementId": MASTER_ID}
+    page_elements = []; flags = []
+    cid = lambda n: re.sub(r'[^a-z0-9]', '_', n.lower())
+
+    def measures_of(ins):
+        out = []
+        for b in ins["content"]["buckets"]:
+            if b["localIdentifier"] == "measures":
+                for it in b["items"]:
+                    mid = it["measure"]["definition"]["measureDefinition"]["item"]["identifier"]["id"]
+                    out.append((mid, it["measure"].get("title", mid), resolve(metric_maql[mid])))
+        return out
+
+    def dims_of(ins, kinds):
+        out = []
+        for b in ins["content"]["buckets"]:
+            if b["localIdentifier"] in kinds:
+                for it in b["items"]:
+                    aid = it["attribute"]["displayForm"]["identifier"]["id"].rsplit(".", 1)[0]
+                    out.append(aid)
+        return out
+
+    for iid, ins in insights.items():
+        if target_iids is not None and iid not in target_iids: continue  # --dashboard scope
+        url = ins["content"]["visualizationUrl"]; title = ins["title"]
+        if url in FLAGGED:
+            flags.append({"insight": iid, "url": url, "reason": f"{url} has no Sigma equivalent → migrate as table or skip"}); continue
+        meas = measures_of(ins)
+        if any(f is None for _, _, f in meas):
+            flags.append({"insight": iid, "reason": "measure uses workbook-level MAQL (BY ALL / FOR)"}); continue
+        mcols = []
+        for m, t, f in meas:
+            c = {"id": cid(t) or m, "formula": to_master(f), "name": t}
+            fmt = gd_fmt(metric_fmt.get(m))
+            if fmt: c["format"] = fmt
+            mcols.append(c)
+
+        if url == "local:headline":          # KPI
+            page_elements.append({"id": iid, "kind": "kpi-chart", "name": title, "source": SRC_M,
+                "columns": mcols[:1], "value": {"columnId": mcols[0]["id"]}})
+        elif url == "local:table":            # table (flat) or pivot-table (has columns shelf)
+            rows = dims_of(ins, {"attribute", "view"}); colshelf = dims_of(ins, {"columns"})
+            dcols = [{"id": cid(attr[a_]["title"]), "formula": dim_ref(a_), "name": attr[a_]["title"]} for a_ in rows + colshelf]
+            if colshelf:                      # pivot
+                page_elements.append({"id": iid, "kind": "pivot-table", "name": title, "source": SRC_M,
+                    "columns": dcols + mcols, "values": [c["id"] for c in mcols],
+                    "rowsBy": [{"id": cid(attr[a_]["title"])} for a_ in rows],
+                    "columnsBy": [{"id": cid(attr[a_]["title"])} for a_ in colshelf]})
+            else:                             # flat aggregated table
+                page_elements.append({"id": iid, "kind": "table", "name": title, "source": SRC_M,
+                    "columns": dcols + mcols,
+                    "groupings": [{"id": "g", "groupBy": [c["id"] for c in dcols], "calculations": [c["id"] for c in mcols]}]})
+        elif url in CHART:                    # bar/column/line/area/donut/pie
+            kind = CHART[url]; dims = dims_of(ins, {"view", "trend", "segment", "stack"})  # line/area use "trend"
+            dcols = [{"id": cid(attr[a_]["title"]), "formula": dim_ref(a_), "name": attr[a_]["title"]} for a_ in dims]
+            el = {"id": iid, "kind": kind, "name": title, "source": SRC_M, "columns": dcols + mcols}
+            if kind in ("donut-chart", "pie-chart"):
+                el["value"] = {"id": mcols[0]["id"]}
+                if dcols: el["color"] = {"id": dcols[0]["id"]}
+            else:
+                if dcols: el["xAxis"] = {"columnId": dcols[0]["id"]}
+                el["yAxis"] = {"columnIds": [c["id"] for c in mcols]}
+                if url == "local:bar": el["orientation"] = "horizontal"
+            page_elements.append(el)
+        else:
+            flags.append({"insight": iid, "url": url, "reason": f"unmapped visualizationUrl {url}"})
+
+    # ---- MASTER detail table: row-grain source for every element above ----
+    # Build ONLY the columns the elements actually reference ([Data/<name>]), so a
+    # column that doesn't exist on the DM fact element (e.g. an attribute the DM
+    # predates) can't sneak in as a broken ref. Candidates: every fact/attribute of
+    # the fact dataset ([FACT/name]) + every related dim used ([FACT/REL/name]).
+    candidates = {}   # display name -> DM-fact-element formula
+    for f in (fds or {}).get("facts", []): candidates[f["title"]] = f"[{P}/{f['title']}]"
+    for at in (fds or {}).get("attributes", []): candidates[at["title"]] = f"[{P}/{at['title']}]"
+    for aid in needed_xdims:
+        a_ = attr[aid]; candidates[a_["title"]] = f"[{P}/{ds_table[a_['ds']]}/{a_['title']}]"
+    used = set(re.findall(rf"\[{re.escape(MASTER_NAME)}/([^\]]+)\]",
+                          json.dumps([e.get("columns", []) for e in page_elements])))
+    mseen = {}; mcolumns = []
+    def mcol(name, formula):
+        c = cid(name)
+        if c not in mseen:
+            mseen[c] = {"id": c, "name": name, "formula": formula}; mcolumns.append(mseen[c])
+        return c
+    for name in sorted(used):
+        if name in candidates: mcol(name, candidates[name])
+        else: flags.append({"column": name, "reason": "referenced by an element but not found on the DM fact element"})
+    order_date_cid = None
+    if dkey:
+        # parse the YYYYMMDD integer key into a real date for the date-range control
+        order_date_cid = mcol("Order Date",
+            f"MakeDate(Floor({dkey} / 10000), Floor(Mod({dkey}, 10000) / 100), Mod({dkey}, 100))")
+    master_el = {"id": MASTER_ID, "kind": "table", "name": MASTER_NAME, "source": SRC_DM,
+                 "columns": mcolumns, "visibleAsSource": False}
+
+    # ---- date-range controls (one per dashboard that has a relative date filter) ----
+    dash_control = {}   # dashboard id -> control element
+    for d in an.get("analyticalDashboards", []):
+        if a.dashboard and d["id"] != a.dashboard:
+            continue
+        filt = detect_filter(d)
+        if filt and order_date_cid:
+            ctl = {"id": f"ctl_{cid(d['id'])}"[:60], "kind": "control",
+                   "controlId": f"date_{cid(d['id'])}"[:60], "name": "Order Date",
+                   "controlType": "date-range",
+                   "filters": [{"source": {"kind": "table", "elementId": MASTER_ID}, "columnId": order_date_cid}]}
+            ctl.update({k: v for k, v in filt.items()})   # flat top-level mode/unit/value/...
+            dash_control[d["id"]] = ctl
+        elif filt and not order_date_cid:
+            flags.append({"dashboard": d["id"], "reason": "relative date filter present but no YYYYMMDD date key found to build a date control"})
+
+    # ---- TIME_INTEL: FOR PREVIOUS/NEXT metrics -> date-grouped trend + DateLookback ----
+    date_for_di = {}
+    for d in ldm["datasets"]:
+        for r in d.get("references", []):
+            for s in r.get("sources", []):
+                if (s.get("target") or {}).get("type") == "date":
+                    date_for_di[s["target"]["id"]] = (d["id"], s["column"])
+    UNITS = {"day", "week", "month", "quarter", "year"}
+
+    def date_ref(di_id):
+        ds_id, scol = date_for_di[di_id]
+        return f"[{P}/{ds_table[ds_id]}/{scol.replace('_', ' ').title()}]"
+
+    for m in an.get("metrics", []):
+        if a.dashboard: break  # trend metric isn't a dashboard widget; skip in single-dashboard mode
+        mm = metric_maql.get(m["id"], "")
+        fp = re.search(r"FOR\s+(PREVIOUS|NEXT)\(\s*\{label/([^.}]+)\.(\w+)\}(?:\s*,\s*(\d+))?\s*\)", mm, re.I)
+        base = re.search(r"\{metric/([^}]+)\}", mm)
+        if not (fp and base):
+            continue
+        direction, di_id, gran, n = fp.group(1).lower(), fp.group(2), fp.group(3).lower(), int(fp.group(4) or 1)
+        if di_id not in date_for_di or gran not in UNITS:
+            flags.append({"metric": m["id"], "reason": f"FOR {direction}: date dim/granularity not resolvable"}); continue
+        base_formula = resolve(metric_maql[base.group(1)])
+        if base_formula is None:
+            flags.append({"metric": m["id"], "reason": "FOR PREVIOUS base metric not translatable"}); continue
+        off = n if direction == "previous" else -n
+        eid = cid(m["id"])
+        page_elements.append({"id": eid, "kind": "table", "name": m.get("title") or m["id"], "source": SRC_DM,
+            "columns": [
+                {"id": "ti_period", "name": gran.capitalize(), "formula": f'DateTrunc("{gran}", {date_ref(di_id)})'},
+                {"id": "ti_base", "name": base.group(1), "formula": base_formula},
+                {"id": "ti_prior", "name": m.get("title") or m["id"],
+                 "formula": f'DateLookback({base_formula}, [{gran.capitalize()}], {off}, "{gran}")'}],
+            "groupings": [{"id": "ti_g", "groupBy": ["ti_period"], "calculations": ["ti_base", "ti_prior"]}]})
+
+    # ---- LAYOUT: one Sigma page per GoodData dashboard, control on top ----
+    # GoodData dashboards use a 12-col grid (widget size.xl.gridWidth); Sigma uses
+    # 24 cols. Map section→row band, gridWidth→column span (×2). The control sits in
+    # its own band above the widgets. Applied as the LAST write (a bare spec without
+    # it stacks every element full-width). The master detail table + any FOR PREVIOUS
+    # trend live on a separate "Data" page.
+    elem_by_id = {e["id"]: e for e in page_elements}
+    KPI_H, BODY_H, CTL_H, GAP = 6, 13, 3, 1
+
+    def widget_iid(it):
+        return (((it.get("widget") or {}).get("insight") or {}).get("identifier") or {}).get("id")
+
+    dash_of = {}
+    for d in an.get("analyticalDashboards", []):
+        for sec in d["content"].get("layout", {}).get("sections", []):
+            for it in sec.get("items", []):
+                iid = widget_iid(it)
+                if iid and iid in elem_by_id and iid not in dash_of:
+                    dash_of[iid] = d["id"]
+
+    def page_xml(pid, placed):
+        rows = "\n".join(f'  <LayoutElement elementId="{e}" gridColumn="{c} / {c+cs}" gridRow="{r} / {r+rs}"/>'
+                         for e, c, cs, r, rs in placed)
+        return f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="{pid}">\n{rows}\n</Page>'
+
+    def layout_for(d, present, start_row):
+        placed = []; row = start_row
+        for sec in d["content"].get("layout", {}).get("sections", []):
+            items = [it for it in sec.get("items", []) if widget_iid(it) in present]
+            if not items: continue
+            col = 1; maxh = 0
+            for it in items:
+                iid = widget_iid(it)
+                gw = (((it.get("size") or {}).get("xl") or {}).get("gridWidth")) or 6
+                cspan = max(2, min(24, int(gw) * 2))
+                if col + cspan > 25:
+                    col = 1; row += maxh + GAP; maxh = 0
+                h = KPI_H if elem_by_id[iid]["kind"] == "kpi-chart" else BODY_H
+                placed.append((iid, col, cspan, row, h)); col += cspan; maxh = max(maxh, h)
+            row += maxh + GAP
+        return placed
+
+    pages, xml_pages = [], []
+    for d in an.get("analyticalDashboards", []):
+        present = [iid for iid in elem_by_id if dash_of.get(iid) == d["id"]]
+        if not present: continue
+        pid = cid(d.get("title") or d["id"])
+        ctl = dash_control.get(d["id"])
+        els = ([ctl] if ctl else []) + [elem_by_id[iid] for iid in present]
+        placed = []; start = 1
+        if ctl:
+            placed.append((ctl["id"], 1, 8, 1, CTL_H)); start = 1 + CTL_H + GAP
+        placed += layout_for(d, set(present), start)
+        pages.append({"id": pid, "name": d.get("title") or d["id"], "elements": els})
+        xml_pages.append(page_xml(pid, placed))
+
+    # "Data" page: the master detail table + any orphan (FOR PREVIOUS) elements
+    orphans = [e for e in page_elements if e["id"] not in dash_of]
+    data_els = [master_el] + orphans
+    placed, row = [], 1
+    placed.append((MASTER_ID, 1, 24, row, BODY_H)); row += BODY_H + GAP
+    for e in orphans:
+        h = KPI_H if e["kind"] == "kpi-chart" else BODY_H
+        placed.append((e["id"], 1, 24, row, h)); row += h + GAP
+    pages.append({"id": "data", "name": "Data", "elements": data_els})
+    xml_pages.append(page_xml("data", placed))
+
+    spec = {"name": layout.get("name") or "GoodData Migration", "schemaVersion": 1, "folderId": a.folder_id,
+            "pages": pages, "layout": "\n".join(xml_pages)}
+    json.dump(spec, open(a.out, "w"), indent=2)
+    n_ctl = len(dash_control)
+    print(f"workbook -> {a.out}: {len(pages)} page(s), {len(page_elements)} elements, "
+          f"{len(mcolumns)} master cols, {n_ctl} date control(s), {len(flags)} flagged")
+    for p in pages: print(f"   page '{p['name']}': {len(p['elements'])} elements")
+    for fl in flags: print("   FLAG", fl)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/convert.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/convert.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""convert.py — GoodData workspace layout → Sigma data model spec.
+
+Maps the LDM (datasets/attributes/facts/references) to a Sigma data model and
+translates MAQL metrics to Sigma metric formulas (via maql.py). Datasets become
+warehouse-table elements on the SAME warehouse GoodData reads, so parity runs
+same-warehouse. Dimension datasets are emitted before fact datasets (Sigma
+requires dim-before-fact ordering). Metrics that don't translate cleanly are
+recorded in the flags file (flag, never fake).
+
+Usage:
+  python3 convert.py --workspace gd_workspace.json --connection-id <uuid> \
+      --db CSA --schema TJ --out dm_spec.json --flags flags.json
+"""
+import argparse, json, re, sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from maql import translate
+
+
+def sid(prefix, gid):
+    return f"{prefix}_{re.sub(r'[^a-zA-Z0-9]', '_', gid)}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workspace", required=True)
+    ap.add_argument("--connection-id", required=True)
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--schema", required=True)
+    ap.add_argument("--folder-id", required=True)
+    ap.add_argument("--out", default="dm_spec.json")
+    ap.add_argument("--flags", default="flags.json")
+    a = ap.parse_args()
+
+    layout = json.load(open(a.workspace))
+    ldm = layout.get("ldm", {}) or {}
+    an = layout.get("analytics", {}) or {}
+    datasets = ldm.get("datasets", []) or []
+
+    # symbol tables: GoodData object id -> Sigma display name (for MAQL translation)
+    syms = {"fact": {}, "attribute": {}, "metric": {}}
+    for d in datasets:
+        for at in d.get("attributes", []):
+            syms["attribute"][at["id"]] = at.get("title") or at["id"]
+        for f in d.get("facts", []):
+            syms["fact"][f["id"]] = f.get("title") or f["id"]
+    for m in an.get("metrics", []):
+        syms["metric"][m["id"]] = m.get("title") or m["id"]
+
+    dataset_ids = {d["id"] for d in datasets}
+    # dim-before-fact: datasets that are referenced (targets) first
+    referenced = {r["identifier"]["id"] for d in datasets for r in d.get("references", [])} & dataset_ids
+    ordered = [d for d in datasets if d["id"] in referenced] + \
+              [d for d in datasets if d["id"] not in referenced]
+
+    elements, flags = [], []
+    el_id = {d["id"]: sid("el", d["id"]) for d in datasets}
+    # per-dataset column id maps (for relationship keys + FK columns)
+    col_by_srccol = {d["id"]: {} for d in datasets}
+
+    # A SQL-backed dataset (dataSourceTableId null) is mapped to a warehouse-table on
+    # its FROM table — Sigma's spec API can't resolve columns on a kind:"sql" source
+    # (it would have to RUN the query to discover output columns), so a direct
+    # warehouse-table is the reliable target. SQL-derived alias columns (a synthetic
+    # grain key) are translated to Sigma formulas; passthrough columns map straight
+    # through. Anything that won't translate is flagged (never faked).
+    def from_path(d):
+        m = re.search(r"\bFROM\s+([\w.\"]+)", (d.get("sql") or {}).get("statement", ""), re.I)
+        parts = [p.strip('"') for p in m.group(1).split(".")] if m else []
+        if len(parts) == 3: return parts
+        if len(parts) == 2: return [a.db] + parts
+        if len(parts) == 1: return [a.db, a.schema] + parts
+        return [a.db, a.schema, d["id"].upper()]
+
+    def table_of(d):
+        return d["dataSourceTableId"]["id"] if d.get("dataSourceTableId") else from_path(d)[-1]
+
+    def source_of(d, table):
+        if d.get("sql"):
+            return {"kind": "warehouse-table", "connectionId": a.connection_id, "path": from_path(d)}
+        return {"kind": "warehouse-table", "connectionId": a.connection_id, "path": [a.db, a.schema, table]}
+
+    # translate a SQL scalar expression to a Sigma formula (concatenation + CAST is
+    # the common GoodData synthetic-key case); returns None if it can't be confident.
+    _SQLKW = {"AND", "OR", "NOT", "AS", "CASE", "WHEN", "THEN", "ELSE", "END", "NULL", "DISTINCT"}
+    def sql_expr_to_formula(expr, table):
+        def cast_repl(m):
+            inner, typ = m.group(1).strip(), m.group(2).upper()
+            return f"Text({inner})" if any(t in typ for t in ("CHAR", "TEXT", "STRING")) else inner
+        e = re.sub(r"CAST\s*\(\s*(.+?)\s+AS\s+(\w+)\s*\)", cast_repl, expr, flags=re.I)
+        e = e.replace("||", "&")
+        out = []
+        for i, seg in enumerate(re.split(r"('[^']*')", e)):   # odd segments are quoted literals — leave them
+            if i % 2 == 1:
+                out.append(seg); continue
+            def pref(m):
+                w = m.group(1)
+                return w if (w.upper() in _SQLKW or w == "Text") else f"[{table}/{w}]"
+            out.append(re.sub(r"(?<![\w\[/])([A-Za-z_]\w*)(?!\s*\()(?![\w\]])", pref, seg))
+        e2 = "".join(out)
+        if re.search(r"(?<![\w])(?!Text\b)[A-Za-z_]\w*\s*\(", e2):   # an unhandled function call remains
+            return None
+        return e2
+
+    # output-column -> Sigma formula map for a SQL dataset's SELECT list
+    def sel_map_of(d, table):
+        if not d.get("sql"):
+            return {}
+        m = re.search(r"\bSELECT\b(.*?)\bFROM\b", d["sql"]["statement"], flags=re.I | re.S)
+        if not m:
+            return {}
+        items, depth, cur = [], 0, ""
+        for ch in m.group(1):
+            if ch == "(": depth += 1
+            elif ch == ")": depth -= 1
+            if ch == "," and depth == 0:
+                items.append(cur); cur = ""
+            else:
+                cur += ch
+        if cur.strip(): items.append(cur)
+        out = {}
+        for it in (x.strip() for x in items):
+            am = re.search(r"\s+AS\s+(\w+)\s*$", it, re.I)
+            if am:
+                alias, expr = am.group(1), it[:am.start()].strip()
+                out[alias] = (f"[{table}/{expr.split('.')[-1].strip(chr(34))}]"
+                              if re.fullmatch(r"[\w.\"]+", expr) else sql_expr_to_formula(expr, table))
+            else:
+                col = it.split(".")[-1].strip('"')
+                if col != "*":
+                    out[col] = f"[{table}/{col}]"
+        return out
+
+    # FK columns on the source side, across both GoodData reference shapes.
+    def ref_fk_cols(r):
+        return [s["column"] for s in r["sources"]] if r.get("sources") else list(r.get("sourceColumns", []))
+
+    for d in ordered:
+        table = table_of(d)
+        sel = sel_map_of(d, table)
+        cols = []
+        def add_col(cid, name, srccol):
+            # passthrough by default; for SQL datasets honor the SELECT-list mapping
+            formula = sel.get(srccol, f"[{table}/{srccol}]") if d.get("sql") else f"[{table}/{srccol}]"
+            if formula is None:
+                flags.append({"column": srccol, "dataset": d["id"],
+                              "reason": f"SQL-derived column not translatable: {srccol}"}); return
+            cols.append({"id": cid, "name": name, "formula": formula})
+            col_by_srccol[d["id"]][srccol] = cid
+        for at in d.get("attributes", []):
+            add_col(sid("c", at["id"]), at.get("title") or at["id"], at["sourceColumn"])
+        for f in d.get("facts", []):
+            add_col(sid("c", f["id"]), f.get("title") or f["id"], f["sourceColumn"])
+        # ensure FK columns referenced by relationships exist on the source side
+        for r in d.get("references", []):
+            for fk in ref_fk_cols(r):
+                if fk not in col_by_srccol[d["id"]]:
+                    add_col(sid("fk", fk), fk.replace("_", " ").title(), fk)
+
+        elements.append({
+            "id": el_id[d["id"]], "name": table, "kind": "table",
+            "source": source_of(d, table),
+            "columns": cols,
+        })
+
+    # relationships (on the fact/source element, pointing at the dim/target)
+    for d in ordered:
+        el = next(e for e in elements if e["id"] == el_id[d["id"]])
+        rels = []
+        for r in d.get("references", []):
+            tgt = r["identifier"]["id"]
+            # date-dimension links point at a dateInstance, not a dataset (either the
+            # legacy sources[].target.type=="date" or a bare ref to a dateInstance id) —
+            # skip; the date column stays a plain column available for grouping.
+            if tgt not in dataset_ids:
+                continue
+            if any((s.get("target") or {}).get("type") == "date" for s in r.get("sources", [])):
+                continue
+            # join keys, across both reference shapes:
+            #  legacy  -> sources:[{column, target:{id}}]  (target is an attribute id)
+            #  current -> sourceColumns:["FK"]             (target is the ref'd dataset's grain)
+            keys = []
+            if r.get("sources"):
+                for s in r["sources"]:
+                    keys.append({"sourceColumnId": col_by_srccol[d["id"]][s["column"]],
+                                 "targetColumnId": col_by_srccol[tgt][_attr_srccol(datasets, tgt, s["target"]["id"])]})
+            elif r.get("sourceColumns"):
+                grain = [g["id"] for g in next(x for x in datasets if x["id"] == tgt).get("grain", []) if g.get("type") == "attribute"]
+                for i, fk in enumerate(r["sourceColumns"]):
+                    tgt_attr = grain[i] if i < len(grain) else (grain[0] if grain else None)
+                    if tgt_attr is None:
+                        continue
+                    keys.append({"sourceColumnId": col_by_srccol[d["id"]][fk],
+                                 "targetColumnId": col_by_srccol[tgt][_attr_srccol(datasets, tgt, tgt_attr)]})
+            if not keys:
+                continue
+            tgt_table = table_of(next(x for x in datasets if x["id"] == tgt))
+            rels.append({"id": sid("rel", f"{d['id']}_{tgt}"), "name": tgt_table,
+                         "targetElementId": el_id[tgt], "keys": keys})
+        if rels:
+            el["relationships"] = rels
+
+    # metrics -> attach to the fact element (the last/non-referenced one)
+    fact_el = next(e for e in elements if e["id"] == el_id[ordered[-1]["id"]])
+    metrics = []
+    for m in an.get("metrics", []):
+        res = translate((m.get("content") or {}).get("maql", ""), syms)
+        if res["ok"]:
+            metrics.append({"id": sid("m", m["id"]), "name": m.get("title") or m["id"], "formula": res["formula"]})
+        else:
+            flags.append({"metric": m["id"], "title": m.get("title"), "category": res.get("category"),
+                          "maql": (m.get("content") or {}).get("maql"), "reason": res["reason"]})
+    if metrics:
+        fact_el["metrics"] = metrics
+
+    spec = {"name": layout.get("name") or "GoodData Migration", "schemaVersion": 1,
+            "folderId": a.folder_id,
+            "pages": [{"id": "p1", "name": "Model", "elements": elements}]}
+    json.dump(spec, open(a.out, "w"), indent=2)
+    json.dump(flags, open(a.flags, "w"), indent=2)
+    print(f"DM spec -> {a.out}: {len(elements)} elements, "
+          f"{sum(len(e.get('columns', [])) for e in elements)} cols, {len(metrics)} metrics translated")
+    print(f"flags -> {a.flags}: {len(flags)} metric(s) flagged")
+    for fl in flags:
+        print(f"   FLAG {fl['metric']}: {fl['reason']}")
+
+
+def _attr_srccol(datasets, ds_id, attr_id):
+    d = next(x for x in datasets if x["id"] == ds_id)
+    at = next(a for a in d.get("attributes", []) if a["id"] == attr_id)
+    return at["sourceColumn"]
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/discover.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/discover.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""discover.py — GoodData Cloud / .CN declarative workspace export.
+
+Phase 1 of the migration: pull the entire workspace (LDM + analytics model) via
+the declarative layout API and summarize it. This is the FIRST thing to validate
+against a live trial workspace before any conversion is built.
+
+Usage:
+  eval "$(./get-token.sh)"
+  python3 discover.py --workspace <id> [--out workspace_layout.json]
+  python3 discover.py --list                 # list all workspaces
+
+Env: GOODDATA_HOST, GOODDATA_TOKEN (see get-token.sh).
+
+Status: functional, NOT yet run against a live workspace. Endpoints/shape per
+refs/gooddata-api.md (docs-verified June 2026); confirm field paths on first
+live run and adjust the summary extractors.
+"""
+import argparse, json, os, ssl, sys, urllib.request, urllib.error
+
+# Some GoodData trial/corp endpoints present a CA chain Python rejects
+# ("CA cert does not include key usage extension"); fall back to an unverified
+# context. Set GOODDATA_TLS_VERIFY=1 to force strict verification.
+_CTX = ssl.create_default_context()
+if os.environ.get("GOODDATA_TLS_VERIFY") != "1":
+    _CTX.check_hostname = False
+    _CTX.verify_mode = ssl.CERT_NONE
+
+
+def api(path):
+    host = os.environ["GOODDATA_HOST"].rstrip("/")
+    req = urllib.request.Request(host + path)
+    req.add_header("Authorization", f"Bearer {os.environ['GOODDATA_TOKEN']}")
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=60, context=_CTX) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as e:
+        sys.exit(f"GET {path} -> {e.code}: {e.read()[:300].decode(errors='replace')}")
+
+
+def summarize(layout):
+    ldm = layout.get("ldm", {}) or {}
+    an = layout.get("analytics", {}) or {}
+    datasets = ldm.get("datasets", []) or []
+    metrics = an.get("metrics", []) or []
+    insights = an.get("visualizationObjects", []) or []
+    dashboards = an.get("analyticalDashboards", []) or []
+    print(f"  datasets:    {len(datasets)}")
+    print(f"  dateInstances:{len(ldm.get('dateInstances', []) or [])}")
+    print(f"  metrics:     {len(metrics)}  (MAQL — the translation surface)")
+    print(f"  insights:    {len(insights)}")
+    print(f"  dashboards:  {len(dashboards)}")
+    # crude MAQL-construct histogram to size the translator gap
+    import re
+    kw = {}
+    for m in metrics:
+        maql = ((m.get("content") or {}).get("maql") or "")
+        for k in ("BY ALL", "WITHIN", " BY ", "WHERE", "FOR PREVIOUS", "FOR NEXT", "TOP(", "BOTTOM("):
+            if k.strip() and k in maql.upper():
+                kw[k.strip()] = kw.get(k.strip(), 0) + 1
+    if kw:
+        print("  MAQL keywords seen:", ", ".join(f"{k}×{v}" for k, v in sorted(kw.items(), key=lambda x: -x[1])))
+    # insight viz-type histogram
+    viz = {}
+    for i in insights:
+        url = ((i.get("content") or {}).get("visualizationUrl") or "?")
+        viz[url] = viz.get(url, 0) + 1
+    if viz:
+        print("  insight types:", ", ".join(f"{k}×{v}" for k, v in sorted(viz.items(), key=lambda x: -x[1])))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workspace", default=os.environ.get("GOODDATA_WORKSPACE"))
+    ap.add_argument("--list", action="store_true")
+    ap.add_argument("--out", default="workspace_layout.json")
+    a = ap.parse_args()
+
+    if a.list:
+        d = api("/api/v1/layout/workspaces")
+        for w in (d.get("workspaces") or d.get("workspaceDataFilters") or []):
+            print(w.get("id"), "|", w.get("name") or (w.get("meta") or {}).get("title", ""))
+        return
+
+    if not a.workspace:
+        sys.exit("--workspace <id> required (or set GOODDATA_WORKSPACE)")
+
+    layout = api(f"/api/v1/layout/workspaces/{a.workspace}?exclude=ACTIVITY_INFO")
+    with open(a.out, "w") as f:
+        json.dump(layout, f, indent=2)
+    print(f"=== workspace {a.workspace} → {a.out} ===")
+    summarize(layout)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/escalate-gap.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/escalate-gap.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""escalate-gap — opt-in GitHub-issue filer for gap-scout escalations.
+
+Shared across every migration skill (vendored identically into each plugin's
+scripts/). When the gap scout can't find a working Sigma translation for a
+source feature, the main agent offers the user the *option* to open a tracking
+issue in the appropriate repo. This script is what turns that "yes" into filed
+issues — with dedupe, repo routing, converter-repo mirroring, and a cross-linked
+bead.
+
+DESIGN: opt-in, never automatic.
+  - Default (no --yes): DRY RUN. Prints the drafted issue(s), the target repo(s),
+    and any existing open issues/beads that already cover this gap. Files NOTHING.
+    This is what the agent shows the user.
+  - With --yes: actually files. Skips any repo where dedupe already found a match
+    (unless --force).
+
+ROUTING (category -> repos):
+  converter  -> twells89/sigma-data-model-manager + twells89/sigma-data-model-mcp
+               (a source expression the *converter* failed to translate — the
+                browser tool and the MCP must stay in sync, so mirror to both)
+  builder    -> twells89/sigma-migration-skills   (workbook/DM spec builder gap)
+  skill      -> twells89/sigma-migration-skills   (skill-logic / discovery gap)
+
+Usage (dry-run draft the agent shows the user):
+  python3 scout/escalate-gap.py \
+    --skill tableau-to-sigma --category converter \
+    --feature WINDOW_AVG --description 'moving average over SUM' \
+    --source-pattern 'WINDOW_AVG(SUM([...]))' \
+    --template-attempted 'MovingAvg(Sum([Master/\\1]), -10, 10)' \
+    --test-formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+    --sigma-response '<failing column type / error json>' \
+    --example-from 'Sales.twb line 412' \
+    --escalation-yaml ~/.tableau-to-sigma/escalations/window_avg.yaml
+
+Then, only if the user says yes, the agent re-runs the same command with --yes.
+
+Requires `gh` on PATH and authed for the target repos. `bd` (beads) optional.
+Exit codes: 0 = ok (drafted or filed), 3 = nothing fileable / gh missing on --yes.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+ROUTES = {
+    "converter": ["twells89/sigma-data-model-manager", "twells89/sigma-data-model-mcp"],
+    "builder":   ["twells89/sigma-migration-skills"],
+    "skill":     ["twells89/sigma-migration-skills"],
+}
+BEADS_DIR = os.path.expanduser("~/.beads-sigma")
+
+
+def have(cmd):
+    return shutil.which(cmd) is not None
+
+
+def run(args, **kw):
+    """Run a command, return (ok, stdout, stderr)."""
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, **kw)
+        return p.returncode == 0, p.stdout.strip(), p.stderr.strip()
+    except Exception as e:  # noqa: BLE001
+        return False, "", str(e)
+
+
+def build_issue(a):
+    title = f"{a.skill} gap: {a.feature}" + (f" ({a.description})" if a.description else "")
+    body = []
+    body.append(f"**Skill:** `{a.skill}`")
+    body.append(f"**Gap category:** `{a.category}`")
+    body.append(f"**Feature:** `{a.feature}`")
+    if a.description:
+        body.append(f"**Description:** {a.description}")
+    if a.source_pattern:
+        body.append(f"**Source pattern:** `{a.source_pattern}`")
+    if a.template_attempted:
+        body.append(f"**Sigma template attempted:** `{a.template_attempted}`")
+    if a.test_formula:
+        body.append(f"**Test formula POSTed:** `{a.test_formula}`")
+    if a.sigma_response:
+        body.append(f"**Sigma response:**\n```\n{a.sigma_response}\n```")
+    body.append(f"**Example source:** {a.example_from or '(not provided)'}")
+    if a.escalation_yaml:
+        body.append(f"**Local escalation record:** `{a.escalation_yaml}`")
+    body.append("\n_Filed via the gap-scout opt-in escalation flow (`escalate-gap.py`)._")
+    return title, "\n\n".join(body)
+
+
+def labels_for(a):
+    return ["gap-scout-escalation", a.skill, f"category:{a.category}"]
+
+
+def ensure_labels(repo, labels):
+    """Best-effort: create labels so `gh issue create --label` won't fail."""
+    for lab in labels:
+        run(["gh", "label", "create", lab, "--repo", repo, "--force"])
+
+
+def find_dupes(repo, feature, skill):
+    """Return list of {number,title,url} open issues that look like this gap."""
+    ok, out, _ = run([
+        "gh", "issue", "list", "--repo", repo, "--state", "open",
+        "--label", "gap-scout-escalation", "--search", feature,
+        "--json", "number,title,url",
+    ])
+    if not ok or not out:
+        return []
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return []
+    feat = feature.lower()
+    return [i for i in items if feat in (i.get("title", "").lower())]
+
+
+def find_bead_dupe(feature):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    ok, out, _ = run(["bd", "list", "--json"], cwd=BEADS_DIR)
+    if not ok or not out:
+        return None
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return None
+    rows = items if isinstance(items, list) else items.get("issues", items.get("beads", []))
+    feat = feature.lower()
+    for b in rows or []:
+        if feat in (str(b.get("title", "")) + str(b.get("summary", ""))).lower():
+            return b.get("id") or b.get("bead_id")
+    return None
+
+
+def create_bead(title, body, skill, category):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    labels = f"sigma-converter,{skill},gap-scout-escalation,category:{category}"
+    ok, out, _ = run([
+        "bd", "create", title, "--priority", "2", "--labels", labels,
+        "--description", body, "--silent",
+    ], cwd=BEADS_DIR)
+    return out.strip() if ok else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--feature", required=True)
+    ap.add_argument("--category", default="converter", choices=list(ROUTES))
+    ap.add_argument("--description", default="")
+    ap.add_argument("--source-pattern", default="")
+    ap.add_argument("--template-attempted", default="")
+    ap.add_argument("--test-formula", default="")
+    ap.add_argument("--sigma-response", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--escalation-yaml", default="")
+    ap.add_argument("--extra-repo", action="append", default=[],
+                    help="additional target repo(s), repeatable")
+    ap.add_argument("--yes", action="store_true",
+                    help="actually file. Without it: dry-run, prints the draft only.")
+    ap.add_argument("--force", action="store_true",
+                    help="file even if a matching open issue already exists")
+    ap.add_argument("--no-beads", action="store_true")
+    a = ap.parse_args()
+
+    repos = list(dict.fromkeys(ROUTES[a.category] + a.extra_repo))
+    title, body = build_issue(a)
+    labels = labels_for(a)
+
+    # Dedupe scan (read-only) up front so the agent can show it to the user.
+    gh_ok = have("gh")
+    dupes = {r: (find_dupes(r, a.feature, a.skill) if gh_ok else []) for r in repos}
+    bead_dupe = None if a.no_beads else find_bead_dupe(a.feature)
+
+    if not a.yes:
+        # DRY RUN — this is what the agent presents to the user.
+        out = {
+            "mode": "draft",
+            "would_file_in": repos,
+            "labels": labels,
+            "title": title,
+            "body": body,
+            "existing_issues": {r: d for r, d in dupes.items() if d},
+            "existing_bead": bead_dupe,
+            "gh_available": gh_ok,
+            "next_step": "re-run with --yes to file (skips repos already covered)",
+        }
+        print(json.dumps(out, indent=2))
+        return 0
+
+    # --yes: actually file.
+    if not gh_ok:
+        print(json.dumps({"status": "error", "error": "gh not on PATH; cannot file"}))
+        return 3
+
+    # Bead first (authoritative tracker), so its id can be embedded in issues.
+    bead_id = bead_dupe
+    if bead_id is None and not a.no_beads:
+        bead_id = create_bead(title, body, a.skill, a.category)
+    issue_body = body + (f"\n\n**Bead:** `{bead_id}`" if bead_id else "")
+
+    filed, skipped = [], []
+    for repo in repos:
+        if dupes.get(repo) and not a.force:
+            skipped.append({"repo": repo, "existing": dupes[repo]})
+            continue
+        ensure_labels(repo, labels)
+        ok, out, err = run([
+            "gh", "issue", "create", "--repo", repo,
+            "--title", title, "--body", issue_body,
+            "--label", ",".join(labels),
+        ])
+        if ok:
+            filed.append({"repo": repo, "url": out.strip()})
+        else:
+            # retry once without labels (in case label creation was denied)
+            ok2, out2, err2 = run([
+                "gh", "issue", "create", "--repo", repo,
+                "--title", title, "--body", issue_body,
+            ])
+            if ok2:
+                filed.append({"repo": repo, "url": out2.strip(), "note": "filed without labels"})
+            else:
+                filed.append({"repo": repo, "error": err or err2})
+
+    # Cross-link mirrored issues to each other.
+    urls = [f["url"] for f in filed if f.get("url")]
+    if len(urls) > 1:
+        for f in filed:
+            if not f.get("url"):
+                continue
+            others = [u for u in urls if u != f["url"]]
+            num = f["url"].rstrip("/").split("/")[-1]
+            link_body = issue_body + "\n\n**Mirrored to:** " + ", ".join(others)
+            run(["gh", "issue", "edit", num, "--repo", f["repo"], "--body", link_body])
+
+    # Cross-link the bead back to the filed issue urls.
+    if bead_id and urls and have("bd"):
+        run(["bd", "update", bead_id, "--description",
+             issue_body + "\n\nFiled issues: " + ", ".join(urls)], cwd=BEADS_DIR)
+
+    print(json.dumps({
+        "status": "filed",
+        "filed": filed,
+        "skipped_existing": skipped,
+        "bead_id": bead_id,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/find-or-pick-dm.rb
@@ -1,0 +1,372 @@
+#!/usr/bin/env ruby
+# Phase 1.5 — Reuse existing Sigma data models when one already covers the
+# Tableau workbook's needs. Goals:
+#   1. Avoid DM sprawl: don't add a 4th "Orders" DM when the customer already
+#      has three that all point at the same warehouse table.
+#   2. Performance: skip Phase 2 (warehouse column discovery) and Phase 3
+#      (DM build + POST + validate) when reusing — often 2-3 min savings.
+#
+# This script DOES NOT mutate any DM. It only scores existing DMs against the
+# Tableau workbook signature and recommends a candidate (with a warning about
+# inherited columns / RLS / metrics). The downstream phase decides whether to
+# reuse or create new.
+#
+# Usage:
+#   ruby scripts/find-or-pick-dm.rb \
+#     --workbook-signature /tmp/<name>/workbook-signature.json \
+#     --out /tmp/<name>/dm-match.json \
+#     [--limit 200]                    # max DMs to scan
+#     [--min-score 0.6]                # below: no recommendation, build new
+#     [--force-new]                    # always recommend new (skip scan)
+#
+# Input signature shape (produced by Phase 1 + 2.5 — adjust paths as needed):
+#   {
+#     "tableau_workbook":   "Monthly Revenue",
+#     "warehouse_tables":   ["CSA.ORDER_FACT"],          # FQN list
+#     "referenced_columns": ["ORDER_DATE","GROSS_REVENUE","REGION","STATE"],
+#     "measures":           [{"col":"GROSS_REVENUE","derivation":"Sum"}, ...]
+#   }
+#
+# Output: dm-match.json with shape documented in SKILL.md Phase 1.5.
+# Exit: 0 if any candidate ≥ --min-score, 1 if none (caller can choose to
+# build new). Never aborts on missing inputs — always emits a result file so
+# the agent can decide.
+
+require 'json'
+require 'yaml'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
+# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
+# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
+# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
+# picker run with no score regression. beads-sigma-3kw.
+opts = { limit: 25, min_score: 0.6 }
+OptionParser.new do |p|
+  p.on('--workbook-signature P') { |v| opts[:sig]      = v }
+  p.on('--out P')                { |v| opts[:out]      = v }
+  p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
+  p.on('--force-new')            { |_| opts[:force_new]= true }
+  p.on('--auto-pick',
+       'Auto-recommend without UX prompt when top score >= --auto-pick-threshold AND no other candidate within --auto-pick-tie-window of it. Sets `auto_picked: true` on the result so the caller can WARN about inherited columns.') { |_| opts[:auto_pick] = true }
+  p.on('--auto-pick-threshold F', Float, 'Min score for auto-pick (default 0.55).')                  { |v| opts[:auto_pick_threshold] = v }
+  p.on('--auto-pick-tie-window F', Float, 'Gap from top score within which other candidates count as a tie that disables auto-pick (default 0.05).') { |v| opts[:auto_pick_tie_window] = v }
+end.parse!
+%i[sig out].each { |k| abort "missing --#{k}" unless opts[k] }
+
+BASE = ENV.fetch('SIGMA_BASE_URL')
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+# DM-shortlisting scans many candidates and is called per-follower in cluster
+# orchestration — auto-refresh on 401 to survive long batch runs.
+def http_get(path)
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{BASE}#{path}")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept'] = 'application/json'
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
+end
+
+sig = JSON.parse(File.read(opts[:sig]))
+warn "workbook: #{sig['tableau_workbook'] || '(unnamed)'}"
+warn "  warehouse_tables:   #{sig['warehouse_tables']&.size || 0}"
+warn "  referenced_columns: #{sig['referenced_columns']&.size || 0}"
+
+# Force-new short-circuit: emit a no-match result and exit 1.
+if opts[:force_new]
+  File.write(opts[:out], JSON.pretty_generate({
+    'recommended_dm_id' => nil,
+    'score' => 0.0,
+    'rationale' => '--force-new: bypassed DM-reuse scan',
+    'candidates' => []
+  }))
+  warn "force-new mode — wrote empty match"
+  exit 1
+end
+
+# 1. List ALL data models, then sort deterministically before applying --limit.
+# Sigma's /v2/dataModels list endpoint returns server page-order, not
+# relevance order. Without a stable client-side sort, the same workbook
+# picks different candidates on different runs (observed: 3 conversions of
+# the same Tableau workbook reached 3 different recommendations). Fix:
+# fetch all DMs (cheap — one list call per 100), sort by updatedAt desc
+# (recent DMs are usually more relevant), then take the first --limit for
+# parallel spec-fetch + scoring. Stable tiebreaker by name. beads-sigma-3kw.
+all_dms = []
+page = nil
+hard_cap = 500
+loop do
+  qs = "limit=100"
+  qs += "&page=#{page}" if page
+  r = http_get("/v2/dataModels?#{qs}")
+  break unless r.code.to_i == 200
+  data = JSON.parse(r.body)
+  rows = data['entries'] || data['dataModels'] || []
+  break if rows.empty?
+  all_dms.concat(rows)
+  break if all_dms.size >= hard_cap
+  page = data['nextPage']
+  break if page.nil? || page.empty?
+end
+
+# Deterministic ranking: updatedAt desc, then name asc.
+# NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
+# every timestamp rescues to 0, and the sort silently degrades to name-ascending
+# (recently-updated DMs past the --limit window are never scanned).
+require 'time'
+all_dms = all_dms.sort_by do |dm|
+  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+end
+
+warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+
+# 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
+def normalize_fqn(s)
+  return nil if s.nil? || s.empty?
+  parts = s.to_s.split('.').reject(&:empty?).map(&:upcase)
+  parts.join('.')
+end
+
+def normalize_col(s)
+  s.to_s.upcase.gsub(/[^A-Z0-9]/, '')
+end
+
+# Fetch all DM specs in parallel (10 threads). Some DMs return non-200
+# (archived, permission-restricted, broken refs) — log and continue. Single
+# transient 5xx errors are retried once.
+dm_specs = {}
+dm_failures = []
+require 'thread'
+mu = Mutex.new
+queue = Queue.new
+all_dms.take(opts[:limit]).each { |dm| queue << dm }
+threads = 5.times.map do
+  Thread.new do
+    until queue.empty?
+      dm = queue.pop(true) rescue nil
+      break unless dm
+      dm_id = dm['dataModelId'] || dm['id']
+      next unless dm_id
+      r = nil
+      # Retry on 429 (Cloudflare burst limit) with exponential backoff. The
+      # /v2/dataModels endpoint commonly 429s at >5 concurrent across
+      # tj-wells-1989 — see beads-sigma-cn5.
+      4.times do |attempt|
+        r = http_get("/v2/dataModels/#{dm_id}/spec")
+        code = r.code.to_i
+        break if code == 200 || (code != 429 && code < 500)
+        sleep (0.5 * (2 ** attempt))  # 0.5s, 1s, 2s, 4s
+      end
+      if r.code.to_i != 200
+        mu.synchronize { dm_failures << { name: dm['name'], id: dm_id, code: r.code, body_head: r.body[0..80] } }
+        next
+      end
+      spec = begin
+        JSON.parse(r.body)
+      rescue JSON::ParserError
+        YAML.safe_load(r.body, permitted_classes: [Date, Time])
+      end
+      mu.synchronize { dm_specs[dm_id] = spec }
+    end
+  end
+end
+threads.each(&:join)
+warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
+dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
+
+dm_signatures = []
+all_dms.take(opts[:limit]).each do |dm|
+  dm_id = dm['dataModelId'] || dm['id']
+  spec = dm_specs[dm_id]
+  next unless spec
+
+  tables = []
+  columns = []
+  metrics = []
+  column_captions = {}  # normalized → original, so output can be human-readable
+
+  # Walk every element. Sigma DM specs nest elements under pages[*].elements
+  # (NOT top-level `elements` — that's a workbook-only convention). Fall back
+  # to top-level for robustness in case schema changes.
+  all_elements = spec['elements'] || (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  all_elements.each do |el|
+    src = el['source'] || {}
+    case src['kind']
+    when 'warehouse-table', 'table'
+      # source like { kind: warehouse-table, connectionId, path: "DB.SCHEMA.TABLE" }.
+      # Live API specs return path as an ARRAY (["DB","SCHEMA","TABLE"]) — join it,
+      # else normalize_fqn sees the array's to_s and table-match never fires.
+      raw = src['path']
+      fqn = raw.is_a?(Array) ? raw.join('.') : (raw || [src['database'], src['schema'], src['name']].compact.join('.'))
+      tables << normalize_fqn(fqn) if fqn && !fqn.empty?
+    when 'sql'
+      # Custom SQL — surface a sentinel so the agent knows; not directly comparable
+      tables << 'CUSTOM_SQL'
+    end
+    (el['columns'] || []).each do |c|
+      colname = c['name'] || (c['formula'].to_s.match(/\[.*?([^\/\]]+)\]/) || [])[1]
+      if colname && !colname.empty?
+        norm = normalize_col(colname)
+        columns << norm
+        column_captions[norm] ||= colname
+      end
+    end
+    (el['metrics'] || []).each do |m|
+      metrics << "#{m['name']}/#{m['aggregation'] || m['derivation']}"
+    end
+  end
+
+  dm_signatures << {
+    dm_id: dm_id,
+    dm_name: dm['name'],
+    tables: tables.uniq.compact,
+    columns: columns.uniq.compact,
+    column_captions: column_captions,
+    metrics: metrics.uniq.compact,
+    raw_element_count: all_elements.size
+  }
+end
+
+# 3. Score each DM.
+tableau_tables  = (sig['warehouse_tables']   || []).map { |t| normalize_fqn(t) }.compact
+# Keep both forms: normalized for matching, original for human-readable output.
+tableau_columns_orig = (sig['referenced_columns'] || [])
+tableau_columns      = tableau_columns_orig.map { |c| normalize_col(c) }
+tableau_col_caption  = tableau_columns.zip(tableau_columns_orig).to_h
+tableau_measure_keys = (sig['measures'] || []).map { |m| "#{normalize_col(m['col'])}/#{m['derivation']}" }
+
+candidates = dm_signatures.map do |dm|
+  # Table match: 1.0 if Tableau tables ⊆ DM tables. 0.5 if partial. 0 if disjoint.
+  shared_tables = (tableau_tables & dm[:tables])
+  table_match =
+    if tableau_tables.empty?
+      0.0
+    elsif shared_tables.size == tableau_tables.size
+      1.0
+    elsif shared_tables.any?
+      0.5 + 0.5 * (shared_tables.size.to_f / tableau_tables.size)
+    else
+      0.0
+    end
+
+  # Column match: % of Tableau-referenced columns present in DM.
+  shared_cols = (tableau_columns & dm[:columns])
+  col_match =
+    tableau_columns.empty? ? 0.0 : shared_cols.size.to_f / tableau_columns.size
+
+  # Metric overlap (small weight).
+  shared_metrics = (tableau_measure_keys & dm[:metrics])
+  metric_match =
+    tableau_measure_keys.empty? ? 0.0 : shared_metrics.size.to_f / tableau_measure_keys.size
+
+  # Weighting rationale: column overlap is the most reliable signal —
+  # a DM's source table FQN can vary (raw warehouse table vs view vs joined
+  # element) but the column set must be a superset of what the workbook
+  # references for reuse to be safe. Table-match is a soft tiebreaker.
+  score = 0.2 * table_match + 0.7 * col_match + 0.1 * metric_match
+
+  # Extras the workbook would inherit. Surface original captions (not the
+  # normalized form) so the user-facing report is readable.
+  extra_cols_norm = dm[:columns] - tableau_columns
+  caption_of = ->(norm) { dm[:column_captions][norm] || norm }
+  {
+    'dm_id'             => dm[:dm_id],
+    'dm_name'           => dm[:dm_name],
+    'score'             => score.round(3),
+    'table_match'       => table_match.round(2),
+    'column_match'      => col_match.round(2),
+    'metric_match'      => metric_match.round(2),
+    'shared_tables'     => shared_tables,
+    'missing_tables'    => tableau_tables - dm[:tables],
+    'shared_columns'    => shared_cols.map(&caption_of),
+    'missing_columns'   => (tableau_columns - dm[:columns]).map { |c| tableau_col_caption[c] || c },
+    'extra_columns'     => extra_cols_norm.size,
+    'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
+    'raw_element_count' => dm[:raw_element_count]
+  }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
+
+best = candidates.first
+second = candidates[1]
+
+# Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
+# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
+# workbook's source tables (table_match 1.0). Table coverage is the safety
+# invariant: a DM that sources every table the workbook needs can satisfy every
+# column ref through its element set, so reusing it is safe; a DM missing a table
+# is never auto-picked (its denorm view can't resolve the missing columns).
+#
+# We deliberately DO NOT block on a score tie here. A tie among table-covering
+# candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
+# exactly what reuse-first exists to collapse — so we take the top (the
+# deterministic tie-break already prefers a name match, then the fewest extra
+# columns, over the most-recently-updated set). A column-SUPERSET (every
+# referenced column present, column_match 1.0) is the safest case and always
+# qualifies. Callers should reuse `recommended_dm_id` only when `auto_picked`.
+auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
+auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
+tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+best_covers_tables   = best && best['table_match'].to_f >= 1.0
+best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables)
+
+# Standard recommend path keeps the old semantics (printed for human opt-in).
+recommended_via_std  = best && best['score'] >= opts[:min_score]
+recommended_dm_id    = (auto_picked || recommended_via_std) ? best['dm_id'] : nil
+
+rationale =
+  if best.nil?
+    'no DMs in org'
+  elsif auto_picked
+    kind = best_is_superset ? 'column-superset' : 'covers all source tables'
+    tie  = tie_with_second ? " (collapsing a #{best['score']}-score tie — duplicate-DM sprawl)" : ''
+    "AUTO-PICKED at score #{best['score']} — #{kind}#{tie}. #{best['shared_columns'].size}/#{tableau_columns.size} cols, #{best['shared_tables'].size}/#{tableau_tables.size} tables matched. Caller must WARN about #{best['extra_columns']} inherited columns."
+  elsif opts[:auto_pick] && best['score'] >= auto_pick_threshold && !best_covers_tables
+    "score #{best['score']} clears the bar but the candidate is MISSING source table(s) #{best['missing_tables'].join(', ')} — not a safe reuse — build a new DM"
+  elsif best['score'] >= opts[:min_score]
+    'ambiguous match — ASK USER before reusing'
+  else
+    'no candidate above min-score; build a new DM'
+  end
+
+result = {
+  'workbook_signature_path' => opts[:sig],
+  'scanned_dm_count'        => candidates.size,
+  'recommended_dm_id'       => recommended_dm_id,
+  'auto_picked'             => auto_picked,
+  'score'                   => best ? best['score'] : 0.0,
+  'rationale'               => rationale,
+  'warning'                 => (best && best['extra_columns'] > 0) ? "Reusing inherits #{best['extra_columns']} extra columns (sample: #{best['extra_columns_sample'].join(', ')})" : nil,
+  'candidates'              => candidates.first(5)
+}.compact
+
+File.write(opts[:out], JSON.pretty_generate(result))
+warn ""
+warn "wrote #{opts[:out]}"
+warn "best score: #{result['score']}  →  #{result['rationale']}"
+exit result['recommended_dm_id'].nil? ? 1 : 0

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get-token.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get-token.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Exchange Sigma client credentials for a bearer token.
+# Usage:  eval "$(scripts/get-token.sh)"
+# Sets SIGMA_API_TOKEN in the calling shell.
+
+set -euo pipefail
+
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  "$SIGMA_BASE_URL/v2/auth/token") || {
+    echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null \
+  || echo "$RESPONSE" | ruby -r json -e "print JSON.parse(STDIN.read)['access_token']")
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Token exchange failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+echo "export SIGMA_API_TOKEN=${TOKEN}"

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
+        end
+        fill = covered.count(true).to_f / ncols
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb
@@ -1,0 +1,115 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Preflight lint for a workbook spec — catches the two EDNA-class failure modes
+# BEFORE POST, with a precise message instead of the opaque "Invalid kind: control"
+# or a silently-detail-rendered table.
+#
+#   ruby preflight_lint.rb <workbook-spec.json>
+#     exit 0  = clean
+#     exit 1  = violations (printed, one per line)
+#
+# Checks:
+#   T1  a `table` with aggregate column(s) + dimension(s) but NO `groupings`
+#       → renders raw detail rows (the 9.6M-row / $0 / duplicate-dim EDNA bug).
+#   T2  a `groupings.calculations` column that is a PASSTHROUGH of an aggregate
+#       (re-aggregates to "multiple values"); calc cols must be Sum(...)/etc.
+#   C1  a `control` missing id / controlId / controlType.
+#   C2  any control nesting its value fields under a bogus `value` OBJECT
+#       (control fields are FLAT top-level) → the opaque `Invalid kind: control`.
+#       NOTE: a scalar `value:` is legitimate (slider handle position); only an
+#       OBJECT value is the trap. Also: a `source`, if present, must be double-nested.
+#   C3  a list/segmented/hierarchy control wired to NOTHING — neither a `source`
+#       (value-list) nor `filters` (target columns). A filters-only list control
+#       is VALID (live-verified), so source is NOT independently required.
+require 'json'
+
+AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
+PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
+LISTY = %w[list segmented hierarchy].freeze
+
+def lint(spec)
+  errs = []
+  cols_by_id = {}
+  pages = spec['pages'] || []
+  pages.each do |pg|
+    (pg['elements'] || []).each do |el|
+      (el['columns'] || []).each { |c| cols_by_id[c['id']] = c }
+    end
+  end
+  pages.each do |pg|
+    (pg['elements'] || []).each do |el|
+      kind = el['kind']
+      name = el['name'] || el['id'] || '(unnamed)'
+      cols = el['columns'] || []
+
+      if kind == 'table'
+        agg = cols.select { |c| c['formula'].to_s =~ AGG }
+        dim = cols.select { |c| c['formula'].to_s =~ PLAIN_REF }
+        grouped = el['groupings'].is_a?(Array) && !el['groupings'].empty?
+        if agg.any? && dim.any? && !grouped
+          errs << "T1 table '#{name}': has aggregate column(s) #{agg.map { |c| c['name'] }.inspect} + dimension(s) but NO `groupings` → will render raw detail rows, not an aggregated summary. Add groupings:[{groupBy:[<dim id>], calculations:[<agg id>...]}]."
+        end
+        # T2: a grouping calculation that points at a passthrough-of-aggregate column
+        (el['groupings'] || []).each do |g|
+          (g['calculations'] || []).each do |cid|
+            f = (cols_by_id[cid] || {})['formula'].to_s
+            # a calc that is a plain ref to another column whose own formula is an aggregate
+            if f =~ PLAIN_REF
+              # can't always resolve cross-element; flag bare passthroughs that look like measures
+              errs << "T2 table '#{name}': grouping calculation '#{cid}' is a passthrough (`#{f}`) — a grouped calculation must be an aggregate expression (Sum([...]) etc.), not a passthrough of an already-aggregated column (renders 'multiple values')." if cols_by_id[cid] && (cols_by_id[cid]['name'].to_s =~ /total|sum|count|avg|revenue|profit|tcv|amount/i)
+            end
+          end
+        end
+      end
+
+      if kind == 'control'
+        %w[id controlId controlType].each do |f|
+          errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
+        end
+        errs << "C1 control '#{name}': `id` and `controlId` must be DISTINCT." if !el['id'].to_s.empty? && el['id'] == el['controlId']
+
+        # C2: control value fields are FLAT top-level — never nested under a `value` OBJECT.
+        # (Live-verified: a nested value:{...} yields the opaque "Invalid kind: control" for
+        #  list / date-range / number-range / slider alike.) A SCALAR value: is legitimate
+        #  (the slider handle position), so only flag `value` when it is a Hash.
+        errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
+
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an EDNA measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
+          errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
+        end
+
+        # C3: a list-type control must be wired to SOMETHING — a `source` (value-list) and/or
+        # `filters` (target columns). A filters-only list control is VALID (live-verified), so we
+        # require source OR filters, never both, and never the bare mode/selectionMode/values.
+        if LISTY.include?(el['controlType'])
+          has_source  = el['source'].is_a?(Hash)
+          has_filters = el['filters'].is_a?(Array) && !el['filters'].empty?
+          unless has_source || has_filters
+            errs << "C3 control '#{name}': list-type control has neither `source` (value-list) nor `filters` (target columns) — it controls nothing. Add filters:[{source:{kind:table,elementId}, columnId}] and/or a double-nested source."
+          end
+        end
+      end
+    end
+  end
+  errs
+end
+
+if __FILE__ == $PROGRAM_NAME
+  path = ARGV[0] or abort('usage: preflight_lint.rb <workbook-spec.json>')
+  spec = JSON.parse(File.read(path))
+  errs = lint(spec)
+  if errs.empty?
+    puts 'preflight lint: clean'
+    exit 0
+  end
+  warn "preflight lint: #{errs.size} violation(s)"
+  errs.each { |e| warn "  ✗ #{e}" }
+  exit 1
+end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
@@ -1,0 +1,130 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Sigma creds aren't in ENV yet, load
+# them from the neutral cred file written by setup.rb. Existing env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env) do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN'] || refresh_token!
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      @token_mutex.synchronize { @token_override = tok }
+      # Surface the refreshed token to child processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/maql.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/maql.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""maql.py — MAQL → Sigma formula translator.
+
+Scoped to the constructs the converter handles cleanly; everything else is
+returned as UNHANDLED with the raw MAQL (flag, never fake). The hard MAQL
+surface — BY / WITHIN / BY ALL context and FOR time transforms — is detected and
+flagged here, to be measured by gap-scout, not silently mis-translated.
+
+translate(maql, syms) -> {"ok": bool, "formula": str|None, "reason": str|None}
+  syms = {"fact": {id: "Display Name"}, "attribute": {id:.}, "metric": {id:.}}
+"""
+import re
+
+AGG = {"SUM": "Sum", "AVG": "Avg", "MIN": "Min", "MAX": "Max", "MEDIAN": "Median"}
+# Hard MAQL surface, categorized so flags are actionable (not just "unsupported").
+# These are workbook-level constructs, NOT data-model metrics — they route to the
+# workbook builder, not the DM. category drives gap-scout / assessment reporting.
+TIME_KW = ["FOR PREVIOUS", "FOR NEXT", "FOR "]      # -> Sigma DateLookback in a date-grouped element
+CONTEXT_KW = ["BY ALL", "WITHIN", " BY "]            # -> Sigma grouping / Level-scoped aggregate
+
+
+def _ref(syms, kind, gid):
+    name = syms.get(kind, {}).get(gid)
+    return f"[{name}]" if name else None
+
+
+def translate(maql, syms):
+    src = " ".join(maql.split())
+    body = re.sub(r"^\s*SELECT\s+", "", src, flags=re.I).strip()
+
+    up = body.upper()
+    for kw in TIME_KW:
+        if kw in up:
+            return {"ok": False, "formula": None, "category": "TIME_INTEL",
+                    "reason": f"time transform '{kw.strip()}' → Sigma DateLookback in a date-grouped workbook element (workbook-level, not a DM metric)"}
+    for kw in CONTEXT_KW:
+        if kw in up:
+            return {"ok": False, "formula": None, "category": "CONTEXT",
+                    "reason": f"context aggregation '{kw.strip()}' → Sigma workbook grouping / Level-scoped aggregate (workbook-level, not a DM metric)"}
+
+    # WHERE filter -> conditional aggregate (SumIf/AvgIf/.../CountDistinctIf).
+    # Split off the WHERE clause and translate the predicate; aggregates below
+    # then emit their *If variants. MEDIAN+WHERE has no Sigma *If → unhandled.
+    cond = None
+    parts = re.split(r"\sWHERE\s", body, maxsplit=1, flags=re.I)
+    if len(parts) == 2:
+        body, where = parts[0].strip(), parts[1].strip()
+        c = re.sub(r"\{label/([^.}]+)\.[^}]+\}", lambda m: _ref(syms, "attribute", m.group(1)) or m.group(0), where)
+        c = re.sub(r"\{attribute/([^}]+)\}", lambda m: _ref(syms, "attribute", m.group(1)) or m.group(0), c)
+        if re.search(r"\{[^}]+\}", c):
+            return {"ok": False, "formula": None, "category": "UNHANDLED",
+                    "reason": f"WHERE predicate has an unresolved reference: {where[:60]}"}
+        cond = c.strip()
+        if re.search(r"\bMEDIAN\b", body, re.I):
+            return {"ok": False, "formula": None, "category": "UNHANDLED",
+                    "reason": "MEDIAN with WHERE has no Sigma conditional-aggregate equivalent"}
+
+    out = body
+    # COUNT({attribute/x}) -> CountDistinct([Name]) (GoodData COUNT of an attribute = distinct)
+    def count_attr(m):
+        r = _ref(syms, "attribute", m.group(1))
+        if not r: return m.group(0)
+        return f"CountDistinctIf({r}, {cond})" if cond else f"CountDistinct({r})"
+    out = re.sub(r"COUNT\(\s*\{attribute/([^}]+)\}\s*\)", count_attr, out, flags=re.I)
+
+    # AGG({fact/x}) and AGG(<expr of facts>) -> Sigma agg (conditional when WHERE present)
+    def agg_fact(m):
+        fn = AGG[m.group(1).upper()]
+        inner = m.group(2)
+        return f"{fn}If({inner}, {cond})" if cond else f"{fn}({inner})"
+    # first resolve fact refs to column names inside any expression
+    def fact_ref(m):
+        r = _ref(syms, "fact", m.group(1))
+        return r if r else m.group(0)
+    out = re.sub(r"\{fact/([^}]+)\}", fact_ref, out)
+    out = re.sub(r"(SUM|AVG|MIN|MAX|MEDIAN)\(([^()]*)\)", agg_fact, out, flags=re.I)
+
+    # metric refs -> reference other DM metrics by name
+    def metric_ref(m):
+        r = _ref(syms, "metric", m.group(1))
+        return r if r else m.group(0)
+    out = re.sub(r"\{metric/([^}]+)\}", metric_ref, out)
+
+    # leftover unresolved object refs => unhandled
+    leftover = re.search(r"\{(fact|attribute|metric|label)/([^}]+)\}", out)
+    if leftover:
+        return {"ok": False, "formula": None, "category": "UNHANDLED",
+                "reason": f"unresolved MAQL reference {leftover.group(0)}"}
+
+    return {"ok": True, "formula": out.strip(), "category": "AUTO", "reason": None}
+
+
+if __name__ == "__main__":
+    syms = {"fact": {"net_revenue": "Net Revenue", "net_profit": "Net Profit"},
+            "attribute": {"order_id": "Order Id", "region": "Region"},
+            "metric": {"m_net_revenue": "Net Revenue", "m_order_count": "Order Count"}}
+    for q in ["SELECT SUM({fact/net_revenue})",
+              "SELECT COUNT({attribute/order_id})",
+              "SELECT {metric/m_net_revenue} / {metric/m_order_count}",
+              "SELECT {metric/m_net_revenue} / (SELECT {metric/m_net_revenue} BY ALL {attribute/region})"]:
+        print(q, "->", translate(q, syms))

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/scan_gaps.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/scan_gaps.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""scan_gaps.py — gap-scout for MAQL coverage.
+
+Runs the MAQL translator over every metric in a workspace export and reports
+coverage by category (AUTO / TIME_INTEL / CONTEXT / UNHANDLED), so MAQL
+translation coverage is *measured*, not assumed — and appends UNHANDLED
+constructs to a learned-rules file for follow-up (flag, never fake).
+
+Usage:
+  python3 scan_gaps.py --workspace gd_workspace.json [--rules learned-rules.json]
+"""
+import argparse, json, os, sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from maql import translate
+
+CATEGORY_NOTE = {
+    "AUTO": "translated to a Sigma data-model metric",
+    "TIME_INTEL": "workbook-level: Sigma DateLookback in a date-grouped element",
+    "CONTEXT": "workbook-level: Sigma grouping / Level-scoped aggregate",
+    "UNHANDLED": "no translation — needs review (learned-rules)",
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workspace", required=True)
+    ap.add_argument("--rules", default="learned-rules.json")
+    a = ap.parse_args()
+    layout = json.load(open(a.workspace))
+    ldm = layout.get("ldm", {}) or {}; an = layout.get("analytics", {}) or {}
+    syms = {"fact": {}, "attribute": {}, "metric": {}}
+    for d in ldm.get("datasets", []):
+        for at in d.get("attributes", []): syms["attribute"][at["id"]] = at.get("title") or at["id"]
+        for f in d.get("facts", []): syms["fact"][f["id"]] = f.get("title") or f["id"]
+    for m in an.get("metrics", []): syms["metric"][m["id"]] = m.get("title") or m["id"]
+
+    metrics = an.get("metrics", [])
+    by_cat = {}; unhandled = []
+    for m in metrics:
+        res = translate((m.get("content") or {}).get("maql", ""), syms)
+        cat = res.get("category", "UNHANDLED")
+        by_cat.setdefault(cat, []).append(m["id"])
+        if cat == "UNHANDLED":
+            unhandled.append({"metric": m["id"], "maql": (m.get("content") or {}).get("maql"), "reason": res["reason"]})
+
+    total = len(metrics) or 1
+    auto = len(by_cat.get("AUTO", []))
+    print(f"=== MAQL coverage: {len(metrics)} metrics ===")
+    for cat in ("AUTO", "TIME_INTEL", "CONTEXT", "UNHANDLED"):
+        ids = by_cat.get(cat, [])
+        if ids:
+            print(f"  {cat:10} {len(ids):3}  ({CATEGORY_NOTE[cat]})")
+            for i in ids: print(f"       - {i}")
+    print(f"  ---\n  data-model-AUTO: {auto}/{len(metrics)} ({100*auto//total}%); "
+          f"workbook-portable: {len(by_cat.get('TIME_INTEL', []))+len(by_cat.get('CONTEXT', []))}; "
+          f"unhandled: {len(by_cat.get('UNHANDLED', []))}")
+
+    if unhandled:
+        prev = json.load(open(a.rules)) if os.path.exists(a.rules) else []
+        seen = {r["maql"] for r in prev}
+        prev += [u for u in unhandled if u["maql"] not in seen]
+        json.dump(prev, open(a.rules, "w"), indent=2)
+        print(f"  appended {len(unhandled)} unhandled construct(s) -> {a.rules}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/setup.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/setup.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
+
+print "Client Secret (hidden): "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/sigma-export-png.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/sigma-export-png.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""sigma-export-png.py — render a Sigma workbook page or element to PNG via the
+REST export API, for VISUAL QA of a migrated workbook (Phase 4: side-by-side
+against the source Looker dashboard).
+
+A PNG is more reliable than an MCP SQL query for catching LAYOUT/render problems —
+hidden KPI titles, orphaned filters, overlapping tiles, wrong chart kinds — that a
+numeric parity check can't see.
+
+POST /v2/workbooks/{id}/export {pageId|elementId, format:{type:"png",pixelWidth,pixelHeight}}
+  -> {queryId, jobComplete}; then GET /v2/query/{queryId}/download until the PNG is ready.
+
+Env: SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/get-token.sh)").
+Usage:
+  python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png
+  python3 sigma-export-png.py --workbook <id> --element <elId> --out /tmp/x.png [--w 1600 --h 900]
+"""
+import argparse, os, sys, time, requests
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook", required=True)
+    ap.add_argument("--page"); ap.add_argument("--element")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--w", type=int, default=1600); ap.add_argument("--h", type=int, default=900)
+    a = ap.parse_args()
+    base = os.environ["SIGMA_BASE_URL"]; tok = os.environ["SIGMA_API_TOKEN"]
+    h = {"Authorization": f"Bearer {tok}", "Content-Type": "application/json"}
+    fmt = {"type": "png", "pixelWidth": a.w, "pixelHeight": a.h}
+    body = {"format": fmt}
+    if a.element: body["elementId"] = a.element
+    elif a.page:  body["pageId"] = a.page
+    else: sys.exit("need --page or --element")
+    r = requests.post(f"{base}/v2/workbooks/{a.workbook}/export", headers=h, json=body)
+    if r.status_code != 200: sys.exit(f"export POST {r.status_code}: {r.text[:300]}")
+    qid = r.json()["queryId"]
+    dl = f"{base}/v2/query/{qid}/download"
+    for i in range(60):
+        g = requests.get(dl, headers={"Authorization": f"Bearer {tok}"})
+        ct = g.headers.get("Content-Type", "")
+        if g.status_code == 200 and ("image" in ct or g.content[:8] == b"\x89PNG\r\n\x1a\n"):
+            open(a.out, "wb").write(g.content)
+            print(f"[png] {len(g.content)} bytes -> {a.out}"); return
+        time.sleep(3)
+    sys.exit("timed out waiting for PNG")
+
+if __name__ == "__main__":
+    main()

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -5,6 +5,7 @@
       "canonical": "shared/lib/sigma_rest.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb",
         "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb",
@@ -19,6 +20,7 @@
       "canonical": "shared/lib/preflight_lint.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/preflight_lint.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/preflight_lint.rb",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/preflight_lint.rb",
         "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/preflight_lint.rb",
@@ -32,6 +34,7 @@
       "canonical": "shared/lib/layout_lint.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/layout_lint.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/layout_lint.rb",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/layout_lint.rb",
         "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/layout_lint.rb",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/layout_lint.rb",
@@ -159,6 +162,7 @@
       "canonical": "shared/scripts/escalate-gap.py",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/escalate-gap.py",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/escalate-gap.py",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/escalate-gap.py",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/escalate-gap.py",
         "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/escalate-gap.py",
@@ -197,6 +201,7 @@
       "canonical": "shared/scripts/sigma-export-png.py",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/sigma-export-png.py",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/sigma-export-png.py",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/sigma-export-png.py",
         "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/sigma-export-png.py",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/sigma-export-png.py",
@@ -209,6 +214,7 @@
       "canonical": "shared/scripts/find-or-pick-dm.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/find-or-pick-dm.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/find-or-pick-dm.rb",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/find-or-pick-dm.rb",
         "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/find-or-pick-dm.rb",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/find-or-pick-dm.rb",
@@ -233,6 +239,7 @@
       "canonical": "shared/scripts/get-token.sh",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get-token.sh",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get-token.sh",
         {
           "path": "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get-token.sh",
           "exception": "Intentional: credential sanity-check additions (looker postmortem 2026-06-18)."
@@ -250,6 +257,7 @@
       "canonical": "shared/scripts/setup.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/setup.rb",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb",
         "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb",
@@ -263,6 +271,7 @@
       "canonical": "shared/assessment/dup-dashboards.py",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-assessment/scripts/dup-dashboards.py",
+        "plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/dup-dashboards.py",
         "plugins/looker-to-sigma/skills/looker-assessment/scripts/dup-dashboards.py",
         "plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/dup-dashboards.py",
         "plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/dup-dashboards.py",
@@ -275,6 +284,7 @@
       "canonical": "shared/refs/layout-visual-qa.md",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/layout-visual-qa.md",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/layout-visual-qa.md",
         "plugins/looker-to-sigma/skills/looker-to-sigma/refs/layout-visual-qa.md",
         "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/layout-visual-qa.md",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/layout-visual-qa.md",
@@ -289,6 +299,7 @@
       "canonical": "shared/scripts/setup.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/setup.rb",
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/setup.rb",
         "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/setup.rb",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/setup.rb",


### PR DESCRIPTION
## What & why

`gooddata-to-sigma` was the **one converter never actually folded into the monorepo**. The `plugins/gooddata-to-sigma/` directory existed only as an accidental skeleton: the telemetry rollout (#175) and later shared-script rollouts blindly wrote scaffolding into the path as if the skill were vendored — so it carried 6 shared scripts but **no `SKILL.md`, no `plugin.json`, no converter**, and was **absent from `marketplace.json`**. The real skill lived only in the standalone `twells89/gooddata-to-sigma` repo.

This vendors the full skill in and wires it into the governance machinery so it's a real sibling of the other converters.

## Changes

- **Skill substance** (from the standalone repo): `plugin.json`, plugin `README.md`, both `SKILL.md` files, `refs/`, `fixtures/`, `QUICKSTART.md`, and the converter scripts (`convert/discover/build_workbook/maql/scan_gaps.py`, `assess.py`).
- **Shared infra**: added gooddata as a target for the same shared files cognos uses (`sigma_rest`, `preflight_lint`, `layout_lint`, `find-or-pick-dm`, `escalate-gap`, `get-token`, `setup`, `sigma-export-png`, `layout-visual-qa`, `dup-dashboards`) in `shared/manifest.json`, then `sync-shared.rb` to vendor them byte-identical. (The pre-existing 6 telemetry/parity scripts are untouched.)
- **Registration**: `marketplace.json` entry, root `README.md` install line + table row, `AGENTS.md` rows, and a `docs/phase-schema.md` mapping section (required by `lint-skills.rb`).
- **Corpus**: a creds-free regression case (`corpus/gooddata/orders-workspace`) with a golden DM spec generated offline from the test fixture; exercises the `BY ALL` flag path.

## Gates

All green locally (also enforced by the git hooks on push):

- `tools/check-shared.rb` — 196 shared-file copies match canonical
- `tools/lint-skills.rb` — 10 converter SKILL.md files document all mandatory gates
- `corpus/run-corpus.sh --check` — 14/14 cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)