### PR TITLE
fix(tableau): wire calc-bound quick-filters to already-materialized master columns

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -595,6 +595,43 @@ def map_column(header, mmap)
   nil
 end
 
+# Resolve a calc-bound quick-filter to an ALREADY-materialized master column by
+# the calc's IDENTITY, not a naive caption match (bead: calc-bound-filter wiring
+# / #259). A quick-filter on a calculated field maps to no raw column, so
+# map_column(cap) is nil and the control was recorded `needs-materialization` —
+# even when the calc is already a column on the master. The filter's caption can
+# arrive as EITHER form, so we bridge both against `columns_by_guid` (keyed by
+# internal name → friendly caption):
+#   - cap is an INTERNAL name, often blend-suffixed ("Calculation_NNN 1"): strip
+#     the " N" secondary-source suffix, resolve to the friendly caption, and try
+#     that against the master (a calc materialized + renamed to its caption — the
+#     an "N. <Level>" hierarchy-level calc case).
+#   - cap is a CAPTION ("Team Bucket"): find the internal name(s) carrying it and
+#     try those (a calc materialized under its raw internal name).
+# Returns the mmap column entry when the calc is already materialized (→ wire it
+# like any quick-filter), else nil (→ genuinely needs materialization). Pure.
+def materialized_calc_column(cap, columns_by_guid, mmap, norm)
+  return nil if cap.nil? || columns_by_guid.nil?
+  base   = cap.to_s.sub(/\s+\d+\z/, '').strip   # strip a blend/secondary suffix
+  target = norm.call(cap)
+  base_n = norm.call(base)
+
+  # Direction 1: cap IS an internal calc name → friendly caption → master.
+  info = columns_by_guid[cap.to_s] || columns_by_guid[base]
+  if info && info['caption']
+    m = map_column(info['caption'], mmap)
+    return m if m
+  end
+
+  # Direction 2: cap is a caption → internal name(s) carrying it → master.
+  columns_by_guid.each do |internal, ci|
+    next unless ci && [target, base_n].include?(norm.call(ci['caption']))
+    m = map_column(internal, mmap)
+    return m if m
+  end
+  nil
+end
+
 # Resolve which Sigma column a Tableau <sort column="..."> targets: the chart's
 # dim or its measure. Tableau sort columns look like
 # `[federated.X].[none:REGION:nk]` or `[sum:NET_REVENUE:qk]` — pull the middle
@@ -4169,6 +4206,15 @@ unless opts[:no_auto_controls]   # default-on: never miss a .twb parameter/filte
       next
     end
     m = map_column(cap, mmap)
+    if m.nil?
+      # Calc-bound filter that's ALREADY materialized on the master under its
+      # internal name (bead: calc-bound-filter wiring / #259) — match by the
+      # calc's identity, not its caption, and wire it like any quick-filter
+      # instead of falsely flagging needs-materialization. (The plan-hierarchy
+      # miss: a hierarchy-level filter whose Calculation_NNN column exists.)
+      m = materialized_calc_column(cap, meta['columns_by_guid'] || {}, mmap, norm_cap)
+      warnings << "quick filter '#{cap}' binds to a calculated field that is ALREADY materialized on the master (matched by calc identity) — wiring it" if m
+    end
     if m.nil?
       # No master-map regex matched. If the caption names a CALCULATED field,
       # that's expected — a calc dim ("Team Bucket", "Tier") has no raw column

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calc-bound-filter-wiring.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-calc-bound-filter-wiring.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Regression test for calc-bound-filter wiring (#259 — the plan-hierarchy miss).
+#
+# A quick-filter bound to a CALCULATED field arrives with a caption that is
+# EITHER the calc's Tableau-internal name (often blend-suffixed, "Calculation_NNN
+# 1") or the friendly caption. When that calc is already MATERIALIZED on the
+# master, the control must WIRE (matched by the calc's identity) instead of being
+# falsely recorded `needs-materialization`. materialized_calc_column bridges both
+# directions against columns_by_guid.
+#
+# Pure-helper extraction harness (same pattern as test-param-measure-picker.rb).
+# Genericized fixtures — no customer identifiers.
+#
+# Usage:  ruby scripts/test-calc-bound-filter-wiring.rb
+require 'json'
+
+DIR = __dir__
+SRC = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+%w[map_column materialized_calc_column].each do |fn|
+  m = SRC.match(/^def #{fn}\b.*?\n^end$/m) or abort("could not extract #{fn}")
+  eval(m[0]) # rubocop:disable Security/Eval — test-only extraction of first-party code
+end
+
+NORM = ->(s) { s.to_s.strip.downcase.gsub(/[^a-z0-9]+/, '') }
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# columns_by_guid: internal calc name → friendly caption (as parse-twb-layout emits).
+CBG = {
+  'Calculation_10000000000000001' => { 'caption' => '2. Region Group' },
+  'Team Bucket'                   => { 'caption' => 'Team Bucket' }
+}
+
+# ---- Direction 1: filter caption is the INTERNAL name, blend-suffixed --------
+# Master materialized the calc UNDER ITS CAPTION ("2. Region Group") — the
+# rename-to-caption case. Filter arrives as "Calculation_NNN 1".
+MMAP_CAPTION = { '(?i)^2\. Region Group$' => { 'id' => 'm-rg', 'name' => '2. Region Group' } }
+m1 = materialized_calc_column('Calculation_10000000000000001 1', CBG, MMAP_CAPTION, NORM)
+check(m1 && m1['id'] == 'm-rg',
+      "internal-name (blend-suffixed) filter → resolves to caption, matches materialized column (got #{m1.inspect})", fails)
+
+# same without the blend suffix
+m1b = materialized_calc_column('Calculation_10000000000000001', CBG, MMAP_CAPTION, NORM)
+check(m1b && m1b['id'] == 'm-rg', 'internal-name (no suffix) filter also resolves', fails)
+
+# ---- Direction 2: filter caption is the CAPTION, calc materialized under raw internal name
+MMAP_INTERNAL = { '(?i)^Calculation_10000000000000001$' => { 'id' => 'm-raw', 'name' => 'Calculation_10000000000000001' } }
+m2 = materialized_calc_column('2. Region Group', CBG, MMAP_INTERNAL, NORM)
+check(m2 && m2['id'] == 'm-raw',
+      "caption filter → finds the internal-named materialized column (got #{m2.inspect})", fails)
+
+# ---- Not materialized → nil (genuinely needs materialization) ----------------
+check(materialized_calc_column('Calculation_10000000000000001 1', CBG, {}, NORM).nil?,
+      'calc absent from master → nil (still needs-materialization)', fails)
+check(materialized_calc_column('Unknown Calc', CBG, MMAP_CAPTION, NORM).nil?,
+      'caption not in columns_by_guid → nil', fails)
+
+# ---- A plain raw-column filter is unaffected (map_column handles it directly) -
+# materialized_calc_column is only a FALLBACK; a raw caption that maps directly
+# never reaches it, but if it did it must not misfire.
+check(materialized_calc_column('Team Bucket', { 'Team Bucket' => { 'caption' => 'Team Bucket' } },
+      { '(?i)^Team Bucket$' => { 'id' => 'm-tb', 'name' => 'Team Bucket' } }, NORM)&.fetch('id') == 'm-tb',
+      'caption==internal-name still resolves (no infinite/degenerate skip)', fails)
+
+# ---- degenerate ----
+check(materialized_calc_column(nil, CBG, MMAP_CAPTION, NORM).nil?, 'nil caption → nil', fails)
+check(materialized_calc_column('x', nil, MMAP_CAPTION, NORM).nil?, 'nil columns_by_guid → nil', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — calc-bound-filter wiring: identity match (both directions) + blend-suffix strip'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end


### PR DESCRIPTION
Part of #259 (TASK 2 — control auto-wiring; the calc-bound-filter net-new item).

## Problem — the plan-hierarchy miss

A quick-filter bound to a **calculated field** was recorded `needs-materialization` whenever `map_column(caption)` missed — **even when that calc is already a column on the master**. The converter only tried a naive caption match, but a calc-bound filter's caption arrives as *either*:
- the calc's Tableau-**internal** name, often **blend-suffixed** (`Calculation_NNN 1`), or
- the **friendly caption** (`2. <Level>`),

and the materialized column may be named under *either* form (the "materialize + rename to caption" case). So a hierarchy-level filter whose column plainly exists was flagged as missing instead of wired.

## Fix

- **`materialized_calc_column`** (new pure helper): bridges both directions against `columns_by_guid` (internal-name → caption) and strips the `" N"` secondary-source suffix.
  - Direction 1 — internal-name (blend-suffixed) filter → resolve friendly caption → match master column (rename-to-caption case).
  - Direction 2 — caption filter → find the internal-named materialized column.
  - Returns the mmap column entry when the calc is already materialized, else `nil`.
- **Calc-bound quick-filter branch**: try `materialized_calc_column` **before** recording `needs-materialization`, and wire it (`status: emitted`, surfaced with a warning) when the column exists. A calc genuinely absent from the master keeps its `needs-materialization` record (never silent).

Pairs with the `mechanical-specs` materialize+rename item (tracked separately): once a calc column is materialized under its caption, this wiring binds it automatically.

## Test

`test-calc-bound-filter-wiring.rb` — 8 checks (both directions, blend-suffix strip, not-materialized → nil, degenerate), genericized fixtures mirroring the real hierarchy-level filter shape. Full tableau suite green (34/35; `test-calc-discovery` pre-fails on `main` — needs `TABLEAU_AUTH_TOKEN`). `tableau-only` — no shared re-vendor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)