### PR TITLE
tableau(Phase 1): parser extracts zone fill/border + control display mode

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -891,6 +891,40 @@ end
 # column, and `children` (direct-child zones only). This is ADDITIVE: the flat
 # `zones` list (below) is preserved for every downstream consumer that wants the
 # geometry-banded path; the layout builder prefers the tree when present.
+# ── Phase-1 style extraction (composition/style layer, gaps B2/D1/E1) ────────
+# Tableau stores a dashboard zone's fill/border on the zone's DIRECT <zone-style>
+# child (NOT a <style-rule element='dash-zone'> — that scope does not exist):
+#   <zone …><zone-style>
+#     <format attr='background-color' value='#RRGGBBAA'/>   ← region-card tint / canvas
+#     <format attr='border-color' value='#hex'/> …
+#   </zone-style></zone>
+# Values may be 8-digit alpha hex (#rrggbbaa) — Sigma style.backgroundColor accepts
+# them verbatim. Returns {} when the zone has no explicit styling (→ plain container,
+# never worse than today's output). Verified against the "Job Loss from Mass
+# Deportations" benchmark (region tints #07b4a2/#e8519a/#827bb8/#f28e2b at alpha).
+def zone_style_fields(z)
+  out = {}
+  z.elements.each('zone-style/format') do |f|
+    a = f.attributes['attr']; v = f.attributes['value']
+    next if v.nil? || v.empty?
+    case a
+    when 'background-color'
+      out['fill_color'] = v unless v.downcase == '#00000000' # skip fully-transparent
+    when 'border-color'  then out['border_color'] = v
+    when 'border-style'  then out['border_style'] = v
+    end
+  end
+  out
+end
+
+# Tableau quick-filter / parameter display mode (zone `mode` attr) → E1 control-style
+# hint. mode='compact' → dropdown (Sigma controlType:list); 'type_in' → text input;
+# absent → default button/radio (Sigma segmented). Returns nil when unset.
+def zone_control_display(z)
+  m = z.attributes['mode']
+  m && !m.empty? ? m : nil
+end
+
 def build_zone_tree(z)
   type_v2 = z.attributes['type-v2']
   caption = z.attributes['name']
@@ -908,6 +942,10 @@ def build_zone_tree(z)
   # layout-flow's `param` is the stack direction; a vertical flow stacks its
   # children top-to-bottom (the classic left filter-rail), horizontal L→R.
   node['direction'] = (param == 'vert' ? 'vert' : 'horz') if type_v2 == 'layout-flow'
+  # Phase-1 style: per-zone fill/border (region-card tints, canvas) + control mode.
+  node.merge!(zone_style_fields(z))
+  cd = zone_control_display(z)
+  node['control_display'] = cd if cd
   # filter/param zones resolve their target column from `param` (a column GUID).
   if kind == 'filter' || kind == 'parameter'
     g = guid_from_param(param)
@@ -958,6 +996,10 @@ xml.elements.each('//dashboard') do |d|
       filter_col_datatype = info && info[:datatype]
     end
 
+    # Phase-1 style: per-zone fill/border (tints, canvas) + control display mode.
+    zstyle = zone_style_fields(z)
+    zdisp  = zone_control_display(z)
+
     zones << {
       'id'           => z.attributes['id'],
       'kind'         => kind,
@@ -990,7 +1032,11 @@ xml.elements.each('//dashboard') do |d|
       'is_kpi'       => (kind == 'chart' ? ws_meta&.dig(:is_kpi)        : nil),
       # Resolved filter target (filter/parameter zones only)
       'filter_column_caption'  => (kind == 'filter' || kind == 'parameter' ? filter_col_caption  : nil),
-      'filter_column_datatype' => (kind == 'filter' || kind == 'parameter' ? filter_col_datatype : nil)
+      'filter_column_datatype' => (kind == 'filter' || kind == 'parameter' ? filter_col_datatype : nil),
+      # Phase-1 composition/style signals (gaps B2/E1; nil when the zone is unstyled)
+      'fill_color'      => zstyle['fill_color'],
+      'border_color'    => zstyle['border_color'],
+      'control_display' => zdisp
     }
   end
   # A "storyboard" dashboard is Tableau's story container (sequential story

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-zone-style-extraction.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-zone-style-extraction.rb
@@ -1,0 +1,124 @@
+#!/usr/bin/env ruby
+# Regression test for Phase-1 composition/style extraction in parse-twb-layout.rb
+# (gaps B2 container tints / E1 control display). Tableau stores a dashboard
+# zone's fill + border on the zone's DIRECT <zone-style> child, and a
+# quick-filter/parameter display mode on the zone `mode` attr:
+#
+#   <zone …><zone-style>
+#     <format attr='background-color' value='#07b4a24e'/>   ← region-card tint (8-digit alpha)
+#     <format attr='border-color' value='#07b4a2'/>
+#   </zone-style></zone>
+#   <zone type-v2='filter' mode='compact' …/>               ← dropdown (Sigma controlType:list)
+#
+# Asserts, end-to-end through the ACTUAL parse-twb-layout.rb (no Tableau/Sigma
+# calls), that the parser now surfaces these signals (previously dropped):
+#   1. flat `zones`: a tinted container carries fill_color (8-digit alpha, verbatim)
+#      + border_color.
+#   2. a fully-transparent fill (#00000000) is NOT emitted (no visible tint).
+#   3. a filter zone with mode='compact' carries control_display='compact'.
+#   4. the nested `zone_tree` container node also carries fill_color.
+#
+# Usage:  ruby scripts/test-zone-style-extraction.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Mirrors the "Job Loss from Mass Deportations" benchmark: a region column with a
+# teal 8-digit-alpha tint + border, a chart zone with a transparent fill, and a
+# compact (dropdown) filter control.
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='Sales' name='federated.x'>
+        <column caption='Region' name='[Region]' datatype='string' role='dimension' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Sales by Region'><table><view><datasource-dependencies datasource='federated.x' /></view></table></worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Regions'>
+        <zones>
+          <zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+            <zone id='2' type-v2='layout-flow' param='vert' x='0' y='0' w='25000' h='100000'>
+              <zone-style>
+                <format attr='border-style' value='none' />
+                <format attr='background-color' value='#07b4a24e' />
+                <format attr='border-color' value='#07b4a2' />
+              </zone-style>
+              <zone id='3' type-v2='filter' param='[federated.x].[none:Region:nk]' mode='compact' x='0' y='0' w='25000' h='40000' />
+            </zone>
+            <zone id='5' name='Sales by Region' x='25000' y='0' w='75000' h='100000'>
+              <zone-style>
+                <format attr='background-color' value='#00000000' />
+              </zone-style>
+            </zone>
+          </zone>
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+layout = nil
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  File.write(twb, TWB)
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  layout = JSON.parse(File.read(lay))
+end
+
+dash  = (layout || []).find { |x| x['dashboard'] == 'Regions' }
+zones = (dash && dash['zones']) || []
+
+# ---- 1. tinted container: fill_color (8-digit alpha, verbatim) + border_color
+z2 = zones.find { |z| z['id'] == '2' }
+check(z2 && z2['fill_color'] == '#07b4a24e',
+      "flat zones: tinted container keeps 8-digit-alpha fill_color (got #{z2 && z2['fill_color'].inspect})", fails)
+check(z2 && z2['border_color'] == '#07b4a2',
+      "flat zones: container border_color extracted (got #{z2 && z2['border_color'].inspect})", fails)
+
+# ---- 2. transparent fill is NOT emitted ------------------------------------
+z5 = zones.find { |z| z['id'] == '5' }
+check(z5 && z5['fill_color'].nil?,
+      "flat zones: fully-transparent (#00000000) fill is skipped (got #{z5 && z5['fill_color'].inspect})", fails)
+
+# ---- 3. control display mode ------------------------------------------------
+z3 = zones.find { |z| z['id'] == '3' }
+check(z3 && z3['control_display'] == 'compact',
+      "flat zones: filter mode='compact' → control_display (got #{z3 && z3['control_display'].inspect})", fails)
+
+# ---- 4. nested zone_tree also carries the fill -----------------------------
+tree = (dash && dash['zone_tree']) || []
+def find_zone(nodes, id)
+  nodes.each do |n|
+    return n if n['id'] == id
+    r = find_zone(n['children'] || [], id)
+    return r if r
+  end
+  nil
+end
+t2 = find_zone(tree, '2')
+check(t2 && t2['fill_color'] == '#07b4a24e',
+      "zone_tree: nested container node carries fill_color (got #{t2 && t2['fill_color'].inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — Phase-1 zone-style extraction works'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
First implementation increment of the composition/style layer (design doc in #241). The skill had a data-correctness layer but **no composition/style layer** — this teaches `parse-twb-layout.rb` to surface three style signals it previously dropped, on both the flat `zones` array and the nested `zone_tree`.

## New sidecar fields
- **`fill_color`** — a dashboard zone's `<zone-style><format attr='background-color'>` (region-card tints / canvas). 8-digit alpha hex (`#rrggbbaa`) passed through verbatim (Sigma `style.backgroundColor` accepts it); fully-transparent `#00000000` skipped. *(B2, beads-sigma-ubr5.6)*
- **`border_color`** — `<zone-style><format attr='border-color'>`. *(B2)*
- **`control_display`** — the zone `mode` attr (`compact`→dropdown/`list`, `type_in`→text, absent→default `segmented`). Supplies E1's missing signal. *(E1, beads-sigma-ubr5.17)*

## Verified tokens (correcting the design doc)
The design doc was written before the workbook was in hand and **guessed** the XML tokens. Verified against the real benchmark `.twb` (Tableau Public), the truth is:
- fills live on the zone's **direct `<zone-style>` child**, **not** `<style-rule element='dash-zone'>` (that scope doesn't exist for zones);
- control display is the zone **`mode`** attr, **not** `param-mode`.

Running the patched parser on the benchmark extracts **all four region tints** — `#07b4a2` teal (South) / `#e8519a` pink (West) / `#827bb8` purple (Northeast) / `#f28e2b` orange (Midwest), each at 3 alphas — plus the grey KPI-card fills, and `control_display` compact×6 / type_in×2. (I'll reconcile the design-doc token table when #241 merges.)

## Tests
- New `test-zone-style-extraction.rb` — 5 asserts on a synthetic `.twb` (tint + border + transparent-skip + `mode` + nested tree). **All pass.**
- Existing `test-container-layout.rb` still green (shared zone builders unchanged in behavior).

## Scope
Additive only — every existing field/consumer unchanged. This is parser tasks 1–3 partial (fill/border/control_display); remaining Phase-1 parser tasks (palette `channels.color.palette`, `text_runs`, `kpi_composite`) and the builder `emit_composition` stage follow in subsequent PRs per the design doc's sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)