### PR TITLE
tableau(Phase 1): E1 — dropdown vs segmented control style

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -3799,6 +3799,35 @@ filter_zone_dashboards = lambda do |cap|
   end.map { |d| d['dashboard'] }
 end
 
+# E1 (gap ubr5.17): a parameter/filter control's Tableau display mode → Sigma
+# control style. parse-twb-layout surfaces the zone `mode` attr as
+# `control_display` ('compact' → dropdown/Sigma controlType:list; 'type_in' →
+# text; absent → default button/radio → segmented). control_display_for looks it
+# up by the control's caption across all dashboards' (flat, all-descendant) zones,
+# returning nil when Tableau gave no explicit mode (→ caller keeps segmented).
+# `norm` is the caption normalizer (passed so this stays a pure, testable def).
+def control_display_for(layout, cap, norm)
+  (layout || []).each do |d|
+    (d['zones'] || []).each do |z|
+      next unless z['kind'] == 'filter' || z['kind'] == 'parameter'
+      next unless norm.call(z['filter_column_caption']) == norm.call(cap)
+      cd = z['control_display']
+      return cd if cd && !cd.to_s.empty?
+    end
+  end
+  nil
+end
+
+# Map a Tableau control_display to a Sigma controlType for a discrete/list param.
+# compact → list (dropdown); type_in → text; otherwise segmented (button row).
+def sigma_control_type(disp)
+  case disp
+  when 'compact' then 'list'
+  when 'type_in' then 'text'
+  else 'segmented'
+  end
+end
+
 # Worksheets whose own view filters carry `[Action (<cap>)]` — the .twb scopes
 # those cross-sheet filter actions to specific sheets.
 action_worksheets = lambda do |cap|
@@ -3888,7 +3917,9 @@ if opts[:auto_controls]
       'includeNulls' => 'when-no-value-is-selected'
     }
     if p['param_domain'] == 'list'
-      spec['controlType']   = 'segmented'
+      # E1: dropdown vs segmented from the Tableau control display mode; default
+      # segmented (button row) when Tableau declared no explicit mode.
+      spec['controlType']   = sigma_control_type(control_display_for(layout, cap, norm_cap))
       values = p['members'] || []
       # Tableau list parameters often store integer-coded members (1..13) whose
       # human meaning lives in the parameter's value ALIASES (1→"TCV", 3→"ACV").
@@ -3965,7 +3996,9 @@ $param_switches.each do |sw|
     'kind'        => 'control',
     'controlId'   => sw['control_id'],
     'name'        => pcap,
-    'controlType' => 'segmented',
+    # E1: a measure-picker often renders as a dropdown (Tableau 'compact'); honor
+    # its display mode, else segmented (button row).
+    'controlType' => sigma_control_type(control_display_for(layout, pcap, norm_cap)),
     'source'      => { 'kind' => 'manual', 'valueType' => 'text', 'values' => values, 'labels' => values },
     'value'       => values.first,
     'includeNulls' => 'when-no-value-is-selected'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-display-type.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-display-type.rb
@@ -1,0 +1,81 @@
+#!/usr/bin/env ruby
+# Regression test for E1 (gap beads-sigma-ubr5.17): dropdown vs segmented control
+# style. Tableau surfaces a quick-filter/parameter display mode on the zone `mode`
+# attr, which parse-twb-layout emits as `control_display` ('compact' → dropdown,
+# 'type_in' → text, absent → default button/radio). Before this fix the builder
+# hardcoded every list-domain parameter control to `segmented`.
+#
+# Exercises the two pure build-layer helpers directly (no live POST, no --tab):
+#   - control_display_for(layout, cap, norm): finds a control's display mode by
+#     caption across the dashboards' flat zones (filter/parameter kinds only)
+#   - sigma_control_type(disp): maps a Tableau display mode → Sigma controlType
+#
+# Usage:  ruby scripts/test-control-display-type.rb
+require 'json'
+
+DIR = __dir__
+SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+
+# Pull the pure helpers out of the script (which otherwise runs main).
+%w[control_display_for sigma_control_type].each do |fn|
+  m = SRC.match(/^def #{fn}\b.*?\n^end$/m) or abort("could not extract #{fn} from build-charts-from-signals.rb")
+  eval(m[0]) # rubocop:disable Security/Eval — test-only extraction of first-party code
+end
+
+# Mirrors norm_cap in build-charts-from-signals.rb (L3757).
+NORM = ->(s) { s.to_s.strip.downcase.gsub(/[^a-z0-9]+/, '') }
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# ---- 1. sigma_control_type mapping -----------------------------------------
+check(sigma_control_type('compact') == 'list',      "compact → list (dropdown)", fails)
+check(sigma_control_type('type_in') == 'text',      "type_in → text", fails)
+check(sigma_control_type(nil)       == 'segmented', "no explicit mode → segmented (default preserved)", fails)
+check(sigma_control_type('radio')   == 'segmented', "unknown/radio → segmented", fails)
+
+# ---- 2. control_display_for lookup (mirrors the benchmark's controls) -------
+LAYOUT = [{
+  'dashboard' => 'Job Losses',
+  'zones' => [
+    { 'kind' => 'parameter', 'filter_column_caption' => 'Job Loss Metric', 'control_display' => 'compact' },
+    { 'kind' => 'parameter', 'filter_column_caption' => 'Immigrant / U.S.-born' }, # no mode → nil → segmented
+    { 'kind' => 'filter',    'filter_column_caption' => 'Highlight State', 'control_display' => 'type_in' },
+    { 'kind' => 'chart',     'filter_column_caption' => 'Region Chart', 'control_display' => 'compact' } # wrong kind: ignored
+  ]
+}]
+
+check(control_display_for(LAYOUT, 'Job Loss Metric', NORM) == 'compact',
+      "finds 'compact' for the Metric dropdown", fails)
+check(control_display_for(LAYOUT, 'Immigrant / U.S.-born', NORM).nil?,
+      "returns nil when a control has no explicit mode (→ segmented)", fails)
+check(control_display_for(LAYOUT, 'Highlight State', NORM) == 'type_in',
+      "finds 'type_in' on a filter zone", fails)
+check(control_display_for(LAYOUT, 'JOB   loss  metric!', NORM) == 'compact',
+      "caption match is normalized (case/space/punct-insensitive)", fails)
+check(control_display_for(LAYOUT, 'Region Chart', NORM).nil?,
+      "ignores non-filter/parameter zones (a chart zone's stray mode)", fails)
+check(control_display_for(LAYOUT, 'Nonexistent', NORM).nil?,
+      "returns nil for an unknown caption", fails)
+
+# ---- 3. end-to-end mapping for the benchmark's 5 controls ------------------
+# Metric/Labels/Median are compact dropdowns → list; share/rank have no mode → segmented.
+mapped = {
+  'Job Loss Metric'       => sigma_control_type(control_display_for(LAYOUT, 'Job Loss Metric', NORM)),
+  'Immigrant / U.S.-born' => sigma_control_type(control_display_for(LAYOUT, 'Immigrant / U.S.-born', NORM))
+}
+check(mapped['Job Loss Metric'] == 'list',       "Metric picker → list (matches oracle)", fails)
+check(mapped['Immigrant / U.S.-born'] == 'segmented', "share toggle → segmented (matches oracle)", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — E1 control display type (dropdown vs segmented)'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
**Stacked on #242** (base branch `tableau-phase1-parser-style`; consumes its `control_display` parser field). Review/merge #242 first.

## Problem
The builder hardcoded every list-domain parameter control — and the measure-picker Switch control — to `controlType: 'segmented'`. The answer-key spec (TJ's hand-built migration) shows the dashboard actually uses **list×3** (Job Loss Metric / Labels / Median dropdowns) + **segmented×2** (Immigrant|U.S.-born, Rank).

## Fix
Honor the Tableau display mode that `parse-twb-layout` now surfaces as `control_display` (the zone `mode` attr):
- `compact` → `list` (dropdown)
- `type_in` → `text`
- absent → `segmented` (default preserved — no behavior change where Tableau gave no mode)

Two pure helpers (`control_display_for`, `sigma_control_type`) wired into both control-emit sites (auto-param list-domain + param-switch measure picker).

## Verification
- `test-control-display-type.rb` — **12 asserts**: the mapping, the caption-normalized lookup, wrong-kind-zone ignore, and the benchmark's 5-control split (Metric→list, share→segmented).
- Existing `test-param-measure-picker.rb` still green.
- (Full-pipeline controlType assertion needs a `--tab` fixture — deferred; the parser signal is tested in #242 + verified on the real benchmark `.twb` as compact×6/type_in×2.)

beads-sigma-ubr5.17 (E1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)