### PR TITLE
tableau: Phase-1 B3 parser — KPI scorecard (Shape/Circle BAN) detection

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -350,12 +350,59 @@ xml.elements.each('/workbook/datasources/datasource') do |ds|
   end
 end
 
+# ── Phase-1 B3: KPI scorecard <customized-label> (BAN) extraction ────────────
+# A Tableau "big number" scorecard often uses a Shape/Circle mark with the value
+# rendered as a <customized-label> BAN inside the pane, e.g.:
+#   <customized-label><formatted-text>
+#     <run fontcolor='#333' fontsize='10'>Total Job Losses</run>   ← label
+#     <run fontsize='26'><[…measure…]></run>                        ← BAN value
+#     <run fontcolor='#666' fontsize='8'>of U.S. total</run>        ← annotation
+#   </formatted-text></customized-label>
+# Returns {label, value_font_size, annotation_runs} when a BAN (a run whose font
+# size is >= KPI_BAN_MIN_FONT — the "big number") is present, else nil. The BAN
+# lets a Shape/Circle-mark scorecard qualify as a KPI (narrow: a real scatter has
+# no big-font customized-label), and feeds the B3 composite emit (label + big
+# value + side annotation). Runs mirror zone_text_fields' shape (Æ = U+00C6
+# line-break sentinel); `ref`=true marks a dynamic <[…]> field/measure token.
+KPI_BAN_MIN_FONT = 16
+def parse_customized_label(ws)
+  cl = ws.elements['.//customized-label']
+  return nil unless cl
+  runs = []
+  cl.elements.each('.//run') do |r|
+    txt = r.text.to_s.gsub("Æ", '')
+    a = r.attributes
+    runs << {
+      'text'      => txt,
+      'color'     => (c = a['fontcolor']) && !c.empty? ? c : nil,
+      'font_size' => (fs = a['fontsize']) && !fs.empty? ? fs.to_i : nil,
+      'bold'      => a['bold'] == 'true',
+      'break'     => txt.include?("\n"),
+      'ref'       => txt.include?('<[')
+    }.compact
+  end
+  return nil if runs.empty?
+  ban_i    = runs.each_index.max_by { |i| runs[i]['font_size'] || 0 }
+  ban_font = (runs[ban_i] && runs[ban_i]['font_size']) || 0
+  return nil if ban_font < KPI_BAN_MIN_FONT
+  # Label = leading non-ref, non-spacer, non-tiny (>= 6pt) text runs before the
+  # BAN value run (drops the invisible filler runs Tableau injects for spacing).
+  label = runs[0...ban_i]
+          .reject { |r| r['ref'] || r['text'].to_s.strip.empty? || (r['font_size'] && r['font_size'] < 6) }
+          .map { |r| r['text'] }.join(' ').gsub(/\s+/, ' ').strip
+  { 'label'           => (label.empty? ? nil : label),
+    'value_font_size' => ban_font,
+    'annotation_runs' => (runs[(ban_i + 1)..] || []) }.compact
+end
+
 worksheets = {}
 xml.elements.each('//worksheet') do |ws|
   name = ws.attributes['name']
   next unless name
   mark = ws.elements['.//mark']
   mark_class = mark ? (mark.attributes['class'].to_s) : nil
+  # Phase-1 B3: a Shape/Circle scorecard's big-number <customized-label> (nil otherwise).
+  kpi_ban = parse_customized_label(ws)
 
   geo_role = nil
   has_lat  = false
@@ -649,8 +696,13 @@ xml.elements.each('//worksheet') do |ws|
   # zero-dim single-measure sheet renders as a big-number text table — the
   # FATSCALE rehearsal lost 14/40 tiles because these fell through to the
   # CSV-driven flow (1-column CSV → zone dropped).
+  # Phase-1 B3: a Shape/Circle scorecard carrying a big-number <customized-label>
+  # BAN is a KPI too (Tableau's "big number on a dot" idiom). Narrow by design —
+  # a real scatter/symbol plot has no large-font customized-label — so ordinary
+  # Shape/Circle marks keep flowing to scatter.
+  ban_scorecard_mark = !kpi_ban.nil? && %w[shape circle].include?(mark_class.to_s.downcase)
   kpi_capable_mark = is_text_mark || mark_class.to_s.downcase == 'automatic' ||
-                     mark_class.to_s.empty?
+                     mark_class.to_s.empty? || ban_scorecard_mark
   total_dim_count = rows_shelf['dim_count'] + cols_shelf['dim_count']
   total_measure_count = rows_shelf['measure_count'] + cols_shelf['measure_count'] + measures.size
   is_kpi = kpi_capable_mark && !is_crosstab &&
@@ -715,7 +767,11 @@ xml.elements.each('//worksheet') do |ws|
     rows_shelf:       rows_shelf,
     cols_shelf:       cols_shelf,
     is_crosstab:      is_crosstab,
-    is_kpi:           is_kpi
+    is_kpi:           is_kpi,
+    # Phase-1 B3: KPI composite signals (nil unless a BAN scorecard label exists)
+    kpi_label:            kpi_ban && kpi_ban['label'],
+    kpi_value_font_size:  kpi_ban && kpi_ban['value_font_size'],
+    kpi_annotation_runs:  kpi_ban && kpi_ban['annotation_runs']
   }
 end
 
@@ -840,10 +896,10 @@ def chart_kind_for(meta)
   when 'line'       then 'line'
   when 'area'       then 'area'
   when 'pie'        then 'pie'
-  when 'circle'     then 'scatter'                # symbol marks (non-geo) = scatter
+  when 'circle'     then (meta[:is_kpi] ? 'kpi' : 'scatter')  # BAN scorecard on a dot, else symbol=scatter
   when 'square'     then (meta[:is_crosstab] ? 'pivot-table' : (meta[:is_kpi] ? 'kpi' : 'table'))
   when 'text'       then (meta[:is_crosstab] ? 'pivot-table' : (meta[:is_kpi] ? 'kpi' : 'table'))
-  when 'shape'      then 'scatter'
+  when 'shape'      then (meta[:is_kpi] ? 'kpi' : 'scatter')  # big-number BAN, else symbol=scatter
   # Automatic is Tableau's default-pick — but a zero-dim single-measure sheet
   # under Automatic renders as a big-number text table, i.e. a KPI (bead 3w4d).
   when 'automatic'
@@ -1087,6 +1143,10 @@ xml.elements.each('//dashboard') do |d|
       'cols_shelf'   => (kind == 'chart' ? ws_meta&.dig(:cols_shelf)    : nil),
       'is_crosstab'  => (kind == 'chart' ? ws_meta&.dig(:is_crosstab)   : nil),
       'is_kpi'       => (kind == 'chart' ? ws_meta&.dig(:is_kpi)        : nil),
+      # Phase-1 B3: KPI composite signals (nil unless a BAN scorecard)
+      'kpi_label'           => (kind == 'chart' ? ws_meta&.dig(:kpi_label)           : nil),
+      'kpi_value_font_size' => (kind == 'chart' ? ws_meta&.dig(:kpi_value_font_size) : nil),
+      'kpi_annotation_runs' => (kind == 'chart' ? ws_meta&.dig(:kpi_annotation_runs) : nil),
       # Resolved filter target (filter/parameter zones only)
       'filter_column_caption'  => (kind == 'filter' || kind == 'parameter' ? filter_col_caption  : nil),
       'filter_column_datatype' => (kind == 'filter' || kind == 'parameter' ? filter_col_datatype : nil),
@@ -1161,6 +1221,9 @@ if dashboards.empty? && !worksheets.empty?
         'cols_shelf'   => ws_meta[:cols_shelf],
         'is_crosstab'  => ws_meta[:is_crosstab],
         'is_kpi'       => ws_meta[:is_kpi],
+        'kpi_label'           => ws_meta[:kpi_label],
+        'kpi_value_font_size' => ws_meta[:kpi_value_font_size],
+        'kpi_annotation_runs' => ws_meta[:kpi_annotation_runs],
         'filter_column_caption'  => nil,
         'filter_column_datatype' => nil
       }]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-scorecard-detection.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-scorecard-detection.rb
@@ -1,0 +1,144 @@
+#!/usr/bin/env ruby
+# Regression test for Phase-1 B3 KPI-scorecard detection in parse-twb-layout.rb.
+# Tableau "big number" scorecards frequently use a Shape/Circle mark with the
+# value rendered as a <customized-label> BAN (a large-font run), e.g. the "Job
+# Loss from Mass Deportations" region cards:
+#   <pane><mark class='Shape'/>
+#     <customized-label><formatted-text>
+#       <run fontcolor='#333' fontsize='10'>Total Job Losses</run>   ← label
+#       <run fontcolor='#f5f5f5' fontsize='2'>2</run>                ← invisible filler
+#       <run fontsize='26'><[…measure…]></run>                       ← BAN value
+#       <run fontcolor='#666' fontsize='8'>of U.S. total</run>       ← annotation
+#     </formatted-text></customized-label></pane>
+# Before B3 the parser mapped Shape → scatter, so is_kpi was FALSE and the KPI
+# path never fired for these tiles. Detection is NARROW: only a Shape/Circle mark
+# that carries a big-font customized-label BAN qualifies — an ordinary symbol
+# scatter (no BAN) must stay a scatter.
+#
+# Asserts, end-to-end through the ACTUAL parse-twb-layout.rb:
+#   1. Shape mark + BAN customized-label + zero dims → chart_kind == 'kpi'.
+#   2. kpi_label = the leading label run ("Total Job Losses"); the invisible
+#      tiny filler run is dropped from the label.
+#   3. kpi_value_font_size = the BAN run's size (26).
+#   4. kpi_annotation_runs carries the trailing annotation ("of U.S. total"),
+#      with the dynamic <[…]> value run flagged ref=true and the Æ sentinel gone.
+#   5. A Shape mark WITHOUT a big customized-label (a real scatter) stays
+#      chart_kind == 'scatter' and is_kpi is false (narrow — no false positives).
+#
+# Usage:  ruby scripts/test-kpi-scorecard-detection.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='Fact' name='federated.x'>
+        <column caption='Job Losses' name='[JL]' datatype='real' role='measure' type='quantitative' />
+        <column caption='Rate' name='[RT]' datatype='real' role='measure' type='quantitative' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Region BAN'>
+        <table>
+          <view><datasource-dependencies datasource='federated.x'>
+            <column caption='Job Losses' name='[JL]' datatype='real' role='measure' type='quantitative' />
+            <column-instance column='[JL]' derivation='Sum' name='[sum:JL:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies></view>
+          <pane>
+            <mark class='Shape' />
+            <customized-label>
+              <formatted-text>
+                <run bold='false' fontcolor='#333333' fontsize='10'>Total Job Losses</run>
+                <run bold='false' fontcolor='#f5f5f5' fontsize='2'>2</run>
+                <run fontsize='26'><![CDATA[<[federated.x].[sum:JL:qk]>]]></run>
+                <run>Æ&#10;</run>
+                <run fontcolor='#666666' fontsize='12'><![CDATA[<[federated.x].[usr:pct:qk]>]]></run>
+                <run bold='false' fontcolor='#666666' fontsize='8'>Æ of U.S. total</run>
+              </formatted-text>
+            </customized-label>
+          </pane>
+        </table>
+      </worksheet>
+      <worksheet name='Scatter Plot'>
+        <table>
+          <view><datasource-dependencies datasource='federated.x'>
+            <column caption='Job Losses' name='[JL]' datatype='real' role='measure' type='quantitative' />
+            <column caption='Rate' name='[RT]' datatype='real' role='measure' type='quantitative' />
+            <column-instance column='[JL]' derivation='Sum' name='[sum:JL:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[RT]' derivation='Sum' name='[sum:RT:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies></view>
+          <rows>[federated.x].[sum:JL:qk]</rows>
+          <cols>[federated.x].[sum:RT:qk]</cols>
+          <pane><mark class='Shape' /></pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='D'>
+        <zones><zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+          <zone id='2' name='Region BAN'  x='0'     y='0' w='50000' h='100000' />
+          <zone id='3' name='Scatter Plot' x='50000' y='0' w='50000' h='100000' />
+        </zone></zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+layout = nil
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  File.write(twb, TWB)
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  layout = JSON.parse(File.read(lay))
+end
+zones = (layout || []).find { |x| x['dashboard'] == 'D' }&.dig('zones') || []
+
+ban = zones.find { |z| z['caption'] == 'Region BAN' }
+scat = zones.find { |z| z['caption'] == 'Scatter Plot' }
+
+# ---- 1. Shape + BAN → kpi --------------------------------------------------
+check(ban && ban['chart_kind'] == 'kpi',
+      "Shape mark + BAN customized-label → chart_kind 'kpi' (got #{ban && ban['chart_kind'].inspect})", fails)
+# ---- 2. label extracted, filler dropped ------------------------------------
+check(ban && ban['kpi_label'] == 'Total Job Losses',
+      "kpi_label = leading label, tiny filler run dropped (got #{ban && ban['kpi_label'].inspect})", fails)
+# ---- 3. BAN font size -------------------------------------------------------
+check(ban && ban['kpi_value_font_size'] == 26,
+      "kpi_value_font_size = BAN run size 26 (got #{ban && ban['kpi_value_font_size'].inspect})", fails)
+# ---- 4. annotation runs: trailing text + ref flag + no Æ -------------------
+ann = ban && ban['kpi_annotation_runs']
+check(ann.is_a?(Array) && ann.any? { |r| r['text'].to_s.include?('of U.S. total') },
+      "kpi_annotation_runs carries the trailing annotation text (got #{ann.inspect})", fails)
+check(ann && ann.any? { |r| r['ref'] == true },
+      'the dynamic <[…]> percent run is flagged ref=true (emit strips it)', fails)
+check(ann && ann.none? { |r| r['text'].to_s.include?('Æ') },
+      'the Æ line-break sentinel is stripped from annotation runs', fails)
+# ---- 5. NARROW: real Shape scatter stays scatter ---------------------------
+check(scat && scat['chart_kind'] == 'scatter',
+      "Shape mark WITHOUT a BAN stays 'scatter' (got #{scat && scat['chart_kind'].inspect})", fails)
+check(scat && !scat['is_kpi'],
+      "the scatter is NOT a false-positive KPI (is_kpi=#{scat && scat['is_kpi'].inspect})", fails)
+check(scat && scat['kpi_label'].nil?,
+      'the scatter carries no kpi_label', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — B3 KPI-scorecard detection (Shape/Circle + BAN → kpi; narrow, no scatter false-positives)'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
**Stacked on #254** (base = `tableau-phase1-b4-text-emit`). Merge #252 → #254 → this in order.

## What

The design doc assumed KPI detection "just works" for the benchmark — it doesn't. Every KPI tile in *Job Loss from Mass Deportations* (the 4 region "Total Job Losses" cards + the rail BAN) uses `<mark class='Shape'/>`, which the parser mapped to `scatter`, so `is_kpi` was **false** and the KPI path never fired. This is the prerequisite for the B3 composite emit.

## Change (`parse-twb-layout.rb`)

- New `parse_customized_label(ws)` — reads a worksheet's pane `<customized-label>` BAN (the "big number" on a Shape/Circle mark), returns `{label, value_font_size, annotation_runs}` when a large-font run (`>= KPI_BAN_MIN_FONT=16`) exists, else `nil`. Æ sentinel stripped; dynamic `<[…]>` runs flagged `ref=true`; invisible tiny-font filler dropped from the label.
- KPI detection: a Shape/Circle mark **with a BAN** now counts as `kpi_capable` — **narrow by design**, so an ordinary symbol scatter (no BAN) keeps flowing to scatter. The `is_kpi` gate (zero dims + ≥1 measure) is otherwise unchanged.
- `chart_kind_for`: `shape`/`circle` → `'kpi'` when `is_kpi` (else `'scatter'`).
- Surfaces `kpi_label` / `kpi_value_font_size` / `kpi_annotation_runs` on chart zones for the emit PR.

Detection only; the composite emit (label + big value + annotation, reusing B4's `text_body_from_runs`) is the next PR — same parser→emit split as #252→#254.

## Test

`test-kpi-scorecard-detection.rb` runs the **real parser** on a synthetic `.twb` with a Shape BAN scorecard (→`kpi`, label/fontSize/annotation extracted) **and** a real Shape scatter (→stays `scatter`, no false-positive). Verified on the real benchmark: the 4 region cards now detect as `chart_kind=kpi` (fontSize 26, label "Total Job Losses"). Regression suite green.

Bead: `beads-sigma-ubr5.7` (KPI-detection half; composite-emit half next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)