### PR TITLE
fix(tableau): param metric-switch workbooks render (float value + nameless-Custom-SQL fixes)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -1490,10 +1490,26 @@ end
 # Tableau `WHEN 1`) makes Sigma reject the Switch: "Argument N invalid … Expected
 # text; received number." Quote bare numeric case literals so they match the
 # text control. Leave already-quoted strings and non-numeric tokens untouched.
+# Canonicalise a Switch match value so a param CONTROL's option value and the
+# translated Switch's WHEN key compare equal regardless of numeric form. Tableau
+# stores list-parameter member values as FLOATS ("0.", "1.", "2.0") but writes
+# CASE `WHEN 0` as an INTEGER — so the control emits value "0." while the Switch
+# key is "0", and Sigma's Switch matches NOTHING (the picker renders blank).
+# Verified live 2026-07-07 (metric-switch E2E). Fold both to a canonical numeric
+# string ("0."→"0", "1.0"→"1", "2.5"→"2.5"); non-numerics pass through.
+def canonical_switch_value(v)
+  s = v.to_s.strip.gsub(/\A["']|["']\z/, '')
+  if s =~ /\A-?\d+(?:\.\d*)?\z/ || s =~ /\A-?\.\d+\z/
+    f = s.to_f
+    return (f == f.to_i ? f.to_i.to_s : f.to_s)
+  end
+  s
+end
+
 def coerce_case_literal(v)
   s = v.to_s.strip
   return s if s.start_with?('"') || s.start_with?("'")
-  return "\"#{s}\"" if s =~ /\A-?\d+(?:\.\d+)?\z/
+  return "\"#{canonical_switch_value(s)}\"" if s =~ /\A-?\d+(?:\.\d*)?\z/ || s =~ /\A-?\.\d+\z/
   s
 end
 
@@ -4358,7 +4374,11 @@ unless opts[:no_auto_controls]   # default-on: never miss a .twb parameter/filte
       # E1: dropdown vs segmented from the Tableau control display mode; default
       # segmented (button row) when Tableau declared no explicit mode.
       spec['controlType']   = sigma_control_type(control_display_for(layout, cap, norm_cap))
-      values = p['members'] || []
+      # Canonicalise member values to the SAME numeric form the translated Switch
+      # uses for its WHEN keys (Tableau stores members as floats "0."/"1." but
+      # writes CASE `WHEN 0`), so the control's option value actually matches the
+      # Switch key — else the measure-switch renders blank (live-verified 2026-07-07).
+      values = (p['members'] || []).map { |m| canonical_switch_value(m) }
       # Tableau list parameters often store integer-coded members (1..13) whose
       # human meaning lives in the parameter's value ALIASES (1→"TCV", 3→"ACV").
       # parse-twb-layout captures these in column_aliases keyed by the param
@@ -4371,7 +4391,7 @@ unless opts[:no_auto_controls]   # default-on: never miss a .twb parameter/filte
                     (meta['column_aliases'] || {})[p['name'].to_s.gsub(/^\[|\]$/, '')]
       labels = []
       if alias_pairs && !alias_pairs.empty?
-        amap = alias_pairs.each_with_object({}) { |a, h| h[a['key'].to_s] = a['value'] }
+        amap = alias_pairs.each_with_object({}) { |a, h| h[canonical_switch_value(a['key'])] = a['value'] }
         labels = values.map { |v| amap[v.to_s] || v.to_s }
         labels = [] if labels == values.map(&:to_s) # all unmapped → omit (no value-add)
       end
@@ -4386,7 +4406,8 @@ unless opts[:no_auto_controls]   # default-on: never miss a .twb parameter/filte
       # ARRAY. Pin single so the scalar default applies and the Switch resolves.
       # (Verified live 2026-07-05: without this the picker ships dead.)
       spec['selectionMode'] = 'single'
-      spec['value'] = p['default_value']
+      # Canonicalise so the default matches a control option value (0.→0).
+      spec['value'] = canonical_switch_value(p['default_value'])
     elsif p['param_domain'] == 'range' && %w[integer real].include?(p['datatype'])
       # Numeric range parameter → Sigma `number-range` control (discovered by
       # gap-scout 2026-05-20, beads-sigma-ebw). Two-handle slider; the single-

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
@@ -73,6 +73,12 @@ target = if opts[:dm_el_name]
          end
 dm_el_id   = target['id']
 dm_el_name = target['name']
+# A Custom SQL DM element is NAMELESS in the spec (rule 3: omit the element-level
+# name), but Sigma assigns it the name "Custom SQL" on the server. Without this
+# fallback the master column formula becomes an INVALID `[/Col]` (empty element
+# name) → the workbook POSTs but renders EMPTY (every published-DS / Custom-SQL-
+# sourced workbook). Use the server-assigned name so refs are `[Custom SQL/Col]`.
+dm_el_name = 'Custom SQL' if dm_el_name.to_s.strip.empty?
 
 # Master columns: either explicit from --master-cols or auto-passthrough from the DM element
 master_columns =

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/hydrate-custom-sql.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/hydrate-custom-sql.rb
@@ -290,8 +290,7 @@ module HydrateCustomSql
         existing&.each_element('metadata-record') do |m|
           rn = (m.get_text('remote-name')&.value || '').strip
           cap = (m.get_text('caption')&.value || '').strip
-          info = { 'class' => (m.attributes['class'] || 'column'),
-                   'ltype' => (m.get_text('local-type')&.value || '').strip,
+          info = { 'ltype' => (m.get_text('local-type')&.value || '').strip,
                    'agg'   => (m.get_text('aggregation')&.value || '').strip }
           cached[alias_for(rn)] = info unless rn.empty?
           cached[cap.downcase] = info unless cap.empty?
@@ -300,7 +299,12 @@ module HydrateCustomSql
         mrs = REXML::Element.new('metadata-records')
         columns.each do |c|
           info = cached[alias_for(c)] || cached[c.to_s.downcase] || {}
-          rec = mrs.add_element('metadata-record', 'class' => (info['class'] || 'column'))
+          # ALWAYS class='column': the converter's Custom-SQL column build SKIPS
+          # any metadata-record whose class != 'column' (tableau.ts), so a cached
+          # class='measure' would silently DROP that column from the DM element —
+          # and a Switch measure referencing it then can't resolve (live-caught
+          # 2026-07-07: Amount USD/PROFIT vanished). Keep the local-type hint.
+          rec = mrs.add_element('metadata-record', 'class' => 'column')
           rec.add_element('remote-name').text = alias_for(c)
           rec.add_element('local-name').text = "[#{c}]"
           rec.add_element('parent-name').text = "[#{rel_name}]"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -836,6 +836,12 @@ module MechanicalSpecs
   # refs and the bare Tableau chart captions still resolve. Without real_labels
   # we fall back to the bare-name formula (correct only for non-virtual conns).
   def derive_master(fact_el, fact_name, base_el = nil, real_labels = nil, model = nil)
+    # A Custom SQL fact element is NAMELESS in the DM spec (rule 3), but Sigma
+    # assigns it the name "Custom SQL" server-side. An empty fact_name makes every
+    # master column formula an INVALID `[/Col]` (empty element segment) → the
+    # workbook POSTs but renders EMPTY (all published-DS / Custom-SQL-sourced
+    # workbooks). Fall back to the server-assigned name so refs are `[Custom SQL/Col]`.
+    fact_name = 'Custom SQL' if fact_name.to_s.strip.empty?
     master_columns = []
     mmap = {}
     seen = {}

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-hydrate-custom-sql.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-hydrate-custom-sql.rb
@@ -182,7 +182,7 @@ H.hydrate_pds!(hdoc, descriptors: [{'contentUrl'=>'PDS_X','relationType'=>'text'
 hrecs = {}
 hdoc.each_element("//metadata-record") { |m| hrecs[m.get_text('remote-name').value] = m }
 check(hrecs.keys.sort == %w[AMOUNT_USD SALES_REGION SFDC_OPPTY_ID], 'full 3-column set emitted (not just the 1 cached)', fails)
-check(hrecs['AMOUNT_USD'].attributes['class'] == 'measure', 'cached measure class PRESERVED', fails)
+check(hrecs['AMOUNT_USD'].attributes['class'] == 'column', 'class forced to "column" (converter drops non-column custom-SQL metadata-records)', fails)
 check(hrecs['AMOUNT_USD'].get_text('local-type').value == 'real', 'cached local-type=real PRESERVED (not downgraded to string)', fails)
 check(hrecs['SALES_REGION'].get_text('local-type').value == 'string' && hrecs['SALES_REGION'].attributes['class'] == 'column', 'uncached column defaults to string/column', fails)
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-metric-switch.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-metric-switch.rb
@@ -65,10 +65,13 @@ def cols_of(spec)
 end
 
 puts 'Pattern A — numeric-coded param, CASE inside the aggregate: SUM(CASE [P] WHEN 0 THEN [A]…)'
+# Members are the REAL Tableau float form ("0."/"1.") — the shape that shipped a
+# blank switcher (control value "0." vs Switch key "0"). They must canonicalise
+# to match the WHEN keys.
 specA = build(zone_for('SUM(CASE [Parameters].[Type] WHEN 0 THEN [Net Revenue] WHEN 1 THEN [Cost] END)'),
               [{ 'caption' => 'Type', 'name' => '[Type]', 'param_domain' => 'list', 'datatype' => 'real',
-                 'members' => %w[0 1], 'default_value' => '0' }],
-              { 'Type' => [{ 'key' => '0', 'value' => 'Revenue' }, { 'key' => '1', 'value' => 'Cost' }] })
+                 'members' => ['0.', '1.'], 'default_value' => '0.' }],
+              { 'Type' => [{ 'key' => '0.', 'value' => 'Revenue' }, { 'key' => '1.', 'value' => 'Cost' }] })
 abort "build A produced no spec" unless specA
 elsA, colsA = cols_of(specA)
 measA = colsA.find { |c| c['formula'].to_s.include?('Switch([ctl-param-type]') }
@@ -81,8 +84,11 @@ ctlA = elsA.find { |e| e['kind'] == 'control' && e['controlId'] == 'ctl-param-ty
 check(!ctlA.nil?, 'Type control emitted', fails)
 vals = ctlA && (ctlA.dig('source', 'values') || ctlA['values'])
 labs = ctlA && (ctlA.dig('source', 'labels') || ctlA['labels'])
-check(vals == %w[0 1], "control option VALUES equal the Switch keys 0/1 — got #{vals.inspect}", fails)
-check(labs == %w[Revenue Cost], "alias LABELS carried (Revenue/Cost) — got #{labs.inspect}", fails)
+check(vals == %w[0 1], "control option VALUES canonicalised to match Switch keys 0/1 (float members '0.'/'1.') — got #{vals.inspect}", fails)
+check(labs == %w[Revenue Cost], "alias LABELS carried through canonicalisation (Revenue/Cost) — got #{labs.inspect}", fails)
+# The measure Switch keys and the control values must be identical strings.
+switch_keys = measA['formula'].scan(/"(\d+)"/).flatten
+check(switch_keys == vals, "Switch keys #{switch_keys.inspect} == control values #{vals.inspect} (the fix)", fails)
 check((ctlA && ctlA['selectionMode']) == 'single', 'control is single-select (scalar Switch compare)', fails)
 
 puts 'Pattern B — string param, per-branch aggregate: IF [P]="Revenue" THEN SUM([A]) ELSE SUM([B])'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-swap-translation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-swap-translation.rb
@@ -32,7 +32,7 @@ end
 # Extract the translation helpers from the (non-requireable, CLI) script and
 # eval them over stubs, so we test the shipped bodies verbatim.
 src = File.read(BUILD)
-defs = %w[coerce_case_literal remap_param_branch translate_case_on_param
+defs = %w[canonical_switch_value coerce_case_literal remap_param_branch translate_case_on_param
           translate_if_chain_on_param param_control_ref rewire_param_switch!].map do |fn|
   boundary = fn =~ /[!?]\z/ ? '' : '\b'
   m = src.match(/^def #{Regexp.escape(fn)}#{boundary}.*?\nend\n/m)


### PR DESCRIPTION
Follow-up to #280, from a **live workbook E2E** (publish metric-switch `.twb` → orchestrator → POST **workbook** → query the element). #280 fixed the DM-level binding; this fixes two bugs that made the **workbook** POST "succeed" but render **empty/blank** — only visible when testing the workbook layer, not the DM.

## Bug 1 — numeric param float-vs-int value mismatch
Tableau stores list-param members as floats (`"0."`/`"1."`) but writes CASE `WHEN 0`. The control emitted option value `"0."` while the Switch key was `"0"` → Sigma's Switch **matched nothing** → measure blank. Added `canonical_switch_value()` applied to `coerce_case_literal` (Switch keys) **and** the control values/labels/default, so both fold to the same canonical string (`"0."`→`"0"`).

## Bug 2 — nameless Custom SQL element → invalid `[/Col]` master refs
A Custom SQL DM element is nameless (spec rule 3); Sigma assigns it `"Custom SQL"` server-side. `derive_master` / `build-workbook-spec` used the empty name → every master column formula became `[/Col]` (invalid) → workbook POSTs but **no column resolves → empty**. Now fall back to `"Custom SQL"` → `[Custom SQL/Col]`. **Affects ALL published-DS / Custom-SQL-sourced workbooks, not just metric-switch.**

## Also
Hydrate splice forces `class='column'` on synthesized metadata-records — the converter's Custom-SQL column build skips `class!='column'`, so a cached `class='measure'` silently dropped the measure columns (Amount USD / PROFIT) from the DM, leaving the Switch unable to resolve them.

## Verified LIVE end-to-end
Published metric-switch workbook → migrate → **workbook POST clean (10 columns resolve, 0 error, control lint clean)** → **workbook element query returns real per-region values** through `Sum(Switch([ctl],…))`, control values `["0","1"]` matching the Switch keys. `test-param-metric-switch` now uses the real float member form and asserts value==key. Full offline suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)