### PR TITLE
feat(powerbi): Import-mode → Snowflake data-landing skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,7 +37,7 @@
     {
       "name": "powerbi-to-sigma",
       "source": "./plugins/powerbi-to-sigma",
-      "description": "Power BI models/reports \u2192 Sigma, DAX translation + gap-scout, with parity verification. Bundles powerbi-to-sigma + powerbi-assessment.",
+      "description": "Power BI models/reports \u2192 Sigma, DAX translation + gap-scout, with parity verification. Bundles powerbi-to-sigma + powerbi-assessment + powerbi-import-to-snowflake (Import-mode data landing).",
       "category": "migration",
       "keywords": [
         "powerbi",

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -3,9 +3,9 @@
   "name": "powerbi-to-sigma",
   "displayName": "Power BI → Sigma",
   "version": "1.0.0",
-  "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction, DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill.",
+  "description": "Migrate Power BI models and reports to Sigma — TMSL + report extraction, DAX → Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode → Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": { "name": "Thomas Wells" },
   "license": "MIT",
-  "keywords": ["powerbi", "power-bi", "dax", "sigma", "migration", "bi", "converter"],
+  "keywords": ["powerbi", "power-bi", "dax", "sigma", "migration", "bi", "converter", "snowflake", "import-mode"],
   "skills": "./skills/"
 }

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/PRIVACY.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/PRIVACY.md
@@ -1,0 +1,44 @@
+# Privacy & data handling — `powerbi-import-to-snowflake`
+
+Read this before running the skill, and share it with your privacy / security /
+legal team if your organization reviews tools that move data.
+
+## What this skill does with data — it MOVES ROW-LEVEL DATA
+
+Unlike the read-only assessment skills, this skill **extracts the actual rows**
+from an Import-mode Power BI model and **writes them into your Snowflake**. Plan
+accordingly.
+
+It connects to three systems on your behalf:
+
+1. **Your Power BI / Fabric tenant** — Fabric REST + Power BI REST, authenticated
+   as **you** via a Microsoft first-party public client (device-code sign-in, no
+   Entra app, no admin consent). Token cached locally at `/tmp/pbiauth/cache.bin`.
+   Reads: model structure (TMSL `getDefinition`) and **table rows** via
+   `/executeQueries`.
+2. **Your Snowflake** — via the Snowflake CLI (`snow`), using your configured
+   connection. Writes: `CREATE TABLE` + `PUT`/`COPY` of the extracted rows, plus
+   `GRANT`s. Nothing is dropped or overwritten outside the target schema you name.
+3. **Your Sigma org** (only with `--sigma-connection`) — `POST /v2/connections/
+   <id>/sync` to index the new tables. Sends only table *paths*, not row data.
+
+## What crosses the Anthropic API
+
+The agent driving this skill runs through Claude. **Row data does not need to
+pass through the model** — extraction writes rows straight to local CSV and then
+to Snowflake. What the agent sees is metadata (table/column names, types, row
+counts) and any output you ask it to summarize. Avoid pasting extracted row
+values into the conversation if they are sensitive.
+
+## Local artifacts
+
+- `out/<dataset>/*.csv` — the extracted rows, on your disk. Delete when done.
+- `out/<dataset>/manifest.json`, `load.sql` — metadata + DDL, no secrets.
+- `/tmp/pbiauth/cache.bin` — your cached Power BI token.
+
+## Least privilege
+
+- Land into a **dedicated schema** you control (`--target-schema`), not a shared one.
+- `--grant-role` defaults to `PUBLIC`; scope it to the Sigma connection's role
+  for tighter access, or `--grant-role ""` to grant nothing and handle it yourself.
+- Use `--dry-run` first to review the generated `load.sql` before any write.

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/README.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/README.md
@@ -1,0 +1,23 @@
+# powerbi-import-to-snowflake
+
+The **data track** for migrating an Import-mode Power BI model to a
+warehouse-native tool (Sigma).
+
+Sigma queries live warehouse tables — it has no in-memory import engine. When a
+`.pbix` imports its data from Excel / Power Query / flat files, there is no
+warehouse behind it, so the data must be landed first. This skill extracts the
+model's source tables and lands them in Snowflake, producing a manifest that the
+`powerbi-to-sigma` converter's output repoints onto — with column names aligned
+so no remapping is needed.
+
+- **In scope:** Import-mode (or the Import tables of a mixed model) → Snowflake.
+- **Out of scope:** DirectQuery models (already on a warehouse); DAX/relationship
+  conversion (that's `powerbi-to-sigma`).
+
+See `SKILL.md` for the workflow and `refs/` for the gotchas. `PRIVACY.md`
+covers data handling — note this skill moves **row-level data**, unlike the
+read-only assessment skills.
+
+Validated end-to-end on Microsoft's public Retail Analysis Sample: 923,371 SALES
+rows landed with exact row parity; the converted Sigma data model returned
+`$41,013,686.95` total regular sales — matching the Power BI value to the cent.

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: powerbi-import-to-snowflake
+description: Land an Import-mode Power BI model's source data into Snowflake so a warehouse-native tool (Sigma) can query it. Use when a .pbix / semantic model is Import mode over Excel / Power Query / flat files (no live warehouse behind it) and a migration needs the data physically in a warehouse first. This is the DATA track that runs BEFORE powerbi-to-sigma converts the model logic. Not for DirectQuery models (those already point at a warehouse) and not a logic/DAX converter.
+user-invocable: true
+---
+
+# Power BI (Import mode) → Snowflake
+
+Sigma is warehouse-native: it has no in-memory import engine, so every table,
+column, and metric resolves as live SQL against a connected warehouse. When a
+`.pbix` **imports** its data from Excel / Power Query / flat files, that data
+lives only in Power BI's VertiPaq store — there is no warehouse table for Sigma
+to point at. This skill extracts that data and lands it in Snowflake, then hands
+off to `powerbi-to-sigma` for the model logic.
+
+**Two tracks, one migration** (this skill is track 1):
+
+```
+1. DATA   (this skill)      Import-mode .pbix  → Snowflake tables + manifest
+2. LOGIC  (powerbi-to-sigma) model.bim (DAX/relationships) → Sigma data model
+3. REPOINT                  DM sources → the landed Snowflake tables  → live parity
+```
+
+Track 3 is automatic when column names line up — this skill's landed column
+names **byte-match** what `powerbi-to-sigma`'s converter emits (see
+`refs/naming-alignment.md`), so no remapping is needed.
+
+> Skip this skill for **DirectQuery** models — they already query a warehouse.
+> Only Import-mode (or mixed, for the Import tables) needs data landing.
+
+## What it does
+
+`scripts/pbi_import_to_snowflake.py` (generic — no hardcoded schemas):
+
+1. **Auth** — silent MSAL (Power BI + Fabric scopes), cached, device-code fallback.
+2. **Resolve** — workspace + dataset by name/id; or `--pbix` uploads the file first
+   via the Power BI REST `/imports` endpoint.
+3. **Enumerate** — model tables/columns/`dataType` via TMSL `getDefinition`
+   (version-independent; `INFO.TABLES()` fails on old compat levels). Skips
+   auto date tables and calculated/binary columns (see `refs/what-gets-landed.md`).
+4. **Extract** — rows via `/executeQueries` (DAX `SELECTCOLUMNS`), with automatic
+   integer-key **band pagination** (executeQueries silently truncates ~48k rows).
+5. **Load** — typed DDL + `PUT`/`COPY` via `snow sql`, with `GRANT`s.
+6. **Sync** — `--sigma-connection <id>` registers the new tables with Sigma
+   (`POST /v2/connections/<id>/sync`) so the DM POST resolves them immediately.
+7. **Manifest** — `out/<dataset>/manifest.json`: `pbi_table.col → sf_table.COLUMN`.
+
+## Run
+
+```bash
+# dry run — extract + generate load.sql, do not touch Snowflake
+python scripts/pbi_import_to_snowflake.py \
+  --dataset "<dataset name or id>" \
+  --target-db <DB> --target-schema <SCHEMA> --dry-run
+
+# full: extract → land → grant → sync into Sigma
+python scripts/pbi_import_to_snowflake.py \
+  --dataset "<dataset name or id>" \
+  --target-db <DB> --target-schema <SCHEMA> \
+  --sf-conn <snow-cli-connection> \
+  --sigma-connection <sigma-connection-uuid>
+```
+
+Useful flags: `--pbix <file>` (upload first), `--only "A,B"` (subset),
+`--limit-rows N` (cheap smoke test), `--grant-role <ROLE>` (default `PUBLIC`),
+`PBI_BAND_MAX=<n>` (force/soften pagination — testing).
+
+Requires: `msal`, `requests`, `truststore` (corp TLS); the Snowflake CLI
+(`snow`) configured; and `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` in the
+environment for `--sigma-connection` sync. See `../powerbi-to-sigma/SKILL.md`
+for the connect/auth details (same device-code path, no Entra app).
+
+## Then hand off
+
+1. Convert the model with `powerbi-to-sigma` (or locally:
+   `node scripts/run_converter.mjs <model.bim> <sigma-conn-id> <DB> <SCHEMA> dm.json`).
+2. POST the DM — sources resolve against the landed tables (names align).
+3. Verify parity — query the DM and compare to the PBI `executeQueries` golden.
+   Validated end-to-end on Microsoft's Retail Analysis Sample: 923,371 SALES rows,
+   live Sigma DM total `$41,013,686.95` == PBI golden, to the cent.
+
+## Gotchas (read `refs/` before a real run)
+
+- `refs/naming-alignment.md` — why landed columns must match `sigmaPhysicalName`.
+- `refs/what-gets-landed.md` — skip rules (auto date tables, calc + binary columns).
+- `refs/sync-and-grant.md` — new tables 404 on DM POST until GRANT + connection sync.
+- `refs/pagination.md` — the ~48k executeQueries truncation and band strategy.
+- `refs/metric-query-quirk.md` — converted metrics don't resolve via ad-hoc
+  `metric()` SQL (they render in the workbook UI); sum base columns for parity.

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/fixtures/sample-manifest.json
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/fixtures/sample-manifest.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Sanitized example output from Microsoft's public Retail Analysis Sample. Real dataset/workspace/connection ids are replaced with placeholders. Shows the pbi_table.col -> sf_table.COLUMN mapping used to repoint the converted Sigma data model.",
+  "dataset": "<pbi-dataset-id>",
+  "workspace": "<pbi-workspace-id>",
+  "target": "YOUR_DB.YOUR_SCHEMA",
+  "tables": [
+    {
+      "pbi_table": "Sales",
+      "sf_table": "YOUR_DB.YOUR_SCHEMA.SALES",
+      "rows": 923371,
+      "columns": [
+        { "pbi": "MonthID", "sf": "MONTH_ID", "sf_type": "NUMBER(38,0)" },
+        { "pbi": "ItemID", "sf": "ITEM_ID", "sf_type": "NUMBER(38,0)" },
+        { "pbi": "LocationID", "sf": "LOCATION_ID", "sf_type": "NUMBER(38,0)" },
+        { "pbi": "Sum_GrossMarginAmount", "sf": "SUM_GROSS_MARGIN_AMOUNT", "sf_type": "FLOAT" },
+        { "pbi": "Sum_Regular_Sales_Dollars", "sf": "SUM_REGULAR_SALES_DOLLARS", "sf_type": "FLOAT" },
+        { "pbi": "Sum_Markdown_Sales_Dollars", "sf": "SUM_MARKDOWN_SALES_DOLLARS", "sf_type": "FLOAT" },
+        { "pbi": "Sum_Regular_Sales_Units", "sf": "SUM_REGULAR_SALES_UNITS", "sf_type": "FLOAT" }
+      ]
+    },
+    {
+      "pbi_table": "District",
+      "sf_table": "YOUR_DB.YOUR_SCHEMA.DISTRICT",
+      "rows": 9,
+      "columns": [
+        { "pbi": "DistrictID", "sf": "DISTRICT_ID", "sf_type": "NUMBER(38,0)" },
+        { "pbi": "District", "sf": "DISTRICT", "sf_type": "VARCHAR" },
+        { "pbi": "DM", "sf": "DM", "sf_type": "VARCHAR" }
+      ]
+    }
+  ]
+}

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/refs/metric-query-quirk.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/refs/metric-query-quirk.md
@@ -1,0 +1,32 @@
+# Verifying value parity — the ad-hoc `metric()` quirk
+
+When you verify the migrated model, prefer summing **base columns** over calling
+converted metrics through the ad-hoc SQL path.
+
+## The quirk
+
+Converted metrics that reference *other metrics by display name* (e.g.
+`TotalSales = [Regular_Sales_Dollars] + [Markdown_Sales_Dollars]`) do **not**
+resolve through the programmatic `metric('<id>', t)` SQL path:
+
+- `Missing Metric`, or
+- `Unknown reference: [Regular_Sales_Dollars]`, or
+- `Could not resolve metric column …` when the metric's base column is
+  `hidden: true` (the converter hides base measure columns by default).
+
+These metrics **render correctly in the Sigma workbook UI** — the quirk is only
+in the ad-hoc `metric()` SQL evaluator, not in the model.
+
+## Reliable parity check
+
+Query the data-model element and `SUM` the base columns directly:
+
+```sql
+SELECT ROUND(SUM("<col-id-of-Sum-Regular-Sales-Dollars>"),2) AS regular_sales
+FROM "datamodel"."<elementId>" t
+```
+
+Get the exact opaque column ids from `describe` (`datamodel-element`). If base
+columns are hidden and you need them selectable, unhide them in the DM spec
+(`hidden: false`) and re-POST — a straight `SUM` then matches the PBI
+`executeQueries` golden exactly.

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/refs/naming-alignment.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/refs/naming-alignment.md
@@ -1,0 +1,24 @@
+# Column-name alignment — the crux of a remap-free repoint
+
+For the converted Sigma data model to resolve against the landed tables with **no
+remapping**, the warehouse column names must exactly match what the
+`powerbi-to-sigma` converter emits.
+
+The converter uses two different conventions (see `sigma-ids.js` in the converter):
+
+- **Columns** → `sigmaPhysicalName`: camelCase / acronym / digit boundaries become
+  `_`, then uppercased; a name that is already `[A-Z0-9_]+` passes through verbatim.
+  - `LocationID` → `LOCATION_ID`
+  - `City Name` → `CITY_NAME`
+  - `Sum_GrossMarginAmount` → `SUM_GROSS_MARGIN_AMOUNT`
+  - `DM` → `DM` (already canonical)
+- **Tables** → plain `.toUpperCase()` (no snake-casing).
+
+This tool replicates `sigmaPhysicalName` for column names (`sigma_physical_name`
+in the script) so the two agree byte-for-byte. If you change the converter's
+normalization, change it here too, or the DM POST will fail with
+`Source not found` / columns won't resolve.
+
+**Caveat:** a Power BI table name containing spaces would produce an invalid
+Snowflake identifier under plain `.toUpperCase()`. Single-token / no-space table
+names (the common case) are fine. For spaced table names, rename before landing.

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/refs/pagination.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/refs/pagination.md
@@ -1,0 +1,28 @@
+# executeQueries truncation & band pagination
+
+The Power BI `/executeQueries` endpoint **silently truncates** large results
+(~48k rows / response — no error, just fewer rows). Landing a fact table naively
+would lose data with no warning.
+
+## Strategy
+
+1. Extract with `EVALUATE SELECTCOLUMNS('<table>', ...)` (explicit scalar columns).
+2. If the first pull returns `>= BAND_MAX` (default 45,000) rows, paginate:
+   - Pick the **highest-cardinality `int64` column** as the band key
+     (`DISTINCTCOUNT` across int columns). A low-cardinality key like `MonthID`
+     won't split a fact table cleanly; `ItemID` will.
+   - Get `MIN`/`MAX`, walk the range in bands, **halving** any band that still
+     returns `>= BAND_MAX`.
+   - If a single-value band (`step == 1`) is still too big, **fail loud** rather
+     than silently truncate — that table needs a composite/manual band.
+
+## Verification
+
+- Row counts are asserted against the source (`COUNTROWS`) implicitly by the
+  final `COUNT(*)` in `load.sql`.
+- Band reassembly was validated dup/loss-free: forcing `PBI_BAND_MAX=50` on a
+  734-row table drove ~15 bands and reassembled to exactly 734, `uniq -d` empty.
+- At scale: SALES 923,371 and ITEM 364,184 landed with exact row parity, banded
+  on `ItemID`.
+
+`PBI_BAND_MAX` (env) tunes the ceiling — lower to exercise the band path in tests.

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/refs/sync-and-grant.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/refs/sync-and-grant.md
@@ -1,0 +1,36 @@
+# Making Sigma see the newly-landed tables
+
+A freshly created warehouse table is invisible to Sigma until two things happen.
+The tool does both when you pass `--sigma-connection <id>`; otherwise do them
+manually.
+
+## 1. GRANT (in the generated `load.sql`)
+
+The Sigma connection queries as some Snowflake role (for an OAuth connection,
+each user's own role; `PUBLIC` covers everyone). The tool appends:
+
+```sql
+GRANT USAGE  ON SCHEMA <db>.<schema>               TO ROLE <grant-role>;   -- default PUBLIC
+GRANT SELECT ON ALL TABLES IN SCHEMA <db>.<schema> TO ROLE <grant-role>;
+```
+
+Override the role with `--grant-role <ROLE>`; `--grant-role ""` skips grants.
+
+## 2. Connection sync
+
+Even after GRANT, a DM POST fails with:
+
+```
+Source not found: warehouse table 'DB.SCHEMA.TABLE' on connection '<uuid>'.
+```
+
+…until the connection has indexed the new table. Trigger per table:
+
+```
+POST /v2/connections/<connectionId>/sync
+Body: {"path": ["<DB>", "<SCHEMA>", "<TABLE>"]}
+```
+
+The tool calls this for every landed table (`sigma_sync`, using
+`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`). Note the endpoint is `/sync` and it
+takes a `path` body — there is no separate `/lookup` route (404).

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/refs/what-gets-landed.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/refs/what-gets-landed.md
@@ -1,0 +1,40 @@
+# What gets landed (and what's deliberately skipped)
+
+The tool lands **only stored source data**. Everything derived is left for the
+converter to recreate in Sigma — one source of truth, no drift.
+
+## Skipped tables
+
+- **Auto date tables** — `DateTableTemplate_*` and `LocalDateTable_*`. These are
+  Power BI's internal time-intelligence scaffolding, not source data. Sigma
+  handles dates natively.
+- **Pure calculated tables** — any table whose columns are *all* calculated.
+
+## Skipped columns (within a landed table)
+
+- **Calculated columns** (`type: calculated` / `calculatedTableColumn`) — DAX
+  logic. The converter re-emits these as Sigma formula columns. Example: the
+  Retail sample's `Store` has 19 columns but only **14** are stored; the 5 extras
+  (`Open Year`, `Store Type`, `Open Month`, …) are `Year([Open Date])`-style calcs.
+- **Binary columns** (`dataType: binary`) — embedded images/blobs. No warehouse
+  representation, AND critically they **collapse `EVALUATE <table>` to 1 row**.
+  (Observed: `District` has a `DMImage` binary column; `COUNTROWS` = 9 but
+  `EVALUATE 'District'` returned 1. Fixed by projecting explicit scalar columns
+  via `SELECTCOLUMNS` and dropping binary.)
+
+## Not skipped: hidden ≠ skip
+
+A table can be `isHidden: true` and still be real source data — the Retail
+sample hides its 923k-row `Sales` fact. The skip rule keys on *calc-only /
+auto-date*, never on `isHidden`.
+
+## Type mapping (TMSL `dataType` → Snowflake)
+
+| PBI | Snowflake |
+|---|---|
+| int64 | NUMBER(38,0) |
+| double | FLOAT |
+| decimal | NUMBER(38,4) |
+| string | VARCHAR |
+| boolean | BOOLEAN |
+| dateTime | TIMESTAMP_NTZ |

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/scripts/pbi_import_to_snowflake.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/scripts/pbi_import_to_snowflake.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""
+pbi_import_to_snowflake.py — Land an Import-mode Power BI semantic model's
+source tables into Snowflake, generically.
+
+This is the "data track" that a warehouse-native tool (e.g. Sigma) needs when a
+.pbix imports its data from Excel / Power Query / flat files and has no live
+warehouse behind it. It does NOT convert model logic (measures/relationships) —
+that is the job of the powerbi->sigma converter. It produces real Snowflake
+tables + a manifest mapping (pbi_table.column -> sf_table.COLUMN) so the
+converted model can be repointed onto the warehouse.
+
+Pipeline:
+  1. Silent-auth to Power BI + Fabric (cached MSAL token, no device-code prompt).
+  2. Resolve workspace + dataset (by name or id); optionally upload a .pbix first.
+  3. Read the model structure via TMSL getDefinition (version-independent):
+     enumerate tables + columns + dataTypes.
+     - SKIP auto date tables (DateTableTemplate_/LocalDateTable_) and any table
+       whose columns are ALL calculated (pure calc tables).
+     - Within a kept table, land only STORED columns (skip calculated columns —
+       those are DAX logic, recreated in Sigma).
+  4. Extract rows per table via /executeQueries (DAX `EVALUATE`), with automatic
+     integer-key band pagination (executeQueries silently truncates ~48k
+     rows/response) -> CSV in out/<dataset>/.
+  5. Generate load.sql (typed DDL from TMSL + PUT/COPY) and, unless --dry-run,
+     execute it via `snow sql`.
+  6. Emit manifest.json for the repoint step.
+
+No customer/identifiable data is embedded here — target db/schema are CLI args.
+"""
+import argparse, os, sys, json, csv, base64, time, re, subprocess
+try:
+    import truststore; truststore.inject_into_ssl()  # corp TLS inspection
+except Exception:
+    pass
+import msal, requests
+from requests.adapters import HTTPAdapter
+try:
+    from urllib3.util.retry import Retry
+except Exception:
+    from requests.packages.urllib3.util.retry import Retry
+
+# Corp TLS inspection resets long connections intermittently -> retry POST/GET.
+SESS = requests.Session()
+_retry = Retry(total=5, connect=5, read=5, backoff_factor=1.5,
+               status_forcelist=(429, 500, 502, 503, 504),
+               allowed_methods=frozenset(["GET", "POST"]))
+SESS.mount("https://", HTTPAdapter(max_retries=_retry))
+
+CLIENT_ID = "ea0616ba-638b-4df5-95b9-636659ae5121"  # public Power BI Desktop client
+AUTHORITY = "https://login.microsoftonline.com/organizations"
+CACHE = os.environ.get("PBI_TOKEN_CACHE", "/tmp/pbiauth/cache.bin")
+PBI_BASE = "https://api.powerbi.com/v1.0/myorg"
+FABRIC_BASE = "https://api.fabric.microsoft.com/v1"
+BAND_MAX = int(os.environ.get("PBI_BAND_MAX", "45000"))  # under executeQueries' silent truncation ceiling
+
+# ---- auth ----------------------------------------------------------------
+def _app():
+    cache = msal.SerializableTokenCache()
+    if os.path.exists(CACHE):
+        cache.deserialize(open(CACHE).read())
+    app = msal.PublicClientApplication(CLIENT_ID, authority=AUTHORITY, token_cache=cache)
+    return app, cache
+
+def get_tokens():
+    app, cache = _app()
+    accts = app.get_accounts()
+    def acq(scope):
+        for a in accts:
+            r = app.acquire_token_silent([scope], account=a)
+            if r and "access_token" in r:
+                return r["access_token"]
+        return None
+    pbi = acq("https://analysis.windows.net/powerbi/api/.default")
+    fab = acq("https://api.fabric.microsoft.com/.default")
+    if not pbi or not fab:
+        flow = app.initiate_device_flow(scopes=["https://analysis.windows.net/powerbi/api/.default"])
+        print(">>> LOGIN: " + flow["verification_uri"] + "  CODE " + flow["user_code"], file=sys.stderr)
+        app.acquire_token_by_device_flow(flow)
+        accts = app.get_accounts()
+        pbi = acq("https://analysis.windows.net/powerbi/api/.default")
+        fab = acq("https://api.fabric.microsoft.com/.default")
+    if cache.has_state_changed:
+        os.makedirs(os.path.dirname(CACHE), exist_ok=True)
+        open(CACHE, "w").write(cache.serialize())
+    if not (pbi and fab):
+        sys.exit("could not acquire tokens")
+    return pbi, fab
+
+# ---- resolve -------------------------------------------------------------
+def resolve_workspace(fab, name_or_id):
+    r = SESS.get(f"{FABRIC_BASE}/workspaces", headers={"Authorization": f"Bearer {fab}"})
+    r.raise_for_status()
+    wss = r.json()["value"]
+    if not name_or_id:  # default: My workspace (Personal)
+        w = next((w for w in wss if w.get("type") == "Personal"), None)
+        return w["id"], w["displayName"]
+    for w in wss:
+        if name_or_id in (w["id"], w.get("displayName")):
+            return w["id"], w["displayName"]
+    sys.exit(f"workspace not found: {name_or_id}")
+
+def resolve_dataset(pbi, name_or_id, pbix=None):
+    H = {"Authorization": f"Bearer {pbi}"}
+    def find():
+        r = SESS.get(f"{PBI_BASE}/datasets", headers=H); r.raise_for_status()
+        for d in r.json()["value"]:
+            if name_or_id in (d["id"], d["name"]):
+                return d["id"]
+        return None
+    ds = find()
+    if ds:
+        return ds
+    if pbix:
+        disp = name_or_id if not name_or_id.count("-") == 4 else os.path.splitext(os.path.basename(pbix))[0]
+        with open(pbix, "rb") as f:
+            r = SESS.post(f"{PBI_BASE}/imports?datasetDisplayName={disp}&nameConflict=CreateOrOverwrite",
+                              headers=H, files={"file": (os.path.basename(pbix), f)})
+        r.raise_for_status()
+        imp = r.json()["id"]
+        for _ in range(120):
+            time.sleep(5)
+            st = SESS.get(f"{PBI_BASE}/imports/{imp}", headers=H).json()
+            if st.get("importState") == "Succeeded":
+                return st["datasets"][0]["id"]
+            if st.get("importState") == "Failed":
+                sys.exit(f"pbix import failed: {json.dumps(st)[:400]}")
+        sys.exit("pbix import timed out")
+    sys.exit(f"dataset not found and no --pbix given: {name_or_id}")
+
+# ---- model structure via TMSL -------------------------------------------
+def get_model(fab, ws, ds):
+    H = {"Authorization": f"Bearer {fab}"}
+    r = SESS.post(f"{FABRIC_BASE}/workspaces/{ws}/semanticModels/{ds}/getDefinition?format=TMSL", headers=H)
+    if r.status_code == 200:
+        res = r.json()
+    elif r.status_code == 202:
+        loc = r.headers["Location"]; res = None
+        for _ in range(40):
+            time.sleep(3)
+            s = SESS.get(loc, headers=H); st = s.json().get("status")
+            if st == "Succeeded":
+                res = SESS.get(loc + "/result", headers=H).json(); break
+            if st == "Failed":
+                sys.exit(f"getDefinition LRO failed: {s.text[:300]}")
+        if not res:
+            sys.exit("getDefinition timed out")
+    else:
+        sys.exit(f"getDefinition {r.status_code}: {r.text[:300]}")
+    for p in res["definition"]["parts"]:
+        if p["path"].endswith("model.bim") or p["path"].endswith(".bim"):
+            return json.loads(base64.b64decode(p["payload"]))
+    sys.exit("no model.bim in TMSL definition")
+
+AUTO_DATE = re.compile(r"^(DateTableTemplate_|LocalDateTable_)")
+CALC_TYPES = {"calculated", "calculatedTableColumn"}
+# TMSL dataType -> Snowflake type
+SF_TYPE = {
+    "int64": "NUMBER(38,0)", "double": "FLOAT", "decimal": "NUMBER(38,4)",
+    "string": "VARCHAR", "boolean": "BOOLEAN", "dateTime": "TIMESTAMP_NTZ",
+}
+
+def clean_ident(name):
+    """Table physical name — matches the PBI->Sigma converter's tableName.toUpperCase()
+    (converter uses plain uppercase for tables), with non-alnum->_ for SQL safety."""
+    s = re.sub(r"[^0-9A-Za-z]+", "_", name).strip("_").upper()
+    if not s:
+        s = "TBL"
+    if s[0].isdigit():
+        s = "_" + s
+    return s
+
+def sigma_physical_name(s):
+    """Column physical name — MUST byte-match the converter's sigmaPhysicalName()
+    (build/sigma-ids.js) so landed warehouse columns line up with the emitted DM
+    column refs (no repoint remap). camelCase/acronym/digit boundaries -> snake_case;
+    already-uppercase names pass through verbatim (e.g. 'DM' -> 'DM')."""
+    r = (s or "").strip()
+    if re.fullmatch(r"[A-Z0-9_]+", r):
+        return r
+    n = re.sub(r"[^A-Za-z0-9_\s]", " ", r)
+    n = re.sub(r"([a-z])([A-Z])", r"\1_\2", n)
+    n = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", n)
+    n = re.sub(r"([A-Za-z])([0-9])", r"\1_\2", n)
+    n = re.sub(r"([0-9])([A-Za-z])", r"\1_\2", n)
+    out = "_".join(p for p in re.split(r"[_\s]+", n.upper()) if p)
+    return out or "COL"
+
+def plan_tables(model, only=None):
+    """Return [{pbi_name, sf_name, cols:[{pbi,sf,dtype,sftype}]}] for landable tables."""
+    out = []
+    for t in model.get("model", {}).get("tables", []):
+        name = t["name"]
+        if AUTO_DATE.match(name):
+            continue
+        # skip calculated cols (DAX logic, recreated in Sigma) and binary/image
+        # cols (unrepresentable in a warehouse AND they break EVALUATE <table>).
+        stored = [c for c in t.get("columns", [])
+                  if c.get("type") not in CALC_TYPES and c.get("dataType") != "binary"]
+        if not stored:  # pure calculated table
+            continue
+        if only and name not in only:
+            continue
+        cols = [{"pbi": c["name"], "sf": sigma_physical_name(c["name"]),
+                 "dtype": c.get("dataType", "string"),
+                 "sftype": SF_TYPE.get(c.get("dataType", "string"), "VARCHAR")}
+                for c in stored]
+        # dedupe cleaned column names
+        seen = {}
+        for c in cols:
+            base = c["sf"]; n = seen.get(base, 0)
+            if n:
+                c["sf"] = f"{base}_{n}"
+            seen[base] = n + 1
+        out.append({"pbi_name": name, "sf_name": clean_ident(name), "cols": cols,
+                    "hidden": t.get("isHidden", False)})
+    return out
+
+# ---- extraction ----------------------------------------------------------
+def dax(pbi, ds, q):
+    r = SESS.post(f"{PBI_BASE}/datasets/{ds}/executeQueries",
+                      headers={"Authorization": f"Bearer {pbi}"},
+                      json={"queries": [{"query": q}], "serializerSettings": {"includeNulls": True}})
+    if r.status_code != 200:
+        raise RuntimeError(f"{r.status_code}: {r.text[:300]}")
+    return r.json()["results"][0]["tables"][0]["rows"]
+
+def strip_key(k):
+    return k.split("[", 1)[1].rstrip("]") if "[" in k else k
+
+def extract_table(pbi, ds, tbl, cols, limit=None):
+    """Extract via explicit SELECTCOLUMNS projection (deterministic columns;
+    avoids binary/image columns collapsing `EVALUATE <table>` to 1 row).
+    Integer-key band pagination for tables over the truncation ceiling."""
+    proj = ", ".join(f"\"{c['pbi']}\", '{tbl}'[{c['pbi']}]" for c in cols)
+    def sc(table_expr):
+        return dax(pbi, ds, f"EVALUATE SELECTCOLUMNS({table_expr}, {proj})")
+    if limit:
+        return sc(f"TOPN({int(limit)}, '{tbl}')")
+    first = sc(f"'{tbl}'")
+    if len(first) < BAND_MAX:
+        return first
+    # need pagination — pick the HIGHEST-cardinality int64 column as band key
+    # (a low-cardinality key like MonthID won't split a fact table cleanly).
+    int_cols = [c["pbi"] for c in cols if c["dtype"] == "int64"]
+    if not int_cols:
+        raise RuntimeError(f"{tbl}: >{BAND_MAX} rows and no int64 key to paginate; add a manual band")
+    if len(int_cols) == 1:
+        key = int_cols[0]
+    else:
+        card = dax(pbi, ds, "EVALUATE ROW(" +
+                   ", ".join(f'"{c}", DISTINCTCOUNT(\'{tbl}\'[{c}])' for c in int_cols) + ")")[0]
+        key = max(int_cols, key=lambda c: int(strip_val(card, c)))
+    kq = f"'{tbl}'[{key}]"
+    agg = dax(pbi, ds, f'EVALUATE ROW("mn", MINX(\'{tbl}\', {kq}), "mx", MAXX(\'{tbl}\', {kq}))')[0]
+    mn, mx = int(strip_val(agg, "mn")), int(strip_val(agg, "mx"))
+    print(f"[paginate] {tbl}: band key '{key}' range {mn}..{mx}", file=sys.stderr)
+    rows, lo, step = [], mn, max(1, (mx - mn) // 20 + 1)
+    while lo <= mx:
+        hi = lo + step
+        band = sc(f"FILTER('{tbl}', {kq} >= {lo} && {kq} < {hi})")
+        if len(band) >= BAND_MAX:
+            if step > 1:
+                step = max(1, step // 2); continue
+            raise RuntimeError(f"{tbl}: single-key band {key}={lo} has >={BAND_MAX} rows "
+                               f"(would truncate). Needs a composite/manual band.")
+        rows.extend(band); lo = hi
+    return rows
+
+def strip_val(row, name):
+    for k, v in row.items():
+        if strip_key(k) == name:
+            return v
+    raise KeyError(name)
+
+def write_csv(path, cols, rows):
+    keymap = None
+    if rows:
+        keymap = {strip_key(k): k for k in rows[0].keys()}
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow([c["sf"] for c in cols])
+        for r in rows:
+            w.writerow([r.get(keymap.get(c["pbi"], c["pbi"])) if keymap else None for c in cols])
+
+# ---- load.sql ------------------------------------------------------------
+def gen_load_sql(db, schema, plan, outdir, grant_role="PUBLIC"):
+    L = [f"CREATE SCHEMA IF NOT EXISTS {db}.{schema};",
+         f"USE SCHEMA {db}.{schema};",
+         "CREATE OR REPLACE FILE FORMAT PBI_IMPORT_CSV",
+         "  TYPE=CSV SKIP_HEADER=1 FIELD_OPTIONALLY_ENCLOSED_BY='\"'",
+         "  NULL_IF=('') EMPTY_FIELD_AS_NULL=TRUE TIMESTAMP_FORMAT='YYYY-MM-DD\"T\"HH24:MI:SS';", ""]
+    for t in plan:
+        cols = ",\n  ".join(f'{c["sf"]} {c["sftype"]}' for c in t["cols"])
+        L.append(f'CREATE OR REPLACE TABLE {t["sf_name"]} (\n  {cols}\n);')
+    L.append("")
+    for t in plan:
+        f = os.path.join(outdir, f'{t["sf_name"]}.csv')
+        L.append(f'PUT file://{f} @%{t["sf_name"]} AUTO_COMPRESS=TRUE OVERWRITE=TRUE;')
+    L.append("")
+    for t in plan:
+        L.append(f'COPY INTO {t["sf_name"]} FROM @%{t["sf_name"]} '
+                 f'FILE_FORMAT=(FORMAT_NAME=PBI_IMPORT_CSV) ON_ERROR=ABORT_STATEMENT;')
+    L.append("")
+    # GRANTs so the Sigma connection's role can read the new tables
+    # (new warehouse tables are invisible to Sigma until granted + conn-synced).
+    if grant_role:
+        L.append(f"GRANT USAGE ON SCHEMA {db}.{schema} TO ROLE {grant_role};")
+        L.append(f"GRANT SELECT ON ALL TABLES IN SCHEMA {db}.{schema} TO ROLE {grant_role};")
+        L.append("")
+    counts = "\nUNION ALL ".join(f"SELECT '{t['sf_name']}' t, COUNT(*) n FROM {t['sf_name']}" for t in plan)
+    L.append(counts + ";")
+    return "\n".join(L)
+
+def sigma_sync(plan, db, schema, connection_id):
+    """Register newly-landed tables with the Sigma connection so a DM POST can
+    resolve them. Uses SIGMA_CLIENT_ID/SECRET from the environment."""
+    cid, sec = os.environ.get("SIGMA_CLIENT_ID"), os.environ.get("SIGMA_CLIENT_SECRET")
+    if not (cid and sec):
+        print("[sigma-sync] SIGMA_CLIENT_ID/SECRET not set — skipping sync", file=sys.stderr)
+        return
+    base = "https://aws-api.sigmacomputing.com"
+    tok = SESS.post(f"{base}/v2/auth/token", data={
+        "grant_type": "client_credentials", "client_id": cid, "client_secret": sec}).json()["access_token"]
+    H = {"Authorization": f"Bearer {tok}", "Content-Type": "application/json"}
+    for t in plan:
+        r = SESS.post(f"{base}/v2/connections/{connection_id}/sync", headers=H,
+                      json={"path": [db, schema, t["sf_name"]]})
+        print(f"[sigma-sync] {t['sf_name']} -> {r.status_code}", file=sys.stderr)
+
+# ---- main ----------------------------------------------------------------
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", required=True, help="dataset name or id")
+    ap.add_argument("--workspace", default=None, help="workspace name or id (default: My workspace)")
+    ap.add_argument("--pbix", default=None, help="upload this .pbix first if dataset absent")
+    ap.add_argument("--target-db", required=True)
+    ap.add_argument("--target-schema", required=True)
+    ap.add_argument("--sf-conn", default="tj")
+    ap.add_argument("--grant-role", default="PUBLIC", help="Snowflake role to GRANT SELECT (empty to skip)")
+    ap.add_argument("--sigma-connection", default=None,
+                    help="Sigma connection UUID — if set, auto-sync landed tables into Sigma after load "
+                         "(uses SIGMA_CLIENT_ID/SECRET env)")
+    ap.add_argument("--only", default=None, help="comma-separated PBI table names to include")
+    ap.add_argument("--limit-rows", type=int, default=None, help="TOPN per table (cheap testing)")
+    ap.add_argument("--dry-run", action="store_true", help="extract + gen SQL, do not execute in Snowflake")
+    args = ap.parse_args()
+
+    only = set(s.strip() for s in args.only.split(",")) if args.only else None
+    pbi, fab = get_tokens()
+    ws, wsname = resolve_workspace(fab, args.workspace)
+    ds = resolve_dataset(pbi, args.dataset, args.pbix)
+    print(f"[workspace] {wsname} ({ws})\n[dataset] {ds}", file=sys.stderr)
+
+    model = get_model(fab, ws, ds)
+    plan = plan_tables(model, only)
+    outdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "out", clean_ident(args.dataset).lower())
+    os.makedirs(outdir, exist_ok=True)
+    print(f"[plan] {len(plan)} landable tables -> {args.target_db}.{args.target_schema}", file=sys.stderr)
+    for t in plan:
+        print(f"   {t['pbi_name']} -> {t['sf_name']} ({len(t['cols'])} cols)"
+              + ("  [hidden]" if t["hidden"] else ""), file=sys.stderr)
+
+    manifest = {"dataset": ds, "workspace": ws, "target": f"{args.target_db}.{args.target_schema}", "tables": []}
+    for t in plan:
+        rows = extract_table(pbi, ds, t["pbi_name"], t["cols"], limit=args.limit_rows)
+        csvpath = os.path.join(outdir, f'{t["sf_name"]}.csv')
+        write_csv(csvpath, t["cols"], rows)
+        print(f"[extract] {t['pbi_name']}: {len(rows)} rows -> {os.path.basename(csvpath)}", file=sys.stderr)
+        manifest["tables"].append({
+            "pbi_table": t["pbi_name"], "sf_table": f"{args.target_db}.{args.target_schema}.{t['sf_name']}",
+            "rows": len(rows),
+            "columns": [{"pbi": c["pbi"], "sf": c["sf"], "sf_type": c["sftype"]} for c in t["cols"]],
+        })
+
+    sql = gen_load_sql(args.target_db, args.target_schema, plan, outdir, args.grant_role)
+    sqlpath = os.path.join(outdir, "load.sql")
+    open(sqlpath, "w").write(sql)
+    open(os.path.join(outdir, "manifest.json"), "w").write(json.dumps(manifest, indent=2))
+    print(f"[sql] {sqlpath}\n[manifest] {os.path.join(outdir,'manifest.json')}", file=sys.stderr)
+
+    if args.dry_run:
+        print("[dry-run] skipping Snowflake load", file=sys.stderr)
+        return
+    print(f"[load] executing via snow sql -c {args.sf_conn}", file=sys.stderr)
+    r = subprocess.run(["snow", "sql", "-c", args.sf_conn, "-f", sqlpath], capture_output=True, text=True)
+    sys.stdout.write(r.stdout)
+    if r.returncode != 0:
+        sys.stderr.write(r.stderr); sys.exit(f"snow sql failed ({r.returncode})")
+
+    if args.sigma_connection:
+        print("[sigma-sync] registering tables with Sigma connection", file=sys.stderr)
+        sigma_sync(plan, args.target_db, args.target_schema, args.sigma_connection)
+
+if __name__ == "__main__":
+    main()

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/scripts/run_converter.mjs
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/scripts/run_converter.mjs
@@ -1,0 +1,13 @@
+import { convertPowerBIToSigma } from "/Users/tjwells/sigma-data-model-mcp/build/powerbi.js";
+import fs from "fs";
+const bim = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const out = convertPowerBIToSigma(bim, { connectionId: process.argv[3]||"", database: process.argv[4]||"", schema: process.argv[5]||"" });
+fs.writeFileSync(process.argv[6], JSON.stringify(out, null, 2));
+const m = out.model || out;
+console.log("keys:", Object.keys(out).join(","));
+console.log("warnings:", (out.warnings||[]).length);
+const els = (m.elements||[]);
+console.log("elements:", els.length);
+for (const e of els.slice(0,8)) {
+  console.log(` - ${e.elementType||e.type||"?"} name=${e.name} source=${JSON.stringify(e.source||e.sources||{}).slice(0,120)}`);
+}


### PR DESCRIPTION
## What & why

Adds **`powerbi-import-to-snowflake`** — the **data track** for migrating an Import-mode Power BI model to a warehouse-native tool (Sigma).

Sigma has no in-memory import engine; it queries live warehouse tables. When a `.pbix` **imports** its data from Excel / Power Query / flat files, there is no warehouse behind it, so the data must be landed first. This skill extracts the model's source tables and lands them in Snowflake, then hands off to `powerbi-to-sigma` for the model logic. Column names are aligned so the converter's output repoints with **no remapping**.

Companion to the existing `powerbi-to-sigma` (logic) and `powerbi-assessment` skills, in the same plugin.

## The tool

`scripts/pbi_import_to_snowflake.py` — fully generic (no hardcoded schemas):
- **Enumerate** via TMSL `getDefinition` (version-independent; `INFO.TABLES()` fails on old compat levels)
- **Skip** auto date tables + calculated + binary columns (land only stored source data)
- **Extract** via `SELECTCOLUMNS` with int-key **band pagination** (executeQueries silently truncates ~48k rows)
- **Load** typed DDL + `PUT`/`COPY`, with `GRANT`s
- **Sync** the new tables into Sigma (`--sigma-connection`)
- **Manifest** mapping `pbi_table.col → sf_table.COLUMN`

## Validated end-to-end

Microsoft's public Retail Analysis Sample: **923,371** SALES rows landed with exact row parity; the converted Sigma data model returned **\$41,013,686.95** total regular sales — matching the Power BI value to the cent.

## Gotchas captured in `refs/`
- `naming-alignment.md` — landed columns must match the converter's `sigmaPhysicalName`
- `what-gets-landed.md` — skip rules; binary columns collapse `EVALUATE <table>` to 1 row
- `sync-and-grant.md` — new tables 404 on DM POST until GRANT + connection sync
- `pagination.md` — the ~48k truncation and band strategy
- `metric-query-quirk.md` — converted metrics don't resolve via ad-hoc `metric()` SQL (render fine in the UI)

## Notes
- Scope: Import-mode only (DirectQuery already points at a warehouse). Logic/DAX conversion stays in `powerbi-to-sigma`.
- `PRIVACY.md` flags that this skill moves **row-level data** (unlike the read-only assessment skills).
- No customer/identifiable data in the diff — fixtures use the public MS sample with placeholder ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)