### PR TITLE
docs(#230 part 1): stabilize fragile cross-skill phase-number references

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -176,7 +176,7 @@ Emits the Sigma data-model JSON on stdout; stats + warnings on stderr. Read the
 warnings aloud to the user — they are the parts that need manual authoring
 (running-totals, cross-element metrics, FIXED-LOD-style calcs, localization).
 
-## Phase 1.5 — Reuse an existing DM? (avoid sprawl — mirrors tableau Phase 1.5 / powerbi Phase 3.5)
+## Phase 1.5 — Reuse an existing DM? (avoid sprawl — the reuse-first DM gate every converter runs before building)
 
 Before POSTing a NEW data model in Phase 2, check whether an existing Sigma DM already
 covers the same warehouse tables (don't add a 4th near-identical DM for the same module):

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -497,7 +497,7 @@ shapes so you recognize a regression:
 > bug. Verify metric values via the **raw aggregate** (`Sum(...)`, `CountDistinct(...)`), not via
 > `metric()`.
 
-### Phase 2.5 — Reuse an existing DM? (run BEFORE 2c — avoid sprawl, mirrors tableau Phase 1.5 / powerbi Phase 3.5)
+### Phase 2.5 — Reuse an existing DM? (run BEFORE 2c — avoid sprawl; the reuse-first DM gate every converter runs before building)
 
 Before POSTing a NEW data model, check whether an existing Sigma DM already covers the
 same warehouse tables (don't add a 4th near-identical "Orders" DM):

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -248,7 +248,7 @@ the converter emits a deterministic SQL element reproducing the grid. Read
 the live validation, so the bundled fixture runs end-to-end without a
 Strategy One instance.)
 
-## Phase 2.6 — Reuse an existing DM? (avoid sprawl — mirrors tableau Phase 1.5 / cognos Phase 1.5)
+## Phase 2.6 — Reuse an existing DM? (avoid sprawl — the reuse-first DM gate every converter runs before building)
 
 Before POSTing a new data model, score the org's existing Sigma DMs against this
 dossier's tables/columns and reuse on a strong match — don't create a 4th

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -108,7 +108,7 @@ resume with `--converter-out`. The hosted MCP is a fallback, not the default pat
 - **Known gap `j89`**: the Snowflake `Snowflake.Databases(...) + Navigation` M pattern isn't parsed → pass `database`/`schema` explicitly until fixed.
 - **DAX gaps → gap-scout**: for measures the converter buckets `b` (restructure) or `c` (no-equivalent) — `RANKX`, `ALLEXCEPT`, `SUMMARIZE`, `USERELATIONSHIP`, `PATH*` — spawn the **gap-scout** sub-agent (`scripts/gap-scout.md`): it proposes a Sigma translation, validates it against the live API (`scripts/scout-validate.py`), and persists the rule to `~/.powerbi-to-sigma/learned-rules.yaml` (loaded by `scripts/learned-rules.py`) so future conversions auto-apply it. Time-intelligence (YTD/SPLY) is usually translatable — see `refs/measure-patterns.md`, not the scout.
 
-## Phase 3.5 — Reuse an existing DM? (avoid sprawl — mirrors tableau Phase 1.5)
+## Phase 3.5 — Reuse an existing DM? (avoid sprawl — the reuse-first DM gate every converter runs before building)
 Before posting a NEW data model, check whether an existing Sigma DM already
 covers the same warehouse tables (don't add a 4th near-identical "Orders" DM):
 ```

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -213,7 +213,7 @@ POST-block the whole DM), inter-record `Above/Below/Peek/Previous/RowNo`, rankin
 converter emits an `ℹ … references fields from N elements` warning — host that metric on
 the **denormalized element** (which carries all fields) or it errors as cross-element.
 
-## Phase 2.5 — Reuse an existing DM? (avoid sprawl — mirrors tableau Phase 1.5)
+## Phase 2.5 — Reuse an existing DM? (avoid sprawl — the reuse-first DM gate every converter runs before building)
 Before building a NEW data model in Phase 3, check whether an existing Sigma DM already
 covers the same warehouse tables (don't add a 4th near-identical "Orders" DM):
 ```bash

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -131,7 +131,7 @@ What the converter handles vs. what it doesn't (see `refs/migration-test-slate.m
 
 For an untranslated calc-field expression, spawn the **gap-scout subagent** (see `scripts/gap-scout.md`): it proposes a Sigma formula, validates it against the live DM via `scripts/scout-validate-and-persist.rb`, and on success persists a rule to `~/.quicksight-to-sigma/learned-rules.yaml` (customer home — `git pull` can't clobber; the build script auto-applies it next run via `LearnedRules.load`). On failure the scout returns an **opt-in** `escalate-gap.py` command — filing a tracking issue is never automatic: run the returned `escalation.dry_run_cmd` to draft the issue (shows target repo + dedupe), show the user, and only re-run with `--yes` if they accept. Calc-field gaps route to the converter repos (`sigma-data-model-manager` + `sigma-data-model-mcp`, mirrored) with a cross-linked bead.
 
-## Phase 3.5 — Reuse an existing DM? (avoid sprawl — mirrors tableau Phase 1.5 / powerbi Phase 3.5)
+## Phase 3.5 — Reuse an existing DM? (avoid sprawl — the reuse-first DM gate every converter runs before building)
 
 Before Phase 4 POSTs a NEW data model, check whether an existing Sigma DM already covers
 the same warehouse tables (don't add a 4th near-identical "Orders" DM):

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -212,7 +212,7 @@ python3 scripts/migrate.py --model-tml fixtures/retail-analytics-model.tml \
       then **re-render and re-read**.
    3. Loop until the render passes inspection.
 
-## Step 2.5 — Reuse an existing DM? (between convert and POST — mirrors tableau Phase 1.5 / powerbi Phase 3.5)
+## Step 2.5 — Reuse an existing DM? (between convert and POST — the reuse-first DM gate every converter runs before building)
 
 Before step 2 POSTs a NEW data model, check whether an existing Sigma DM already covers
 the same warehouse tables (don't add a 4th near-identical DM for the same star):


### PR DESCRIPTION
Part 1 of #230 (the safe half).

## Why
Every converter's "Reuse an existing DM?" heading hardcoded a cross-reference to *another* converter's phase **number** — e.g. `(avoid sprawl — mirrors tableau Phase 1.5 / powerbi Phase 3.5)`. Those references rot the instant any converter renumbers, and they were a maintainability trap flagged in the audit.

## What changed
Replaced all 7 with a stable, number-free phrase: `the reuse-first DM gate every converter runs before building`. **No phase numbers changed; docs-only.**

## Scope note — the other half of #230 is intentionally deferred
The number-*alignment* half (making the same semantic phase share one number fleet-wide, e.g. Convert always = Phase 2) is **not** in this PR. It cascades into **~225** hardcoded `Phase 6` / `assert-phase6-ran` / `phase6-parity` references across scripts and gates, so it needs a code+docs lockstep migration (ideally one converter per PR, CI-gated) rather than a docs pass. Recommendation + plan posted on #230; leaving that issue open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)