### PR TITLE
tableau-to-sigma: gate the Phase 1d dashboard-read (stop skipped PNG reads)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -28,6 +28,15 @@ user-invocable: true
 Convert a Tableau datasource into a Sigma data model, then build a Sigma workbook
 that mirrors the Tableau dashboard layout as closely as possible.
 
+> **🚧 GATE convention.** A step marked **🚧 GATE** is backed by a script that
+> *fails the run* if the step was skipped — it is not advisory. Every 🚧 GATE
+> requires an **artifact** (a file on disk) and a downstream check that refuses
+> to proceed without it. If a step is important but merely prose, it will get
+> skipped under load — so the load-bearing steps are gated, one marker per real
+> gate. Current gates: **Phase 1d source dashboard-read** (`png-read.json` →
+> `assert-dashboard-read.rb`, enforced again inside `build-charts-from-signals.rb`),
+> **Phase 6 source-parity** and **Phase 6f visual render** (`assert-phase6-ran.rb`).
+
 **Read ALL of the following before replying or taking any action. Do not make assumptions about skill conventions, prompts, or global instructions — read the files.**
 - `refs/operating-contract.md` — **READ FIRST.** The non-negotiable guardrails: obtain the source render + calcs, build from the source's own logic (not `SUM(col)`), render + value-check EVERY page against the source, never ship empty or waive silently, don't spin. This is what keeps a run on the rails.
 - `refs/composition-recipe.md` — composition pass (hero/panels/carded KPIs + brand-from-source), value-fidelity rules (materialized `(copy)` calc columns, exact aggregate/population, period filter), controls/params rebuild, and the spec/API gotchas that otherwise cost round-trips.
@@ -76,6 +85,16 @@ ruby scripts/migrate-tableau.rb \
 ruby scripts/migrate-tableau.rb --workbook "<name>" \
   --finalize --actuals <workdir>/parity-actuals.json [--allow-missing-tiles N]
 ```
+
+> **🚧 Expect PASS 1 to hard-stop once for the Phase 1d dashboard-read.** The orchestrator
+> fetches view CSVs but **cannot read the source dashboard PNG** — that's your job. On the
+> first cold run it aborts **before posting the data model** (so no stray DM) with
+> "Phase 1d dashboard-read gate". When it does: fetch the dashboard view PNG with
+> `mcp__tableau__get-view-image` (solo), Read it, write `<workdir>/png-read.json` (schema in
+> Phase 1d — every tile with its Sigma `kind`, plus `text_elements` and `filter_shelf`), then
+> **re-run the same PASS 1 command** (discovery artifacts are reused). This is the fix for the
+> #1 escape: shipping a workbook with the right numbers but missing tiles the source rendered.
+> If the PNG is genuinely unavailable, re-run with `--skip-dashboard-read "<reason>"`.
 
 > **Converter backend — LOCAL by default, zero config, never upload customer data silently.**
 > The mechanical path needs the Tableau→Sigma converter, which is **not a server** — it's a
@@ -576,7 +595,29 @@ If `get-view-data` returns 401 for a view, retry that view solo (the contention 
 
 > **Do not parallel-fire `get-view-image` calls.** Even if the CSVs succeeded in parallel, concurrent image requests still 401 due to VizQL session contention. Images are always solo.
 
-> **Reading the dashboard image is MANDATORY before writing the workbook spec in Phase 5.** The CSV headers tell you a chart's dimensions and measures; they do NOT tell you (a) the chart's *kind* (a `Category, Count` CSV could back a bar OR a pie OR a donut), (b) any text annotations (titles, section headers, footnotes), or (c) the filter shelf. Skipping the image read is the most common Phase 5 mistake — you ship a workbook that has the right numbers but is missing tiles the source dashboard actually rendered.
+> **🚧 GATE — read the dashboard image AND record what you saw in `png-read.json` before Phase 5.** The CSV headers tell you a chart's dimensions and measures; they do NOT tell you (a) the chart's *kind* (a `Category, Count` CSV could back a bar OR a pie OR a donut), (b) any text annotations (titles, section headers, footnotes), or (c) the filter shelf. Skipping the image read is the most common Phase 5 mistake — you ship a workbook that has the right numbers but is missing tiles the source dashboard actually rendered.
+>
+> This step was prose-only, so it got skipped under load. It is now gated: after Reading the dashboard PNG, write `<workdir>/png-read.json` capturing your interpretation, then confirm the gate:
+>
+> ```bash
+> ruby scripts/assert-dashboard-read.rb --workdir /tmp/<name>
+> ```
+>
+> `png-read.json` schema (enumerate EVERY zone — chart AND non-chart):
+>
+> ```json
+> {
+>   "source_png": "views/<dashboardViewId>.png",
+>   "tiles": [
+>     { "title": "Revenue by Region", "kind": "bar-chart", "measures": ["Gross Revenue"] },
+>     { "title": "Filters", "kind": "control" }
+>   ],
+>   "text_elements": ["Orders Dashboard"],
+>   "filter_shelf": [ { "label": "Order Date", "control_type": "date-range" } ]
+> }
+> ```
+>
+> `kind` must be a valid Sigma element kind (see the "Sigma spec supports:" list below). Set `text_elements` / `filter_shelf` to `[]` only after confirming from the image that the dashboard genuinely has none. Both build paths enforce this file: `build-charts-from-signals.rb` (Phase 5a) **refuses to build without it**, and the orchestrator (`migrate-tableau.rb`) hard-stops **before posting the data model** if it's missing. The Phase 6 gate sequence re-runs `assert-dashboard-read.rb` as a final belt. Genuinely can't read the PNG? Pass `--skip-dashboard-read "<reason>"` and name the waiver in your report.
 
 **Phase 1d checklist — confirm before moving on:**
 
@@ -1166,6 +1207,8 @@ On error: read the message → fix the offending column formula → re-validate 
 
 ### 5a-auto. Run build-charts-from-signals first
 
+> **🚧 GATE:** this script exits 1 unless `<workdir>/png-read.json` exists (the Phase 1d dashboard-read artifact). If it blocks, go back to Phase 1d — Read the dashboard PNG and write `png-read.json` — don't reach for `--skip-dashboard-read` unless the PNG is genuinely unavailable.
+
 For most workbooks, `build-charts-from-signals.rb` produces a usable starting spec:
 
 ```bash
@@ -1527,6 +1570,7 @@ ruby scripts/build-parity-plan.rb --workbook-id <wb> \
   --out <WORK>/parity-plan.json --emit-spec <WORK>/wb-readback.json
 ruby scripts/verify-warehouse.rb --plan <WORK>/parity-plan.json \
   --workbook-id <wb> --workbook-spec <WORK>/wb-readback.json --out <WORK>/parity-final.json
+ruby scripts/assert-dashboard-read.rb --workdir <WORK>                  # 🚧 Phase 1d belt
 ruby scripts/assert-phase6-ran.rb --workdir <WORK> --workbook-id <wb>   # Gate 1 + banner
 ```
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-dashboard-read.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-dashboard-read.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# 🚧 GATE — proves the Phase 1d SOURCE dashboard-read actually happened.
+#
+# Reading the source Tableau dashboard PNG and enumerating its tiles/text/filter
+# shelf BEFORE building is the most-skipped load-bearing step in the conversion:
+# it produced no artifact anything required, so it silently got dropped and the
+# workbook shipped with the right numbers but missing tiles. This gate requires
+# the artifact of that read — png-read.json (schema in scripts/lib/dashboard_read.rb).
+#
+# It fires at two points:
+#   - Phase 5 build (build-charts-from-signals.rb) calls the same validator and
+#     refuses to build without it — point-of-use enforcement.
+#   - This standalone script is the safety net for the hand-written-spec path,
+#     and is what the orchestrator / manual runs invoke explicitly.
+#
+# Usage:
+#   ruby scripts/assert-dashboard-read.rb --tableau /tmp/<name>
+#     [--workdir DIR]                  # alias of --tableau
+#     [--skip-dashboard-read REASON]   # waive — REQUIRED reason; name it in your report
+#
+# Exit codes:
+#   0  png-read.json present + well-formed (or waived) — build may proceed
+#   1  png-read.json missing or malformed — the Phase 1d read was skipped
+#   2  usage error
+
+require 'json'
+require 'optparse'
+require_relative 'lib/dashboard_read'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--tableau DIR')       { |v| opts[:dir] = v }
+  p.on('--workdir DIR', 'alias of --tableau') { |v| opts[:dir] = v }
+  p.on('--skip-dashboard-read REASON',
+       'waive the Phase 1d dashboard-read gate — REQUIRED reason string; name it in your migration report') do |v|
+    opts[:skip] = v
+  end
+end.parse!
+
+unless opts[:dir]
+  warn '--workdir (or --tableau) required'
+  exit 2
+end
+
+if opts[:skip]
+  puts "[SKIP] dashboard-read gate WAIVED via --skip-dashboard-read (#{opts[:skip]})."
+  puts '       Name this waiver in your migration report — the workbook was built WITHOUT'
+  puts '       confirming its tiles/text/filters against the source dashboard PNG.'
+  exit 0
+end
+
+ok, errs = DashboardRead.validate(opts[:dir])
+if ok
+  n = DashboardRead.tile_count(opts[:dir])
+  src = (JSON.parse(File.read(DashboardRead.path(opts[:dir])))['source_png'] rescue nil) || 'the dashboard PNG'
+  puts "[PASS] dashboard-read gate: #{n} tile(s) enumerated from #{src}."
+  exit 0
+end
+
+warn "[FAIL] Phase 1d dashboard-read gate — #{DashboardRead.path(opts[:dir])}"
+errs.each { |e| warn "       - #{e}" }
+warn ''
+warn '       Read the SOURCE Tableau dashboard PNG (get-view-image, solo) and write'
+warn '       png-read.json enumerating EVERY tile with its Sigma `kind`, plus text_elements'
+warn '       and filter_shelf. See SKILL.md Phase 1d. This is the hard gate that stops'
+warn '       shipping a workbook with the right numbers but missing tiles the source rendered.'
+warn '       Genuinely cannot read it? Waive with --skip-dashboard-read "<reason>".'
+exit 1

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -82,8 +82,31 @@ OptionParser.new do |p|
   # Where the migration COVERAGE ledger lands (the aggregated drop/approx report
   # migrate-tableau.rb surfaces). Default: coverage.json next to --out. bead beads-sigma-59mk.
   p.on('--coverage-out PATH')       { |v| opts[:coverage_out] = v }
+  # 🚧 GATE escape hatch — waive the Phase 1d dashboard-read requirement. Use ONLY
+  # when the source dashboard PNG genuinely cannot be read; name the reason in your report.
+  p.on('--skip-dashboard-read REASON', 'waive the Phase 1d dashboard-read gate (REQUIRED reason; name it in your report)') { |v| opts[:skip_dashboard_read] = v }
 end.parse!
 %i[tab layout mmap out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+
+# 🚧 GATE (Phase 1d) — refuse to build charts until the SOURCE dashboard PNG has
+# been read and enumerated. png-read.json is the artifact of that read; without it
+# the build produces the right numbers but silently drops tiles/text/filters the
+# source dashboard rendered (the most common Phase 5 escape). Escape hatch:
+# --skip-dashboard-read "<reason>". See scripts/lib/dashboard_read.rb + SKILL.md Phase 1d.
+require_relative 'lib/dashboard_read'
+if opts[:skip_dashboard_read]
+  warn "[SKIP] dashboard-read gate WAIVED (#{opts[:skip_dashboard_read]}) — name this in your migration report."
+else
+  dr_ok, dr_errs = DashboardRead.validate(opts[:tab])
+  unless dr_ok
+    warn "[FAIL] Phase 1d dashboard-read gate blocks chart build (#{DashboardRead.path(opts[:tab])}):"
+    dr_errs.each { |e| warn "       - #{e}" }
+    warn '       Read the dashboard PNG (get-view-image, solo) and write png-read.json enumerating'
+    warn '       every tile with its Sigma `kind` + text_elements + filter_shelf (SKILL.md Phase 1d),'
+    warn '       or waive with --skip-dashboard-read "<reason>" and name it in your report.'
+    exit 1
+  end
+end
 
 # ---- chart_kind → Sigma element kind ----
 SIGMA_KIND = {

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/dashboard_read.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/dashboard_read.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+#
+# Shared validator for the Phase 1d dashboard-read artifact (png-read.json).
+#
+# WHY THIS EXISTS. Reading the SOURCE Tableau dashboard PNG and enumerating its
+# tiles/text/filters *before* building is the single most-skipped load-bearing
+# step in the whole conversion. It gets skipped because — unlike Phase 6 — it
+# was prose-only: it produced no artifact anything downstream required, so under
+# time/token pressure an agent heads-down on the DM+workbook drops it. The
+# result is a workbook with the right NUMBERS but missing tiles/text/filters the
+# source dashboard actually rendered (the most common Phase 5 escape).
+#
+# This module turns that invisible attention step into a required INPUT:
+#   - Phase 5 build (build-charts-from-signals.rb) refuses to run without a
+#     well-formed png-read.json.
+#   - The final gate (assert-phase6-ran.rb) re-checks it as a safety net for the
+#     hand-written-spec path that bypasses the build script.
+#
+# png-read.json schema — the agent writes this in Phase 1d AFTER Reading the PNG:
+#   {
+#     "source_png": "views/<dashboardViewId>.png",  # the PNG that was read
+#     "tiles": [                                     # >=1, one per dashboard zone
+#       { "title":    "Revenue by Region",
+#         "kind":     "bar-chart",                   # a valid Sigma element kind
+#         "measures": ["Gross Revenue"],             # optional
+#         "note":     "..." }                        # optional
+#     ],
+#     "text_elements": ["Orders Dashboard"],         # page title/section headers ([] if none)
+#     "filter_shelf": [                              # dashboard-level controls ([] if none)
+#       { "label": "Order Date", "control_type": "date-range" }
+#     ]
+#   }
+#
+# text_elements and filter_shelf must be PRESENT (use [] when the dashboard
+# genuinely has none) — their absence signals the agent never looked for the two
+# most-dropped non-chart surfaces.
+
+require 'json'
+
+module DashboardRead
+  # Valid Sigma element kinds a tile may declare — the chart kinds PLUS the
+  # non-chart surfaces the read must still enumerate (text/control/image). Kept
+  # in sync with the "Sigma spec supports:" list in SKILL.md Phase 1d.
+  VALID_KINDS = %w[
+    bar-chart line-chart area-chart combo-chart scatter-chart kpi-chart
+    pie-chart donut-chart region-map point-map table pivot-table
+    control text image container
+  ].freeze
+
+  def self.path(dir)
+    File.join(dir, 'png-read.json')
+  end
+
+  # Is this workdir a Tableau conversion that SHOULD have a dashboard read?
+  # Trigger on the tableau-only zone-tree artifact so the final-gate check stays
+  # invisible to the other converters that share assert-phase6-ran.rb.
+  def self.expected?(dir)
+    %w[dashboard-layout.json get-workbook.json].any? { |f| File.exist?(File.join(dir, f)) }
+  end
+
+  # Returns [ok(Boolean), errors(Array<String>)].
+  def self.validate(dir)
+    p = path(dir)
+    return [false, ["#{p} does not exist — the Phase 1d dashboard-read step was skipped."]] unless File.exist?(p)
+
+    begin
+      doc = JSON.parse(File.read(p))
+    rescue JSON::ParserError => e
+      return [false, ["#{p} is malformed JSON: #{e.message}"]]
+    end
+
+    errs = []
+    tiles = doc['tiles']
+    if !tiles.is_a?(Array) || tiles.empty?
+      errs << 'png-read.json has no `tiles` — enumerate EVERY dashboard zone from the image ' \
+              '(chart AND non-chart: text, filter shelf, legend).'
+    else
+      tiles.each_with_index do |t, i|
+        unless t.is_a?(Hash) && t['kind']
+          errs << "tiles[#{i}] missing `kind` — decide the Sigma element kind from the IMAGE, not the CSV header."
+          next
+        end
+        unless VALID_KINDS.include?(t['kind'])
+          errs << "tiles[#{i}].kind=#{t['kind'].inspect} is not a valid Sigma kind (#{VALID_KINDS.join(', ')})."
+        end
+      end
+    end
+
+    %w[text_elements filter_shelf].each do |k|
+      next if doc.key?(k)
+      errs << "png-read.json missing `#{k}` — set it to [] if the dashboard genuinely has none, " \
+              'but confirm from the image first (these are the two most-dropped surfaces).'
+    end
+
+    [errs.empty?, errs]
+  end
+
+  # Convenience: tile count for PASS messages (0 if unreadable).
+  def self.tile_count(dir)
+    doc = JSON.parse(File.read(path(dir)))
+    doc['tiles'].is_a?(Array) ? doc['tiles'].size : 0
+  rescue StandardError
+    0
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -83,6 +83,7 @@ require 'date'
 require 'time'
 require 'set'
 require_relative 'lib/scout_gate'
+require_relative 'lib/dashboard_read'
 require_relative 'hydrate-custom-sql'
 
 $stdout.sync = true # progress lines interleave correctly when piped/captured
@@ -138,6 +139,7 @@ OptionParser.new do |o|
   o.on('--force')            {     opts[:force]   = true }
   o.on('--reuse-dm [ID]')    { |v| opts[:reuse_dm] = v || :recommended }
   o.on('--skip-reuse-scan')  {     opts[:skip_reuse] = true }
+  o.on('--skip-dashboard-read REASON', 'waive the Phase 1d source dashboard-read gate — REQUIRED reason; name it in your report') { |v| opts[:skip_dashboard_read] = v }
   o.on('--row-scale F', Float) { |v| opts[:row_scale] = v }
   o.on('--master-col PAIR', "'Name=<Sigma formula>' — extra master column (repeatable). The resume path " \
                             'for the exit-4 handoff when a chart dim is a master-level calc the mechanical ' \
@@ -1456,6 +1458,37 @@ if opts[:folder].to_s.empty?
   end
 end
 mark('folder-resolve')
+
+# ---------------------------------------------------------------------------
+# 🚧 GATE (Phase 1d) — source dashboard-read, enforced BEFORE any DM/workbook
+# POST. The orchestrated pass fetches CSVs but CANNOT read the source dashboard
+# PNG (that's an agent vision step), so historically it shipped number-correct
+# workbooks missing tiles/text/filters the source rendered. build-charts later
+# runs under allow_fail:true, which would SWALLOW its own gate into a silent
+# empty dashboard — so enforce it HARD here, before we post anything, so a cold
+# first run aborts clean (no stray DM) and the agent re-runs after the read.
+# The agent must have fetched the dashboard PNG (mcp get-view-image, solo) and
+# written png-read.json (SKILL.md Phase 1d). Fires only on a Tableau workdir.
+# ---------------------------------------------------------------------------
+if opts[:skip_dashboard_read]
+  line "dashboard-read gate WAIVED (--skip-dashboard-read: #{opts[:skip_dashboard_read]}) — name this in your report"
+elsif DashboardRead.expected?(WORK)
+  dr_ok, dr_errs = DashboardRead.validate(WORK)
+  unless dr_ok
+    warn ''
+    warn "[FAIL] Phase 1d source dashboard-read gate — #{DashboardRead.path(WORK)}"
+    dr_errs.each { |e| warn "       - #{e}" }
+    warn ''
+    warn '       The orchestrator cannot read images. Before it can build the workbook you must:'
+    warn "         1. Fetch the dashboard view PNG with mcp__tableau__get-view-image (solo) into #{WORK}/views/"
+    warn '         2. Read it and write png-read.json enumerating every tile (with its Sigma `kind`),'
+    warn '            text_elements, and filter_shelf — schema in SKILL.md Phase 1d.'
+    warn "         3. Re-run this command (discovery artifacts in #{WORK} are reused — no stray DM was posted)."
+    warn '       Genuinely no PNG access? Re-run with --skip-dashboard-read "<reason>" (name it in your report).'
+    abort 'FATAL: Phase 1d dashboard-read not done — refusing to build a number-only dashboard.'
+  end
+  line "dashboard-read gate: #{DashboardRead.tile_count(WORK)} tile(s) enumerated (png-read.json)"
+end
 
 # ---------------------------------------------------------------------------
 # Phase 3 — Build + POST the data model.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-complex-dashboard-e2e.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-complex-dashboard-e2e.rb
@@ -128,7 +128,7 @@ Dir.mktmpdir do |d|
               '--master-element-id', 'master', '--auto-controls',
               '--title', 'Pipeline Dashboard', '--out', out,
               err: '/dev/stdout', out: File::NULL) rescue false
-  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --auto-controls --title Pipeline --out #{out} 2>&1`
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --skip-dashboard-read unit-test --auto-controls --title Pipeline --out #{out} 2>&1`
   build_out = (JSON.parse(File.read(out)) rescue nil) if File.exist?(out)
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-empty-csv-build-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-empty-csv-build-from-signals.rb
@@ -90,6 +90,12 @@ Dir.mktmpdir do |d|
              JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => 'Monthly Revenue Trend' }] }))
   Dir.mkdir(File.join(d, 'views'))
   File.write(File.join(d, 'views', 'v1.csv'), '')   # 0 bytes — the whole point
+  # Phase 1d dashboard-read artifact (the build script now gates on it). A real
+  # conversion writes this after Reading the dashboard PNG; enumerate the one tile.
+  File.write(File.join(d, 'png-read.json'),
+             JSON.dump('source_png' => 'views/v1.png',
+                       'tiles' => [{ 'title' => 'Monthly Revenue Trend', 'kind' => 'line-chart' }],
+                       'text_elements' => [], 'filter_shelf' => []))
   abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
   out = File.join(d, 'specs.json')
   build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --title Dash --out #{out} 2>&1`

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-composite-emit.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-kpi-composite-emit.rb
@@ -89,7 +89,7 @@ Dir.mktmpdir do |d|
   File.write(File.join(d, 'views', 'v1.csv'), '')
   abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
   out = File.join(d, 'specs.json')
-  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --title D --out #{out} 2>&1`
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --skip-dashboard-read unit-test --title D --out #{out} 2>&1`
   build_out = JSON.parse(File.read(out)) if File.exist?(out)
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-metric-switch.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-metric-switch.rb
@@ -42,7 +42,7 @@ def build(zone, params, column_aliases)
     File.write("#{d}/get-workbook.json", JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => zone['caption'] }] }))
     Dir.mkdir("#{d}/views"); File.write("#{d}/views/v1.csv", "Partner Name,#{zone['caption']}\nAcme,1\n")
     o = "#{d}/specs.json"
-    `ruby #{BUILD} --tableau-dir #{d} --layout #{d}/layout.json --meta #{d}/meta.json --master-map #{d}/mm.json --master-element-id master --title Dash --auto-controls --out #{o} 2>&1`
+    `ruby #{BUILD} --tableau-dir #{d} --layout #{d}/layout.json --meta #{d}/meta.json --master-map #{d}/mm.json --master-element-id master --skip-dashboard-read unit-test --title Dash --auto-controls --out #{o} 2>&1`
     out = JSON.parse(File.read(o)) if File.exist?(o)
   end
   out

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-scoping-wiring.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-param-scoping-wiring.rb
@@ -68,7 +68,7 @@ Dir.mktmpdir do |d|
   File.write(File.join(d, 'views', 'v1.csv'), '')
   File.write(File.join(d, 'views', 'v2.csv'), '')
   out = File.join(d, 'specs.json')
-  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{meta} --master-map #{mm} --master-element-id master --title Dash --out #{out} 2>&1`
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{meta} --master-map #{mm} --master-element-id master --skip-dashboard-read unit-test --title Dash --out #{out} 2>&1`
   build_out = JSON.parse(File.read(out)) if File.exist?(out)
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-styled-text-layout.rb
@@ -104,7 +104,7 @@ Dir.mktmpdir do |d|
   abort 'parse-twb-layout failed' unless system('ruby', PARSER, twb, lay, out: File::NULL, err: File::NULL)
 
   out = File.join(d, 'specs.json')
-  charts_log = `ruby #{CHARTS} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --title Story --out #{out} 2>&1`
+  charts_log = `ruby #{CHARTS} --tableau-dir #{d} --layout #{lay} --meta #{lay.sub(/\.json$/, '-meta.json')} --master-map #{mm} --master-element-id master --skip-dashboard-read unit-test --title Story --out #{out} 2>&1`
   specs = JSON.parse(File.read(out)) if File.exist?(out)
 
   # Synthesize the workbook readback (wb-ids) from the emitted flat element list:

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-topn-filter-emission.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-topn-filter-emission.rb
@@ -61,7 +61,7 @@ Dir.mktmpdir do |d|
   File.write(File.join(d, 'views', 'v1.csv'), '')   # empty → build from .twb signals
   File.write(File.join(d, 'views', 'v2.csv'), '')
   out = File.join(d, 'specs.json')
-  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{meta} --master-map #{mm} --master-element-id master --title Dash --out #{out} 2>&1`
+  build_log = `ruby #{BUILD} --tableau-dir #{d} --layout #{lay} --meta #{meta} --master-map #{mm} --master-element-id master --skip-dashboard-read unit-test --title Dash --out #{out} 2>&1`
   build_out = JSON.parse(File.read(out)) if File.exist?(out)
 end
 


### PR DESCRIPTION
## What & why

Migration sessions were **skipping the Phase 1d dashboard-read** (reading the source Tableau dashboard PNG before building). It was prose-only — `> Reading the dashboard image is MANDATORY…` in SKILL.md — with **no artifact and no enforcing gate**, so under load agents dropped it and shipped workbooks with the right *numbers* but **missing tiles/text/filters the source actually rendered** (the #1 Phase 5 escape). The orchestrated path made it structural: `migrate-tableau.rb` fetches CSVs but can't read a PNG, so it never did the read at all.

Root cause (from auditing the skill): only the steps backed by a *failing script* (Phase 6) survive; "MANDATORY" prose (15 occurrences) doesn't. Fix: turn the invisible attention step into a **required input with a gate** — the same pattern that keeps Phase 6 from being skipped.

No bead (hackathon fast-follow — Tier 1 of a larger "make load-bearing steps gates, not prose" plan).

## Scope

- Plugin(s) touched: **tableau-to-sigma** only
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

New/changed:
- `scripts/lib/dashboard_read.rb` — validator + schema for `png-read.json` (every tile with a valid Sigma `kind`, plus `text_elements`/`filter_shelf`); `expected()` keys on tableau-only artifacts.
- `scripts/assert-dashboard-read.rb` — standalone 🚧 GATE (pass/fail/waive).
- `build-charts-from-signals.rb` — **refuses to build** without `png-read.json` (point-of-use); `--skip-dashboard-read "<reason>"` escape hatch.
- `migrate-tableau.rb` — **hard-stops before posting the DM** if the read is missing (cold first run aborts clean, no stray DM) with re-run instructions.
- `SKILL.md` — 🚧 GATE convention/legend; Phase 1d rewritten to require+validate the artifact; Phase 5a note, Phase 6 belt, orchestrated-path heads-up.

Deliberately **not** editing the shared `assert-phase6-ran.rb` (would force `dashboard_read.rb` into all 11 plugins); the Phase 6 belt runs the tableau-only `assert-dashboard-read.rb` instead.

## Checklist

- [x] `ruby tools/check-shared.rb` — green (no shared file touched)
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green (14/14; corpus doesn't execute the gated build layer)
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes swept in (built in a clean worktree off origin/main)

Tests: added a `png-read.json` fixture to `test-empty-csv-build-from-signals.rb` (now exercises the gate happy-path); the 6 chart-emission unit tests that drive the build pass `--skip-dashboard-read` (they test emission, not the read gate). Full offline suite 47/48 (the 1 failure — `test-calc-discovery.rb` — is pre-existing and needs a live Tableau token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)