### PR TITLE
tableau: Phase-1 B4 emit — styled static-text elements + layout placement

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -3711,6 +3711,44 @@ layout.each do |dash|
   end
 end
 
+# ---- B4: styled static text (gap ubr5.8) -----------------------------------
+# Assemble a Sigma text.body from Tableau formatted-text runs (parse-twb-layout
+# `text_runs`). Each run → an inline <span style> carrying its source color +
+# font-size (px, verbatim — the source point size faithfully preserves relative
+# weight, so no fragile markdown-heading guessing), with **bold** for bold runs;
+# hard-break runs (the Æ+newline sentinel) split paragraphs (\n\n). A run's
+# literal whitespace is emitted plain (keeps inter-run spacing). Dynamic Tableau
+# tokens (<[Parameters]…>) can't be reproduced as static text and would corrupt
+# the HTML body, so they're stripped (caller WARNs). `align` wraps center/right
+# in a <p> (left is Sigma's default and 400s if forced — styling.md); `bg` wraps
+# the content in a background-color span (a pill/chip). Returns nil when nothing
+# visible remains. All colors are hex (var(--…) 400s). Pure/self-contained so
+# test-styled-text-body.rb can extract and eval it.
+def text_body_from_runs(runs, align: nil, bg: nil)
+  return nil if runs.nil? || runs.empty?
+  # Split into paragraphs on hard-break runs.
+  lines = [[]]
+  runs.each { |r| r['break'] ? (lines << []) : (lines.last << r) }
+  rendered = lines.map do |line|
+    line.map do |r|
+      raw = r['text'].to_s
+      raw = raw.gsub(/<\[[^\]]*\][^>]*>/, '') if raw.include?('<[') # drop dynamic tokens
+      next '' if raw.empty?
+      next raw if raw.strip.empty? # whitespace spacer → literal (keeps run spacing)
+      esc = raw.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+      esc = "**#{esc}**" if r['bold']
+      styles = []
+      styles << "color: #{r['color']}" if r['color']
+      styles << "font-size: #{r['font_size']}px" if r['font_size']
+      styles.empty? ? esc : %(<span style="#{styles.join('; ')}">#{esc}</span>)
+    end.join
+  end
+  body = rendered.reject { |l| l.strip.empty? }.join("\n\n")
+  return nil if body.strip.empty?
+  body = %(<span style="background-color: #{bg}">#{body}</span>) if bg
+  %w[center right].include?(align.to_s) ? %(<p style="text-align: #{align}">#{body}</p>) : body
+end
+
 # ---- Title text element ----
 # If --title given, emit a text element. If --title omitted AND the parser
 # found a title/text zone, infer the dashboard name from the parser output.
@@ -3735,6 +3773,35 @@ if title_text
     'body' => %(# <span style="color: #FFFFFF">#{title_text}</span>)
   }
 end
+
+# ---- B4: styled static-text elements ---------------------------------------
+# Emit each dashboard text/title zone that carries run-level formatting as a
+# Sigma `text` element (id "text-<zoneid>") that the layout stage places at the
+# zone's own geometry (build-dashboard-layout resolve_leaf). These were dropped
+# entirely before — subtitle, captions, credit line, section headers, and BAN
+# annotations all vanished. Dashboard-level chrome, so skipped in
+# --page-per-worksheet (which ignores the dashboard layout by design).
+styled_text_by_dash = Hash.new { |h, k| h[k] = [] }
+unless opts[:pages_mode] == :worksheet
+  layout.each do |dash|
+    (dash['zones'] || []).each do |z|
+      next unless %w[text title].include?(z['kind']) && z['text_runs']
+      body = text_body_from_runs(z['text_runs'], align: z['text_align'],
+                                 bg: (z['is_pill'] ? z['fill_color'] : nil))
+      next if body.nil?
+      if z['text_runs'].any? { |r| r['text'].to_s.include?('<[') }
+        warnings << "dashboard '#{dash['dashboard']}' text zone #{z['id']}: dynamic Tableau token(s) " \
+                    '(<[Parameters]…>) dropped from static text — not reproducible as literal text'
+      end
+      el = { 'id' => "text-#{z['id']}", 'kind' => 'text', 'body' => body }
+      # Short single-line annotations/pills read better vertically centered.
+      el['verticalAlign'] = 'middle' if z['is_pill'] || z['text_runs'].none? { |r| r['break'] }
+      el['_dashboard'] = dash['dashboard']
+      styled_text_by_dash[dash['dashboard']] << el
+    end
+  end
+end
+styled_text_all = styled_text_by_dash.values.flatten(1)
 
 # ---- Control targeting: intended-scope closure ------------------------------
 # A control filter applied to an element propagates to every element that
@@ -4285,6 +4352,9 @@ elsif opts[:pages_mode] == :dashboard
       # White span: the layout builder wraps this in the DARK header band.
       'body' => %(# <span style="color: #FFFFFF">#{dash_name}</span>)
     }]
+    # B4: this dashboard's styled static-text elements (subtitle/annotations/
+    # credit/section headers). Placed by the layout stage at their zone geometry.
+    styled_text_by_dash[dash_name].each { |e| page_extras << e.reject { |k, _| k == '_dashboard' } }
     ctl_rewrites = {}
     param_control_ids = param_controls.map { |c| c['controlId'] }
     (param_controls + auto_controls).each do |c|
@@ -4340,9 +4410,11 @@ elsif opts[:pages_mode] == :dashboard
 else
   elements.each { |e| e.delete('_worksheet'); e.delete('_dashboard') }
   all_extras.each { |e| e.delete('_scope_dashboards') }
-  all_elements = all_extras + elements
+  styled_text_all.each { |e| e.delete('_dashboard') }
+  all_elements = all_extras + styled_text_all + elements
   File.write(opts[:out], JSON.pretty_generate(all_elements))
-  warn "wrote #{opts[:out]}  (#{all_elements.size} elements: #{all_extras.size} controls/text + #{elements.size} charts)"
+  warn "wrote #{opts[:out]}  (#{all_elements.size} elements: #{all_extras.size} controls/text + " \
+       "#{styled_text_all.size} styled-text + #{elements.size} charts)"
   if data_elements.any?
     side = opts[:out].sub(/\.json$/, '-data-elements.json')
     File.write(side, JSON.pretty_generate(data_elements))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -181,6 +181,11 @@ def resolve_leaf(node, ctx)
     if ctx[:title_el] && !ctx[:title_used]
       ctx[:title_used] = true
       ctx[:title_el]['id']
+    else
+      # B4 (gap ubr5.8): styled static-text zone → its emitted element
+      # (build-charts id "text-<zoneid>"), placed at the zone's own geometry.
+      el = ctx[:els_by_id]["text-#{node['id']}"]
+      el && el['id']
     end
   end
 end
@@ -226,10 +231,14 @@ def build_page_from_tree(dashboard, page, opts)
   els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
   ctl_by_name = page['elements'].select { |e| e['kind'] == 'control' && e['name'] }
                     .each_with_object({}) { |e, h| h[e['name'].to_s.downcase] = e }
-  title_el    = page['elements'].find { |e| e['kind'] == 'text' }
+  els_by_id   = page['elements'].each_with_object({}) { |e, h| h[e['id']] = e if e['id'] }
+  # Pin the header title to the dedicated title element (build-charts prepends id
+  # "title-text"/"title-<slug>"); a bare first-text-element match would grab a B4
+  # styled-text element once those exist. Falls back to the page name when absent.
+  title_el    = page['elements'].find { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('title') }
 
   ctx = { page_id: page['id'], renames: opts[:renames], els_by_name: els_by_name,
-          ctl_by_name: ctl_by_name, title_el: title_el, title_used: false,
+          ctl_by_name: ctl_by_name, els_by_id: els_by_id, title_el: title_el, title_used: false,
           extra: [], placed: [], zone_to_ctl: {} }
 
   # Assign workbook control elements to control zones (filter/parameter), in
@@ -284,7 +293,9 @@ def build_page_from_tree(dashboard, page, opts)
   # zone, or a control with no dashboard zone) lands in a bottom band so nothing
   # silently drops from the layout.
   unplaced = page['elements'].select do |e|
-    %w[chart control].include?(e['kind']) && e['name'] && !ctx[:placed].include?(e['id'])
+    (%w[chart control].include?(e['kind']) && e['name'] ||
+     e['kind'] == 'text' && e['id'].to_s.start_with?('text-')) && # B4 styled text
+      !ctx[:placed].include?(e['id'])
   end
   unless unplaced.empty?
     n = unplaced.length
@@ -308,7 +319,9 @@ end
 def build_page_for_dashboard(dashboard, page, opts)
   chart_zones = dashboard['zones'].select { |z| z['kind'] == 'chart' && z['caption'] }
   els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
-  title_el = page['elements'].find { |e| e['kind'] == 'text' }
+  # Pin to the dedicated title element (see build_page_from_tree) so a B4
+  # styled-text element isn't mistaken for the header title.
+  title_el = page['elements'].find { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('title') }
   ctl_els  = page['elements'].select { |e| e['kind'] == 'control' }
 
   # Per-dashboard copy of the band tuning — auto-fit must not leak between
@@ -394,6 +407,28 @@ def build_page_for_dashboard(dashboard, page, opts)
     cid = "#{ov_prefix}-#{i + 1}"
     extra_els << container_el(cid)
     children << band_container_xml(cid, band, row_offset: band_offset)
+  end
+
+  # B4 (gap ubr5.8): the banded fallback places charts by geometry but not text.
+  # Rather than orphan the emitted styled-text elements (present in the workbook,
+  # absent from the layout), tile them across a labelled bottom band so nothing
+  # silently drops — WARN, since their exact source position isn't reproduced in
+  # the banded path (the container-tree path DOES place them at zone geometry).
+  text_els = page['elements'].select { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('text-') }
+  unless text_els.empty?
+    tn = text_els.length
+    r0 = 1 + HEADER_ROWS + ctl_rows + bands.sum { |b| b.map { |i| i[4] }.max - b.map { |i| i[3] }.min }
+    inner = text_els.each_with_index.map do |e, i|
+      c0 = 1 + (o[:page_cols] * i / tn.to_f).round
+      c1 = i == tn - 1 ? o[:page_cols] + 1 : [1 + (o[:page_cols] * (i + 1) / tn.to_f).round, c0 + 1].max
+      le(e['id'], c0, c1, 1, 4)
+    end.join("\n")
+    tid = "#{ov_prefix}-text"
+    extra_els << container_el(tid)
+    children << gc(tid, 1, o[:page_cols] + 1, r0, r0 + 4, inner)
+    warn "WARN: #{tn} styled-text element(s) placed in a bottom band on banded page #{page['name'].inspect} " \
+         "(source position not reproduced — the container-tree layout places them by geometry): " \
+         "#{text_els.map { |e| e['id'] }.join(', ')}"
   end
 
   [page_xml(page['id'], *children), extra_els, chart_layouts.length, bands.length, ctl_els.length]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-body.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-body.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# Unit test for the B4 (gap ubr5.8) text-body assembler in
+# build-charts-from-signals.rb: `text_body_from_runs`, which turns Tableau
+# formatted-text runs (parse-twb-layout `text_runs`) into a Sigma text.body —
+# color/font-size spans + **bold**, Æ-break paragraphs, center/right <p>
+# wrappers, pill background spans, dynamic-token stripping. Extracted as a
+# top-level pure def (SRC.match, same pattern as test-control-display-type.rb /
+# test-theme-derivation.rb) so no data-pipeline inputs are needed.
+#
+# Usage:  ruby scripts/test-styled-text-body.rb
+
+require 'json'
+
+DIR = __dir__
+SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+m = SRC.match(/^def text_body_from_runs\b.*?\n^end$/m) or
+  abort 'could not extract text_body_from_runs from build-charts-from-signals.rb'
+eval(m[0])
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# ---- 1. nil / empty ---------------------------------------------------------
+check(text_body_from_runs(nil).nil?, 'nil runs → nil', fails)
+check(text_body_from_runs([]).nil?, 'empty runs → nil', fails)
+check(text_body_from_runs([{ 'text' => '   ' }]).nil?,
+      'whitespace-only single run → nil (nothing visible)', fails)
+
+# ---- 2. single styled run → one span with color + font-size + bold ---------
+b = text_body_from_runs([{ 'text' => 'Job Losses', 'color' => '#1b1b1b', 'font_size' => 24, 'bold' => true }])
+check(b == '<span style="color: #1b1b1b; font-size: 24px">**Job Losses**</span>',
+      "single run → color+size span with **bold** (got #{b.inspect})", fails)
+
+# ---- 3. run with no attrs → plain text (no empty span) ---------------------
+check(text_body_from_runs([{ 'text' => 'plain' }]) == 'plain',
+      'attribute-free run → bare text, no empty span', fails)
+
+# ---- 4. Æ+whitespace spacer kept literal; hard break → \n\n paragraphs ------
+runs = [
+  { 'text' => 'Job Losses', 'color' => '#1b1b1b', 'bold' => true },
+  { 'text' => ' ', 'bold' => true },                    # Æ+whitespace spacer
+  { 'text' => 'from Deportations', 'font_size' => 12 },
+  { 'text' => "\n", 'break' => true },                  # hard break
+  { 'text' => 'Estimating the job loss.', 'color' => '#333333' }
+]
+b = text_body_from_runs(runs)
+check(b.include?('**Job Losses**</span> <span style="font-size: 12px">from Deportations</span>'),
+      "spacer keeps literal space between runs (got #{b.inspect})", fails)
+check(b.split("\n\n").length == 2 && b.split("\n\n").last.include?('Estimating'),
+      'hard-break run splits body into two paragraphs (\n\n)', fails)
+
+# ---- 5. HTML in run text is escaped (can't inject markup) ------------------
+b = text_body_from_runs([{ 'text' => 'a < b & c > d' }])
+check(b == 'a &lt; b &amp; c &gt; d', "raw <, &, > escaped (got #{b.inspect})", fails)
+
+# ---- 6. dynamic Tableau tokens stripped ------------------------------------
+b = text_body_from_runs([{ 'text' => 'The <[Parameters].[Parameter 3]> states', 'color' => '#333333' }])
+check(b && !b.include?('[Parameter') && b.include?('The ') && b.include?('states'),
+      "dynamic <[Parameters]…> token dropped, surrounding text kept (got #{b.inspect})", fails)
+
+# ---- 7. center align → <p style="text-align: center"> wrapper --------------
+b = text_body_from_runs([{ 'text' => 'Learn More', 'bold' => true }], align: 'center')
+check(b == '<p style="text-align: center">**Learn More**</p>',
+      "center align wraps in <p> (got #{b.inspect})", fails)
+# left align is Sigma's default and 400s if forced → never wrapped
+check(!text_body_from_runs([{ 'text' => 'x' }], align: 'left').include?('<p'),
+      'left align is NOT wrapped in <p> (Sigma default; forcing it 400s)', fails)
+
+# ---- 8. pill background span wraps content INSIDE the <p> (valid nesting) ---
+b = text_body_from_runs([{ 'text' => 'Learn More', 'bold' => true }], align: 'center', bg: '#fbe7a8')
+check(b == '<p style="text-align: center"><span style="background-color: #fbe7a8">**Learn More**</span></p>',
+      "pill: bg span nests inside the align <p> (got #{b.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — B4 text_body_from_runs'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-layout.rb
@@ -1,0 +1,177 @@
+#!/usr/bin/env ruby
+# End-to-end test for B4 (gap ubr5.8) styled static text: parse → build-charts →
+# build-dashboard-layout (no Tableau/Sigma calls). A dashboard text zone that
+# carries run-level formatting must (1) be EMITTED by build-charts as a Sigma
+# `text` element (id "text-<zoneid>") with a color/size-span body, and (2) be
+# PLACED by the layout stage at the text zone's own geometry — while the
+# dedicated title element still owns the header band (header pinning: a bare
+# first-text-element match would otherwise grab the styled text once it exists).
+#
+# Usage:  ruby scripts/test-styled-text-layout.rb
+
+require 'json'
+require 'rexml/document'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+CHARTS = File.join(DIR, 'build-charts-from-signals.rb')
+LAYOUT = File.join(DIR, 'build-dashboard-layout.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# A dashboard whose <zones> root container holds a chart, a Region filter (forces
+# the container-tree layout path), and a styled text zone (bold label + hard
+# break + muted annotation) mirroring the benchmark's region-card annotations.
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='ORDER_FACT' name='federated.fact'>
+        <connection class='federated'>
+          <named-connections>
+            <named-connection name='snow'><connection class='snowflake' dbname='CSA' schema='TJ' /></named-connection>
+          </named-connections>
+          <relation connection='snow' name='ORDER_FACT' table='[TJ].[ORDER_FACT]' type='table' />
+        </connection>
+        <column caption='Gross Revenue' name='[m-gr]' datatype='real' role='measure' type='quantitative' />
+        <column caption='Region' name='[m-reg]' datatype='string' role='dimension' type='nominal' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Sales by Region'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.fact'>
+              <column caption='Gross Revenue' name='[m-gr]' datatype='real' role='measure' type='quantitative' />
+              <column caption='Region' name='[m-reg]' datatype='string' role='dimension' type='nominal' />
+              <column-instance column='[m-reg]' derivation='None' name='[none:m-reg:nk]' pivot='key' type='nominal' />
+              <column-instance column='[m-gr]' derivation='Sum' name='[sum:m-gr:qk]' pivot='key' type='quantitative' />
+            </datasource-dependencies>
+          </view>
+          <rows>[federated.fact].[sum:m-gr:qk]</rows>
+          <cols>[federated.fact].[none:m-reg:nk]</cols>
+          <pane><mark class='Bar' /></pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Story'>
+        <zones>
+          <zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+            <zone id='2' type-v2='layout-flow' param='vert' x='0' y='0' w='30000' h='100000'>
+              <zone id='3' type-v2='filter' param='[federated.fact].[none:m-reg:nk]' x='0' y='0' w='30000' h='20000' />
+              <zone id='6' type-v2='text' x='0' y='20000' w='30000' h='15000'>
+                <formatted-text>
+                  <run bold='true' fontcolor='#1f8a70' fontsize='13'>Total Job Losses</run>
+                  <run>Æ&#10;</run>
+                  <run fontcolor='#666666' fontsize='10'>40% of U.S. total</run>
+                </formatted-text>
+              </zone>
+            </zone>
+            <zone id='5' name='Sales by Region' x='30000' y='0' w='70000' h='100000' />
+          </zone>
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+MASTER_MAP = {
+  '(?i)^Gross Revenue$' => { 'id' => 'm-gr',  'name' => 'Gross Revenue' },
+  '(?i)^Region$'        => { 'id' => 'm-reg', 'name' => 'Region' }
+}
+
+specs = nil
+charts_log = ''
+build_log = ''
+xml_doc = nil
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  mm  = File.join(d, 'master-map.json')
+  File.write(twb, TWB)
+  File.write(mm, JSON.dump(MASTER_MAP))
+  # get-workbook view list + empty CSV (chart rebuilds from .twb signals).
+  File.write(File.join(d, 'get-workbook.json'),
+             JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => 'Sales by Region' }] }))
+  Dir.mkdir(File.join(d, 'views'))
+  File.write(File.join(d, 'views', 'v1.csv'), '')
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+
+  out = File.join(d, 'specs.json')
+  charts_log = `ruby #{CHARTS} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --title Story --out #{out} 2>&1`
+  specs = JSON.parse(File.read(out)) if File.exist?(out)
+
+  # Synthesize the workbook readback (wb-ids) from the emitted flat element list:
+  # a Data page (master table) + the dashboard page carrying every emitted
+  # element's id/kind/name — exactly what build-dashboard-layout consumes.
+  flat = specs.is_a?(Array) ? specs : (specs['elements'] || [])
+  page_els = flat.map { |e| { 'id' => e['id'], 'kind' => e['kind'], 'name' => e['name'] } }
+  wb_ids = { 'pages' => [
+    { 'name' => 'Data',  'elements' => [{ 'id' => 'master', 'kind' => 'table', 'name' => 'Data' }] },
+    { 'name' => 'Story', 'elements' => page_els }
+  ] }
+  wbf = File.join(d, 'wb-ids.json')
+  lxml = File.join(d, 'layout.xml')
+  File.write(wbf, JSON.dump(wb_ids))
+  build_log = `ruby #{LAYOUT} --layout #{lay} --wb-ids #{wbf} --out #{lxml} 2>&1`
+  if File.exist?(lxml)
+    body = File.read(lxml).sub(/\A<\?xml[^>]*\?>\s*/, '')
+    xml_doc = REXML::Document.new("<Root>#{body}</Root>")
+  end
+end
+
+# ---- 1. build-charts EMITTED the styled text element -----------------------
+flat  = specs && (specs.is_a?(Array) ? specs : (specs['elements'] || []))
+txt   = flat && flat.find { |e| e['id'] == 'text-6' }
+check(txt && txt['kind'] == 'text', "build-charts emitted text zone as element id 'text-6' (got #{txt && txt['kind'].inspect})", fails)
+body  = txt && txt['body'].to_s
+check(body.include?('<span style="color: #1f8a70; font-size: 13px">**Total Job Losses**</span>'),
+      "emitted body carries the bold label span (got #{body.inspect})", fails)
+check(body.include?("\n\n") && body.include?('40% of U.S. total'),
+      'emitted body keeps the hard-break paragraph + annotation', fails)
+# the title element is separate and header-bound
+title = flat && flat.find { |e| e['id'] == 'title-text' }
+check(title && title['kind'] == 'text', 'the dashboard title-text element is still emitted separately', fails)
+
+# ---- 2. layout PLACED the text element at its zone geometry ----------------
+gcs = xml_doc ? xml_doc.elements.to_a('//GridContainer') : []
+def descendant_el_ids(gc)
+  gc.elements.to_a('.//LayoutElement').map { |le| le.attributes['elementId'] }
+end
+all_placed = gcs.flat_map { |g| descendant_el_ids(g) }.uniq
+check(all_placed.include?('text-6'), "layout placed the styled-text element 'text-6' (placed: #{all_placed.inspect})", fails)
+check(build_log.include?('container-tree layout'), 'layout took the container-tree path', fails)
+
+# text-6 lives INSIDE the same rail container as the Region control (its Tableau
+# container), not loose at page root.
+rail_gc = gcs.find do |g|
+  ids = descendant_el_ids(g)
+  ids.include?('text-6') && g.elements.to_a('.//GridContainer').empty?
+end
+check(!rail_gc.nil?, "styled text 'text-6' placed inside its Tableau container (the rail)", fails)
+
+# ---- 3. header pinning: the title element owns the header, NOT the text -----
+# The header band is the container wrapping the title-text element; text-6 must
+# not be the one wrapped in the dark HEADER_STYLE band.
+hdr = gcs.find { |g| descendant_el_ids(g) == ['title-text'] }
+check(!hdr.nil?, 'header band wraps the dedicated title-text element', fails)
+check(all_placed.count('text-6') >= 1 && !(hdr && descendant_el_ids(hdr).include?('text-6')),
+      'the styled-text element is NOT mistaken for the header title', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — B4 styled text: emitted by build-charts + placed at zone geometry by the layout (header pinned)'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  puts "\n--- build-charts log (tail) ---\n#{charts_log.to_s.lines.last(8).join}"
+  puts "\n--- layout log (tail) ---\n#{build_log.to_s.lines.last(8).join}"
+  exit 1
+end


### PR DESCRIPTION
**Stacked on #252** (base = `tableau-phase1-b4-text-parser`). Merge #252 first; this diff shows only the emit/layout half.

## What

Consumes the parser's B4 `text_runs` (#252) to **emit** each dashboard text/title zone that carries run-level formatting as a Sigma `text` element and **place** it at the zone's own geometry. Before this, these zones were dropped entirely — hero subtitle, section headers, captions, credit line, and BAN annotations never reached the workbook.

## `build-charts-from-signals.rb`

- New pure top-level `text_body_from_runs(runs, align:, bg:)` — runs → inline `<span style>` with the **source** color + font-size (px, verbatim) + `**bold**`; Æ+newline breaks → `\n\n` paragraphs; literal whitespace preserved; raw `<`,`&`,`>` escaped; dynamic Tableau tokens (`<[Parameters]…>`) stripped; center/right → `<p>` wrapper (left 400s); pill fill → `background-color` span nested inside the `<p>`. Hex-only. Per `styling.md`.
- Emits `text-<zoneid>` elements in **flat** + **--page-per-dashboard** modes; skipped in **--page-per-worksheet** (ignores dashboard layout by design). **WARN** when a zone's dynamic tokens are dropped — never silent.

## `build-dashboard-layout.rb`

- **Container-tree path**: `resolve_leaf` places `text-<zoneid>` at zone geometry (inside its own Tableau container — faithful position).
- **Header pinning** (both paths): header title matches the dedicated `title-*` element, not "first text element" (else a B4 text element could be grabbed as the header). No behavior change pre-B4.
- **Banded fallback**: styled text tiled into a labelled bottom band + **WARN** (position not reproduced there) — nothing orphans or silently drops.

Colors/sizes track the **source** `.twb`, not the hand-build's aesthetic tweaks (fidelity mandate). Markdown-heading polish to match the oracle's `#`/`##` exactly is a noted follow-up; font-size spans already carry the visual weight.

## Tests

- `test-styled-text-body.rb` — unit tests the extracted pure helper (spans/bold/breaks/escaping/token-strip/align/pill/nil).
- `test-styled-text-layout.rb` — full **parse → build-charts → build-dashboard-layout**: asserts emit (`text-<id>` + body) AND tree-path placement inside the Tableau container, with the title pinned to the header.

Verified against the **real benchmark** `.twb`. Full tableau suite green (30/31; `test-calc-discovery` pre-fails on `main` — needs `TABLEAU_AUTH_TOKEN`).

⚠️ Fleet PNG gate: B4 intentionally makes previously-dropped text appear, so render baselines shift — CI/maintainer should re-baseline as part of merge.

Bead: `beads-sigma-ubr5.8` (emit half; parser half = #252)

🤖 Generated with [Claude Code](https://claude.com/claude-code)