### PR TITLE
fix(tableau): don't flag slash-bearing column names as unreachable relationships

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -382,12 +382,22 @@ module MechanicalSpecs
       rel_names = (src_el['relationships'] || []).map { |r| r['name'] }.compact
       base_names = [src_el['name'], display_name((src_el.dig('source', 'path') || []).last.to_s),
                     (src_el.dig('source', 'path') || []).last].compact.uniq.reject(&:empty?)
+      # Columns on the base element, by their referenceable name — used to tell a
+      # 3-segment relationship path apart from a 2-segment [Element/Column] ref
+      # whose COLUMN NAME contains a literal '/' (e.g. a Snowflake column named
+      # "Margin Pct H/L").
+      src_cols = (src_el['columns'] || []).map { |cc| col_display(cc) }.compact
       (el['columns'] || []).each do |c|
         f = c['formula'].to_s
         m = f.match(/\A\[([^\/\]]+)\/([^\/\]]+)\/([^\]]+)\]\z/)
         next unless m
         next unless base_names.include?(m[1])
         next if rel_names.include?(m[2])
+        # The '/'-split assumed [Base/REL/Field], but the middle isn't a known
+        # relationship. If the whole tail after the base names a real column on
+        # the base element, this is [Element/Column] with a slash in the column
+        # name — a column ref, NOT an unreachable relationship. Don't flag it.
+        next if src_cols.include?("#{m[2]}/#{m[3]}")
         out << "derived column #{(col_display(c) || c['id']).inspect} refs relationship #{m[2].inspect} which does not exist on '#{elem_name(src_el)}' (have: #{rel_names.join(', ')})"
       end
     end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-reachability-slash.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-relationship-reachability-slash.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for relationship_reachability_violations (2026-07-01).
+# Deterministic + offline.
+#
+# Guards the false-positive class: a real Snowflake column whose NAME contains a
+# literal '/' (e.g. "Margin Pct H/L") makes a 2-segment
+# [Element/Column] ref look like a 3-segment [Base/REL/Field] relationship path.
+# The reachability guard split on '/' and flagged "Margin Pct
+# T" as a missing relationship, failing an otherwise-clean conversion.
+#
+# The fix: if the tail after the base names a real COLUMN on the base element,
+# it's a column ref, not a relationship path — no violation. Genuine unreachable
+# relationships must still be caught.
+#
+# Usage:  ruby scripts/test-relationship-reachability-slash.rb
+
+require_relative 'mechanical-specs'
+
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}"; end
+
+# Base element with a slash-bearing column and a few real relationships (mirrors
+# the incident: an extract-backed element whose rels are CUSTOMER/PRODUCT/…).
+SLASH_COL = 'Margin Pct H/L'
+base = {
+  'id' => 'e-sales', 'name' => 'SALES',
+  'source' => { 'kind' => 'warehouse-table', 'path' => %w[DB PUBLIC SALES] },
+  'columns' => [
+    { 'id' => 'c-slash', 'name' => SLASH_COL },
+    { 'id' => 'c-amt',   'name' => 'Amount' }
+  ],
+  'relationships' => [
+    { 'name' => 'CUSTOMER' }, { 'name' => 'PRODUCT' },
+    { 'name' => 'REGION' },    { 'name' => 'ORDER DATE' }
+  ]
+}
+
+def model_with(base, formula)
+  { 'pages' => [{ 'elements' => [
+    base,
+    { 'id' => 'e-derived', 'name' => 'Derived',
+      'source' => { 'kind' => 'table', 'elementId' => 'e-sales' },
+      'columns' => [{ 'id' => 'd0', 'name' => 'D0', 'formula' => formula }] }
+  ] }] }
+end
+
+puts 'Part A — slash-bearing column ref is NOT a false relationship violation'
+v = MechanicalSpecs.relationship_reachability_violations(model_with(base, "[SALES/#{SLASH_COL}]"))
+check(v.empty?, "no violation for [SALES/#{SLASH_COL}] (got #{v.inspect})", fails)
+
+puts 'Part B — a genuine unreachable relationship is STILL flagged'
+v = MechanicalSpecs.relationship_reachability_violations(model_with(base, '[SALES/Ghost Rel/Some Col]'))
+check(v.any? { |s| s.include?('Ghost Rel') },
+      "flags [SALES/Ghost Rel/Some Col] as unreachable (got #{v.inspect})", fails)
+
+puts 'Part C — a valid relationship path is not flagged'
+v = MechanicalSpecs.relationship_reachability_violations(model_with(base, '[SALES/CUSTOMER/Name]'))
+check(v.empty?, "no violation for a real relationship path (got #{v.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — slash-column false positive fixed, real violations still caught'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end


### PR DESCRIPTION
## Problem

A tableau→sigma run failed its relationship-reachability gate on a clean workbook. `relationship_reachability_violations` (`scripts/mechanical-specs.rb`) parsed **any** bracketed ref with two slashes as `[Base/RELATIONSHIP/Field]`:

```ruby
m = f.match(/\A\[([^\/\]]+)\/([^\/\]]+)\/([^\]]+)\]\z/)
```

A warehouse column whose name contains a literal `/` (e.g. `Margin Pct H/L`) is a **2-segment** `[Element/Column]` ref, but the regex split it into `Base` / `REL` / `Field` and reported the middle segment as a missing relationship — a false positive that blocked the whole conversion.

## Fix

When the middle segment isn't a known relationship, reconstruct the tail and check whether it names a real **column** on the base element. If it does, the ref is `[Element/Column]` with a `/` in the column name — not a relationship path — so it's not flagged. Genuine unreachable relationships are still caught.

## Test

New `test-relationship-reachability-slash.rb` (deterministic, offline): slash-column ref → no violation; ghost relationship → still flagged; valid relationship path → no violation. `ALL PASS`.

Gates: `check-shared` OK, `lint-skills` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)