### PR TITLE
fix(#227): vendored converter is the default; no silent dev-build auto-discovery

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate every corpus case against its golden
         run: ./corpus/run-corpus.sh --check
+      - name: Converter-default regression (issue #227 — vendored default, no silent dev-checkout)
+        # Creds-free, network-free: proves each orchestrator defaults to the pinned
+        # vendored bundle and only uses a local build via an explicit env/flag.
+        run: ./corpus/converter-default-test.sh
 
   script-syntax:
     name: syntax-check every script (ruby -c / py_compile / bash -n)

--- a/corpus/converter-default-test.sh
+++ b/corpus/converter-default-test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Converter-default regression test (GitHub issue #227). CREDS-FREE, network-free.
+#
+# Guards the invariant that made customers see different behavior than demos: the
+# orchestrators must default to the PINNED VENDORED converter bundle and must NOT
+# silently auto-discover a developer's ~/sigma-data-model-mcp checkout. A local
+# build is used ONLY when EXPLICITLY opted in via an env var / flag.
+#
+# Two layers:
+#   1. STATIC (all 5 orchestrators): no implicit `~/…sigma-data-model-mcp…` probe
+#      and no hardcoded `/Users/<name>/…` developer path may reappear.
+#   2. DYNAMIC (the 4 with a --print-converter mode): with a planted fake ~ checkout
+#      + clean env → resolves to the vendored bundle; with the explicit env var →
+#      resolves to the dev build.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+fail=0
+note() { printf '  %s\n' "$*"; }
+
+# ── Layer 1: static — no implicit home-dir / hardcoded dev-path probing ──────────
+echo "== static: no silent dev-checkout auto-discovery in any orchestrator"
+STATIC_HITS=$(grep -rnE "expand_path\(['\"]~/[^'\"]*sigma-data-model-mcp|expanduser\(['\"]~/[^'\"]*sigma-data-model-mcp|/Users/[a-z]+/[^ ]*sigma-data-model-mcp" \
+  plugins/*/skills/*/scripts/migrate-*.rb plugins/*/skills/*/scripts/migrate-*.py 2>/dev/null || true)
+if [ -n "$STATIC_HITS" ]; then
+  echo "FAIL: implicit dev-checkout probing reintroduced:"; echo "$STATIC_HITS"; fail=1
+else
+  note "OK — no implicit ~/ or /Users/<name>/ sigma-data-model-mcp probes"
+fi
+
+# ── Layer 2: dynamic — vendored default vs explicit override ─────────────────────
+# fields: label | orchestrator | runner | env_var | build_basename | vendored_basename
+CASES=(
+  "powerbi|plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb|ruby|PBI_MCP_DIR|powerbi.js|powerbi.mjs"
+  "quicksight|plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb|ruby|QS_MCP_DIR|quicksight.js|quicksight.mjs"
+  "qlik|plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb|ruby|QLIK_MCP_DIR|qlik.js|qlik.mjs"
+  "looker|plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py|python3|CONVERTER_PATH|lookml.js|lookml.mjs"
+)
+
+for spec in "${CASES[@]}"; do
+  IFS='|' read -r label orch runner envvar build vendored <<<"$spec"
+  echo "== dynamic: $label"
+  if [ ! -f "$orch" ]; then echo "FAIL: orchestrator missing: $orch"; fail=1; continue; fi
+
+  fh=$(mktemp -d)
+  # Plant a fake dev checkout in BOTH well-known home locations — must be ignored.
+  mkdir -p "$fh/sigma-data-model-mcp/build" "$fh/Desktop/sigma-data-model-mcp/build"
+  echo "x" > "$fh/sigma-data-model-mcp/build/$build"
+  echo "x" > "$fh/Desktop/sigma-data-model-mcp/build/$build"
+
+  # (a) clean env + planted checkout → MUST resolve to the vendored bundle
+  out_default=$(HOME="$fh" env -u "$envvar" "$runner" "$orch" --print-converter 2>/dev/null | head -1)
+  if [[ "$out_default" == *"/converter/$vendored" ]]; then
+    note "OK default → vendored ($vendored), planted ~ checkout ignored"
+  else
+    echo "FAIL default: expected vendored .../converter/$vendored, got: $out_default"; fail=1
+  fi
+
+  # (b) explicit override env var → MUST resolve to that dev build
+  dd=$(mktemp -d); mkdir -p "$dd/build"; echo "x" > "$dd/build/$build"
+  if [ "$envvar" = "CONVERTER_PATH" ]; then ovval="$dd/build/$build"; else ovval="$dd"; fi
+  out_dev=$(HOME="$fh" env "$envvar=$ovval" "$runner" "$orch" --print-converter 2>/dev/null | head -1)
+  if [[ "$out_dev" == "$dd/build/$build" ]]; then
+    note "OK override ($envvar) → dev build honored"
+  else
+    echo "FAIL override: expected $dd/build/$build, got: $out_dev"; fail=1
+  fi
+  rm -rf "$fh" "$dd"
+done
+
+echo
+if [ "$fail" -eq 0 ]; then echo "converter-default: ALL PASS"; else echo "converter-default: FAILURES above"; fi
+exit $fail

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -82,11 +82,40 @@ from build_workbook import build_field_index, parse_join_aliases, disp, leaf
 HERE = os.path.dirname(os.path.abspath(__file__))
 T0 = time.time()
 MCP_TOOL = "mcp__sigma-data-model__convert_lookml_to_sigma"
-# ~/sigma-data-model-mcp FIRST: the Desktop copy is routinely a stale clone
-# (version-skew footgun, bead 8nq5) — prefer the canonical checkout and warn
-# loudly (warn_converter_skew) when whichever one resolves is behind origin/main.
-CONVERTER_HOMES = [os.path.expanduser(p) for p in
-                   ("~/sigma-data-model-mcp", "~/Desktop/sigma-data-model-mcp")]
+VENDORED_CONVERTER = os.path.join(HERE, "..", "converter", "lookml.mjs")
+
+
+def resolve_converter():
+    """Converter resolution (issue #227). The pinned VENDORED bundle is the
+    DEFAULT so a developer machine and a customer machine produce identical
+    output for the same input. A local sigma-data-model-mcp checkout/build is
+    used ONLY when EXPLICITLY opted in via CONVERTER_SRC (src/lookml.ts, run via
+    tsx) or CONVERTER_PATH (build/lookml.js) — there is NO silent auto-discovery
+    of ~/sigma-data-model-mcp or ~/Desktop/sigma-data-model-mcp checkouts (that
+    was the "works in my demo, differs for the customer" footgun).
+
+    Returns (kind, path, desc) where kind is one of "src", "build", "vendored",
+    or None (no converter resolvable — the MCP-request fallback applies)."""
+    src = os.environ.get("CONVERTER_SRC")
+    build = os.environ.get("CONVERTER_PATH")
+    if not src and not build and os.path.exists(VENDORED_CONVERTER):
+        build = VENDORED_CONVERTER
+    if src:
+        return "src", src, f"DEV SRC {src} (explicit opt-in via CONVERTER_SRC)"
+    if build:
+        if build == VENDORED_CONVERTER:
+            prov_path = os.path.join(os.path.dirname(VENDORED_CONVERTER), "PROVENANCE.json")
+            commit = None
+            try:
+                commit = json.load(open(prov_path)).get("source_commit")
+            except Exception:
+                pass
+            return ("vendored", build,
+                    f"VENDORED {os.path.basename(VENDORED_CONVERTER)}"
+                    f"{f' (pinned {commit})' if commit else ''} — no data egress")
+        return "build", build, f"DEV BUILD {build} (explicit opt-in via CONVERTER_PATH)"
+    return None, None, ("NONE — vendored bundle missing; convert_lookml_to_sigma "
+                        "MCP / --converted fallback applies")
 
 
 def warn_converter_skew(resolved_path):
@@ -451,7 +480,17 @@ def main():
                          "build-new (reuse only via explicit --reuse-dm).")
     ap.add_argument("--yes", action="store_true")
     ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--print-converter", action="store_true",
+                    help="Resolve the converter (CONVERTER_SRC -> CONVERTER_PATH -> "
+                         "vendored bundle), print the resolved path + a one-line "
+                         "provenance description, and exit 0. No other args, Sigma "
+                         "creds, or network access required.")
     a = ap.parse_args()
+    if a.print_converter:
+        _kind, _path, _desc = resolve_converter()
+        print(_path or "none")
+        print(_desc)
+        return 0
     if not a.dashboard and not a.dashboard_id:
         ap.error("--dashboard (offline .dashboard.lookml) or --dashboard-id (live) required")
     if not a.lookml_dir and not a.project:
@@ -588,23 +627,15 @@ def main():
         json.dump(spec, open(dm_spec_path, "w"), indent=2)
         print(f"   using MCP converter output {a.converted} -> {dm_spec_path}")
     else:
-        src = os.environ.get("CONVERTER_SRC") or next(
-            (os.path.join(h, "src", "lookml.ts") for h in CONVERTER_HOMES
-             if os.path.exists(os.path.join(h, "src", "lookml.ts"))
-             and os.path.exists(os.path.join(h, "node_modules", ".bin", "tsx"))), None)
-        build = os.environ.get("CONVERTER_PATH") or next(
-            (os.path.join(h, "build", "lookml.js") for h in CONVERTER_HOMES
-             if os.path.exists(os.path.join(h, "build", "lookml.js"))), None)
-        # Zero-config fallback: the converter is VENDORED in the skill as a
-        # self-contained ESM bundle (converter/lookml.mjs) — no clone, no MCP, no
-        # network. A dev's CONVERTER_SRC/CONVERTER_PATH (or a CONVERTER_HOMES
-        # checkout) still wins above; this is the guaranteed floor so conversion
-        # runs locally out of the box. Imported by the same `build` node shim below.
-        vendored = os.path.join(HERE, "..", "converter", "lookml.mjs")
-        if not src and not build and os.path.exists(vendored):
-            build = vendored
+        # Converter resolution (issue #227): the pinned VENDORED bundle is the
+        # DEFAULT so a dev machine and a customer machine convert identically. A
+        # local checkout/build is used ONLY via explicit CONVERTER_SRC /
+        # CONVERTER_PATH — no silent auto-discovery of ~/… checkouts.
+        kind, path, desc = resolve_converter()
+        src = path if kind == "src" else None
+        build = path if kind in ("build", "vendored") else None
+        print(f"   converter: {desc}", file=sys.stderr)
         if src or build:
-            print(f"   converter: {src or build}")
             warn_converter_skew(src or build)
         if src:
             repo = os.path.dirname(os.path.dirname(src))

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -72,6 +72,29 @@ require 'coverage_gate' # workbook-build coverage.json → consolidated report +
 require 'pbi_element_match' # converter→readback element pairing (POST reorders; regression-tested)
 require 'pbi_timeintel_route' # time-intel fallback-router fact-provenance guard (regression-tested)
 
+# Converter resolution (issue #227). The pinned VENDORED bundle is the DEFAULT so a
+# developer machine and a customer machine produce identical output for the same
+# input. A local sigma-data-model-mcp build is used ONLY when EXPLICITLY opted in
+# via --mcp-dir / PBI_MCP_DIR — there is NO silent auto-discovery of ~/… checkouts
+# (that was the "works in my demo, differs for the customer" footgun). Returns
+# [conv_module, mcp_build_dir_or_nil, loud_provenance_line].
+def resolve_converter(mcp_dir, vendored, build_basename)
+  build_dir = (mcp_dir && File.exist?(File.join(mcp_dir, 'build', build_basename))) ? mcp_dir : nil
+  conv = build_dir ? File.join(build_dir, 'build', build_basename) :
+         (File.exist?(vendored) ? vendored : nil)
+  desc =
+    if conv && conv == vendored
+      prov = File.join(File.dirname(vendored), 'PROVENANCE.json')
+      commit = (JSON.parse(File.read(prov))['source_commit'] rescue nil)
+      "VENDORED #{File.basename(vendored)}#{commit ? " (pinned #{commit})" : ''} — no data egress"
+    elsif conv
+      "DEV BUILD #{conv} (explicit opt-in via --mcp-dir/PBI_MCP_DIR)"
+    else
+      'NONE — vendored bundle missing; convert_powerbi_to_sigma MCP / --converter-out fallback applies'
+    end
+  [conv, build_dir, desc]
+end
+
 opts = { db: '', schema: '' }
 OptionParser.new do |o|
   o.on('--tmsl PATH')       { |v| opts[:tmsl]   = File.expand_path(v) }
@@ -96,6 +119,9 @@ OptionParser.new do |o|
   o.on('--mcp-dir DIR')        { |v| opts[:mcp_dir] = File.expand_path(v) }
   o.on('--converter-out PATH') { |v| opts[:cvt_out] = File.expand_path(v) }
   o.on('--python PATH')        { |v| opts[:python]  = File.expand_path(v) }
+  # Resolve + print which converter would run (vendored vs explicit dev build), then
+  # exit 0 — no creds/args needed. Used by the converter-default regression test.
+  o.on('--print-converter')    {     opts[:print_converter] = true }
   # bead fmte — SOURCE-FRESHNESS PREFLIGHT. --workspace/--dataset identify the
   # LIVE semantic model (workspace id or "me" for My workspace) so Phase 1.5 can
   # pull its refresh history + a cheap executeQueries snapshot. Optional: without
@@ -118,6 +144,14 @@ OptionParser.new do |o|
   o.on('--no-reuse')           {     opts[:no_reuse] = true }
 end.parse!
 
+VENDORED_PBI = File.expand_path('../converter/powerbi.mjs', __dir__)
+if opts[:print_converter]
+  conv, _bd, desc = resolve_converter(opts[:mcp_dir] || ENV['PBI_MCP_DIR'], VENDORED_PBI, 'powerbi.js')
+  puts(conv || 'none')
+  puts desc
+  exit 0
+end
+
 abort 'missing --tmsl' unless opts[:tmsl]
 abort "--tmsl not found: #{opts[:tmsl]}" unless opts[:tmsl] && File.exist?(opts[:tmsl])
 abort 'missing --pbir' unless opts[:pbir]
@@ -132,23 +166,14 @@ if opts[:conn] && opts[:conn] !~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
         "got #{opts[:conn].inspect}. List connections with GET /v2/connections."
 end
 
-# Local converter build (the convert_powerbi_to_sigma MCP tool, imported directly).
-# bead 7o01: no hardcoded developer paths — resolve from --mcp-dir / PBI_MCP_DIR,
-# else probe common clone locations under $HOME. When NONE is found, Phase 2 does
-# NOT abort: it stops with a gate instructing the agent to run the
-# convert_powerbi_to_sigma MCP tool and resume with --converter-out (the default
-# converter route on machines without a local build).
-MCP_DIR = [opts[:mcp_dir], ENV['PBI_MCP_DIR'],
-           File.expand_path('~/Desktop/sigma-data-model-mcp'),
-           File.expand_path('~/sigma-data-model-mcp')]
-          .compact.find { |d| File.exist?(File.join(d, 'build', 'powerbi.js')) }
-# ZERO-config local converter: a dev's build (above) wins, else the self-contained
-# bundle VENDORED in the skill (converter/powerbi.mjs) — no clone, no npm, no
-# network, no MCP. CONV_MODULE is what the Phase-2 shim imports; nil only if the
-# bundle is also absent (then --converter-out / the MCP gate applies).
-VENDORED_PBI = File.expand_path('../converter/powerbi.mjs', __dir__)
-CONV_MODULE = MCP_DIR ? File.join(MCP_DIR, 'build', 'powerbi.js') :
-              (File.exist?(VENDORED_PBI) ? VENDORED_PBI : nil)
+# Converter resolution (issue #227): the pinned VENDORED bundle is the DEFAULT so a
+# dev machine and a customer machine convert identically. A local build is used ONLY
+# via explicit --mcp-dir / PBI_MCP_DIR — no silent auto-discovery of ~/… checkouts.
+# CONV_MODULE is what the Phase-2 shim imports; nil only if the bundle is also absent
+# (then --converter-out / the convert_powerbi_to_sigma MCP gate applies).
+CONV_MODULE, MCP_DIR, CONVERTER_DESC =
+  resolve_converter(opts[:mcp_dir] || ENV['PBI_MCP_DIR'], VENDORED_PBI, 'powerbi.js')
+warn "converter: #{CONVERTER_DESC}"
 
 name_slug = File.basename(opts[:tmsl], '.*').gsub(/[^A-Za-z0-9_-]/, '-')
 WORK = opts[:out] || File.expand_path("~/powerbi-migration/#{name_slug}")

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -133,7 +133,41 @@ OptionParser.new do |o|
   o.on('--no-reuse')          {     opts[:no_reuse] = true }
   o.on('--dry-run')           {     opts[:dry_run]  = true }
   o.on('--skip-layout-lint')  {     opts[:skip_layout_lint] = true }
+  # Resolve + print which converter would run (vendored vs explicit dev build), then
+  # exit 0 — no creds/args needed. Used by the converter-default regression test.
+  o.on('--print-converter')   {     opts[:print_converter] = true }
 end.parse!
+
+# Converter resolution (issue #227). The pinned VENDORED bundle is the DEFAULT so a
+# developer machine and a customer machine produce identical output for the same
+# input. A local sigma-data-model-mcp build is used ONLY when EXPLICITLY opted in
+# via QLIK_MCP_DIR — there is NO silent auto-discovery of ~/… checkouts (that was
+# the "works in my demo, differs for the customer" footgun). Returns
+# [conv_module, mcp_build_dir_or_nil, loud_provenance_line].
+def resolve_converter(mcp_dir, vendored, build_basename)
+  build_dir = (mcp_dir && File.exist?(File.join(mcp_dir, 'build', build_basename))) ? mcp_dir : nil
+  conv = build_dir ? File.join(build_dir, 'build', build_basename) :
+         (File.exist?(vendored) ? vendored : nil)
+  desc =
+    if conv && conv == vendored
+      prov = File.join(File.dirname(vendored), 'PROVENANCE.json')
+      commit = (JSON.parse(File.read(prov))['source_commit'] rescue nil)
+      "VENDORED #{File.basename(vendored)}#{commit ? " (pinned #{commit})" : ''} — no data egress"
+    elsif conv
+      "DEV BUILD #{conv} (explicit opt-in via QLIK_MCP_DIR)"
+    else
+      'NONE — vendored bundle missing; convert_qlik_to_sigma MCP / --converter-out (converter-out.json) resume applies'
+    end
+  [conv, build_dir, desc]
+end
+
+VENDORED_QLIK = File.expand_path('../converter/qlik.mjs', __dir__)
+if opts[:print_converter]
+  conv, _bd, desc = resolve_converter(ENV['QLIK_MCP_DIR'], VENDORED_QLIK, 'qlik.js')
+  puts(conv || 'none')
+  puts desc
+  exit 0
+end
 
 abort 'missing --app (or --from-discovery)' unless opts[:app] || opts[:from]
 # intake.rb (front-door) caches the resolved connection in <out>/connection.json; honor it
@@ -141,21 +175,14 @@ abort 'missing --app (or --from-discovery)' unless opts[:app] || opts[:from]
 opts[:conn] ||= (JSON.parse(File.read(File.join(opts[:out], 'connection.json')))['connection_id'] rescue nil) if opts[:out]
 abort 'missing --connection (pass --connection <id>, or run intake.rb first and point --out at its --workdir)' unless opts[:conn]
 
-# Converter (exports convertQlikToSigma) — ZERO-config, local, no MCP. A dev's
-# own build wins via QLIK_MCP_DIR (or a local sigma-data-model-mcp checkout);
-# otherwise the self-contained bundle VENDORED in the skill (converter/qlik.mjs)
-# is used — no clone, no npm install, no network. Refresh it with
-# tools/vendor-converters.sh (see converter/PROVENANCE.json).
-MCP_DIR = ENV['QLIK_MCP_DIR'] || %w[
-  /Users/tjwells/Desktop/sigma-data-model-mcp
-  /Users/tjwells/sigma-data-model-mcp
-].find { |d| File.exist?(File.join(d, 'build', 'qlik.js')) }
-VENDORED_QLIK = File.expand_path('../converter/qlik.mjs', __dir__)
-# The converter module the Phase-2 shim imports: a dev build if present, else the
-# vendored bundle. nil only if BOTH are somehow absent (a prior converter-out.json
-# may then still be reused).
-CONV_MODULE = MCP_DIR ? File.join(MCP_DIR, 'build', 'qlik.js') :
-              (File.exist?(VENDORED_QLIK) ? VENDORED_QLIK : nil)
+# Converter resolution (issue #227): the pinned VENDORED bundle is the DEFAULT so a
+# dev machine and a customer machine convert identically. A local build is used ONLY
+# via explicit QLIK_MCP_DIR — no silent auto-discovery of ~/… checkouts. CONV_MODULE
+# is what the Phase-2 shim imports; nil only if the bundle is also absent (then
+# --converter-out / the convert_qlik_to_sigma MCP gate applies).
+CONV_MODULE, MCP_DIR, CONVERTER_DESC =
+  resolve_converter(ENV['QLIK_MCP_DIR'], VENDORED_QLIK, 'qlik.js')
+warn "converter: #{CONVERTER_DESC}"
 
 name_slug = (opts[:app] || File.basename(opts[:from].to_s)).gsub(/[^A-Za-z0-9_-]/, '-')
 WORK = opts[:out] || File.expand_path("~/qlik-migration/#{name_slug}")

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
@@ -54,6 +54,29 @@ require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub saf
 HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
 
+# Converter resolution (issue #227). The pinned VENDORED bundle is the DEFAULT so a
+# developer machine and a customer machine produce identical output for the same
+# input. A local sigma-data-model-mcp build is used ONLY when EXPLICITLY opted in
+# via --mcp-dir / QS_MCP_DIR — there is NO silent auto-discovery of ~/… checkouts
+# (that was the "works in my demo, differs for the customer" footgun). Returns
+# [conv_module, mcp_build_dir_or_nil, loud_provenance_line].
+def resolve_converter(mcp_dir, vendored, build_basename)
+  build_dir = (mcp_dir && File.exist?(File.join(mcp_dir, 'build', build_basename))) ? mcp_dir : nil
+  conv = build_dir ? File.join(build_dir, 'build', build_basename) :
+         (File.exist?(vendored) ? vendored : nil)
+  desc =
+    if conv && conv == vendored
+      prov = File.join(File.dirname(vendored), 'PROVENANCE.json')
+      commit = (JSON.parse(File.read(prov))['source_commit'] rescue nil)
+      "VENDORED #{File.basename(vendored)}#{commit ? " (pinned #{commit})" : ''} — no data egress"
+    elsif conv
+      "DEV BUILD #{conv} (explicit opt-in via --mcp-dir/QS_MCP_DIR)"
+    else
+      'NONE — vendored bundle missing; convert_quicksight_to_sigma MCP / --converted fallback applies'
+    end
+  [conv, build_dir, desc]
+end
+
 opts = { region: 'us-east-1' }
 OptionParser.new do |o|
   o.on('--analysis-id ID')  { |v| opts[:analysis] = v }
@@ -81,7 +104,18 @@ OptionParser.new do |o|
   o.on('--actuals PATH')    { |v| opts[:actuals]  = File.expand_path(v) }
   o.on('--extract-mode')    {     opts[:extract]  = true }
   o.on('--extract-tol F', Float) { |v| opts[:tol] = v }
+  # Resolve + print which converter would run (vendored vs explicit dev build), then
+  # exit 0 — no creds/args needed. Used by the converter-default regression test.
+  o.on('--print-converter') {     opts[:print_converter] = true }
 end.parse!
+
+VENDORED_QS = File.expand_path('../converter/quicksight.mjs', __dir__)
+if opts[:print_converter]
+  conv, _bd, desc = resolve_converter(opts[:mcp_dir] || ENV['QS_MCP_DIR'], VENDORED_QS, 'quicksight.js')
+  puts(conv || 'none')
+  puts desc
+  exit 0
+end
 
 abort 'missing --analysis-id (or --from-fixtures)' unless opts[:analysis] || opts[:fixtures]
 abort 'missing --account-id (live discovery)' if opts[:analysis] && !opts[:fixtures] && !opts[:account]
@@ -93,24 +127,15 @@ if opts[:conn] !~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
   abort "FATAL: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}"
 end
 
-# Local converter build. The skill defers DM conversion to the sigma-data-model-mcp
-# `convert_quicksight_to_sigma` tool; that tool is an ESM module not loadable from a
-# plain shell, so we import its exported convertQuickSightToSigma() directly via a tiny
-# node shim. No hardcoded developer paths (mirrors migrate-powerbi.rb): resolve from
-# --mcp-dir / QS_MCP_DIR, else probe common clone locations under $HOME. When NONE is
-# found, Phase 2 does NOT abort — it prints the convert-model.rb --emit-mcp request and
-# gates; resume with --converted <mcp tool result> (the default route without a build).
-MCP_DIR = [opts[:mcp_dir], ENV['QS_MCP_DIR'],
-           File.expand_path('~/Desktop/sigma-data-model-mcp'),
-           File.expand_path('~/sigma-data-model-mcp')]
-          .compact.find { |d| File.exist?(File.join(d, 'build', 'quicksight.js')) }
-# ZERO-config local converter: a dev's build (above) wins, else the self-contained
-# bundle VENDORED in the skill (converter/quicksight.mjs) — no clone, no npm, no
-# network, no MCP. CONV_MODULE is what the Phase-2 shim imports; nil only if the
-# bundle is also absent (then --converted / the MCP gate applies).
-VENDORED_QS = File.expand_path('../converter/quicksight.mjs', __dir__)
-CONV_MODULE = MCP_DIR ? File.join(MCP_DIR, 'build', 'quicksight.js') :
-              (File.exist?(VENDORED_QS) ? VENDORED_QS : nil)
+# Converter resolution (issue #227): the pinned VENDORED bundle is the DEFAULT so a
+# dev machine and a customer machine convert identically. A local sigma-data-model-mcp
+# build is used ONLY via explicit --mcp-dir / QS_MCP_DIR — no silent auto-discovery of
+# ~/… checkouts (that was the "works in my demo, differs for the customer" footgun).
+# CONV_MODULE is what the Phase-2 shim imports; nil only if the bundle is also absent
+# (then --converted / the convert_quicksight_to_sigma MCP tool gate applies).
+CONV_MODULE, MCP_DIR, CONVERTER_DESC =
+  resolve_converter(opts[:mcp_dir] || ENV['QS_MCP_DIR'], VENDORED_QS, 'quicksight.js')
+warn "converter: #{CONVERTER_DESC}"
 
 name_slug = (opts[:analysis] || File.basename(opts[:fixtures].to_s)).gsub(/[^A-Za-z0-9_-]/, '-')
 WORK = opts[:out] || File.expand_path("~/quicksight-migration/#{name_slug}")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -692,26 +692,28 @@ if mechanical
     line "WARN: TABLEAU_MCP_BUILD=#{mcp_build} does not exist — ignoring"
     mcp_build = nil
   end
-  # Auto-discover a LOCAL converter build when TABLEAU_MCP_BUILD is unset, so the
+  # Resolve the LOCAL converter build when TABLEAU_MCP_BUILD is unset, so the
   # no-egress local path is the ZERO-config default — the mechanical path runs
   # without any setup instead of dropping to the manual STOP. The VENDORED build
-  # (converter/tableau.js, shipped inside this skill) is the guaranteed final
+  # (converter/tableau.mjs, shipped inside this skill) is the guaranteed final
   # fallback: no clone, no npm install, no network. The local converter is NOT a
   # server — it's a pure function (XML → Sigma JSON) run via `node`; nothing
   # leaves the box. First hit wins; purely filesystem (never the network), so a
-  # miss just falls through to the consent/STOP logic below. Earlier entries (env
-  # override, a local sigma-data-model-mcp checkout) win when present, so a dev
-  # with a fresher converter still uses it. Set TABLEAU_MCP_BUILD to override.
+  # miss just falls through to the consent/STOP logic below.
+  #
+  # issue #227: a local dev checkout is used ONLY when EXPLICITLY pointed at —
+  # TABLEAU_MCP_BUILD, SIGMA_DATA_MODEL_MCP, or the fetch-converter.sh vendor
+  # target. There is NO silent auto-discovery of ~/… checkouts (that made a dev's
+  # machine convert differently from a customer's). Otherwise the pinned vendored
+  # bundle runs, so output is identical everywhere.
   # Explicit `--converter hosted` is a deliberate opt-in to off-box conversion —
-  # don't let local auto-discovery (esp. the always-present vendored build)
-  # silently override it. SIGMA_CONVERTER_ALLOW_HOSTED is only a *permission*, not
-  # a preference, so it still prefers local when a build is found.
+  # don't let local resolution (esp. the always-present vendored build) silently
+  # override it. SIGMA_CONVERTER_ALLOW_HOSTED is only a *permission*, not a
+  # preference, so it still prefers local when a build is found.
   if mcp_build.nil? && opts[:converter] != 'hosted'
     auto = [
       (ENV['SIGMA_DATA_MODEL_MCP'] && File.join(ENV['SIGMA_DATA_MODEL_MCP'], 'build', 'tableau.js')),
-      File.join(HERE, 'vendor', 'sigma-data-model-mcp', 'build', 'tableau.js'), # fetch-converter.sh target (gitignored)
-      File.expand_path('~/sigma-data-model-mcp/build/tableau.js'),
-      File.expand_path('~/Desktop/sigma-data-model-mcp/build/tableau.js'),
+      File.join(HERE, 'vendor', 'sigma-data-model-mcp', 'build', 'tableau.js'), # fetch-converter.sh target (gitignored, explicit dev opt-in)
       File.expand_path('../converter/tableau.mjs', HERE) # vendored in-skill — always present
     ].compact.find { |p| File.exist?(p) }
     if auto


### PR DESCRIPTION
Closes #227.

## Why
Even after #226 pointed the docs at the "local" converter, the orchestrators **silently auto-discovered a developer's `~/sigma-data-model-mcp` checkout** and used it in preference to the pinned vendored bundle (qlik even hardcoded `/Users/tjwells/...`). So a dev's machine converted through *their* build while a customer converted through the vendored `.mjs` — identical input, **different output**. This was the deeper cause of "customers see different behavior than the demo."

## What changed
Each orchestrator now **defaults to the pinned vendored bundle** and uses a local build **only via an explicit opt-in**; there is **no implicit `~/…` probing**. Every run prints a loud `converter: …` provenance line (vendored + pinned commit, or the explicit dev-build path).

| Converter | Removed (implicit) | Kept (explicit opt-in) |
|---|---|---|
| powerbi | `~/Desktop`, `~/` probes | `--mcp-dir` / `PBI_MCP_DIR` |
| quicksight | `~/Desktop`, `~/` probes | `--mcp-dir` / `QS_MCP_DIR` |
| qlik | **hardcoded `/Users/tjwells/...`** | `QLIK_MCP_DIR` |
| looker | `CONVERTER_HOMES` auto-discovery | `CONVERTER_SRC` / `CONVERTER_PATH` (skew-warn retained) |
| tableau | two `~/…/build/tableau.js` probes | `TABLEAU_MCP_BUILD`, `SIGMA_DATA_MODEL_MCP`, fetch-target, vendored floor |

## Testing (end-to-end)
- **New creds-free regression test** `corpus/converter-default-test.sh`, wired into `corpus-check.yml`:
  - *static* — no `~/` or `/Users/<name>/` sigma-data-model-mcp probe may reappear in any orchestrator
  - *dynamic* — with a planted fake `~/sigma-data-model-mcp` checkout + clean env, each orchestrator (`--print-converter`) resolves to the **vendored** bundle; with the explicit env var it resolves to the **dev build**
- **Real conversion**: the vendored qlik bundle converts the `exec-overview` corpus fixture end-to-end (11 elements / 231 columns / 13 metrics / 5 relationships, 0 warnings).
- Local: `corpus --check` 14/14, converter-default **ALL PASS**, shared-lib drift OK, all 5 orchestrators parse.

## Notes
- `--print-converter` was added to powerbi/quicksight/qlik/looker (clean top-level resolution). Tableau's resolution is mid-flow in a high-traffic path, so it's covered by the *static* guard + its existing loud logging rather than a `--print-converter` mode — called out here intentionally.
- Not addressed here (separate tickets): #228 get-token.sh drift, #229 sisense hardcoded path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)