### PR TITLE
docs(migration): Migration Operating Contract for every converter + tableau composition recipe

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -35,6 +35,7 @@ Convert a Cognos **Data Module** into a Sigma **data model**, then convert the C
 cleanly; **flag what doesn't** (runtime macros, running-totals, localization) instead
 of emitting wrong logic.
 
+> **READ FIRST — `refs/operating-contract.md`**: the fidelity guardrails (render + value-check EVERY page against the source; never ship empty or silently drop a tile; don't spin — surface blockers).
 > Read `refs/` before relying on shapes: `design-notes.md` (translation surface + scope),
 > `format-shapes.md` (the real CA Data-Module JSON + report-spec XML structures),
 > `expression-dsl.md` (the Cognos-expression → Sigma-formula mapping table),

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/operating-contract.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/operating-contract.md
@@ -1,0 +1,45 @@
+# Migration Operating Contract — read before you touch anything
+
+> A tool- and model-agnostic set of guardrails for any agent running a BI→Sigma
+> migration. The failure it prevents: an agent runs for an hour and ships a
+> structurally-clean but visually-empty, numerically-wrong workbook, then reports
+> "done, 0 errors." Fidelity is not optional and it is not eyeballed — it is gated.
+
+## Ground truth
+- **The source dashboard is the spec.** Before building, obtain (a) its **rendered
+  image** — run the Cognos report to an output format over the CA REST API (report
+  output / `.../reports/{id}/reportData`), or screenshot the rendered report /
+  dashboard in Cognos Analytics — and (b) its **calc definitions + filters** from the
+  Cognos report-spec XML (and dashboard/exploration JSON), whose logic is written in
+  **Cognos report expressions**. You are matching *that*, not your idea of it.
+
+## Build from the source's own logic
+- **KPIs are usually parameter/ratio/expression-driven, not `SUM(column)`.** Read each
+  field's calc. If the source already materialized its validated calc as a stored
+  column, `SUM` *that* — it already encodes the per-row logic. Use the source's exact
+  aggregate (`Count` vs `CountDistinct` matters).
+- **Map source parameters/prompts/filters → Sigma controls; wire `filters` to the base
+  tables.** Apply the source's dashboard/period filters so aggregates run over the same
+  **population** — otherwise ratios/averages drift even when formulas are "right."
+- **Rebuild every source viz** (donuts, trends, crosstabs). If a viz has no standalone
+  data export, reconstruct it from the model. **Never silently drop a tile.**
+
+## Verify — don't assume (this is what keeps you on the rails)
+- After every write, GET the spec back. A rejected PUT is **atomic** — read the 400.
+- **Render EVERY page** to PNG and compare side-by-side to the source image. A page
+  that is >40% empty, missing tiles, or visually unlike the source is a **FAIL** — fix it.
+- **Value-check**: for each KPI/table, compare the **number** to the source's number.
+  "It compiles" is not "it matches." Record the comparison.
+- Verify the model's existing filter state (`GET /columns`, read element `filters`)
+  before assuming anything is or isn't applied.
+
+## Don't spin, don't fake
+- **"Can't verify" ≠ "passed."** If a gate can't pass, STOP and report the specific
+  blocker. Do not waive it silently or loop to force green.
+- Escape hatches (skip/allow flags) require a **named reason that goes in the report**.
+- If you've retried the same failing step ~2×, change approach or surface it — never grind.
+
+## Done means
+- 0 error columns; every page rendered and visually matching the source; every KPI's
+  number matching the source (or the delta explained); controls present and wired; no
+  silently dropped tiles. Anything short of that is **reported, not hidden.**

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -36,6 +36,7 @@ workbook(s) that mirror the Looker dashboards (user-defined OR LookML-defined) a
 closely as possible — and verify the numbers match Looker AND the warehouse.
 
 **Read ALL of the following before replying or taking any action. Do not make assumptions about skill conventions, prompts, or global instructions — read the files.**
+- `refs/operating-contract.md` — **READ FIRST**: the fidelity guardrails (render + value-check EVERY page against the source; never ship empty or silently drop a tile; don't spin — surface blockers).
 - `refs/dashboard-contract.md` — the normalized Looker Dashboard JSON contract both the live API fetch and the offline LookML parse produce. The dashboard pipeline is source-agnostic; it only sees this contract.
 - `refs/looker-dashboard-layout.md` — the deep desk study: Looker layout modes, newspaper→24-col grid math, tile-type / filter-type maps, and the full translation-hazard catalog (Liquid, `merged_results`, table calcs, view/explore field resolution, cross-filtering). **This is the design backbone of the dashboard pipeline.**
 - `refs/layered-lookml.md` — layered/derived LookML: derived tables on derived tables, cross-view `${view.SQL_TABLE_NAME}` refs (CTE inlining vs `LOOKER_SCRATCH` placeholders), CTE-continuation fragments, incremental/persisted PDTs → the **Sigma materialization handoff**, dimension_group edge cases, and untranslatable formatting measures. **Read before converting any project with `derived_table:` views.**

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/operating-contract.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/operating-contract.md
@@ -1,0 +1,45 @@
+# Migration Operating Contract — read before you touch anything
+
+> A tool- and model-agnostic set of guardrails for any agent running a BI→Sigma
+> migration. The failure it prevents: an agent runs for an hour and ships a
+> structurally-clean but visually-empty, numerically-wrong workbook, then reports
+> "done, 0 errors." Fidelity is not optional and it is not eyeballed — it is gated.
+
+## Ground truth
+- **The source dashboard is the spec.** Before building, obtain (a) its **rendered
+  image** — the Looker render API (`POST /render_tasks/dashboards/{id}/png`, REST 4.0,
+  no MCP required), or a screenshot of the dashboard — and (b) its **calc definitions +
+  filters** from the LookML (models/views/dashboards) and the Dashboard API JSON, whose
+  logic is written in **LookML / Looker expressions**. You are matching *that*, not your
+  idea of it.
+
+## Build from the source's own logic
+- **KPIs are usually parameter/ratio/expression-driven, not `SUM(column)`.** Read each
+  field's calc. If the source already materialized its validated calc as a stored
+  column, `SUM` *that* — it already encodes the per-row logic. Use the source's exact
+  aggregate (`Count` vs `CountDistinct` matters).
+- **Map source parameters/filters → Sigma controls; wire `filters` to the base tables.**
+  Apply the source's dashboard/period filters so aggregates run over the same
+  **population** — otherwise ratios/averages drift even when formulas are "right."
+- **Rebuild every source viz** (donuts, trends, matrices). If a viz has no standalone
+  data export, reconstruct it from the model. **Never silently drop a tile.**
+
+## Verify — don't assume (this is what keeps you on the rails)
+- After every write, GET the spec back. A rejected PUT is **atomic** — read the 400.
+- **Render EVERY page** to PNG and compare side-by-side to the source image. A page
+  that is >40% empty, missing tiles, or visually unlike the source is a **FAIL** — fix it.
+- **Value-check**: for each KPI/table, compare the **number** to the source's number.
+  "It compiles" is not "it matches." Record the comparison.
+- Verify the model's existing filter state (`GET /columns`, read element `filters`)
+  before assuming anything is or isn't applied.
+
+## Don't spin, don't fake
+- **"Can't verify" ≠ "passed."** If a gate can't pass, STOP and report the specific
+  blocker. Do not waive it silently or loop to force green.
+- Escape hatches (skip/allow flags) require a **named reason that goes in the report**.
+- If you've retried the same failing step ~2×, change approach or surface it — never grind.
+
+## Done means
+- 0 error columns; every page rendered and visually matching the source; every KPI's
+  number matching the source (or the delta explained); controls present and wired; no
+  silently dropped tiles. Anything short of that is **reported, not hidden.**

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -43,6 +43,7 @@ logic.
 > Analytical-Engine row-collapse report. Chart-viz emission and the newer
 > "Data Model" object are roadmap (`refs/design-notes.md`).
 
+> **READ FIRST — `refs/operating-contract.md`**: the fidelity guardrails (render + value-check EVERY page against the source; never ship empty or silently drop a tile; don't spin — surface blockers).
 > Read `refs/` before relying on shapes: `mstr-rest-api.md` (every verified
 > REST gotcha — changesets, locks, lowercase response headers, session-bound
 > dossier flows), `ae-row-collapse.md` (the one MSTR behavior no clean SQL

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/operating-contract.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/operating-contract.md
@@ -1,0 +1,45 @@
+# Migration Operating Contract — read before you touch anything
+
+> A tool- and model-agnostic set of guardrails for any agent running a BI→Sigma
+> migration. The failure it prevents: an agent runs for an hour and ships a
+> structurally-clean but visually-empty, numerically-wrong workbook, then reports
+> "done, 0 errors." Fidelity is not optional and it is not eyeballed — it is gated.
+
+## Ground truth
+- **The source dashboard is the spec.** Before building, obtain (a) its **rendered
+  image** — export the dossier/document to PDF or image over the MSTR REST API, or
+  screenshot the rendered dossier — and (b) its **calc definitions + filters** from the
+  MSTR REST object/report/document definition, whose logic is written in **MSTR metrics
+  / expressions**. You are matching *that*, not your idea of it.
+
+## Build from the source's own logic
+- **KPIs (metrics) are usually ratio/compound/expression-driven, not `SUM(column)`.**
+  Read each metric's calc. If the source already materialized its validated calc as a
+  stored column, `SUM` *that* — it already encodes the per-row logic. Use the source's
+  exact aggregate (`Count` vs `Count<Distinct=True>` matters).
+- **Map source prompts/parameters/filters → Sigma controls; wire `filters` to the base
+  tables.** Apply the source's report/dossier filters so aggregates run over the same
+  **population** — otherwise ratios/averages drift even when formulas are "right."
+- **Rebuild every source viz** (grids, trends, matrices). If a viz has no standalone
+  data export, reconstruct it from the model. **Never silently drop a tile.**
+
+## Verify — don't assume (this is what keeps you on the rails)
+- After every write, GET the spec back. A rejected PUT is **atomic** — read the 400.
+- **Render EVERY page** to PNG and compare side-by-side to the source image. A page
+  that is >40% empty, missing tiles, or visually unlike the source is a **FAIL** — fix it.
+- **Value-check**: for each KPI/table, compare the **number** to the source's number.
+  "It compiles" is not "it matches." Record the comparison. (MSTR's own reported numbers,
+  including any Analytical-Engine row collapse, are the oracle.)
+- Verify the model's existing filter state (`GET /columns`, read element `filters`)
+  before assuming anything is or isn't applied.
+
+## Don't spin, don't fake
+- **"Can't verify" ≠ "passed."** If a gate can't pass, STOP and report the specific
+  blocker. Do not waive it silently or loop to force green.
+- Escape hatches (skip/allow flags) require a **named reason that goes in the report**.
+- If you've retried the same failing step ~2×, change approach or surface it — never grind.
+
+## Done means
+- 0 error columns; every page rendered and visually matching the source; every KPI's
+  number matching the source (or the delta explained); controls present and wired; no
+  silently dropped tiles. Anything short of that is **reported, not hidden.**

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -23,6 +23,7 @@ If the user didn't supply a destination (no `--folder <id>`), ASK before buildin
 
 If a destination is already supplied, honor it silently — don't ask.
 
+> **READ FIRST — `refs/operating-contract.md`**: the fidelity guardrails (render + value-check EVERY page against the source; never ship empty or silently drop a tile; don't spin — surface blockers).
 > Status: **foundation** (validated end-to-end 2026-05-31 on the "Employee Dashboard" workforce report).
 > Beads: build = `beads-sigma-cs2`; converter gaps = `j89` (M-Snowflake path), `tkd` (element names / schemaVersion / folderId).
 > Defers to: `sigma-workbooks` (canonical workbook spec), `sigma-data-models` (DM spec), the `convert_powerbi_to_sigma` MCP tool, and `tableau-to-sigma/scripts/*` (reused verbatim for posting + layout + parity).

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/operating-contract.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/operating-contract.md
@@ -1,0 +1,46 @@
+# Migration Operating Contract — read before you touch anything
+
+> A tool- and model-agnostic set of guardrails for any agent running a BI→Sigma
+> migration. The failure it prevents: an agent runs for an hour and ships a
+> structurally-clean but visually-empty, numerically-wrong workbook, then reports
+> "done, 0 errors." Fidelity is not optional and it is not eyeballed — it is gated.
+
+## Ground truth
+- **The source dashboard is the spec.** Before building, obtain (a) its **rendered
+  image** — the Power BI REST export-to-file API (export report to PNG/PDF), or a
+  screenshot of the report page — and (b) its **calc definitions + filters** from the
+  TMSL model + the report definition (`report.json` / PBIR / classic `Report/Layout`),
+  whose measure logic is written in **DAX**. You are matching *that*, not your idea of it.
+
+## Build from the source's own logic
+- **KPIs (measures) are usually ratio/time-intelligence/expression-driven, not
+  `SUM(column)`.** Read each measure's DAX. If the source already materialized its
+  validated calc as a stored column, `SUM` *that* — it already encodes the per-row logic.
+  Use the source's exact aggregate (`Count` vs `CountDistinct` matters).
+- **Map source slicers/parameters/filters → Sigma controls; wire `filters` to the base
+  tables.** Apply the source's report/page/visual filters so aggregates run over the same
+  **population** — otherwise ratios/averages drift even when formulas are "right."
+- **Rebuild every source viz** (donuts, trends, matrices). If a viz has no standalone
+  data export, reconstruct it from the model. **Never silently drop a tile.**
+
+## Verify — don't assume (this is what keeps you on the rails)
+- After every write, GET the spec back. A rejected PUT is **atomic** — read the 400.
+- **Render EVERY page** to PNG and compare side-by-side to the source image. A page
+  that is >40% empty, missing tiles, or visually unlike the source is a **FAIL** — fix it.
+- **Value-check**: for each KPI/table, compare the **number** to the source's number
+  (`executeQueries` DAX is the oracle). "It compiles" is not "it matches." Record the
+  comparison. Import-mode models are frozen snapshots — classify a staleness delta as
+  STALE-EXPLAINED, not a conversion error.
+- Verify the model's existing filter state (`GET /columns`, read element `filters`)
+  before assuming anything is or isn't applied.
+
+## Don't spin, don't fake
+- **"Can't verify" ≠ "passed."** If a gate can't pass, STOP and report the specific
+  blocker. Do not waive it silently or loop to force green.
+- Escape hatches (skip/allow flags) require a **named reason that goes in the report**.
+- If you've retried the same failing step ~2×, change approach or surface it — never grind.
+
+## Done means
+- 0 error columns; every page rendered and visually matching the source; every KPI's
+  number matching the source (or the delta explained); controls present and wired; no
+  silently dropped tiles. Anything short of that is **reported, not hidden.**

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -72,6 +72,7 @@ independently runnable script if you need to intervene mid-pipeline.
 — see `fixtures/README.md`.
 
 **Read ALL of the following before replying or taking any action:**
+- `refs/operating-contract.md` — **READ FIRST**: the fidelity guardrails (render + value-check EVERY page against the source; never ship empty or silently drop a tile; don't spin — surface blockers).
 - `refs/sigma-build-gotchas.md` — the hard-won spec rules (SQL element, workbook master, YAML responses). **This is the difference between a 2xx that errors at query time and a working migration.**
 - The repo `~/Desktop/sigma-data-model-mcp/CLAUDE.md` — Sigma DM spec correctness rules + the verified CSA.TJ test connection.
 - `~/sigma-skills/sigma-workbooks/SKILL.md` + the Sigma OpenAPI — canonical workbook spec.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/operating-contract.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/operating-contract.md
@@ -1,0 +1,44 @@
+# Migration Operating Contract — read before you touch anything
+
+> A tool- and model-agnostic set of guardrails for any agent running a BI→Sigma
+> migration. The failure it prevents: an agent runs for an hour and ships a
+> structurally-clean but visually-empty, numerically-wrong workbook, then reports
+> "done, 0 errors." Fidelity is not optional and it is not eyeballed — it is gated.
+
+## Ground truth
+- **The source dashboard is the spec.** Before building, obtain (a) its **rendered
+  image** — export the Qlik sheet/chart via the Qlik export API, or screenshot the
+  rendered app sheet — and (b) its **calc definitions + filters** from the Qlik app
+  layout pulled over the Engine/REST API (app JSON), whose logic is written in **Qlik
+  expressions / set analysis**. You are matching *that*, not your idea of it.
+
+## Build from the source's own logic
+- **KPIs are usually expression/set-analysis-driven, not `SUM(column)`.** Read each
+  measure's expression. If the source already materialized its validated calc as a stored
+  column, `SUM` *that* — it already encodes the per-row logic. Use the source's exact
+  aggregate (`Count` vs `Count(DISTINCT …)` matters).
+- **Map source variables/parameters/selections → Sigma controls; wire `filters` to the
+  base tables.** Apply the source's selection/period filters so aggregates run over the
+  same **population** — otherwise ratios/averages drift even when formulas are "right."
+- **Rebuild every source viz** (donuts, trends, pivots). If a viz has no standalone
+  data export, reconstruct it from the model. **Never silently drop a tile.**
+
+## Verify — don't assume (this is what keeps you on the rails)
+- After every write, GET the spec back. A rejected PUT is **atomic** — read the 400.
+- **Render EVERY page** to PNG and compare side-by-side to the source image. A page
+  that is >40% empty, missing tiles, or visually unlike the source is a **FAIL** — fix it.
+- **Value-check**: for each KPI/table, compare the **number** to the source's number.
+  "It compiles" is not "it matches." Record the comparison.
+- Verify the model's existing filter state (`GET /columns`, read element `filters`)
+  before assuming anything is or isn't applied.
+
+## Don't spin, don't fake
+- **"Can't verify" ≠ "passed."** If a gate can't pass, STOP and report the specific
+  blocker. Do not waive it silently or loop to force green.
+- Escape hatches (skip/allow flags) require a **named reason that goes in the report**.
+- If you've retried the same failing step ~2×, change approach or surface it — never grind.
+
+## Done means
+- 0 error columns; every page rendered and visually matching the source; every KPI's
+  number matching the source (or the delta explained); controls present and wired; no
+  silently dropped tiles. Anything short of that is **reported, not hidden.**

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -23,6 +23,7 @@ If the user didn't supply a destination (no `--folder <id-or-name>`), ASK before
 
 If a destination is already supplied, honor it silently — don't ask.
 
+> **READ FIRST — `refs/operating-contract.md`**: the fidelity guardrails (render + value-check EVERY page against the source; never ship empty or silently drop a tile; don't spin — surface blockers).
 > Status: **foundation** (converter MCP + browser shipped 2026-05-28).
 > Beads: converter = `beads-sigma-j5e`; CustomSql/DIRECT_QUERY fixup = `beads-sigma-vy4k`.
 > Defers to: `sigma-workbooks` (canonical workbook spec), `sigma-data-models` (DM spec), the `convert_quicksight_to_sigma` MCP tool, and the shared vendor-neutral Sigma-side scripts (`post-and-readback.rb`, `put-layout.rb`, `find-or-pick-dm.rb`, `verify-parity.rb`) reused across the migration skills.

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/operating-contract.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/operating-contract.md
@@ -1,0 +1,45 @@
+# Migration Operating Contract — read before you touch anything
+
+> A tool- and model-agnostic set of guardrails for any agent running a BI→Sigma
+> migration. The failure it prevents: an agent runs for an hour and ships a
+> structurally-clean but visually-empty, numerically-wrong workbook, then reports
+> "done, 0 errors." Fidelity is not optional and it is not eyeballed — it is gated.
+
+## Ground truth
+- **The source dashboard is the spec.** Before building, obtain (a) its **rendered
+  image** — the QuickSight dashboard snapshot/export job (`StartDashboardSnapshotJob` →
+  PDF/PNG), or a screenshot of the dashboard — and (b) its **calc definitions + filters**
+  from the QuickSight dashboard/analysis definition (`describe-dashboard-definition` /
+  `describe-analysis-definition`), whose logic is written in **QuickSight calculated
+  fields**. You are matching *that*, not your idea of it.
+
+## Build from the source's own logic
+- **KPIs are usually calculated-field/ratio/expression-driven, not `SUM(column)`.** Read
+  each field's calc. If the source already materialized its validated calc as a stored
+  column, `SUM` *that* — it already encodes the per-row logic. Use the source's exact
+  aggregate (`count` vs `distinct_count` matters).
+- **Map source parameters/controls/filters → Sigma controls; wire `filters` to the base
+  tables.** Apply the source's sheet/filter-group filters so aggregates run over the same
+  **population** — otherwise ratios/averages drift even when formulas are "right."
+- **Rebuild every source viz** (donuts, trends, pivots). If a viz has no standalone
+  data export, reconstruct it from the model. **Never silently drop a tile.**
+
+## Verify — don't assume (this is what keeps you on the rails)
+- After every write, GET the spec back. A rejected PUT is **atomic** — read the 400.
+- **Render EVERY page** to PNG and compare side-by-side to the source image. A page
+  that is >40% empty, missing tiles, or visually unlike the source is a **FAIL** — fix it.
+- **Value-check**: for each KPI/table, compare the **number** to the source's number.
+  "It compiles" is not "it matches." Record the comparison.
+- Verify the model's existing filter state (`GET /columns`, read element `filters`)
+  before assuming anything is or isn't applied.
+
+## Don't spin, don't fake
+- **"Can't verify" ≠ "passed."** If a gate can't pass, STOP and report the specific
+  blocker. Do not waive it silently or loop to force green.
+- Escape hatches (skip/allow flags) require a **named reason that goes in the report**.
+- If you've retried the same failing step ~2×, change approach or surface it — never grind.
+
+## Done means
+- 0 error columns; every page rendered and visually matching the source; every KPI's
+  number matching the source (or the delta explained); controls present and wired; no
+  silently dropped tiles. Anything short of that is **reported, not hidden.**

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/SKILL.md
@@ -37,6 +37,7 @@ widgets) — never emit confidently-wrong logic.
 > never fake — treemap/sunburst (no native Sigma equivalent) and unsupported
 > JAQL functions. See `refs/design-notes.md`.
 
+> **READ FIRST — `refs/operating-contract.md`**: the fidelity guardrails (render + value-check EVERY page against the source; never ship empty or silently drop a tile; don't spin — surface blockers).
 > Read `refs/` before relying on shapes: `sisense-rest-api.md` (validated
 > endpoint map + auth + the access-key-vs-token gotcha), `jaql-mapping.md`
 > (JAQL → Sigma formula + what's flagged), `widget-type-mapping.md` (widget →

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/operating-contract.md
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/operating-contract.md
@@ -1,0 +1,45 @@
+# Migration Operating Contract — read before you touch anything
+
+> A tool- and model-agnostic set of guardrails for any agent running a BI→Sigma
+> migration. The failure it prevents: an agent runs for an hour and ships a
+> structurally-clean but visually-empty, numerically-wrong workbook, then reports
+> "done, 0 errors." Fidelity is not optional and it is not eyeballed — it is gated.
+
+## Ground truth
+- **The source dashboard is the spec.** Before building, obtain (a) its **rendered
+  image** — export the Sisense dashboard/widget (dashboard export or widget image via
+  the REST API), or screenshot the rendered dashboard — and (b) its **calc definitions +
+  filters** from the Sisense dashboard JSON (dashboards/widgets over REST), whose logic
+  is written in **Sisense JAQL formulas**. You are matching *that*, not your idea of it.
+
+## Build from the source's own logic
+- **KPIs are usually JAQL-formula/ratio/expression-driven, not `SUM(column)`.** Read each
+  field's JAQL. If the source already materialized its validated calc as a stored column,
+  `SUM` *that* — it already encodes the per-row logic. Use the source's exact aggregate
+  (`count` vs `countDistinct` / `dupCount` matters).
+- **Map source filters/parameters → Sigma controls; wire `filters` to the base tables.**
+  Apply the source's dashboard/widget filters so aggregates run over the same
+  **population** — otherwise ratios/averages drift even when formulas are "right."
+- **Rebuild every source viz** (indicators, trends, pivots). If a viz has no standalone
+  data export, reconstruct it from the model. **Never silently drop a tile.**
+
+## Verify — don't assume (this is what keeps you on the rails)
+- After every write, GET the spec back. A rejected PUT is **atomic** — read the 400.
+- **Render EVERY page** to PNG and compare side-by-side to the source image. A page
+  that is >40% empty, missing tiles, or visually unlike the source is a **FAIL** — fix it.
+- **Value-check**: for each KPI/table, compare the **number** to the source's number
+  (Sisense's own JAQL engine is the oracle). "It compiles" is not "it matches." Record
+  the comparison.
+- Verify the model's existing filter state (`GET /columns`, read element `filters`)
+  before assuming anything is or isn't applied.
+
+## Don't spin, don't fake
+- **"Can't verify" ≠ "passed."** If a gate can't pass, STOP and report the specific
+  blocker. Do not waive it silently or loop to force green.
+- Escape hatches (skip/allow flags) require a **named reason that goes in the report**.
+- If you've retried the same failing step ~2×, change approach or surface it — never grind.
+
+## Done means
+- 0 error columns; every page rendered and visually matching the source; every KPI's
+  number matching the source (or the delta explained); controls present and wired; no
+  silently dropped tiles. Anything short of that is **reported, not hidden.**

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -15,6 +15,8 @@ Convert a Tableau datasource into a Sigma data model, then build a Sigma workboo
 that mirrors the Tableau dashboard layout as closely as possible.
 
 **Read ALL of the following before replying or taking any action. Do not make assumptions about skill conventions, prompts, or global instructions — read the files.**
+- `refs/operating-contract.md` — **READ FIRST.** The non-negotiable guardrails: obtain the source render + calcs, build from the source's own logic (not `SUM(col)`), render + value-check EVERY page against the source, never ship empty or waive silently, don't spin. This is what keeps a run on the rails.
+- `refs/composition-recipe.md` — composition pass (hero/panels/carded KPIs + brand-from-source), value-fidelity rules (materialized `(copy)` calc columns, exact aggregate/population, period filter), controls/params rebuild, and the spec/API gotchas that otherwise cost round-trips.
 - `refs/column-gotchas.md` — column naming rules and special-character landmines
 - `refs/data-model-spec.md` — data model JSON schema, element format, relationship format
 - `refs/workbook-layout.md` — Ruby layout generation (mandatory), multi-series chart patterns

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/composition-recipe.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/composition-recipe.md
@@ -1,0 +1,104 @@
+# Composition, fidelity & spec-gotcha recipe — turning a correct migration into a *good* one
+
+> A mechanically-correct migration (0 error columns) can still ship visually empty and
+> numerically wrong. This ref captures the composition pass, the value-fidelity rules, and
+> the spec/API gotchas that otherwise cost round-trips. Pair it with `operating-contract.md`.
+> **Style fields** are documented in `sigma-workbooks/reference/specification/styling.md`;
+> this adds the migration workflow and the failure modes that doc doesn't teach.
+
+## When to run a composition pass
+Whenever the source dashboard has visual sections (containers/zones with headers) — i.e.
+almost always for a report-style dashboard. Skip only for a bare single-table extract.
+**Fidelity to the source wins** — mirror its section structure and brand, not a house style.
+Signature of a page that needs it (catch on the Phase 5b render): every tile the same width
+stacked in one column; >40% of the page empty; the title invisible; source viz missing.
+
+## The composition recipe (verified to render on `/v2/workbooks/{id}/spec` PUT)
+1. **Workbook theme** — top-level `themeName: Light` + `themeOverrides`: `borderRadius: round`,
+   `hasCards: hidden` (so *you* control which elements get card chrome), and
+   `categoricalScheme: [...]` — the **only** spec path to donut/pie slice colors (per-element
+   `color.scheme` is silently dropped on donut/pie).
+2. **Hero strip** — a full-width `kind: container` with `style.backgroundColor` holding the
+   title text. This is the real full-width bar; a text element alone cannot make one (below).
+3. **Section panels** — one white `container` per source section, each opening with a **nested**
+   colored `container` header bar (nested `<GridContainer>` works).
+4. **Stat cards** — mirror the source card grouping. A source "2-value" card → one card container
+   holding a label text + two `kpi-chart`s side-by-side, each with a grey subtitle. Set each
+   KPI's value-column `name: ' '` (single space) so its own title doesn't duplicate the label.
+5. **Number formats** — money `$,.0f`; compact `$,.2s` when two values share a narrow half-card.
+
+Donut specifics: `holeValue:{id:<a column whose id ≠ value's>}` puts the **centre total** in the
+ring; `legend:{visibility:hidden}` on donuts that share a legend with a sibling (show it once).
+
+**Extract brand colors from the source file** (grep `<style>`/`format`/`run` for `#`-hex near the
+title worksheets and dashboard style); apply via `themeOverrides` + the hero/section bars. A generic
+blue reads as "close but not their brand." (`scan-customer-style.rb` can supply org-level defaults.)
+
+## Value-fidelity — why migrated numbers come out wrong
+A KPI can be off by orders of magnitude if you sum a raw column instead of translating the calc.
+
+- **KPIs are frequently parameter/ratio/LOD-driven, not `SUM(col)`.** Resolve each field's
+  `<calculation formula>` (incl. `[Parameters].[…]` refs and FIXED-LOD) and emit the real kind:
+  a constant param → a value/control ref; a ratio → division; an LOD → a grouping. Summing a raw
+  column where the source computes a ratio/param yields garbage (e.g. a 5-digit "ROI").
+- **Prefer the source's materialized validated calc columns.** Migrations often already carry the
+  source's validated calcs as columns (e.g. `…(copy)…` fields). Summing *those* reproduces the
+  per-row logic (including per-row rate lookups) exactly — far better than re-deriving `SUM(x)*param`.
+  Caveat: those materialized columns' **display names can be mislabeled** (a field tagged `(NR)` may
+  hold the `NR+MD` value) — trust the *values* against the source, not the name.
+- **Use the source's exact aggregate + population.** `Count` vs `CountDistinct` changes the number;
+  a numerator and denominator running over different filtered populations (e.g. cost excludes a
+  category but the divisor doesn't) makes averages/ratios drift. Match each measure's aggregate AND
+  the rows it runs over.
+- **Apply the source's dashboard/period filters.** If the source scopes the dashboard to a period
+  (often via a parameter-driven boolean calc, sometimes materialized as an `In Report Period`-style
+  column), apply it to the built tables/elements — and **verify** the model's existing filter state
+  (`GET /columns`, read element `filters`) rather than assuming it is or isn't applied.
+- **Pick the date-*typed* column, not its text twin.** A model may carry both a text and a datetime
+  version of a date field; `DateTrunc("month", <text col>)` fails with **"Argument 2 invalid for
+  function"** and collapses a time series into one error bar. Resolve to the datetime column or cast.
+
+## Controls & parameters rarely survive — rebuild them
+Migrations commonly drop the interactive layer. Rebuild from the source's parameters + quick filters:
+- **List control**: `controlType: list` + double-nested `source: {kind: source, source: {kind: table,
+  elementId}, columnId}` + `filters: [{source: {kind: table, elementId}, columnId}]` + flat
+  `mode`/`selectionMode`/`values`.
+- **Date-range control**: `controlType: date-range`, `mode: between` (+ optional `startDate`/`endDate`;
+  other modes carry their own flat fields).
+- Wire `filters` to the **base tables** so the control filters workbook-wide.
+- **Parameters → controls, wired into the formulas** (number controls are safe to reference by
+  `[ControlId]` in arithmetic; only date/list control refs hit the variant bug). Don't hardcode.
+- Gate idea: source has parameters/quick-filters but the workbook has 0 controls → flag it.
+
+## Spec/API gotchas (each avoids a wasted round-trip)
+- **`/spec` GET returns YAML; PUT takes JSON.**
+- **A rejected PUT is atomic** — nothing is written. Guard every write (assert `pages` exists; assert
+  the prior layout string is unchanged when you only meant to touch formulas) so a bad token or field
+  can never half-corrupt a workbook. A missing element is often a *silent earlier 400*, not a render bug.
+- **pivot `values` is a `string[]`** of column ids, not `[{id}]`. `rowsBy`/`columnsBy` ARE `[{id, sort?}]`.
+- **Text inline HTML is whitelisted:** only `<u> <sub> <sup> <span> <a>`. **`<div>` is rejected.**
+  `<span style>` allows only `color`/`background-color`/`font-size`/`font-family`. Centre/right via
+  `<p style="text-align: center|right">`; **`text-align: left` is rejected** (default) — use a plain
+  span/heading. A full-width colored bar is only achievable via a `container` `style.backgroundColor`.
+- **Donut/pie:** `color.scheme` is silently stripped (use `themeOverrides.categoricalScheme`);
+  `holeValue.id == value.id` silently drops the element (use a distinct column).
+- **KPI title suppression:** only `name: ' '` (single space) works; omitting re-derives the title.
+- **Bar/line `color`** = `{by, column, scheme}`, not a bare `{scheme}`. Single-series charts omit it.
+- **Never bulk-rename a live column's display name** — formulas reference columns by `[Element/Name]`,
+  so a rename throws `Dependency not found`. Rename only element-local pivot columns, or set friendly
+  names at build time on freshly-created columns.
+- **Sigma auto-appends unplaced elements to the layout on save.** To delete an element, remove BOTH the
+  element AND its (possibly auto-added) `<LayoutElement>` ref, or the next PUT 400s on a dangling ref.
+- **API tokens are short-lived** — re-auth immediately before each GET/PUT/export.
+
+## Wiring into the converter (the actual leverage)
+1. **Composition pass (Phase 5e)** — build theme + panels + bars + carded KPIs from the parsed zones;
+   this is the reference output for the composition-layer epic.
+2. **Fix the layout fallback** so it never emits a half-width single-column stack; fix
+   `build-dashboard-layout.rb`'s bottom-band safety net (its `kind` check never matches real chart
+   kinds like `bar-chart`/`kpi-chart`/`table`, so unmatched tiles vanish silently).
+3. **Hard visual + value gates** (see `assert-phase6-ran.rb` gate 8b, now enforced by default):
+   fail — not warn — on empty/low-fill pages and on KPI numbers that don't match the source.
+4. **White-title trap:** when a source title uses white text meant for a header band, build the band
+   (a colored container) OR recolor — never emit invisible white-on-light.
+5. **Reconstruct no-standalone-view viz** from the model (donuts/trends/matrices) instead of dropping.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/operating-contract.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/operating-contract.md
@@ -1,0 +1,43 @@
+# Migration Operating Contract — read before you touch anything
+
+> A tool- and model-agnostic set of guardrails for any agent running a BI→Sigma
+> migration. The failure it prevents: an agent runs for an hour and ships a
+> structurally-clean but visually-empty, numerically-wrong workbook, then reports
+> "done, 0 errors." Fidelity is not optional and it is not eyeballed — it is gated.
+
+## Ground truth
+- **The source dashboard is the spec.** Before building, obtain (a) its **rendered
+  image** — Tableau REST `Query View Image` with the PAT works with no MCP — and
+  (b) its **calc definitions + filters** from the source file (`.twb` etc.). You are
+  matching *that*, not your idea of it.
+
+## Build from the source's own logic
+- **KPIs are usually parameter/ratio/LOD-driven, not `SUM(column)`.** Read each
+  field's calc. If the model already materialized the source's validated calc as a
+  column (e.g. a `…(copy)…` field), `SUM` *that* — it already encodes the per-row
+  logic. Use the source's exact aggregate (`Count` vs `CountDistinct` matters).
+- **Map source parameters → Sigma controls; wire `filters` to the base tables.**
+  Apply the source's dashboard/period filters so aggregates run over the same
+  **population** — otherwise ratios/averages drift even when formulas are "right."
+- **Rebuild every source viz** (donuts, trends, matrices). If a viz has no standalone
+  data export, reconstruct it from the model. **Never silently drop a tile.**
+
+## Verify — don't assume (this is what keeps you on the rails)
+- After every write, GET the spec back. A rejected PUT is **atomic** — read the 400.
+- **Render EVERY page** to PNG and compare side-by-side to the source image. A page
+  that is >40% empty, missing tiles, or visually unlike the source is a **FAIL** — fix it.
+- **Value-check**: for each KPI/table, compare the **number** to the source's number.
+  "It compiles" is not "it matches." Record the comparison.
+- Verify the model's existing filter state (`GET /columns`, read element `filters`)
+  before assuming anything is or isn't applied.
+
+## Don't spin, don't fake
+- **"Can't verify" ≠ "passed."** If a gate can't pass, STOP and report the specific
+  blocker. Do not waive it silently or loop to force green.
+- Escape hatches (skip/allow flags) require a **named reason that goes in the report**.
+- If you've retried the same failing step ~2×, change approach or surface it — never grind.
+
+## Done means
+- 0 error columns; every page rendered and visually matching the source; every KPI's
+  number matching the source (or the delta explained); controls present and wired; no
+  silently dropped tiles. Anything short of that is **reported, not hidden.**

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -23,6 +23,8 @@ If the user didn't supply a destination (no `SIGMA_FOLDER_ID`), ASK before build
 
 If `SIGMA_FOLDER_ID` is already set, honor it silently — don't ask.
 
+> **READ FIRST — `refs/operating-contract.md`**: the fidelity guardrails (render + value-check EVERY page against the source; never ship empty or silently drop a tile; don't spin — surface blockers).
+
 Recreate a ThoughtSpot **model/worksheet** as a Sigma **data model**, and its
 **Liveboards** as Sigma **workbooks**, with parity verified against the live
 warehouse.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/operating-contract.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/operating-contract.md
@@ -1,0 +1,46 @@
+# Migration Operating Contract — read before you touch anything
+
+> A tool- and model-agnostic set of guardrails for any agent running a BI→Sigma
+> migration. The failure it prevents: an agent runs for an hour and ships a
+> structurally-clean but visually-empty, numerically-wrong workbook, then reports
+> "done, 0 errors." Fidelity is not optional and it is not eyeballed — it is gated.
+
+## Ground truth
+- **The source dashboard is the spec.** Before building, obtain (a) its **rendered
+  image** — screenshot the rendered Liveboard/answer (or use ThoughtSpot's export where
+  available) — and (b) its **calc definitions + filters** from the TML (answer / Liveboard
+  definitions), whose logic is written in **TML formulas**. You are matching *that*, not
+  your idea of it.
+
+## Build from the source's own logic
+- **KPIs (headline metrics) are usually formula/ratio/aggregation-driven, not
+  `SUM(column)`.** Read each field's formula and its `headline_aggregation`. If the
+  source already materialized its validated calc as a stored column, `SUM` *that* — it
+  already encodes the per-row logic. Use the source's exact aggregate (`count` vs
+  `unique_count` matters).
+- **Map source filters/parameters → Sigma controls; wire `filters` to the base tables.**
+  Apply the source's Liveboard/answer filters so aggregates run over the same
+  **population** — otherwise ratios/averages drift even when formulas are "right."
+- **Rebuild every source viz** (KPIs, trends, pivots). If a viz has no standalone
+  data export, reconstruct it from the model. **Never silently drop a tile.**
+
+## Verify — don't assume (this is what keeps you on the rails)
+- After every write, GET the spec back. A rejected PUT is **atomic** — read the 400.
+- **Render EVERY page** to PNG and compare side-by-side to the source image. A page
+  that is >40% empty, missing tiles, or visually unlike the source is a **FAIL** — fix it.
+- **Value-check**: for each KPI/table, compare the **number** to the source's number
+  (ThoughtSpot's `searchdata` result is the oracle). "It compiles" is not "it matches."
+  Record the comparison.
+- Verify the model's existing filter state (`GET /columns`, read element `filters`)
+  before assuming anything is or isn't applied.
+
+## Don't spin, don't fake
+- **"Can't verify" ≠ "passed."** If a gate can't pass, STOP and report the specific
+  blocker. Do not waive it silently or loop to force green.
+- Escape hatches (skip/allow flags) require a **named reason that goes in the report**.
+- If you've retried the same failing step ~2×, change approach or surface it — never grind.
+
+## Done means
+- 0 error columns; every page rendered and visually matching the source; every KPI's
+  number matching the source (or the delta explained); controls present and wired; no
+  silently dropped tiles. Anything short of that is **reported, not hidden.**


### PR DESCRIPTION
## Why
Prevents the failure mode where a migration agent runs for a long time and ships a **structurally-clean but visually-empty / numerically-wrong** workbook, then reports "done, 0 errors." Encodes the guardrails so this holds **consistently across any coding agent/model**.

## What (additive only)
- **`refs/operating-contract.md` in all 9 converter skills** (tableau, cognos, looker, microstrategy, powerbi, qlik, quicksight, sisense, thoughtspot). Universal core + a per-tool **Ground truth** section (that tool's source render/export mechanism + definition/calc artifact — no MCP required where a REST/PAT path exists):
  - Build from the source's own logic — **not `SUM(col)`**; prefer materialized validated calc columns; match the source's exact aggregate + population; apply the source's period/dashboard filters.
  - **Render + value-check EVERY page against the source.** "It compiles" ≠ "it matches."
  - Never ship empty / waive silently; escape hatches need a named reason; don't spin (~2 retries then surface).
- **`refs/composition-recipe.md` (tableau):** composition pass (hero/panels/carded KPIs + brand-from-source), value-fidelity rules, controls/params rebuild, and the spec/API gotchas that otherwise cost round-trips.
- Each `SKILL.md`: one **READ FIRST** pointer to its operating contract.

## Collision-safety
Purely additive — **new ref files + tiny SKILL.md pointer lines only**. No `scripts/`, no `shared/` libraries touched, so it should not collide with in-flight converter PRs. Governance (shared-drift + gate-doc) passes.

## Deliberately NOT in this PR (tracked separately for sequencing)
- **Gate 8b → enforced by default** (source-vs-target visual verdict). This is a **shared-lib** change (`shared/scripts/assert-phase6-ran.rb` + `sync-shared.rb` across all converters) — highest collision surface, so it's split out to merge deliberately after in-flight PRs settle.
- **Emit-side fixes** (materialized-calc-column preference, controls/param emission, no-REST-view tile synthesis, parity denominator, phase-6 waive preservation, composition pass). See the tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)