### PR TITLE
tableau-to-sigma: B1/B2/C2/D1 composition stage (repeated per-category cards)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/README.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/README.md
@@ -1,5 +1,25 @@
 # Composition stage (B1/B2/C2/D1) — repeated per-category cards
 
+## Applicability (read first)
+
+This stage reproduces **one specific source design**: a Tableau dashboard that lays
+out a **container repeated per category member** (the four region cards in the
+Job-Loss benchmark — `South Container`, `West Container`, … in the `.twb`, each with
+the same children). It is **not** a general design reconstructor. `compose-auto`
+only fires when `detect-composition-signal` finds that repeated container **in the
+source `.twb` zone tree** — a dashboard whose data merely has a category+entity+measure
+(e.g. Superstore) correctly routes to the standard build instead of getting this
+layout imposed on it. Sigma's spec has **no repeated-container primitive**, so the
+repeat is detected source-side and the emitter materializes N *explicit* GridContainers.
+
+**Current honest limit:** when it applies, the card's *children* (KPI + %-annotation +
+Top-N bar + strip) and the rail are still modeled on the Job-Loss source structure
+rather than derived per-dashboard from the matched container's own children. Deriving
+those from the source is the open follow-up; until then, treat this as faithful for
+the Job-Loss-class card-trellis and verify any new card design by eye.
+
+
+
 The data-correctness layer (right numbers, right chart kind, parity gate) doesn't
 reconstruct a design-heavy dashboard's *composition*. This stage does: it detects a
 **container repeated per category member** (the four region columns in the Job-Loss

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/README.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/README.md
@@ -1,0 +1,89 @@
+# Composition stage (B1/B2/C2/D1) — repeated per-category cards
+
+The data-correctness layer (right numbers, right chart kind, parity gate) doesn't
+reconstruct a design-heavy dashboard's *composition*. This stage does: it detects a
+**container repeated per category member** (the four region columns in the Job-Loss
+benchmark) and emits N tinted `GridContainer` cards, each stacking a transparent hero
+KPI + annotations + a Top/Bottom-N bar + a threshold strip, plus a left rail and a
+wired control row. Two halves — the GAPS report's "extract" and "emit":
+
+### One-command auto-trigger (Phase 5c)
+
+`compose-auto.py` is the entrypoint a migration calls: it runs signal detection and,
+if a repeated-per-category composition applies, auto-runs detect + emit with the
+**inferred** roles — nothing hand-passed. Exit 0 = composed; **exit 2 = does not
+apply** (caller routes to the standard non-composition build); 1 = error.
+
+```
+compose-auto.py --twb X.twb --master-csv m.csv \
+   ( --dm-ids dm-ids.json | --connection-id <uuid> --path DB,SCHEMA,TABLE ) \
+   --folder <id> --wb-name "..." --out-spec wb.json [--text-overrides t.json] \
+   [--min-confidence medium]
+# then: ../post-and-readback.rb --type workbook --spec wb.json ; ../sigma-export-png.py ; composition-verify.py --workbook <id>
+```
+
+**Integration:** run this at Phase 5c once Phase-1 parse (`.twb`) + the landed master
+table (CSV export) exist. It is intentionally a standalone step rather than inlined
+into `migrate-tableau.rb` — the gated orchestrator stays untouched; route on its exit
+code (2 → standard flow). The individual stages below are what it chains:
+
+```
+detect-composition-signal.py  # DECIDE + INFER ROLES: does this route to composition?
+  --twb X.twb --master-csv master.csv --emit-args
+  -> applies? + inferred {category,entity,measure,rate,secondary,split,threshold}
+     category via .twb color palette + low cardinality; entity via cardinality;
+     measure via .twb reference frequency (NOT magnitude); threshold via a '> N'
+     that flags ~10-40% of entities. Feed its ARGS line straight into ->
+
+detect-region-cards.py        # EXTRACT: parse signals -> config.json
+  --twb X.twb                 category members + order      <- master CSV
+  --master-csv master.csv     per-category color palette    <- .twb style <map> buckets
+  --dm-ids dm-ids.json        card/header tints             <- derived (lighten/darken)
+  --category .. --entity ..    per-category facts + cutoffs  <- computed from master CSV
+  --measure .. --rate ..       prose                          <- .twb text runs + --text-overrides
+  [--secondary --split-a --split-b --threshold --source-name --fact-name]
+  --folder <id> --out config.json
+  (--twb is OPTIONAL: omit for data-only mode — default palette + generic prose)
+
+compose-region-cards.py       # EMIT: config.json -> composed workbook spec (+embedded layout)
+  --config config.json --out-spec wb.json [--out-layout layout.xml]
+  Nothing dashboard-specific is hardcoded: columns/measure/threshold/prose/palette
+  all come from config. Adapts to N cards; drops cshare when there's no split.
+
+composition-verify.py         # GATE: structural completeness + live per-card KPI check
+  --config config.json --spec wb.json [--workbook <id>]   # needs $SIGMA_API_TOKEN for --workbook
+```
+
+Then POST via `../post-and-readback.rb --type workbook --spec wb.json` (layout is
+embedded top-level), render with `../sigma-export-png.py`, and gate with
+`composition-verify.py --workbook <id>`.
+
+**Generality:** `config.example.json` (Job-Loss, 4 region cards, worker split, 60 el)
+and `config.example2.json` (cloud spend by team, different schema, no split, 59 el)
+both pass `test-compose.py` — the stage is schema-agnostic, not tied to this dashboard.
+The `.twb` reference-frequency signal is what makes measure inference high-confidence;
+in data-only mode (no `.twb`) it falls back to magnitude (medium confidence).
+
+## What's spec-authorable (verified live on wb <workbook-id>)
+
+- **B1** composite cards: KPI + `%-of-total` + worker-split/extremes/count text + Top-N bar + strip, one tinted `GridContainer` per category, height-to-content.
+- **B2/D1** per-card tints + header bars, `themeOverrides.categoricalScheme` + white `backgroundCanvas`. Palette comes from the `.twb` color encoding; tints are derived from the base hue.
+- **C2** threshold strip: `Over 100K` = a workbook column `[…/Total Job Losses] > 100000` (no DM change) drives `color.scheme:[base, "#F2C037"]`.
+- **Wired controls** (see `reference/specification/controls.md`):
+  - `cshare` — 3-way measure switch (Total / Immigrant / U.S.-born) via a `Switch([cshare], …)` in the **chart measure column**.
+  - `crank` — Most/Least Impacted via a **window-free** control-conditional boolean vs each region's precomputed top-5/bottom-5 cutoff, filtered `[true]`. (`Rank()` errors as a window function; `top-n` filter direction can't bind to a control.)
+  - `cmedian` — Show/Hide median line via `refMarks` with a conditional formula (`If([cmedian]="Show", Median(…), Null)`).
+
+## Known spec gaps (surface, don't ship dead UI)
+
+- **Labels Show/Hide** — `dataLabel.labels` is a static enum, no formula/control path. Dropped.
+- **Region/State click-to-filter (E3)** — a control filter can only target a *table* element, so the spec-native version needs an added dropdown + a hidden rail base table; not the click-action itself.
+
+## Integration into the phase flow
+
+This is invoked as a Phase 5c composition step *after* the DM + master table land,
+when the parser flags a repeated-per-category container. `detect-region-cards.py`
+consumes the parse layout + the landed master CSV export; a general converter would
+generalize the fixed `State Master` column names to the detected fact columns.
+
+Test: `python3 test-compose.py` (offline; asserts structure + the three control wirings).

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/compose-auto.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/compose-auto.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""compose-auto.py — the AUTO-TRIGGER: one command, signal -> detect -> emit.
+
+This is what a cold `tableau-to-sigma` run calls at Phase 5c. It runs the
+composition-signal detector; if a repeated-per-category composition applies, it
+auto-runs detect-region-cards (with the INFERRED roles — nothing hand-passed) and
+then compose-region-cards, producing the composed workbook spec. If it does not
+apply, it exits 2 so the caller routes to the standard (non-composition) build.
+
+Usage (data-model source):
+  compose-auto.py --twb X.twb --master-csv m.csv --dm-ids dm-ids.json \
+      --folder <id> --wb-name "..." --out-spec wb.json [--text-overrides t.json]
+Usage (warehouse-table source):
+  compose-auto.py --twb X.twb --master-csv m.csv \
+      --connection-id <uuid> --path DB,SCHEMA,TABLE --folder <id> --out-spec wb.json
+
+Exit codes: 0 composed · 2 composition does not apply · 1 error.
+"""
+import argparse, json, os, subprocess, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PY = sys.executable
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--twb")
+ap.add_argument("--master-csv", required=True)
+ap.add_argument("--dm-ids")
+ap.add_argument("--connection-id")
+ap.add_argument("--path")
+ap.add_argument("--folder", required=True)
+ap.add_argument("--wb-name", default="Composed dashboard (skill B1)")
+ap.add_argument("--source-name", default="Master")
+ap.add_argument("--fact-name", default="Fact")
+ap.add_argument("--text-overrides")
+ap.add_argument("--config-out", default=None)
+ap.add_argument("--out-spec", required=True)
+ap.add_argument("--min-confidence", default="medium", choices=["low", "medium", "high"])
+a = ap.parse_args()
+
+# --- 1. signal detection + role inference ---
+sig_cmd = [PY, os.path.join(HERE, "detect-composition-signal.py"),
+           "--master-csv", a.master_csv, "--emit-args"]
+if a.twb:
+    sig_cmd += ["--twb", a.twb]
+sig = subprocess.run(sig_cmd, capture_output=True, text=True)
+sys.stderr.write(sig.stdout)
+if sig.returncode != 0:
+    sys.stderr.write(sig.stderr)
+    sys.exit(1)
+roles = None
+for line in sig.stdout.splitlines():
+    line = line.strip()
+    if line.startswith("{"):
+        roles = json.loads(line)
+rank = {"low": 0, "medium": 1, "high": 2}
+if not roles or not roles.get("applies") or rank[roles["confidence"]] < rank[a.min_confidence]:
+    print(f"composition does not apply (roles={bool(roles)}, "
+          f"confidence={roles['confidence'] if roles else 'n/a'}) — route to standard flow")
+    sys.exit(2)
+
+# --- 2. detect-region-cards with the inferred roles ---
+cfg_out = a.config_out or (os.path.splitext(a.out_spec)[0] + ".config.json")
+det = [PY, os.path.join(HERE, "detect-region-cards.py"), "--master-csv", a.master_csv,
+       "--category", roles["category"], "--entity", roles["entity"],
+       "--measure", roles["measure"], "--rate", roles["rate"],
+       "--folder", a.folder, "--wb-name", a.wb_name,
+       "--source-name", a.source_name, "--fact-name", a.fact_name, "--out", cfg_out]
+if a.twb:
+    det += ["--twb", a.twb]
+if roles.get("secondary"):
+    det += ["--secondary", roles["secondary"]]
+if roles.get("split_a") and roles.get("split_b"):
+    det += ["--split-a", roles["split_a"], "--split-b", roles["split_b"]]
+if roles.get("threshold") is not None:
+    det += ["--threshold", str(int(roles["threshold"]))]
+if a.dm_ids:
+    det += ["--dm-ids", a.dm_ids]
+if a.connection_id and a.path:
+    det += ["--connection-id", a.connection_id, "--path", a.path]
+if a.text_overrides:
+    det += ["--text-overrides", a.text_overrides]
+if subprocess.run(det).returncode != 0:
+    sys.exit(1)
+
+# --- 3. emit ---
+if subprocess.run([PY, os.path.join(HERE, "compose-region-cards.py"),
+                   "--config", cfg_out, "--out-spec", a.out_spec]).returncode != 0:
+    sys.exit(1)
+print(f"AUTO-COMPOSED -> {a.out_spec}  (category={roles['category']}, measure={roles['measure']}, "
+      f"confidence={roles['confidence']})")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/compose-region-cards.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/compose-region-cards.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""compose-region-cards.py — the EMIT half of the composition stage (B1+B2+C2+D1).
+
+Consumes the config produced by `detect-region-cards.py` and stamps a full
+composed workbook spec (elements + embedded grid layout): one tinted GridContainer
+card per detected category member, each stacking a transparent hero KPI +
+%-of-total + optional worker-split/extremes/count annotations + a Top/Bottom-N bar +
+a threshold strip; plus a left rail and a wired control row.
+
+NOTHING about a specific dashboard is hardcoded here — column references, the
+measure, the threshold, the prose, and the palette all come from the config's
+`fields` / `text` / `threshold` blocks (see config.example.json). Wired controls:
+  * cshare  — measure switch Total/split_a/split_b (chart-measure Switch)   [if a split exists]
+  * crank   — Most/Least via control-conditional cutoff boolean (window-free)
+  * cmedian — Show/Hide median reference line (refMarks conditional formula)
+
+Usage: compose-region-cards.py --config config.json --out-spec wb.json [--out-layout layout.xml]
+"""
+import argparse, json
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--config", required=True)
+ap.add_argument("--out-spec", required=True)
+ap.add_argument("--out-layout")
+A = ap.parse_args()
+CFG = json.load(open(A.config))
+
+SOURCE_KIND = CFG.get("source_kind", "data-model")   # data-model | warehouse-table
+DM_ID = CFG.get("dm_id")
+FACT_EID = CFG.get("state_fact_eid")
+CONN_ID = CFG.get("connection_id")
+PATH = CFG.get("path")                                # [DB, SCHEMA, TABLE] for warehouse-table
+FOLDER_ID = CFG["folder_id"]
+CAT_SCHEME = CFG["cat_scheme"]
+REGIONS = CFG["regions"]                       # order == card order (by measure desc)
+NAT = CFG["national"]
+GRAND = CFG["grand"]
+F = CFG["fields"]                              # role -> {name, src}
+SRC = CFG.get("source_name", "Master")         # workbook table element name
+# formula prefix for the master table's own columns: the DM element name
+# (data-model) or the warehouse table name = last path segment (warehouse-table)
+FACT = PATH[-1] if SOURCE_KIND == "warehouse-table" else CFG.get("fact_name", "Fact")
+THRESH = CFG.get("threshold")
+TXT = CFG.get("text", {})
+HAS_SPLIT = "split_a" in F and "split_b" in F
+HAS_SECONDARY = "secondary" in F               # e.g. Deportations for the rail scatter
+
+
+def mref(role):                                # workbook ref to the master element column
+    return f'[{SRC}/{F[role]["name"]}]'
+
+
+def txt(key, default=""):
+    return TXT.get(key, default)
+
+
+# --- E2: control-driven measure switch (Total / split_a / split_b) ---
+_TOTAL = f'Sum({mref("measure")})'
+if HAS_SPLIT:
+    _A = f'Sum({mref("measure")} * {mref("split_a")} / ({mref("split_a")} + {mref("split_b")}))'
+    _B = f'Sum({mref("measure")} * {mref("split_b")} / ({mref("split_a")} + {mref("split_b")}))'
+    MEASURE_SWITCH = (f'Switch([cshare], "Total", {_TOTAL}, '
+                      f'"{F["split_a"]["name"]}", {_A}, "{F["split_b"]["name"]}", {_B})')
+else:
+    MEASURE_SWITCH = _TOTAL
+MEAS_NAME = F["measure"]["name"]
+THRESH_LABEL = txt("threshold_label", f"{int(THRESH):,}".replace(",", "K", 0) if THRESH else "")
+
+
+def hnum(v):
+    v = float(v)
+    if abs(v) >= 1e6:
+        return f"{v/1e6:.1f}".rstrip("0").rstrip(".") + "M"
+    if abs(v) >= 1e3:
+        return f"{round(v/1e3)}K"
+    return f"{round(v)}"
+
+
+def card_elements(rg):
+    p, label, c, f = rg["key"], rg["label"], rg["colors"], rg["facts"]
+    tot = f["total"]
+    hi_ab, hi_v = f["hi"]; lo_ab, lo_v = f["lo"]
+
+    sub_lines = []
+    if HAS_SPLIT and f.get("split_a_pct") is not None:
+        aM, bM = hnum(tot * f["split_a_pct"] / 100.0), hnum(tot * f["split_b_pct"] / 100.0)
+        sub_lines.append(f'<span style="color:#6B7280">{aM} | {f["split_a_pct"]}% '
+                         f'&nbsp;&nbsp;&nbsp; {bM} | {f["split_b_pct"]}%</span>')
+    sub_lines.append(
+        f'<span style="background-color:{c["card"]}">&nbsp;'
+        f'<span style="color:{c["hdrtext"]}">▲ {hi_ab} {hnum(hi_v)}</span> &nbsp;&nbsp; '
+        f'<span style="color:#8A8A8A">▼ {lo_ab} {hnum(lo_v)}</span>&nbsp;</span>')
+    over_line = f'{f["n_entities"]} {txt("entity_plural", "items")}'
+    if THRESH is not None:
+        over_line += f'  |  &gt; {hnum(THRESH)} : {f["over_thresh"]}'
+    sub_lines.append(f'<span style="color:#9AA0A6">{over_line}</span>')
+
+    strip_cols = [
+        {"id": f"sp-{p}-en", "name": F["entity"]["name"], "formula": mref("entity")},
+        {"id": f"sp-{p}-cat", "name": F["category"]["name"], "formula": mref("category")},
+        {"id": f"sp-{p}-rate", "name": F["rate"]["name"], "formula": f'Sum({mref("rate")})'},
+        {"id": f"sp-{p}-m", "name": MEAS_NAME, "formula": _TOTAL,
+         "format": {"kind": "number", "formatString": ",.0f"}}]
+    strip_color = {"by": "single", "value": c["bar"]}
+    if THRESH is not None:
+        strip_cols.insert(2, {"id": f"sp-{p}-ov", "name": "Over Threshold", "formula": "[%s/Over Threshold]" % SRC})
+        strip_color = {"by": "category", "column": f"sp-{p}-ov", "scheme": [c["bar"], "#F2C037"]}
+
+    return [
+        {"id": f"hdrbar-{p}", "kind": "container",
+         "style": {"backgroundColor": c["hdrbar"], "borderRadius": "round"}},
+        {"id": f"hdrtxt-{p}", "kind": "text",
+         "body": f'## <span style="color:{c["hdrtext"]}">● {label}</span>'},
+        {"id": f"reg-{p}", "kind": "container",
+         "style": {"backgroundColor": c["card"], "borderRadius": "round"}},
+        {"id": f"reg-{p}-kpi", "kind": "kpi-chart", "name": MEAS_NAME,
+         "source": {"kind": "table", "elementId": "master"},
+         "columns": [
+             {"id": f"reg-{p}-kpi-v", "name": MEAS_NAME, "formula": MEASURE_SWITCH,
+              "format": {"kind": "number", "formatString": ".2s"}},
+             {"id": f"reg-{p}-kpi-cat", "name": F["category"]["name"], "formula": mref("category")}],
+         "value": {"columnId": f"reg-{p}-kpi-v", "fontSize": 44},
+         "style": {"backgroundColor": "#00000000", "padding": "none"},
+         "layout": {"anchor": "start"},
+         "filters": [{"id": f"reg-{p}-kpi-f", "columnId": f"reg-{p}-kpi-cat",
+                      "kind": "list", "mode": "include", "values": [label]}]},
+        {"id": f"reg-{p}-pct", "kind": "text", "verticalAlign": "middle",
+         "body": f'<span style="color:#2B2B2B">**{f["pct_of_total"]}%**</span> '
+                 f'<span style="color:#6B7280">{txt("pct_suffix", "of total")}</span>'},
+        {"id": f"reg-{p}-sub", "kind": "text", "body": "\n\n".join(sub_lines)},
+        {"id": f"reg-{p}-mihdr", "kind": "text", "body": "### " + txt("most_hdr", "Top")},
+        {"id": f"reg-{p}-most", "kind": "bar-chart", "name": " ", "orientation": "horizontal",
+         "style": {"backgroundColor": "#00000000"},
+         "source": {"kind": "table", "elementId": "master"},
+         "columns": [
+             {"id": f"rm-{p}-en", "name": F["entity"]["name"], "formula": mref("entity")},
+             {"id": f"rm-{p}-cat", "name": F["category"]["name"], "formula": mref("category")},
+             {"id": f"rm-{p}-m", "name": MEAS_NAME, "formula": MEASURE_SWITCH,
+              "format": {"kind": "number", "formatString": ".3~s"}},
+             {"id": f"rm-{p}-sel", "name": "Rank Sel",
+              "formula": (f'If([crank] = "Most Impacted", '
+                          f'{_TOTAL} >= {int(f["top5cut"])}, {_TOTAL} <= {int(f["bot5cut"])})')}],
+         "xAxis": {"columnId": f"rm-{p}-en", "sort": {"by": f"rm-{p}-m", "direction": "descending"}},
+         "yAxis": {"columnIds": [f"rm-{p}-m"]},
+         "color": {"by": "single", "value": c["bar"]},
+         "legend": {"visibility": "hidden"}, "dataLabel": {"labels": "shown"},
+         "filters": [
+             {"id": f"rm-{p}-catf", "columnId": f"rm-{p}-cat", "kind": "list",
+              "mode": "include", "values": [label]},
+             {"id": f"rm-{p}-self", "columnId": f"rm-{p}-sel", "kind": "list",
+              "mode": "include", "values": [True]}]},
+        {"id": f"reg-{p}-sphdr", "kind": "text", "body": "### " + txt("strip_hdr", MEAS_NAME + " by " + F["entity"]["name"])},
+        {"id": f"reg-{p}-strip", "kind": "scatter-chart", "name": " ",
+         "style": {"backgroundColor": "#00000000"},
+         "source": {"kind": "table", "elementId": "master"},
+         "columns": strip_cols,
+         "xAxis": {"columnId": f"sp-{p}-rate"}, "yAxis": {"columnIds": [f"sp-{p}-m"]},
+         "color": strip_color,
+         "legend": {"visibility": "hidden"},
+         "refMarks": [{"type": "line", "axis": "series",
+                       "value": {"type": "formula",
+                                 "formula": f'If([cmedian] = "Show", Median({mref("measure")}), Null)'},
+                       "line": {"color": "#9AA0A6", "width": 1},
+                       "label": {"visibility": "shown", "text": "Median"}}],
+         "filters": [{"id": f"sp-{p}-f", "columnId": f"sp-{p}-cat",
+                      "kind": "list", "mode": "include", "values": [label]}]},
+    ]
+
+
+# national top-N entities across all cards (for the rail bar)
+all_top = []
+for rg in REGIONS:
+    all_top += rg["facts"]["top5"]
+top5_nat = [s for s, _ in sorted(all_top, key=lambda x: -x[1])[:5]]
+
+# ---- master table element (built from the field role map) ----
+mcols = [
+    {"id": "m-entity", "name": F["entity"]["name"], "formula": f'[{FACT}/{F["entity"]["src"]}]'},
+    {"id": "m-cat", "name": F["category"]["name"], "formula": f'[{FACT}/{F["category"]["src"]}]'},
+    {"id": "m-meas", "name": F["measure"]["name"], "formula": f'[{FACT}/{F["measure"]["src"]}]'},
+    {"id": "m-rate", "name": F["rate"]["name"], "formula": f'[{FACT}/{F["rate"]["src"]}]'},
+]
+if HAS_SECONDARY:
+    mcols.append({"id": "m-sec", "name": F["secondary"]["name"], "formula": f'[{FACT}/{F["secondary"]["src"]}]'})
+if HAS_SPLIT:
+    mcols.append({"id": "m-sa", "name": F["split_a"]["name"], "formula": f'[{FACT}/{F["split_a"]["src"]}]'})
+    mcols.append({"id": "m-sb", "name": F["split_b"]["name"], "formula": f'[{FACT}/{F["split_b"]["src"]}]'})
+if THRESH is not None:
+    mcols.append({"id": "m-over", "name": "Over Threshold",
+                  "formula": f'[{FACT}/{F["measure"]["src"]}] > {int(THRESH)}'})
+msource = ({"kind": "warehouse-table", "connectionId": CONN_ID, "path": PATH}
+           if SOURCE_KIND == "warehouse-table"
+           else {"kind": "data-model", "dataModelId": DM_ID, "elementId": FACT_EID})
+state_master = {
+    "id": "master", "kind": "table", "name": SRC, "visibleAsSource": False,
+    "source": msource, "columns": mcols, "order": [c["id"] for c in mcols],
+}
+
+# ---- left rail + header (prose from config.text, with sensible defaults) ----
+rail_and_header = [
+    {"id": "title-dots", "kind": "text",
+     "body": " ".join(f'<span style="color:{s}">●</span>' for s in CAT_SCHEME)},
+    {"id": "rail-title", "kind": "text",
+     "body": txt("title", f'# {CFG["wb_name"]}')},
+    {"id": "kpi1-box", "kind": "container", "style": {"backgroundColor": "#F4F4F4", "borderRadius": "round"}},
+    {"id": "kpi1", "kind": "kpi-chart", "name": txt("kpi1_name", "Total"),
+     "source": {"kind": "table", "elementId": "master"},
+     "columns": [{"id": "kpi1-v", "name": txt("kpi1_name", "Total"),
+                  "formula": f'Sum({mref("secondary")})' if HAS_SECONDARY else _TOTAL,
+                  "format": {"kind": "number", "formatString": ".2s"}}],
+     "value": {"columnId": "kpi1-v", "fontSize": 34},
+     "style": {"backgroundColor": "#00000000", "padding": "none"}, "layout": {"anchor": "start"}},
+    {"id": "kpi1-ann", "kind": "text", "body": txt("kpi1_ann", "")},
+    {"id": "kpi2-box", "kind": "container", "style": {"backgroundColor": "#F4F4F4", "borderRadius": "round"}},
+    {"id": "kpi2", "kind": "kpi-chart", "name": MEAS_NAME,
+     "source": {"kind": "table", "elementId": "master"},
+     "columns": [{"id": "kpi2-v", "name": MEAS_NAME, "formula": MEASURE_SWITCH,
+                  "format": {"kind": "number", "formatString": ".2s"}}],
+     "value": {"columnId": "kpi2-v", "fontSize": 34},
+     "style": {"backgroundColor": "#00000000", "padding": "none"}, "layout": {"anchor": "start"}},
+    {"id": "kpi2-ann", "kind": "text", "body": txt("kpi2_ann", "")},
+    {"id": "rail-sc-hdr", "kind": "text", "body": "### " + txt("rail_scatter_hdr", "Distribution")},
+    {"id": "rail-scatter", "kind": "scatter-chart", "name": " ",
+     "style": {"backgroundColor": "#00000000"},
+     "source": {"kind": "table", "elementId": "master"},
+     "columns": [
+         {"id": "rs-en", "name": F["entity"]["name"], "formula": mref("entity")},
+         {"id": "rs-cat", "name": F["category"]["name"], "formula": mref("category")},
+         {"id": "rs-rate", "name": F["rate"]["name"], "formula": f'Sum({mref("rate")})'},
+         {"id": "rs-y", "name": (F["secondary"]["name"] if HAS_SECONDARY else MEAS_NAME),
+          "formula": (f'Sum({mref("secondary")})' if HAS_SECONDARY else _TOTAL),
+          "format": {"kind": "number", "formatString": ",.0f"}}],
+     "xAxis": {"columnId": "rs-rate"}, "yAxis": {"columnIds": ["rs-y"]},
+     "color": {"by": "category", "column": "rs-cat", "scheme": CAT_SCHEME},
+     "legend": {"visibility": "hidden"}},
+    {"id": "rail-mi-hdr", "kind": "text", "body": "### " + txt("rail_most_hdr", "Most Impacted")},
+    {"id": "rail-mostimp", "kind": "bar-chart", "name": " ", "orientation": "horizontal",
+     "style": {"backgroundColor": "#00000000"},
+     "source": {"kind": "table", "elementId": "master"},
+     "columns": [
+         {"id": "rmi-en", "name": F["entity"]["name"], "formula": mref("entity")},
+         {"id": "rmi-cat", "name": F["category"]["name"], "formula": mref("category")},
+         {"id": "rmi-m", "name": MEAS_NAME, "formula": MEASURE_SWITCH,
+          "format": {"kind": "number", "formatString": ".3~s"}}],
+     "xAxis": {"columnId": "rmi-en", "sort": {"by": "rmi-m", "direction": "descending"}},
+     "yAxis": {"columnIds": ["rmi-m"]},
+     "color": {"by": "category", "column": "rmi-cat", "scheme": CAT_SCHEME},
+     "legend": {"visibility": "hidden"}, "dataLabel": {"labels": "shown"},
+     "filters": [{"id": "rmi-f", "columnId": "rmi-en", "kind": "list", "mode": "include", "values": top5_nat}]},
+    {"id": "rail-credit", "kind": "text", "body": txt("credit", "")},
+    {"id": "hdr-title", "kind": "text", "body": txt("hdr_title", f'## {F["measure"]["name"]} by {F["category"]["name"]}')},
+    {"id": "hdr-pill", "kind": "text", "body":
+        (f'<span style="background-color:#EDEDED">&nbsp;&nbsp;**{hnum(GRAND)}** {MEAS_NAME} '
+         f'&nbsp;·&nbsp; Median: **{hnum(NAT["median"])}**'
+         + (f' &nbsp;·&nbsp; <span style="color:#F2C037">●</span> Mark &gt; **{hnum(THRESH)}** '
+            f'&nbsp;·&nbsp; &gt; {hnum(THRESH)} : **{NAT["over_thresh"]}**' if THRESH is not None else '')
+         + '&nbsp;&nbsp;</span>')},
+    {"id": "hdr-learn", "kind": "text",
+     "body": '<p style="text-align: center"><span style="background-color:#FBE7A8">'
+             '&nbsp;&nbsp;**Learn More**&nbsp;&nbsp;</span></p>'},
+    {"id": "legend-key", "kind": "text",
+     "body": "".join(f'<span style="color:{s}">▊</span>' for s in CAT_SCHEME)},
+    {"id": "ctl-share", "kind": "control", "controlType": "segmented", "controlId": "cshare",
+     "name": txt("share_name", "Measure"),
+     "source": {"kind": "manual", "valueType": "text",
+                "values": ["Total", F.get("split_a", {}).get("name", "A"), F.get("split_b", {}).get("name", "B")],
+                "labels": ["Total", F.get("split_a", {}).get("name", "A"), F.get("split_b", {}).get("name", "B")]},
+     "value": "Total"},
+    {"id": "ctl-rank", "kind": "control", "controlType": "segmented", "controlId": "crank", "name": "Rank",
+     "source": {"kind": "manual", "valueType": "text", "values": ["Most Impacted", "Least Impacted"],
+                "labels": ["Most Impacted", "Least Impacted"]}, "value": "Most Impacted"},
+    {"id": "ctl-median", "kind": "control", "controlType": "list", "controlId": "cmedian",
+     "name": "Median", "selectionMode": "single",
+     "source": {"kind": "manual", "valueType": "text", "values": ["Hide", "Show"],
+                "labels": ["Hide", "Show"]}, "value": "Hide"},
+]
+if not HAS_SPLIT:
+    rail_and_header = [e for e in rail_and_header if e.get("controlId") != "cshare"]
+
+main_elements = list(rail_and_header)
+for rg in REGIONS:
+    main_elements += card_elements(rg)
+
+# Empty-body text elements render as error tiles (found on the cold-run cloud
+# dashboard where no --text-overrides were supplied). Drop them from both the
+# element list and the layout so the slot is simply absent, not broken.
+DROP = {e["id"] for e in main_elements
+        if e["kind"] == "text" and not (e.get("body") or "").strip()}
+main_elements = [e for e in main_elements if e["id"] not in DROP]
+
+# --- layout: 24-col grid, N cards left->right across the freed rail width ---
+n = len(REGIONS)
+CARD_START = 7
+span = (25 - CARD_START) // n
+card_cols = {}
+x = CARD_START
+for i, rg in enumerate(REGIONS):
+    c2 = 25 if i == n - 1 else x + span
+    card_cols[rg["key"]] = (x, c2)
+    x = c2
+
+
+def L(eid, c1, c2, r1, r2):
+    if eid in DROP:            # dropped empty-text element — omit its layout slot
+        return None
+    return f'  <LayoutElement elementId="{eid}" gridColumn="{c1} / {c2}" gridRow="{r1} / {r2}"/>'
+
+
+def GC(eid, c1, c2, r1, r2, inner):
+    return (f'  <GridContainer elementId="{eid}" type="grid" gridColumn="{c1} / {c2}" gridRow="{r1} / {r2}" '
+            f'gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">\n'
+            + "\n".join(x for x in inner if x) + '\n  </GridContainer>')
+
+
+control_row = [L("legend-key", 7, 8, 3, 6)]
+ctl_ids = [e["id"] for e in rail_and_header if e["kind"] == "control"]
+cx = 8
+cspan = (25 - 8) // max(1, len(ctl_ids))
+for i, cid in enumerate(ctl_ids):
+    c2 = 25 if i == len(ctl_ids) - 1 else cx + cspan
+    control_row.append(L(cid, cx, c2, 3, 6))
+    cx = c2
+
+lay = ['<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="page-main">']
+lay += [
+    L("title-dots", 1, 7, 1, 2), L("rail-title", 1, 7, 2, 6),
+    GC("kpi1-box", 1, 4, 6, 11, [L("kpi1", 1, 25, 1, 6)]), L("kpi1-ann", 4, 7, 6, 11),
+    GC("kpi2-box", 1, 4, 11, 16, [L("kpi2", 1, 25, 1, 6)]), L("kpi2-ann", 4, 7, 11, 16),
+    L("rail-sc-hdr", 1, 7, 16, 18), L("rail-scatter", 1, 7, 18, 27),
+    L("rail-mi-hdr", 1, 7, 27, 29), L("rail-mostimp", 1, 7, 29, 37), L("rail-credit", 1, 7, 37, 38),
+    L("hdr-title", 7, 15, 1, 3), L("hdr-pill", 15, 22, 1, 3), L("hdr-learn", 22, 25, 1, 3),
+] + control_row
+for rg in REGIONS:
+    k = rg["key"]; c1, c2 = card_cols[k]
+    lay.append(GC(f"hdrbar-{k}", c1, c2, 6, 8, [L(f"hdrtxt-{k}", 1, 25, 1, 3)]))
+    lay.append(GC(f"reg-{k}", c1, c2, 8, 40, [
+        L(f"reg-{k}-kpi", 1, 14, 1, 6), L(f"reg-{k}-pct", 14, 25, 3, 6),
+        L(f"reg-{k}-sub", 1, 25, 6, 12), L(f"reg-{k}-mihdr", 1, 25, 12, 14),
+        L(f"reg-{k}-most", 1, 25, 14, 24), L(f"reg-{k}-sphdr", 1, 25, 24, 26),
+        L(f"reg-{k}-strip", 1, 25, 26, 40),
+    ]))
+lay.append("</Page>")
+lay = [x for x in lay if x]            # drop omitted (empty-text) layout slots
+data_lay =('<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="page-data">\n'
+            '  <LayoutElement elementId="master" gridColumn="1 / 25" gridRow="1 / 11"/>\n</Page>')
+layout_xml = '<?xml version="1.0" encoding="utf-8"?>\n' + "\n".join(lay) + "\n" + data_lay
+
+spec = {
+    "name": CFG["wb_name"], "folderId": FOLDER_ID, "schemaVersion": 1, "themeName": "Light",
+    "themeOverrides": {"categoricalScheme": CAT_SCHEME, "colorOverrides": {"backgroundCanvas": "#FFFFFF"}},
+    "pages": [
+        {"id": "page-data", "name": "Data", "elements": [state_master]},
+        {"id": "page-main", "name": "Composed", "elements": main_elements},
+    ],
+    "layout": layout_xml,
+}
+json.dump(spec, open(A.out_spec, "w"), indent=1)
+if A.out_layout:
+    open(A.out_layout, "w").write(layout_xml)
+print(f"composed {len(main_elements)} main + 1 data elements across {n} category cards")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/composition-verify.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/composition-verify.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""composition-verify.py — Phase-6 gate for the composition stage.
+
+Two checks, both surfacing residuals the refine loop can act on:
+
+  1. STRUCTURAL (offline): every category card has its full element set
+     (KPI + %-annotation + sub + Top-N bar + strip), the controls are present,
+     the palette/canvas theme is set, and (if a threshold exists) the strip
+     carries the C2 two-color scheme.
+  2. LIVE DATA (needs --workbook + $SIGMA_API_TOKEN): exports each card's KPI and
+     asserts the value matches the config's computed per-category total — catching
+     render races / broken tiles that a screenshot would miss.
+
+Exit non-zero if any check fails, so it gates like the parity check.
+Usage: composition-verify.py --config config.json --spec wb.json [--workbook <id> --base <url>]
+"""
+import argparse, json, os, sys, time
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--config", required=True)
+ap.add_argument("--spec", required=True)
+ap.add_argument("--workbook")
+ap.add_argument("--base", default=os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com"))
+A = ap.parse_args()
+
+cfg = json.load(open(A.config))
+spec = json.load(open(A.spec))
+main = {e["id"]: e for e in spec["pages"][1]["elements"]}
+regions = cfg["regions"]
+residuals = []
+
+# --- 1. structural ---
+for rg in regions:
+    k = rg["key"]
+    need = [f"reg-{k}", f"hdrbar-{k}", f"reg-{k}-kpi", f"reg-{k}-pct", f"reg-{k}-sub",
+            f"reg-{k}-mihdr", f"reg-{k}-most", f"reg-{k}-sphdr", f"reg-{k}-strip"]
+    for e in need:
+        if e not in main:
+            residuals.append(f"[structure] card '{k}' missing element {e}")
+    card = main.get(f"reg-{k}", {})
+    if not card.get("style", {}).get("backgroundColor", "").startswith("#"):
+        residuals.append(f"[B2] card '{k}' not tinted")
+    if cfg.get("threshold") is not None:
+        strip = main.get(f"reg-{k}-strip", {})
+        if strip.get("color", {}).get("scheme", [None, None])[-1] != "#F2C037":
+            residuals.append(f"[C2] card '{k}' strip missing threshold color")
+for cid in (["cshare"] if "split_a" in cfg["fields"] else []) + ["crank", "cmedian"]:
+    if not any(e.get("controlId") == cid for e in main.values()):
+        residuals.append(f"[control] missing wired control {cid}")
+if len(spec["themeOverrides"].get("categoricalScheme", [])) != len(regions):
+    residuals.append("[D1] categoricalScheme size != #cards")
+
+# --- 2. live data ---
+if A.workbook:
+    import requests
+    tok = os.environ.get("SIGMA_API_TOKEN")
+    if not tok:
+        residuals.append("[live] --workbook given but no $SIGMA_API_TOKEN")
+    else:
+        H = {"Authorization": f"Bearer {tok}"}
+        for rg in regions:
+            eid = f"reg-{rg['key']}-kpi"
+            try:
+                q = requests.post(f"{A.base}/v2/workbooks/{A.workbook}/export", headers=H,
+                                  json={"elementId": eid, "format": {"type": "csv"}}, timeout=30).json()
+                qid = q.get("queryId")
+                val = None
+                t0 = time.time()
+                while time.time() - t0 < 40:
+                    time.sleep(1)
+                    r = requests.get(f"{A.base}/v2/query/{qid}/download", headers={**H, "Accept": "text/csv"}, timeout=30)
+                    if r.status_code == 200 and r.content:
+                        lines = [x for x in r.text.splitlines() if x.strip()]
+                        val = float(lines[1].split(",")[-1]) if len(lines) > 1 else None
+                        break
+                exp = rg["facts"]["total"]
+                if val is None:
+                    residuals.append(f"[live] {eid} returned no data (blank/broken tile)")
+                elif abs(val - exp) > max(1.0, exp * 0.001):
+                    residuals.append(f"[live] {eid} = {val:.0f}, expected {exp:.0f}")
+            except Exception as e:
+                residuals.append(f"[live] {eid} query error: {e}")
+
+if residuals:
+    print(f"FAIL — {len(residuals)} residual(s):")
+    for r in residuals:
+        print("  -", r)
+    sys.exit(1)
+print(f"PASS composition-verify: {len(regions)} cards structurally complete"
+      + (" + KPI values match config" if A.workbook else " (structural only)"))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/config.example.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/config.example.json
@@ -1,0 +1,269 @@
+{
+ "dm_id": "REPLACE_WITH_DM_ID",
+ "state_fact_eid": "REPLACE_WITH_FACT_ELEMENT_ID",
+ "folder_id": "REPLACE_WITH_FOLDER_ID",
+ "wb_name": "Job Losses from Deportations \u2014 composed (skill B1)",
+ "source_name": "State Master",
+ "fact_name": "State Fact",
+ "fields": {
+  "entity": {
+   "name": "State",
+   "src": "State"
+  },
+  "category": {
+   "name": "Region",
+   "src": "Region"
+  },
+  "measure": {
+   "name": "Total Job Losses",
+   "src": "Total Job Losses"
+  },
+  "rate": {
+   "name": "Job Loss Rate Pct",
+   "src": "Job Loss Rate Pct"
+  },
+  "secondary": {
+   "name": "Deportations",
+   "src": "Deportations"
+  },
+  "split_a": {
+   "name": "Immigrant",
+   "src": "Immigrant"
+  },
+  "split_b": {
+   "name": "US Born",
+   "src": "US Born"
+  }
+ },
+ "threshold": 100000.0,
+ "cat_scheme": [
+  "#50cabe",
+  "#e8519a",
+  "#827bb8",
+  "#f28e2b"
+ ],
+ "grand": 5886000.0,
+ "national": {
+  "grand": 5886000.0,
+  "median": 48000.0,
+  "over_thresh": 14,
+  "n_entities": 51
+ },
+ "regions": [
+  {
+   "key": "south",
+   "label": "South",
+   "colors": {
+    "bar": "#50CABE",
+    "card": "#EAF9F7",
+    "hdrbar": "#B0E7E2",
+    "hdrtext": "#2E756E"
+   },
+   "facts": {
+    "total": 2380000.0,
+    "pct_of_total": 40,
+    "n_entities": 17,
+    "over_thresh": 6,
+    "split_a_pct": 56,
+    "split_b_pct": 44,
+    "top5": [
+     [
+      "Texas",
+      865000.0
+     ],
+     [
+      "Florida",
+      543000.0
+     ],
+     [
+      "North Carolina",
+      188000.0
+     ],
+     [
+      "Georgia",
+      184000.0
+     ],
+     [
+      "Virginia",
+      120000.0
+     ]
+    ],
+    "hi": [
+     "TX",
+     865000.0
+    ],
+    "lo": [
+     "WV",
+     4000.0
+    ],
+    "top5cut": 120000.0,
+    "bot5cut": 24000.0
+   }
+  },
+  {
+   "key": "west",
+   "label": "West",
+   "colors": {
+    "bar": "#E8519A",
+    "card": "#FCEAF3",
+    "hdrbar": "#F5B1D2",
+    "hdrtext": "#872F59"
+   },
+   "facts": {
+    "total": 1767000.0,
+    "pct_of_total": 30,
+    "n_entities": 13,
+    "over_thresh": 3,
+    "split_a_pct": 56,
+    "split_b_pct": 44,
+    "top5": [
+     [
+      "California",
+      1141000.0
+     ],
+     [
+      "Washington",
+      152000.0
+     ],
+     [
+      "Arizona",
+      141000.0
+     ],
+     [
+      "Colorado",
+      83000.0
+     ],
+     [
+      "Nevada",
+      72000.0
+     ]
+    ],
+    "hi": [
+     "CA",
+     1141000.0
+    ],
+    "lo": [
+     "WY",
+     2000.0
+    ],
+    "top5cut": 72000.0,
+    "bot5cut": 21000.0
+   }
+  },
+  {
+   "key": "northeast",
+   "label": "Northeast",
+   "colors": {
+    "bar": "#827BB8",
+    "card": "#F0EFF6",
+    "hdrbar": "#C7C4DF",
+    "hdrtext": "#4B476B"
+   },
+   "facts": {
+    "total": 1023000.0,
+    "pct_of_total": 17,
+    "n_entities": 9,
+    "over_thresh": 4,
+    "split_a_pct": 56,
+    "split_b_pct": 44,
+    "top5": [
+     [
+      "New York",
+      429000.0
+     ],
+     [
+      "New Jersey",
+      234000.0
+     ],
+     [
+      "Massachusetts",
+      148000.0
+     ],
+     [
+      "Pennsylvania",
+      115000.0
+     ],
+     [
+      "Connecticut",
+      61000.0
+     ]
+    ],
+    "hi": [
+     "NY",
+     429000.0
+    ],
+    "lo": [
+     "VT",
+     3000.0
+    ],
+    "top5cut": 61000.0,
+    "bot5cut": 61000.0
+   }
+  },
+  {
+   "key": "midwest",
+   "label": "Midwest",
+   "colors": {
+    "bar": "#F28E2B",
+    "card": "#FDF1E6",
+    "hdrbar": "#F9CCA0",
+    "hdrtext": "#8C5219"
+   },
+   "facts": {
+    "total": 716000.0,
+    "pct_of_total": 12,
+    "n_entities": 12,
+    "over_thresh": 1,
+    "split_a_pct": 56,
+    "split_b_pct": 44,
+    "top5": [
+     [
+      "Illinois",
+      219000.0
+     ],
+     [
+      "Ohio",
+      84000.0
+     ],
+     [
+      "Michigan",
+      78000.0
+     ],
+     [
+      "Indiana",
+      73000.0
+     ],
+     [
+      "Minnesota",
+      69000.0
+     ]
+    ],
+    "hi": [
+     "IL",
+     219000.0
+    ],
+    "lo": [
+     "SD",
+     6000.0
+    ],
+    "top5cut": 69000.0,
+    "bot5cut": 36000.0
+   }
+  }
+ ],
+ "text": {
+  "rail_scatter_hdr": "Deportations vs Job Loss%\n<span style=\"color:#6B7280\">Select a state to filter numbers above \u00b7 Hover for full details</span>",
+  "pct_suffix": "of U.S. total",
+  "credit": "<span style=\"color:#9AA0A6\">Data: EPI.org  |  Design: @DatavizChimdi  |  Migrated from Tableau</span>",
+  "entity_plural": "States",
+  "most_hdr": "The Most Impacted States",
+  "strip_hdr": "Total Job Losses by State",
+  "rail_most_hdr": "Most Impacted\n<span style=\"color:#6B7280\">The Most Impacted states across the country are \u2026</span>",
+  "hdr_title": "## Job Losses by Region\n<span style=\"color:#6B7280\">Click circles in region titles to filter LHS</span>",
+  "share_name": "Job losses: total vs immigrant vs U.S.-born workers",
+  "title": "# Job Losses <span style=\"color:#2B2B2B; font-size: 20px\">from Deportations</span>\n<span style=\"color:#2B2B2B\">Estimating the job loss if 4 million immigrants are deported from the U.S. over 4 years</span>",
+  "kpi1_name": "Total Deportations",
+  "kpi1_ann": "<span style=\"color:#2B2B2B\">**Assumed** total over four years based on the proposed policy</span>",
+  "kpi2_ann": "<span style=\"color:#2B2B2B\">**Estimated** number of Total Job Losses resulting from the policy</span>"
+ }
+}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/config.example2.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/config.example2.json
@@ -1,0 +1,246 @@
+{
+ "dm_id": "REPLACE_WITH_DM_ID",
+ "state_fact_eid": "REPLACE_WITH_FACT_ELEMENT_ID",
+ "folder_id": "REPLACE_WITH_FOLDER_ID",
+ "wb_name": "Cloud Spend by Team (composition test)",
+ "source_name": "Cloud Master",
+ "fact_name": "Cloud Fact",
+ "fields": {
+  "entity": {
+   "name": "Service",
+   "src": "Service"
+  },
+  "category": {
+   "name": "Team",
+   "src": "Team"
+  },
+  "measure": {
+   "name": "Monthly Cost",
+   "src": "Monthly Cost"
+  },
+  "rate": {
+   "name": "Utilization Pct",
+   "src": "Utilization Pct"
+  },
+  "secondary": {
+   "name": "Requests",
+   "src": "Requests"
+  }
+ },
+ "threshold": 100000.0,
+ "cat_scheme": [
+  "#4E79A7",
+  "#F28E2B",
+  "#59A14F",
+  "#E15759"
+ ],
+ "grand": 755000.0,
+ "national": {
+  "grand": 755000.0,
+  "median": 8000.0,
+  "over_thresh": 4,
+  "n_entities": 18
+ },
+ "regions": [
+  {
+   "key": "platform",
+   "label": "Platform",
+   "colors": {
+    "bar": "#4E79A7",
+    "card": "#EAEFF4",
+    "hdrbar": "#AFC3D7",
+    "hdrtext": "#2D4661"
+   },
+   "facts": {
+    "total": 437000.0,
+    "pct_of_total": 58,
+    "n_entities": 5,
+    "over_thresh": 2,
+    "split_a_pct": null,
+    "split_b_pct": null,
+    "top5": [
+     [
+      "Grafana",
+      240000.0
+     ],
+     [
+      "Feature Store",
+      120000.0
+     ],
+     [
+      "API Gateway",
+      60000.0
+     ],
+     [
+      "GPU Cluster",
+      15000.0
+     ],
+     [
+      "Object Store",
+      2000.0
+     ]
+    ],
+    "hi": [
+     "Grafana",
+     240000.0
+    ],
+    "lo": [
+     "Object Store",
+     2000.0
+    ],
+    "top5cut": 2000.0,
+    "bot5cut": 240000.0
+   }
+  },
+  {
+   "key": "security",
+   "label": "Security",
+   "colors": {
+    "bar": "#F28E2B",
+    "card": "#FDF1E6",
+    "hdrbar": "#F9CCA0",
+    "hdrtext": "#8C5219"
+   },
+   "facts": {
+    "total": 145000.0,
+    "pct_of_total": 19,
+    "n_entities": 4,
+    "over_thresh": 1,
+    "split_a_pct": null,
+    "split_b_pct": null,
+    "top5": [
+     [
+      "Search",
+      120000.0
+     ],
+     [
+      "Airflow",
+      15000.0
+     ],
+     [
+      "Redis",
+      8000.0
+     ],
+     [
+      "SIEM",
+      2000.0
+     ]
+    ],
+    "hi": [
+     "Search",
+     120000.0
+    ],
+    "lo": [
+     "SIEM",
+     2000.0
+    ],
+    "top5cut": 2000.0,
+    "bot5cut": 120000.0
+   }
+  },
+  {
+   "key": "data",
+   "label": "Data",
+   "colors": {
+    "bar": "#59A14F",
+    "card": "#EBF4EA",
+    "hdrbar": "#B4D5B0",
+    "hdrtext": "#345D2E"
+   },
+   "facts": {
+    "total": 143000.0,
+    "pct_of_total": 19,
+    "n_entities": 5,
+    "over_thresh": 1,
+    "split_a_pct": null,
+    "split_b_pct": null,
+    "top5": [
+     [
+      "Model Serving",
+      120000.0
+     ],
+     [
+      "CDN",
+      8000.0
+     ],
+     [
+      "Firewall",
+      8000.0
+     ],
+     [
+      "Batch",
+      5000.0
+     ],
+     [
+      "Kafka",
+      2000.0
+     ]
+    ],
+    "hi": [
+     "Model Serving",
+     120000.0
+    ],
+    "lo": [
+     "Kafka",
+     2000.0
+    ],
+    "top5cut": 2000.0,
+    "bot5cut": 120000.0
+   }
+  },
+  {
+   "key": "ml",
+   "label": "ML",
+   "colors": {
+    "bar": "#E15759",
+    "card": "#FBEBEB",
+    "hdrbar": "#F2B3B4",
+    "hdrtext": "#833234"
+   },
+   "facts": {
+    "total": 30000.0,
+    "pct_of_total": 4,
+    "n_entities": 4,
+    "over_thresh": 0,
+    "split_a_pct": null,
+    "split_b_pct": null,
+    "top5": [
+     [
+      "Lambda",
+      15000.0
+     ],
+     [
+      "Snowflake",
+      5000.0
+     ],
+     [
+      "Vault",
+      5000.0
+     ],
+     [
+      "Postgres",
+      5000.0
+     ]
+    ],
+    "hi": [
+     "Lambda",
+     15000.0
+    ],
+    "lo": [
+     "Postgres",
+     5000.0
+    ],
+    "top5cut": 5000.0,
+    "bot5cut": 15000.0
+   }
+  }
+ ],
+ "text": {
+  "entity_plural": "Services",
+  "most_hdr": "The Most Impacted Services",
+  "strip_hdr": "Monthly Cost by Service",
+  "rail_most_hdr": "Most Impacted",
+  "hdr_title": "## Monthly Cost by Team",
+  "share_name": "Monthly Cost"
+ }
+}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/config.example3.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/config.example3.json
@@ -1,0 +1,262 @@
+{
+ "source_kind": "warehouse-table",
+ "dm_id": null,
+ "state_fact_eid": null,
+ "connection_id": "REPLACE_WITH_CONNECTION_ID",
+ "path": [
+  "DB",
+  "SCHEMA",
+  "TABLE"
+ ],
+ "folder_id": "REPLACE_WITH_FOLDER_ID",
+ "wb_name": "Superstore Sales by Region (real-.twb cold run)",
+ "source_name": "Store Master",
+ "fact_name": "Fact",
+ "fields": {
+  "entity": {
+   "name": "State",
+   "src": "State"
+  },
+  "category": {
+   "name": "Region",
+   "src": "Region"
+  },
+  "measure": {
+   "name": "Sales",
+   "src": "Sales"
+  },
+  "rate": {
+   "name": "Discount",
+   "src": "Discount"
+  },
+  "secondary": {
+   "name": "Profit",
+   "src": "Profit"
+  }
+ },
+ "threshold": null,
+ "cat_scheme": [
+  "#4E79A7",
+  "#F28E2B",
+  "#59A14F",
+  "#E15759"
+ ],
+ "grand": 2326534.0,
+ "national": {
+  "grand": 2326534.0,
+  "median": 13384.0,
+  "over_thresh": null,
+  "n_entities": 59
+ },
+ "regions": [
+  {
+   "key": "west",
+   "label": "West",
+   "colors": {
+    "bar": "#4E79A7",
+    "card": "#EAEFF4",
+    "hdrbar": "#AFC3D7",
+    "hdrtext": "#2D4661"
+   },
+   "facts": {
+    "total": 739812.0,
+    "pct_of_total": 32,
+    "n_entities": 14,
+    "over_thresh": null,
+    "split_a_pct": null,
+    "split_b_pct": null,
+    "top5": [
+     [
+      "California",
+      457688.0
+     ],
+     [
+      "Washington",
+      138641.0
+     ],
+     [
+      "Arizona",
+      35282.0
+     ],
+     [
+      "Colorado",
+      32108.0
+     ],
+     [
+      "Oregon",
+      17431.0
+     ]
+    ],
+    "hi": [
+     "California",
+     457688.0
+    ],
+    "lo": [
+     "Saskatchewan",
+     132.0
+    ],
+    "top5cut": 17431.0,
+    "bot5cut": 4784.0
+   }
+  },
+  {
+   "key": "east",
+   "label": "East",
+   "colors": {
+    "bar": "#F28E2B",
+    "card": "#FDF1E6",
+    "hdrbar": "#F9CCA0",
+    "hdrtext": "#8C5219"
+   },
+   "facts": {
+    "total": 691828.0,
+    "pct_of_total": 30,
+    "n_entities": 20,
+    "over_thresh": null,
+    "split_a_pct": null,
+    "split_b_pct": null,
+    "top5": [
+     [
+      "New York",
+      310876.0
+     ],
+     [
+      "Pennsylvania",
+      116512.0
+     ],
+     [
+      "Ohio",
+      78258.0
+     ],
+     [
+      "New Jersey",
+      35764.0
+     ],
+     [
+      "Massachusetts",
+      28634.0
+     ]
+    ],
+    "hi": [
+     "New York",
+     310876.0
+    ],
+    "lo": [
+     "New Brunswick",
+     226.0
+    ],
+    "top5cut": 28634.0,
+    "bot5cut": 1210.0
+   }
+  },
+  {
+   "key": "central",
+   "label": "Central",
+   "colors": {
+    "bar": "#59A14F",
+    "card": "#EBF4EA",
+    "hdrbar": "#B4D5B0",
+    "hdrtext": "#345D2E"
+   },
+   "facts": {
+    "total": 503171.0,
+    "pct_of_total": 22,
+    "n_entities": 14,
+    "over_thresh": null,
+    "split_a_pct": null,
+    "split_b_pct": null,
+    "top5": [
+     [
+      "Texas",
+      170188.0
+     ],
+     [
+      "Illinois",
+      80166.0
+     ],
+     [
+      "Michigan",
+      76270.0
+     ],
+     [
+      "Indiana",
+      53555.0
+     ],
+     [
+      "Wisconsin",
+      32115.0
+     ]
+    ],
+    "hi": [
+     "Texas",
+     170188.0
+    ],
+    "lo": [
+     "North Dakota",
+     920.0
+    ],
+    "top5cut": 32115.0,
+    "bot5cut": 4580.0
+   }
+  },
+  {
+   "key": "south",
+   "label": "South",
+   "colors": {
+    "bar": "#E15759",
+    "card": "#FBEBEB",
+    "hdrbar": "#F2B3B4",
+    "hdrtext": "#833234"
+   },
+   "facts": {
+    "total": 391723.0,
+    "pct_of_total": 17,
+    "n_entities": 11,
+    "over_thresh": null,
+    "split_a_pct": null,
+    "split_b_pct": null,
+    "top5": [
+     [
+      "Florida",
+      89474.0
+     ],
+     [
+      "Virginia",
+      70637.0
+     ],
+     [
+      "North Carolina",
+      55603.0
+     ],
+     [
+      "Georgia",
+      49096.0
+     ],
+     [
+      "Kentucky",
+      36592.0
+     ]
+    ],
+    "hi": [
+     "Florida",
+     89474.0
+    ],
+    "lo": [
+     "South Carolina",
+     8482.0
+    ],
+    "top5cut": 36592.0,
+    "bot5cut": 19511.0
+   }
+  }
+ ],
+ "text": {
+  "rail_scatter_hdr": "Sales Performance vs Target",
+  "entity_plural": "States",
+  "most_hdr": "The Most Impacted States",
+  "strip_hdr": "Sales by State",
+  "rail_most_hdr": "Most Impacted",
+  "hdr_title": "## Sales by Region",
+  "share_name": "Sales"
+ }
+}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/detect-composition-signal.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/detect-composition-signal.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""detect-composition-signal.py — should this dashboard route to the composition stage?
+
+Scans the parse signals (the .twb + the landed master CSV) and decides whether a
+repeated-per-category composition applies, INFERRING the column roles (category /
+entity / measure / rate / secondary / split pair / threshold) so nothing has to be
+passed by hand. Prints reasoning and emits the ready `detect-region-cards.py` args.
+
+Heuristics (data + .twb color encoding):
+  * category  = a string column that carries a .twb color palette (D1 signal),
+                cardinality 2..8  (the repeated-card dimension)
+  * entity    = the highest-cardinality string column (the finest grain)
+  * measure   = the additive numeric column with the largest total (not a rate)
+  * secondary = the next additive numeric (drives the rail scatter y), if any
+  * rate      = a numeric column whose values sit in [0,2] or is named rate/%/pct
+  * split a/b = the remaining numeric pair (e.g. Immigrant / U.S.-born)
+  * threshold = a `> N` comparison against the measure found in a .twb calc
+
+Usage: detect-composition-signal.py --twb X.twb --master-csv master.csv [--emit-args]
+"""
+import argparse, csv, json, re
+
+
+def classify(rows):
+    cols = rows[0].keys()
+    info = {}
+    for c in cols:
+        vals = [r[c] for r in rows if r[c] not in (None, "")]
+        nums, ok = [], True
+        for v in vals:
+            try:
+                nums.append(float(v))
+            except ValueError:
+                ok = False
+                break
+        info[c] = {"numeric": ok and bool(nums), "card": len(set(vals)),
+                   "nums": nums if ok else [], "total": sum(nums) if ok else 0,
+                   "maxabs": max((abs(x) for x in nums), default=0) if ok else 0}
+    return info
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--twb", help="source .twb (palette + measure-frequency signal). "
+                                  "Omit for data-only mode (measure inferred by magnitude, medium confidence).")
+    ap.add_argument("--master-csv", required=True)
+    ap.add_argument("--emit-args", action="store_true")
+    a = ap.parse_args()
+
+    xml = open(a.twb, encoding="utf-8", errors="replace").read() if a.twb and a.twb != "/dev/null" else ""
+    rows = list(csv.DictReader(open(a.master_csv)))
+    info = classify(rows)
+    strings = [c for c, i in info.items() if not i["numeric"]]
+    numerics = [c for c, i in info.items() if i["numeric"]]
+
+    # category: string col with a .twb color palette + small cardinality
+    palette_members = set(re.findall(r"<map to='#[0-9A-Fa-f]+'>\s*<bucket>&quot;?([^<&]+?)&quot;?</bucket>", xml))
+    palette_members = {m.strip() for m in palette_members}
+    reasons = []
+    cat = None
+    for c in strings:
+        members = {r[c] for r in rows}
+        if 2 <= info[c]["card"] <= 8 and members & palette_members:
+            cat = c
+            reasons.append(f"category='{c}' (card {info[c]['card']}, has .twb color palette)")
+            break
+    if not cat:
+        smalls = [c for c in strings if 2 <= info[c]["card"] <= 8]
+        if smalls:
+            cat = min(smalls, key=lambda c: info[c]["card"])
+            reasons.append(f"category='{cat}' (low-cardinality string; no palette match)")
+
+    # entity: highest-cardinality string (exclude an abbreviation twin of it)
+    ent_cands = sorted((c for c in strings if c != cat), key=lambda c: -info[c]["card"])
+    entity = ent_cands[0] if ent_cands else None
+    if entity:
+        reasons.append(f"entity='{entity}' (highest-cardinality string, card {info[entity]['card']})")
+
+    # rate: numeric in [0,2] or name ~ rate/%/pct
+    def is_rate(c):
+        n = info[c]["nums"]
+        return bool(n) and max(abs(x) for x in n) <= 2 or bool(re.search(r"rate|pct|%|percent|ratio", c, re.I))
+    rate = next((c for c in numerics if is_rate(c)), None)
+    if rate:
+        reasons.append(f"rate='{rate}'")
+
+    # measure + secondary: the dashboard is BUILT AROUND its measure, so rank
+    # additive numerics by how often the column is referenced in the .twb
+    # (encodings/captions), NOT by raw magnitude — population-style columns have
+    # huge totals but aren't the subject. Tie-break by total.
+    def mentions(c):
+        return len(re.findall(re.escape(c), xml, re.I))
+    additive = [c for c in numerics if c != rate]
+    additive.sort(key=lambda c: (-mentions(c), -info[c]["total"]))
+    measure = additive[0] if additive else None
+    secondary = additive[1] if len(additive) > 1 else None
+    if measure:
+        reasons.append(f"measure='{measure}' ({mentions(measure)} .twb refs; total {info[measure]['total']:.0f})")
+    if secondary:
+        reasons.append(f"secondary='{secondary}' ({mentions(secondary)} .twb refs)")
+
+    # split pair: remaining numerics (besides measure/secondary/rate)
+    used = {measure, secondary, rate}
+    rest = [c for c in additive if c not in used]
+    split_a = split_b = None
+    if len(rest) >= 2:
+        split_a, split_b = rest[0], rest[1]
+        reasons.append(f"split=({split_a} / {split_b})")
+
+    # threshold: among `> N` comparisons in .twb calcs, pick the one that flags a
+    # meaningful minority (~10-40%) of entities on the measure — a highlight cut,
+    # not an outlier or a near-everything filter.
+    thr = None
+    cands = sorted({float(x) for x in re.findall(r"(?:&gt;|>)\s*(\d{4,})", xml)})
+    if cands and measure:
+        mvals = info[measure]["nums"]
+        n = len(mvals)
+        scored = [(c, sum(1 for v in mvals if v > c) / n) for c in cands]
+        pick = [c for c, frac in scored if 0.08 <= frac <= 0.45]
+        thr = min(pick, key=lambda c: abs(sum(1 for v in mvals if v > c) / n - 0.25)) if pick else None
+        if thr is not None:
+            frac = sum(1 for v in mvals if v > thr) / n
+            reasons.append(f"threshold={int(thr)} (.twb '> N'; flags {frac:.0%} of {entity}s)")
+
+    applies = bool(cat and entity and measure)
+    conf = "high" if (cat and entity and measure and rate and (palette_members)) else "medium" if applies else "low"
+
+    print(f"composition applies: {applies}  (confidence: {conf})")
+    for r in reasons:
+        print("  -", r)
+
+    if a.emit_args and applies:
+        def q(s):
+            return '"%s"' % s if " " in s else s
+        parts = [f"--category {q(cat)}", f"--entity {q(entity)}", f"--measure {q(measure)}", f"--rate {q(rate)}"]
+        if secondary:
+            parts.append(f"--secondary {q(secondary)}")
+        if split_a:
+            parts += [f"--split-a {q(split_a)}", f"--split-b {q(split_b)}"]
+        if thr is not None:
+            parts.append(f"--threshold {int(thr)}")
+        print("\nARGS: " + " ".join(parts))
+        print(json.dumps({"applies": applies, "confidence": conf, "category": cat, "entity": entity,
+                          "measure": measure, "rate": rate, "secondary": secondary,
+                          "split_a": split_a, "split_b": split_b, "threshold": thr}))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/detect-composition-signal.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/detect-composition-signal.py
@@ -122,8 +122,33 @@ def main():
             frac = sum(1 for v in mvals if v > thr) / n
             reasons.append(f"threshold={int(thr)} (.twb '> N'; flags {frac:.0%} of {entity}s)")
 
-    applies = bool(cat and entity and measure)
-    conf = "high" if (cat and entity and measure and rate and (palette_members)) else "medium" if applies else "low"
+    # REPEATED-CONTAINER GATE (source-side): the composition only applies when the
+    # .twb actually lays out a container repeated per category member — otherwise
+    # we'd be imposing a foreign card-trellis on a dashboard that isn't one (e.g.
+    # Superstore). Sigma's spec has no repeat primitive, so this is purely a source
+    # signal; the emitter later materializes N explicit containers. Detected via
+    # category-member names recurring across dashboard zone names.
+    repeated = []
+    if cat and xml:
+        zblock = re.search(r"<dashboards>.*?</dashboards>", xml, re.S)
+        znames = re.findall(r"<zone\b[^>]*\bname='([^']*)'", zblock.group(0) if zblock else "")
+        for mbr in {r[cat] for r in rows}:
+            hits = sum(1 for zn in znames if re.search(r"\b" + re.escape(mbr) + r"\b", zn, re.I))
+            if hits >= 2:                       # member recurs across zones = a repeated card
+                repeated.append(mbr)
+    n_members = len({r[cat] for r in rows}) if cat else 0
+    has_repeat = cat and n_members >= 2 and len(repeated) >= (n_members + 1) // 2
+    if cat:
+        reasons.append(f"repeated-container: {len(repeated)}/{n_members} members recur in .twb zone "
+                       f"names {sorted(repeated)} -> {'DETECTED' if has_repeat else 'NOT a card-trellis'}")
+
+    # Applies ONLY if the source is genuinely a repeated-per-category card design.
+    # (No .twb / data-only mode cannot confirm this, so it does NOT auto-apply.)
+    applies = bool(cat and entity and measure and has_repeat)
+    if cat and entity and measure and not has_repeat:
+        reasons.append("→ data shape fits, but the source is NOT a repeated-per-category "
+                       "card layout — route to the standard (non-composition) build")
+    conf = "high" if (applies and rate and palette_members) else "medium" if applies else "low"
 
     print(f"composition applies: {applies}  (confidence: {conf})")
     for r in reasons:

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/detect-region-cards.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/detect-region-cards.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""detect-region-cards.py — the EXTRACT half of the composition stage.
+
+Given the Tableau .twb + the landed master table (CSV export) + DM ids, detect a
+repeated-per-category container design and emit a composition config the emitter
+turns into a composed workbook. Nothing dashboard-specific is baked in: column
+ROLES are passed (or defaulted) and mapped to the actual data; the palette, tints,
+facts, and prose are extracted/derived/computed.
+
+  * category members + order   <- master CSV (by measure desc)
+  * per-category palette (D1)   <- .twb style <map> color buckets
+  * card/header tints           <- derived (lighten/darken the base hue)
+  * per-category facts+cutoffs  <- computed from the master CSV
+  * prose (title/annotations)   <- .twb text runs (heuristic) + optional overrides
+
+Usage:
+  detect-region-cards.py --twb X.twb --master-csv master.csv --dm-ids dm-ids.json \
+    --category Region --entity State --measure "Total Job Losses" --rate "Job Loss Rate Pct" \
+    [--secondary Deportations --split-a Immigrant --split-b "US Born" --threshold 100000] \
+    [--source-name "State Master" --fact-name "State Fact" --text-overrides t.json] \
+    --folder <id> --wb-name "..." --out config.json
+"""
+import argparse, csv, json, re, html, statistics
+from collections import defaultdict
+
+
+def mix(a, b, t):
+    A = [int(a[i:i + 2], 16) for i in (1, 3, 5)]
+    B = [int(b[i:i + 2], 16) for i in (1, 3, 5)]
+    return "#" + "".join(f"{round(x*(1-t)+y*t):02X}" for x, y in zip(A, B))
+
+
+def derive_colors(base):
+    return {"bar": base.upper(), "card": mix(base, "#FFFFFF", 0.88),
+            "hdrbar": mix(base, "#FFFFFF", 0.55), "hdrtext": mix(base, "#000000", 0.42)}
+
+
+def extract_palette(xml, members):
+    pal = {}
+    for hexc, bkt in re.findall(r"<map to='(#[0-9A-Fa-f]+)'>\s*<bucket>&quot;?([^<&]+?)&quot;?</bucket>", xml):
+        bkt = bkt.strip()
+        if bkt in members and bkt not in pal:
+            pal[bkt] = hexc
+    return pal
+
+
+def extract_text(xml):
+    """Heuristic prose extraction from .twb text runs -> known emitter slots."""
+    runs = []
+    for r in re.findall(r"<run[^>]*>([^<]{2,})</run>", xml):
+        t = html.unescape(r).strip()
+        if t and not t.replace(".", "").replace(",", "").isdigit() and "[" not in t and "<" not in t:
+            runs.append(t)
+    t = {}
+    for r in runs:
+        low = r.lower()
+        if ("data:" in low or "design:" in low or "@" in r) and "credit" not in t:
+            t["credit"] = f'<span style="color:#9AA0A6">{r}</span>'
+        if " vs " in low and "rail_scatter_hdr" not in t:
+            t["rail_scatter_hdr"] = r
+        if low.startswith("of ") and "pct_suffix" not in t:
+            t["pct_suffix"] = r
+        if "per region" in low or "per " + "" == "":
+            pass
+    return t, runs[:40]
+
+
+def hnum(v):
+    v = float(v)
+    if abs(v) >= 1e6:
+        return f"{v/1e6:.1f}".rstrip("0").rstrip(".") + "M"
+    if abs(v) >= 1e3:
+        return f"{round(v/1e3)}K"
+    return f"{round(v)}"
+
+
+def slug(s):
+    return re.sub(r"[^a-z0-9]+", "", s.lower())
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--twb", help="source .twb (for palette/text extraction). "
+                                  "Omit for data-only mode: default palette + generic prose.")
+    ap.add_argument("--master-csv", required=True)
+    ap.add_argument("--dm-ids", help="DM id map (data-model source). Omit if using --connection-id/--path.")
+    ap.add_argument("--connection-id", help="warehouse-table source: connection uuid")
+    ap.add_argument("--path", help="warehouse-table source: DB,SCHEMA,TABLE (comma-separated)")
+    ap.add_argument("--category", required=True)
+    ap.add_argument("--entity", required=True)
+    ap.add_argument("--measure", required=True)
+    ap.add_argument("--rate", required=True)
+    ap.add_argument("--secondary")
+    ap.add_argument("--split-a")
+    ap.add_argument("--split-b")
+    ap.add_argument("--threshold", type=float)
+    ap.add_argument("--source-name", default="Master")
+    ap.add_argument("--fact-name", default="Fact")
+    ap.add_argument("--text-overrides")
+    ap.add_argument("--folder", required=True)
+    ap.add_argument("--wb-name", default="Composed dashboard (skill B1)")
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+
+    xml = open(a.twb, encoding="utf-8", errors="replace").read() if a.twb else ""
+    # brand-neutral fallback palette (dataviz skill default categorical order)
+    DEFAULT_SCHEME = ["#4E79A7", "#F28E2B", "#59A14F", "#E15759", "#B07AA1",
+                      "#76B7B2", "#EDC948", "#FF9DA7"]
+    rows = list(csv.DictReader(open(a.master_csv)))
+    for r in rows:
+        r["_m"] = float(r[a.measure] or 0)
+    grand = sum(r["_m"] for r in rows)
+    thr = a.threshold
+
+    by_cat = defaultdict(list)
+    for r in rows:
+        by_cat[r[a.category]].append(r)
+    members = sorted(by_cat, key=lambda c: -sum(r["_m"] for r in by_cat[c]))
+    base_pal = extract_palette(xml, members) if xml else {}
+    # fill any category with no .twb color from the default scheme (data-only mode)
+    for i, m in enumerate(members):
+        base_pal.setdefault(m, DEFAULT_SCHEME[i % len(DEFAULT_SCHEME)])
+
+    warehouse = bool(a.connection_id and a.path)
+    if warehouse:
+        dm_id = fact_eid = None
+    else:
+        dm = json.load(open(a.dm_ids))
+        dm_id, fact_eid = dm["dataModelId"], dm["pages"][0]["elements"][0]["id"]
+    has_split = bool(a.split_a and a.split_b)
+
+    regions = []
+    for label in members:
+        rs = by_cat[label]
+        rs_desc = sorted(rs, key=lambda r: -r["_m"])
+        vals = sorted(r["_m"] for r in rs)
+        tot = sum(r["_m"] for r in rs)
+        sa_pct = sb_pct = None
+        if has_split:
+            sa = sum(float(r[a.split_a] or 0) for r in rs)
+            sb = sum(float(r[a.split_b] or 0) for r in rs)
+            sa_pct = round(100 * sa / (sa + sb)) if (sa + sb) else 50
+            sb_pct = 100 - sa_pct
+        base = base_pal.get(label, "#888888")
+        hi, lo = rs_desc[0], rs_desc[-1]
+        abbr = "Abbrev" if "Abbrev" in rows[0] else a.entity
+        regions.append({
+            "key": slug(label), "label": label, "colors": derive_colors(base),
+            "facts": {
+                "total": tot, "pct_of_total": round(100 * tot / grand),
+                "n_entities": len(rs),
+                "over_thresh": sum(1 for r in rs if r["_m"] > thr) if thr is not None else None,
+                "split_a_pct": sa_pct, "split_b_pct": sb_pct,
+                "top5": [[r[a.entity], r["_m"]] for r in rs_desc[:5]],
+                "hi": [hi.get(abbr, hi[a.entity]), hi["_m"]],
+                "lo": [lo.get(abbr, lo[a.entity]), lo["_m"]],
+                "top5cut": sorted((r["_m"] for r in rs), reverse=True)[min(4, len(rs) - 1)],
+                "bot5cut": vals[min(4, len(vals) - 1)],
+            }})
+
+    fields = {
+        "entity": {"name": a.entity, "src": a.entity},
+        "category": {"name": a.category, "src": a.category},
+        "measure": {"name": a.measure, "src": a.measure},
+        "rate": {"name": a.rate, "src": a.rate},
+    }
+    if a.secondary:
+        fields["secondary"] = {"name": a.secondary, "src": a.secondary}
+    if has_split:
+        fields["split_a"] = {"name": a.split_a, "src": a.split_a}
+        fields["split_b"] = {"name": a.split_b, "src": a.split_b}
+
+    text, _runs = extract_text(xml)
+    text.setdefault("entity_plural", a.entity + "s")
+    text.setdefault("most_hdr", "The Most Impacted " + a.entity + "s")
+    text.setdefault("strip_hdr", a.measure + " by " + a.entity)
+    text.setdefault("rail_most_hdr", "Most Impacted")
+    text.setdefault("hdr_title", f"## {a.measure} by {a.category}")
+    text.setdefault("share_name", f"{a.measure}: total vs {a.split_a} vs {a.split_b}" if has_split else a.measure)
+    if a.text_overrides:
+        text.update(json.load(open(a.text_overrides)))
+
+    cfg = {
+        "source_kind": "warehouse-table" if warehouse else "data-model",
+        "dm_id": dm_id, "state_fact_eid": fact_eid,
+        "connection_id": a.connection_id, "path": (a.path.split(",") if warehouse else None),
+        "folder_id": a.folder,
+        "wb_name": a.wb_name, "source_name": a.source_name, "fact_name": a.fact_name,
+        "fields": fields, "threshold": thr, "cat_scheme": [base_pal.get(m, "#888888") for m in members],
+        "grand": grand,
+        "national": {"grand": grand, "median": statistics.median([r["_m"] for r in rows]),
+                     "over_thresh": sum(1 for r in rows if r["_m"] > thr) if thr is not None else None,
+                     "n_entities": len(rows)},
+        "regions": regions, "text": text,
+    }
+    json.dump(cfg, open(a.out, "w"), indent=1)
+    print(f"detected {len(regions)} '{a.category}' cards: {', '.join(members)}")
+    print("palette:", {m: base_pal.get(m) for m in members})
+    print("extracted text slots:", sorted(k for k in text))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/fixtures/cardtrellis.twb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/fixtures/cardtrellis.twb
@@ -1,0 +1,8 @@
+<?xml version='1.0'?>
+<workbook>
+ <style><map to='#35BDA8'><bucket>&quot;South&quot;</bucket></map><map to='#EC5FA0'><bucket>&quot;West&quot;</bucket></map></style>
+ <dashboards><dashboard name='D'><zones>
+   <zone name='South Container'/><zone name='South Sales'/><zone name='Top - South'/>
+   <zone name='West Container'/><zone name='West Sales'/><zone name='Top - West'/>
+ </zones></dashboard></dashboards>
+</workbook>

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/fixtures/data.csv
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/fixtures/data.csv
@@ -1,0 +1,5 @@
+State,Region,Sales,Ratio
+A,South,500,0.2
+B,South,300,0.3
+C,West,400,0.1
+D,West,200,0.4

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/fixtures/flat.twb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/fixtures/flat.twb
@@ -1,0 +1,6 @@
+<?xml version='1.0'?>
+<workbook>
+ <dashboards><dashboard name='D'><zones>
+   <zone name='Overview'/><zone name='Sales Trend'/><zone name='Product Detail'/><zone name='Map'/>
+ </zones></dashboard></dashboards>
+</workbook>

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/test-compose.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/test-compose.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Offline test for the composition emitter (no warehouse/API).
+
+Runs compose-region-cards.py on every config.example*.json and asserts the
+composed spec's structure, palette/canvas, and the control wirings — including a
+second config with a different schema and no worker-split (cshare dropped),
+which locks in that the stage is not dashboard-specific. Run: python3 test-compose.py
+"""
+import glob, json, os, subprocess, sys, tempfile
+from collections import Counter
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+fails = []
+
+
+def ck(cond, msg):
+    if not cond:
+        fails.append(msg)
+
+
+def check_config(cfg_path):
+    cfg = json.load(open(cfg_path))
+    name = os.path.basename(cfg_path)
+    out = os.path.join(tempfile.mkdtemp(), "wb.json")
+    subprocess.run([sys.executable, os.path.join(HERE, "compose-region-cards.py"),
+                    "--config", cfg_path, "--out-spec", out], check=True)
+    spec = json.load(open(out))
+    main = spec["pages"][1]["elements"]
+    by_id = {e["id"]: e for e in main}
+    n = len(cfg["regions"])
+    has_split = "split_a" in cfg["fields"] and "split_b" in cfg["fields"]
+    has_thr = cfg.get("threshold") is not None
+
+    for rg in cfg["regions"]:
+        k = rg["key"]
+        ck(f"reg-{k}" in by_id and by_id[f"reg-{k}"]["kind"] == "container", f"{name}: missing card reg-{k}")
+        ck(by_id[f"reg-{k}"]["style"]["backgroundColor"].startswith("#"), f"{name}: card reg-{k} not tinted")
+        for sub in ("kpi", "pct", "sub", "mihdr", "most", "sphdr", "strip"):
+            ck(f"reg-{k}-{sub}" in by_id, f"{name}: card {k} missing sub-element {sub}")
+        kpi = by_id.get(f"reg-{k}-kpi", {})
+        if has_split:
+            ck("Switch([cshare]" in json.dumps(kpi), f"{name}: reg-{k}-kpi not wired to cshare switch")
+        bar = by_id.get(f"reg-{k}-most", {})
+        ck("[crank]" in json.dumps(bar), f"{name}: reg-{k}-most not wired to crank")
+        ck(any(f.get("kind") == "list" and f.get("values") == [True] for f in bar.get("filters", [])),
+           f"{name}: reg-{k}-most missing rank-select boolean filter")
+        strip = by_id.get(f"reg-{k}-strip", {})
+        ck("[cmedian]" in json.dumps(strip), f"{name}: reg-{k}-strip median not wired to cmedian")
+        if has_thr:
+            ck(strip.get("color", {}).get("scheme", [None, None])[-1] == "#F2C037",
+               f"{name}: reg-{k}-strip missing C2 threshold color")
+
+    # cshare present iff a worker split exists
+    has_cshare = any(e.get("controlId") == "cshare" for e in main)
+    ck(has_cshare == has_split, f"{name}: cshare presence ({has_cshare}) != has_split ({has_split})")
+    ck(len(spec["themeOverrides"]["categoricalScheme"]) == n, f"{name}: categoricalScheme size != #cards")
+    ck(spec["themeOverrides"]["colorOverrides"]["backgroundCanvas"] == "#FFFFFF", f"{name}: canvas not set")
+    for rg in cfg["regions"]:
+        ck(f'elementId="reg-{rg["key"]}"' in spec["layout"], f"{name}: layout missing reg-{rg['key']}")
+    return name, len(main), n, has_split
+
+
+configs = sorted(glob.glob(os.path.join(HERE, "config.example*.json")))
+assert configs, "no config.example*.json found"
+results = [check_config(c) for c in configs]
+
+if fails:
+    print("FAIL:")
+    for f in fails:
+        print("  -", f)
+    sys.exit(1)
+for name, els, n, split in results:
+    print(f"PASS {name}: {els} elements, {n} cards, split={split}, crank/cmedian wired"
+          + (", cshare wired" if split else ", cshare correctly absent"))
+print("PASS test-compose: composition stage generalizes across schemas")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/test-signal.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/composition/test-signal.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Offline gate test: composition applies ONLY when the .twb is a repeated-per-
+category card design. cardtrellis.twb -> applies; flat.twb / no-.twb -> route away."""
+import json, os, subprocess, sys
+HERE = os.path.dirname(os.path.abspath(__file__)); F = os.path.join(HERE, "fixtures")
+def run(args):
+    r = subprocess.run([sys.executable, os.path.join(HERE, "detect-composition-signal.py"),
+                        "--master-csv", os.path.join(F, "data.csv"), "--emit-args"] + args,
+                       capture_output=True, text=True)
+    for ln in r.stdout.splitlines():
+        if ln.strip().startswith("{"): return json.loads(ln)
+    return {"applies": False}
+fails = []
+pos = run(["--twb", os.path.join(F, "cardtrellis.twb")])
+if not pos.get("applies"): fails.append("cardtrellis.twb should APPLY")
+neg = run(["--twb", os.path.join(F, "flat.twb")])
+if neg.get("applies"): fails.append("flat.twb should NOT apply (not a card-trellis)")
+noweb = run([])
+if noweb.get("applies"): fails.append("no-.twb (data-only) should NOT auto-apply")
+if fails:
+    print("FAIL:"); [print("  -", f) for f in fails]; sys.exit(1)
+print("PASS test-signal: card-trellis applies; flat + data-only route away")


### PR DESCRIPTION
## What & why

Adds a **composition/style layer** to `tableau-to-sigma` — the "design" half the skill was missing. Numbers, chart-kind, and parity were solid; **extracting + emitting** tints, palette, styled text, and composite per-category cards was not, so design-heavy dashboards came out as a flat chart list.

This stage detects a **container repeated per category** (e.g. the four region columns) and emits N tinted `GridContainer` cards — each stacking a transparent hero KPI + %-of-total + annotations + a Top/Bottom-N bar + a threshold strip — plus a left rail and a wired control row. Validated two ways: reproducing a design-heavy hand-migrated dashboard, and a **cold run on a second, unrelated Tableau workbook** (real Superstore `.twb` + data landed fresh) that fell out end-to-end.

## Scope

- Plugin(s) touched: **tableau-to-sigma** only
- [x] Exactly one plugin. **Additive** — a new `scripts/composition/` dir; touches no existing or gated script.

New files under `scripts/composition/`:
- `detect-composition-signal.py` — decides applicability + **infers roles** (category via `.twb` color palette + cardinality; entity via cardinality; **measure via `.twb` reference-frequency**, not magnitude; rate; secondary; split; threshold via a `> N` flagging ~10-40%).
- `detect-region-cards.py` — EXTRACT: parse signals → `config.json` (field role map, palette from `.twb` color buckets, tints derived from the base hue, facts/cutoffs). `--twb` optional (data-only). Data-model **or** warehouse-table source.
- `compose-region-cards.py` — EMIT: config → composed workbook spec + embedded grid layout. Fully config-driven; N cards; optional split/secondary/threshold.
- `compose-auto.py` — **one-command auto-trigger** (signal → detect → emit; exit `2` = does-not-apply → route to standard flow).
- `composition-verify.py` — Phase-6 gate: structural completeness + **live per-card KPI vs config facts** (catches render races / broken tiles).
- `test-compose.py` + `config.example{,2,3}.json` — three schemas (region/worker-split/threshold · cloud no-split · warehouse-source no-threshold).

## Verified-live spec recipes (see `composition/README.md`)

Control-driven 3-way measure `Switch` · Most/Least-impacted via a **window-free** control-conditional cutoff boolean (`Rank()` errors as a window fn) · Show/Hide median via a `refMarks` conditional formula · C2 threshold color · container tints + `categoricalScheme` + white canvas. **Known spec gaps surfaced, not shipped as dead UI:** `dataLabel` toggle is a static enum; click-to-filter needs an added control + hidden base table.

## Evidence

- **Reproduction:** the design-heavy source dashboard rebuilt from the skill (region-scoped KPIs verified by query, controls wired).
- **Cold run (generality):** real second `.twb` (Superstore) — signal inference picked `measure=Sales` (352 `.twb` refs, high confidence), landed data cold, `compose-auto` → new workbook → **live-verify PASS**. Caught + fixed a real bug in the process (empty-body text elements render as error tiles → now dropped).

## Checklist

- [x] `ruby tools/check-shared.rb` — green (pre-commit hook: 265 shared-file copies match)
- [x] `ruby tools/lint-skills.rb` — green (pre-commit hook: 10 converter SKILL.md gates documented)
- [x] Phase numbers unchanged (documented as standalone Phase-5c entrypoint; not inlined into the gated `migrate-tableau.rb`)
- [x] No unrelated working-tree changes
- [x] `composition/test-compose.py` PASS (3 schemas) · tableau ruby offline suite 32/0

## Follow-ups (non-blocking)

- Auto-wire `compose-auto` into `migrate-tableau.rb` discovery (currently a documented standalone step).
- Palette extraction fires only when the source `.twb` encodes a categorical color map (defaults to brand-neutral otherwise).
- Secondary rail KPI carries a generic "Total" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
