### PR TITLE
docs(converters): local vendored converter is the default; MCP is fallback-only + phase-heading cleanup

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/QUICKSTART.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/QUICKSTART.md
@@ -49,8 +49,12 @@ Duration: 2
   `scripts/get-cognos-session.sh`.
 - **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`).
 - A **Sigma connection to the same warehouse** the Cognos content reports on (for true parity).
-- The **`convert_cognos_to_sigma`** + **`convert_cognos_report_to_sigma`** converters (part of
-  the sigma-data-model MCP), or the bundled `converter/` (Node + `fast-xml-parser`).
+- The **Cognos → Sigma converter** — ships **inside the skill** as a prebuilt local bundle
+  (`converter/cli.mjs`, Node + `fast-xml-parser`) and runs via plain `node` (no clone, no
+  `npm install`, no `tsx`, no network, **no data egress**). This is the default and works out
+  of the box; it requires only `node` on PATH. The hosted `sigma-data-model` MCP
+  (`convert_cognos_to_sigma` / `convert_cognos_report_to_sigma`) is only a fallback if the
+  local bundle can't run.
 
 negative
 : CAoC (Cognos on Cloud) sessions are short-lived and sit behind Akamai bot-protection — a copied session can return **HTTP 441** within minutes (the SPA's `X-CA-SSO: 441` header is the re-auth signal), and curl replay may be rejected outright. Re-login + re-copy a *hot* session, or use a **CA API key / service credential** where the tenant allows it (the durable path).

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -21,7 +21,7 @@ user-invocable: true
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.
 
-## Phase 0 — Choose where to build (ask first when no destination given)
+## Phase 0a — Choose where to build (ask first when no destination given)
 
 Don't silently land the migrated data model + workbook in My Documents.
 If the user didn't supply a destination (no `--folder <id>`), ASK before building:
@@ -124,7 +124,7 @@ checkpoint, never silently ported or dropped).
 
 ---
 
-## Phase 0 — Discover (CA REST)
+## Phase 0b — Discover (CA REST)
 
 **Work in batch windows.** CAoC sessions die in MINUTES — never walk an estate one
 object per agent turn (each re-auth costs the human a browser round-trip). The moment

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/QUICKSTART.md
@@ -81,14 +81,27 @@ summary (never silently drop RLS). Validated live with exact 3-way parity ($38,9
 
 ## 3. Convert the semantic model
 
-Feed the LookML **model** (not the warehouse tables) to the **`convert_lookml_to_sigma`** MCP
-tool — it resolves the explore's join graph. For fixed output against a patched converter
-source tree (the MCP server serves the *deployed* build), run it directly:
+Feed the LookML **model** (not the warehouse tables) to the converter — it resolves the
+explore's join graph. **This runs locally by default**: the skill ships a self-contained
+vendored bundle (`converter/lookml.mjs`) and `scripts/convert_dm.mjs` runs it in-process via
+`node` — no clone, no `npm install`, no network call, and your LookML never leaves the machine:
+```bash
+LOOKML_DIR=/path/to/lookml \
+  node --import tsx/esm scripts/convert_dm.mjs <explore> /tmp/look/dm-spec.json
+```
+A dev's own checkout wins automatically when set — point `CONVERTER_SRC` at a patched
+`sigma-data-model-mcp/src/lookml.ts` (the long-running MCP server only serves its *deployed*
+build, so a source-tree fix needs this direct path to take effect):
 ```bash
 LOOKML_DIR=/path/to/lookml \
 CONVERTER_SRC=/path/to/sigma-data-model-mcp/src/lookml.ts \
   node --import tsx/esm scripts/convert_dm.mjs <explore> /tmp/look/dm-spec.json
 ```
+The hosted **`convert_lookml_to_sigma`** MCP tool is a **manual fallback only** — reached when
+neither the vendored bundle nor a local build is available. In that case
+`scripts/migrate-looker.py` writes `convert-request.json` (the exact MCP arguments) and exits
+`3`; call the tool by hand, save its JSON output, and resume with `--converted <file>`.
+
 Read the printed warnings. Before POSTing, run the **DM-reuse check** (SKILL.md Phase 2.5):
 `lookml-dm-signature.py` + `find-or-pick-dm.rb --auto-pick` score the org's existing data
 models against the explore's tables/columns — on a strong match the skill asks reuse-vs-new

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   LookML projects, explores, or dashboards (user-defined OR LookML-defined) —
   and wants to recreate it in Sigma. Discovery via the Looker REST API 4.0 /
   Looker MCP server (or LookML files offline), model conversion via the
-  convert_lookml_to_sigma converter, dashboard → workbook conversion from the
+  local vendored LookML converter (convert_lookml_to_sigma MCP tool as a
+  manual fallback), dashboard → workbook conversion from the
   Looker Dashboard API JSON, build via the Sigma REST API, and 3-way parity
   verification against the source warehouse — driven by `scripts/*`.
 user-invocable: true
@@ -22,7 +23,7 @@ user-invocable: true
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.
 
-## Phase 0 — Choose where to build (ask first when no destination given)
+## Phase 0a — Choose where to build (ask first when no destination given)
 
 Don't silently land the migrated data model + workbook in an auto-picked folder.
 If the user didn't supply a destination (no `--folder <id>` and no `SIGMA_FOLDER_ID`), ASK before building:
@@ -54,7 +55,7 @@ Looker has two independent layers; convert them separately.
 
 | Layer | Source (production = API-first) | Converter | Sigma output |
 |---|---|---|---|
-| **Semantic model** | LookML views+model (Looker API/MCP, or files offline) | `mcp__sigma-data-model__convert_lookml_to_sigma` | data model |
+| **Semantic model** | LookML views+model (Looker API/MCP, or files offline) | local vendored `converter/lookml.mjs` (run in-process via `node`; the `convert_lookml_to_sigma` MCP tool is a manual fallback only) | data model |
 | **Dashboards** | `GET /dashboards/{id}` JSON — covers **user-defined (UDD) AND LookML dashboards** | `fetch_looker_dashboard.py` → contract → `build_workbook.py` | workbook |
 
 **Critical — UDD is the primary path.** Most real Looker dashboards are **user-defined
@@ -227,7 +228,7 @@ unusable for Looker. To stand up an end-to-end test pointed at the same warehous
 
 ---
 
-## Phase 0 — Assess the Looker estate
+## Phase 0b — Assess the Looker estate
 
 Scope the migration before converting anything — inventory models/explores/dashboards, score
 complexity, and rank a migration shortlist. This is handled by the **`looker-assessment`**
@@ -401,26 +402,46 @@ plain DM/element filter; `access_grant` → the recorded note. (Team mode =
 LookML views + model → Sigma data model. Resolve the explore's join graph, convert, POST,
 **register the model**, and verify.
 
-### 2a. Convert with `convert_lookml_to_sigma`
+### 2a. Convert — local by default, MCP only as a manual fallback
 
-The MCP tool `mcp__sigma-data-model__convert_lookml_to_sigma(files, connectionId, exploreName,
-joinStrategy)` is the primary path. Feed it the **LookML model**, NOT the warehouse tables —
-the converter walks the explore's `join`s to resolve `view.field` prefixes (alias vs `from:`
-view) and emits one element per resolved view plus a denormalized explore element.
+Feed it the **LookML model**, NOT the warehouse tables — the converter walks the explore's
+`join`s to resolve `view.field` prefixes (alias vs `from:` view) and emits one element per
+resolved view plus a denormalized explore element.
 
-> **Converter-build gotcha.** The long-running MCP server serves the **deployed** build. After
-> editing `src/lookml.ts` + `npm run build`, the running MCP tool still serves the OLD code
-> until it restarts. For fixed output against an edited source tree, run the converter directly:
->
-> ```bash
-> LOOKML_DIR=/path/to/lookml \
-> CONVERTER_SRC=/path/to/sigma-data-model-mcp/src/lookml.ts \
->   node --import tsx/esm scripts/convert_dm.mjs <exploreName> /tmp/<name>/dm-spec.json
-> ```
->
-> `convert_dm.mjs` reads `<model>.model.lkml` + every `views/*.view.lkml`, converts the explore
-> with `joinStrategy: 'relationships'`, and writes `res.model` (the return property is `.model`,
-> **not** `.sigmaDataModel`). It prints stats + warnings — **read every warning.**
+**Default: the converter runs locally, in-process, no MCP, no data egress.** The skill ships a
+self-contained vendored bundle at `converter/lookml.mjs`; `migrate-looker.py` (and
+`scripts/convert_dm.mjs` directly) run it via a `node` shim — no clone, no `npm install`, no
+network call, and your LookML never leaves the machine:
+
+```bash
+LOOKML_DIR=/path/to/lookml \
+  node --import tsx/esm scripts/convert_dm.mjs <exploreName> /tmp/<name>/dm-spec.json
+```
+
+`convert_dm.mjs` reads `<model>.model.lkml` + every `views/*.view.lkml`, converts the explore
+with `joinStrategy: 'relationships'`, and writes `res.model` (the return property is `.model`,
+**not** `.sigmaDataModel`). It prints stats + warnings — **read every warning.**
+
+A dev's own checkout wins automatically when present: `migrate-looker.py` first checks
+`CONVERTER_SRC` (a `src/lookml.ts` + `tsx`, for fixed output against a patched source tree —
+see the build gotcha below) or `CONVERTER_PATH` (a built `build/lookml.js`), resolved from
+`~/sigma-data-model-mcp` or `~/Desktop/sigma-data-model-mcp` (`CONVERTER_HOMES`) if set. The
+vendored `converter/lookml.mjs` bundle is the guaranteed floor underneath both — it is what runs
+out of the box with nothing configured.
+
+**Fallback only — no local converter and no `node`:** `migrate-looker.py` writes
+`convert-request.json` (the exact `mcp__sigma-data-model__convert_lookml_to_sigma(files,
+connectionId, exploreName, joinStrategy)` arguments) and **exits 3**. Call the MCP tool by hand
+with those arguments, save its JSON output to `<workdir>/converted.json`, and resume with
+`--converted <workdir>/converted.json`. Reach for this only when the vendored bundle is missing —
+routing through the hosted MCP by default means your LookML leaves the machine and you're at the
+mercy of whatever converter version the MCP happens to be running (version drift vs the vendored
+bundle / a patched source tree).
+
+> **Converter-build gotcha (only relevant when using `CONVERTER_SRC`).** The long-running MCP
+> server serves the **deployed** build. After editing `src/lookml.ts` + `npm run build`, the
+> running MCP tool still serves the OLD code until it restarts — another reason the local
+> `CONVERTER_SRC`/vendored-bundle path is preferred over calling the MCP tool.
 
 ### 2b. Converter coverage (all live-validated 2026-06-10) — and what's still lossy
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -21,7 +21,7 @@ user-invocable: true
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.
 
-## Phase 0 — Choose where to build (ask first; `--folder-id` is required downstream)
+## Phase 0a — Choose where to build (ask first; `--folder-id` is required downstream)
 
 Don't pick the destination folder for the user. `convert.py` requires `--folder-id`,
 so resolve it WITH the user before building:
@@ -82,7 +82,7 @@ logic.
   gate stack: `put-layout.rb`, `assert-phase6-ran.rb`, `probe-controls.rb`,
   `scripts/lib/*.rb` — vendored byte-identical across the sibling plugins).
 
-## Phase 0 — Discover
+## Phase 0b — Discover
 
 Run the sibling **`microstrategy-assessment`** skill for an estate-wide
 inventory (reports/dossiers, viz histogram, complexity tags) — its

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/QUICKSTART.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/QUICKSTART.md
@@ -52,7 +52,7 @@ Duration: 2
 - **Power BI / Fabric access** — you do **not** need to register an Entra app. The skill uses **device-code auth** with the well-known Power BI Desktop public client, which works against *My workspace* and any workspace you can access.
 - **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`)
 - A **Sigma connection to the same warehouse** the model uses (for parity)
-- The **`convert_powerbi_to_sigma`** converter (part of the sigma-data-model MCP)
+- The **Power BI → Sigma converter** — ships **inside the skill** as a prebuilt local bundle (`converter/powerbi.mjs`) and runs **in-process via `node`** (no clone, no `npm install`, no network, **no data egress** — your `model.bim` never leaves your machine). This is the default and works out of the box; it requires only `node` on PATH. A dev's own converter build wins via `--mcp-dir` / `$PBI_MCP_DIR`. The hosted `sigma-data-model` MCP is **only** a manual fallback: if the bundle *and* `node` are both unavailable the orchestrator stops (exit 10) and prints the exact `convert_powerbi_to_sigma` call for you to run, then resume with `--converter-out`.
 
 negative
 : Two API audiences are involved — **Fabric** (`api.fabric.microsoft.com`) for `getDefinition` (TMSL/PBIR) and **Power BI REST** (`analysis.windows.net/powerbi`) for refresh history, Activity Events, and `executeQueries` (DAX parity). The skill acquires both from one device-code session; corporate TLS requires `truststore.inject_into_ssl()`.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -35,7 +35,7 @@ If a destination is already supplied, honor it silently — don't ask.
 ```
 1. CONNECT   device-code login, well-known PowerBI-Desktop client, NO Entra app   → scripts/fabric-extract.py
 2. EXTRACT   Fabric getDefinition?format=TMSL → model.bim   (+ .pbix Report/Layout for visuals)
-3. CONVERT   convert_powerbi_to_sigma MCP (model.bim + connectionId + db/schema) → Sigma DM JSON
+3. CONVERT   local vendored converter (converter/powerbi.mjs via node) — model.bim + connectionId + db/schema → Sigma DM JSON   [MCP only as manual fallback]
 4. POST DM   fix spec (schemaVersion + folderId/ownerId + element names) → POST /v2/dataModels/spec
 5. WORKBOOK  Data page (master tables per DM element) + chart elements → POST /v2/workbooks/spec
 6. LAYOUT    PBIX/PBIR visual x,y,w,h → 24-col grid XML → put-layout.rb
@@ -83,11 +83,19 @@ Import-mode PBI models are **frozen snapshots**; Sigma reads the LIVE warehouse.
 
 Pulls the refresh history (`GET datasets/{id}/refreshes` via the cached token) — last successful refresh + **FAILED refreshes** (expired warehouse creds are the classic cause; surfaced loudly) — plus a cheap `executeQueries` row-count/max-date snapshot per table (the per-table probes run **4-wide in parallel** — a 6-table model snapshots in one round-trip's wall time). The preflight is **NON-BLOCKING**: it is only CONSUMED at Phase 6/7 parity, so `run.sh` (stage 1.5) and `migrate-powerbi.rb` (Phase 1.5) launch it as a **background lane concurrent with Convert/Build** and join it (replaying its log) right before parity — 3-8s of Power BI round-trips off the critical path. A run that stops at a gate leaves the detached probe to finish; the resume run reuses the written `freshness.json`. Phase 6/7 parity is then **LED by the staleness banner**, and deltas classify **MATCH / STALE-EXPLAINED / DIVERGENT — only DIVERGENT blocks** (a "Sigma shows more data" delta on a stale snapshot is explained, not a conversion error). `migrate-powerbi.rb` also always writes per-phase **`timings.json`** and prints a `PHASE TIMINGS` line at every terminal exit.
 
-## Phase 3 — Convert (MCP)
-`convert_powerbi_to_sigma(model_json, connection_id, database, schema)`.
+## Phase 3 — Convert (local, zero-config)
+The conversion runs **locally by default**: `migrate-powerbi.rb` executes the vendored
+converter bundle (`converter/powerbi.mjs`, `convertPowerBIToSigma`) in-process via a `node`
+shim — no clone, no `npm install`, no network, **no MCP, no data egress**. A dev's own build
+wins via `--mcp-dir` / `$PBI_MCP_DIR`. Only if the bundle is **also** absent does it gate
+(exit 10) with instructions to run the `convert_powerbi_to_sigma` MCP tool **manually** and
+resume with `--converter-out`. The hosted MCP is a fallback, not the default path.
 
-> ⚠️ **`--converter-out` takes the MCP converter's output — never a hand-authored spec.**
-> The flag exists so you can run the `convert_powerbi_to_sigma` MCP tool, save its
+`convertPowerBIToSigma(model_json, connection_id, database, schema)`.
+
+> ⚠️ **`--converter-out` takes the converter's output — never a hand-authored spec.**
+> The flag exists so you can run the converter (the fallback `convert_powerbi_to_sigma`
+> MCP tool when the local bundle is unavailable), save its
 > result, and resume the pipeline with it (`convert-model.rb --converter-out <that file>`).
 > It is **not** an invitation to write `dm-raw.json` by hand. Hand-authored specs skip
 > the converter's column-name/SQL/formula-prefix guarantees and reliably produce

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/QUICKSTART.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/QUICKSTART.md
@@ -59,7 +59,7 @@ Duration: 2
 - **Qlik Cloud access** — an API key *or* an OAuth client (Admin → OAuth). For creating/round-tripping content, an **M2M impersonation** client is ideal (acts as a real user so content is visible).
 - **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`).
 - A **Sigma connection to the same warehouse** the Qlik app loads from (for true parity).
-- The **`convert_qlik_to_sigma`** converter (part of the sigma-data-model MCP).
+- The **`convert_qlik_to_sigma`** converter — ships inside the skill as a local vendored bundle (`converter/qlik.mjs`, run in-process via `node`, no clone/npm/network); the sigma-data-model MCP tool of the same name is only a manual fallback if the bundle is somehow missing.
 
 negative
 : A *plain* M2M OAuth client can authenticate and discover apps, but it (a) only sees content in spaces it's a member of and (b) cannot reload apps that use space data-connections. Use an API key or an M2M-impersonation client for anything beyond read-only discovery.
@@ -167,8 +167,11 @@ it chains these phases (each also independently runnable from `scripts/*`):
    stale and Sigma (live warehouse) will show more data.
 2. **Reconcile** (`reconcile-columns.py`) — auto-derive the Qlik-field → real-warehouse
    column map from the load script's `AS` aliases (`ORDER_STORE_KEY AS STORE_KEY`).
-3. **Translate** — `convert_qlik_to_sigma` turns master measures into Sigma metrics and
-   builds relationships from shared keys. **Set Analysis** → Sigma `SumIf`/`CountIf`.
+3. **Convert** — the local vendored converter (`converter/qlik.mjs` via `node`, no clone/
+   npm/network/MCP/data-egress) runs `convertQlikToSigma`, turning master measures into
+   Sigma metrics and building relationships from shared keys. **Set Analysis** → Sigma
+   `SumIf`/`CountIf`. A dev build wins via `QLIK_MCP_DIR`; the hosted
+   `convert_qlik_to_sigma` MCP tool is only a manual fallback if no converter is found.
 4. **Build the data model** (`gen-denorm-sql.py` + `build-sigma-dm.py`) — a clean star
    plus a denormalized SQL element; POST to `/v2/dataModels/spec`.
 5. **Build the workbook** (`build-sigma-workbook.py`) — one Sigma page per Qlik sheet,

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -4,8 +4,9 @@ description: >-
   Convert a Qlik Sense / Qlik Cloud app into a Sigma data model and matching
   workbook. Use when the user has a Qlik Cloud tenant/app and wants to recreate
   it in Sigma. Discovery via qlik-cli (Engine + REST), Qlik-expression →
-  Sigma-formula translation via the convert_qlik_to_sigma converter, data model
-  + workbook creation via the Sigma REST API, and parity verification against
+  Sigma-formula translation via the local vendored convert_qlik_to_sigma
+  converter (MCP tool only as a manual fallback), data model + workbook
+  creation via the Sigma REST API, and parity verification against
   the source warehouse. Requires qlik-cli + a Sigma SIGMA_API_TOKEN.
 user-invocable: true
 ---
@@ -84,12 +85,15 @@ independently runnable script if you need to intervene mid-pipeline.
 
 ## The one big idea
 
-Qlik's calc language (master measures/dimensions, Set Analysis) translates via the
-existing **`mcp__sigma-data-model__convert_qlik_to_sigma`** tool. But the decisive
-move is **what you feed it**: the Qlik *in-memory model* (post-LOAD-script field
-names), NOT the raw warehouse tables. The Qlik LOAD script's renames/drops are
-exactly what disambiguate a clean star; raw warehouse column names collide
-(CITY/STATE/REGION/UNIT_COST shared across dims → spurious relationships).
+Qlik's calc language (master measures/dimensions, Set Analysis) translates via
+`convertQlikToSigma` — run **locally by default** (the vendored `converter/qlik.mjs`
+bundle, in-process via a `node` shim, no clone/npm/network/MCP/data-egress); the
+hosted `mcp__sigma-data-model__convert_qlik_to_sigma` tool is only a manual fallback
+when no converter is available. But the decisive move is **what you feed it**: the
+Qlik *in-memory model* (post-LOAD-script field names), NOT the raw warehouse tables.
+The Qlik LOAD script's renames/drops are exactly what disambiguate a clean star; raw
+warehouse column names collide (CITY/STATE/REGION/UNIT_COST shared across dims →
+spurious relationships).
 
 The Qlik LOAD script ≈ a Sigma **custom-SQL element**. Reproduce it as SQL and
 every Qlik field name resolves.
@@ -178,14 +182,16 @@ staleness) blocks GREEN.
 > same Phase-2 translation. No row counts in a `-prj` folder → relationships are by shared
 > field name only; review join directions.
 
-## Phase 2 — Translate (convert_qlik_to_sigma)
-**Converter — zero-config, local, no MCP.** `migrate-qlik.rb` runs
+## Phase 2 — Convert (convert_qlik_to_sigma)
+**Local by default, zero-config, no MCP.** `migrate-qlik.rb` runs
 `convertQlikToSigma` in-process via a `node` shim against the self-contained bundle
-VENDORED in the skill (`converter/qlik.mjs`) — no clone, no npm, no network, no MCP.
-A dev's own build still wins via `QLIK_MCP_DIR` (or a local `sigma-data-model-mcp`
-checkout); refresh the bundle with `tools/vendor-converters.sh`. (The
-`mcp__sigma-data-model__convert_qlik_to_sigma` MCP tool produces the same
-`model_json → Sigma DM spec` and remains available for manual/agent use.)
+VENDORED in the skill (`converter/qlik.mjs`) — no clone, no npm, no network, **no
+MCP, no data egress**. A dev's own build wins via `QLIK_MCP_DIR` (or a local
+`sigma-data-model-mcp` checkout); refresh the bundle with `tools/vendor-converters.sh`.
+Only if the vendored bundle is **also** missing (and `QLIK_MCP_DIR` unset) does
+`migrate-qlik.rb` abort, at which point run the `mcp__sigma-data-model__convert_qlik_to_sigma`
+MCP tool **manually** (same `model_json → Sigma DM spec` contract) and feed its output
+back in as `converter-out.json`. The hosted MCP is a fallback, not the default path.
 Output = Sigma DM spec (warehouse-table elements + relationships on shared keys +
 metrics from measures + auto "Dim View" denormalized elements).
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/QUICKSTART.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/QUICKSTART.md
@@ -47,7 +47,7 @@ Duration: 2
 - **An Enterprise-edition QuickSight account** + the analysis (or dashboard) id you want to migrate.
 - **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`).
 - A **Sigma connection to the same warehouse** the datasets use (its `connection_id` feeds the converter), and a target **folder id**.
-- The **`convert_quicksight_to_sigma`** converter (part of the sigma-data-model MCP).
+- The **QuickSight → Sigma converter** — ships **inside the skill** as a prebuilt local bundle (`converter/quicksight.mjs`) and runs **in-process via `node`** (no clone, no `npm install`, no network, **no data egress** — your analysis/dataset JSON never leaves your machine). This is the default and works out of the box; it requires only `node` on PATH. A dev's own converter build wins via `--mcp-dir` / `$QS_MCP_DIR`. The hosted `sigma-data-model` MCP's `convert_quicksight_to_sigma` tool is **only** a manual fallback: if the bundle *and* `node` are both unavailable the orchestrator stops (exit 10) and prints the exact MCP call for you to run, then resume with `--converted`.
 
 ## The two-skill ecosystem
 Duration: 2
@@ -97,9 +97,13 @@ Point the `quicksight-to-sigma` skill at an analysis. Phases:
 
 1. **Discover** (`quicksight-discover.py`) — AWS CLI → `describe-analysis-definition`
    + datasets + data sources → `signals.json` and raw JSON.
-2. **Convert** — `convert-model.rb --emit-mcp` prints the exact
-   `convert_quicksight_to_sigma` MCP call (analysis + dataset jsons + your Sigma
-   `connection_id`); run it and save the returned Sigma data-model JSON.
+2. **Convert** — runs **locally by default**: the vendored converter bundle
+   (`converter/quicksight.mjs`, `convertQuickSightToSigma`) executes in-process via
+   `node` over the analysis + dataset jsons + your Sigma `connection_id` — no clone,
+   no network, no MCP. Only if that bundle (and a dev's `--mcp-dir`/`$QS_MCP_DIR`
+   build) are both absent does `convert-model.rb --emit-mcp` print the
+   `convert_quicksight_to_sigma` MCP call as a **manual fallback**; run it yourself
+   and save the returned Sigma data-model JSON, then resume with `--converted`.
 3. **Build the data model** — `convert-model.rb --fixup` (names elements, rewrites
    sql refs, `schemaVersion: 1`, folder) → validate → POST to `/v2/dataModels/spec`;
    verify every column has a concrete type (no `error` columns).

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quicksight-to-sigma
-description: Convert an Amazon QuickSight analysis or dashboard into a Sigma data model and matching dashboard. Use when the user has a QuickSight analysis/dashboard and wants to recreate it in Sigma. Covers AWS-CLI extraction of the analysis definition + datasets + data sources, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, posting the data model + workbook via the Sigma REST API, layout, and parity verification against the same warehouse.
+description: Convert an Amazon QuickSight analysis or dashboard into a Sigma data model and matching dashboard. Use when the user has a QuickSight analysis/dashboard and wants to recreate it in Sigma. Covers AWS-CLI extraction of the analysis definition + datasets + data sources, calc-field / data-prep translation via the local vendored converter (the convert_quicksight_to_sigma MCP tool is a manual fallback only), posting the data model + workbook via the Sigma REST API, layout, and parity verification against the same warehouse.
 user-invocable: true
 ---
 
@@ -29,13 +29,13 @@ If a destination is already supplied, honor it silently — don't ask.
 
 > Status: **foundation** (converter MCP + browser shipped 2026-05-28).
 > Beads: converter = `beads-sigma-j5e`; CustomSql/DIRECT_QUERY fixup = `beads-sigma-vy4k`.
-> Defers to: `sigma-workbooks` (canonical workbook spec), `sigma-data-models` (DM spec), the `convert_quicksight_to_sigma` MCP tool, and the shared vendor-neutral Sigma-side scripts (`post-and-readback.rb`, `put-layout.rb`, `find-or-pick-dm.rb`, `verify-parity.rb`) reused across the migration skills.
+> Defers to: `sigma-workbooks` (canonical workbook spec), `sigma-data-models` (DM spec), the local vendored converter (`converter/quicksight.mjs`, exporting `convertQuickSightToSigma` — the `convert_quicksight_to_sigma` MCP tool is a manual fallback only), and the shared vendor-neutral Sigma-side scripts (`post-and-readback.rb`, `put-layout.rb`, `find-or-pick-dm.rb`, `verify-parity.rb`) reused across the migration skills.
 
 ## What's proven (the happy path)
 ```
 1. AUTH      AWS CLI → QuickSight (Enterprise edition REQUIRED); Sigma creds via get-token.sh
 2. DISCOVER  describe-analysis-definition + describe-data-set(s) + describe-data-source(s)  → quicksight-discover.py → signals.json
-3. CONVERT   convert_quicksight_to_sigma MCP (analysis.json + dataset jsons + connectionId)  → Sigma DM JSON      [MCP gate]
+3. CONVERT   local vendored converter (converter/quicksight.mjs via node) — analysis.json + dataset jsons + connectionId → Sigma DM JSON   [MCP only as manual fallback]
 4. POST DM   fixup (name elements + passthrough cols, rewrite sql refs, schemaVersion=1) → validate → POST /v2/dataModels/spec
 5. WORKBOOK  master tables per DM element + chart elements mirroring the QS visuals → POST /v2/workbooks/spec
 6. LAYOUT    QS grid x,y,w,h → 24-col layout XML → put-layout.rb
@@ -108,7 +108,13 @@ Pulls `describe-analysis-definition` (or `-dashboard-definition`) + `describe-da
 - **Batch mode**: `--analysis-ids a,b,c --pool 4` (cap 8) runs per-analysis discovery in parallel into `<out-dir>/<id>/`, sharing the estate cache with single-flight de-duplication (concurrent threads needing the same dataset trigger exactly one describe).
 - **Test coverage (live AWS is IAM-blocked — see below)**: `python3 scripts/tests/test-quicksight-discover.py` — 11 tests covering both transports (fake-boto3 injection + stubbed CLI), datetime normalization, cache hit/invalidation/single-flight, batch mode, and the offline fixture path. **Still awaiting live-AWS validation**: real boto3 session/profile auth, real `list-data-sets` pagination + permissions, Enterprise-edition `describe-*-definition` latency, and measured before/after numbers on a real estate. The mocked harness + the `--from-fixtures` E2E (`migrate-quicksight.rb`, parity 5/5 strict) are the offline proof.
 
-## Phase 3 — Convert (MCP gate)
+## Phase 3 — Convert (local, zero-config)
+
+The conversion runs **locally by default**: `migrate-quicksight.rb` executes the vendored
+converter bundle (`converter/quicksight.mjs`, `convertQuickSightToSigma`) in-process via a
+`node` shim over `analysis.json` + each `datasets/*.json` — no clone, no `npm install`, no
+network, **no MCP, no data egress**. A dev's own build wins via `--mcp-dir` / `$QS_MCP_DIR`.
+Only if the bundle is **also** absent does it gate (exit 10):
 
 ```bash
 ruby scripts/convert-model.rb --emit-mcp \
@@ -117,7 +123,7 @@ ruby scripts/convert-model.rb --emit-mcp \
   [--database <DB> --schema <SCHEMA>]
 ```
 
-This prints the exact `convert_quicksight_to_sigma` MCP-tool call — `files` = `analysis.json` + each `datasets/*.json`, plus `connection_id` (and `database`/`schema` overrides if a dataset's source path is incomplete). **The agent then runs that MCP tool** and saves the returned Sigma data-model JSON (e.g. `converter-out.json`).
+This prints the exact `convert_quicksight_to_sigma` MCP-tool call — `files` = `analysis.json` + each `datasets/*.json`, plus `connection_id` (and `database`/`schema` overrides if a dataset's source path is incomplete). Run that MCP tool **manually** — it is a fallback, not the default path — save its result, and resume with `--converted <mcp-tool-result.json>` (e.g. `converter-out.json`).
 
 What the converter handles vs. what it doesn't (see `refs/migration-test-slate.md` for the full taxonomy):
 - **Handled**: RelationalTable, CustomSql, JoinInstruction, DataTransforms (CreateColumns/Rename/Cast/Filter/Project), ~40 calc-field functions (`ifelse`→`If`, `switch`→nested `If`), parameters → Sigma controls. KPI / bar / line / donut/pie visuals on the workbook side.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -84,8 +84,10 @@ ruby scripts/migrate-tableau.rb --workbook "<name>" \
 > it yourself" (that skips preflight/control lint, Phase-6 parity, and the
 > `assert-phase6-ran` hard gate — the exact way a workbook ships with missing controls and
 > an unverified parity claim). Instead author the specs *once* and let the scripts run them:
-> 1. Get the **DM spec** — call the `sigma-data-model` MCP's `convert_tableau_to_sigma` on
->    the `.twb` if it's available to you, else author it by hand (see `sigma-data-models`).
+> 1. Get the **DM spec** — normally the vendored local converter (`converter/tableau.mjs`)
+>    produces this automatically; reach here only if even that can't run. In that case call
+>    the hosted `sigma-data-model` MCP's `convert_tableau_to_sigma` on the `.twb` if it's
+>    available to you, else author it by hand (see `sigma-data-models`).
 > 2. Author the **workbook spec** (see the companion `sigma-workbooks` skill). Reference the
 >    data model with placeholders the orchestrator binds to the live readback ids:
 >    `"__DM_ID__"` (top-level `dataModelId`) and `"__DM_ELEMENT__:<ElementName>"` per element

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/QUICKSTART.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/QUICKSTART.md
@@ -45,11 +45,16 @@ python3 scripts/ts_discover.py <LIVEBOARD_ID> LIVEBOARD   # viz chart types + li
 ```
 
 ## 3. Convert the model
-Feed the model's TML to the **`convert_thoughtspot_to_sigma`** MCP tool (or point
-`CONVERTER_PATH` at a `sigma-data-model-mcp` build for the one-shot path). With
-neither, `migrate.py` writes `<workdir>/convert-request.json` (the exact MCP
-arguments) and exits 3 — call the tool, save its JSON output, and re-run with
-`--converted <file>`. The converter emits a Sigma data model with a denormalized
+Conversion runs **locally by default**: the skill ships a self-contained
+converter bundle (`converter/thoughtspot.mjs`), and `migrate.py` defaults
+`CONVERTER_PATH` to it, so `convert_model.mjs` runs the bundle in-process via
+`node` — no clone, no `npm install`, no network, **no MCP, no data egress**. A
+dev's own build wins via an explicit `CONVERTER_PATH`. The hosted
+**`convert_thoughtspot_to_sigma`** MCP tool is **only** a manual fallback: if
+the bundle is also unavailable, `migrate.py` writes
+`<workdir>/convert-request.json` (the exact MCP arguments) and exits 3 — call
+the tool yourself, save its JSON output, and re-run with `--converted <file>`.
+The converter emits a Sigma data model with a denormalized
 **"<root> View"** element that surfaces joined-dim columns — the workbook master
 reads from it. Rules: `refs/model-conversion-rules.md`.
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -123,17 +123,20 @@ prefix applied to BOTH the data model and every workbook; workbooks and pages
 are named after the Liveboard's **display name** (resolved from its TML, never
 the UUID).
 
-**Converter — zero-config, local, no MCP.** A self-contained converter bundle
-ships in the skill at `converter/thoughtspot.mjs` and is the default: conversion
-runs locally via `node` with no clone, no `npm install`, no network, no MCP.
-`CONVERTER_PATH` defaults to it; a dev's own `build/thoughtspot.js` still wins when
-set. Refresh the bundle with `tools/vendor-converters.sh` (see
-`converter/PROVENANCE.json`). Only if the bundle is missing AND `CONVERTER_PATH` is
-unset does migrate.py fall back to the **MCP path**: it writes `<workdir>/model.tml`
-+ `<workdir>/convert-request.json` (the exact
-`mcp__sigma-data-model__convert_thoughtspot_to_sigma` arguments) and exits 3 — call
-the tool, save its JSON to `<workdir>/converted.json`, and re-run with
-`--converted <workdir>/converted.json`.
+**Converter — local by default, MCP is a fallback.** Conversion runs **locally
+by default**: the skill ships a self-contained converter bundle at
+`converter/thoughtspot.mjs`, and both `migrate.py` and `migrate-thoughtspot.py`
+default `CONVERTER_PATH` to it, so `convert_model.mjs` runs the bundle
+in-process via `node` — no clone, no `npm install`, no network, **no MCP, no
+data egress**. A dev's own build (`build/thoughtspot.js`) still wins via an
+explicit `CONVERTER_PATH`. Refresh the bundle with `tools/vendor-converters.sh`
+(see `converter/PROVENANCE.json`). The hosted `sigma-data-model` MCP is
+**only** a manual fallback: if the bundle is **also** missing AND
+`CONVERTER_PATH` is unset, `migrate.py` writes `<workdir>/model.tml` +
+`<workdir>/convert-request.json` (the exact
+`mcp__sigma-data-model__convert_thoughtspot_to_sigma` arguments) and exits 3 —
+call the tool yourself, save its JSON to `<workdir>/converted.json`, and re-run
+with `--converted <workdir>/converted.json`.
 
 **Offline mode** (no live ThoughtSpot needed): `--model-tml <file>` +
 `--liveboard-tml <file>` read exported TML from disk — `fixtures/` ships a real
@@ -149,9 +152,13 @@ python3 scripts/migrate.py --model-tml fixtures/retail-analytics-model.tml \
 1. **Discover** — `ts_discover.py [<id> <type>]` lists models + Liveboards or
    summarizes one (chart types, search queries, lineage). `metadata/search` +
    `metadata/tml/export`.
-2. **Convert the model** — export the model TML and run it through
-   `convert_thoughtspot_to_sigma` (`convert_model.mjs` imports the built converter;
-   the browser tool / MCP also work). ThoughtSpot exports the **`model:`** format
+2. **Convert the model** — export the model TML and convert it **locally by
+   default**: `convert_model.mjs` runs the vendored converter bundle
+   (`converter/thoughtspot.mjs`) in-process via `node` — no clone, no `npm
+   install`, no network, **no MCP, no data egress**. Only if that bundle (and
+   any dev-supplied `CONVERTER_PATH`) is unavailable does it fall back to the
+   **`convert_thoughtspot_to_sigma`** MCP tool, called manually. ThoughtSpot
+   exports the **`model:`** format
    (joins inline on `model_tables[].joins[]`, `[TABLE::COL]` formula refs,
    `col.properties.column_type`) — the converter handles it. POST to
    `/v2/dataModels/spec`; then read the posted DM spec to find the denormalized
@@ -290,8 +297,11 @@ region, quarter all match to the cent). Per-run ids land in `<workdir>/migrate_o
   converter's regression diet.
 
 ## Notes
-- `convert_thoughtspot_to_sigma` is the converter (MCP github.com/twells89/sigma-data-model-mcp
-  + browser sigma-data-model-manager) — keep both in lockstep.
+- The vendored bundle (`converter/thoughtspot.mjs`) is the local, default path for
+  conversion. It's built from the same `convert_thoughtspot_to_sigma` logic as the
+  hosted MCP (github.com/twells89/sigma-data-model-mcp) and the browser
+  sigma-data-model-manager — keep all three in lockstep; the MCP tool itself is only
+  a manual fallback when the local bundle is unavailable.
 - **Rename gotcha**: `PATCH /v2/workbooks/{id}` silently no-ops for renames
   (200, name unchanged) — rename via `PATCH /v2/files/{id} {"name": …}`
   (delete and unarchive are files-side too).


### PR DESCRIPTION
## Why

Audit of the converter skills found that PRs #220–223 moved the **code** to a local, zero-config, no-egress vendored converter as the default — but the **prose** in most `SKILL.md` / `QUICKSTART.md` files still presented the hosted `sigma-data-model` MCP `convert_*` tool as *the* conversion step.

Consequence (the "MCP is still being used" + "acts inconsistently depending on where it runs" reports):
- An agent driving via the **orchestrator script** → local vendored `.mjs` (consistent, no egress).
- An agent following the **SKILL/QUICKSTART prose** → calls the **hosted MCP** at `sigma-data-model-mcp.onrender.com` → data egress + version drift between the vendored bundles and the separately-hosted MCP.

Only Tableau had been fully rewritten. This aligns every converter's docs with the code.

## What changed (docs only — no scripts, no phase numbers, no tool renames)

**Convert-path prose** rewritten to `local default → dev-build override → MCP manual fallback`, with wording **verified against each orchestrator** (correct per-converter env var / gate exit code — no invented flags):

| Converter | Files | Notes |
|---|---|---|
| powerbi | SKILL + QUICKSTART | reference exemplar (Phase 3 header, intro, pipeline summary, bullet) |
| qlik | SKILL + QUICKSTART | "Phase 2 — Translate" → "Convert"; `QLIK_MCP_DIR`; abort-then-`converter-out.json` fallback |
| quicksight | SKILL + QUICKSTART | "Phase 3 — Convert (MCP gate)" → "(local, zero-config)"; `--mcp-dir`/`QS_MCP_DIR`; `--emit-mcp`/`--converted` gate |
| looker | SKILL + QUICKSTART | §2a rewritten; `CONVERTER_SRC`/`CONVERTER_PATH`/`CONVERTER_HOMES`; exit-3 fallback |
| thoughtspot | SKILL + QUICKSTART | `converter/thoughtspot.mjs` via `convert_model.mjs`; exit-3 fallback |
| cognos | QUICKSTART | SKILL Phase 1 was already local-first; QUICKSTART bullet fixed |
| tableau | SKILL | clarified the "no converter available" block is a genuine fallback, not MCP-first |

**Phase-heading cleanup:** fixed duplicate `## Phase 0` collisions in **looker / cognos / microstrategy** (destination-picker → `0a`, discover/assess → `0b`). Used the repo's existing `0a`/`0b` sub-lettering idiom rather than renumbering — `Phase 6` and friends are hardcoded in gates/scripts 225× and must not shift.

Pre-commit hook passed: 262 shared-file copies still match canonical; all 10 SKILL.md gate-docs intact.

## Deliberately NOT in this PR (follow-ups)
- **Full canonical phase spine** (e.g. same phase *numbers* fleet-wide) — risky: would cascade into 225 hardcoded `Phase 6`/`assert-phase6-ran`/`phase6-parity` references in scripts and gates. Needs its own careful PR.
- **Group B story** (gooddata / microstrategy / sisense use bespoke inline Python/node converters, no shared engine, no `convert_*` MCP tool) — currently silent; worth documenting explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)