### PR TITLE
docs(controls): control-parity gotcha for [controlId]-in-formula reach + type (closes #245)

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/control-parity.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/control-parity.md
@@ -97,3 +97,20 @@ Same class as the datetime strip: a list control whose filter target column is
 numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
 `Text()` cast column on the target element and point the control at the cast.
 (Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)
+
+## Gotcha: a `[controlId]` formula reference is only "reach" if consumed type-compatibly
+The lint counts a `[<controlId>]` reference in a calc/formula as control **reach**
+— but reach ≠ resolves. A control's value is **typed** (`number`/`slider`→number,
+`date-range`→a `{start,end}` variant, `list`/`segmented`→a set, `checkbox`/`switch`→
+bool, `text`→text). Consuming it in a type-incompatible op (bare arithmetic on a
+`date-range`/`list`, e.g. `[Range] + 1`) reads back clean but `#ERROR`s **at query
+time** with `Expected number; received variant` — the same silent-until-query class
+as the numeric-list-target strip above. Two failure shapes to avoid:
+- referencing the element **`id`** instead of the **`controlId`** → `Unknown column`
+  (never "reach"); and
+- a type-mismatched `controlId` reference → counts as reach, renders, then `#ERROR`s.
+
+Consume per type (`[Range].start`, `Text([Ctl])`, `[Col] = [ListCtl]`), don't strip
+the control. Full syntax + typed-value table + worked examples:
+`sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md`
+→ "Referencing a Control's Value in a Formula". (Verified live 2026-07-01.)

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/control-parity.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/control-parity.md
@@ -97,3 +97,20 @@ Same class as the datetime strip: a list control whose filter target column is
 numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
 `Text()` cast column on the target element and point the control at the cast.
 (Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)
+
+## Gotcha: a `[controlId]` formula reference is only "reach" if consumed type-compatibly
+The lint counts a `[<controlId>]` reference in a calc/formula as control **reach**
+— but reach ≠ resolves. A control's value is **typed** (`number`/`slider`→number,
+`date-range`→a `{start,end}` variant, `list`/`segmented`→a set, `checkbox`/`switch`→
+bool, `text`→text). Consuming it in a type-incompatible op (bare arithmetic on a
+`date-range`/`list`, e.g. `[Range] + 1`) reads back clean but `#ERROR`s **at query
+time** with `Expected number; received variant` — the same silent-until-query class
+as the numeric-list-target strip above. Two failure shapes to avoid:
+- referencing the element **`id`** instead of the **`controlId`** → `Unknown column`
+  (never "reach"); and
+- a type-mismatched `controlId` reference → counts as reach, renders, then `#ERROR`s.
+
+Consume per type (`[Range].start`, `Text([Ctl])`, `[Col] = [ListCtl]`), don't strip
+the control. Full syntax + typed-value table + worked examples:
+`sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md`
+→ "Referencing a Control's Value in a Formula". (Verified live 2026-07-01.)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/control-parity.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/control-parity.md
@@ -97,3 +97,20 @@ Same class as the datetime strip: a list control whose filter target column is
 numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
 `Text()` cast column on the target element and point the control at the cast.
 (Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)
+
+## Gotcha: a `[controlId]` formula reference is only "reach" if consumed type-compatibly
+The lint counts a `[<controlId>]` reference in a calc/formula as control **reach**
+— but reach ≠ resolves. A control's value is **typed** (`number`/`slider`→number,
+`date-range`→a `{start,end}` variant, `list`/`segmented`→a set, `checkbox`/`switch`→
+bool, `text`→text). Consuming it in a type-incompatible op (bare arithmetic on a
+`date-range`/`list`, e.g. `[Range] + 1`) reads back clean but `#ERROR`s **at query
+time** with `Expected number; received variant` — the same silent-until-query class
+as the numeric-list-target strip above. Two failure shapes to avoid:
+- referencing the element **`id`** instead of the **`controlId`** → `Unknown column`
+  (never "reach"); and
+- a type-mismatched `controlId` reference → counts as reach, renders, then `#ERROR`s.
+
+Consume per type (`[Range].start`, `Text([Ctl])`, `[Col] = [ListCtl]`), don't strip
+the control. Full syntax + typed-value table + worked examples:
+`sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md`
+→ "Referencing a Control's Value in a Formula". (Verified live 2026-07-01.)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/control-parity.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/control-parity.md
@@ -97,3 +97,20 @@ Same class as the datetime strip: a list control whose filter target column is
 numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
 `Text()` cast column on the target element and point the control at the cast.
 (Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)
+
+## Gotcha: a `[controlId]` formula reference is only "reach" if consumed type-compatibly
+The lint counts a `[<controlId>]` reference in a calc/formula as control **reach**
+— but reach ≠ resolves. A control's value is **typed** (`number`/`slider`→number,
+`date-range`→a `{start,end}` variant, `list`/`segmented`→a set, `checkbox`/`switch`→
+bool, `text`→text). Consuming it in a type-incompatible op (bare arithmetic on a
+`date-range`/`list`, e.g. `[Range] + 1`) reads back clean but `#ERROR`s **at query
+time** with `Expected number; received variant` — the same silent-until-query class
+as the numeric-list-target strip above. Two failure shapes to avoid:
+- referencing the element **`id`** instead of the **`controlId`** → `Unknown column`
+  (never "reach"); and
+- a type-mismatched `controlId` reference → counts as reach, renders, then `#ERROR`s.
+
+Consume per type (`[Range].start`, `Text([Ctl])`, `[Col] = [ListCtl]`), don't strip
+the control. Full syntax + typed-value table + worked examples:
+`sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md`
+→ "Referencing a Control's Value in a Formula". (Verified live 2026-07-01.)

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/control-parity.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/control-parity.md
@@ -97,3 +97,20 @@ Same class as the datetime strip: a list control whose filter target column is
 numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
 `Text()` cast column on the target element and point the control at the cast.
 (Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)
+
+## Gotcha: a `[controlId]` formula reference is only "reach" if consumed type-compatibly
+The lint counts a `[<controlId>]` reference in a calc/formula as control **reach**
+— but reach ≠ resolves. A control's value is **typed** (`number`/`slider`→number,
+`date-range`→a `{start,end}` variant, `list`/`segmented`→a set, `checkbox`/`switch`→
+bool, `text`→text). Consuming it in a type-incompatible op (bare arithmetic on a
+`date-range`/`list`, e.g. `[Range] + 1`) reads back clean but `#ERROR`s **at query
+time** with `Expected number; received variant` — the same silent-until-query class
+as the numeric-list-target strip above. Two failure shapes to avoid:
+- referencing the element **`id`** instead of the **`controlId`** → `Unknown column`
+  (never "reach"); and
+- a type-mismatched `controlId` reference → counts as reach, renders, then `#ERROR`s.
+
+Consume per type (`[Range].start`, `Text([Ctl])`, `[Col] = [ListCtl]`), don't strip
+the control. Full syntax + typed-value table + worked examples:
+`sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md`
+→ "Referencing a Control's Value in a Formula". (Verified live 2026-07-01.)

--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
@@ -18,7 +18,7 @@ A `control` element has exactly these fields:
 |---|---|---|
 | `kind` | yes | Always `control` |
 | `id` | yes | Element ID — must be unique on the page |
-| `controlId` | yes | Formula reference name (e.g., `RegionFilter`) — keep distinct from `id`. This is the human-meaningful handle used when referring to the control's value from formulas. |
+| `controlId` | yes | Formula reference name (e.g., `RegionFilter`) — keep distinct from `id`. This is the human-meaningful handle used when referring to the control's value from formulas (syntax + typed-value rules: see [Referencing a Control's Value in a Formula](#referencing-a-controls-value-in-a-formula)). |
 | `controlType` | yes | Any value the recipe above returns. Determines the widget and filter behavior. |
 | `filters` | — | Array of `{ source, columnId }` — connects the control to the column(s) it filters. `source` is `{ kind: table, elementId: ... }`. |
 | `source` | list/segmented | Where the widget's VALUE LIST comes from. Double-nested: `{ kind: source, source: { kind: table, elementId: ... }, columnId: ... }`. |

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/control-parity.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/control-parity.md
@@ -97,3 +97,20 @@ Same class as the datetime strip: a list control whose filter target column is
 numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
 `Text()` cast column on the target element and point the control at the cast.
 (Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)
+
+## Gotcha: a `[controlId]` formula reference is only "reach" if consumed type-compatibly
+The lint counts a `[<controlId>]` reference in a calc/formula as control **reach**
+— but reach ≠ resolves. A control's value is **typed** (`number`/`slider`→number,
+`date-range`→a `{start,end}` variant, `list`/`segmented`→a set, `checkbox`/`switch`→
+bool, `text`→text). Consuming it in a type-incompatible op (bare arithmetic on a
+`date-range`/`list`, e.g. `[Range] + 1`) reads back clean but `#ERROR`s **at query
+time** with `Expected number; received variant` — the same silent-until-query class
+as the numeric-list-target strip above. Two failure shapes to avoid:
+- referencing the element **`id`** instead of the **`controlId`** → `Unknown column`
+  (never "reach"); and
+- a type-mismatched `controlId` reference → counts as reach, renders, then `#ERROR`s.
+
+Consume per type (`[Range].start`, `Text([Ctl])`, `[Col] = [ListCtl]`), don't strip
+the control. Full syntax + typed-value table + worked examples:
+`sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md`
+→ "Referencing a Control's Value in a Formula". (Verified live 2026-07-01.)

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/control-parity.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/control-parity.md
@@ -97,3 +97,20 @@ Same class as the datetime strip: a list control whose filter target column is
 numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
 `Text()` cast column on the target element and point the control at the cast.
 (Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)
+
+## Gotcha: a `[controlId]` formula reference is only "reach" if consumed type-compatibly
+The lint counts a `[<controlId>]` reference in a calc/formula as control **reach**
+— but reach ≠ resolves. A control's value is **typed** (`number`/`slider`→number,
+`date-range`→a `{start,end}` variant, `list`/`segmented`→a set, `checkbox`/`switch`→
+bool, `text`→text). Consuming it in a type-incompatible op (bare arithmetic on a
+`date-range`/`list`, e.g. `[Range] + 1`) reads back clean but `#ERROR`s **at query
+time** with `Expected number; received variant` — the same silent-until-query class
+as the numeric-list-target strip above. Two failure shapes to avoid:
+- referencing the element **`id`** instead of the **`controlId`** → `Unknown column`
+  (never "reach"); and
+- a type-mismatched `controlId` reference → counts as reach, renders, then `#ERROR`s.
+
+Consume per type (`[Range].start`, `Text([Ctl])`, `[Col] = [ListCtl]`), don't strip
+the control. Full syntax + typed-value table + worked examples:
+`sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md`
+→ "Referencing a Control's Value in a Formula". (Verified live 2026-07-01.)


### PR DESCRIPTION
Finishes #245. Its primary ask — a "Referencing a Control's Value in a Formula" section in `sigma-workbooks/reference/specification/controls.md` — already landed in #247 (controlId-vs-element-id, the typed-value table, the `received variant` type-mismatch, worked examples, dead-control framing). This PR closes the remaining half:

- **`control-parity.md`** (all 7 byte-identical converter copies): a companion gotcha — a `[controlId]` reference counts as lint **reach** but only *resolves* if consumed **type-compatibly**. Element-`id` refs → `Unknown column`; bare arithmetic on a `date-range`/`list` control → `#ERROR` at query time (`received variant`) — same silent-until-query class as the numeric-list-target strip documented just above. Cross-links the full table in controls.md.
- **`controls.md`**: cross-linked the `controlId` field-table row (the bare one-liner #245 flagged) to the section.

No behavior change — docs + a cross-converter reference note. `check-shared` green.

Closes #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)