### PR TITLE
tableau: param controls single-select (ubr5.18) + spec-API-limit coverage surfacing (ubr5.20)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -4239,6 +4239,13 @@ unless opts[:no_auto_controls]   # default-on: never miss a .twb parameter/filte
         'kind' => 'manual', 'valueType' => 'text',
         'values' => values, 'labels' => labels
       }
+      # A Tableau parameter is ALWAYS single-valued. Sigma defaults a `list`
+      # control to selectionMode:"multiple", which (a) drops the scalar default
+      # `value` on readback and (b) makes the translated Switch/If measure-picker
+      # compile to type "error" — a scalar case-compare against a multi-select
+      # ARRAY. Pin single so the scalar default applies and the Switch resolves.
+      # (Verified live 2026-07-05: without this the picker ships dead.)
+      spec['selectionMode'] = 'single'
       spec['value'] = p['default_value']
     elsif p['param_domain'] == 'range' && %w[integer real].include?(p['datatype'])
       # Numeric range parameter → Sigma `number-range` control (discovered by
@@ -4314,6 +4321,10 @@ $param_switches.each do |sw|
     # its display mode, else segmented (button row).
     'controlType' => sigma_control_type(control_display_for(layout, pcap, norm_cap)),
     'source'      => { 'kind' => 'manual', 'valueType' => 'text', 'values' => values, 'labels' => values },
+    # Measure-pickers are single-valued (see the param-control path above): a
+    # `list` control defaults to multiple, which drops the scalar `value` and
+    # errors the Switch (scalar vs array). Pin single. Verified live 2026-07-05.
+    'selectionMode' => 'single',
     'value'       => values.first,
     'includeNulls' => 'when-no-value-is-selected'
   }
@@ -4874,6 +4885,67 @@ unless actions.empty?
   warn "wrote #{actions_md_path} (#{actions.size} action entries)"
 end
 
+# ---- spec-API limits — unsupported source primitives/features (bead ubr5.20) --
+# Some Tableau viz kinds + features have NO Sigma spec path. When the builder
+# can't emit them it produces NOTHING and NO warning — so they vanish silently
+# from coverage.json (the #1 "the report said clean but the dashboard is missing
+# things" failure). Scan the SOURCE dashboard zones and name each unsupported
+# primitive/feature explicitly. Detectors are CONSERVATIVE (fire only on a clear
+# structural signal) to avoid false positives; one entry per zone.
+def spec_api_limit_entries(layout)
+  entries = []
+  add = lambda do |cap, severity, detail, action|
+    entries << { 'visual' => cap.to_s, 'source_type' => 'worksheet',
+                 'severity' => severity, 'recoverable' => false,
+                 'detail' => detail, 'action' => action }
+  end
+  (layout || []).each do |dash|
+    (dash['zones'] || []).each do |z|
+      next unless z['kind'] == 'chart'
+      cap  = (z['caption'] || z['id']).to_s
+      mk   = z['mark_class'].to_s
+      ck   = z['chart_kind'].to_s
+      calc = (z['calculations'] || []).map { |c| "#{c['caption']} #{c['formula']}" }.join(' ')
+      meas = (z['measures'] || []).map { |m| m['column'] }.join(' ')
+      # Bump / rank-flow: a line chart whose plotted value is a RANK/INDEX table
+      # calc (one line per entity connecting rank positions over time). ubr5.21.
+      if (mk == 'Line' || ck == 'line') &&
+         (meas =~ /\[?rank\b/i || calc =~ /\b(?:RANK(?:_UNIQUE|_DENSE|_MODIFIED|_PERCENTILE)?|INDEX)\s*\(/i)
+        add.call(cap, 'dropped',
+                 'bump / rank-flow chart (line-per-entity rank over a time axis) — no Sigma chart primitive',
+                 'Rebuild as a line chart with a computed Rank() y-value on an inverted axis, or omit (see bead ubr5.21).')
+        next
+      end
+      # Shape / image mark used as an icon or decorative graphic — Sigma has no
+      # shape mark; these are silently dropped today.
+      if mk == 'Shape'
+        add.call(cap, 'dropped',
+                 'shape / image-mark worksheet (icon or decorative graphic) — Sigma has no shape mark',
+                 'Recreate with a hosted image element (kind:image + URL) or omit; not auto-migrated.')
+        next
+      end
+      # Filled map / choropleth with a color gradient — limited Sigma geo support.
+      if z['geo_role'] && (mk =~ /map|polygon/i || ck =~ /map|choropleth/i)
+        add.call(cap, 'degraded',
+                 'filled map / choropleth — Sigma polygon/value-gradient geography support is limited',
+                 'Verify against a Sigma map element; a point/bubble-map fallback may be needed.')
+        next
+      end
+      # KPI ▲/▼ delta: the big number migrates, but the vs-prior comparison
+      # indicator (arrow + % change) is UI-only, not spec-authorable.
+      if (z['is_kpi'] || ck == 'kpi') &&
+         (calc =~ /(?:up|down)\s*arrow|%\s*change|change from prev|vs\.?\s*prev|prior (?:month|period|year)/i ||
+          meas =~ /arrow|%\s*change/i)
+        add.call(cap, 'degraded',
+                 'KPI comparison indicator (▲/▼ + % vs prior period) is UI-only — the value migrates, the delta does not',
+                 'Add the trend/comparison in the Sigma editor after publish (not spec-authorable; memory sigma-kpi-trend-comparison-ui-only).')
+        next
+      end
+    end
+  end
+  entries
+end
+
 # ---- coverage.json — ONE consolidated "what didn't carry over (and why)" ledger
 # (bead beads-sigma-59mk; ports powerbi-to-sigma PR #177). The builder already
 # emits the facts — 87 build WARN lines + the dropped-control / inferred-tile /
@@ -4935,6 +5007,14 @@ warnings.each do |w|
     'detail' => ws[0, 300],
     'action' => (recoverable ? 'Resolve the field on the master (map it / add the calc column), then re-run.' : nil)
   }
+end
+
+# (5) spec-API limits — unsupported source primitives/features (bead ubr5.20).
+# Skip any zone already surfaced by a warning above (avoid double-listing).
+_already = coverage_unresolved.map { |u| u['visual'].to_s.downcase }
+spec_api_limit_entries(layout).each do |e|
+  next if _already.include?(e['visual'].to_s.downcase)
+  coverage_unresolved << e
 end
 
 built_n = (defined?(elements) && elements.respond_to?(:size)) ? elements.size : 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-measure-picker.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-measure-picker.rb
@@ -116,6 +116,19 @@ check(idx2['region picker'] == true, 'GUID-keyed param_name resolves caption via
 idx3 = picker_param_caps_index(sws, [], {})
 check(idx3.empty?, 'un-wired picker → no dedup (control still emitted)', fails)
 
+# --- selectionMode:single regression (live-verified 2026-07-05) --------------
+# A Tableau parameter is single-valued. Sigma defaults a `list` control to
+# selectionMode:"multiple", which drops the scalar default `value` AND errors
+# the translated Switch/If (scalar case-compare vs a multi-select ARRAY) — the
+# picker ships DEAD. Both control-emission sites MUST pin single. These assert
+# on SRC because the emission is inline (not an extractable function).
+picker_block = SRC[/param_controls << \{.*?'controlId'\s*=>\s*sw\['control_id'\].*?\n\s*\}/m]
+check(picker_block && picker_block.include?("'selectionMode' => 'single'"),
+      "param measure-picker control pins selectionMode:'single'", fails)
+list_param_block = SRC[/if p\['param_domain'\] == 'list'.*?spec\['value'\] = p\['default_value'\]/m]
+check(list_param_block && list_param_block.include?("spec['selectionMode'] = 'single'"),
+      "list parameter control pins selectionMode:'single'", fails)
+
 puts
 if fails.empty?
   puts 'ALL PASS — param measure-picker: control-driven Switch, metric inlining, graceful null, window skip'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-spec-api-coverage.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-spec-api-coverage.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# Regression: spec_api_limit_entries (bead ubr5.20) surfaces unsupported source
+# primitives/features in coverage.json that the builder can't emit — so they
+# never vanish silently. Also guards against FALSE POSITIVES on supported vizzes
+# (plain bar/line/KPI). Extracts the function from build-charts-from-signals.rb
+# (it's an inline top-level def, like test-param-measure-picker.rb does).
+require 'json'
+
+SRC = File.read(File.join(__dir__, 'build-charts-from-signals.rb'))
+fn  = SRC[/^def spec_api_limit_entries.*?^end/m] or abort('could not extract spec_api_limit_entries')
+eval(fn)
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+layout = [{
+  'dashboard' => 'D', 'zones' => [
+    # --- SHOULD fire ---
+    { 'kind' => 'chart', 'caption' => 'Rank Bump', 'chart_kind' => 'line', 'mark_class' => 'Line',
+      'measures' => [{ 'column' => '[Rank]' }], 'calculations' => [] },
+    { 'kind' => 'chart', 'caption' => 'Bump via INDEX', 'chart_kind' => 'line', 'mark_class' => 'Line',
+      'measures' => [], 'calculations' => [{ 'caption' => 'Rank', 'formula' => 'INDEX()' }] },
+    { 'kind' => 'chart', 'caption' => 'Logo', 'chart_kind' => 'scatter', 'mark_class' => 'Shape',
+      'measures' => [], 'calculations' => [] },
+    { 'kind' => 'chart', 'caption' => 'Sales KPI', 'chart_kind' => 'kpi', 'mark_class' => 'Automatic', 'is_kpi' => true,
+      'measures' => [], 'calculations' => [{ 'caption' => 'Up Arrow', 'formula' => '' }, { 'caption' => '% Change', 'formula' => '' }] },
+    { 'kind' => 'chart', 'caption' => 'Filled Map', 'chart_kind' => 'map', 'mark_class' => 'Map',
+      'geo_role' => 'state', 'measures' => [], 'calculations' => [] },
+    # --- should NOT fire (false-positive guards) ---
+    { 'kind' => 'chart', 'caption' => 'Sales by Region', 'chart_kind' => 'bar', 'mark_class' => 'Automatic',
+      'measures' => [{ 'column' => '[Sales]' }], 'calculations' => [] },
+    { 'kind' => 'chart', 'caption' => 'Sales Trend', 'chart_kind' => 'line', 'mark_class' => 'Line',
+      'measures' => [{ 'column' => '[Sales]' }], 'calculations' => [] },
+    { 'kind' => 'chart', 'caption' => 'Plain KPI', 'chart_kind' => 'kpi', 'mark_class' => 'Automatic', 'is_kpi' => true,
+      'measures' => [{ 'column' => '[Sales]' }], 'calculations' => [] },
+    { 'kind' => 'text', 'caption' => 'A note' } # non-chart zone ignored
+  ]
+}]
+
+e = spec_api_limit_entries(layout)
+by_vis = e.each_with_object({}) { |x, h| h[x['visual']] = x }
+
+# fires
+check(by_vis['Rank Bump'] && by_vis['Rank Bump']['severity'] == 'dropped' &&
+      by_vis['Rank Bump']['detail'] =~ /bump/i, 'bump via [Rank] measure → dropped', fails)
+check(by_vis['Bump via INDEX'] && by_vis['Bump via INDEX']['detail'] =~ /bump/i,
+      'bump via INDEX() calc → dropped', fails)
+check(by_vis['Logo'] && by_vis['Logo']['severity'] == 'dropped' &&
+      by_vis['Logo']['detail'] =~ /shape/i, 'shape/image mark → dropped', fails)
+check(by_vis['Sales KPI'] && by_vis['Sales KPI']['severity'] == 'degraded' &&
+      by_vis['Sales KPI']['detail'] =~ /comparison|▲/, 'KPI ▲/▼ delta → degraded', fails)
+check(by_vis['Filled Map'] && by_vis['Filled Map']['detail'] =~ /map|choropleth/i,
+      'filled map / choropleth → surfaced', fails)
+
+# false-positive guards
+check(!by_vis['Sales by Region'], 'plain bar NOT flagged', fails)
+check(!by_vis['Sales Trend'],     'plain line (no rank) NOT flagged', fails)
+check(!by_vis['Plain KPI'],       'plain KPI (no delta fields) NOT flagged', fails)
+check(e.size == 5, "exactly 5 entries (got #{e.size})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — spec-API-limit coverage surfacing (ubr5.20): unsupported primitives named, no false positives'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"
+  fails.each { |x| puts "  - #{x}" }
+  exit 1
+end


### PR DESCRIPTION
## What
Two fixes surfaced by the **YouTube Analytics cold run** (memory `youtube-coldrun-diagnostic`).

### `ubr5.18` — param measure-picker shipped DEAD
The emitted `list` control set no `selectionMode`, so Sigma defaults it to `"multiple"`, which:
1. **drops** the scalar default `value` on readback (widget shows "Select value"), and
2. makes the translated `Switch`/`If` compile to type **`error`** — a scalar case-compare against a multi-select **array**.

A Tableau parameter is always single-valued → pin `selectionMode: 'single'` on **both** control-emission paths (list-param + `kind:param-switch`). Regression checks added to `test-param-measure-picker.rb`.

### `ubr5.20` — spec-API-limit gaps vanished silently
Unsupported primitives/features that the builder can't emit produced **nothing and no warning**, so they never reached `coverage.json`. Added `spec_api_limit_entries()` — a conservative source-zone scan (fires only on a clear structural signal, deduped vs warnings) that surfaces:
- **bump / rank-flow** (line + `Rank`/`INDEX`) → `dropped` (see `ubr5.21`)
- **shape / image-mark** icons + decorative → `dropped`
- **filled map / choropleth** → `degraded`
- **KPI ▲/▼ %-delta** comparison (UI-only) → `degraded`

New test `test-spec-api-coverage.rb` (9 checks incl. false-positive guards on plain bar/line/KPI).

## Testing
- Full offline suite green (37 pass; `test-calc-discovery` skipped — live-cred integration test).
- **Live E2E on the real `.twb`**: integrated builder emits all 7 param controls with `selectionMode:single` + scalar `value`; `coverage.json` surfaces all 12 previously-silent drops with zero false positives.
- **Live render**: workbook `f244e5b2` confirms the `list/single/value` control shape renders and drives its tile in Sigma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)