### PR TITLE
tableau(Phase 1): D1 + canvas — workbook themeOverrides

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
@@ -14,6 +14,9 @@
 #     --folder-id   <uuid>
 #     [--mode dashboard|page-per-worksheet]         # default: page-per-worksheet
 #     [--dm-element-name "Order Fact"]              # which DM element the master sources from (default: first non-Date)
+#     [--layout /tmp/<name>/dashboard-layout.json]  # parse-twb-layout output — derives themeName + themeOverrides
+#                                                    #   (backgroundCanvas from the page fill; categoricalScheme
+#                                                    #   from the tinted region-card palette). Omit → no theme.
 #     --out /tmp/<name>/wb-spec.json
 #
 # --master-cols schema (YAML):
@@ -45,6 +48,7 @@ OptionParser.new do |p|
   p.on('--folder-id S')         { |v| opts[:folder_id] = v }
   p.on('--mode S')              { |v| opts[:mode] = v }
   p.on('--dm-element-name S')   { |v| opts[:dm_el_name] = v }
+  p.on('--layout PATH', 'parse-twb-layout output — used to derive workbook theme (canvas + region palette)') { |v| opts[:layout] = v }
   p.on('--out PATH')            { |v| opts[:out] = v }
 end.parse!
 %i[specs dm_ids name folder_id out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
@@ -156,6 +160,47 @@ else
   abort('chart-specs.json must be either { pages: [...] } or [ ... ]')
 end
 
+# Derive the workbook theme from the parsed layout (Phase-1 composition/style,
+# gaps D1 + Pass-7 canvas). Two pieces, both spec-authorable (themeName +
+# themeOverrides), emitted only when the source actually declares them:
+#   - backgroundCanvas: the outermost dashboard zone's fill (the page canvas).
+#   - categoricalScheme: the SOURCE region palette, recovered from the tinted
+#     container cards. Tableau stores region-card tints as 8-digit-alpha hex
+#     (#07b4a24e = the saturated base #07b4a2 over the canvas); stripping the
+#     alpha yields the mark color, which is the faithful chart palette (the
+#     hand-built spec's hexes are aesthetic tweaks not present in the .twb, so
+#     the source colors are the correct automated target). Ordered by first
+#     appearance, deduped. Solid 6-digit fills (grey KPI cards) are excluded so
+#     only the categorical region hues form the scheme. Returns {} when nothing
+#     is derivable → no theme emitted (Sigma defaults apply; never worse).
+def derive_theme(layout)
+  dashes = layout.is_a?(Array) ? layout : []
+  return {} if dashes.empty?
+  roots = dashes.first['zone_tree'] || []
+  canvas = nil
+  palette = []
+  seen = {}
+  walk = lambda do |nodes, depth|
+    (nodes || []).each do |n|
+      fc = n['fill_color']
+      canvas ||= fc if depth.zero? && fc # outermost zone fill = page canvas
+      if n['kind'] == 'container' && fc.is_a?(String) && fc =~ /\A#[0-9a-fA-F]{8}\z/
+        base = fc[0, 7].downcase # strip 8-digit alpha → saturated base (mark color)
+        unless seen[base]
+          seen[base] = true
+          palette << base
+        end
+      end
+      walk.call(n['children'], depth + 1)
+    end
+  end
+  walk.call(roots, 0)
+  theme = {}
+  theme['backgroundCanvas'] = canvas if canvas
+  theme['categoricalScheme'] = palette if palette.size >= 2 # only the multi-member region pattern
+  theme
+end
+
 wb = {
   'name'          => opts[:name],
   'schemaVersion' => 1,
@@ -163,6 +208,19 @@ wb = {
   'pages'         => [data_page] + visible_pages
 }
 wb['description'] = opts[:description] if opts[:description]
+
+# Phase-1 theme (D1 palette + Pass-7 canvas), when a --layout was provided.
+if opts[:layout]
+  theme = derive_theme(JSON.parse(File.read(opts[:layout])))
+  unless theme.empty?
+    wb['themeName'] = 'Light'
+    overrides = {}
+    overrides['colorOverrides'] = { 'backgroundCanvas' => theme['backgroundCanvas'] } if theme['backgroundCanvas']
+    overrides['categoricalScheme'] = theme['categoricalScheme'] if theme['categoricalScheme']
+    wb['themeOverrides'] = overrides unless overrides.empty?
+    warn "  theme: canvas=#{theme['backgroundCanvas'] || '(default)'}, categoricalScheme=#{(theme['categoricalScheme'] || []).size} color(s)"
+  end
+end
 
 File.write(opts[:out], JSON.pretty_generate(wb))
 warn "wrote #{opts[:out]}"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/synth-twb-e2e.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/synth-twb-e2e.rb
@@ -301,7 +301,8 @@ run!(['ruby', File.join(HERE, 'build-workbook-spec.rb'),
       '--chart-specs', chart_specs_path, '--dm-ids', dm_ids_path,
       '--master-cols', master_cols_path, '--workbook-name', NAME,
       '--folder-id', opts[:folder], '--mode', 'dashboard',
-      '--dm-element-name', fact['name'], '--out', wb_spec_path], allow_fail: true)
+      '--dm-element-name', fact['name'], '--layout', layout_path,
+      '--out', wb_spec_path], allow_fail: true)
 
 wbspec = JSON.parse(File.read(wb_spec_path))
 # Sigma page ids must match /^[a-zA-Z0-9_-]{1,64}$/; the slug can contain invalid

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-derivation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-derivation.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+# Regression test for D1 + Pass-7 canvas (gaps beads-sigma-ubr5.15 / .6): the
+# workbook theme derived from the parsed layout. build-workbook-spec.rb turns the
+# outermost zone fill into themeOverrides.colorOverrides.backgroundCanvas and the
+# tinted region-card container fills into themeOverrides.categoricalScheme (the
+# SOURCE mark palette — 8-digit-alpha tint #07b4a24e → base #07b4a2).
+#
+# Exercises the pure derive_theme(layout) helper directly (no live POST).
+# Usage:  ruby scripts/test-theme-derivation.rb
+require 'json'
+
+DIR = __dir__
+SRC = File.read(File.join(DIR, 'build-workbook-spec.rb'))
+m = SRC.match(/^def derive_theme\b.*?\n^end$/m) or abort('could not extract derive_theme')
+eval(m[0]) # rubocop:disable Security/Eval — test-only extraction of first-party code
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Mirrors the benchmark: a white-canvas dashboard, 4 region cards tinted with
+# 8-digit-alpha region hues, plus a grey solid KPI card (must NOT enter the scheme).
+LAYOUT = [{
+  'dashboard' => 'Job Losses',
+  'zone_tree' => [{
+    'id' => '1', 'kind' => 'container', 'fill_color' => '#ffffff', 'children' => [
+      { 'id' => 'kpi', 'kind' => 'container', 'fill_color' => '#e6e6e6' }, # grey solid → excluded
+      { 'id' => 'south', 'kind' => 'container', 'caption' => 'South',    'fill_color' => '#07b4a24e' },
+      { 'id' => 'west',  'kind' => 'container', 'caption' => 'West',     'fill_color' => '#e8519a4e' },
+      { 'id' => 'ne',    'kind' => 'container', 'caption' => 'Northeast','fill_color' => '#827bb84e' },
+      { 'id' => 'mw',    'kind' => 'container', 'caption' => 'Midwest',  'fill_color' => '#f28e2b4e' }
+    ]
+  }]
+}]
+
+theme = derive_theme(LAYOUT)
+
+check(theme['backgroundCanvas'] == '#ffffff',
+      "canvas = outermost zone fill (got #{theme['backgroundCanvas'].inspect})", fails)
+check(theme['categoricalScheme'] == %w[#07b4a2 #e8519a #827bb8 #f28e2b],
+      "categoricalScheme = source region bases, alpha stripped, in order (got #{theme['categoricalScheme'].inspect})", fails)
+check(!(theme['categoricalScheme'] || []).include?('#e6e6e6'),
+      "grey solid KPI-card fill excluded from the scheme", fails)
+
+# No styled containers → no theme (Sigma defaults; never worse).
+plain = derive_theme([{ 'dashboard' => 'X', 'zone_tree' => [
+  { 'id' => '1', 'kind' => 'container', 'children' => [{ 'id' => 'c', 'kind' => 'chart' }] }
+] }])
+check(plain == {}, "unstyled dashboard → empty theme (got #{plain.inspect})", fails)
+
+# Single tinted card → no categoricalScheme (needs the multi-member pattern).
+one = derive_theme([{ 'dashboard' => 'X', 'zone_tree' => [
+  { 'id' => '1', 'kind' => 'container', 'fill_color' => '#07b4a24e' }
+] }])
+check(one['categoricalScheme'].nil?, "single tinted container → no scheme (needs >=2)", fails)
+
+# Dedup: same base at two alphas collapses to one scheme entry.
+dup = derive_theme([{ 'dashboard' => 'X', 'zone_tree' => [
+  { 'id' => 'a', 'kind' => 'container', 'fill_color' => '#07b4a24e' },
+  { 'id' => 'b', 'kind' => 'container', 'fill_color' => '#07b4a21b' },
+  { 'id' => 'c', 'kind' => 'container', 'fill_color' => '#e8519a4e' }
+] }])
+check(dup['categoricalScheme'] == %w[#07b4a2 #e8519a], "same base at 2 alphas dedups (got #{dup['categoricalScheme'].inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — D1/Pass-7 theme derivation (canvas + region palette)'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
Continues the composition/style layer with the **workbook theme**, gated against the answer-key spec.

## Change
`build-workbook-spec.rb` gains an optional `--layout` input and derives `themeName: 'Light'` + `themeOverrides`:
- **`colorOverrides.backgroundCanvas`** ← the outermost dashboard zone's fill (Pass-7 canvas).
- **`categoricalScheme`** ← the **source** region palette, recovered from the tinted region-card containers. Tableau stores tints as 8-digit-alpha hex (`#07b4a24e`); stripping the alpha gives the saturated mark color (`#07b4a2`). The hand-built spec's hexes (`#35bda8` …) are aesthetic tweaks **not present in the `.twb`**, so the source colors are the faithful automated target. Ordered by first appearance, deduped; solid grey KPI-card fills excluded; emitted only for the ≥2-member region pattern.

Emitted only when the source declares it — no styled source → no theme (Sigma defaults; never worse). Wires `--layout` into the `synth-twb-e2e` harness.

## Verification
- `test-theme-derivation.rb` — 6 asserts (canvas, ordered source palette, grey-exclusion, dedup, unstyled→empty, single-card→no-scheme).
- On the **real benchmark** layout: `categoricalScheme = [#07b4a2, #e8519a, #827bb8, #f28e2b]` — the four source region colors.

beads-sigma-ubr5.15 (D1) + Pass-7 canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)