### PR TITLE
feat(tableau): support self-hosted Tableau Server

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/tableau_rest.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/tableau_rest.rb
@@ -175,6 +175,41 @@ module Tableau
     list.first
   end
 
+  # ---- server capabilities -------------------------------------------------
+  # Tableau Cloud always exposes the latest REST API, VDS, and the Metadata API.
+  # A self-hosted Tableau Server is pinned to its installed release and ships
+  # with VDS (2024.2+) and the Metadata API OFF by default — so the discovery
+  # path must know which capabilities are live before it leans on them.
+
+  # Server-level info (no site scope). Returns e.g.
+  #   {"productVersion"=>{"value"=>"2024.2", ...}, "restApiVersion"=>"3.23"}
+  def serverinfo
+    request(:get, "/api/#{api_version}/serverinfo")['serverInfo']
+  end
+
+  # Is the Metadata API (GraphQL) turned on? Always on in Cloud; DISABLED BY
+  # DEFAULT on Tableau Server (admin enables via `tsm maintenance
+  # metadata-services enable`). When off the endpoint 404s and calc-formula
+  # extraction falls back to parsing the .twb XML.
+  def metadata_api_available?
+    r = graphql('{ __typename }')
+    !r.nil? && (r['errors'].nil? || r['errors'].empty?)
+  rescue Error
+    false
+  end
+
+  # Best-effort capability summary for the discovery banner. `vds` is left nil:
+  # VDS has no auth-free ping, so the discover pool detects it per datasource and
+  # falls back to .twb on failure. Never raises.
+  def capabilities
+    info = (serverinfo rescue nil) || {}
+    {
+      'product_version'  => info.dig('productVersion', 'value'),
+      'rest_api_version' => info['restApiVersion'] || api_version,
+      'metadata_api'     => (metadata_api_available? rescue false),
+    }
+  end
+
   # VizQL Data Service — full field list with calc formulas. This is the REST equivalent
   # of mcp__tableau__get-datasource-metadata.
   def read_metadata(datasource_luid)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/tableau_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/tableau_rest.rb
@@ -175,6 +175,41 @@ module Tableau
     list.first
   end
 
+  # ---- server capabilities -------------------------------------------------
+  # Tableau Cloud always exposes the latest REST API, VDS, and the Metadata API.
+  # A self-hosted Tableau Server is pinned to its installed release and ships
+  # with VDS (2024.2+) and the Metadata API OFF by default — so the discovery
+  # path must know which capabilities are live before it leans on them.
+
+  # Server-level info (no site scope). Returns e.g.
+  #   {"productVersion"=>{"value"=>"2024.2", ...}, "restApiVersion"=>"3.23"}
+  def serverinfo
+    request(:get, "/api/#{api_version}/serverinfo")['serverInfo']
+  end
+
+  # Is the Metadata API (GraphQL) turned on? Always on in Cloud; DISABLED BY
+  # DEFAULT on Tableau Server (admin enables via `tsm maintenance
+  # metadata-services enable`). When off the endpoint 404s and calc-formula
+  # extraction falls back to parsing the .twb XML.
+  def metadata_api_available?
+    r = graphql('{ __typename }')
+    !r.nil? && (r['errors'].nil? || r['errors'].empty?)
+  rescue Error
+    false
+  end
+
+  # Best-effort capability summary for the discovery banner. `vds` is left nil:
+  # VDS has no auth-free ping, so the discover pool detects it per datasource and
+  # falls back to .twb on failure. Never raises.
+  def capabilities
+    info = (serverinfo rescue nil) || {}
+    {
+      'product_version'  => info.dig('productVersion', 'value'),
+      'rest_api_version' => info['restApiVersion'] || api_version,
+      'metadata_api'     => (metadata_api_available? rescue false),
+    }
+  end
+
   # VizQL Data Service — full field list with calc formulas. This is the REST equivalent
   # of mcp__tableau__get-datasource-metadata.
   def read_metadata(datasource_luid)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/tableau_rest.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/tableau_rest.rb
@@ -175,6 +175,41 @@ module Tableau
     list.first
   end
 
+  # ---- server capabilities -------------------------------------------------
+  # Tableau Cloud always exposes the latest REST API, VDS, and the Metadata API.
+  # A self-hosted Tableau Server is pinned to its installed release and ships
+  # with VDS (2024.2+) and the Metadata API OFF by default — so the discovery
+  # path must know which capabilities are live before it leans on them.
+
+  # Server-level info (no site scope). Returns e.g.
+  #   {"productVersion"=>{"value"=>"2024.2", ...}, "restApiVersion"=>"3.23"}
+  def serverinfo
+    request(:get, "/api/#{api_version}/serverinfo")['serverInfo']
+  end
+
+  # Is the Metadata API (GraphQL) turned on? Always on in Cloud; DISABLED BY
+  # DEFAULT on Tableau Server (admin enables via `tsm maintenance
+  # metadata-services enable`). When off the endpoint 404s and calc-formula
+  # extraction falls back to parsing the .twb XML.
+  def metadata_api_available?
+    r = graphql('{ __typename }')
+    !r.nil? && (r['errors'].nil? || r['errors'].empty?)
+  rescue Error
+    false
+  end
+
+  # Best-effort capability summary for the discovery banner. `vds` is left nil:
+  # VDS has no auth-free ping, so the discover pool detects it per datasource and
+  # falls back to .twb on failure. Never raises.
+  def capabilities
+    info = (serverinfo rescue nil) || {}
+    {
+      'product_version'  => info.dig('productVersion', 'value'),
+      'rest_api_version' => info['restApiVersion'] || api_version,
+      'metadata_api'     => (metadata_api_available? rescue false),
+    }
+  end
+
   # VizQL Data Service — full field list with calc formulas. This is the REST equivalent
   # of mcp__tableau__get-datasource-metadata.
   def read_metadata(datasource_luid)

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/SKILL.md
@@ -6,8 +6,9 @@ user-invocable: true
 
 # Tableau Assessment
 
-Surveys a Tableau Cloud site via the Tableau Admin Insights project (MCP) and the
-workbook-content REST endpoint (PAT). Emits a markdown readout + JSON inventory
+Surveys a Tableau **Cloud** site via the Tableau Admin Insights project (MCP) and the
+workbook-content REST endpoint (PAT) — or a self-hosted **Tableau Server** site via REST
+only (`inventory-rest.rb`; no Admin Insights, so no usage/refresh stats). Emits a markdown readout + JSON inventory
 the user can hand to a Sigma rep, a Hakkoda engagement, or directly to the
 `tableau-to-sigma` skill for conversion of the shortlisted workbooks.
 
@@ -69,6 +70,7 @@ permissions audit, dataset similarity at depth). Those still live in Hakkoda.
 | `scripts/setup-tableau.sh` | Symlink to the tableau-to-sigma PAT setup wizard |
 | `scripts/get-tableau-token.sh` | Symlink to the tableau-to-sigma token-refresh wrapper |
 | `scripts/probe-admin-insights.rb` | Confirm the Admin Insights project is visible (gates whether license/refresh/usage sections run) |
+| `scripts/inventory-rest.rb` | **Tableau Server fallback** for Phases 1–2: build `inventory.json` (`mode: rest-server`, counts + per-workbook sheet_count, `usage_available: false`) from the plain REST workbooks/views/datasources endpoints. No usage/refresh (needs Admin Insights or the Server repository DB). |
 | `scripts/fetch-all-twbs.rb` | Parallel download of all workbook `.twb` files via REST (PAT mode only) |
 | `scripts/aggregate-complexity.rb` | Run `scan-workbook-gaps.rb` (from tableau-to-sigma) against every `.twb`; emit `complexity.json`. Also derives a **predicted-parity %** + A–D band per workbook (y9rd.6): an occurrence-weighted roll-up of the gap-scanner's status tiers (`auto`=1.0, `hint`=0.85, `manual`=0.5, `unhandled`=0.0) — a *pre-migration prediction* from static `.twb` signal, NOT the post-migration measured value-parity score (`verify-parity.rb`). Flags hard workbooks (band C/D) before any conversion. |
 | `scripts/build-shortlist.rb` | Cross-tabulate usage × complexity; rank by `value / (1 + cost)`; emit `shortlist.json` (carries `predicted_parity_pct` + `parity_band`) |
@@ -159,6 +161,26 @@ mcp__tableau__list-views                                         # → view coun
 ```
 
 Write the rolled-up counts to `inventory.json`'s `environment_overview` key.
+
+### Self-hosted Tableau Server (no MCP / no Admin Insights)
+
+Tableau Server has **no Admin Insights project** (that's a Cloud feature) and the hosted
+Tableau MCP targets Cloud, so Phases 1–2 above don't apply. Instead build the inventory
+from the standard REST endpoints with a PAT:
+
+```bash
+eval "$(scripts/get-tableau-token.sh)"            # negotiates the Server's REST API version
+ruby scripts/inventory-rest.rb --out /tmp/assessment-<site>
+```
+
+This writes `inventory.json` (`mode: "rest-server"`) with workbook/datasource/view counts,
+a per-workbook `sheet_count`, and `usage_available: false`. **Usage, license, and refresh
+history are NOT available** over plain REST — they require Admin Insights (Cloud) or the
+Tableau Server **repository** (the "workgroup" Postgres DB an admin must enable). Phase 3
+complexity (`fetch-all-twbs.rb` + `scan-workbook-gaps.rb`) is already REST/PAT and runs
+unchanged. `build-shortlist.rb` detects `usage_available: false` and ranks by complexity
+(easiest first) — it will **not** tag zero-usage workbooks `retire`, since on Server a
+missing access count is not evidence of disuse.
 
 ---
 

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/build-shortlist.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/build-shortlist.rb
@@ -7,12 +7,18 @@
 #   cost  = 10·unhandled + 3·manual + 1·hint
 #   score = value / (1 + cost)
 #
-# Tags:
+# Tags (when usage IS known — Cloud / Admin Insights):
 #   accesses == 0                                 → "retire"
 #   unhandled >= 1                                → "needs-gap-scout"
 #   score >= 20 and (manual + unhandled) == 0     → "migrate-first"
 #   score >= 10                                   → "easy-win"
 #   else                                          → "moderate"
+#
+# When usage is NOT known (inventory 'usage_available' == false, e.g. a Tableau
+# Server REST-only inventory with no Admin Insights / repository DB), we must NOT
+# tag zero-access workbooks "retire" — a missing access count is not proof of
+# disuse. In that mode we rank by inverse complexity (easiest first) and tag on
+# complexity alone.
 #
 # Usage:
 #   ruby scripts/build-shortlist.rb --out /tmp/assessment-<site>
@@ -48,6 +54,11 @@ if usage_by_name.empty?
   end
 end
 
+# usage_available is set explicitly by inventory-rest.rb (Server); for older
+# Cloud inventory.json shapes that predate the flag, infer it from whether any
+# usage rows survived.
+usage_known = inventory.key?('usage_available') ? inventory['usage_available'] : !usage_by_name.empty?
+
 rows = []
 complexity.each do |luid, r|
   name = r['name']
@@ -57,21 +68,36 @@ complexity.each do |luid, r|
   actors   = (usage && usage['actors'])   || 0
 
   cost  = r['n_unhandled'] * 10 + r['n_manual'] * 3 + r['n_hint'] * 1
-  value = accesses * Math.sqrt([actors, 1].max).to_f
-  score = value / (1 + cost).to_f
 
-  tag =
-    if accesses.zero?
-      'retire'
-    elsif r['n_unhandled'] >= 1
-      'needs-gap-scout'
-    elsif score >= 20 && (r['n_manual'] + r['n_unhandled']).zero?
-      'migrate-first'
-    elsif score >= 10
-      'easy-win'
-    else
-      'moderate'
-    end
+  if usage_known
+    value = accesses * Math.sqrt([actors, 1].max).to_f
+    score = value / (1 + cost).to_f
+    tag =
+      if accesses.zero?
+        'retire'
+      elsif r['n_unhandled'] >= 1
+        'needs-gap-scout'
+      elsif score >= 20 && (r['n_manual'] + r['n_unhandled']).zero?
+        'migrate-first'
+      elsif score >= 10
+        'easy-win'
+      else
+        'moderate'
+      end
+  else
+    # No usage signal: rank by inverse complexity (easiest first), tag on
+    # complexity alone. Never "retire" — absence of a count is not disuse.
+    value = nil
+    score = 100.0 / (1 + cost)
+    tag =
+      if r['n_unhandled'] >= 1
+        'needs-gap-scout'
+      elsif (r['n_manual'] + r['n_unhandled']).zero?
+        'easy-win'
+      else
+        'moderate'
+      end
+  end
 
   rows << {
     'name'                 => name,
@@ -86,7 +112,7 @@ complexity.each do |luid, r|
     # Pre-migration parity PREDICTION (y9rd.6) carried through from complexity.json.
     'predicted_parity_pct' => r['predicted_parity_pct'],
     'parity_band'          => r['parity_band'],
-    'value'                => value.round(1),
+    'value'                => value&.round(1),
     'cost'                 => cost,
     'score'                => score.round(2),
     'tag'                  => tag
@@ -97,6 +123,10 @@ rows.sort_by! { |r| -r['score'] }
 
 File.write(File.join(opts[:out], 'shortlist.json'), JSON.pretty_generate(rows))
 puts "wrote shortlist.json (#{rows.size} workbooks)"
+unless usage_known
+  puts "NOTE: no usage data (Tableau Server REST-only inventory) — ranked by complexity"
+  puts "      (easiest first); 'acc' column is 0 for all rows and NOT a retire signal."
+end
 puts
 printf "%-46s %5s %5s %5s %5s %6s %7s %s\n", 'Workbook', 'acc', 'view', 'manl', 'unhd', 'parity', 'score', 'tag'
 rows.each do |r|

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/get-tableau-token.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/get-tableau-token.sh
@@ -6,6 +6,8 @@
 # IMPORTANT: this makes ONE signin attempt. Tableau invalidates a PAT after
 # four consecutive failed signins, so do not wrap this in a retry loop with
 # different name/secret combos — fix the credentials and call once.
+# Works against both Tableau Cloud and self-hosted Tableau Server (the REST
+# signin + serverinfo endpoints are identical; the API version is negotiated).
 
 set -euo pipefail
 
@@ -17,11 +19,40 @@ if [ -z "${TABLEAU_PAT_SECRET:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
 fi
 
 : "${TABLEAU_SERVER_URL:?Run scripts/setup-tableau.rb to configure credentials}"
-: "${TABLEAU_SITE_CONTENT_URL:?Run scripts/setup-tableau.rb to configure credentials}"
 : "${TABLEAU_PAT_NAME:?Run scripts/setup-tableau.rb to configure credentials}"
 : "${TABLEAU_PAT_SECRET:?Run scripts/setup-tableau.rb to configure credentials}"
+# contentUrl may legitimately be EMPTY — that's the Tableau Server "Default" site.
+# Require it to be SET (so we know setup ran) but allow an empty value; a bare
+# `:?` guard would reject the Default site.
+if [ -z "${TABLEAU_SITE_CONTENT_URL+x}" ]; then
+  echo "TABLEAU_SITE_CONTENT_URL not set — run scripts/setup-tableau.rb to configure credentials" >&2
+  exit 1
+fi
 
-API_VER="${TABLEAU_API_VERSION:-3.22}"
+# --- REST API version negotiation -------------------------------------------
+# Tableau Cloud always speaks the latest REST API version, but a self-hosted
+# Tableau Server is pinned to whatever its installed release supports. Signing
+# in against a version the server doesn't know returns a 400 that looks like a
+# credential failure. Ask the server which version it speaks — serverinfo needs
+# NO auth, so the probe never counts against the 4-strike PAT lockout — and use
+# that. An explicit TABLEAU_API_VERSION always wins.
+if [ -n "${TABLEAU_API_VERSION:-}" ]; then
+  API_VER="$TABLEAU_API_VERSION"
+else
+  # 2.4 is supported by every Tableau Server release still in the field and by Cloud.
+  API_VER=$(curl -sS -H "Accept: application/json" \
+    "${TABLEAU_SERVER_URL}/api/2.4/serverinfo" 2>/dev/null | python3 -c "
+import sys, json
+try:
+    print(json.load(sys.stdin)['serverInfo']['restApiVersion'])
+except Exception:
+    print('')
+" 2>/dev/null)
+  if [ -z "$API_VER" ]; then
+    API_VER="3.22"
+    echo "serverinfo probe failed; defaulting to REST API ${API_VER} (override with TABLEAU_API_VERSION)." >&2
+  fi
+fi
 
 RESPONSE=$(curl -sS -X POST \
   -H "Content-Type: application/xml" \
@@ -49,7 +80,8 @@ print(d['credentials']['token'])
     if [ "$ERR_CODE" = "401001" ]; then
       echo >&2
       echo "401001 means the PAT name or secret is wrong — OR the token has been invalidated by 4+" >&2
-      echo "consecutive failed signins. Create a fresh PAT in Tableau Cloud and re-run setup-tableau.rb." >&2
+      echo "consecutive failed signins. Create a fresh PAT (Account Settings → Personal Access" >&2
+      echo "Tokens, on Tableau Server or Cloud) and re-run setup-tableau.rb." >&2
     fi
     exit 1
   fi

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/inventory-rest.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/inventory-rest.rb
@@ -1,0 +1,127 @@
+#!/usr/bin/env ruby
+# REST-only site inventory — the Tableau Server fallback for Phase 1/2.
+#
+# Tableau Cloud exposes the Admin Insights project (usage, licenses, refresh
+# history) that the MCP-driven Phase 2 queries. A self-hosted Tableau Server has
+# NO Admin Insights — the equivalent lives in the Server repository (a separate
+# Postgres "workgroup" DB an admin must enable). This script produces the
+# inventory the downstream pipeline needs (build-shortlist.rb, migration-plan.rb)
+# from the STANDARD REST endpoints alone: workbooks, views, datasources. It does
+# NOT emit usage/refresh stats — those need Admin Insights (Cloud) or the
+# repository DB. Per-workbook complexity still comes from fetch-all-twbs.rb +
+# scan-workbook-gaps.rb (already REST/PAT and Server-compatible).
+#
+# Usage:
+#   eval "$(scripts/get-tableau-token.sh)"
+#   ruby scripts/inventory-rest.rb --out /tmp/assessment-<site>
+#
+# Output:
+#   <out>/inventory.json  — { mode, counts, workbook_inventory, datasource_inventory,
+#                             workbook_usage: [] }  (shape build-shortlist.rb reads)
+
+require 'json'
+require 'fileutils'
+require 'optparse'
+require 'time'
+$LOAD_PATH.unshift File.expand_path('../../tableau-to-sigma/scripts/lib', __dir__)
+require 'tableau_rest'
+
+opts = { exclude_projects: ['Personal Space'] }
+OptionParser.new do |p|
+  p.on('--out DIR') { |v| opts[:out] = v }
+  # Comma-separated. Use --exclude-projects '' to include Personal Space.
+  p.on('--exclude-projects LIST') { |v| opts[:exclude_projects] = v.split(',').map(&:strip).reject(&:empty?) }
+end.parse!
+abort('--out required') unless opts[:out]
+FileUtils.mkdir_p(opts[:out])
+
+# Walk a paginated Tableau REST collection, returning the flattened array.
+# `root`/`item` name the JSON envelope keys, e.g. ('workbooks','workbook').
+def list_all(path, root, item)
+  out = []
+  page = 1
+  loop do
+    sep = path.include?('?') ? '&' : '?'
+    resp = Tableau.request(:get, "#{Tableau.base_path}#{path}#{sep}pageSize=100&pageNumber=#{page}")
+    batch = resp.dig(root, item) || []
+    batch = [batch] unless batch.is_a?(Array)
+    out.concat(batch)
+    total = (resp['pagination'] || {})['totalAvailable'].to_i
+    break if batch.empty? || out.size >= total
+    page += 1
+  end
+  out
+end
+
+caps = (Tableau.capabilities rescue {})
+warn "inventory-rest: product=#{caps['product_version'] || '?'} REST API=#{caps['rest_api_version'] || Tableau.api_version}"
+
+workbooks   = list_all('/workbooks',   'workbooks',   'workbook')
+datasources = list_all('/datasources', 'datasources', 'datasource')
+views       = list_all('/views',       'views',       'view')
+warn "listed #{workbooks.size} workbooks, #{datasources.size} datasources, #{views.size} views"
+
+excluded = opts[:exclude_projects]
+in_excluded = ->(row) { excluded.include?(row.dig('project', 'name')) }
+
+# Per-workbook sheet count from the views list (each view carries its workbook
+# ref) — avoids a get_workbook call per workbook.
+sheets_by_wb = Hash.new(0)
+views.each { |v| wb = v.dig('workbook', 'id'); sheets_by_wb[wb] += 1 if wb }
+
+workbook_inventory = workbooks.reject(&in_excluded).map do |w|
+  {
+    'luid'        => w['id'],
+    'name'        => w['name'],
+    'project'     => w.dig('project', 'name'),
+    'owner'       => w.dig('owner', 'name') || w.dig('owner', 'id'),
+    'content_url' => w['contentUrl'],
+    'created_at'  => w['createdAt'],
+    'updated_at'  => w['updatedAt'],
+    'size_mb'     => w['size'] && (w['size'].to_f / 1_048_576).round(2),
+    'sheet_count' => sheets_by_wb[w['id']],
+    # No accesses/actors on Server without Admin Insights / repository DB.
+    'accesses'    => 0,
+    'actors'      => 0,
+  }
+end
+
+datasource_inventory = datasources.reject(&in_excluded).map do |d|
+  {
+    'luid'         => d['id'],
+    'name'         => d['name'],
+    'project'      => d.dig('project', 'name'),
+    'type'         => d['type'],
+    'has_extracts' => d['hasExtracts'],
+    'updated_at'   => d['updatedAt'],
+  }
+end
+
+inventory = {
+  'mode'         => 'rest-server',
+  'generated_at' => Time.now.utc.iso8601,
+  'server'       => (Tableau.server_url rescue nil),
+  'site_id'      => (Tableau.site_id rescue nil),
+  'capabilities' => caps,
+  'counts'       => {
+    'workbooks'        => workbook_inventory.size,
+    'datasources'      => datasource_inventory.size,
+    'views'            => views.size,
+    'workbooks_raw'    => workbooks.size,
+  },
+  'excluded_projects'    => excluded,
+  'workbook_inventory'   => workbook_inventory,
+  'datasource_inventory' => datasource_inventory,
+  # Usage requires Admin Insights (Cloud) or the Server repository DB — absent here.
+  # build-shortlist.rb tolerates this and ranks by complexity/cost alone.
+  'workbook_usage'       => [],
+  'usage_available'      => false,
+}
+
+out_path = File.join(opts[:out], 'inventory.json')
+File.write(out_path, JSON.pretty_generate(inventory))
+puts "wrote #{out_path}"
+puts "  #{workbook_inventory.size} workbooks, #{datasource_inventory.size} datasources, #{views.size} views"
+puts "  mode=rest-server — usage/refresh stats NOT available (needs Admin Insights on Cloud, or the"
+puts "  Tableau Server repository DB). Shortlist will rank by complexity/cost only. Run"
+puts "  fetch-all-twbs.rb + scan-workbook-gaps.rb next for per-workbook complexity."

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/setup-tableau.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/setup-tableau.sh
@@ -34,12 +34,24 @@ puts "Tableau credential setup"
 puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
 puts
 
-print "Server URL [https://10ay.online.tableau.com]: "
-server = $stdin.gets.chomp
-server = "https://10ay.online.tableau.com" if server.empty?
+print "Deployment — [c]loud or self-hosted [s]erver? [c]: "
+is_server = $stdin.gets.to_s.strip.downcase.start_with?("s")
+
+if is_server
+  print "Server URL (e.g. https://tableau.mycompany.com): "
+  server = $stdin.gets.chomp
+else
+  print "Server URL [https://10ay.online.tableau.com]: "
+  server = $stdin.gets.chomp
+  server = "https://10ay.online.tableau.com" if server.empty?
+end
 server = server.sub(%r{/+$}, '')
 
-print "Site contentUrl (the path segment after /site/ in the Tableau URL, e.g. 'dataflow'): "
+if is_server
+  print "Site contentUrl (path segment after /site/ in the URL; LEAVE BLANK for the Default site): "
+else
+  print "Site contentUrl (the path segment after /site/ in the Tableau URL, e.g. 'dataflow'): "
+end
 content_url = $stdin.gets.chomp
 
 print "PAT name (the label you typed when creating the token in Tableau): "
@@ -49,8 +61,10 @@ print "PAT secret (will be hidden): "
 pat_secret = $stdin.noecho(&:gets).chomp
 puts
 
-if [server, content_url, pat_name, pat_secret].any?(&:empty?)
-  abort "All four values are required. Aborting without writing settings."
+# contentUrl is intentionally allowed to be empty — that's the Tableau Server
+# "Default" site. Everything else is required.
+if [server, pat_name, pat_secret].any?(&:empty?)
+  abort "Server URL, PAT name, and PAT secret are required. Aborting without writing settings."
 end
 
 settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/tableau-rest.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/tableau-rest.md
@@ -13,6 +13,33 @@ Use PAT mode when:
 - You want to **download the workbook's `.twb` XML** for layout-hint extraction (the MCP
   doesn't expose this).
 - The workbook uses an **embedded datasource** the MCP can't see (REST + `.twb` parsing can).
+- You're on **self-hosted Tableau Server** (see below) — the hosted Tableau MCP targets Cloud.
+
+## Tableau Server vs Cloud
+
+The REST signin and the core endpoints (workbooks, views, view-data CSV, view-image PNG,
+`.twb`/`.twbx` content) are **identical** on Cloud and self-hosted Server, so PAT mode works
+on both. Four differences matter:
+
+| | Tableau Cloud | Self-hosted Tableau Server |
+|---|---|---|
+| **REST API version** | always the latest | pinned to the installed release |
+| **VDS** (`/api/v1/vizql-data-service`) | always on | needs **2024.2+** AND admin-enabled |
+| **Metadata API** (`/api/metadata/graphql`) | always on | **OFF by default** (`tsm maintenance metadata-services enable`) |
+| **Default site `contentUrl`** | n/a (always a named site) | the Default site uses an **empty** contentUrl |
+
+Handled automatically:
+
+- **Version negotiation** — `get-tableau-token.sh` reads the server's max `restApiVersion`
+  from `/api/2.4/serverinfo` (no auth, so it can't trip the 4-strike PAT lockout) and signs
+  in against that. Set `TABLEAU_API_VERSION` to override.
+- **Default site** — `setup-tableau.rb` accepts an empty contentUrl; leave it blank when
+  prompted on Server.
+- **Capability banner** — `tableau-discover.rb` prints product version, REST API version,
+  and Metadata-API on/off up front. When VDS/Metadata are off, calc formulas come from the
+  downloaded `.twb` XML instead of `ds-metadata.json`/`graphql-fields.json` — discovery
+  degrades gracefully rather than failing, but the banner tells you which mode you're in so
+  a thin `ds-metadata.json` isn't mistaken for a bug.
 
 ## One-time setup
 
@@ -24,10 +51,10 @@ Prompts for:
 
 | Value | Where to find it |
 |---|---|
-| Server URL | The hostname only (e.g. `https://10ay.online.tableau.com`). No trailing slash needed. |
-| Site contentUrl | The path segment after `/site/` in any Tableau URL — e.g. `dataflow`. |
+| Server URL | The hostname only — Cloud `https://10ay.online.tableau.com` or Server `https://tableau.mycompany.com`. No trailing slash needed. |
+| Site contentUrl | The path segment after `/site/` in any Tableau URL — e.g. `dataflow`. **Leave blank** for a Tableau Server "Default" site. |
 | PAT name | The label you typed when creating the token in **Account Settings → Personal Access Tokens**. Case-sensitive. |
-| PAT secret | The string shown at creation time. Copy verbatim — Tableau Cloud secrets are formatted as `base64==:base64`, the colon is part of the secret. |
+| PAT secret | The string shown at creation time. Copy verbatim — Tableau secrets are formatted as `base64==:base64`, the colon is part of the secret. |
 
 Stored in `~/.claude/settings.json` as `TABLEAU_SERVER_URL`, `TABLEAU_SITE_CONTENT_URL`,
 `TABLEAU_PAT_NAME`, `TABLEAU_PAT_SECRET`. Open a new Claude Code session (or

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-tableau-token.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-tableau-token.sh
@@ -6,6 +6,8 @@
 # IMPORTANT: this makes ONE signin attempt. Tableau invalidates a PAT after
 # four consecutive failed signins, so do not wrap this in a retry loop with
 # different name/secret combos — fix the credentials and call once.
+# Works against both Tableau Cloud and self-hosted Tableau Server (the REST
+# signin + serverinfo endpoints are identical; the API version is negotiated).
 
 set -euo pipefail
 
@@ -17,11 +19,40 @@ if [ -z "${TABLEAU_PAT_SECRET:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
 fi
 
 : "${TABLEAU_SERVER_URL:?Run scripts/setup-tableau.rb to configure credentials}"
-: "${TABLEAU_SITE_CONTENT_URL:?Run scripts/setup-tableau.rb to configure credentials}"
 : "${TABLEAU_PAT_NAME:?Run scripts/setup-tableau.rb to configure credentials}"
 : "${TABLEAU_PAT_SECRET:?Run scripts/setup-tableau.rb to configure credentials}"
+# contentUrl may legitimately be EMPTY — that's the Tableau Server "Default" site.
+# Require it to be SET (so we know setup ran) but allow an empty value; a bare
+# `:?` guard would reject the Default site.
+if [ -z "${TABLEAU_SITE_CONTENT_URL+x}" ]; then
+  echo "TABLEAU_SITE_CONTENT_URL not set — run scripts/setup-tableau.rb to configure credentials" >&2
+  exit 1
+fi
 
-API_VER="${TABLEAU_API_VERSION:-3.22}"
+# --- REST API version negotiation -------------------------------------------
+# Tableau Cloud always speaks the latest REST API version, but a self-hosted
+# Tableau Server is pinned to whatever its installed release supports. Signing
+# in against a version the server doesn't know returns a 400 that looks like a
+# credential failure. Ask the server which version it speaks — serverinfo needs
+# NO auth, so the probe never counts against the 4-strike PAT lockout — and use
+# that. An explicit TABLEAU_API_VERSION always wins.
+if [ -n "${TABLEAU_API_VERSION:-}" ]; then
+  API_VER="$TABLEAU_API_VERSION"
+else
+  # 2.4 is supported by every Tableau Server release still in the field and by Cloud.
+  API_VER=$(curl -sS -H "Accept: application/json" \
+    "${TABLEAU_SERVER_URL}/api/2.4/serverinfo" 2>/dev/null | python3 -c "
+import sys, json
+try:
+    print(json.load(sys.stdin)['serverInfo']['restApiVersion'])
+except Exception:
+    print('')
+" 2>/dev/null)
+  if [ -z "$API_VER" ]; then
+    API_VER="3.22"
+    echo "serverinfo probe failed; defaulting to REST API ${API_VER} (override with TABLEAU_API_VERSION)." >&2
+  fi
+fi
 
 RESPONSE=$(curl -sS -X POST \
   -H "Content-Type: application/xml" \
@@ -49,7 +80,8 @@ print(d['credentials']['token'])
     if [ "$ERR_CODE" = "401001" ]; then
       echo >&2
       echo "401001 means the PAT name or secret is wrong — OR the token has been invalidated by 4+" >&2
-      echo "consecutive failed signins. Create a fresh PAT in Tableau Cloud and re-run setup-tableau.rb." >&2
+      echo "consecutive failed signins. Create a fresh PAT (Account Settings → Personal Access" >&2
+      echo "Tokens, on Tableau Server or Cloud) and re-run setup-tableau.rb." >&2
     fi
     exit 1
   fi

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.rb
@@ -175,6 +175,41 @@ module Tableau
     list.first
   end
 
+  # ---- server capabilities -------------------------------------------------
+  # Tableau Cloud always exposes the latest REST API, VDS, and the Metadata API.
+  # A self-hosted Tableau Server is pinned to its installed release and ships
+  # with VDS (2024.2+) and the Metadata API OFF by default — so the discovery
+  # path must know which capabilities are live before it leans on them.
+
+  # Server-level info (no site scope). Returns e.g.
+  #   {"productVersion"=>{"value"=>"2024.2", ...}, "restApiVersion"=>"3.23"}
+  def serverinfo
+    request(:get, "/api/#{api_version}/serverinfo")['serverInfo']
+  end
+
+  # Is the Metadata API (GraphQL) turned on? Always on in Cloud; DISABLED BY
+  # DEFAULT on Tableau Server (admin enables via `tsm maintenance
+  # metadata-services enable`). When off the endpoint 404s and calc-formula
+  # extraction falls back to parsing the .twb XML.
+  def metadata_api_available?
+    r = graphql('{ __typename }')
+    !r.nil? && (r['errors'].nil? || r['errors'].empty?)
+  rescue Error
+    false
+  end
+
+  # Best-effort capability summary for the discovery banner. `vds` is left nil:
+  # VDS has no auth-free ping, so the discover pool detects it per datasource and
+  # falls back to .twb on failure. Never raises.
+  def capabilities
+    info = (serverinfo rescue nil) || {}
+    {
+      'product_version'  => info.dig('productVersion', 'value'),
+      'rest_api_version' => info['restApiVersion'] || api_version,
+      'metadata_api'     => (metadata_api_available? rescue false),
+    }
+  end
+
   # VizQL Data Service — full field list with calc formulas. This is the REST equivalent
   # of mcp__tableau__get-datasource-metadata.
   def read_metadata(datasource_luid)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup-tableau.rb
@@ -34,12 +34,24 @@ puts "Tableau credential setup"
 puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
 puts
 
-print "Server URL [https://10ay.online.tableau.com]: "
-server = $stdin.gets.chomp
-server = "https://10ay.online.tableau.com" if server.empty?
+print "Deployment — [c]loud or self-hosted [s]erver? [c]: "
+is_server = $stdin.gets.to_s.strip.downcase.start_with?("s")
+
+if is_server
+  print "Server URL (e.g. https://tableau.mycompany.com): "
+  server = $stdin.gets.chomp
+else
+  print "Server URL [https://10ay.online.tableau.com]: "
+  server = $stdin.gets.chomp
+  server = "https://10ay.online.tableau.com" if server.empty?
+end
 server = server.sub(%r{/+$}, '')
 
-print "Site contentUrl (the path segment after /site/ in the Tableau URL, e.g. 'dataflow'): "
+if is_server
+  print "Site contentUrl (path segment after /site/ in the URL; LEAVE BLANK for the Default site): "
+else
+  print "Site contentUrl (the path segment after /site/ in the Tableau URL, e.g. 'dataflow'): "
+end
 content_url = $stdin.gets.chomp
 
 print "PAT name (the label you typed when creating the token in Tableau): "
@@ -49,8 +61,10 @@ print "PAT secret (will be hidden): "
 pat_secret = $stdin.noecho(&:gets).chomp
 puts
 
-if [server, content_url, pat_name, pat_secret].any?(&:empty?)
-  abort "All four values are required. Aborting without writing settings."
+# contentUrl is intentionally allowed to be empty — that's the Tableau Server
+# "Default" site. Everything else is required.
+if [server, pat_name, pat_secret].any?(&:empty?)
+  abort "Server URL, PAT name, and PAT secret are required. Aborting without writing settings."
 end
 
 settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
@@ -146,6 +146,19 @@ views = wb.dig('views', 'view') || []
 views = [views] unless views.is_a?(Array)
 log "wrote get-workbook.json  (id=#{wb['id']} views=#{views.size})"
 
+# --- 1b. Capability banner ---------------------------------------------------
+# Tableau Server can lack VDS and the Metadata API that Cloud always exposes.
+# Announce the mode up front so an operator isn't left debugging why
+# ds-metadata.json / graphql-fields.json never appeared — the .twb XML path
+# covers both calc-formula sources when those services are off.
+caps = (Tableau.capabilities rescue {})
+if caps.any?
+  meta_state = caps['metadata_api'] ? 'available' : 'OFF → calc formulas from .twb XML'
+  log "capabilities: product=#{caps['product_version'] || '?'} " \
+      "REST API=#{caps['rest_api_version'] || '?'}  Metadata API: #{meta_state}"
+  log 'note: VDS is probed per-datasource below; on failure discovery falls back to the .twb XML.' unless caps['metadata_api']
+end
+
 # --- 2. Build the task queue -------------------------------------------------
 queue = Queue.new
 twb_done = Queue.new # signals twb completion (for auto-ds fallback)

--- a/shared/lib/tableau_rest.rb
+++ b/shared/lib/tableau_rest.rb
@@ -175,6 +175,41 @@ module Tableau
     list.first
   end
 
+  # ---- server capabilities -------------------------------------------------
+  # Tableau Cloud always exposes the latest REST API, VDS, and the Metadata API.
+  # A self-hosted Tableau Server is pinned to its installed release and ships
+  # with VDS (2024.2+) and the Metadata API OFF by default — so the discovery
+  # path must know which capabilities are live before it leans on them.
+
+  # Server-level info (no site scope). Returns e.g.
+  #   {"productVersion"=>{"value"=>"2024.2", ...}, "restApiVersion"=>"3.23"}
+  def serverinfo
+    request(:get, "/api/#{api_version}/serverinfo")['serverInfo']
+  end
+
+  # Is the Metadata API (GraphQL) turned on? Always on in Cloud; DISABLED BY
+  # DEFAULT on Tableau Server (admin enables via `tsm maintenance
+  # metadata-services enable`). When off the endpoint 404s and calc-formula
+  # extraction falls back to parsing the .twb XML.
+  def metadata_api_available?
+    r = graphql('{ __typename }')
+    !r.nil? && (r['errors'].nil? || r['errors'].empty?)
+  rescue Error
+    false
+  end
+
+  # Best-effort capability summary for the discovery banner. `vds` is left nil:
+  # VDS has no auth-free ping, so the discover pool detects it per datasource and
+  # falls back to .twb on failure. Never raises.
+  def capabilities
+    info = (serverinfo rescue nil) || {}
+    {
+      'product_version'  => info.dig('productVersion', 'value'),
+      'rest_api_version' => info['restApiVersion'] || api_version,
+      'metadata_api'     => (metadata_api_available? rescue false),
+    }
+  end
+
   # VizQL Data Service — full field list with calc formulas. This is the REST equivalent
   # of mcp__tableau__get-datasource-metadata.
   def read_metadata(datasource_luid)


### PR DESCRIPTION
## Why

Customer feedback (Tableau **Server** shop): the leading-indicator dashboard took ~6 hours with heavy debugging just to render. Root cause is that the tableau-to-sigma converter + tableau-assessment skills assumed **Tableau Cloud** everywhere. Server differs in four ways that either fail signin or silently degrade discovery with no signal to the operator.

Auth and most REST endpoints are actually identical on Server and Cloud — so this is targeted, not a rewrite.

## What changed

**Converter (`tableau-to-sigma`)**
- **REST API version negotiation** — `get-tableau-token.sh` reads the server's max `restApiVersion` from `/api/2.4/serverinfo` (no auth → can't trip the 4-strike PAT lockout) instead of hardcoding `3.22`. Explicit `TABLEAU_API_VERSION` still wins.
- **Default-site empty `contentUrl`** — setup + the token guard now accept an empty contentUrl (the Server "Default" site); previously setup aborted.
- **Deployment-aware setup** — `setup-tableau.{rb,sh}` prompts Cloud vs Server; drops the Cloud default host on Server.
- **Capability banner** — `tableau_rest.rb` gains `serverinfo` / `capabilities` / `metadata_api_available?`; `tableau-discover.rb` prints product, REST API version, and Metadata-API on/off up front, so a `.twb`-primary run (VDS/Metadata off) announces itself instead of looking like a bug.

**Assessment (`tableau-assessment`)**
- **`inventory-rest.rb`** — new REST-only inventory (`mode: rest-server`) for Server, where there's no Admin Insights: workbook/datasource/view counts + per-workbook `sheet_count`, `usage_available: false`. Complexity (Phase 3) already runs over REST/PAT.
- **`build-shortlist.rb`** — honors `usage_available`; with no usage it ranks by complexity (easiest first) and never mis-tags workbooks `retire`. Cloud path unchanged (regression-tested).

**Docs** — `tableau-rest.md` "Tableau Server vs Cloud" section; assessment SKILL.md Server path.

## Scope note
REST-only Server mode per decision — usage/refresh stats (Admin Insights on Cloud, or the Server repository DB) are explicitly out of scope and clearly surfaced as unavailable.

## Testing
Offline-tested: serverinfo parse, `capabilities` branching (Metadata on/off), and `inventory-rest.rb → build-shortlist.rb` for both Server (no-usage) and Cloud (usage) paths. `tools/check-shared.rb` green; pre-commit gates pass. Not yet run against a live Server (no test instance) — flagged for E2E once one is available.

Separate tracks (not in this PR): rolling/relative date-filter translation and parameter/table-calc gaps — converter issues, not Server-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)