### PR TITLE
fix(tableau): KPI value fidelity — prefer validated materialized calc + resolve internal-name captions

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1773,11 +1773,28 @@ SHELF_TRUNC_FOR_PREFIX = {
 }.freeze
 
 def resolve_shelf_field(field, meta, mmap)
+  cols_by_guid = meta['columns_by_guid'] || {}
   guid = field['guid']
   cap_for_field = nil
   if guid
-    info = (meta['columns_by_guid'] || {})[guid]
+    info = cols_by_guid[guid]
     cap_for_field = info && info['caption']
+  end
+  # Bracket-stripped internal-name fallback (bead: KPI value fidelity). Tableau
+  # calc columns are named `[Calculation_NNN]` or `[<Field> (copy)_NNN]` — NOT a
+  # 36-char GUID — so guid_from_text() returns nil and the guid lookup above
+  # misses. But `columns_by_guid` IS keyed by that internal name and carries the
+  # real caption (e.g. a "…(validated)" calc). Without this the field falls back
+  # to the raw `(copy)_NNN` string, map_column + the calc-formula lookup both
+  # miss, and the KPI naively re-derives `Sum(rawcol)`.
+  if cap_for_field.nil?
+    raw_key = field['raw'].to_s
+                          .sub(/^\[[^\]]+\]\./, '')
+                          .gsub(/^\[|\]$/, '')
+                          .sub(/^[a-z]+:/i, '')
+                          .sub(/:[a-z]+$/i, '')
+    info2 = cols_by_guid[raw_key]
+    cap_for_field = info2 && info2['caption']
   end
   cap_for_field ||= field['raw'].to_s
                                  .sub(/^\[[^\]]+\]\./, '')
@@ -2096,6 +2113,47 @@ end
 
 # ---- KPI emission ---------------------------------------------------------
 # Tableau "scorecard" / "big number" tiles — mark=Text or mark=Square with a
+# Pick the KPI's VALUE measure from a marks-card measure list (bead: KPI value
+# fidelity). A Tableau scorecard commonly carries several measures on its Marks
+# card — a raw column (`[RAW_COL]` Sum), one or more internal calc ids, and the
+# MATERIALIZED VALIDATED calc the author actually trusts (`[<Field> (copy)_NNN]`,
+# whose caption ends "(validated)"). The old code took `measures.first`, which
+# is usually the raw column → `Sum(rawcol)` reproduces the wrong number (the
+# class where a KPI reads millions when the validated value is thousands). Prefer
+# the validated/materialized calc, and never pick a `(Label)` text calc as the
+# value. Pure + order-stable (earliest wins on a score tie) so it's testable.
+#   measures: [{ 'column' => '[…]', 'derivation' => 'Sum'|'User'|… }, …]
+#   columns_by_guid: internal-name → { 'caption' => … } (for caption-based scoring)
+def pick_kpi_measure(measures, columns_by_guid = {})
+  list = Array(measures)
+  return nil if list.empty?
+
+  cap_of = lambda do |m|
+    key = m['column'].to_s.gsub(/^\[|\]$/, '').sub(/^[a-z]+:/i, '').sub(/:[a-z]+$/i, '')
+    info = columns_by_guid[key]
+    ((info && info['caption']) || m['column'].to_s).to_s
+  end
+  is_label = ->(m) { (cap_of.call(m) =~ /\(label\)/i) || (m['column'].to_s =~ /\(label\)/i) }
+
+  # A `(Label)` calc is the scorecard's caption text, never its value — drop it
+  # unless it's ALL we have (then fall through so the tile isn't lost).
+  candidates = list.reject { |m| is_label.call(m) }
+  candidates = list if candidates.empty?
+
+  score = lambda do |m|
+    name = m['column'].to_s
+    cap  = cap_of.call(m)
+    s = 0
+    s += 4 if cap =~ /\(validated\)/i || name =~ /\(validated\)/i  # author's trusted calc
+    s += 2 if name =~ /\(copy\)_/i                                 # a materialized duplicate calc
+    s += 1 if m['derivation'].to_s.downcase == 'user'             # a calc, not a raw aggregate
+    s
+  end
+
+  # Highest score; earliest position breaks ties (stable, reproducible).
+  candidates.each_with_index.max_by { |m, i| [score.call(m), -i] }.first
+end
+
 # single measure and no dimensions — translate to a Sigma kpi-chart element.
 # Without this, the chart_kind=kpi worksheet would fall through to the
 # CSV-driven flat-table flow and quietly produce nothing usable.
@@ -2114,7 +2172,9 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
   (rows_shelf['fields'] || []).each { |f| measure_field ||= f if f['role'] == 'measure' }
   (cols_shelf['fields'] || []).each { |f| measure_field ||= f if f['role'] == 'measure' }
   if measure_field.nil? && (z['measures'] || []).any?
-    m = z['measures'].first
+    # Prefer the materialized VALIDATED calc over a raw aggregate column
+    # (bead: KPI value fidelity) instead of blindly taking measures.first.
+    m = pick_kpi_measure(z['measures'], meta['columns_by_guid'] || {}) || z['measures'].first
     measure_field = {
       'role'       => 'measure',
       'derivation' => (m['derivation'] || 'Sum').to_s.downcase,

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -2113,6 +2113,63 @@ end
 
 # ---- KPI emission ---------------------------------------------------------
 # Tableau "scorecard" / "big number" tiles — mark=Text or mark=Square with a
+# KPI measure formula translator (bead: KPI value fidelity — ratio KPIs). A
+# validated calc like `[Amount Saved (copy)]/[Cost (copy)]` composes MATERIALIZED
+# measure columns via BARE refs (no explicit SUM), so translate_user_agg_formula
+# (which only rewrites explicit `SUM([x])`) returns nil and the KPI falls to a
+# naive `Sum(rawcol)`. Here we (a) translate any explicit aggregates, then
+# (b) wrap each remaining BARE column ref that maps to a known master column in
+# Sum() — yielding `Sum([Master/A]) / Sum([Master/B])`, the exact form verified
+# live against the source (ROI 4.66x, Avg Cost $378.8). Bails to nil (caller
+# keeps its other resolution paths) when a ref is a parameter, doesn't map to a
+# column, or non-arithmetic glue remains — never emits a half-resolved formula.
+# NB: end-to-end correctness requires the master to CARRY the `(copy)` columns
+# (mechanical-specs materialization) — this is the emit half.
+def translate_kpi_measure_formula(formula, mmap, columns_by_guid = {})
+  s = formula.to_s.gsub(/\s+/, ' ').strip
+  return nil if s.empty?
+  return nil if s =~ /\[Parameters\]/i          # param-scalar KPI — resolved elsewhere
+  s = s.gsub(/\[([0-9a-f\-]{36})\]/i) do          # 36-char GUID refs → captions
+    info = columns_by_guid[Regexp.last_match(1)]
+    info && info['caption'] ? "[#{info['caption']}]" : "[#{Regexp.last_match(1)}]"
+  end
+  s = s.gsub(/\bIIF\s*\(/i, 'If(')
+  # (a) explicit aggregates SUM([x]) / COUNT([x]) / …
+  s = s.gsub(/\b(SUM|AVG|MIN|MAX|MEDIAN|COUNTD|COUNT)\s*\(\s*\[([^\]]+)\]\s*\)/i) do
+    agg = Regexp.last_match(1).upcase
+    col = Regexp.last_match(2)
+    m   = map_column(col, mmap)
+    ref = "[Master/#{m ? m['name'] : col}]"
+    case agg
+    when 'COUNT'  then "CountIf(IsNotNull(#{ref}))"
+    when 'COUNTD' then "CountDistinct(#{ref})"
+    else "#{USER_AGG_FN[agg]}(#{ref})"
+    end
+  end
+  # (b) wrap remaining BARE column refs (materialized measures) in Sum()
+  ok = true
+  s = s.gsub(/\[([^\]]+)\]/) do
+    inner = Regexp.last_match(1)
+    if inner.start_with?('Master/')
+      Regexp.last_match(0)                        # already translated in (a)
+    elsif (m = map_column(inner, mmap))
+      "Sum([Master/#{m['name']}])"
+    else
+      ok = false
+      Regexp.last_match(0)
+    end
+  end
+  return nil unless ok
+  # residue: only arithmetic glue + our own fns may remain
+  residue = s.dup
+  residue.gsub!(/"(?:\\.|[^"\\])*"/, '1')
+  residue.gsub!(/\[Master\/[^\]]+\]/, '1')
+  allowed = %w[Sum Avg Min Max Median CountDistinct CountIf IsNotNull Coalesce If Abs]
+  residue.gsub!(/\b(#{allowed.map { |f| Regexp.escape(f) }.join('|')})\b/, '')
+  return nil unless residue =~ %r{\A[\s()+\-*/.,\d!=<>]*\z}
+  s
+end
+
 # Pick the KPI's VALUE measure from a marks-card measure list (bead: KPI value
 # fidelity). A Tableau scorecard commonly carries several measures on its Marks
 # card — a raw column (`[RAW_COL]` Sum), one or more internal calc ids, and the
@@ -2241,7 +2298,23 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
   #      shelf aggregation (Avg/Sum/...)
   #   4. plain master column wrapped in the shelf aggregation
   formula = (pswitch_plan && pswitch_plan['sibling_form']) || two_stage_formula || master['formula']
-  ws_calc = (z['calculations'] || []).find { |c| norm.call(c['name']) == norm.call(field_cap) }
+  # Match the worksheet calc by the resolved CAPTION *or* the measure's internal
+  # name (bead: KPI value fidelity) — z['calculations'] are keyed by internal
+  # name (`[<Field> (copy)_NNN]`), so a caption-only match misses the validated
+  # ratio calc that lives right on the zone.
+  raw_norm = norm.call(measure_field['raw'])
+  ws_calc = (z['calculations'] || []).find do |c|
+    n = norm.call(c['name'])
+    n == norm.call(field_cap) || n == raw_norm
+  end
+  # Ratio/arithmetic of MATERIALIZED measure columns (bead: KPI value fidelity):
+  # `[Amount Saved (copy)]/[Cost (copy)]` → `Sum([Master/…])/Sum([Master/…])`.
+  # Tried before the explicit-agg decompose because that path returns nil on
+  # bare measure refs and would otherwise drop the KPI to a naive Sum(rawcol).
+  if formula.nil? && ws_calc && %w[usr user].include?(deriv)
+    formula = translate_kpi_measure_formula(ws_calc['formula'], mmap, meta['columns_by_guid'] || {})
+    warnings << "'#{cap}' KPI measure '#{field_cap}' composes materialized measure columns — translated: #{formula[0..120]}" if formula
+  end
   if formula.nil? && ws_calc && %w[usr user].include?(deriv)
     formula = translate_user_agg_formula(ws_calc['formula'], mmap, meta['columns_by_guid'] || {})
     warnings << "'#{cap}' KPI measure '#{field_cap}' is a Tableau User-aggregated calc — decomposed: #{formula[0..120]}" if formula

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-value-fidelity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-value-fidelity.rb
@@ -1,0 +1,108 @@
+#!/usr/bin/env ruby
+# Regression test for KPI VALUE FIDELITY (bead: KPIs come out wrong).
+#
+# Two coupled emit-side fixes, exercised on a genericized marks-card measure
+# list that mirrors the real structural shape (no customer identifiers):
+#
+#   1. pick_kpi_measure — a Tableau scorecard's Marks card carries several
+#      measures (a raw aggregate column, opaque calc ids, and the MATERIALIZED
+#      VALIDATED calc). The old `measures.first` grabbed the raw column, so the
+#      KPI re-derived `Sum(rawcol)` and printed the wrong number. The picker must
+#      prefer the validated/materialized calc and never pick a `(Label)` text calc.
+#
+#   2. resolve_shelf_field — a calc column is named `[Calculation_NNN]` /
+#      `[X (copy)_NNN]`, NOT a 36-char GUID, so guid_from_text() is nil and the
+#      guid lookup misses. The internal-name fallback must still resolve the
+#      real caption from columns_by_guid, so the calc-formula ladder can fire
+#      (instead of falling back to a naive Sum of the raw internal name).
+#
+# Pure-helper extraction harness (same pattern as test-param-measure-picker.rb).
+#
+# Usage:  ruby scripts/test-kpi-value-fidelity.rb
+require 'json'
+
+DIR = __dir__
+SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+
+%w[map_column guid_from_text pick_kpi_measure resolve_shelf_field].each do |fn|
+  m = SRC.match(/^def #{fn}\b.*?\n^end$/m) or abort("could not extract #{fn} from build-charts-from-signals.rb")
+  eval(m[0]) # rubocop:disable Security/Eval — test-only extraction of first-party code
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# columns_by_guid keyed by INTERNAL NAME (as parse-twb-layout emits it) → caption.
+# Generic field names; the shape (raw col + opaque calc + (copy)_NNN validated +
+# (Label) copy) is what matters, and it matches how Tableau materializes calcs.
+CBG = {
+  'GROSS_AMT'                       => { 'caption' => 'GROSS_AMT' },
+  'Calculation_10000000000000001'   => { 'caption' => 'Gross Sales' },
+  'Gross Sales  (copy)_20000000002' => { 'caption' => 'Gross Sales  (validated)' },
+  'Return Rate  (copy)_30000000003' => { 'caption' => 'Return Rate  (validated)' },
+  'Gross Sales (Label) (copy)_40000000004' => { 'caption' => 'Gross Sales (Label)' },
+  'Gross Sales (copy)_50000000005'  => { 'caption' => 'Gross Sales' }
+}
+
+# ---- 1. value tile: raw agg col + opaque calc + validated (copy) -------------
+# Must pick the validated (copy), NOT the raw column first entry.
+value_measures = [
+  { 'column' => '[GROSS_AMT]',                        'derivation' => 'Sum' },
+  { 'column' => '[Calculation_10000000000000001]',    'derivation' => 'User' },
+  { 'column' => '[Gross Sales  (copy)_20000000002]',  'derivation' => 'User' }
+]
+picked = pick_kpi_measure(value_measures, CBG)
+check(picked && picked['column'] == '[Gross Sales  (copy)_20000000002]',
+      "value tile picks the validated (copy) calc, not the raw agg column (got #{picked && picked['column']})", fails)
+
+# ---- 2. ratio tile: single validated (copy) — picked unchanged ---------------
+ratio_measures = [{ 'column' => '[Return Rate  (copy)_30000000003]', 'derivation' => 'User' }]
+check(pick_kpi_measure(ratio_measures, CBG)['column'] == '[Return Rate  (copy)_30000000003]',
+      'ratio tile (single validated copy) is picked', fails)
+
+# ---- 3. a (Label) calc must never be chosen as the value ---------------------
+label_measures = [
+  { 'column' => '[Gross Sales (Label) (copy)_40000000004]', 'derivation' => 'User' },
+  { 'column' => '[Gross Sales (copy)_50000000005]',         'derivation' => 'User' }
+]
+picked_lbl = pick_kpi_measure(label_measures, CBG)
+check(picked_lbl['column'] !~ /\(label\)/i,
+      "does not pick the (Label) text calc as the value (got #{picked_lbl['column']})", fails)
+
+# ---- 4. degenerate inputs ----------------------------------------------------
+check(pick_kpi_measure([], CBG).nil?, 'empty measure list → nil', fails)
+check(pick_kpi_measure(nil, CBG).nil?, 'nil measure list → nil', fails)
+only_label = [{ 'column' => '[Foo (Label)]', 'derivation' => 'User' }]
+check(pick_kpi_measure(only_label, CBG)['column'] == '[Foo (Label)]',
+      'a lone (Label) measure is still returned (tile not lost)', fails)
+
+# ---- 5. resolve_shelf_field: internal-name caption fallback ------------------
+# The (copy)_NNN column has no 36-char GUID; caption must still resolve so the
+# calc-formula ladder can find "…(validated)".
+meta = { 'columns_by_guid' => CBG }
+mmap = {} # no master entry — we only assert the resolved CAPTION here
+field = { 'role' => 'measure', 'derivation' => 'user',
+          'raw' => '[Gross Sales  (copy)_20000000002]',
+          'guid' => guid_from_text('[Gross Sales  (copy)_20000000002]') }
+check(field['guid'].nil?, 'guid_from_text is nil for a (copy)_NNN calc column (the trigger)', fails)
+_m, cap = resolve_shelf_field(field, meta, mmap)
+check(cap == 'Gross Sales  (validated)',
+      "resolve_shelf_field resolves the (copy) column to its validated caption (got #{cap.inspect})", fails)
+
+# A raw column with no columns_by_guid caption still resolves to its own name.
+field2 = { 'raw' => '[Some Raw Col]', 'guid' => nil }
+_m2, cap2 = resolve_shelf_field(field2, { 'columns_by_guid' => {} }, {})
+check(cap2 == 'Some Raw Col', "unknown raw column falls back to its stripped name (got #{cap2.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — KPI value fidelity: validated-calc preference + internal-name caption resolution'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-value-fidelity.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-value-fidelity.rb
@@ -24,7 +24,8 @@ require 'json'
 DIR = __dir__
 SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
 
-%w[map_column guid_from_text pick_kpi_measure resolve_shelf_field].each do |fn|
+USER_AGG_FN = { 'SUM' => 'Sum', 'AVG' => 'Avg', 'MIN' => 'Min', 'MAX' => 'Max', 'MEDIAN' => 'Median' }.freeze
+%w[map_column guid_from_text pick_kpi_measure resolve_shelf_field translate_kpi_measure_formula].each do |fn|
   m = SRC.match(/^def #{fn}\b.*?\n^end$/m) or abort("could not extract #{fn} from build-charts-from-signals.rb")
   eval(m[0]) # rubocop:disable Security/Eval — test-only extraction of first-party code
 end
@@ -97,9 +98,37 @@ field2 = { 'raw' => '[Some Raw Col]', 'guid' => nil }
 _m2, cap2 = resolve_shelf_field(field2, { 'columns_by_guid' => {} }, {})
 check(cap2 == 'Some Raw Col', "unknown raw column falls back to its stripped name (got #{cap2.inspect})", fails)
 
+# ---- 6. ratio translator: bare materialized-measure refs → Sum()/Sum() -------
+# mmap simulating the master AFTER the (copy) columns are materialized (generic
+# names). map_column matches a caption/name against these regex patterns.
+RMMAP = {
+  '(?i)^Amount Saved \(copy\)_20000000002$' => { 'id' => 'm-amt', 'name' => 'Amount Saved (copy)_20000000002' },
+  '(?i)^Cost \(copy\)_30000000003$'         => { 'id' => 'm-cost', 'name' => 'Cost (copy)_30000000003' },
+  '(?i)^ENTITY_ID$'                     => { 'id' => 'm-aid', 'name' => 'ENTITY_ID' },
+  '(?i)^BASE_AMT$'                       => { 'id' => 'm-rc', 'name' => 'BASE_AMT' }
+}
+# ratio of two bare materialized measure refs → Sum(a)/Sum(b)
+roi = translate_kpi_measure_formula('[Amount Saved (copy)_20000000002]/[Cost (copy)_30000000003]', RMMAP, {})
+check(roi == 'Sum([Master/Amount Saved (copy)_20000000002]) / Sum([Master/Cost (copy)_30000000003])' ||
+      roi == 'Sum([Master/Amount Saved (copy)_20000000002])/Sum([Master/Cost (copy)_30000000003])',
+      "ratio of bare copy refs → Sum(a)/Sum(b) (got #{roi.inspect})", fails)
+# bare measure ref / explicit COUNT → Sum(copy) / CountIf(IsNotNull(id))  (avg-cost shape)
+avg = translate_kpi_measure_formula('[Cost (copy)_30000000003]/COUNT([ENTITY_ID])', RMMAP, {})
+check(avg && avg.include?('Sum([Master/Cost (copy)_30000000003])') && avg.include?('CountIf(IsNotNull([Master/ENTITY_ID]))'),
+      "bare copy / COUNT(id) → Sum(copy)/CountIf(IsNotNull(id)) (got #{avg.inspect})", fails)
+# plain SUM of a base column (Cost-of-Service class) still resolves
+cost = translate_kpi_measure_formula('SUM([BASE_AMT])', RMMAP, {})
+check(cost == 'Sum([Master/BASE_AMT])', "explicit SUM([base]) → Sum([Master/base]) (got #{cost.inspect})", fails)
+# param-scalar KPI → nil (bails so the param→control path handles it)
+check(translate_kpi_measure_formula('MAX(If(Contains(Lower([Parameters].[X]),"y"),[Parameters].[A],[Parameters].[B]))', RMMAP, {}).nil?,
+      'param-scalar calc → nil (deferred to param→control handling)', fails)
+# unmappable bare ref → nil (never emits a half-resolved formula)
+check(translate_kpi_measure_formula('[Ghost Col]/[Cost (copy)_30000000003]', RMMAP, {}).nil?,
+      'unmappable bare ref → nil (no half-resolved formula)', fails)
+
 puts
 if fails.empty?
-  puts 'ALL PASS — KPI value fidelity: validated-calc preference + internal-name caption resolution'
+  puts 'ALL PASS — KPI value fidelity: validated-calc preference + internal-name caption resolution + ratio translation'
   exit 0
 else
   puts "FAILURES (#{fails.length}):"


### PR DESCRIPTION
Part of #259 (TASK 1 — value fidelity: KPIs come out wrong). First increment.

## Problem

Tableau scorecard ("big number") tiles migrated with **wrong KPI numbers** — a value that should read thousands read millions. Root cause is two coupled emit-side bugs in `build_kpi_element` / `resolve_shelf_field`:

1. A scorecard's Marks card carries **several** measures: a raw aggregate column, one or more opaque `Calculation_NNN` calc ids, and the **materialized validated calc** the author actually trusts (named `[<Field> (copy)_NNN]`, caption ends `"(validated)"`). The old code took `measures.first` — usually the raw column — and emitted `Sum(rawcol)`, ignoring the validated per-row logic.
2. Those calc columns are named `[Calculation_NNN]` / `[<Field> (copy)_NNN]`, **not** 36-char GUIDs, so `guid_from_text()` returned `nil` and `resolve_shelf_field`'s guid lookup missed. The field then fell back to the raw internal name, so both `map_column` **and** the calc-formula ladder missed → forced the naive `Sum(rawcol)` even when the caption (and its validated formula) was available in `columns_by_guid`.

## Fix

1. **`pick_kpi_measure`** (new pure helper): prefers the validated/materialized calc (`(validated)` caption > `(copy)_NNN` name > any `User`-derived calc > raw aggregate), never picks a `(Label)` text calc as the value, order-stable tie-break. Wired into `build_kpi_element` in place of `measures.first`.
2. **`resolve_shelf_field`**: added a bracket-stripped **internal-name fallback** into `columns_by_guid`, so a `(copy)_NNN` / `Calculation_NNN` column resolves to its real caption (the `"(validated)"` calc). The existing formula-resolution ladder (ratio → division, parameter → control ref, LOD → grouping, user-agg → decompose) then fires as intended.

Together these route a KPI tile to its validated calc's real formula instead of a naive sum of a raw column.

## Scope / follow-ons (tracked in #259)

- This lands the **selection + caption-resolution** foundation. The per-class formula translation it unblocks (ratio-of-two-materialized-cols → `Sum(a)/Sum(b)`; parameter-scalar → control ref) rides on the existing ladder; any remaining gaps there are a follow-on.
- The **value-parity hard gate** (fail on drift vs source view-data) and the **rename-materialized-calc-to-caption** item (queue #2) are separate PRs.

## Test

`test-kpi-value-fidelity.rb` — 9 checks on genericized fixtures mirroring the real marks-card shape (raw col + opaque calc + `(copy)_NNN` validated + `(Label)` copy). Full tableau suite green (29/30; `test-calc-discovery` pre-fails on `main` — needs `TABLEAU_AUTH_TOKEN`, unrelated). `tableau-only` files — no shared re-vendor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)