### PR TITLE
Add .gitattributes — normalize line endings so every OS reads identical bytes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,67 @@
+# Encoding + line-ending normalization.
+#
+# WHY: coding agents read SKILL.md / refs as raw text and models are sensitive to
+# byte differences (CRLF vs LF, a stray BOM); scripts break outright if a shebang
+# line carries a CRLF on unix. With no .gitattributes, Git on Windows (default
+# core.autocrlf=true) checks these files out with CRLF, so a mac and a Windows
+# user run DIFFERENT bytes of the same skill. Pinning eol=lf makes every OS check
+# out byte-identical files, so every agent reads and every interpreter runs the
+# same instructions. (doctor.sh already flags CRLF — this prevents it at source.)
+
+# Default: treat everything as text and store/checkout with LF. Git still
+# auto-detects genuine binaries and leaves them untouched.
+* text=auto eol=lf
+
+# --- Scripts: MUST be LF (a CRLF shebang breaks the interpreter on unix) ---
+*.rb   text eol=lf
+*.py   text eol=lf
+*.sh   text eol=lf
+*.mjs  text eol=lf
+*.js   text eol=lf
+*.ts   text eol=lf
+
+# PowerShell is Windows-native; keep it CRLF so it runs cleanly there.
+*.ps1  text eol=crlf
+
+# --- OUR instruction / config text: LF, UTF-8 ---
+*.md   text eol=lf
+*.mdc  text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml  text eol=lf
+*.html text eol=lf
+*.txt  text eol=lf
+
+# --- EXTERNAL source-tool input artifacts / data fixtures: preserve bytes ---
+# These are real exports from the source BI tools (Tableau saves .twb as CRLF on
+# Windows) or captured data fixtures. Do NOT normalize them: forcing LF would
+# rewrite committed corpus goldens and make the fixtures unlike real customer
+# inputs (which the parsers must handle either way). `-text` = leave bytes exactly
+# as committed. If you add a NEW authored file with one of these extensions, that
+# is fine — it just won't be eol-normalized.
+*.twb   -text
+*.twbx  -text
+*.tml   -text
+*.lkml  -text
+*.lookml -text
+*.bim   -text
+*.pbir  -text
+*.qvs   -text
+*.xml   -text
+*.csv   -text
+
+# --- Binaries: never normalize (defensive — none tracked today) ---
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.pdf  binary
+*.hyper binary
+*.twbx binary
+*.zip  binary
+*.xlsx binary
+*.parquet binary
+*.woff binary
+*.woff2 binary
+*.ttf  binary


### PR DESCRIPTION
## What & why

Addresses the **mac/windows encoding** concern: coding agents read `SKILL.md`/refs as raw text (models are sensitive to CRLF vs LF and a stray BOM), and scripts break outright if a shebang line carries a CRLF on unix. **The repo had no `.gitattributes`**, so Git on Windows (default `core.autocrlf=true`) checks these files out with CRLF — a mac user and a Windows user then run **different bytes of the same skill**. `doctor.sh` already flags CRLF reactively; this prevents it at the source.

## What it does

- **Our authored code + docs → `eol=lf`** (`rb`, `py`, `sh`, `mjs`, `js`, `ts`, `md`, `mdc`, `json`, `yaml`, `yml`, `html`, `txt`) — byte-identical on every OS.
- **PowerShell → `eol=crlf`** (Windows-native).
- **External source-tool inputs + data fixtures → `-text`** (`twb`, `twbx`, `tml`, `lkml`, `lookml`, `bim`, `pbir`, `qvs`, `xml`, `csv`) — bytes preserved. Real Tableau `.twb` exports are CRLF; forcing LF would **rewrite committed corpus goldens** and make fixtures unlike real customer inputs (which parsers must handle either way).
- Defensive `binary` rules for image/archive/font types (none tracked today).

## Verification

- `git add --renormalize .` rewrites **0 tracked files** — the repo is already all-LF except one CRLF `.twb` corpus fixture, which is now correctly **preserved** (not rewritten). This PR contains only `.gitattributes`.
- `corpus --check` green · `check-shared` / `lint-skills` green.

## Scope

- [x] Isolated repo-wide infra change (one file), no plugin logic touched.

Part of the consistency-hardening set (with the run-state ledger PR and the agent-neutral-instructions change). Companion finding reported there: `sigma-authoring/skills/*/generated/{cursor,codex,cline,continue}/` ship per-agent instruction copies with no generator + no drift gate — recommend a follow-up to generate-from-canonical + drift-check them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)