### PR TITLE
Windows: sanctioned no-admin Node path + mandatory doctor preflight

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-assessment/refs/environment.md
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/environment.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/refs/environment.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/environment.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/looker-to-sigma/skills/looker-assessment/refs/environment.md
+++ b/plugins/looker-to-sigma/skills/looker-assessment/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/environment.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/refs/environment.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/environment.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/environment.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/environment.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/refs/environment.md
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/environment.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/environment.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/environment.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/refs/environment.md
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/sigma-authoring/skills/sigma-workbooks/refs/environment.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/refs/environment.md
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/environment.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/refs/environment.md
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -11,9 +11,19 @@ user-invocable: true
 
 # Tableau → Sigma Conversion
 
-> **Windows / first run — run the environment doctor before anything else:**
-> `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
-> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
+> ## ⛔ STEP 0 — MANDATORY environment preflight (do this before any other step)
+> On the **first run in a session**, run the doctor and read its output **before**
+> touching Tableau discovery or the converter:
+> - macOS / Linux / Git Bash: `bash scripts/doctor.sh`
+> - Windows PowerShell: `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1`
+>
+> It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes.
+> **If the doctor reports a missing runtime (exit 1): STOP.** Present its fix to the user
+> and get their OK — **do not** self-install a runtime, download an unpinned binary, or
+> edit the machine's PATH on your own initiative. That is a hard-to-reverse, outward-facing
+> action to confirm first, not improvise mid-run. Node in particular: on locked-down
+> Windows use the no-admin path in `refs/environment.md` (#5), and let the **user** run it.
+> Details: `refs/environment.md`.
 
 Convert a Tableau datasource into a Sigma data model, then build a Sigma workbook
 that mirrors the Tableau dashboard layout as closely as possible.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/environment.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/environment.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/environment.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------

--- a/shared/refs/environment.md
+++ b/shared/refs/environment.md
@@ -14,7 +14,7 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 |---|---|---|
 | **ruby** | the `*-to-sigma` orchestrators (tableau, qlik, powerbi, quicksight, cognos) | not preinstalled on Windows |
 | **python 3** | looker / thoughtspot / microstrategy / sisense entrypoints + all discovery scripts | **Windows: the Store-alias stub bites — see below** |
-| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | |
+| **node 18+** | the vendored converters (`converter/*.mjs`) and `*.mjs` build steps | **Windows: see #5 for the no-admin install** |
 | **bash** | `get-token.sh`, `*-auth.sh` (Sigma token minting) | **Windows: needs Git Bash or WSL** |
 
 ## Windows footguns (and fixes)
@@ -40,6 +40,28 @@ Exit 0 = good to go. Exit 1 = a required tool is missing (each ✗/[X] line has 
 
 4. **Ruby not on PATH.** Install **RubyInstaller** (https://rubyinstaller.org), tick
    *Add Ruby to PATH*, reopen the shell.
+
+5. **No `node`, no admin rights.** Node is a hard prerequisite (the converters are
+   ESM run via `node`), but the nodejs.org MSI and `winget install OpenJS.NodeJS.LTS`
+   both want admin — which locked-down corporate machines don't grant. Sanctioned
+   options, in order:
+   - **If you have admin:** install Node LTS from **https://nodejs.org** or
+     `winget install OpenJS.NodeJS.LTS`, reopen the shell.
+   - **No admin — user-scoped version manager (preferred):**
+     `winget install Schniz.fnm` then `fnm install --lts && fnm use --lts`. fnm is a
+     single user-scoped binary; no admin, and it persists across sessions.
+   - **No admin, no winget — portable zip (last resort):** download the **LTS** zip
+     from nodejs.org, extract to `%USERPROFILE%\node`, and add it to PATH. Pin an
+     explicit LTS version (do **not** grab whatever is "latest"), and prefer a build
+     that is at least a few days old. This is a *documented, deliberate* step — not
+     something to improvise mid-run.
+
+> **Agents: do not silently install runtimes.** If the doctor reports a missing
+> runtime, surface its fix and get the user's OK before downloading binaries or
+> editing PATH. Never munge the machine's PATH or fetch an unpinned installer on your
+> own initiative — a self-directed download/PATH change is exactly the kind of action
+> to confirm first. The doctor tells you *what's* missing and *how* to fix it; the
+> human decides *whether* to run it.
 
 > The converters themselves need **no clone, no `npm install`, no network, no MCP** —
 > each skill ships a self-contained `converter/*.mjs` bundle run via `node`. So on

--- a/shared/scripts/doctor.ps1
+++ b/shared/scripts/doctor.ps1
@@ -56,7 +56,8 @@ else {
 # --- node ------------------------------------------------------------------
 $node = Get-Command node -ErrorAction SilentlyContinue
 if ($node) { Ok "node - $((& node --version 2>$null))" }
-else { Bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)." }
+else { Bad "node not found (required - the vendored converters/*.mjs run via node)" `
+           "Admin: install Node LTS from https://nodejs.org or 'winget install OpenJS.NodeJS.LTS'. NO admin: 'winget install Schniz.fnm' then 'fnm install --lts; fnm use --lts' (user-scoped, no admin). See refs/environment.md #5. Don't auto-download an unpinned Node - ask first." }
 
 # --- bash (REQUIRED for get-token.sh / *-auth.sh token minting) ------------
 $bash = Get-Command bash -ErrorAction SilentlyContinue

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -69,7 +69,7 @@ fi
 if command -v node >/dev/null 2>&1; then
   ok "node — $(node --version 2>/dev/null)"
 else
-  bad "node not found" "Install Node 18+ from https://nodejs.org (the vendored converters/*.mjs run via node)."
+  bad "node not found (required — the vendored converters/*.mjs run via node)" "macOS/Linux: install Node 18+ from https://nodejs.org or your package manager. Windows no-admin: 'winget install Schniz.fnm' then 'fnm install --lts && fnm use --lts'. See refs/environment.md #5 — don't auto-download an unpinned Node, ask first."
 fi
 
 # --- bash (token minting + *.sh helpers) -----------------------------------


### PR DESCRIPTION
## Problem
A Windows user (locked-down box, no admin) ran the tableau→sigma skill and the agent **improvised** an unpinned portable Node.js zip download + PATH munge. Root cause: `environment.md`/`doctor` named Node as required but only pointed at the nodejs.org MSI (needs admin). No sanctioned no-admin path, and no rule telling the agent not to self-install runtimes.

Confirmed the customer was on a **post-#224** build (their agent quoted `environment.md` verbatim) — so this is a guidance gap, not a stale bundle.

## Changes
- **`environment.md` #5** — Node install ladder: admin (nodejs.org / winget) → **no-admin preferred (`fnm`, user-scoped)** → pinned-LTS portable zip as documented last resort. Plus an **agent guardrail**: never silently download binaries or edit PATH — surface the doctor's fix and get user consent.
- **`doctor.ps1` / `doctor.sh`** — node-missing fix string now gives the no-admin path + "ask first".
- **`tableau-to-sigma/SKILL.md`** — soft banner → **⛔ STEP 0 mandatory preflight**; STOP on exit 1 and let the user install.

Canonical edits under `shared/`, fanned out via `tools/sync-shared.rb` (`check-shared` passes, 265/265).

## Follow-ups (not in this PR)
- Fan the STEP-0 banner to the other converter SKILL.md files.
- Re-vendor `quickstarts-public` (its tableau bundle is frozen at 2026-06-02 — missing the converter + doctor entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)