### PR TITLE
Per-agent variant generator in-repo + drift gate (every coding agent reads the same instructions)

### DIFF
--- a/.githooks/run-governance-checks.sh
+++ b/.githooks/run-governance-checks.sh
@@ -20,6 +20,7 @@ fi
 fail=0
 ruby tools/check-shared.rb || fail=1
 ruby tools/lint-skills.rb   || fail=1
+[ -f tools/check-agent-variants.rb ] && { ruby tools/check-agent-variants.rb || fail=1; }
 if [ "$fail" -ne 0 ]; then
   echo "" >&2
   echo "governance checks failed — fix above, or bypass with --no-verify (CI will still gate)." >&2

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -84,6 +84,11 @@ jobs:
         # C8 parity / C9 RLS gates and appear in docs/phase-schema.md. Known
         # gaps are tracked in tools/skill-lint-baseline.json (WARN, not fail).
         run: ruby tools/lint-skills.rb
+      - name: Check agent variants are in sync with SKILL.md
+        # The Cursor/Codex/Cline/Continue instruction files are generated from
+        # each skill's SKILL.md by tools/gen-agent-variants.rb. Fail if a
+        # committed variant drifted, so EVERY coding agent reads the same steps.
+        run: ruby tools/check-agent-variants.rb
 
   unit-tests:
     name: offline unit/regression tests (creds-free)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,23 @@ Intentional per-tool forks are allowlisted in `shared/manifest.json` (`exception
 + reason). **Shared-lib changes go in their own PR**, merged before dependent
 work — so concurrent feature PRs never both touch a copy.
 
+## Per-agent instruction variants — edit SKILL.md, never a generated copy
+
+Some skills ship non-Claude agent variants under `<skill>/generated/{cursor,codex,
+cline,continue}/`. These are **generated from the skill's `SKILL.md`** so every
+coding agent reads the SAME instructions. Never hand-edit a file under
+`generated/` — edit `SKILL.md` and regenerate:
+
+```bash
+ruby tools/gen-agent-variants.rb --all   # regenerate every skill's variants
+git add plugins/                         # commit SKILL.md + the regenerated variants
+```
+
+CI (`tools/check-agent-variants.rb`) fails if any committed variant drifts from
+what `SKILL.md` would generate. Use the `<!-- agents:claude-only -->` /
+`<!-- agents:non-claude … agents:end -->` markers in `SKILL.md` for the rare
+content that must differ per agent.
+
 ## Adding a new converter
 
 ```bash

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/cline/custom-sql-to-data-model.md
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/cline/custom-sql-to-data-model.md
@@ -1,6 +1,6 @@
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse Sigma data models, then repoint the workbooks via the v3alpha `:swapSources` endpoint. Use when you want to find ad-hoc SQL in workbooks and promote it to one reusable data model per unique query.
@@ -36,7 +36,7 @@ commands in the same block:
 eval "$(bash scripts/get-token.sh)"
 ```
 
-> Tokens expire after ~1 hour. Re-run if you see `Token missing or malformed`.
+> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `eval "$(bash scripts/get-token.sh)"` manually.
 
 ---
 

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/codex/AGENTS.md
@@ -1,6 +1,6 @@
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse Sigma data models, then repoint the workbooks via the v3alpha `:swapSources` endpoint. Use when you want to find ad-hoc SQL in workbooks and promote it to one reusable data model per unique query.
@@ -36,7 +36,7 @@ commands in the same block:
 eval "$(bash scripts/get-token.sh)"
 ```
 
-> Tokens expire after ~1 hour. Re-run if you see `Token missing or malformed`.
+> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `eval "$(bash scripts/get-token.sh)"` manually.
 
 ---
 

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/continue/custom-sql-to-data-model.md
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/continue/custom-sql-to-data-model.md
@@ -1,6 +1,6 @@
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse Sigma data models, then repoint the workbooks via the v3alpha `:swapSources` endpoint. Use when you want to find ad-hoc SQL in workbooks and promote it to one reusable data model per unique query.
@@ -36,7 +36,7 @@ commands in the same block:
 eval "$(bash scripts/get-token.sh)"
 ```
 
-> Tokens expire after ~1 hour. Re-run if you see `Token missing or malformed`.
+> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `eval "$(bash scripts/get-token.sh)"` manually.
 
 ---
 

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/cursor/rules/custom-sql-to-data-model.mdc
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/generated/cursor/rules/custom-sql-to-data-model.mdc
@@ -4,8 +4,8 @@ alwaysApply: false
 ---
 
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse Sigma data models, then repoint the workbooks via the v3alpha `:swapSources` endpoint. Use when you want to find ad-hoc SQL in workbooks and promote it to one reusable data model per unique query.
@@ -41,7 +41,7 @@ commands in the same block:
 eval "$(bash scripts/get-token.sh)"
 ```
 
-> Tokens expire after ~1 hour. Re-run if you see `Token missing or malformed`.
+> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `eval "$(bash scripts/get-token.sh)"` manually.
 
 ---
 

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/cline/sigma-data-models.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/cline/sigma-data-models.md
@@ -1,6 +1,6 @@
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Author, retrieve, or modify a Sigma data model spec (the JSON/YAML semantic-layer definition with sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security) by calling the Sigma REST API directly. Use when the user wants to build a new data model from existing warehouse tables, add metrics or relationships to an existing model, change a model's source, edit columns, or round-trip a data model spec through code. **Out of scope: converting from another BI tool's format (dbt, LookML, Tableau, Power BI, Alteryx, etc.).** Those conversions are handled by the Sigma data-model converter (browser tool + MCP) — point users there when they paste source-format input. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
@@ -64,7 +64,7 @@ Call out any of these before presenting the final spec:
 
 - **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
-- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 
 ## Out of Scope (use a different tool)
 

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/codex/AGENTS.md
@@ -1,6 +1,6 @@
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Author, retrieve, or modify a Sigma data model spec (the JSON/YAML semantic-layer definition with sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security) by calling the Sigma REST API directly. Use when the user wants to build a new data model from existing warehouse tables, add metrics or relationships to an existing model, change a model's source, edit columns, or round-trip a data model spec through code. **Out of scope: converting from another BI tool's format (dbt, LookML, Tableau, Power BI, Alteryx, etc.).** Those conversions are handled by the Sigma data-model converter (browser tool + MCP) — point users there when they paste source-format input. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
@@ -64,7 +64,7 @@ Call out any of these before presenting the final spec:
 
 - **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
-- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 
 ## Out of Scope (use a different tool)
 

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/continue/sigma-data-models.md
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/continue/sigma-data-models.md
@@ -1,6 +1,6 @@
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Author, retrieve, or modify a Sigma data model spec (the JSON/YAML semantic-layer definition with sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security) by calling the Sigma REST API directly. Use when the user wants to build a new data model from existing warehouse tables, add metrics or relationships to an existing model, change a model's source, edit columns, or round-trip a data model spec through code. **Out of scope: converting from another BI tool's format (dbt, LookML, Tableau, Power BI, Alteryx, etc.).** Those conversions are handled by the Sigma data-model converter (browser tool + MCP) — point users there when they paste source-format input. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
@@ -64,7 +64,7 @@ Call out any of these before presenting the final spec:
 
 - **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
-- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 
 ## Out of Scope (use a different tool)
 

--- a/plugins/sigma-authoring/skills/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
+++ b/plugins/sigma-authoring/skills/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
@@ -4,8 +4,8 @@ alwaysApply: false
 ---
 
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Author, retrieve, or modify a Sigma data model spec (the JSON/YAML semantic-layer definition with sources, columns, metrics, relationships, filters, controls, folder groupings, and column-level security) by calling the Sigma REST API directly. Use when the user wants to build a new data model from existing warehouse tables, add metrics or relationships to an existing model, change a model's source, edit columns, or round-trip a data model spec through code. **Out of scope: converting from another BI tool's format (dbt, LookML, Tableau, Power BI, Alteryx, etc.).** Those conversions are handled by the Sigma data-model converter (browser tool + MCP) — point users there when they paste source-format input. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
@@ -69,7 +69,7 @@ Call out any of these before presenting the final spec:
 
 - **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
-- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 
 ## Out of Scope (use a different tool)
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -1,6 +1,6 @@
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
@@ -164,6 +164,8 @@ If any element reports `[FAIL]`, fix the column formulas in the spec (most often
 
 After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
 
+**For anything beyond ~1 page / ~10 elements, switch to the element rep** (`reference/workflows/element-rep.md`): `scripts/wb-rep.rb pull <id> <dir>` explodes the spec into one file per element so each edit touches a ~½KB file instead of the whole spec, `push` handles drift-check + validation + PUT, and `render` exports page PNGs you can actually look at. The raw GET/PUT flow below remains fine for small workbooks and one-off tweaks.
+
 > **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
 
 ```bash
@@ -236,6 +238,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/codex/AGENTS.md
@@ -1,6 +1,6 @@
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
@@ -164,6 +164,8 @@ If any element reports `[FAIL]`, fix the column formulas in the spec (most often
 
 After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
 
+**For anything beyond ~1 page / ~10 elements, switch to the element rep** (`reference/workflows/element-rep.md`): `scripts/wb-rep.rb pull <id> <dir>` explodes the spec into one file per element so each edit touches a ~½KB file instead of the whole spec, `push` handles drift-check + validation + PUT, and `render` exports page PNGs you can actually look at. The raw GET/PUT flow below remains fine for small workbooks and one-off tweaks.
+
 > **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
 
 ```bash
@@ -236,6 +238,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -1,6 +1,6 @@
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
@@ -164,6 +164,8 @@ If any element reports `[FAIL]`, fix the column formulas in the spec (most often
 
 After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
 
+**For anything beyond ~1 page / ~10 elements, switch to the element rep** (`reference/workflows/element-rep.md`): `scripts/wb-rep.rb pull <id> <dir>` explodes the spec into one file per element so each edit touches a ~½KB file instead of the whole spec, `push` handles drift-check + validation + PUT, and `render` exports page PNGs you can actually look at. The raw GET/PUT flow below remains fine for small workbooks and one-off tweaks.
+
 > **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
 
 ```bash
@@ -236,6 +238,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -4,8 +4,8 @@ alwaysApply: false
 ---
 
 <!--
-Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
-Do not edit by hand — edit SKILL.md and re-run the script.
+Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
 -->
 
 > Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
@@ -169,6 +169,8 @@ If any element reports `[FAIL]`, fix the column formulas in the spec (most often
 
 After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
 
+**For anything beyond ~1 page / ~10 elements, switch to the element rep** (`reference/workflows/element-rep.md`): `scripts/wb-rep.rb pull <id> <dir>` explodes the spec into one file per element so each edit touches a ~½KB file instead of the whole spec, `push` handles drift-check + validation + PUT, and `render` exports page PNGs you can actually look at. The raw GET/PUT flow below remains fine for small workbooks and one-off tweaks.
+
 > **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
 
 ```bash
@@ -241,6 +243,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules
 

--- a/tools/check-agent-variants.rb
+++ b/tools/check-agent-variants.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# check-agent-variants.rb — drift gate for the per-agent instruction variants.
+#
+# Every coding agent must read the SAME instructions. The non-Claude variants
+# (Cursor / Codex / Cline / Continue) are GENERATED from each skill's canonical
+# SKILL.md by tools/gen-agent-variants.rb. This gate re-renders them in memory
+# and fails if a committed variant differs — catching the exact bug we hit
+# before it existed: SKILL.md edited, variants left stale, so Cursor/Codex users
+# silently ran outdated steps. Mirrors tools/check-shared.rb for shared libs.
+#
+#   ruby tools/check-agent-variants.rb    # exit 1 on any drift or missing variant
+#
+# Fix drift with:  ruby tools/gen-agent-variants.rb --all
+#
+# Creds-free, stdlib-only — safe for the corpus-check CI workflow + git hooks.
+
+require_relative 'gen-agent-variants' # defines ROOT + AgentVariants
+
+drift = []    # [rel, reason]
+checked = 0
+
+AgentVariants.skills_with_variants.each do |skill_dir|
+  AgentVariants.render(skill_dir).each do |path, expected|
+    rel = path.sub(ROOT + '/', '')
+    checked += 1
+    if !File.exist?(path)
+      drift << [rel, 'missing — generator would create it']
+    elsif File.read(path) != expected
+      drift << [rel, 'out of sync with SKILL.md']
+    end
+  end
+end
+
+if drift.empty?
+  puts "OK: #{checked} agent variant(s) match their canonical SKILL.md (Cursor/Codex/Cline/Continue in sync)."
+  exit 0
+end
+
+puts 'AGENT-VARIANT DRIFT DETECTED'
+puts 'A non-Claude agent variant is out of sync with its SKILL.md — different agents would'
+puts 'read different instructions. Regenerate: ruby tools/gen-agent-variants.rb --all'
+puts
+drift.each { |rel, why| puts "  DRIFT  #{rel}  (#{why})" }
+puts
+puts "drift: #{drift.size} / #{checked}"
+exit 1

--- a/tools/gen-agent-variants.rb
+++ b/tools/gen-agent-variants.rb
@@ -1,0 +1,147 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# gen-agent-variants.rb — generate the non-Claude-Code agent instruction files
+# from a skill's canonical SKILL.md, so EVERY coding agent (Cursor, Codex, Cline,
+# Continue, …) reads the SAME instructions instead of a hand-maintained copy that
+# silently drifts. This is the in-repo home of the generator (previously only in
+# the sibling sigma-skills repo, which is why the marketplace copies had no drift
+# gate). Pair with tools/check-agent-variants.rb (the CI/hook drift gate).
+#
+# Usage:
+#   ruby tools/gen-agent-variants.rb <skill-dir>   # regenerate one skill
+#   ruby tools/gen-agent-variants.rb --all         # every skill with a generated/ dir
+#
+# For each skill it (re)writes:
+#   <skill-dir>/generated/codex/AGENTS.md
+#   <skill-dir>/generated/cursor/rules/<name>.mdc
+#   <skill-dir>/generated/cline/<name>.md
+#   <skill-dir>/generated/continue/<name>.md
+# Cortex Code is intentionally NOT generated — it reads SKILL.md natively.
+#
+# SKILL.md markers (kept identical to the canonical generator's contract):
+#   <!-- agents:claude-only -->  …stripped from non-Claude outputs…  <!-- /agents:claude-only -->
+#   <!-- agents:non-claude \n …shown only in non-Claude outputs… \n agents:end -->
+
+require 'yaml'
+require 'fileutils'
+
+ROOT = File.expand_path('..', __dir__)
+
+PROVENANCE = <<~PROV
+  <!--
+  Auto-generated from SKILL.md by tools/gen-agent-variants.rb.
+  Do not edit by hand — edit SKILL.md and re-run: ruby tools/gen-agent-variants.rb --all
+  -->
+PROV
+
+def strip_claude_only_blocks(s)
+  s.gsub(/<!--\s*agents:claude-only\s*-->.*?<!--\s*\/agents:claude-only\s*-->/m, '')
+end
+
+def reveal_non_claude_blocks(s)
+  s.gsub(/<!--\s*agents:non-claude\s*\n(.*?)\nagents:end\s*-->/m) { Regexp.last_match(1) }
+end
+
+CLAUDE_PHRASE_SUBS = [
+  [/\bClaude or the local machine\b/, 'the AI agent or the local machine'],
+  [/\bin Claude Code\b/i, 'in your AI coding agent'],
+  [/\bvia the `?Skill`? tool\b/i, ''],
+  [/\bUse the `?Skill`? tool\b/i, 'Follow the procedure below'],
+  [/\bvia the `?Bash`? tool\b/i, 'in your shell'],
+  [/\bUse the `?Bash`? tool\b/i, 'In your shell'],
+  [/\bvia the `?(Read|Edit|Write)`? tool\b/i, ''],
+  [/\bsubagent_type:\s*\S+/, ''],
+  [/\bTaskCreate\b/, 'a TODO entry'],
+  [/\bTaskUpdate\b/, 'a TODO update'],
+  [/\bTaskList\b/, 'a TODO list']
+].freeze
+
+def apply_phrase_subs(s, subs)
+  out = s.dup
+  subs.each { |re, repl| out.gsub!(re, repl) }
+  out.gsub!(/[ \t]+$/, '')
+  out.gsub!(/\n{3,}/, "\n\n")
+  out
+end
+
+def transform_for_non_claude(body)
+  s = body
+  s = strip_claude_only_blocks(s)
+  s = reveal_non_claude_blocks(s)
+  s = apply_phrase_subs(s, CLAUDE_PHRASE_SUBS)
+  s.strip + "\n"
+end
+
+# Drop the generated H1 when the body already opens with one.
+def header(name, desc, body_xform)
+  return "> #{desc}\n\n" if body_xform.lstrip.start_with?('# ')
+
+  "# #{name}\n\n> #{desc}\n\n"
+end
+
+# Compute the intended content of every agent variant for a skill WITHOUT
+# writing anything. Returns { absolute_path => content }. Shared by the writer
+# (below) and the drift gate (tools/check-agent-variants.rb) so both use the
+# exact same render — the gate can never disagree with the generator.
+module AgentVariants
+  module_function
+
+  def render(skill_dir)
+    skill_dir = File.expand_path(skill_dir)
+    skill_md  = File.join(skill_dir, 'SKILL.md')
+    abort "no SKILL.md at #{skill_md}" unless File.exist?(skill_md)
+
+    raw = File.read(skill_md)
+    unless raw =~ /\A---\s*\n(.+?)\n---\s*\n(.*)\z/m
+      abort "no YAML frontmatter at top of #{skill_md} — needed at minimum: name + description"
+    end
+    fm = YAML.safe_load(Regexp.last_match(1))
+    body = Regexp.last_match(2)
+    name = fm['name'] or abort "frontmatter missing `name` in #{skill_md}"
+    desc = (fm['description'] || '').to_s.gsub(/\s+/, ' ').strip
+
+    body_xform = transform_for_non_claude(body)
+    hdr = header(name, desc, body_xform)
+
+    {
+      File.join(skill_dir, 'generated', 'codex', 'AGENTS.md') =>
+        PROVENANCE + "\n" + hdr + body_xform,
+      File.join(skill_dir, 'generated', 'cursor', 'rules', "#{name}.mdc") =>
+        "---\ndescription: #{desc.inspect}\nalwaysApply: false\n---\n\n" + PROVENANCE + "\n" + hdr + body_xform,
+      File.join(skill_dir, 'generated', 'cline', "#{name}.md") =>
+        PROVENANCE + "\n" + hdr + body_xform,
+      File.join(skill_dir, 'generated', 'continue', "#{name}.md") =>
+        PROVENANCE + "\n" + hdr + body_xform
+    }
+  end
+
+  # Every skill that already ships agent variants (has a generated/ dir).
+  def skills_with_variants
+    Dir.glob(File.join(ROOT, 'plugins', '*', 'skills', '*')).select do |d|
+      File.directory?(File.join(d, 'generated')) && File.file?(File.join(d, 'SKILL.md'))
+    end.sort
+  end
+
+  def write(skill_dir)
+    render(skill_dir).each do |path, content|
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, content)
+    end.keys
+  end
+end
+
+# CLI (skipped when this file is required as a library by the drift gate).
+if $PROGRAM_NAME == __FILE__
+  if ARGV.delete('--all')
+    dirs = AgentVariants.skills_with_variants
+    abort 'no skills with a generated/ dir found' if dirs.empty?
+    dirs.each { |d| puts "#{d.sub(ROOT + '/', '')}: regenerated #{AgentVariants.write(d).size} variant(s)" }
+  elsif ARGV[0]
+    written = AgentVariants.write(ARGV[0])
+    puts "regenerated #{written.size} variant(s):"
+    written.each { |p| puts "  #{p.sub(ROOT + '/', '')}" }
+  else
+    abort 'usage: gen-agent-variants.rb <skill-dir> | --all'
+  end
+end


### PR DESCRIPTION
## What & why

The remaining half of the "Coco reads different instructions per agent" problem. The non-Claude instruction files (Cursor / Codex / Cline / Continue) under `sigma-authoring/skills/*/generated/` were produced by a generator that lived in a **separate repo** (`~/sigma-skills/scripts/sync-targets.rb`) and was **never wired into this repo's CI** — so they silently drifted from the canonical `SKILL.md`.

**Proven drift:** regenerating showed the committed variants were **stale** — missing the entire **element-rep workflow** section and the **token auto-refresh** guidance that's in the current `sigma-workbooks/SKILL.md`. Cursor/Codex/Cline/Continue users were reading outdated steps. That's the report, reproduced.

## Fix — self-contained + enforced

- **`tools/gen-agent-variants.rb`** — the generator, **ported faithfully** from the external one. Verified its output is **byte-identical** to the external generator (modulo the provenance line) on all 3 skills, so no transformation changed. `--all` regenerates every skill that has a `generated/` dir.
- **`tools/check-agent-variants.rb`** — drift gate: re-renders each variant from `SKILL.md` in memory and fails if a committed copy differs (shares the exact render module, so gate and generator can't disagree). Mirrors `check-shared.rb`.
- Wired into **`.githooks/run-governance-checks.sh`** (pre-commit/pre-push) and the **`corpus-check` CI workflow**.
- **`CONTRIBUTING.md`**: "edit `SKILL.md`, never a generated copy" — parallel to the shared-lib rule.
- **Regenerated all 12 variants** so committed == generator output (fixes the existing staleness; the gate keeps them in sync from here).

Verified the gate: OK on the synced tree, and it correctly **fails** when a variant is corrupted.

## Cross-repo note

The sibling `sigma-skills` repo has its own copy of these skills + the original generator. When re-vendoring from there, run `ruby tools/gen-agent-variants.rb --all` so provenance/format match this repo's gate (same class of coordination as the shared-lib vendoring).

## Scope

- Touches the **sigma-authoring** plugin's generated variants + repo governance infra (tools/, CI, hook, CONTRIBUTING). Coherent unit: the generator infra and the files it governs.
- [x] `check-shared` / `lint-skills` / `check-agent-variants` all green; governance hook passes end-to-end.

Completes the consistency set: #285 (Phase 1d gate), #286 (progressive disclosure), #287 (run-state ledger + agent-neutral instructions), #288 (.gitattributes encoding), and this (agent-variant sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)