### PR TITLE
docs(#231): document Group B bespoke-converter architecture (gooddata/mstr/sisense)

### DIFF
--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
@@ -42,6 +42,17 @@ and all data-model authoring to **sigma-data-models**.
 - `refs/viz-type-mapping.md` — insight + dashboard → Sigma element mapping.
 - `refs/design-notes.md` — full architecture, parity, RLS, risks, build order.
 
+## Converter architecture (read if you know the other migration skills)
+
+Unlike the **Group-A** converters (tableau, powerbi, qlik, quicksight, looker,
+thoughtspot, cognos) — which share the vendored `sigma-data-model-mcp` engine
+(`converter/*.mjs`, with the hosted `convert_*` MCP tool as a fallback) — this
+skill uses a **self-contained Python converter that ships in `scripts/`**
+(`convert.py` + `maql.py`). It runs locally via `python3`; there is **no vendored
+`.mjs` bundle, no `convert_gooddata_to_sigma` MCP tool, and no `--converter` /
+`*_MCP_DIR` override** — those concepts do not apply here. Nothing about the model
+conversion leaves your machine.
+
 ## Phases
 
 **Phase 0 — Assess.** Run the `gooddata-assessment` skill for an inventory +

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -21,6 +21,17 @@ user-invocable: true
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.
 
+## Converter architecture (read if you know the other migration skills)
+
+Unlike the **Group-A** converters (tableau, powerbi, qlik, quicksight, looker,
+thoughtspot, cognos) — which share the vendored `sigma-data-model-mcp` engine
+(`converter/*.mjs`, with the hosted `convert_*` MCP tool as a fallback) — this
+skill uses a **self-contained Python converter that ships in `scripts/`**
+(`convert.py`). It runs locally via `python3`; there is **no vendored `.mjs`
+bundle, no `convert_microstrategy_to_sigma` MCP tool, and no `--converter` /
+`*_MCP_DIR` override** — those concepts do not apply here. Nothing about the model
+conversion leaves your machine.
+
 ## Phase 0a — Choose where to build (ask first; `--folder-id` is required downstream)
 
 Don't pick the destination folder for the user. `convert.py` requires `--folder-id`,

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
@@ -67,6 +67,17 @@ widgets) — never emit confidently-wrong logic.
   pointing both tools at it — see `refs/design-notes.md` ("Snowflake-parity").
 - **Python 3** (stdlib only).
 
+## Converter architecture (read if you know the other migration skills)
+
+Unlike the **Group-A** converters (tableau, powerbi, qlik, quicksight, looker,
+thoughtspot, cognos) — which share the vendored `sigma-data-model-mcp` engine
+(`converter/*.mjs`, with the hosted `convert_*` MCP tool as a fallback) — this
+skill uses a **self-contained Python converter that ships in `scripts/`**
+(`convert.py` + `jaql_expr.py`). It runs locally via `python3`; there is **no
+vendored `.mjs` bundle, no `convert_sisense_to_sigma` MCP tool, and no
+`--converter` / `*_MCP_DIR` override** — those concepts do not apply here. Nothing
+about the model conversion leaves your machine.
+
 ## Phase 0 — Assess (optional)
 Run the `sisense-assessment` skill for an estate inventory + converter-coverage
 scoring before committing to conversions.


### PR DESCRIPTION
Closes #231.

## Why
The repo has two converter families and the split was undocumented:
- **Group A** (tableau, powerbi, qlik, quicksight, looker, thoughtspot, cognos): shared `sigma-data-model-mcp` engine, vendored as `converter/*.mjs`, hosted MCP as fallback, with `--converter` / `*_MCP_DIR` overrides.
- **Group B** (gooddata, microstrategy, sisense): **self-contained Python converters** (`scripts/convert.py` + helpers like `maql.py` / `jaql_expr.py`). No vendored `.mjs`, no `convert_*_to_sigma` MCP tool, no `--converter` flag.

Readers/agents assumed the Group-A model applied to all converters, which is a source of wrong expectations and inconsistent phrasing.

## What changed
Added a short, consistent **"Converter architecture"** note to each of the three Group B `SKILL.md` files (tailored to that skill's actual scripts) stating the local-Python design and that the vendored-bundle / MCP-tool / `--converter` / `*_MCP_DIR` concepts do not apply. Docs-only.

Remaining audit ticket: #230 (phase-spine standardization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)