### PR TITLE
fix(controls): don't fail the control gate on already-surfaced coverage gaps

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/control_lint.rb
@@ -270,7 +270,16 @@ module ControlLint
     end
 
     # (c) annotated controls that never made it into the spec ------------------
+    # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/
+    # unreferenced parameter the builder intentionally does not place as a dead
+    # control; needs-materialization: a calc-bound filter whose column isn't on
+    # the model yet) is recorded in the controls-coverage ledger, NOT silently
+    # dropped — so its absence from the spec is expected, not a "not migrated"
+    # failure. Only a control the builder recorded as EMITTED but that's missing
+    # from the spec is a real bug the source filter was lost.
+    surfaced_gap = %w[needs-wiring needs-materialization].freeze
     scope_by_cid.each do |cid, c|
+      next if surfaced_gap.include?(c['status'].to_s)
       violations << "missing control: control-scope.json expects control #{cid.inspect}" \
                     "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
                     'has no control with that controlId — the source filter was not migrated'

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/control_lint.rb
@@ -202,8 +202,18 @@ module ControlLint
         scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
       end
       # (c) the Qlik class: source had filter signals, spec built zero controls.
+      # BUT suppress when every scope entry is an already-surfaced gap
+      # (needs-wiring / needs-materialization): the builder DID account for each
+      # source signal in the coverage ledger — e.g. a dashboard whose only
+      # "filter" is an orphan/unreferenced parameter that legitimately becomes no
+      # placeable control. That's a surfaced gap, not the silent static-workbook
+      # miss this rule targets. A genuinely silent miss has signals but NO scope
+      # entries explaining them → still fails.
       signals = scope['sourceFilterSignals'].to_i
-      if signals.positive? && rows.empty?
+      scoped = Array(scope['controls'])
+      all_surfaced_gaps = scoped.any? &&
+                          scoped.all? { |c| %w[needs-wiring needs-materialization].include?(c['status'].to_s) }
+      if signals.positive? && rows.empty? && !all_surfaced_gaps
         violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
                       '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
                       'elements — the source dashboard is interactive and the migration shipped a ' \

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
@@ -270,7 +270,16 @@ module ControlLint
     end
 
     # (c) annotated controls that never made it into the spec ------------------
+    # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/
+    # unreferenced parameter the builder intentionally does not place as a dead
+    # control; needs-materialization: a calc-bound filter whose column isn't on
+    # the model yet) is recorded in the controls-coverage ledger, NOT silently
+    # dropped — so its absence from the spec is expected, not a "not migrated"
+    # failure. Only a control the builder recorded as EMITTED but that's missing
+    # from the spec is a real bug the source filter was lost.
+    surfaced_gap = %w[needs-wiring needs-materialization].freeze
     scope_by_cid.each do |cid, c|
+      next if surfaced_gap.include?(c['status'].to_s)
       violations << "missing control: control-scope.json expects control #{cid.inspect}" \
                     "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
                     'has no control with that controlId — the source filter was not migrated'

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
@@ -202,8 +202,18 @@ module ControlLint
         scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
       end
       # (c) the Qlik class: source had filter signals, spec built zero controls.
+      # BUT suppress when every scope entry is an already-surfaced gap
+      # (needs-wiring / needs-materialization): the builder DID account for each
+      # source signal in the coverage ledger — e.g. a dashboard whose only
+      # "filter" is an orphan/unreferenced parameter that legitimately becomes no
+      # placeable control. That's a surfaced gap, not the silent static-workbook
+      # miss this rule targets. A genuinely silent miss has signals but NO scope
+      # entries explaining them → still fails.
       signals = scope['sourceFilterSignals'].to_i
-      if signals.positive? && rows.empty?
+      scoped = Array(scope['controls'])
+      all_surfaced_gaps = scoped.any? &&
+                          scoped.all? { |c| %w[needs-wiring needs-materialization].include?(c['status'].to_s) }
+      if signals.positive? && rows.empty? && !all_surfaced_gaps
         violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
                       '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
                       'elements — the source dashboard is interactive and the migration shipped a ' \

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/control_lint.rb
@@ -270,7 +270,16 @@ module ControlLint
     end
 
     # (c) annotated controls that never made it into the spec ------------------
+    # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/
+    # unreferenced parameter the builder intentionally does not place as a dead
+    # control; needs-materialization: a calc-bound filter whose column isn't on
+    # the model yet) is recorded in the controls-coverage ledger, NOT silently
+    # dropped — so its absence from the spec is expected, not a "not migrated"
+    # failure. Only a control the builder recorded as EMITTED but that's missing
+    # from the spec is a real bug the source filter was lost.
+    surfaced_gap = %w[needs-wiring needs-materialization].freeze
     scope_by_cid.each do |cid, c|
+      next if surfaced_gap.include?(c['status'].to_s)
       violations << "missing control: control-scope.json expects control #{cid.inspect}" \
                     "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
                     'has no control with that controlId — the source filter was not migrated'

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/control_lint.rb
@@ -202,8 +202,18 @@ module ControlLint
         scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
       end
       # (c) the Qlik class: source had filter signals, spec built zero controls.
+      # BUT suppress when every scope entry is an already-surfaced gap
+      # (needs-wiring / needs-materialization): the builder DID account for each
+      # source signal in the coverage ledger — e.g. a dashboard whose only
+      # "filter" is an orphan/unreferenced parameter that legitimately becomes no
+      # placeable control. That's a surfaced gap, not the silent static-workbook
+      # miss this rule targets. A genuinely silent miss has signals but NO scope
+      # entries explaining them → still fails.
       signals = scope['sourceFilterSignals'].to_i
-      if signals.positive? && rows.empty?
+      scoped = Array(scope['controls'])
+      all_surfaced_gaps = scoped.any? &&
+                          scoped.all? { |c| %w[needs-wiring needs-materialization].include?(c['status'].to_s) }
+      if signals.positive? && rows.empty? && !all_surfaced_gaps
         violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
                       '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
                       'elements — the source dashboard is interactive and the migration shipped a ' \

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# Regression test for control_lint's "missing control" gate (#259).
+#
+# A control-scope entry flagged as an ALREADY-SURFACED gap — needs-wiring (an
+# orphan/unreferenced parameter the builder intentionally does not place as a
+# dead control) or needs-materialization (a calc-bound filter whose column isn't
+# on the model yet) — is recorded in the controls-coverage ledger, NOT silently
+# dropped. So its absence from the spec must NOT be reported as "missing control"
+# (which hard-fails the migration gate). Only an EMITTED-status entry that's
+# absent from the spec is a real "the source filter was not migrated" failure.
+#
+# The bug this guards: a stray Tableau parameter (referenced by no calc) blocked
+# the whole control gate — very common, would have broken most migrations.
+#
+# Usage:  ruby scripts/test-control-lint.rb   (run from a vendored plugin copy)
+require 'json'
+require 'set'
+require_relative 'lib/control_lint'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Minimal non-degenerate spec: one page, one non-control element, NO controls —
+# so any "missing control" comes purely from the scope↔spec reconciliation.
+SPEC = { 'pages' => [{ 'name' => 'P1', 'elements' => [
+  { 'id' => 'tbl-1', 'kind' => 'table', 'name' => 'T' }
+] }] }.freeze
+
+def scope_with(status)
+  ctl = { 'controlId' => 'ctl-orphan', 'name' => 'Orphan', 'sourceName' => "param 'Orphan'" }
+  ctl['status'] = status unless status.nil?
+  { 'sourceFilterSignals' => 0, 'controls' => [ctl] }
+end
+
+missing = ->(vs) { vs.any? { |v| v.include?('missing control') && v.include?('ctl-orphan') } }
+
+# needs-wiring (orphan/unreferenced param) → NOT a missing-control failure
+v1 = ControlLint.lint(SPEC, scope: scope_with('needs-wiring'))
+check(!missing.call(v1), "needs-wiring scope entry absent from spec → NO 'missing control' (got #{v1.inspect})", fails)
+
+# needs-materialization (calc-bound filter, column not yet on the model) → likewise
+v2 = ControlLint.lint(SPEC, scope: scope_with('needs-materialization'))
+check(!missing.call(v2), 'needs-materialization scope entry absent from spec → NO missing-control', fails)
+
+# emitted status but absent from spec → this IS a real failure (guard against over-suppression)
+v3 = ControlLint.lint(SPEC, scope: scope_with('emitted'))
+check(missing.call(v3), 'emitted scope entry absent from spec → DOES flag missing-control (regression guard)', fails)
+
+# no status → defaults to emitted → still flags (a bare scope entry must not slip through)
+v4 = ControlLint.lint(SPEC, scope: scope_with(nil))
+check(missing.call(v4), 'missing status defaults to emitted → flags missing-control', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — control_lint honors needs-wiring/needs-materialization coverage gaps'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb
@@ -53,6 +53,19 @@ check(missing.call(v3), 'emitted scope entry absent from spec → DOES flag miss
 v4 = ControlLint.lint(SPEC, scope: scope_with(nil))
 check(missing.call(v4), 'missing status defaults to emitted → flags missing-control', fails)
 
+# --- "no controls built" (Qlik-class) must also honor surfaced gaps -----------
+no_built = ->(vs) { vs.any? { |v| v.include?('no controls built') } }
+# 1 filter signal, ZERO controls, but the only scope entry is a needs-wiring
+# orphan param → the signal is accounted for as a surfaced gap → NOT a failure.
+sig_gap = { 'sourceFilterSignals' => 1,
+            'controls' => [{ 'controlId' => 'ctl-orphan', 'name' => 'Orphan', 'status' => 'needs-wiring' }] }
+check(!no_built.call(ControlLint.lint(SPEC, scope: sig_gap)),
+      'signals>0 + zero controls but all scope entries needs-wiring → NO "no controls built" (the ComplexPivot case)', fails)
+# genuine silent miss: signals but NO scope entries explaining them → still fails.
+sig_silent = { 'sourceFilterSignals' => 1, 'controls' => [] }
+check(no_built.call(ControlLint.lint(SPEC, scope: sig_silent)),
+      'signals>0 + zero controls + NO scope entries → DOES flag "no controls built" (Qlik silent-miss preserved)', fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS — control_lint honors needs-wiring/needs-materialization coverage gaps'

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/control_lint.rb
@@ -270,7 +270,16 @@ module ControlLint
     end
 
     # (c) annotated controls that never made it into the spec ------------------
+    # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/
+    # unreferenced parameter the builder intentionally does not place as a dead
+    # control; needs-materialization: a calc-bound filter whose column isn't on
+    # the model yet) is recorded in the controls-coverage ledger, NOT silently
+    # dropped — so its absence from the spec is expected, not a "not migrated"
+    # failure. Only a control the builder recorded as EMITTED but that's missing
+    # from the spec is a real bug the source filter was lost.
+    surfaced_gap = %w[needs-wiring needs-materialization].freeze
     scope_by_cid.each do |cid, c|
+      next if surfaced_gap.include?(c['status'].to_s)
       violations << "missing control: control-scope.json expects control #{cid.inspect}" \
                     "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
                     'has no control with that controlId — the source filter was not migrated'

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/control_lint.rb
@@ -202,8 +202,18 @@ module ControlLint
         scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
       end
       # (c) the Qlik class: source had filter signals, spec built zero controls.
+      # BUT suppress when every scope entry is an already-surfaced gap
+      # (needs-wiring / needs-materialization): the builder DID account for each
+      # source signal in the coverage ledger — e.g. a dashboard whose only
+      # "filter" is an orphan/unreferenced parameter that legitimately becomes no
+      # placeable control. That's a surfaced gap, not the silent static-workbook
+      # miss this rule targets. A genuinely silent miss has signals but NO scope
+      # entries explaining them → still fails.
       signals = scope['sourceFilterSignals'].to_i
-      if signals.positive? && rows.empty?
+      scoped = Array(scope['controls'])
+      all_surfaced_gaps = scoped.any? &&
+                          scoped.all? { |c| %w[needs-wiring needs-materialization].include?(c['status'].to_s) }
+      if signals.positive? && rows.empty? && !all_surfaced_gaps
         violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
                       '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
                       'elements — the source dashboard is interactive and the migration shipped a ' \

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/control_lint.rb
@@ -270,7 +270,16 @@ module ControlLint
     end
 
     # (c) annotated controls that never made it into the spec ------------------
+    # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/
+    # unreferenced parameter the builder intentionally does not place as a dead
+    # control; needs-materialization: a calc-bound filter whose column isn't on
+    # the model yet) is recorded in the controls-coverage ledger, NOT silently
+    # dropped — so its absence from the spec is expected, not a "not migrated"
+    # failure. Only a control the builder recorded as EMITTED but that's missing
+    # from the spec is a real bug the source filter was lost.
+    surfaced_gap = %w[needs-wiring needs-materialization].freeze
     scope_by_cid.each do |cid, c|
+      next if surfaced_gap.include?(c['status'].to_s)
       violations << "missing control: control-scope.json expects control #{cid.inspect}" \
                     "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
                     'has no control with that controlId — the source filter was not migrated'

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/control_lint.rb
@@ -202,8 +202,18 @@ module ControlLint
         scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
       end
       # (c) the Qlik class: source had filter signals, spec built zero controls.
+      # BUT suppress when every scope entry is an already-surfaced gap
+      # (needs-wiring / needs-materialization): the builder DID account for each
+      # source signal in the coverage ledger — e.g. a dashboard whose only
+      # "filter" is an orphan/unreferenced parameter that legitimately becomes no
+      # placeable control. That's a surfaced gap, not the silent static-workbook
+      # miss this rule targets. A genuinely silent miss has signals but NO scope
+      # entries explaining them → still fails.
       signals = scope['sourceFilterSignals'].to_i
-      if signals.positive? && rows.empty?
+      scoped = Array(scope['controls'])
+      all_surfaced_gaps = scoped.any? &&
+                          scoped.all? { |c| %w[needs-wiring needs-materialization].include?(c['status'].to_s) }
+      if signals.positive? && rows.empty? && !all_surfaced_gaps
         violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
                       '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
                       'elements — the source dashboard is interactive and the migration shipped a ' \

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_lint.rb
@@ -270,7 +270,16 @@ module ControlLint
     end
 
     # (c) annotated controls that never made it into the spec ------------------
+    # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/
+    # unreferenced parameter the builder intentionally does not place as a dead
+    # control; needs-materialization: a calc-bound filter whose column isn't on
+    # the model yet) is recorded in the controls-coverage ledger, NOT silently
+    # dropped — so its absence from the spec is expected, not a "not migrated"
+    # failure. Only a control the builder recorded as EMITTED but that's missing
+    # from the spec is a real bug the source filter was lost.
+    surfaced_gap = %w[needs-wiring needs-materialization].freeze
     scope_by_cid.each do |cid, c|
+      next if surfaced_gap.include?(c['status'].to_s)
       violations << "missing control: control-scope.json expects control #{cid.inspect}" \
                     "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
                     'has no control with that controlId — the source filter was not migrated'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/control_lint.rb
@@ -202,8 +202,18 @@ module ControlLint
         scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
       end
       # (c) the Qlik class: source had filter signals, spec built zero controls.
+      # BUT suppress when every scope entry is an already-surfaced gap
+      # (needs-wiring / needs-materialization): the builder DID account for each
+      # source signal in the coverage ledger — e.g. a dashboard whose only
+      # "filter" is an orphan/unreferenced parameter that legitimately becomes no
+      # placeable control. That's a surfaced gap, not the silent static-workbook
+      # miss this rule targets. A genuinely silent miss has signals but NO scope
+      # entries explaining them → still fails.
       signals = scope['sourceFilterSignals'].to_i
-      if signals.positive? && rows.empty?
+      scoped = Array(scope['controls'])
+      all_surfaced_gaps = scoped.any? &&
+                          scoped.all? { |c| %w[needs-wiring needs-materialization].include?(c['status'].to_s) }
+      if signals.positive? && rows.empty? && !all_surfaced_gaps
         violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
                       '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
                       'elements — the source dashboard is interactive and the migration shipped a ' \

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# Regression test for control_lint's "missing control" gate (#259).
+#
+# A control-scope entry flagged as an ALREADY-SURFACED gap — needs-wiring (an
+# orphan/unreferenced parameter the builder intentionally does not place as a
+# dead control) or needs-materialization (a calc-bound filter whose column isn't
+# on the model yet) — is recorded in the controls-coverage ledger, NOT silently
+# dropped. So its absence from the spec must NOT be reported as "missing control"
+# (which hard-fails the migration gate). Only an EMITTED-status entry that's
+# absent from the spec is a real "the source filter was not migrated" failure.
+#
+# The bug this guards: a stray Tableau parameter (referenced by no calc) blocked
+# the whole control gate — very common, would have broken most migrations.
+#
+# Usage:  ruby scripts/test-control-lint.rb   (run from a vendored plugin copy)
+require 'json'
+require 'set'
+require_relative 'lib/control_lint'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Minimal non-degenerate spec: one page, one non-control element, NO controls —
+# so any "missing control" comes purely from the scope↔spec reconciliation.
+SPEC = { 'pages' => [{ 'name' => 'P1', 'elements' => [
+  { 'id' => 'tbl-1', 'kind' => 'table', 'name' => 'T' }
+] }] }.freeze
+
+def scope_with(status)
+  ctl = { 'controlId' => 'ctl-orphan', 'name' => 'Orphan', 'sourceName' => "param 'Orphan'" }
+  ctl['status'] = status unless status.nil?
+  { 'sourceFilterSignals' => 0, 'controls' => [ctl] }
+end
+
+missing = ->(vs) { vs.any? { |v| v.include?('missing control') && v.include?('ctl-orphan') } }
+
+# needs-wiring (orphan/unreferenced param) → NOT a missing-control failure
+v1 = ControlLint.lint(SPEC, scope: scope_with('needs-wiring'))
+check(!missing.call(v1), "needs-wiring scope entry absent from spec → NO 'missing control' (got #{v1.inspect})", fails)
+
+# needs-materialization (calc-bound filter, column not yet on the model) → likewise
+v2 = ControlLint.lint(SPEC, scope: scope_with('needs-materialization'))
+check(!missing.call(v2), 'needs-materialization scope entry absent from spec → NO missing-control', fails)
+
+# emitted status but absent from spec → this IS a real failure (guard against over-suppression)
+v3 = ControlLint.lint(SPEC, scope: scope_with('emitted'))
+check(missing.call(v3), 'emitted scope entry absent from spec → DOES flag missing-control (regression guard)', fails)
+
+# no status → defaults to emitted → still flags (a bare scope entry must not slip through)
+v4 = ControlLint.lint(SPEC, scope: scope_with(nil))
+check(missing.call(v4), 'missing status defaults to emitted → flags missing-control', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — control_lint honors needs-wiring/needs-materialization coverage gaps'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb
@@ -53,6 +53,19 @@ check(missing.call(v3), 'emitted scope entry absent from spec → DOES flag miss
 v4 = ControlLint.lint(SPEC, scope: scope_with(nil))
 check(missing.call(v4), 'missing status defaults to emitted → flags missing-control', fails)
 
+# --- "no controls built" (Qlik-class) must also honor surfaced gaps -----------
+no_built = ->(vs) { vs.any? { |v| v.include?('no controls built') } }
+# 1 filter signal, ZERO controls, but the only scope entry is a needs-wiring
+# orphan param → the signal is accounted for as a surfaced gap → NOT a failure.
+sig_gap = { 'sourceFilterSignals' => 1,
+            'controls' => [{ 'controlId' => 'ctl-orphan', 'name' => 'Orphan', 'status' => 'needs-wiring' }] }
+check(!no_built.call(ControlLint.lint(SPEC, scope: sig_gap)),
+      'signals>0 + zero controls but all scope entries needs-wiring → NO "no controls built" (the ComplexPivot case)', fails)
+# genuine silent miss: signals but NO scope entries explaining them → still fails.
+sig_silent = { 'sourceFilterSignals' => 1, 'controls' => [] }
+check(no_built.call(ControlLint.lint(SPEC, scope: sig_silent)),
+      'signals>0 + zero controls + NO scope entries → DOES flag "no controls built" (Qlik silent-miss preserved)', fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS — control_lint honors needs-wiring/needs-materialization coverage gaps'

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/control_lint.rb
@@ -270,7 +270,16 @@ module ControlLint
     end
 
     # (c) annotated controls that never made it into the spec ------------------
+    # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/
+    # unreferenced parameter the builder intentionally does not place as a dead
+    # control; needs-materialization: a calc-bound filter whose column isn't on
+    # the model yet) is recorded in the controls-coverage ledger, NOT silently
+    # dropped — so its absence from the spec is expected, not a "not migrated"
+    # failure. Only a control the builder recorded as EMITTED but that's missing
+    # from the spec is a real bug the source filter was lost.
+    surfaced_gap = %w[needs-wiring needs-materialization].freeze
     scope_by_cid.each do |cid, c|
+      next if surfaced_gap.include?(c['status'].to_s)
       violations << "missing control: control-scope.json expects control #{cid.inspect}" \
                     "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
                     'has no control with that controlId — the source filter was not migrated'

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/control_lint.rb
@@ -202,8 +202,18 @@ module ControlLint
         scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
       end
       # (c) the Qlik class: source had filter signals, spec built zero controls.
+      # BUT suppress when every scope entry is an already-surfaced gap
+      # (needs-wiring / needs-materialization): the builder DID account for each
+      # source signal in the coverage ledger — e.g. a dashboard whose only
+      # "filter" is an orphan/unreferenced parameter that legitimately becomes no
+      # placeable control. That's a surfaced gap, not the silent static-workbook
+      # miss this rule targets. A genuinely silent miss has signals but NO scope
+      # entries explaining them → still fails.
       signals = scope['sourceFilterSignals'].to_i
-      if signals.positive? && rows.empty?
+      scoped = Array(scope['controls'])
+      all_surfaced_gaps = scoped.any? &&
+                          scoped.all? { |c| %w[needs-wiring needs-materialization].include?(c['status'].to_s) }
+      if signals.positive? && rows.empty? && !all_surfaced_gaps
         violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
                       '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
                       'elements — the source dashboard is interactive and the migration shipped a ' \

--- a/shared/lib/control_lint.rb
+++ b/shared/lib/control_lint.rb
@@ -270,7 +270,16 @@ module ControlLint
     end
 
     # (c) annotated controls that never made it into the spec ------------------
+    # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/
+    # unreferenced parameter the builder intentionally does not place as a dead
+    # control; needs-materialization: a calc-bound filter whose column isn't on
+    # the model yet) is recorded in the controls-coverage ledger, NOT silently
+    # dropped — so its absence from the spec is expected, not a "not migrated"
+    # failure. Only a control the builder recorded as EMITTED but that's missing
+    # from the spec is a real bug the source filter was lost.
+    surfaced_gap = %w[needs-wiring needs-materialization].freeze
     scope_by_cid.each do |cid, c|
+      next if surfaced_gap.include?(c['status'].to_s)
       violations << "missing control: control-scope.json expects control #{cid.inspect}" \
                     "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
                     'has no control with that controlId — the source filter was not migrated'

--- a/shared/lib/control_lint.rb
+++ b/shared/lib/control_lint.rb
@@ -202,8 +202,18 @@ module ControlLint
         scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
       end
       # (c) the Qlik class: source had filter signals, spec built zero controls.
+      # BUT suppress when every scope entry is an already-surfaced gap
+      # (needs-wiring / needs-materialization): the builder DID account for each
+      # source signal in the coverage ledger — e.g. a dashboard whose only
+      # "filter" is an orphan/unreferenced parameter that legitimately becomes no
+      # placeable control. That's a surfaced gap, not the silent static-workbook
+      # miss this rule targets. A genuinely silent miss has signals but NO scope
+      # entries explaining them → still fails.
       signals = scope['sourceFilterSignals'].to_i
-      if signals.positive? && rows.empty?
+      scoped = Array(scope['controls'])
+      all_surfaced_gaps = scoped.any? &&
+                          scoped.all? { |c| %w[needs-wiring needs-materialization].include?(c['status'].to_s) }
+      if signals.positive? && rows.empty? && !all_surfaced_gaps
         violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
                       '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
                       'elements — the source dashboard is interactive and the migration shipped a ' \

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -323,6 +323,13 @@
       ]
     },
     {
+      "canonical": "shared/scripts/test-control-lint.rb",
+      "targets": [
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-control-lint.rb",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-control-lint.rb"
+      ]
+    },
+    {
       "canonical": "shared/scripts/test-telemetry-gate.rb",
       "targets": [
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb",

--- a/shared/scripts/test-control-lint.rb
+++ b/shared/scripts/test-control-lint.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# Regression test for control_lint's "missing control" gate (#259).
+#
+# A control-scope entry flagged as an ALREADY-SURFACED gap — needs-wiring (an
+# orphan/unreferenced parameter the builder intentionally does not place as a
+# dead control) or needs-materialization (a calc-bound filter whose column isn't
+# on the model yet) — is recorded in the controls-coverage ledger, NOT silently
+# dropped. So its absence from the spec must NOT be reported as "missing control"
+# (which hard-fails the migration gate). Only an EMITTED-status entry that's
+# absent from the spec is a real "the source filter was not migrated" failure.
+#
+# The bug this guards: a stray Tableau parameter (referenced by no calc) blocked
+# the whole control gate — very common, would have broken most migrations.
+#
+# Usage:  ruby scripts/test-control-lint.rb   (run from a vendored plugin copy)
+require 'json'
+require 'set'
+require_relative 'lib/control_lint'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Minimal non-degenerate spec: one page, one non-control element, NO controls —
+# so any "missing control" comes purely from the scope↔spec reconciliation.
+SPEC = { 'pages' => [{ 'name' => 'P1', 'elements' => [
+  { 'id' => 'tbl-1', 'kind' => 'table', 'name' => 'T' }
+] }] }.freeze
+
+def scope_with(status)
+  ctl = { 'controlId' => 'ctl-orphan', 'name' => 'Orphan', 'sourceName' => "param 'Orphan'" }
+  ctl['status'] = status unless status.nil?
+  { 'sourceFilterSignals' => 0, 'controls' => [ctl] }
+end
+
+missing = ->(vs) { vs.any? { |v| v.include?('missing control') && v.include?('ctl-orphan') } }
+
+# needs-wiring (orphan/unreferenced param) → NOT a missing-control failure
+v1 = ControlLint.lint(SPEC, scope: scope_with('needs-wiring'))
+check(!missing.call(v1), "needs-wiring scope entry absent from spec → NO 'missing control' (got #{v1.inspect})", fails)
+
+# needs-materialization (calc-bound filter, column not yet on the model) → likewise
+v2 = ControlLint.lint(SPEC, scope: scope_with('needs-materialization'))
+check(!missing.call(v2), 'needs-materialization scope entry absent from spec → NO missing-control', fails)
+
+# emitted status but absent from spec → this IS a real failure (guard against over-suppression)
+v3 = ControlLint.lint(SPEC, scope: scope_with('emitted'))
+check(missing.call(v3), 'emitted scope entry absent from spec → DOES flag missing-control (regression guard)', fails)
+
+# no status → defaults to emitted → still flags (a bare scope entry must not slip through)
+v4 = ControlLint.lint(SPEC, scope: scope_with(nil))
+check(missing.call(v4), 'missing status defaults to emitted → flags missing-control', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — control_lint honors needs-wiring/needs-materialization coverage gaps'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end

--- a/shared/scripts/test-control-lint.rb
+++ b/shared/scripts/test-control-lint.rb
@@ -53,6 +53,19 @@ check(missing.call(v3), 'emitted scope entry absent from spec → DOES flag miss
 v4 = ControlLint.lint(SPEC, scope: scope_with(nil))
 check(missing.call(v4), 'missing status defaults to emitted → flags missing-control', fails)
 
+# --- "no controls built" (Qlik-class) must also honor surfaced gaps -----------
+no_built = ->(vs) { vs.any? { |v| v.include?('no controls built') } }
+# 1 filter signal, ZERO controls, but the only scope entry is a needs-wiring
+# orphan param → the signal is accounted for as a surfaced gap → NOT a failure.
+sig_gap = { 'sourceFilterSignals' => 1,
+            'controls' => [{ 'controlId' => 'ctl-orphan', 'name' => 'Orphan', 'status' => 'needs-wiring' }] }
+check(!no_built.call(ControlLint.lint(SPEC, scope: sig_gap)),
+      'signals>0 + zero controls but all scope entries needs-wiring → NO "no controls built" (the ComplexPivot case)', fails)
+# genuine silent miss: signals but NO scope entries explaining them → still fails.
+sig_silent = { 'sourceFilterSignals' => 1, 'controls' => [] }
+check(no_built.call(ControlLint.lint(SPEC, scope: sig_silent)),
+      'signals>0 + zero controls + NO scope entries → DOES flag "no controls built" (Qlik silent-miss preserved)', fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS — control_lint honors needs-wiring/needs-materialization coverage gaps'


### PR DESCRIPTION
Part of #259 (controls track). Found by running a filtered dashboard (RLS Reference) end-to-end.

## Bug — a stray parameter blocks the whole control gate

`control_lint`'s "missing control" check hard-failed whenever a `control-scope.json` entry had no matching control in the spec — **including entries the builder intentionally records as gaps rather than placing:**

- **`needs-wiring`** — an orphan/unreferenced Tableau parameter (e.g. a stray `Year Filter` that no calc references). The builder emits it *for coverage*, and the page-assembly dead-control guard correctly **skips placing** it (a control that changes nothing shouldn't ship as furniture) — but the scope record survived, so the gate failed with *"missing control … the source filter was not migrated."*
- **`needs-materialization`** — a calc-bound filter whose column isn't on the model yet (surfaced for the operator to materialize).

Both are recorded in the controls-coverage ledger — **not silent drops** — so their absence from the spec is expected, not a failure. As-is, **any dashboard carrying a stray parameter** (extremely common) died at the control gate. The `jwsf` fix had covered only *measure-picker* params (which are referenced, so they get placed); plain orphan value params still tripped it.

## Fix

In the scope↔spec reconciliation, skip entries whose `status` is `needs-wiring` / `needs-materialization`. Only an **`emitted`**-status entry missing from the spec remains a real "not migrated" failure (regression-guarded).

## Shared — fixes every converter

Edited canonical `shared/lib/control_lint.rb` + `tools/sync-shared.rb` fan-out to all 7 converter copies, so **every** converter's control gate is fixed (not just Tableau) — relevant for the hackathon. New shared regression test `scripts/test-control-lint.rb` (4 checks: needs-wiring/needs-materialization suppressed; emitted + default-status still flagged), fanned out to powerbi + tableau.

## Verification

- `check-shared` OK (267 copies consistent); control/param test suite green (`test-control-lint`, `test-param-measure-picker`, `test-coverage-gate`, `test-calc-field-controls`, `test-control-display-type`).
- Against the **real posted RLS-Reference workbook** (built E2E into a sandbox org): `control lint` now **clean (3 controls checked)** — the orphan-param FAIL is gone, so the migration passes the control gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)