### PR TITLE
fix(#228): reconcile get-token.sh drift; promote paste-error checks to canonical

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get-token.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get-token.sh
@@ -17,6 +17,19 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
 RESPONSE=$(curl -sf -X POST \
@@ -25,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get-token.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get-token.sh
@@ -17,6 +17,19 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
 RESPONSE=$(curl -sf -X POST \
@@ -25,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get-token.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get-token.sh
@@ -17,6 +17,19 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
 RESPONSE=$(curl -sf -X POST \
@@ -25,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get-token.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get-token.sh
@@ -17,6 +17,19 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
 RESPONSE=$(curl -sf -X POST \
@@ -25,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get-token.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get-token.sh
@@ -17,6 +17,19 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
 RESPONSE=$(curl -sf -X POST \
@@ -25,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get-token.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get-token.sh
@@ -17,6 +17,19 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
 RESPONSE=$(curl -sf -X POST \
@@ -25,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get-token.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get-token.sh
@@ -5,9 +5,30 @@
 
 set -euo pipefail
 
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
 : "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
 
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
@@ -17,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get-token.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get-token.sh
@@ -6,15 +6,29 @@
 set -euo pipefail
 
 # Agent-neutral credential bootstrap. Claude Code auto-loads creds from
-# ~/.claude/settings.json into the env; other agents (Cursor, plain shell)
-# don't. If the creds aren't already present, source the neutral cred file.
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
 if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
   . "$HOME/.sigma-migration/env"
 fi
 
-: "${SIGMA_BASE_URL:?Set SIGMA_BASE_URL (e.g. https://api.sigmacomputing.com)}"
-: "${SIGMA_CLIENT_ID:?Set SIGMA_CLIENT_ID}"
-: "${SIGMA_CLIENT_SECRET:?Set SIGMA_CLIENT_SECRET}"
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
 
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
@@ -24,10 +38,15 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 
-TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null)
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null \
+  || echo "$RESPONSE" | ruby -r json -e "print JSON.parse(STDIN.read)['access_token']")
 
 if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   echo "Token exchange failed — response did not contain access_token" >&2

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-token.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-token.sh
@@ -17,6 +17,19 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
 RESPONSE=$(curl -sf -X POST \
@@ -25,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get-token.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get-token.sh
@@ -17,6 +17,19 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
 RESPONSE=$(curl -sf -X POST \
@@ -25,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh
@@ -17,6 +17,19 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
 RESPONSE=$(curl -sf -X POST \
@@ -25,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -240,14 +240,13 @@
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get-token.sh",
         "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get-token.sh",
-        {
-          "path": "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get-token.sh",
-          "exception": "Intentional: credential sanity-check additions (looker postmortem 2026-06-18)."
-        },
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get-token.sh",
         "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get-token.sh",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get-token.sh",
         "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get-token.sh",
         "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get-token.sh",
+        "plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get-token.sh",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get-token.sh",
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-token.sh",
         "plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get-token.sh",
         "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh"

--- a/shared/scripts/get-token.sh
+++ b/shared/scripts/get-token.sh
@@ -17,6 +17,19 @@ fi
 : "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
 : "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
 
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 
 RESPONSE=$(curl -sf -X POST \
@@ -25,6 +38,10 @@ RESPONSE=$(curl -sf -X POST \
   -d "grant_type=client_credentials" \
   "$SIGMA_BASE_URL/v2/auth/token") || {
     echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
     exit 1
   }
 


### PR DESCRIPTION
Closes #228.

## Why
The shared credential loader `scripts/get-token.sh` had drifted into **4 distinct versions across 13 copies**, and inconsistent auth behavior is exactly the kind of "works in skill X, fails in skill Y" the audit was chasing. Two copies had **escaped the drift gate entirely** because they were never listed as manifest targets.

## Findings
- **sisense** & **sigma-authoring/custom-sql-to-data-model** — stale forks, **not tracked** by `shared/manifest.json`. sigma-authoring's copy even lacked the agent-neutral `~/.sigma-migration/env` bootstrap, so it would fail under Cursor / plain shell where the others succeed.
- **looker** — an *intentional*, allowlisted superset: pre-flight credential sanity checks from the 2026-06-18 postmortem (catches `SIGMA_CLIENT_SECRET` pasted equal to `SIGMA_CLIENT_ID` — the #1 opaque auth blocker — plus char-length hints on failure).

## Fix
- **Promote looker's version to canonical** `shared/scripts/get-token.sh`, so *every* skill gets the paste-error diagnostics (max consistency + strictly better failure messages).
- **Add the two untracked copies** (sisense, sigma-authoring) as manifest targets; **drop looker's allowlist exception** (now identical to canonical).
- Re-sync canonical to all 12 targets via `tools/sync-shared.rb`.

## Result / testing
- All **13 copies byte-identical**; `check-shared.rb`: **265 copies match, 0 allowlisted exceptions**. Future drift now fails CI for *every* copy (the gate gap is closed).
- Verified: all copies parse (`bash -n`); the paste-error guard now fires on a **non-looker** skill (sisense); missing creds produce the actionable `Run scripts/setup.rb` message.

Remaining audit tickets: #229 (sisense hardcoded path), #230 (phase spine), #231 (Group B docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)