### PR TITLE
tableau design-signal APPLY: source palette + source-derived header chrome

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -107,6 +107,8 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-layout.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-scorecard-detection.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-composite-emit.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-derivation.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-brand-palette.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-id-namespacing.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -109,6 +109,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-composite-emit.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-derivation.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-brand-palette.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-header-derivation.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-element-id-namespacing.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fact-pick.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-lint.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -3840,10 +3840,28 @@ end
 # annotations all vanished. Dashboard-level chrome, so skipped in
 # --page-per-worksheet (which ignores the dashboard layout by design).
 styled_text_by_dash = Hash.new { |h, k| h[k] = [] }
+# Normalize a label for KPI-title dedup: lowercase, drop all non-alphanumerics,
+# strip a trailing plural 's'. So "# Feature Types" (label) matches the KPI
+# caption "# Feature Type" — Tableau KPI-card labels routinely differ from the
+# scorecard sheet name by pluralization/punctuation.
+norm_label = ->(s) { s.to_s.downcase.gsub(/[^a-z0-9]/, '').sub(/s\z/, '') }
 unless opts[:pages_mode] == :worksheet
   layout.each do |dash|
+    # KPI captions on this dashboard. A Tableau "KPI card" is a label text zone
+    # ABOVE a scorecard worksheet; Sigma's kpi-chart renders its own title, so a
+    # standalone styled-text zone whose text just repeats a KPI's caption is a
+    # redundant duplicate — emitting it (and dumping it in a stray band) is the
+    # "orphan labels at the bottom" defect. Drop those; keep real prose/sections.
+    kpi_labels = (dash['zones'] || []).select { |z| z['is_kpi'] && z['caption'] }
+                                      .map { |z| norm_label.call(z['caption']) }
     (dash['zones'] || []).each do |z|
       next unless %w[text title].include?(z['kind']) && z['text_runs']
+      plain = norm_label.call(z['text_runs'].map { |r| r['text'] }.join)
+      if !plain.empty? && kpi_labels.include?(plain)
+        warnings << "dashboard '#{dash['dashboard']}' text zone #{z['id']} (#{plain.inspect}) " \
+                    'duplicates a KPI title — dropped (the Sigma kpi-chart renders its own title)'
+        next
+      end
       body = text_body_from_runs(z['text_runs'], align: z['text_align'],
                                  bg: (z['is_pill'] ? z['fill_color'] : nil))
       next if body.nil?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -3822,10 +3822,13 @@ if title_text
   extras << {
     'id'   => 'title-text',
     'kind' => 'text',
-    # White span: build-dashboard-layout.rb wraps this element in the DARK
-    # header band (HEADER_STYLE) — a plain body renders dark-on-dark
-    # (phase-e layout-quality screenshot-checklist catch).
-    'body' => %(# <span style="color: #FFFFFF">#{title_text}</span>)
+    # Theme-default colour (dark on a light canvas). build-dashboard-layout now
+    # emits a colored header band ONLY when the source actually has one; a bare
+    # source title (no styled runs, so we synthesize here) sits on the page
+    # canvas, where a forced-white title would render invisibly. Sources WITH a
+    # styled title zone are handled by the B4 path below (skipped above), which
+    # carries the source's own run colours.
+    'body' => "# #{title_text}"
   }
 end
 
@@ -4468,8 +4471,10 @@ elsif opts[:pages_mode] == :dashboard
     page_extras = [{
       'id'   => "title-#{d_slug}",
       'kind' => 'text',
-      # White span: the layout builder wraps this in the DARK header band.
-      'body' => %(# <span style="color: #FFFFFF">#{dash_name}</span>)
+      # Theme-default colour: the layout builder now emits a colored header band
+      # only when the source has one (else the title sits on the canvas, where
+      # forced-white would be invisible).
+      'body' => "# #{dash_name}"
     }]
     # B4: this dashboard's styled static-text elements (subtitle/annotations/
     # credit/section headers). Placed by the layout stage at their zone geometry.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -43,6 +43,54 @@ require 'optparse'
 require_relative 'lib/layout'
 include SigmaLayout
 
+# ---- Source-derived header chrome -----------------------------------------
+# The skill used to stamp a fixed dark-navy header band on EVERY dashboard,
+# which makes a minimalist white source (title text on the canvas) come out
+# looking nothing like itself. Instead, only emit a COLORED header band when
+# the source actually has a band-like fill in the header region; otherwise the
+# title sits on the page canvas (transparent container), matching the source.
+#
+# "Band-like" = a fill that reads as a deliberate header strip: dark (low
+# luminance, needs light text) OR saturated (a brand colour). Light-neutral
+# fills (white/near-white/grey card backgrounds) are NOT bands — they blend
+# into the canvas, so we emit no band. A full-page background (h≈100%) is the
+# canvas, not a header, so it's excluded by the height/width gate.
+def band_like_fill?(hex)
+  return false unless hex.is_a?(String) && hex =~ /\A#[0-9a-fA-F]{6}/
+  h = hex[1, 6]
+  r, g, b = h[0, 2].to_i(16), h[2, 2].to_i(16), h[4, 2].to_i(16)
+  luminance = 0.299 * r + 0.587 * g + 0.114 * b
+  chroma = [r, g, b].max - [r, g, b].min
+  luminance < 200 || chroma >= 40
+end
+
+# Returns the header container style hash derived from the source dashboard, or
+# nil when the source has no colored header band (→ transparent, title on the
+# canvas). Also returns whether the band is dark (so the title text needs a
+# light colour on the page-name fallback).
+def header_from_source(dashboard)
+  fill = nil
+  walk = lambda do |nodes|
+    (nodes || []).each do |n|
+      y = (n['y_pct'] || 0).to_f
+      w = (n['w_pct'] || 0).to_f
+      hpct = (n['h_pct'] || 0).to_f
+      fc = n['fill_color']
+      # header region: near the top, spans most of the width, but is a strip
+      # (not the full-page canvas background).
+      if fill.nil? && y < 18 && w >= 50 && hpct < 25 && band_like_fill?(fc)
+        fill = fc[0, 7]
+      end
+      walk.call(n['children'])
+    end
+  end
+  walk.call(dashboard['zone_tree'])
+  return [nil, false] unless fill
+  h = fill[1, 6]
+  dark = (0.299 * h[0, 2].to_i(16) + 0.587 * h[2, 2].to_i(16) + 0.114 * h[4, 2].to_i(16)) < 140
+  [{ 'backgroundColor' => fill, 'borderRadius' => 'round' }, dark]
+end
+
 opts = { page_cols: 24, page_rows: 32, row_scale: 1.5, chart_y0: 29.7,
          chart_y1: 100.0, chart_row0: 6, renames: {} }
 OptionParser.new do |p|
@@ -295,15 +343,17 @@ def build_page_from_tree(dashboard, page, opts)
   body_rows = [page_rows - HEADER_ROWS, 4].max
   page_pseudo = { 'x_pct' => 0.0, 'y_pct' => 0.0, 'w_pct' => 100.0, 'h_pct' => 100.0 }
 
-  # Header band (dark title strip), same chrome as the banded path.
+  # Header band derived from the source (colored strip only when the source has
+  # one; otherwise transparent — title on the canvas, no fabricated navy).
+  hdr_style, hdr_dark = header_from_source(dashboard)
   hdr_id = "tc-#{page['id']}-hdr"
-  extra_els << container_el(hdr_id, HEADER_STYLE.dup)
+  extra_els << container_el(hdr_id, hdr_style)
   if title_el
     children << header_band_xml(hdr_id, title_el['id'])
     ctx[:title_used] = true
   else
     txt_id = "tc-#{page['id']}-hdrtext"
-    extra_els << header_text_el(txt_id, page['name'])
+    extra_els << header_text_el(txt_id, page['name'], hdr_dark ? '#FFFFFF' : nil)
     children << header_band_xml(hdr_id, txt_id)
   end
 
@@ -403,15 +453,16 @@ def build_page_for_dashboard(dashboard, page, opts)
   extra_els = []
   ov_prefix = "band-#{page['id']}"
 
-  # Header band: reuse the page's existing title text if present, else add one
-  # (sidecar) named after the page (= the Tableau dashboard name).
+  # Header band derived from the source (colored strip only when the source has
+  # one; otherwise transparent — title on the canvas, no fabricated navy).
+  hdr_style, hdr_dark = header_from_source(dashboard)
   hdr_id = "#{ov_prefix}-hdr"
-  extra_els << container_el(hdr_id, HEADER_STYLE.dup)
+  extra_els << container_el(hdr_id, hdr_style)
   if title_el
     children << header_band_xml(hdr_id, title_el['id'])
   else
     txt_id = "#{ov_prefix}-hdrtext"
-    extra_els << header_text_el(txt_id, page['name'])
+    extra_els << header_text_el(txt_id, page['name'], hdr_dark ? '#FFFFFF' : nil)
     children << header_band_xml(hdr_id, txt_id)
   end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
@@ -195,9 +195,19 @@ def derive_theme(layout)
     end
   end
   walk.call(roots, 0)
+  # Canvas: strip any 8-digit alpha so Sigma gets a solid #rrggbb.
+  canvas = canvas[0, 7] if canvas.is_a?(String) && canvas =~ /\A#[0-9a-fA-F]{8}\z/
+  # Palette preference: the source's real color-encoding brand palette (emitted
+  # by parse-twb-layout as brand_palette) beats the container-tint palette. The
+  # tint palette only fits the region-card idiom; a dashboard whose design is a
+  # color SCHEME (ER's reds, Udemy's subject dots) has no ≥2 tinted containers,
+  # so the old path degenerated to white card fills. Fall back to tints when the
+  # source encodes no brand colors.
+  brand = dashes.first['brand_palette']
+  scheme = (brand.is_a?(Array) && brand.size >= 2) ? brand : palette
   theme = {}
   theme['backgroundCanvas'] = canvas if canvas
-  theme['categoricalScheme'] = palette if palette.size >= 2 # only the multi-member region pattern
+  theme['categoricalScheme'] = scheme if scheme.size >= 2
   theme
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/layout.rb
@@ -58,10 +58,13 @@ module SigmaLayout
     el
   end
 
-  # Spec-side page-title text element (white text over the dark header band).
-  def header_text_el(id, title)
-    { 'id' => id, 'kind' => 'text',
-      'body' => %(# <span style="color: #FFFFFF">#{title}</span>) }
+  # Spec-side page-title text element. `color` sets the title colour: pass a
+  # light hex over a dark header band, or nil to leave the title in the theme's
+  # default text colour (correct when the title sits on the page canvas — no
+  # band — so it isn't forced white-on-white).
+  def header_text_el(id, title, color = nil)
+    span = color ? %(<span style="color: #{color}">#{title}</span>) : title.to_s
+    { 'id' => id, 'kind' => 'text', 'body' => "# #{span}" }
   end
 
   # Header band XML: dark full-width container at the top of the page wrapping

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -88,7 +88,44 @@ def dashboard_in_scope?(name, page_id)
   name_hit || page_hit
 end
 
-xml = TwbXml.parse(File.read(INP))
+TWB_TEXT = File.read(INP)
+xml = TwbXml.parse(TWB_TEXT)
+
+# ---- Brand palette (Phase-1 D1, general) ----------------------------------
+# The workbook's real categorical/brand palette lives in the color ENCODING
+# (<encoding attr='color'> <map to='#rrggbb'>…) and any custom <color-palette>
+# — NOT in container fills. derive_theme previously read only container tints,
+# so a dashboard whose design is a color scheme (not tinted cards) degenerated
+# to picking white card backgrounds. We surface the encoded colors here,
+# frequency-ranked, with neutrals dropped (near-white/black card & text fills,
+# and low-chroma greys), so downstream theming can reproduce the source's own
+# palette. Neutral test mirrors the prototype validated across the benchmark
+# set (ER reds / Quota blue-teal / History blue+orange / Udemy subject dots).
+def color_neutral?(hex)
+  h = hex.delete('#')
+  return true unless h.length == 6
+  r, g, b = h[0, 2].to_i(16), h[2, 2].to_i(16), h[4, 2].to_i(16)
+  mx = [r, g, b].max
+  mn = [r, g, b].min
+  # Low chroma (grey), OR near-white (ALL channels high) OR near-black (ALL
+  # channels low). Test mn/mx not the opposite bound, so a vivid colour with a
+  # single near-max channel (orange #f06719, red #ff0000) is NOT dropped.
+  (mx - mn) < 24 || mn > 235 || mx < 26
+end
+
+def extract_brand_palette(twb_text)
+  freq = Hash.new(0)
+  # color-encoding buckets
+  twb_text.scan(/<map\s+to=(['"])(#[0-9a-fA-F]{6})\1/) { |_q, hex| freq[hex.downcase] += 1 }
+  # user-defined custom palettes
+  twb_text.scan(%r{<color-palette\b[^>]*>(.*?)</color-palette>}m) do |body,|
+    body.to_s.scan(/#[0-9a-fA-F]{6}/) { |hex| freq[hex.downcase] += 1 }
+  end
+  freq.reject! { |hex, _| color_neutral?(hex) }
+  freq.sort_by { |hex, n| [-n, hex] }.map(&:first)
+end
+
+BRAND_PALETTE = extract_brand_palette(TWB_TEXT)
 
 def pct(v)
   return nil if v.nil?
@@ -1173,10 +1210,15 @@ xml.elements.each('//dashboard') do |d|
   end
 
   dashboards << {
-    'dashboard' => d.attributes['name'],
-    'is_story'  => is_story,
-    'zones'     => zones,
-    'zone_tree' => zone_tree
+    'dashboard'     => d.attributes['name'],
+    'is_story'      => is_story,
+    'zones'         => zones,
+    'zone_tree'     => zone_tree,
+    # Phase-1 D1 (general): workbook brand palette from color encodings, so
+    # derive_theme can reproduce the source's own scheme instead of falling
+    # back to white card fills. Empty when the source encodes no non-neutral
+    # colors (theme then omitted — Sigma defaults apply, never worse).
+    'brand_palette' => BRAND_PALETTE
   }
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-brand-palette.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-brand-palette.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# Regression test for the general D1 brand-palette extraction in
+# parse-twb-layout.rb: the workbook's real categorical/brand palette comes from
+# the color ENCODING (<map to='#..'>) + custom <color-palette>, NOT container
+# fills. Neutrals (grey / near-white / near-black) are dropped so a vivid colour
+# with a single near-max channel (orange #f06719, red #ff0000) is KEPT.
+#
+# Exercises the pure helpers directly (no .twb file needed).
+# Usage:  ruby scripts/test-brand-palette.rb
+
+DIR = __dir__
+SRC = File.read(File.join(DIR, 'parse-twb-layout.rb'))
+%w[color_neutral? extract_brand_palette].each do |fn|
+  m = SRC.match(/^def #{Regexp.escape(fn)}.*?\n^end$/m) or abort("could not extract #{fn}")
+  eval(m[0]) # rubocop:disable Security/Eval — test-only extraction of first-party code
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# --- color_neutral? -----------------------------------------------------------
+check(color_neutral?('#ffffff'), "pure white is neutral", fails)
+check(color_neutral?('#fafafa'), "near-white grey is neutral", fails)
+check(color_neutral?('#ececec'), "light grey is neutral", fails)
+check(color_neutral?('#111111'), "near-black is neutral", fails)
+check(!color_neutral?('#f06719'), "vivid orange (r=240) is NOT neutral — the near-white bug", fails)
+check(!color_neutral?('#ff0000'), "pure red (r=255) is NOT neutral", fails)
+check(!color_neutral?('#ba2020'), "brand red is NOT neutral", fails)
+check(!color_neutral?('#b9ddf1'), "light-but-chromatic blue (Water) is NOT neutral", fails)
+
+# --- extract_brand_palette: frequency rank + neutral drop + dedup -------------
+twb = <<~XML
+  <workbook>
+    <worksheet><encoding attr='color'>
+      <map to='#ba2020'></map><map to='#ba2020'></map><map to='#ba2020'></map>
+      <map to='#ececec'></map><map to='#ffffff'></map>
+      <map to="#f06719"></map><map to="#f06719"></map>
+    </encoding></worksheet>
+    <color-palette name='Custom'>
+      <color>#4e79a7</color>
+    </color-palette>
+  </workbook>
+XML
+pal = extract_brand_palette(twb)
+check(pal == %w[#ba2020 #f06719 #4e79a7],
+      "freq-ranked, neutrals dropped, deduped (got #{pal.inspect})", fails)
+check(!pal.include?('#ffffff') && !pal.include?('#ececec'),
+      "white / grey encoding buckets excluded", fails)
+
+# Source with no non-neutral colours → empty palette (theme then omitted).
+mono = extract_brand_palette("<x><map to='#ffffff'></map><map to='#eeeeee'></map></x>")
+check(mono == [], "all-neutral source → empty palette (got #{mono.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — D1 brand-palette extraction (color encodings, neutral drop, freq rank)'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-container-tint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-container-tint.rb
@@ -80,9 +80,17 @@ tinted = containers.find { |c| c.dig('style', 'backgroundColor') == '#07b4a24e' 
 check(!tinted.nil?, "a container carries the zone tint backgroundColor '#07b4a24e' (8-digit alpha, verbatim)", fails)
 check(tinted && tinted.dig('style', 'borderRadius') == 'round', "tinted container has borderRadius: round", fails)
 check(tinted && tinted.dig('style', 'borderColor') == '#07b4a2', "tinted container carries borderColor from the zone", fails)
-# The dark page-header container (HEADER_STYLE) must remain distinct from the tint.
-check(containers.any? { |c| c.dig('style', 'backgroundColor') == '#0F172A' },
-      "page header container still emitted (unaffected)", fails)
+# #271: the page-header container is now SOURCE-DERIVED (header_from_source) — the
+# skill no longer stamps a fixed navy band on every dashboard. This fixture has no
+# header band in the source, so the header container is still emitted but carries
+# NO hardcoded fill (transparent), and stays distinct from the tint.
+# (Was: asserted the old fixed HEADER_STYLE '#0F172A', removed in #271.)
+hdr = containers.find { |c| c['id'].to_s.end_with?('-hdr') }
+check(!hdr.nil?, "page header container still emitted (source-derived)", fails)
+check(hdr && hdr.dig('style', 'backgroundColor') != '#07b4a24e',
+      "header container does NOT inherit the zone tint (stays distinct)", fails)
+check(hdr.nil? || hdr.dig('style', 'backgroundColor') != '#0F172A',
+      "no fixed navy band stamped when the source has no header fill", fails)
 
 puts
 if fails.empty?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-header-derivation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-header-derivation.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+# Regression test for source-derived header chrome in build-dashboard-layout.rb.
+# The skill must NOT stamp a fixed dark-navy header band on every dashboard: it
+# emits a colored band ONLY when the source has a band-like fill in the header
+# region, otherwise the title sits on the page canvas (transparent → no navy on
+# a minimalist white source like jmackinlay's Tableau History).
+#
+# Exercises the pure helpers directly.  Usage: ruby scripts/test-header-derivation.rb
+
+DIR = __dir__
+SRC = File.read(File.join(DIR, 'build-dashboard-layout.rb'))
+%w[band_like_fill? header_from_source].each do |fn|
+  m = SRC.match(/^def #{Regexp.escape(fn)}.*?\n^end$/m) or abort("could not extract #{fn}")
+  eval(m[0]) # rubocop:disable Security/Eval — test-only extraction of first-party code
+end
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# band_like_fill?: dark OR saturated = a real band; light-neutral = blends away.
+check(band_like_fill?('#8f1716'), "dark maroon is band-like", fails)
+check(band_like_fill?('#0f172a'), "dark navy is band-like", fails)
+check(band_like_fill?('#1e88e5'), "saturated blue is band-like", fails)
+check(!band_like_fill?('#ffffff'), "white is NOT band-like", fails)
+check(!band_like_fill?('#f5f5f5'), "near-white grey is NOT band-like", fails)
+check(!band_like_fill?('#ececec'), "light grey card is NOT band-like", fails)
+
+dash = ->(zones) { { 'zone_tree' => zones } }
+
+# Minimalist source: title text on canvas, no header fill → NO band, dark title.
+style, dark = header_from_source(dash.call([{ 'kind' => 'title', 'y_pct' => 1, 'w_pct' => 98, 'h_pct' => 7 }]))
+check(style.nil? && dark == false, "no header fill → transparent (no fabricated navy)", fails)
+
+# Source WITH a dark full-width header strip → reproduce it + light title.
+style, dark = header_from_source(dash.call([{ 'kind' => 'container', 'y_pct' => 0, 'w_pct' => 100, 'h_pct' => 8, 'fill_color' => '#8f1716ff' }]))
+check(style && style['backgroundColor'] == '#8f1716' && dark, "dark maroon strip → maroon band + light title", fails)
+
+# A full-page background (h≈100%) is the CANVAS, not a header band.
+style, = header_from_source(dash.call([{ 'kind' => 'bitmap', 'y_pct' => 0, 'w_pct' => 100, 'h_pct' => 100, 'fill_color' => '#8f1716' }]))
+check(style.nil?, "full-page background is the canvas, not a header band", fails)
+
+# A light-grey top strip must NOT become a band.
+style, = header_from_source(dash.call([{ 'kind' => 'container', 'y_pct' => 0, 'w_pct' => 100, 'h_pct' => 8, 'fill_color' => '#f5f5f5' }]))
+check(style.nil?, "light-grey top strip blends into canvas (no band)", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — source-derived header chrome (no fabricated navy)'
+  exit 0
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-derivation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-theme-derivation.rb
@@ -64,9 +64,35 @@ dup = derive_theme([{ 'dashboard' => 'X', 'zone_tree' => [
 ] }])
 check(dup['categoricalScheme'] == %w[#07b4a2 #e8519a], "same base at 2 alphas dedups (got #{dup['categoricalScheme'].inspect})", fails)
 
+# --- brand_palette (general D1): the source's color-encoding palette wins ----
+# A color-SCHEME dashboard (no tinted region cards) still gets a real scheme
+# from parse-twb-layout's brand_palette, instead of degenerating to white fills.
+brand = derive_theme([{
+  'dashboard' => 'ER', 'brand_palette' => %w[#ba2020 #8f1716 #ac4746],
+  'zone_tree' => [{ 'id' => '1', 'kind' => 'container', 'fill_color' => '#ffffff6d', 'children' => [
+    { 'id' => 'c1', 'kind' => 'container', 'fill_color' => '#ffffff' }, # white card — must NOT be the palette
+    { 'id' => 'c2', 'kind' => 'container', 'fill_color' => '#fafafa' }
+  ] }]
+}])
+check(brand['categoricalScheme'] == %w[#ba2020 #8f1716 #ac4746],
+      "brand_palette (color encodings) beats white card fills (got #{brand['categoricalScheme'].inspect})", fails)
+check(brand['backgroundCanvas'] == '#ffffff',
+      "canvas 8-digit alpha stripped to solid #rrggbb (got #{brand['backgroundCanvas'].inspect})", fails)
+
+# brand_palette with a single colour → too few to theme, fall back to tints.
+fb = derive_theme([{
+  'dashboard' => 'X', 'brand_palette' => %w[#4e79a7],
+  'zone_tree' => [
+    { 'id' => 'a', 'kind' => 'container', 'fill_color' => '#07b4a24e' },
+    { 'id' => 'b', 'kind' => 'container', 'fill_color' => '#e8519a4e' }
+  ]
+}])
+check(fb['categoricalScheme'] == %w[#07b4a2 #e8519a],
+      "single-colour brand_palette falls back to the tint palette (got #{fb['categoricalScheme'].inspect})", fails)
+
 puts
 if fails.empty?
-  puts 'ALL PASS — D1/Pass-7 theme derivation (canvas + region palette)'
+  puts 'ALL PASS — D1/Pass-7 theme derivation (canvas + region palette + brand palette)'
   exit 0
 else
   puts "#{fails.size} FAILURE(S):"


### PR DESCRIPTION
## What
Generalizes the workbook theme derivation so **each migration comes out looking like its own source** at the palette/canvas layer.

Surfaced by the multi-dashboard benchmark: `derive_theme` built `categoricalScheme` **only** from 8-digit-alpha container fills — the Job-Loss region-card *tint* idiom. Any dashboard whose design is a **color scheme** rather than tinted cards (ER's monochromatic reds, Udemy's subject-dot palette) has no such containers, so the theme degenerated to picking **white card backgrounds** as the palette and white as the canvas.

## Change
- **parse-twb-layout.rb**: emit `brand_palette` per dashboard from the color **encoding** (`<map to='#..'>`) + custom `<color-palette>`, frequency-ranked, neutrals dropped. Neutral = low chroma OR near-white (all channels high) OR near-black — tested on `mn`/`mx` so a vivid single-near-max-channel colour (orange `#f06719`, red `#ff0000`) is **kept**.
- **build-workbook-spec.rb** `derive_theme`: prefer `brand_palette` for `categoricalScheme` (falls back to the container-tint palette when the source encodes no brand colours); strip 8-digit alpha off the canvas → solid `#rrggbb`.

## Validated (4-dashboard benchmark)
| Dashboard | Derived palette |
|---|---|
| ER Visits | `#ba2020` + `#8f1716` + red ramp (monochromatic red) |
| Quota | `#0088ff` blue primary + teal |
| Tableau History | `#4e79a7` blue + `#b9ddf1` (Water) + `#f06719` (Gold) |
| Udemy | `#4e79a7`/`#e04053`/`#54a7ae` subject-dot colours |

Each source yields its **own** palette instead of white.

## Tests
- new `test-brand-palette.rb` (extraction, freq-rank, dedup, + the near-white neutral bug)
- extended `test-theme-derivation.rb` (brand_palette beats white fills; alpha-strip; single-colour falls back to tints)
- both gated in `corpus-check.yml`; full offline suite green

Part of the general Tableau→Sigma design-signal layer.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>