### PR TITLE
tableau: general design-signal layer — B4 styled-text + B3 KPI-composite emit (no composition special-case)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -102,6 +102,11 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rls-wiring.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-table-calc-translation.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-topn-filter-emission.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-extraction.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-body.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-layout.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-scorecard-detection.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-composite-emit.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-id-namespacing.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -2241,6 +2241,26 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
     'value'   => { 'columnId' => measure_col_id }
   }
 
+  # B3 (gap ubr5.7): a Tableau "big number" BAN scorecard (Shape/Circle mark with
+  # a <customized-label>, surfaced by the parser as kpi_value_font_size). Style
+  # the composite faithfully: use the label run as the KPI title, keep the
+  # SOURCE font size (fidelity mandate — prefer the .twb value over a hand-tuned
+  # one), and render the hero transparent so a container tint shows through
+  # (composition layer, styling.md). Non-BAN KPIs (Automatic-mark scorecards)
+  # carry no kpi_value_font_size and keep their default styling.
+  if z['kpi_value_font_size']
+    element['name'] = z['kpi_label'] if z['kpi_label'] && !z['kpi_label'].to_s.strip.empty?
+    element['value']['fontSize'] = z['kpi_value_font_size']
+    element['style'] = { 'padding' => 'none', 'backgroundColor' => '#00000000' }
+    # The BAN's side annotation (e.g. "40% of U.S. total") is driven by a dynamic
+    # Tableau calc token that can't be reproduced as static text; emitting the
+    # literal remainder ("of U.S. total") alone would mislead. Surface the gap.
+    if Array(z['kpi_annotation_runs']).any? { |r| r['ref'] }
+      warnings << "'#{cap}' KPI has a customized-label annotation with a dynamic value " \
+                  "(e.g. a '% of total' calc) — the annotation is NOT reproduced (needs a computed column)"
+    end
+  end
+
   # Param measure-picker: materialise the hidden passthrough sibling cols the
   # Switch's branches reference, and register the control for emission (n4pi.10).
   if pswitch_plan

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -3726,6 +3726,44 @@ layout.each do |dash|
   end
 end
 
+# ---- B4: styled static text (gap ubr5.8) -----------------------------------
+# Assemble a Sigma text.body from Tableau formatted-text runs (parse-twb-layout
+# `text_runs`). Each run → an inline <span style> carrying its source color +
+# font-size (px, verbatim — the source point size faithfully preserves relative
+# weight, so no fragile markdown-heading guessing), with **bold** for bold runs;
+# hard-break runs (the Æ+newline sentinel) split paragraphs (\n\n). A run's
+# literal whitespace is emitted plain (keeps inter-run spacing). Dynamic Tableau
+# tokens (<[Parameters]…>) can't be reproduced as static text and would corrupt
+# the HTML body, so they're stripped (caller WARNs). `align` wraps center/right
+# in a <p> (left is Sigma's default and 400s if forced — styling.md); `bg` wraps
+# the content in a background-color span (a pill/chip). Returns nil when nothing
+# visible remains. All colors are hex (var(--…) 400s). Pure/self-contained so
+# test-styled-text-body.rb can extract and eval it.
+def text_body_from_runs(runs, align: nil, bg: nil)
+  return nil if runs.nil? || runs.empty?
+  # Split into paragraphs on hard-break runs.
+  lines = [[]]
+  runs.each { |r| r['break'] ? (lines << []) : (lines.last << r) }
+  rendered = lines.map do |line|
+    line.map do |r|
+      raw = r['text'].to_s
+      raw = raw.gsub(/<\[[^\]]*\][^>]*>/, '') if raw.include?('<[') # drop dynamic tokens
+      next '' if raw.empty?
+      next raw if raw.strip.empty? # whitespace spacer → literal (keeps run spacing)
+      esc = raw.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+      esc = "**#{esc}**" if r['bold']
+      styles = []
+      styles << "color: #{r['color']}" if r['color']
+      styles << "font-size: #{r['font_size']}px" if r['font_size']
+      styles.empty? ? esc : %(<span style="#{styles.join('; ')}">#{esc}</span>)
+    end.join
+  end
+  body = rendered.reject { |l| l.strip.empty? }.join("\n\n")
+  return nil if body.strip.empty?
+  body = %(<span style="background-color: #{bg}">#{body}</span>) if bg
+  %w[center right].include?(align.to_s) ? %(<p style="text-align: #{align}">#{body}</p>) : body
+end
+
 # ---- Title text element ----
 # If --title given, emit a text element. If --title omitted AND the parser
 # found a title/text zone, infer the dashboard name from the parser output.
@@ -3750,6 +3788,35 @@ if title_text
     'body' => %(# <span style="color: #FFFFFF">#{title_text}</span>)
   }
 end
+
+# ---- B4: styled static-text elements ---------------------------------------
+# Emit each dashboard text/title zone that carries run-level formatting as a
+# Sigma `text` element (id "text-<zoneid>") that the layout stage places at the
+# zone's own geometry (build-dashboard-layout resolve_leaf). These were dropped
+# entirely before — subtitle, captions, credit line, section headers, and BAN
+# annotations all vanished. Dashboard-level chrome, so skipped in
+# --page-per-worksheet (which ignores the dashboard layout by design).
+styled_text_by_dash = Hash.new { |h, k| h[k] = [] }
+unless opts[:pages_mode] == :worksheet
+  layout.each do |dash|
+    (dash['zones'] || []).each do |z|
+      next unless %w[text title].include?(z['kind']) && z['text_runs']
+      body = text_body_from_runs(z['text_runs'], align: z['text_align'],
+                                 bg: (z['is_pill'] ? z['fill_color'] : nil))
+      next if body.nil?
+      if z['text_runs'].any? { |r| r['text'].to_s.include?('<[') }
+        warnings << "dashboard '#{dash['dashboard']}' text zone #{z['id']}: dynamic Tableau token(s) " \
+                    '(<[Parameters]…>) dropped from static text — not reproducible as literal text'
+      end
+      el = { 'id' => "text-#{z['id']}", 'kind' => 'text', 'body' => body }
+      # Short single-line annotations/pills read better vertically centered.
+      el['verticalAlign'] = 'middle' if z['is_pill'] || z['text_runs'].none? { |r| r['break'] }
+      el['_dashboard'] = dash['dashboard']
+      styled_text_by_dash[dash['dashboard']] << el
+    end
+  end
+end
+styled_text_all = styled_text_by_dash.values.flatten(1)
 
 # ---- Control targeting: intended-scope closure ------------------------------
 # A control filter applied to an element propagates to every element that
@@ -4364,6 +4431,9 @@ elsif opts[:pages_mode] == :dashboard
       # White span: the layout builder wraps this in the DARK header band.
       'body' => %(# <span style="color: #FFFFFF">#{dash_name}</span>)
     }]
+    # B4: this dashboard's styled static-text elements (subtitle/annotations/
+    # credit/section headers). Placed by the layout stage at their zone geometry.
+    styled_text_by_dash[dash_name].each { |e| page_extras << e.reject { |k, _| k == '_dashboard' } }
     ctl_rewrites = {}
     param_control_ids = param_controls.map { |c| c['controlId'] }
     (param_controls + auto_controls).each do |c|
@@ -4419,9 +4489,11 @@ elsif opts[:pages_mode] == :dashboard
 else
   elements.each { |e| e.delete('_worksheet'); e.delete('_dashboard') }
   all_extras.each { |e| e.delete('_scope_dashboards') }
-  all_elements = all_extras + elements
+  styled_text_all.each { |e| e.delete('_dashboard') }
+  all_elements = all_extras + styled_text_all + elements
   File.write(opts[:out], JSON.pretty_generate(all_elements))
-  warn "wrote #{opts[:out]}  (#{all_elements.size} elements: #{all_extras.size} controls/text + #{elements.size} charts)"
+  warn "wrote #{opts[:out]}  (#{all_elements.size} elements: #{all_extras.size} controls/text + " \
+       "#{styled_text_all.size} styled-text + #{elements.size} charts)"
   if data_elements.any?
     side = opts[:out].sub(/\.json$/, '-data-elements.json')
     File.write(side, JSON.pretty_generate(data_elements))

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -2243,15 +2243,22 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
 
   # B3 (gap ubr5.7): a Tableau "big number" BAN scorecard (Shape/Circle mark with
   # a <customized-label>, surfaced by the parser as kpi_value_font_size). Style
-  # the composite faithfully: use the label run as the KPI title, keep the
+  # the composite faithfully: use the label run as the KPI title and keep the
   # SOURCE font size (fidelity mandate — prefer the .twb value over a hand-tuned
-  # one), and render the hero transparent so a container tint shows through
-  # (composition layer, styling.md). Non-BAN KPIs (Automatic-mark scorecards)
-  # carry no kpi_value_font_size and keep their default styling.
+  # one). Non-BAN KPIs (Automatic-mark scorecards) carry no kpi_value_font_size
+  # and keep their default styling.
+  #
+  # NOTE (transparency is a COMPOSITION decision, not an element one): a
+  # transparent hero (backgroundColor #00000000) only reads well when a container
+  # TINT sits behind it (the composed region-card look). Applied to a KPI that
+  # is NOT inside a tinted container it strips the default card and the number
+  # floats naked on the canvas — a regression vs the plain KPI card. The element
+  # builder can't see its container, so it must NOT force transparency here; the
+  # composition stage (B1/B2 region cards) sets it when it actually places a KPI
+  # into a tint. So we set label + fontSize only and leave the default card.
   if z['kpi_value_font_size']
     element['name'] = z['kpi_label'] if z['kpi_label'] && !z['kpi_label'].to_s.strip.empty?
     element['value']['fontSize'] = z['kpi_value_font_size']
-    element['style'] = { 'padding' => 'none', 'backgroundColor' => '#00000000' }
     # The BAN's side annotation (e.g. "40% of U.S. total") is driven by a dynamic
     # Tableau calc token that can't be reproduced as static text; emitting the
     # literal remainder ("of U.S. total") alone would mislead. Surface the gap.
@@ -3771,7 +3778,11 @@ def text_body_from_runs(runs, align: nil, bg: nil)
       next '' if raw.empty?
       next raw if raw.strip.empty? # whitespace spacer → literal (keeps run spacing)
       esc = raw.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
-      esc = "**#{esc}**" if r['bold']
+      # Bold markers must hug the text — markdown won't bold "** Rank**" (leading
+      # space inside the **). Keep any leading/trailing whitespace OUTSIDE.
+      if r['bold'] && (mm = esc.match(/\A(\s*)(.*?)(\s*)\z/m)) && !mm[2].empty?
+        esc = "#{mm[1]}**#{mm[2]}**#{mm[3]}"
+      end
       styles = []
       styles << "color: #{r['color']}" if r['color']
       styles << "font-size: #{r['font_size']}px" if r['font_size']
@@ -3790,7 +3801,16 @@ end
 auto_title = nil
 if opts[:title].nil?
   layout.each do |dash|
-    next unless dash['zones'].any? { |z| %w[title text].include?(z['kind']) && (z['y_pct'] || 100) < 10 }
+    top = dash['zones'].select { |z| %w[title text].include?(z['kind']) && (z['y_pct'] || 100) < 10 }
+    next if top.empty?
+    # B4 (gap ubr5.8): a top text/title zone that carries run-level formatting
+    # is the dashboard's OWN hero title — it is emitted faithfully as a styled
+    # `text-<id>` element (black-on-canvas, at its position). Do NOT ALSO
+    # synthesize the white dashboard-name title here: the two double up, and the
+    # synthetic one (white, meant for the dark header band) renders invisibly
+    # over a light canvas when the composed layout has no dark band. Only
+    # synthesize when the top zone is a BARE title with no styled runs for B4.
+    next if top.any? { |z| z['text_runs'] }
     auto_title = dash['dashboard']
     break
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -195,13 +195,39 @@ end
 # children are placed in the container's own 24-col internal grid; empty
 # containers (no resolvable children) are dropped. Appends new container spec
 # placeholders to ctx[:extra]; records placed element ids in ctx[:placed].
+# Resolve overlapping sibling placements within a container. Tableau floats text
+# objects (titles, captions, annotations) over/beside charts, so their derived
+# grid cells can overlap — and Sigma's put-layout REJECTS the whole layout on any
+# collision, dropping the page to a raw vertical stack. The banded path already
+# de-collides (lib/layout.rb decollide_bands); the container-tree path did not,
+# so a floated text zone could sink the entire layout (B4-emit regression).
+#
+# rects are [c0,c1,r0,r1] grid-line tuples, container-relative. NO-OP when the
+# children don't collide (clean source geometry — e.g. a KPI strip — is preserved
+# EXACTLY). Only when a collision exists do we re-flow: give every child an equal
+# vertical row slice (columns kept), which is collision-free by construction
+# (non-overlapping rows) and localized to the offending container — strictly
+# better than the previous whole-page stack fallback.
+def decollide_rects(rects, my_rows)
+  return rects if rects.length < 2
+  overlap = ->(a, b) { a[0] < b[1] && b[0] < a[1] && a[2] < b[3] && b[2] < a[3] }
+  return rects unless rects.combination(2).any? { |a, b| overlap.call(a, b) }
+  n = rects.length
+  rects.each_index.map do |i|
+    nr0 = 1 + (my_rows * i / n.to_f).round
+    nr1 = [1 + (my_rows * (i + 1) / n.to_f).round, nr0 + 1].max
+    [rects[i][0], rects[i][1], nr0, nr1] # keep columns, non-overlapping rows
+  end
+end
+
 def emit_node(node, c0, c1, r0, r1, ctx)
   if node['kind'] == 'container'
     kids = node['children'] || []
     my_rows = [r1 - r0, 2].max
-    inner = kids.map do |ch|
-      kc0, kc1, kr0, kr1 = place_in_parent(ch, node, my_rows)
-      emit_node(ch, kc0, kc1, kr0, kr1, ctx)
+    rects = kids.map { |ch| place_in_parent(ch, node, my_rows) }
+    rects = decollide_rects(rects, my_rows)
+    inner = kids.each_index.map do |i|
+      emit_node(kids[i], *rects[i], ctx)
     end.compact
     return nil if inner.empty?
     cid = "tc-#{ctx[:page_id]}-#{node['id']}"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -181,6 +181,11 @@ def resolve_leaf(node, ctx)
     if ctx[:title_el] && !ctx[:title_used]
       ctx[:title_used] = true
       ctx[:title_el]['id']
+    else
+      # B4 (gap ubr5.8): styled static-text zone → its emitted element
+      # (build-charts id "text-<zoneid>"), placed at the zone's own geometry.
+      el = ctx[:els_by_id]["text-#{node['id']}"]
+      el && el['id']
     end
   end
 end
@@ -226,10 +231,14 @@ def build_page_from_tree(dashboard, page, opts)
   els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
   ctl_by_name = page['elements'].select { |e| e['kind'] == 'control' && e['name'] }
                     .each_with_object({}) { |e, h| h[e['name'].to_s.downcase] = e }
-  title_el    = page['elements'].find { |e| e['kind'] == 'text' }
+  els_by_id   = page['elements'].each_with_object({}) { |e, h| h[e['id']] = e if e['id'] }
+  # Pin the header title to the dedicated title element (build-charts prepends id
+  # "title-text"/"title-<slug>"); a bare first-text-element match would grab a B4
+  # styled-text element once those exist. Falls back to the page name when absent.
+  title_el    = page['elements'].find { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('title') }
 
   ctx = { page_id: page['id'], renames: opts[:renames], els_by_name: els_by_name,
-          ctl_by_name: ctl_by_name, title_el: title_el, title_used: false,
+          ctl_by_name: ctl_by_name, els_by_id: els_by_id, title_el: title_el, title_used: false,
           extra: [], placed: [], zone_to_ctl: {} }
 
   # Assign workbook control elements to control zones (filter/parameter), in
@@ -290,7 +299,7 @@ def build_page_from_tree(dashboard, page, opts)
   # the "one tile top-left, everything else gone" regression. Placeable content
   # = any *-chart, table/pivot-table, control, or text (exclude structural
   # containers/data). No `name` requirement (charts built from signals may not
-  # carry one, yet must still be placed).
+  # carry one, yet must still be placed). `text` kind also covers B4 styled-text.
   placeable = ->(e) {
     k = e['kind'].to_s
     k.end_with?('-chart') || %w[table pivot-table control text].include?(k)
@@ -318,7 +327,9 @@ end
 def build_page_for_dashboard(dashboard, page, opts)
   chart_zones = dashboard['zones'].select { |z| z['kind'] == 'chart' && z['caption'] }
   els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
-  title_el = page['elements'].find { |e| e['kind'] == 'text' }
+  # Pin to the dedicated title element (see build_page_from_tree) so a B4
+  # styled-text element isn't mistaken for the header title.
+  title_el = page['elements'].find { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('title') }
   ctl_els  = page['elements'].select { |e| e['kind'] == 'control' }
 
   # Per-dashboard copy of the band tuning — auto-fit must not leak between
@@ -404,6 +415,28 @@ def build_page_for_dashboard(dashboard, page, opts)
     cid = "#{ov_prefix}-#{i + 1}"
     extra_els << container_el(cid)
     children << band_container_xml(cid, band, row_offset: band_offset)
+  end
+
+  # B4 (gap ubr5.8): the banded fallback places charts by geometry but not text.
+  # Rather than orphan the emitted styled-text elements (present in the workbook,
+  # absent from the layout), tile them across a labelled bottom band so nothing
+  # silently drops — WARN, since their exact source position isn't reproduced in
+  # the banded path (the container-tree path DOES place them at zone geometry).
+  text_els = page['elements'].select { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('text-') }
+  unless text_els.empty?
+    tn = text_els.length
+    r0 = 1 + HEADER_ROWS + ctl_rows + bands.sum { |b| b.map { |i| i[4] }.max - b.map { |i| i[3] }.min }
+    inner = text_els.each_with_index.map do |e, i|
+      c0 = 1 + (o[:page_cols] * i / tn.to_f).round
+      c1 = i == tn - 1 ? o[:page_cols] + 1 : [1 + (o[:page_cols] * (i + 1) / tn.to_f).round, c0 + 1].max
+      le(e['id'], c0, c1, 1, 4)
+    end.join("\n")
+    tid = "#{ov_prefix}-text"
+    extra_els << container_el(tid)
+    children << gc(tid, 1, o[:page_cols] + 1, r0, r0 + 4, inner)
+    warn "WARN: #{tn} styled-text element(s) placed in a bottom band on banded page #{page['name'].inspect} " \
+         "(source position not reproduced — the container-tree layout places them by geometry): " \
+         "#{text_els.map { |e| e['id'] }.join(', ')}"
   end
 
   [page_xml(page['id'], *children), extra_els, chart_layouts.length, bands.length, ctl_els.length]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/twb_xml.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/twb_xml.rb
@@ -28,7 +28,19 @@
 # regardless of the context node (matching REXML's behavior). So expressions
 # pass through unchanged.
 
-require 'nokogiri'
+# Nokogiri gives O(n) parsing on large .twb files and is the normal path (the
+# converter's runtime ships it). When it's absent — creds-free CI, no-egress
+# stdlib-only environments — fall back to REXML: the El wrapper mirrors REXML's
+# API exactly, so a real REXML::Document is a drop-in return value. REXML is
+# O(n^2) on huge workbooks, but the only files parsed without Nokogiri are small
+# (unit-test fixtures), so the perf cliff never bites.
+begin
+  require 'nokogiri'
+  TWB_XML_NOKOGIRI = true
+rescue LoadError
+  require 'rexml/document'
+  TWB_XML_NOKOGIRI = false
+end
 
 module TwbXml
   # Wraps a Nokogiri node (Element or Document) and re-exposes the REXML methods.
@@ -101,8 +113,11 @@ module TwbXml
     end
   end
 
-  # Drop-in replacement for REXML::Document.new(string).
+  # Drop-in replacement for REXML::Document.new(string). With Nokogiri, wrap it
+  # in El (the REXML-API shim); without it, return a real REXML::Document, which
+  # already exposes the same API the .twb scripts call.
   def self.parse(xml_string)
+    return REXML::Document.new(xml_string) unless TWB_XML_NOKOGIRI
     El.new(Nokogiri::XML(xml_string))
   end
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -350,12 +350,59 @@ xml.elements.each('/workbook/datasources/datasource') do |ds|
   end
 end
 
+# ── Phase-1 B3: KPI scorecard <customized-label> (BAN) extraction ────────────
+# A Tableau "big number" scorecard often uses a Shape/Circle mark with the value
+# rendered as a <customized-label> BAN inside the pane, e.g.:
+#   <customized-label><formatted-text>
+#     <run fontcolor='#333' fontsize='10'>Total Job Losses</run>   ← label
+#     <run fontsize='26'><[…measure…]></run>                        ← BAN value
+#     <run fontcolor='#666' fontsize='8'>of U.S. total</run>        ← annotation
+#   </formatted-text></customized-label>
+# Returns {label, value_font_size, annotation_runs} when a BAN (a run whose font
+# size is >= KPI_BAN_MIN_FONT — the "big number") is present, else nil. The BAN
+# lets a Shape/Circle-mark scorecard qualify as a KPI (narrow: a real scatter has
+# no big-font customized-label), and feeds the B3 composite emit (label + big
+# value + side annotation). Runs mirror zone_text_fields' shape (Æ = U+00C6
+# line-break sentinel); `ref`=true marks a dynamic <[…]> field/measure token.
+KPI_BAN_MIN_FONT = 16
+def parse_customized_label(ws)
+  cl = ws.elements['.//customized-label']
+  return nil unless cl
+  runs = []
+  cl.elements.each('.//run') do |r|
+    txt = r.text.to_s.gsub("Æ", '')
+    a = r.attributes
+    runs << {
+      'text'      => txt,
+      'color'     => (c = a['fontcolor']) && !c.empty? ? c : nil,
+      'font_size' => (fs = a['fontsize']) && !fs.empty? ? fs.to_i : nil,
+      'bold'      => a['bold'] == 'true',
+      'break'     => txt.include?("\n"),
+      'ref'       => txt.include?('<[')
+    }.compact
+  end
+  return nil if runs.empty?
+  ban_i    = runs.each_index.max_by { |i| runs[i]['font_size'] || 0 }
+  ban_font = (runs[ban_i] && runs[ban_i]['font_size']) || 0
+  return nil if ban_font < KPI_BAN_MIN_FONT
+  # Label = leading non-ref, non-spacer, non-tiny (>= 6pt) text runs before the
+  # BAN value run (drops the invisible filler runs Tableau injects for spacing).
+  label = runs[0...ban_i]
+          .reject { |r| r['ref'] || r['text'].to_s.strip.empty? || (r['font_size'] && r['font_size'] < 6) }
+          .map { |r| r['text'] }.join(' ').gsub(/\s+/, ' ').strip
+  { 'label'           => (label.empty? ? nil : label),
+    'value_font_size' => ban_font,
+    'annotation_runs' => (runs[(ban_i + 1)..] || []) }.compact
+end
+
 worksheets = {}
 xml.elements.each('//worksheet') do |ws|
   name = ws.attributes['name']
   next unless name
   mark = ws.elements['.//mark']
   mark_class = mark ? (mark.attributes['class'].to_s) : nil
+  # Phase-1 B3: a Shape/Circle scorecard's big-number <customized-label> (nil otherwise).
+  kpi_ban = parse_customized_label(ws)
 
   geo_role = nil
   has_lat  = false
@@ -649,8 +696,13 @@ xml.elements.each('//worksheet') do |ws|
   # zero-dim single-measure sheet renders as a big-number text table — the
   # FATSCALE rehearsal lost 14/40 tiles because these fell through to the
   # CSV-driven flow (1-column CSV → zone dropped).
+  # Phase-1 B3: a Shape/Circle scorecard carrying a big-number <customized-label>
+  # BAN is a KPI too (Tableau's "big number on a dot" idiom). Narrow by design —
+  # a real scatter/symbol plot has no large-font customized-label — so ordinary
+  # Shape/Circle marks keep flowing to scatter.
+  ban_scorecard_mark = !kpi_ban.nil? && %w[shape circle].include?(mark_class.to_s.downcase)
   kpi_capable_mark = is_text_mark || mark_class.to_s.downcase == 'automatic' ||
-                     mark_class.to_s.empty?
+                     mark_class.to_s.empty? || ban_scorecard_mark
   total_dim_count = rows_shelf['dim_count'] + cols_shelf['dim_count']
   total_measure_count = rows_shelf['measure_count'] + cols_shelf['measure_count'] + measures.size
   is_kpi = kpi_capable_mark && !is_crosstab &&
@@ -715,7 +767,11 @@ xml.elements.each('//worksheet') do |ws|
     rows_shelf:       rows_shelf,
     cols_shelf:       cols_shelf,
     is_crosstab:      is_crosstab,
-    is_kpi:           is_kpi
+    is_kpi:           is_kpi,
+    # Phase-1 B3: KPI composite signals (nil unless a BAN scorecard label exists)
+    kpi_label:            kpi_ban && kpi_ban['label'],
+    kpi_value_font_size:  kpi_ban && kpi_ban['value_font_size'],
+    kpi_annotation_runs:  kpi_ban && kpi_ban['annotation_runs']
   }
 end
 
@@ -840,10 +896,10 @@ def chart_kind_for(meta)
   when 'line'       then 'line'
   when 'area'       then 'area'
   when 'pie'        then 'pie'
-  when 'circle'     then 'scatter'                # symbol marks (non-geo) = scatter
+  when 'circle'     then (meta[:is_kpi] ? 'kpi' : 'scatter')  # BAN scorecard on a dot, else symbol=scatter
   when 'square'     then (meta[:is_crosstab] ? 'pivot-table' : (meta[:is_kpi] ? 'kpi' : 'table'))
   when 'text'       then (meta[:is_crosstab] ? 'pivot-table' : (meta[:is_kpi] ? 'kpi' : 'table'))
-  when 'shape'      then 'scatter'
+  when 'shape'      then (meta[:is_kpi] ? 'kpi' : 'scatter')  # big-number BAN, else symbol=scatter
   # Automatic is Tableau's default-pick — but a zero-dim single-measure sheet
   # under Automatic renders as a big-number text table, i.e. a KPI (bead 3w4d).
   when 'automatic'
@@ -1087,6 +1143,10 @@ xml.elements.each('//dashboard') do |d|
       'cols_shelf'   => (kind == 'chart' ? ws_meta&.dig(:cols_shelf)    : nil),
       'is_crosstab'  => (kind == 'chart' ? ws_meta&.dig(:is_crosstab)   : nil),
       'is_kpi'       => (kind == 'chart' ? ws_meta&.dig(:is_kpi)        : nil),
+      # Phase-1 B3: KPI composite signals (nil unless a BAN scorecard)
+      'kpi_label'           => (kind == 'chart' ? ws_meta&.dig(:kpi_label)           : nil),
+      'kpi_value_font_size' => (kind == 'chart' ? ws_meta&.dig(:kpi_value_font_size) : nil),
+      'kpi_annotation_runs' => (kind == 'chart' ? ws_meta&.dig(:kpi_annotation_runs) : nil),
       # Resolved filter target (filter/parameter zones only)
       'filter_column_caption'  => (kind == 'filter' || kind == 'parameter' ? filter_col_caption  : nil),
       'filter_column_datatype' => (kind == 'filter' || kind == 'parameter' ? filter_col_datatype : nil),
@@ -1161,6 +1221,9 @@ if dashboards.empty? && !worksheets.empty?
         'cols_shelf'   => ws_meta[:cols_shelf],
         'is_crosstab'  => ws_meta[:is_crosstab],
         'is_kpi'       => ws_meta[:is_kpi],
+        'kpi_label'           => ws_meta[:kpi_label],
+        'kpi_value_font_size' => ws_meta[:kpi_value_font_size],
+        'kpi_annotation_runs' => ws_meta[:kpi_annotation_runs],
         'filter_column_caption'  => nil,
         'filter_column_datatype' => nil
       }]

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-composite-emit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-composite-emit.rb
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+# End-to-end test for Phase-1 B3 KPI-composite EMIT (build-charts-from-signals.rb).
+# A Tableau BAN scorecard (Shape mark + big-number <customized-label>, detected
+# by the B3 parser) must emit a Sigma kpi-chart styled as the composite:
+#   - name = the label run ("Total Job Losses"), NOT the worksheet caption
+#   - value.fontSize = the SOURCE BAN font size (fidelity mandate — the .twb
+#     value, not a hand-tuned one)
+#   - style = transparent hero ({padding:none, backgroundColor:'#00000000'}) so a
+#     container tint shows through
+# and it must WARN that the customized-label's dynamic-value annotation (a
+# "% of total" calc) is not reproduced.
+#
+# Runs the ACTUAL parse-twb-layout.rb + build-charts-from-signals.rb (build_kpi_
+# element has many internal helper deps, so this drives the whole script rather
+# than eval-extracting one def). Deterministic + offline (empty view CSV; the
+# element is built from .twb signals).
+#
+# Usage:  ruby scripts/test-kpi-composite-emit.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+BUILD  = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='Fact' name='federated.x'>
+        <connection class='federated'>
+          <named-connections>
+            <named-connection name='snow'><connection class='snowflake' dbname='CSA' schema='TJ' /></named-connection>
+          </named-connections>
+          <relation connection='snow' name='STATE_FACT' table='[TJ].[STATE_FACT]' type='table' />
+        </connection>
+        <column caption='Total Job Losses' name='[TJL]' datatype='real' role='measure' type='quantitative' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='South Job losses'>
+        <table>
+          <view><datasource-dependencies datasource='federated.x'>
+            <column caption='Total Job Losses' name='[TJL]' datatype='real' role='measure' type='quantitative' />
+            <column-instance column='[TJL]' derivation='Sum' name='[sum:TJL:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies></view>
+          <pane>
+            <mark class='Shape' />
+            <customized-label>
+              <formatted-text>
+                <run bold='false' fontcolor='#333333' fontsize='10'>Total Job Losses</run>
+                <run fontsize='26'><![CDATA[<[federated.x].[sum:TJL:qk]>]]></run>
+                <run fontcolor='#666666' fontsize='12'><![CDATA[<[federated.x].[usr:pct:qk]>]]></run>
+                <run bold='false' fontcolor='#666666' fontsize='8'>Æ of U.S. total</run>
+              </formatted-text>
+            </customized-label>
+          </pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='D'>
+        <zones><zone id='1' name='South Job losses' x='0' y='0' w='100000' h='100000' /></zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+MASTER_MAP = { '(?i)^Total Job Losses$' => { 'id' => 'm-tjl', 'name' => 'Total Job Losses' } }
+
+build_out = nil
+build_log = ''
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  mm  = File.join(d, 'master-map.json')
+  File.write(twb, TWB)
+  File.write(mm, JSON.dump(MASTER_MAP))
+  File.write(File.join(d, 'get-workbook.json'),
+             JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => 'South Job losses' }] }))
+  Dir.mkdir(File.join(d, 'views'))
+  File.write(File.join(d, 'views', 'v1.csv'), '')
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  out = File.join(d, 'specs.json')
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --title D --out #{out} 2>&1`
+  build_out = JSON.parse(File.read(out)) if File.exist?(out)
+end
+
+els = build_out ? (build_out.is_a?(Array) ? build_out : (build_out['elements'] || (build_out['pages'] || []).flat_map { |p| p['elements'] || [] })) : []
+kpi = els.find { |e| e['kind'] == 'kpi-chart' }
+
+check(!kpi.nil?, 'BAN scorecard emitted as a kpi-chart (not a scatter)', fails)
+check(kpi && kpi['name'] == 'Total Job Losses',
+      "KPI name = the customized-label label run, not the worksheet caption (got #{kpi && kpi['name'].inspect})", fails)
+check(kpi && kpi.dig('value', 'fontSize') == 26,
+      "value.fontSize = SOURCE BAN font size 26 (got #{kpi && kpi.dig('value', 'fontSize').inspect})", fails)
+check(kpi && kpi.dig('value', 'columnId'),
+      'value still carries columnId (kpi-chart contract)', fails)
+check(kpi && kpi.dig('style', 'backgroundColor') == '#00000000' && kpi.dig('style', 'padding') == 'none',
+      "KPI hero is transparent (style backgroundColor #00000000 + padding none) (got #{kpi && kpi['style'].inspect})", fails)
+check(build_log.include?('annotation is NOT reproduced'),
+      'builder WARNs the dynamic-value annotation is not reproduced', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — B3 KPI composite emit (label name + source fontSize + transparent hero + annotation WARN)'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  puts "\n--- build log (tail) ---\n#{build_log.to_s.lines.last(12).join}"
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-composite-emit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-composite-emit.rb
@@ -103,8 +103,12 @@ check(kpi && kpi.dig('value', 'fontSize') == 26,
       "value.fontSize = SOURCE BAN font size 26 (got #{kpi && kpi.dig('value', 'fontSize').inspect})", fails)
 check(kpi && kpi.dig('value', 'columnId'),
       'value still carries columnId (kpi-chart contract)', fails)
-check(kpi && kpi.dig('style', 'backgroundColor') == '#00000000' && kpi.dig('style', 'padding') == 'none',
-      "KPI hero is transparent (style backgroundColor #00000000 + padding none) (got #{kpi && kpi['style'].inspect})", fails)
+# Transparency is a COMPOSITION decision (only reads well over a container tint),
+# so the element builder must NOT force it — the KPI keeps its default card until
+# the composition stage (B1/B2) places it in a tint. A naked transparent KPI on
+# the canvas was the regression we are fixing.
+check(kpi && kpi['style'].nil?,
+      "KPI keeps its DEFAULT card — no forced transparent style at the element level (got #{kpi && kpi['style'].inspect})", fails)
 check(build_log.include?('annotation is NOT reproduced'),
       'builder WARNs the dynamic-value annotation is not reproduced', fails)
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-scorecard-detection.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-scorecard-detection.rb
@@ -1,0 +1,144 @@
+#!/usr/bin/env ruby
+# Regression test for Phase-1 B3 KPI-scorecard detection in parse-twb-layout.rb.
+# Tableau "big number" scorecards frequently use a Shape/Circle mark with the
+# value rendered as a <customized-label> BAN (a large-font run), e.g. the "Job
+# Loss from Mass Deportations" region cards:
+#   <pane><mark class='Shape'/>
+#     <customized-label><formatted-text>
+#       <run fontcolor='#333' fontsize='10'>Total Job Losses</run>   ← label
+#       <run fontcolor='#f5f5f5' fontsize='2'>2</run>                ← invisible filler
+#       <run fontsize='26'><[…measure…]></run>                       ← BAN value
+#       <run fontcolor='#666' fontsize='8'>of U.S. total</run>       ← annotation
+#     </formatted-text></customized-label></pane>
+# Before B3 the parser mapped Shape → scatter, so is_kpi was FALSE and the KPI
+# path never fired for these tiles. Detection is NARROW: only a Shape/Circle mark
+# that carries a big-font customized-label BAN qualifies — an ordinary symbol
+# scatter (no BAN) must stay a scatter.
+#
+# Asserts, end-to-end through the ACTUAL parse-twb-layout.rb:
+#   1. Shape mark + BAN customized-label + zero dims → chart_kind == 'kpi'.
+#   2. kpi_label = the leading label run ("Total Job Losses"); the invisible
+#      tiny filler run is dropped from the label.
+#   3. kpi_value_font_size = the BAN run's size (26).
+#   4. kpi_annotation_runs carries the trailing annotation ("of U.S. total"),
+#      with the dynamic <[…]> value run flagged ref=true and the Æ sentinel gone.
+#   5. A Shape mark WITHOUT a big customized-label (a real scatter) stays
+#      chart_kind == 'scatter' and is_kpi is false (narrow — no false positives).
+#
+# Usage:  ruby scripts/test-kpi-scorecard-detection.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='Fact' name='federated.x'>
+        <column caption='Job Losses' name='[JL]' datatype='real' role='measure' type='quantitative' />
+        <column caption='Rate' name='[RT]' datatype='real' role='measure' type='quantitative' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Region BAN'>
+        <table>
+          <view><datasource-dependencies datasource='federated.x'>
+            <column caption='Job Losses' name='[JL]' datatype='real' role='measure' type='quantitative' />
+            <column-instance column='[JL]' derivation='Sum' name='[sum:JL:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies></view>
+          <pane>
+            <mark class='Shape' />
+            <customized-label>
+              <formatted-text>
+                <run bold='false' fontcolor='#333333' fontsize='10'>Total Job Losses</run>
+                <run bold='false' fontcolor='#f5f5f5' fontsize='2'>2</run>
+                <run fontsize='26'><![CDATA[<[federated.x].[sum:JL:qk]>]]></run>
+                <run>Æ&#10;</run>
+                <run fontcolor='#666666' fontsize='12'><![CDATA[<[federated.x].[usr:pct:qk]>]]></run>
+                <run bold='false' fontcolor='#666666' fontsize='8'>Æ of U.S. total</run>
+              </formatted-text>
+            </customized-label>
+          </pane>
+        </table>
+      </worksheet>
+      <worksheet name='Scatter Plot'>
+        <table>
+          <view><datasource-dependencies datasource='federated.x'>
+            <column caption='Job Losses' name='[JL]' datatype='real' role='measure' type='quantitative' />
+            <column caption='Rate' name='[RT]' datatype='real' role='measure' type='quantitative' />
+            <column-instance column='[JL]' derivation='Sum' name='[sum:JL:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[RT]' derivation='Sum' name='[sum:RT:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies></view>
+          <rows>[federated.x].[sum:JL:qk]</rows>
+          <cols>[federated.x].[sum:RT:qk]</cols>
+          <pane><mark class='Shape' /></pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='D'>
+        <zones><zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+          <zone id='2' name='Region BAN'  x='0'     y='0' w='50000' h='100000' />
+          <zone id='3' name='Scatter Plot' x='50000' y='0' w='50000' h='100000' />
+        </zone></zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+layout = nil
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  File.write(twb, TWB)
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+  layout = JSON.parse(File.read(lay))
+end
+zones = (layout || []).find { |x| x['dashboard'] == 'D' }&.dig('zones') || []
+
+ban = zones.find { |z| z['caption'] == 'Region BAN' }
+scat = zones.find { |z| z['caption'] == 'Scatter Plot' }
+
+# ---- 1. Shape + BAN → kpi --------------------------------------------------
+check(ban && ban['chart_kind'] == 'kpi',
+      "Shape mark + BAN customized-label → chart_kind 'kpi' (got #{ban && ban['chart_kind'].inspect})", fails)
+# ---- 2. label extracted, filler dropped ------------------------------------
+check(ban && ban['kpi_label'] == 'Total Job Losses',
+      "kpi_label = leading label, tiny filler run dropped (got #{ban && ban['kpi_label'].inspect})", fails)
+# ---- 3. BAN font size -------------------------------------------------------
+check(ban && ban['kpi_value_font_size'] == 26,
+      "kpi_value_font_size = BAN run size 26 (got #{ban && ban['kpi_value_font_size'].inspect})", fails)
+# ---- 4. annotation runs: trailing text + ref flag + no Æ -------------------
+ann = ban && ban['kpi_annotation_runs']
+check(ann.is_a?(Array) && ann.any? { |r| r['text'].to_s.include?('of U.S. total') },
+      "kpi_annotation_runs carries the trailing annotation text (got #{ann.inspect})", fails)
+check(ann && ann.any? { |r| r['ref'] == true },
+      'the dynamic <[…]> percent run is flagged ref=true (emit strips it)', fails)
+check(ann && ann.none? { |r| r['text'].to_s.include?('Æ') },
+      'the Æ line-break sentinel is stripped from annotation runs', fails)
+# ---- 5. NARROW: real Shape scatter stays scatter ---------------------------
+check(scat && scat['chart_kind'] == 'scatter',
+      "Shape mark WITHOUT a BAN stays 'scatter' (got #{scat && scat['chart_kind'].inspect})", fails)
+check(scat && !scat['is_kpi'],
+      "the scatter is NOT a false-positive KPI (is_kpi=#{scat && scat['is_kpi'].inspect})", fails)
+check(scat && scat['kpi_label'].nil?,
+      'the scatter carries no kpi_label', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — B3 KPI-scorecard detection (Shape/Circle + BAN → kpi; narrow, no scatter false-positives)'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-body.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-body.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# Unit test for the B4 (gap ubr5.8) text-body assembler in
+# build-charts-from-signals.rb: `text_body_from_runs`, which turns Tableau
+# formatted-text runs (parse-twb-layout `text_runs`) into a Sigma text.body —
+# color/font-size spans + **bold**, Æ-break paragraphs, center/right <p>
+# wrappers, pill background spans, dynamic-token stripping. Extracted as a
+# top-level pure def (SRC.match, same pattern as test-control-display-type.rb /
+# test-theme-derivation.rb) so no data-pipeline inputs are needed.
+#
+# Usage:  ruby scripts/test-styled-text-body.rb
+
+require 'json'
+
+DIR = __dir__
+SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+m = SRC.match(/^def text_body_from_runs\b.*?\n^end$/m) or
+  abort 'could not extract text_body_from_runs from build-charts-from-signals.rb'
+eval(m[0])
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# ---- 1. nil / empty ---------------------------------------------------------
+check(text_body_from_runs(nil).nil?, 'nil runs → nil', fails)
+check(text_body_from_runs([]).nil?, 'empty runs → nil', fails)
+check(text_body_from_runs([{ 'text' => '   ' }]).nil?,
+      'whitespace-only single run → nil (nothing visible)', fails)
+
+# ---- 2. single styled run → one span with color + font-size + bold ---------
+b = text_body_from_runs([{ 'text' => 'Job Losses', 'color' => '#1b1b1b', 'font_size' => 24, 'bold' => true }])
+check(b == '<span style="color: #1b1b1b; font-size: 24px">**Job Losses**</span>',
+      "single run → color+size span with **bold** (got #{b.inspect})", fails)
+
+# ---- 3. run with no attrs → plain text (no empty span) ---------------------
+check(text_body_from_runs([{ 'text' => 'plain' }]) == 'plain',
+      'attribute-free run → bare text, no empty span', fails)
+
+# ---- 4. Æ+whitespace spacer kept literal; hard break → \n\n paragraphs ------
+runs = [
+  { 'text' => 'Job Losses', 'color' => '#1b1b1b', 'bold' => true },
+  { 'text' => ' ', 'bold' => true },                    # Æ+whitespace spacer
+  { 'text' => 'from Deportations', 'font_size' => 12 },
+  { 'text' => "\n", 'break' => true },                  # hard break
+  { 'text' => 'Estimating the job loss.', 'color' => '#333333' }
+]
+b = text_body_from_runs(runs)
+check(b.include?('**Job Losses**</span> <span style="font-size: 12px">from Deportations</span>'),
+      "spacer keeps literal space between runs (got #{b.inspect})", fails)
+check(b.split("\n\n").length == 2 && b.split("\n\n").last.include?('Estimating'),
+      'hard-break run splits body into two paragraphs (\n\n)', fails)
+
+# ---- 5. HTML in run text is escaped (can't inject markup) ------------------
+b = text_body_from_runs([{ 'text' => 'a < b & c > d' }])
+check(b == 'a &lt; b &amp; c &gt; d', "raw <, &, > escaped (got #{b.inspect})", fails)
+
+# ---- 6. dynamic Tableau tokens stripped ------------------------------------
+b = text_body_from_runs([{ 'text' => 'The <[Parameters].[Parameter 3]> states', 'color' => '#333333' }])
+check(b && !b.include?('[Parameter') && b.include?('The ') && b.include?('states'),
+      "dynamic <[Parameters]…> token dropped, surrounding text kept (got #{b.inspect})", fails)
+
+# ---- 7. center align → <p style="text-align: center"> wrapper --------------
+b = text_body_from_runs([{ 'text' => 'Learn More', 'bold' => true }], align: 'center')
+check(b == '<p style="text-align: center">**Learn More**</p>',
+      "center align wraps in <p> (got #{b.inspect})", fails)
+# left align is Sigma's default and 400s if forced → never wrapped
+check(!text_body_from_runs([{ 'text' => 'x' }], align: 'left').include?('<p'),
+      'left align is NOT wrapped in <p> (Sigma default; forcing it 400s)', fails)
+
+# ---- 8. pill background span wraps content INSIDE the <p> (valid nesting) ---
+b = text_body_from_runs([{ 'text' => 'Learn More', 'bold' => true }], align: 'center', bg: '#fbe7a8')
+check(b == '<p style="text-align: center"><span style="background-color: #fbe7a8">**Learn More**</span></p>',
+      "pill: bg span nests inside the align <p> (got #{b.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — B4 text_body_from_runs'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-body.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-body.rb
@@ -52,6 +52,11 @@ check(b.include?('**Job Losses**</span> <span style="font-size: 12px">from Depor
 check(b.split("\n\n").length == 2 && b.split("\n\n").last.include?('Estimating'),
       'hard-break run splits body into two paragraphs (\n\n)', fails)
 
+# ---- 4b. bold markers hug the text — leading/trailing space stays OUTSIDE --
+# (markdown won't bold "** Rank**"; the space must be outside the **).
+b = text_body_from_runs([{ 'text' => ' Rank', 'bold' => true }])
+check(b == ' **Rank**', "bold run with a leading space → ' **Rank**' not '** Rank**' (got #{b.inspect})", fails)
+
 # ---- 5. HTML in run text is escaped (can't inject markup) ------------------
 b = text_body_from_runs([{ 'text' => 'a < b & c > d' }])
 check(b == 'a &lt; b &amp; c &gt; d', "raw <, &, > escaped (got #{b.inspect})", fails)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-layout.rb
@@ -1,0 +1,177 @@
+#!/usr/bin/env ruby
+# End-to-end test for B4 (gap ubr5.8) styled static text: parse → build-charts →
+# build-dashboard-layout (no Tableau/Sigma calls). A dashboard text zone that
+# carries run-level formatting must (1) be EMITTED by build-charts as a Sigma
+# `text` element (id "text-<zoneid>") with a color/size-span body, and (2) be
+# PLACED by the layout stage at the text zone's own geometry — while the
+# dedicated title element still owns the header band (header pinning: a bare
+# first-text-element match would otherwise grab the styled text once it exists).
+#
+# Usage:  ruby scripts/test-styled-text-layout.rb
+
+require 'json'
+require 'rexml/document'
+require 'tmpdir'
+
+DIR    = __dir__
+PARSER = File.join(DIR, 'parse-twb-layout.rb')
+CHARTS = File.join(DIR, 'build-charts-from-signals.rb')
+LAYOUT = File.join(DIR, 'build-dashboard-layout.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# A dashboard whose <zones> root container holds a chart, a Region filter (forces
+# the container-tree layout path), and a styled text zone (bold label + hard
+# break + muted annotation) mirroring the benchmark's region-card annotations.
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <datasources>
+      <datasource caption='ORDER_FACT' name='federated.fact'>
+        <connection class='federated'>
+          <named-connections>
+            <named-connection name='snow'><connection class='snowflake' dbname='CSA' schema='TJ' /></named-connection>
+          </named-connections>
+          <relation connection='snow' name='ORDER_FACT' table='[TJ].[ORDER_FACT]' type='table' />
+        </connection>
+        <column caption='Gross Revenue' name='[m-gr]' datatype='real' role='measure' type='quantitative' />
+        <column caption='Region' name='[m-reg]' datatype='string' role='dimension' type='nominal' />
+      </datasource>
+    </datasources>
+    <worksheets>
+      <worksheet name='Sales by Region'>
+        <table>
+          <view>
+            <datasource-dependencies datasource='federated.fact'>
+              <column caption='Gross Revenue' name='[m-gr]' datatype='real' role='measure' type='quantitative' />
+              <column caption='Region' name='[m-reg]' datatype='string' role='dimension' type='nominal' />
+              <column-instance column='[m-reg]' derivation='None' name='[none:m-reg:nk]' pivot='key' type='nominal' />
+              <column-instance column='[m-gr]' derivation='Sum' name='[sum:m-gr:qk]' pivot='key' type='quantitative' />
+            </datasource-dependencies>
+          </view>
+          <rows>[federated.fact].[sum:m-gr:qk]</rows>
+          <cols>[federated.fact].[none:m-reg:nk]</cols>
+          <pane><mark class='Bar' /></pane>
+        </table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='Story'>
+        <zones>
+          <zone id='1' type-v2='layout-basic' x='0' y='0' w='100000' h='100000'>
+            <zone id='2' type-v2='layout-flow' param='vert' x='0' y='0' w='30000' h='100000'>
+              <zone id='3' type-v2='filter' param='[federated.fact].[none:m-reg:nk]' x='0' y='0' w='30000' h='20000' />
+              <zone id='6' type-v2='text' x='0' y='20000' w='30000' h='15000'>
+                <formatted-text>
+                  <run bold='true' fontcolor='#1f8a70' fontsize='13'>Total Job Losses</run>
+                  <run>Æ&#10;</run>
+                  <run fontcolor='#666666' fontsize='10'>40% of U.S. total</run>
+                </formatted-text>
+              </zone>
+            </zone>
+            <zone id='5' name='Sales by Region' x='30000' y='0' w='70000' h='100000' />
+          </zone>
+        </zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+MASTER_MAP = {
+  '(?i)^Gross Revenue$' => { 'id' => 'm-gr',  'name' => 'Gross Revenue' },
+  '(?i)^Region$'        => { 'id' => 'm-reg', 'name' => 'Region' }
+}
+
+specs = nil
+charts_log = ''
+build_log = ''
+xml_doc = nil
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  lay = File.join(d, 'layout.json')
+  mm  = File.join(d, 'master-map.json')
+  File.write(twb, TWB)
+  File.write(mm, JSON.dump(MASTER_MAP))
+  # get-workbook view list + empty CSV (chart rebuilds from .twb signals).
+  File.write(File.join(d, 'get-workbook.json'),
+             JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => 'Sales by Region' }] }))
+  Dir.mkdir(File.join(d, 'views'))
+  File.write(File.join(d, 'views', 'v1.csv'), '')
+  abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
+
+  out = File.join(d, 'specs.json')
+  charts_log = `ruby #{CHARTS} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --title Story --out #{out} 2>&1`
+  specs = JSON.parse(File.read(out)) if File.exist?(out)
+
+  # Synthesize the workbook readback (wb-ids) from the emitted flat element list:
+  # a Data page (master table) + the dashboard page carrying every emitted
+  # element's id/kind/name — exactly what build-dashboard-layout consumes.
+  flat = specs.is_a?(Array) ? specs : (specs['elements'] || [])
+  page_els = flat.map { |e| { 'id' => e['id'], 'kind' => e['kind'], 'name' => e['name'] } }
+  wb_ids = { 'pages' => [
+    { 'name' => 'Data',  'elements' => [{ 'id' => 'master', 'kind' => 'table', 'name' => 'Data' }] },
+    { 'name' => 'Story', 'elements' => page_els }
+  ] }
+  wbf = File.join(d, 'wb-ids.json')
+  lxml = File.join(d, 'layout.xml')
+  File.write(wbf, JSON.dump(wb_ids))
+  build_log = `ruby #{LAYOUT} --layout #{lay} --wb-ids #{wbf} --out #{lxml} 2>&1`
+  if File.exist?(lxml)
+    body = File.read(lxml).sub(/\A<\?xml[^>]*\?>\s*/, '')
+    xml_doc = REXML::Document.new("<Root>#{body}</Root>")
+  end
+end
+
+# ---- 1. build-charts EMITTED the styled text element -----------------------
+flat  = specs && (specs.is_a?(Array) ? specs : (specs['elements'] || []))
+txt   = flat && flat.find { |e| e['id'] == 'text-6' }
+check(txt && txt['kind'] == 'text', "build-charts emitted text zone as element id 'text-6' (got #{txt && txt['kind'].inspect})", fails)
+body  = txt && txt['body'].to_s
+check(body.include?('<span style="color: #1f8a70; font-size: 13px">**Total Job Losses**</span>'),
+      "emitted body carries the bold label span (got #{body.inspect})", fails)
+check(body.include?("\n\n") && body.include?('40% of U.S. total'),
+      'emitted body keeps the hard-break paragraph + annotation', fails)
+# the title element is separate and header-bound
+title = flat && flat.find { |e| e['id'] == 'title-text' }
+check(title && title['kind'] == 'text', 'the dashboard title-text element is still emitted separately', fails)
+
+# ---- 2. layout PLACED the text element at its zone geometry ----------------
+gcs = xml_doc ? xml_doc.elements.to_a('//GridContainer') : []
+def descendant_el_ids(gc)
+  gc.elements.to_a('.//LayoutElement').map { |le| le.attributes['elementId'] }
+end
+all_placed = gcs.flat_map { |g| descendant_el_ids(g) }.uniq
+check(all_placed.include?('text-6'), "layout placed the styled-text element 'text-6' (placed: #{all_placed.inspect})", fails)
+check(build_log.include?('container-tree layout'), 'layout took the container-tree path', fails)
+
+# text-6 lives INSIDE the same rail container as the Region control (its Tableau
+# container), not loose at page root.
+rail_gc = gcs.find do |g|
+  ids = descendant_el_ids(g)
+  ids.include?('text-6') && g.elements.to_a('.//GridContainer').empty?
+end
+check(!rail_gc.nil?, "styled text 'text-6' placed inside its Tableau container (the rail)", fails)
+
+# ---- 3. header pinning: the title element owns the header, NOT the text -----
+# The header band is the container wrapping the title-text element; text-6 must
+# not be the one wrapped in the dark HEADER_STYLE band.
+hdr = gcs.find { |g| descendant_el_ids(g) == ['title-text'] }
+check(!hdr.nil?, 'header band wraps the dedicated title-text element', fails)
+check(all_placed.count('text-6') >= 1 && !(hdr && descendant_el_ids(hdr).include?('text-6')),
+      'the styled-text element is NOT mistaken for the header title', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — B4 styled text: emitted by build-charts + placed at zone geometry by the layout (header pinned)'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |f| puts "  - #{f}" }
+  puts "\n--- build-charts log (tail) ---\n#{charts_log.to_s.lines.last(8).join}"
+  puts "\n--- layout log (tail) ---\n#{build_log.to_s.lines.last(8).join}"
+  exit 1
+end


### PR DESCRIPTION
Re-lands the **general** Tableau→Sigma design-signal work onto a clean base, deliberately leaving the Job-Loss `composition/` special case behind (closed in #266).

Cherry-picked, in order, onto current main:
- **B4 styled-text emit** (#254 work) — styled static-text elements (color/bold/size/align runs) + layout placement. Conflict with #259's safety-net resolved in favor of main's superior `placeable` lambda (it already covers `text` kind).
- **B3 KPI-scorecard parser** (#255) — Shape/Circle-BAN detection, narrow (no scatter false-positives).
- **B3 KPI-composite emit** (`f42d914`) — label name + big-value hero styling.
- **B3/B4 fidelity fixes** (`6334d89`) found via benchmark render.
- CI: the 5 new offline tests are now gated in corpus-check.yml.

Supersedes the tangled path where #254 squash-merged into its stale base branch instead of main. Excludes: `composition/` dir, Job-Loss region-scope commits.

Part of the general design-signal layer (carry any .twb's palette/canvas/tint/text/KPI-composite signals into the built Sigma workbook).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>