### PR TITLE
fix(#229): sisense fetch_inodes.py — portable output path + parameterized dataset

### DIFF
--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/fetch_inodes.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/fetch_inodes.py
@@ -1,17 +1,42 @@
 #!/usr/bin/env python3
-"""Fetch Sigma table inode IDs + warehouse paths for the SISENSE_ECOMMERCE schema.
-Writes inodes.json {TABLE_UPPER: {inodeId, path:[db,schema,table]}}."""
-import os, json, subprocess, sys
-BASE=os.environ["SIGMA_BASE_URL"].rstrip("/"); TOK=os.environ["SIGMA_API_TOKEN"]
+"""Fetch Sigma table inode IDs + warehouse paths for a schema.
+Writes inodes.json {TABLE_UPPER: {inodeId, path:[db,schema,table]}}.
+
+Portable (issue #229): the output path and the db/schema are arguments, not
+hardcoded to one machine/dataset. Defaults match the SISENSE_ECOMMERCE sample so
+the reference demo still runs with no flags; override for any other tenant."""
+import os, json, subprocess, sys, argparse
+
+ap = argparse.ArgumentParser(description="Resolve Sigma table inode ids for a schema")
+ap.add_argument("--database", default="CSA", help="warehouse database (default: CSA)")
+ap.add_argument("--schema", default="SISENSE_ECOMMERCE",
+                help="warehouse schema to match (default: SISENSE_ECOMMERCE)")
+ap.add_argument("--out", default=os.path.expanduser("~/sisense-migration/inodes.json"),
+                help="output path (default: ~/sisense-migration/inodes.json)")
+ap.add_argument("--min", type=int, default=1,
+                help="exit non-zero if fewer than this many tables resolve (default: 1)")
+a = ap.parse_args()
+
+BASE = os.environ["SIGMA_BASE_URL"].rstrip("/")
+TOK = os.environ["SIGMA_API_TOKEN"]
+
+
 def files():
-    out=subprocess.run(["curl","-s",f"{BASE}/v2/files?typeFilters=table&limit=2000",
-        "-H",f"Authorization: Bearer {TOK}"],capture_output=True,text=True).stdout
-    return json.loads(out).get("entries",[])
-ents=[e for e in files() if 'SISENSE_ECOMMERCE' in (e.get('path') or '')]
-inodes={}
+    out = subprocess.run(
+        ["curl", "-s", f"{BASE}/v2/files?typeFilters=table&limit=2000",
+         "-H", f"Authorization: Bearer {TOK}"],
+        capture_output=True, text=True).stdout
+    return json.loads(out).get("entries", [])
+
+
+ents = [e for e in files() if a.schema in (e.get("path") or "")]
+inodes = {}
 for e in ents:
-    name=e.get("name")
-    inodes[name.upper()]={"inodeId":e.get("id"),"path":["CSA","SISENSE_ECOMMERCE",name]}
-json.dump(inodes,open("/Users/tjwells/sisense-migration/inodes.json","w"),indent=2)
-print(f"{len(inodes)}/4 tables:", list(inodes.keys()))
-sys.exit(0 if len(inodes)>=4 else 1)
+    name = e.get("name")
+    inodes[name.upper()] = {"inodeId": e.get("id"),
+                            "path": [a.database, a.schema, name]}
+
+os.makedirs(os.path.dirname(a.out) or ".", exist_ok=True)
+json.dump(inodes, open(a.out, "w"), indent=2)
+print(f"{len(inodes)} table(s) → {a.out}:", list(inodes.keys()))
+sys.exit(0 if len(inodes) >= a.min else 1)


### PR DESCRIPTION
Closes #229.

## Why
`fetch_inodes.py` wrote to a hardcoded `/Users/tjwells/sisense-migration/inodes.json` — on any other machine it errors (missing dir) or writes where nothing reads it. It also hardcoded the `CSA`/`SISENSE_ECOMMERCE` dataset and a `>=4` table success gate, so it only ever worked for the author's demo.

## Fix (defaults preserve the reference-demo behavior)
- `--out` (default `~/sisense-migration/inodes.json`, via `expanduser` + `makedirs`) replaces the literal home path and prints the resolved path.
- `--database` / `--schema` (defaults `CSA` / `SISENSE_ECOMMERCE`) parameterize the dataset.
- `--min` (default `1`) replaces the hardcoded `>=4` gate.

`inodes.json` is passed explicitly to `convert.py` downstream, so nothing else assumes the old path.

## Testing (creds-free)
Stubbed `curl` on PATH returning canned `/v2/files` JSON: the script writes to a custom **nested** `--out` (dir auto-created), filters correctly by `--schema` (drops an out-of-schema table), emits the right structure, and exits 0. `py_compile` passes; no `/Users/` path remains.

Remaining audit tickets: #230 (phase spine), #231 (Group B docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)