### PR TITLE
tableau: --column-mapping for genuine extract-caption renames (#259)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -562,7 +562,7 @@ module MechanicalSpecs
   # warehouse-table columns whose physical name is NOT in the real table are
   # DROPPED as phantom (Tableau virtual-connection flattening invents columns
   # like "REGION (STORE_DIM (CSA.STORE_DIM))" that don't exist in ORDER_FACT).
-  def fixup_dm_spec(model, real_columns = nil)
+  def fixup_dm_spec(model, real_columns = nil, column_mapping: nil)
     begin
       require 'set'
       $LOAD_PATH.unshift File.expand_path('lib', __dir__)
@@ -572,6 +572,11 @@ module MechanicalSpecs
     end
     real = {}
     (real_columns || {}).each { |t, cols| real[t.to_s.upcase] = cols.map { |c| c.to_s.upcase }.to_set }
+    # Column-rename map (--column-mapping): a genuine extract-caption → warehouse
+    # rename ("State" → STATE_PROVINCE) that separator-folding can't recover.
+    # Keyed by the UPPER extract caption; value = the real warehouse column.
+    colmap = {}
+    (column_mapping || {}).each { |src, dest| colmap[src.to_s.strip.upcase] = dest.to_s.strip }
     # Caption hygiene FIRST (bead 320u): Sigma trims display names server-side,
     # so trailing-space captions must be trimmed everywhere refs are built.
     trim_spec_whitespace!(model)
@@ -597,6 +602,7 @@ module MechanicalSpecs
       e['name'] = display_name(tbl) unless tbl.empty?
     end
     phantom = 0
+    remapped = 0
     dropped_col_ids = Set.new
     dropped_disp_by_el = Hash.new { |h, k| h[k] = Set.new } # element id -> dropped display names
     unless real.empty?
@@ -616,10 +622,24 @@ module MechanicalSpecs
           # drop a calc column (it has functions / multiple refs).
           is_base_ref = c['formula'].to_s =~ /\A\[#{Regexp.escape((el.dig('source','path')||[]).last.to_s)}\/[^\]]+\]\z/
           if is_base_ref && phys && !rc.include?(phys)
-            drop[c['id']] = true
-            dn = col_display(c)
-            dropped_disp_by_el[el['id']] << dn if dn
-            phantom += 1
+            # Before dropping a base column absent from the real table, try the
+            # column-rename map: if the caption maps to a REAL warehouse column,
+            # rewrite the ref to it and KEEP the original caption as the display
+            # name (so downstream master/chart refs by caption still resolve).
+            disp = tail.split('/').last
+            dest = colmap[disp.to_s.strip.upcase] || colmap[phys]
+            if dest && rc.include?(dest.upcase)
+              tblname = (el.dig('source', 'path') || []).last.to_s
+              c['name'] = disp if c['name'].to_s.empty?
+              c['formula'] = "[#{tblname}/#{display_name(dest.upcase)}]"
+              remapped += 1
+              keep << c
+            else
+              drop[c['id']] = true
+              dn = col_display(c)
+              dropped_disp_by_el[el['id']] << dn if dn
+              phantom += 1
+            end
           else
             keep << c
           end
@@ -731,7 +751,7 @@ module MechanicalSpecs
         el['metrics'] = kept_metrics
       end
     end
-    { fixed: fixed, dropped: dropped.uniq, phantom: phantom }
+    { fixed: fixed, dropped: dropped.uniq, phantom: phantom, remapped: remapped }
   end
 
   # The display-name suffix Sigma stamps on a derived-view column when its bare

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -108,6 +108,16 @@ OptionParser.new do |o|
     abort "--table-mapping expects 'Src=DEST' (got #{v.inspect})" if val.nil? || k.to_s.empty? || val.empty?
     (opts[:table_mapping] ||= {})[k.strip] = val.strip
   end
+  o.on('--column-mapping PAIR',
+       "'ExtractCaption=WAREHOUSE_COL' — remap a base column whose extract caption " \
+       'is a genuine RENAME of the warehouse column (repeatable). Separator-folding ' \
+       'already handles "Country/Region"/"Sub-Category"; use this only for true renames ' \
+       'like "State"=STATE_PROVINCE, else the column is dropped as phantom. The original ' \
+       'caption is kept as the Sigma column display name.') do |v|
+    k, val = v.split('=', 2)
+    abort "--column-mapping expects 'Src=DEST' (got #{v.inspect})" if val.nil? || k.to_s.empty? || val.empty?
+    (opts[:column_mapping] ||= {})[k.strip] = val.strip
+  end
   o.on('--specs PATH')       { |v| opts[:specs]   = File.expand_path(v) }
   # Agent-authored JSON specs — the manual path's re-entry into the GATED spine.
   # When the mechanical converter backend is unavailable, the agent authors the DM
@@ -1427,8 +1437,9 @@ elsif mechanical
     dim_catalogs[tname.upcase] = cj['columns']
   end
   unless real_cols.empty?
-    pf = MechanicalSpecs.fixup_dm_spec(dm, real_cols)
+    pf = MechanicalSpecs.fixup_dm_spec(dm, real_cols, column_mapping: opts[:column_mapping])
     line "phantom-column filter: dropped #{pf[:phantom]} non-existent base column(s) using #{real_cols.size} live table catalog(s)" if pf[:phantom].to_i.positive?
+    line "column-rename remap: rewired #{pf[:remapped]} base column(s) to their warehouse names (--column-mapping)" if pf[:remapped].to_i.positive?
   end
   # Computed-key join recovery (bead ovud): joins the converter skipped
   # ("DATE([Order Date]) = [Date Key]") are recovered mechanically — via a calc

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-extract-table-mapping.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-extract-table-mapping.rb
@@ -15,6 +15,8 @@
 #            (was a type=error / phantom-dropped column).
 #   Part C — fixup_dm_spec phantom-drop keeps a separator-mismatch column that
 #            exists in the warehouse and drops only a genuine rename.
+#   Part D — --column-mapping remaps a genuine rename to its warehouse column
+#            (keeping the original caption) instead of dropping it.
 #
 # Usage:  ruby scripts/test-extract-table-mapping.rb
 
@@ -95,6 +97,25 @@ check(kept.include?('[ORDERS/Country Region]'), 'Country Region KEPT (exists as 
 check(kept.include?('[ORDERS/Sub Category]'), 'Sub Category KEPT (exists as SUB_CATEGORY)', fails)
 check(kept.none? { |f| f == '[ORDERS/State]' }, 'State DROPPED (genuine rename → STATE_PROVINCE)', fails)
 check(pf[:phantom].to_i == 1, "exactly 1 phantom column dropped (got #{pf[:phantom]})", fails)
+
+puts 'Part D — --column-mapping remaps a genuine rename (keeps the caption)'
+model2 = nil
+Dir.mktmpdir do |dir|
+  twb_path = File.join(dir, 'extract.twb')
+  File.write(twb_path, TWB)
+  model2 = MechanicalSpecs.run_converter(
+    twb_path: twb_path, conn: 'conn-1', db: 'CSA', schema: 'Tableau Test',
+    mcp_build: VENDORED, workdir: dir, table_mapping: { 'Orders$' => 'ORDERS' })['model']
+end
+pf2 = MechanicalSpecs.fixup_dm_spec(model2, real_cols, column_mapping: { 'State' => 'STATE_PROVINCE' })
+el2 = (model2['pages'] || []).flat_map { |p| p['elements'] || [] }
+      .find { |e| e.dig('source', 'kind') == 'warehouse-table' }
+state_col = (el2['columns'] || []).find { |c| c['name'] == 'State' }
+check(pf2[:remapped].to_i == 1, "exactly 1 column remapped (got #{pf2[:remapped]})", fails)
+check(pf2[:phantom].to_i.zero?, "nothing dropped once State is mapped (got phantom #{pf2[:phantom]})", fails)
+check(state_col && state_col['formula'] == '[ORDERS/State Province]',
+      "State refs [ORDERS/State Province] (→ STATE_PROVINCE) (got #{state_col && state_col['formula']})", fails)
+check(state_col && state_col['name'] == 'State', 'original caption "State" preserved as the display name', fails)
 
 puts
 if fails.empty?


### PR DESCRIPTION
Follow-on to #274. Separator-folding (`Country/Region`, `Sub-Category`) can't recover a genuine column **rename** where the extract caption differs from the warehouse column by more than punctuation — e.g. Superstore's `State` vs warehouse `STATE_PROVINCE`. Those base columns were phantom-dropped (surfaced, but the tile using them lost data).

## Change
- New repeatable `--column-mapping 'ExtractCaption=WAREHOUSE_COL'` flag, threaded into the Phase-3 `fixup_dm_spec`.
- Before dropping a base column absent from the live catalog, fixup checks the map: if the caption targets a **real** warehouse column, it rewrites the ref (`[TABLE/<display of warehouse col>]`) and keeps the **original caption** as the column's display name — so downstream master/chart refs by caption still resolve.
- `fixup_dm_spec` returns a `remapped` count; `migrate-tableau` logs it.

## Verification
- Unit test: `test-extract-table-mapping.rb` Part D (13 checks total).
- Live (tj-wells-1989): Superstore KPIs with `--column-mapping State=STATE_PROVINCE` → a **0-error / 0-dropped-column** data model; the `State` column (formula `[ORDERS/State Province]`) queries real state values (Texas, Pennsylvania, New York, …).

Refs #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)