### PR TITLE
feat(tableau): rolling relative-date filters (fixes frozen/empty dashboards)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -145,13 +145,17 @@ Optional `--enhance [--enhance-accept <ids|all-low-risk>]` runs Phase E
   field like `master/ship speed category`, translate the Tableau calc (see
   `calc-fields.json`) and re-run the same command with
   `--master-col 'Name=<Sigma formula>'`.
-- **Shared relative-date filters** — a dashboard-wide filter like
-  `'Order Date ' = this year` only surfaces as a uniform parity DIVERGE (every
-  Sigma value too big). Fix: expose the date key on the DM if the converter
-  consumed it, add a master boolean (e.g. `[Order Year] = Year(Today())`) plus a
-  master `filters: [{id, columnId, kind: list, mode: include, values: [true]}]`
-  entry — it propagates to every chart sourcing the master — then re-query and
-  re-`--finalize`. (Validated live on Orders Conversion Test, 2026-06-10.)
+- **Shared relative-date filters** — `build-charts-from-signals.rb` now maps
+  these to Sigma's native ROLLING date-range modes directly:
+  `this <period>` → `mode:current`, `last N <period>` → `mode:last`
+  (`value:N`, `unit`, `includeToday`), `next N` → `mode:next`. They roll with the
+  clock — no frozen dates and no manual master-boolean workaround. Only a
+  shifted/spanning window (one that doesn't anchor to now) falls back to a frozen
+  `mode:between`, flagged `FROZEN — re-run to refresh`. If a shared relative-date
+  filter still shows a uniform parity DIVERGE (every Sigma value too big),
+  confirm the date key survived into the DM and the control's `filters` target
+  wiring reached the chart's source. (Rolling emission verified 2026-07-01;
+  shapes per `sigma-authoring` controls.md, live 2026-06-15.)
 - **❌-unhandled gap features** — gap-scout subagent or `--force` (degraded).
 - **DM-reuse shape preflight** — when `--reuse-dm` hits a differently-shaped DM
   the workbook gate exits 4; run Phase 1.5b (`inspect-dm-shape.rb`) and the

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -207,6 +207,64 @@ def current_period_bounds(period, now = Time.now)
   relative_period_bounds(period, 0, 0, now)
 end
 
+# Tableau period-type → Sigma date-range `unit` enum. Sigma has no bare "week"
+# (it splits Sunday/Monday anchored) and no "weekday"/other Tableau grains.
+# Returns nil for grains Sigma's rolling modes can't express (caller falls back).
+def sigma_date_unit(period)
+  case period.to_s.downcase
+  when 'year'    then 'year'
+  when 'quarter' then 'quarter'
+  when 'month'   then 'month'
+  when 'week'    then 'week-starting-sunday'
+  when 'day'     then 'day'
+  when 'hour'    then 'hour'
+  when 'minute'  then 'minute'
+  end
+end
+
+# Map a Tableau relative-date filter (period-type + first/last period offsets) to
+# a ROLLING Sigma date-range filter fragment — the fields that sit flat alongside
+# `mode` (verified shapes in sigma-workbooks reference/specification/controls.md).
+#
+# Tableau offsets are period counts relative to now (first=-2,last=0 = "last 3
+# months"; first=0,last=0 = "this month"). We preserve the window LENGTH and
+# whether it reaches the current period, and emit a filter that ROLLS instead of
+# freezing to concrete dates (the old mode:between behaviour broke at every
+# period rollover and rendered empty when the frozen window missed the data).
+#
+# Returns [fragment_hash, kind] where kind ∈ :current/:last/:next/:frozen and the
+# fragment excludes columnId/id/includeNulls (the caller adds those). Returns
+# [nil, :unsupported] only when no Sigma shape fits at all.
+def relative_date_filter_fields(period, first, last, now = Time.now)
+  first = first.to_i
+  last  = last.to_i
+  unit  = sigma_date_unit(period)
+
+  # "This <period>" — rolls automatically (bead z135). Works for every grain.
+  return [{ 'mode' => 'current', 'unit' => (unit || period.to_s.downcase) }, :current] if first.zero? && last.zero?
+
+  if unit
+    # Trailing window that ends at now (last=0) or at the last complete period
+    # (last=-1): "last N <unit>". includeToday distinguishes the two.
+    if last == 0 || last == -1
+      value = last - first + 1
+      return [{ 'mode' => 'last', 'value' => value, 'unit' => unit, 'includeToday' => (last == 0) }, :last] if value >= 1
+    end
+    # Leading (future) window that starts at now (first=0) or the next period
+    # (first=1): "next N <unit>".
+    if first == 0 || first == 1
+      value = last - first + 1
+      return [{ 'mode' => 'next', 'value' => value, 'unit' => unit, 'includeToday' => (first == 0) }, :next] if value >= 1
+    end
+  end
+
+  # Shifted/spanning window (or a grain Sigma can't roll): fall back to explicit
+  # frozen bounds so at least the range is right at build time.
+  start_d, end_d = relative_period_bounds(period, first, last, now)
+  return [{ 'mode' => 'between', 'startDate' => start_d, 'endDate' => end_d }, :frozen] if start_d
+  [nil, :unsupported]
+end
+
 def render_agg(agg, master_col_ref)
   return master_col_ref if agg.nil?
   if agg.include?('%s')
@@ -3443,39 +3501,33 @@ layout.each do |dash|
           'values' => f['members'], 'includeNulls' => 'never'
         }
       when 'relative-date'
-        # Tableau first-period=0, last-period=0 + period-type=year means
-        # "this <period>" → Sigma mode:"current" + unit:<period>. E2E
-        # re-verified 2026-06-10 (bead z135) that mode:current filters the
-        # chart-data SQL — it rolls over automatically instead of freezing.
-        # Offset windows (first/last ≠ 0, e.g. "last 3 months") fall back to
-        # explicit between-bounds (frozen — re-run to refresh).
+        # Tableau relative-date filters → ROLLING Sigma date-range filters:
+        #   "this <period>" (first=last=0)      → mode:current unit:<unit>
+        #   "last N <period>" (e.g. first=-5,0) → mode:last  value:N unit includeToday
+        #   "next N <period>"                   → mode:next  value:N unit includeToday
+        # Only genuinely shifted/spanning windows (which no rolling mode fits)
+        # fall back to frozen mode:between bounds. This replaces the old code
+        # that froze EVERY offset window to static dates (broke at rollover and
+        # rendered empty when the frozen range missed the data — Wendy's dash).
         period   = (f['period_type'] || 'year').downcase
         inc_null = (f['include_null'].to_s == 'true' ? 'always' : 'never')
         fcol = el_filter_col_for.call(m)
         next if fcol.nil? # helper-sourced chart, column unreachable (warned in el_filter_col_for)
-        if f['first_period'].to_i.zero? && f['last_period'].to_i.zero?
-          el_filters << {
-            'columnId' => fcol, 'kind' => 'date-range', 'mode' => 'current',
-            'unit' => period, 'includeNulls' => inc_null
-          }
-          warnings << "'#{cap}' relative-date 'this #{period}' → element filter mode:current unit:#{period} (rolls over automatically; verified to filter chart-data SQL, bead z135)"
-        else
-          start_d, end_d = relative_period_bounds(period, f['first_period'], f['last_period'])
-          if start_d
-            el_filters << {
-              'columnId' => fcol, 'kind' => 'date-range', 'mode' => 'between',
-              'startDate' => start_d, 'endDate' => end_d,
-              'includeNulls' => inc_null
-            }
-            warnings << "'#{cap}' relative-date window #{f['first_period']}..#{f['last_period']} #{period}s → element filter mode:between (#{start_d[0..9]}..#{end_d[0..9]}); FROZEN — re-run to refresh"
-          else
-            el_filters << {
-              'columnId' => fcol, 'kind' => 'date-range', 'mode' => 'relative',
-              'unit' => period, 'count' => 1,
-              'includeNulls' => inc_null
-            }
-            warnings << "'#{cap}' relative-date '#{period}' kept as mode:relative (no bounds computable for '#{period}') — verify it filters the SQL"
-          end
+        fields, kind = relative_date_filter_fields(period, f['first_period'], f['last_period'])
+        if fields.nil?
+          warnings << "'#{cap}' relative-date on '#{fcap}' (period=#{period}, window #{f['first_period']}..#{f['last_period']}) — no Sigma date-range mode fits; filter DROPPED, wire it by hand"
+          next
+        end
+        el_filters << { 'columnId' => fcol, 'kind' => 'date-range', 'includeNulls' => inc_null }.merge(fields)
+        case kind
+        when :current
+          warnings << "'#{cap}' relative-date 'this #{period}' → element filter mode:current unit:#{fields['unit']} (rolls automatically; bead z135)"
+        when :last
+          warnings << "'#{cap}' relative-date → element filter mode:last value:#{fields['value']} unit:#{fields['unit']} includeToday:#{fields['includeToday']} (ROLLS — no frozen dates)"
+        when :next
+          warnings << "'#{cap}' relative-date → element filter mode:next value:#{fields['value']} unit:#{fields['unit']} includeToday:#{fields['includeToday']} (rolls)"
+        when :frozen
+          warnings << "'#{cap}' relative-date window #{f['first_period']}..#{f['last_period']} #{period}s is shifted/spanning — no rolling mode fits → mode:between (#{fields['startDate'][0..9]}..#{fields['endDate'][0..9]}); FROZEN — re-run to refresh"
         end
       when 'number-range'
         fcol = el_filter_col_for.call(m)
@@ -4018,33 +4070,33 @@ if opts[:auto_controls]
       }
       spec['filters'] = targets
     when 'relative-date'
-      # Tableau "this year" / "this month" / "this quarter" → Sigma date-range
-      # control with `mode: "current"` + `unit: <period>`. E2E re-verified
-      # 2026-06-10 (bead z135): mode:current DOES filter the chart-data SQL
-      # when the control's `filters` target wiring is present — the earlier
-      # "render-time only" finding that drove hardcoded between-bounds was
-      # wrong, and the hardcoded dates froze the filter (broke at rollover).
-      # mode:between is kept ONLY for genuinely fixed/offset windows
-      # (first/last period ≠ 0, e.g. "last 3 months"), which Sigma has no
-      # verified rolling-control shape for yet.
+      # Tableau relative-date → ROLLING Sigma date-range control (same rolling
+      # mode vocabulary as an element filter; shapes verified in sigma-workbooks
+      # reference/specification/controls.md, live 2026-06-15):
+      #   "this <period>"  → mode:current unit
+      #   "last N <period>"→ mode:last value:N unit includeToday
+      #   "next N <period>"→ mode:next value:N unit includeToday
+      # Only shifted/spanning windows fall back to frozen mode:between. This
+      # replaces freezing every offset window to static dates (bead z135).
       spec['controlType'] = 'date-range'
       period = (f['period_type'] || 'year').downcase
       spec['filters'] = targets
-      if f['first_period'].to_i.zero? && f['last_period'].to_i.zero?
-        spec['mode'] = 'current'
-        spec['unit'] = period
-        warnings << "shared filter '#{cap}' relative-date 'this #{period}' → date-range control mode:current unit:#{period} (rolls over automatically; no frozen dates)"
+      fields, kind = relative_date_filter_fields(period, f['first_period'], f['last_period'])
+      if fields.nil?
+        # Nothing Sigma can express — leave the picker open rather than emit an invalid mode.
+        spec['mode'] = 'between'
+        warnings << "shared filter '#{cap}' relative-date (period=#{period}, window #{f['first_period']}..#{f['last_period']}) — no Sigma mode fits; emitted an empty date-range picker, set it by hand"
       else
-        start_d, end_d = relative_period_bounds(period, f['first_period'], f['last_period'])
-        if start_d
-          spec['mode']      = 'between'
-          spec['startDate'] = start_d
-          spec['endDate']   = end_d
-          warnings << "shared filter '#{cap}' relative-date window #{f['first_period']}..#{f['last_period']} #{period}s → mode:between (#{start_d[0..9]}..#{end_d[0..9]}); FROZEN — re-run to refresh"
-        else
-          spec['mode'] = 'current'
-          spec['unit'] = period
-          warnings << "shared filter '#{cap}' relative-date '#{period}' window not boundable — emitted mode:current unit:#{period}; verify the window manually"
+        spec.merge!(fields)
+        case kind
+        when :current
+          warnings << "shared filter '#{cap}' relative-date 'this #{period}' → date-range control mode:current unit:#{fields['unit']} (rolls automatically; no frozen dates)"
+        when :last
+          warnings << "shared filter '#{cap}' relative-date → date-range control mode:last value:#{fields['value']} unit:#{fields['unit']} includeToday:#{fields['includeToday']} (ROLLS — no frozen dates)"
+        when :next
+          warnings << "shared filter '#{cap}' relative-date → date-range control mode:next value:#{fields['value']} unit:#{fields['unit']} includeToday:#{fields['includeToday']} (rolls)"
+        when :frozen
+          warnings << "shared filter '#{cap}' relative-date window #{f['first_period']}..#{f['last_period']} #{period}s is shifted/spanning → mode:between (#{fields['startDate'][0..9]}..#{fields['endDate'][0..9]}); FROZEN — re-run to refresh"
         end
       end
     when 'number-range'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relative-date-filter.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relative-date-filter.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# Regression test for ROLLING relative-date filter emission.
+#
+# Tableau relative-date filters ("last 6 months", "this year", "next 2 quarters")
+# used to be FROZEN to static mode:between bounds for any offset window — so the
+# filter stopped rolling and, when the frozen range missed the data, the whole
+# dashboard rendered empty (the customer "leading indicators" dashboard). The
+# fallback path even emitted `mode:'relative'` + `count`, which is NOT a valid
+# Sigma date-range mode (valid: between/last/next/current/on/before/after/custom)
+# and silently dropped.
+#
+# The fix maps Tableau offsets → Sigma's native ROLLING modes:
+#   this <period>  (0,0)      → mode:current unit
+#   last N <period>(-N+1..0)  → mode:last  value:N unit includeToday
+#   next N <period>           → mode:next  value:N unit includeToday
+# and only falls back to frozen mode:between for shifted/spanning windows.
+#
+# Deterministic, offline, creds-free: extracts the pure helper methods straight
+# from build-charts-from-signals.rb and evals them, so it locks the exact
+# mapping without spinning up the whole builder.
+#
+# Usage:  ruby scripts/test-relative-date-filter.rb
+
+require 'date'
+require 'time'
+
+SRC = File.join(__dir__, 'build-charts-from-signals.rb')
+src = File.read(SRC)
+
+# Slice the contiguous helper block: relative_period_bounds → sigma_date_unit →
+# relative_date_filter_fields (ends at the sole `[nil, :unsupported]`).
+m = src[/def relative_period_bounds.*?\[nil, :unsupported\]\nend/m]
+abort "could not extract helper methods from #{SRC} — did they move/rename?" unless m
+eval(m) # rubocop:disable Security/Eval — trusted first-party source, test-only
+
+# Fix "now" so bounds are deterministic (frozen fallback assertions).
+NOW = Time.new(2026, 7, 1, 12, 0, 0)
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# ── this <period> → mode:current ────────────────────────────────────────────
+f, k = relative_date_filter_fields('year', 0, 0, NOW)
+check(k == :current && f == { 'mode' => 'current', 'unit' => 'year' },
+      "this year → mode:current unit:year (got #{k} #{f.inspect})", fails)
+
+# ── last 6 months (Tableau first=-5,last=0) → rolling mode:last ─────────────
+f, k = relative_date_filter_fields('month', -5, 0, NOW)
+check(k == :last && f == { 'mode' => 'last', 'value' => 6, 'unit' => 'month', 'includeToday' => true },
+      "last 6 months → mode:last value:6 unit:month includeToday:true (got #{k} #{f.inspect})", fails)
+
+# ── last 3 COMPLETE months (first=-3,last=-1) → includeToday:false ──────────
+f, k = relative_date_filter_fields('month', -3, -1, NOW)
+check(k == :last && f['value'] == 3 && f['includeToday'] == false,
+      "last 3 complete months → value:3 includeToday:false (got #{f.inspect})", fails)
+
+# ── next 2 quarters incl current (first=0,last=1) → mode:next ──────────────
+f, k = relative_date_filter_fields('quarter', 0, 1, NOW)
+check(k == :next && f == { 'mode' => 'next', 'value' => 2, 'unit' => 'quarter', 'includeToday' => true },
+      "next 2 quarters → mode:next value:2 includeToday:true (got #{k} #{f.inspect})", fails)
+
+# ── week grain → Sigma 'week-starting-sunday' (no bare 'week') ──────────────
+f, k = relative_date_filter_fields('week', -3, 0, NOW)
+check(k == :last && f['unit'] == 'week-starting-sunday' && f['value'] == 4,
+      "last 4 weeks → unit:week-starting-sunday value:4 (got #{f.inspect})", fails)
+
+# ── day grain rolls even though relative_period_bounds can't bound days ─────
+f, k = relative_date_filter_fields('day', -6, 0, NOW)
+check(k == :last && f['unit'] == 'day' && f['value'] == 7,
+      "last 7 days → mode:last value:7 unit:day (got #{f.inspect})", fails)
+
+# ── shifted/spanning window (no rolling mode fits) → frozen mode:between ────
+f, k = relative_date_filter_fields('month', -8, -3, NOW)
+check(k == :frozen && f['mode'] == 'between' && f['startDate'] && f['endDate'],
+      "shifted month window → frozen mode:between with bounds (got #{k} #{f.inspect})", fails)
+
+# ── unsupported grain + unboundable window → [nil,:unsupported] (dropped) ───
+f, k = relative_date_filter_fields('weekday', -8, -3, NOW)
+check(k == :unsupported && f.nil?,
+      "weekday shifted window → unsupported/nil (got #{k} #{f.inspect})", fails)
+
+# ── the OLD bug must never resurface: no invalid mode:'relative' / 'count' ──
+all = [
+  relative_date_filter_fields('month', -5, 0, NOW),
+  relative_date_filter_fields('year', 0, 0, NOW),
+  relative_date_filter_fields('quarter', 0, 1, NOW),
+].map(&:first).compact
+check(all.none? { |x| x['mode'] == 'relative' || x.key?('count') },
+      "never emits invalid mode:'relative' or 'count' key", fails)
+check(all.all? { |x| %w[current last next between].include?(x['mode']) },
+      "every emitted mode is a valid Sigma date-range mode", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — relative-date filters emit rolling mode:current/last/next (frozen only for shifted windows)'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end


### PR DESCRIPTION
## Why

From the customer's "leading indicators" dashboard feedback: a **rolling 6-month date filter** ("always the previous six months") didn't survive migration, and the dashboard rendered empty until debugged for hours.

Root cause in `build-charts-from-signals.rb`: Tableau relative-date filters were **frozen to static `mode:between` bounds** for any offset window. The filter stopped rolling with the clock, and when the frozen range missed the data, every chart came up empty. The last-resort fallback emitted `mode:'relative'` + `count` — **not a valid Sigma date-range mode** (valid: between/last/next/current/on/before/after/custom) — so it silently dropped.

## What changed

Map Tableau offsets → Sigma's **native rolling modes**:

| Tableau | Sigma |
|---|---|
| `this <period>` (0,0) | `mode:current` + `unit` |
| `last N <period>` (e.g. -5,0) | `mode:last` + `value:N`, `unit`, `includeToday` |
| `next N <period>` | `mode:next` + `value:N`, `unit`, `includeToday` |
| shifted/spanning window | `mode:between` frozen (flagged `FROZEN — re-run`) — unchanged, last resort only |

- New shared helper `relative_date_filter_fields` drives **both** the element-filter and shared-control emission paths (previously duplicated).
- Also fixes a latent bug: bare `'week'` is not a valid Sigma unit → now `'week-starting-sunday'`.
- Removes the invalid `mode:'relative'` path.
- Updates the SKILL.md note that told users to hand-build a master-boolean workaround — no longer needed.

Shapes per `sigma-authoring` `controls.md` (live-verified 2026-06-15); `mode:last` confirmed API-valid as a filter (`kpis.md`, 2026-06-24).

## Testing

`scripts/test-relative-date-filter.rb` — deterministic, offline, creds-free (extracts + evals the pure helpers). Covers this/last/next, week→sunday, day, shifted→frozen, unsupported→dropped, and **guards against the old invalid-mode regression**. All 10 pass. Neighboring build-charts tests (topn, empty-csv, chart-kind) still pass.

**Not yet run live** against a workbook end-to-end — the mapping + spec shape are locked by the offline test and the shapes are from the live-verified controls reference, but a Phase-6 parity run on a real "last N months" dashboard would close the loop. Flagging for E2E.

Companion track from the same customer feedback (Tableau Server support) merged in #237. Parameter/table-calc gaps remain a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)