### PR TITLE
tableau(Phase 1): B2 — emit container background tints + borders

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -138,6 +138,17 @@ def tree_has_controls?(tree)
   end
 end
 
+# True when any container in the tree carries a fill (region-card tints etc.).
+# B2 (gap ubr5.6): a designed dashboard with tinted containers but NO controls
+# would otherwise take the banded fallback and lose its tints — the container
+# path is what preserves them (and falls back safely if the tree can't build).
+def tree_has_styled_containers?(tree)
+  (tree || []).any? do |n|
+    (n['kind'] == 'container' && (n['fill_color'] || n['border_color'])) ||
+      tree_has_styled_containers?(n['children'])
+  end
+end
+
 # Place a child within its parent container's internal 24-col grid from pct
 # bounds. parent_rows = grid row-lines the parent spans internally.
 def place_in_parent(ch, p, parent_rows)
@@ -189,7 +200,17 @@ def emit_node(node, c0, c1, r0, r1, ctx)
     end.compact
     return nil if inner.empty?
     cid = "tc-#{ctx[:page_id]}-#{node['id']}"
-    ctx[:extra] << container_el(cid)
+    # B2 (gap ubr5.6): apply the Tableau zone's fill as the Sigma container tint.
+    # parse-twb-layout surfaces fill_color (region-card tints, e.g. #07b4a24e) and
+    # border_color from the zone's <zone-style>. 8-digit-alpha hex renders over the
+    # canvas verbatim (Sigma accepts it), so the region columns keep their color
+    # without a separate pastel-flattening step. Unstyled zones → plain container.
+    cstyle = nil
+    if node['fill_color']
+      cstyle = { 'backgroundColor' => node['fill_color'], 'borderRadius' => 'round' }
+      cstyle['borderColor'] = node['border_color'] if node['border_color']
+    end
+    ctx[:extra] << container_el(cid, cstyle)
     gc(cid, c0, c1, r0, r1, inner.join("\n"))
   else
     eid = resolve_leaf(node, ctx)
@@ -387,7 +408,8 @@ totals = { charts: 0, bands: 0, controls: 0 }
 dash_layout.each do |d|
   page = page_for_dash[d['dashboard']]
   next unless page
-  use_tree = !opts[:no_containers] && tree_has_controls?(d['zone_tree'])
+  use_tree = !opts[:no_containers] &&
+             (tree_has_controls?(d['zone_tree']) || tree_has_styled_containers?(d['zone_tree']))
   if use_tree
     begin
       pxml, extra_els, n_charts, n_bands, n_ctls = build_page_from_tree(d, page, opts)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-container-tint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-container-tint.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+# Regression test for B2 (gap beads-sigma-ubr5.6): container background tints.
+# A Tableau dashboard zone with a <zone-style> fill (a region-card tint) must
+# become a Sigma GridContainer with style.backgroundColor + borderRadius. Before
+# this the layout builder emitted every container plain (no fill).
+#
+# End-to-end through the ACTUAL parse-twb-layout.rb + build-dashboard-layout.rb
+# (no Tableau/Sigma calls): a tinted layout-flow container (8-digit-alpha teal
+# #07b4a24e + teal border) wrapping a chart → assert the emitted container spec
+# (in <out>.elements.json) carries backgroundColor + borderColor + borderRadius.
+#
+# Usage:  ruby scripts/test-container-tint.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-dashboard-layout.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='Sales' name='federated.x'>
+        <column caption='Region' name='[Region]' datatype='string' role='dimension' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Sales by Region'><table><view><datasource-dependencies datasource='federated.x' /></view></table></worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Regions'>
+        <zones>
+          <zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+            <zone id='2' type-v2='layout-flow' param='vert' x='0' y='0' w='50000' h='100000'>
+              <zone-style>
+                <format attr='background-color' value='#07b4a24e' />
+                <format attr='border-color' value='#07b4a2' />
+              </zone-style>
+              <zone id='3' name='Sales by Region' x='0' y='0' w='50000' h='100000' />
+            </zone>
+          </zone>
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+containers = []
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  out = File.join(d, 'layout.xml')
+  File.write(twb, TWB)
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+
+  wb_ids = { 'pages' => [
+    { 'name' => 'Data', 'elements' => [{ 'id' => 'master', 'kind' => 'table', 'name' => 'Data' }] },
+    { 'name' => 'Regions', 'elements' => [{ 'id' => 'el-chart', 'kind' => 'bar-chart', 'name' => 'Sales by Region' }] }
+  ] }
+  wbf = File.join(d, 'wb-ids.json')
+  File.write(wbf, JSON.dump(wb_ids))
+  system('ruby', BUILD, '--layout', lay, '--wb-ids', wbf, '--out', out, out: File::NULL, err: File::NULL)
+
+  ef = "#{out}.elements.json"
+  if File.exist?(ef)
+    sidecar = JSON.parse(File.read(ef))
+    sidecar.each_value { |els| containers.concat(els.select { |e| e['kind'] == 'container' }) }
+  end
+end
+
+tinted = containers.find { |c| c.dig('style', 'backgroundColor') == '#07b4a24e' }
+check(!tinted.nil?, "a container carries the zone tint backgroundColor '#07b4a24e' (8-digit alpha, verbatim)", fails)
+check(tinted && tinted.dig('style', 'borderRadius') == 'round', "tinted container has borderRadius: round", fails)
+check(tinted && tinted.dig('style', 'borderColor') == '#07b4a2', "tinted container carries borderColor from the zone", fails)
+# The dark page-header container (HEADER_STYLE) must remain distinct from the tint.
+check(containers.any? { |c| c.dig('style', 'backgroundColor') == '#0F172A' },
+      "page header container still emitted (unaffected)", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — B2 container tint emit'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
Continues the composition/style layer. Consumes the `fill_color`/`border_color` parser fields (already in main via #242) and emits them as Sigma container style.

## Change
- **Tint emit** (`emit_node`): a container zone's `fill_color` → `style.backgroundColor` (+ `borderColor`, `borderRadius: round`). 8-digit-alpha hex passed through verbatim (Sigma renders it over the canvas — faithful to Tableau, no pastel-flattening needed).
- **Trigger broadened**: `use_tree` previously fired only when the tree had filter/parameter controls, so a designed dashboard with tinted cards but no controls fell to the banded path and lost its tints. Now styled containers (fill/border) also select the container path (still falls back to banded on error). The Job-Loss benchmark takes the tree path regardless (it has 6 controls); this also covers control-less tinted dashboards.

## Verification
- `test-container-tint.rb` — 4 asserts (8-digit-alpha `backgroundColor`, `borderRadius: round`, `borderColor`, header container unaffected).
- Existing `test-container-layout`, `test-layout-lint`, `test-complex-dashboard-e2e` all green.
- Parser side verified on the real benchmark `.twb` (all 4 region tints extracted) in #242.

beads-sigma-ubr5.6 (B2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)