### PR TITLE
fix(tableau): stop silently dropping content — layout safety-net + no-REST-view tiles (#259)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -2319,8 +2319,22 @@ layout.each do |dash|
 
     view = view_by_name[cap]
     if view.nil?
-      warnings << "no Tableau view matched '#{cap}'"
-      next
+      # No standalone Tableau REST view for this worksheet — it's a sheet
+      # embedded inside a dashboard (published without its own tab), so it has no
+      # data export. NOT a reason to drop it (the "5 blend worksheets never
+      # built" regression): give it a synthetic view id (no CSV on disk) so it
+      # falls through to the empty-CSV path below, which reconstructs the tile
+      # from .twb shelf signals. Drop only when the shelves genuinely can't be
+      # reconstructed — and even then, surface it (never silent).
+      if synthesize_view_from_signals(z, meta)
+        warnings << "'#{cap}' has NO standalone Tableau REST view (worksheet embedded in a dashboard) — " \
+                    "building it from .twb shelf signals instead of dropping it (data parity for this tile is manual/image)."
+        view = { 'id' => "signal-only-#{cap.gsub(/\W+/, '-')}" }
+      else
+        warnings << "ZONE DROPPED: '#{cap}' — no Tableau REST view AND shelf signals carry no dim+measure to " \
+                    "reconstruct it. Build the chart by hand; the Phase-6 tile census will report it unmatched."
+        next
+      end
     end
     # Chart kind was INFERRED from shelves (Tableau mark=Automatic) — route it to
     # IMAGE confirmation so a wrong line/bar/scatter guess can't pass silently.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -283,9 +283,19 @@ def build_page_from_tree(dashboard, page, opts)
   # Safety net: any chart/control element NOT placed by the tree (an unmatched
   # zone, or a control with no dashboard zone) lands in a bottom band so nothing
   # silently drops from the layout.
-  unplaced = page['elements'].select do |e|
-    %w[chart control].include?(e['kind']) && e['name'] && !ctx[:placed].include?(e['id'])
-  end
+  # Match REAL Sigma element kinds — the previous `%w[chart control]` check
+  # never matched (kinds are `bar-chart`/`kpi-chart`/`table`/`pivot-table`/
+  # `donut-chart`/…, never the literal `chart`), so unmatched charts/tables
+  # SILENTLY VANISHED from the layout instead of landing in the safety band —
+  # the "one tile top-left, everything else gone" regression. Placeable content
+  # = any *-chart, table/pivot-table, control, or text (exclude structural
+  # containers/data). No `name` requirement (charts built from signals may not
+  # carry one, yet must still be placed).
+  placeable = ->(e) {
+    k = e['kind'].to_s
+    k.end_with?('-chart') || %w[table pivot-table control text].include?(k)
+  }
+  unplaced = page['elements'].select { |e| placeable.call(e) && !ctx[:placed].include?(e['id']) }
   unless unplaced.empty?
     n = unplaced.length
     cw = 24.0 / n
@@ -297,7 +307,7 @@ def build_page_from_tree(dashboard, page, opts)
     bid = "tc-#{page['id']}-extra"
     extra_els << container_el(bid)
     children << gc(bid, 1, 25, [page_rows - 4, HEADER_ROWS + 1].max, page_rows + 1, inner)
-    warn "WARN: #{n} element(s) had no Tableau zone — appended in a bottom band: #{unplaced.map { |e| e['name'] }.join(', ')}"
+    warn "WARN: #{n} element(s) had no Tableau zone — appended in a bottom band: #{unplaced.map { |e| e['name'] || e['id'] }.join(', ')}"
   end
 
   [page_xml(page['id'], *children), extra_els, ctx[:placed].size, tree.length, ctl_by_name.size]


### PR DESCRIPTION
Continues #259. Two fixes for the silent content-loss that let the "0 errors but visually empty / missing tiles" regression ship.

## 1. Layout safety-net matched no real element kinds
`build-dashboard-layout.rb`'s bottom-band "nothing silently drops" net tested `%w[chart control].include?(e['kind'])` — but Sigma kinds are `bar-chart`/`kpi-chart`/`donut-chart`/`table`/`pivot-table`/…, never the literal `chart`. So **unmatched charts/tables vanished** instead of landing in the band — the "one tile top-left, everything else gone" root cause. Now matches any `*-chart` + `table`/`pivot-table`/`control`/`text`, and drops the `name` requirement (signal-built charts may be nameless).

## 2. Embedded worksheets (no REST view) were dropped
`build-charts-from-signals.rb`: a worksheet with no standalone REST view (embedded in a dashboard → no data export) hit a silent `next` — the **"5 blend worksheets never built"** regression. Now it gets a synthetic view id and falls through to the existing empty-CSV path, which **rebuilds the tile from `.twb` shelf signals** (parity downgraded to manual/image). Genuinely unreconstructable zones are surfaced as `ZONE DROPPED`, never silent.

## Safety
Both are tableau-only files — no shared-lib blast radius. Regression tests pass: `empty-csv-build-from-signals`, `container-layout`, `coverage-gate`, `topn-filter-emission`, `layout-lint`.

## #259 remaining after this
value-fidelity (prefer materialized `(copy)` calc cols + value-parity gate), phase-6 waive preservation + census denominator, control auto-wiring, composition pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)