### PR TITLE
tableau-to-sigma: build-charts fidelity — horizontal bars + drop orphan KPI labels (from a live CoCo run)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/workbook-layout.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/workbook-layout.md
@@ -497,7 +497,7 @@ Key facts:
 - **`value` is a wrapped object, not a bare number.** Upstream `sigma-workbooks` charts.md shows `value: 1000` — that shape is rejected by the live API. Use `{ "type": "constant", "value": <number> }` or `{ "type": "formula", "formula": "<expr>" }`.
 - `value.type: "column"` (with `columnId`) is also rejected — wrap the column in a `formula` instead.
 - `axis` is `"series"` for the measure axis (Y), `"series2"` for combo-chart's secondary axis, `"axis"` for the X axis.
-- `label.visibility` is `"shown"` or `"hidden"`. `label.text` is optional — Sigma renders a sensible default when absent.
+- `label.visibility` **must be `"shown"`** on a `refMarks` label. Although the UI exposes a hide toggle, the **spec API rejects `"hidden"`** with `Invalid value: object` (verified; the readback shows `shown`). To visually de-emphasize a reference line, keep `visibility: "shown"` and give it a short `label.text` (e.g. `"Avg monthly"`) rather than trying to hide it. `label.text` is optional — Sigma renders a sensible default when absent.
 - For `type: "band"` — wait for engineering to confirm via another UI-built readback (see `beads-sigma-7ak`).
 
 #### Trendlines (verified 2026-05-22)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -3695,6 +3695,27 @@ layout.each do |dash|
       end
       element['yAxis'] = { 'columnIds' => y_column_ids }
 
+      # Bar orientation (bead: bar-orientation). Tableau puts the DIMENSION on
+      # the Rows shelf and the MEASURE on Columns for a HORIZONTAL bar (bars grow
+      # left→right, categories down the y-axis); the default vertical bar is the
+      # opposite. parse-twb-layout already tags each shelf field's `role`, so read
+      # it straight off the zone. Sigma spec: `orientation: "horizontal"` on a
+      # bar-chart (omit for vertical — "vertical" is REJECTED). Round-trips live
+      # (refs/workbook-layout.md, verified 2026-06-15).
+      if kind == 'bar-chart'
+        # rows_shelf/cols_shelf are a Hash ({fields:[…]}) in the rich parse, but
+        # sometimes just the raw shelf STRING — only the Hash form carries roles.
+        rows_sh = z['rows_shelf']
+        cols_sh = z['cols_shelf']
+        rows_f = rows_sh.is_a?(Hash) ? (rows_sh['fields'] || []) : []
+        cols_f = cols_sh.is_a?(Hash) ? (cols_sh['fields'] || []) : []
+        dim_on_rows  = rows_f.any? { |f| %w[dim dimension].include?(f['role']) }
+        meas_on_cols = cols_f.any? { |f| f['role'] == 'measure' }
+        if dim_on_rows && meas_on_cols
+          element['orientation'] = 'horizontal'
+        end
+      end
+
       # Axis format (log scale, fixed min/max). parse-twb-layout extracts these
       # from Tableau's <style-rule element='axis'><encoding attr='space' ...>
       # nodes per worksheet. Sigma side shape verified 2026-05-22:
@@ -4180,14 +4201,38 @@ unless opts[:pages_mode] == :worksheet
     # standalone styled-text zone whose text just repeats a KPI's caption is a
     # redundant duplicate — emitting it (and dumping it in a stray band) is the
     # "orphan labels at the bottom" defect. Drop those; keep real prose/sections.
-    kpi_labels = (dash['zones'] || []).select { |z| z['is_kpi'] && z['caption'] }
-                                      .map { |z| norm_label.call(z['caption']) }
+    kpi_zones = (dash['zones'] || []).select { |z| z['is_kpi'] }
+    kpi_labels = kpi_zones.select { |z| z['caption'] }
+                          .map { |z| norm_label.call(z['caption']) }.reject(&:empty?)
+    # A Tableau KPI card is often a LABEL text zone sitting directly above the
+    # scorecard sheet in the same column band — and its label is the clean measure
+    # name ("Net Revenue"), which does NOT match the scorecard's internal caption
+    # ("OV KPI Revenue"), so the name dedup above misses it and the labels pile
+    # into a stray bottom band (the "orphan labels" defect). Catch them
+    # POSITIONALLY: a short text zone whose x-band overlaps a KPI zone, is about
+    # the same width (not a full-width section title), and sits just above it is
+    # that card's label — Sigma's kpi-chart renders its own title, so drop it.
+    labels_kpi_positionally = lambda do |t|
+      tx, tw, ty, th = %w[x_pct w_pct y_pct h_pct].map { |k| t[k] }
+      return false unless [tx, tw, ty].all? { |v| v.is_a?(Numeric) } && tw > 0
+
+      kpi_zones.any? do |k|
+        kx, kw, ky = %w[x_pct w_pct y_pct].map { |kk| k[kk] }
+        next false unless [kx, kw, ky].all? { |v| v.is_a?(Numeric) } && kw > 0
+        next false if tw > kw * 1.5                        # wider banner/section title, not a per-card label
+        ovl = [tx + tw, kx + kw].min - [tx, kx].max        # horizontal overlap
+        next false unless ovl / [tw, kw].min >= 0.6        # same column band
+        ty < ky && (ky - ty) <= (th.to_f > 0 ? th * 3 : 14.0) # sits just above the card
+      end
+    end
     (dash['zones'] || []).each do |z|
       next unless %w[text title].include?(z['kind']) && z['text_runs']
-      plain = norm_label.call(z['text_runs'].map { |r| r['text'] }.join)
-      if !plain.empty? && kpi_labels.include?(plain)
+      full_text = z['text_runs'].map { |r| r['text'] }.join
+      plain = norm_label.call(full_text)
+      is_short_label = full_text.split.length <= 5 && z['text_runs'].none? { |r| r['break'] }
+      if !plain.empty? && (kpi_labels.include?(plain) || (is_short_label && labels_kpi_positionally.call(z)))
         warnings << "dashboard '#{dash['dashboard']}' text zone #{z['id']} (#{plain.inspect}) " \
-                    'duplicates a KPI title — dropped (the Sigma kpi-chart renders its own title)'
+                    'labels a KPI card — dropped (the Sigma kpi-chart renders its own title)'
         next
       end
       body = text_body_from_runs(z['text_runs'], align: z['text_align'],

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-bar-orientation-kpi-dedup.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-bar-orientation-kpi-dedup.rb
@@ -1,0 +1,115 @@
+#!/usr/bin/env ruby
+# Regression test for two build-charts fidelity fixes (from a live CoCo run of
+# the Orders Executive Overview dashboard):
+#
+#  (A) Bar orientation — a Tableau bar with the DIMENSION on the Rows shelf and
+#      the MEASURE on the Cols shelf is a HORIZONTAL bar; build-charts must emit
+#      `orientation: "horizontal"`. The default (dim on Cols) stays vertical
+#      (field omitted). Bug: all bars came out vertical.
+#  (B) Orphan KPI-label text zones — a Tableau KPI card is a short label text
+#      zone directly ABOVE a scorecard in the same column band. Sigma's kpi-chart
+#      renders its own title, so those labels are redundant; build-charts must
+#      DROP them (positionally — the label text is the clean measure name and
+#      doesn't match the scorecard's internal caption). A full-width section
+#      title must be KEPT. Bug: the labels piled into a stray bottom band.
+#
+# Deterministic + offline: hand-builds the dashboard-layout.json the parser would
+# emit, runs the ACTUAL build-charts-from-signals.rb, asserts the output spec.
+#
+# Usage: ruby scripts/test-bar-orientation-kpi-dedup.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR   = __dir__
+BUILD = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# One dashboard: a KPI card (label text zone above a scorecard), a full-width
+# section title, a horizontal bar (dim on Rows), and a vertical bar (dim on Cols).
+LAYOUT = [{
+  'dashboard' => 'Exec',
+  'zones' => [
+    { 'id' => 't-title', 'kind' => 'text', 'x_pct' => 0, 'y_pct' => 0, 'w_pct' => 100, 'h_pct' => 4,
+      'text_runs' => [{ 'text' => 'Orders — Executive Overview' }] },
+    { 'id' => 't-lbl', 'kind' => 'text', 'x_pct' => 0, 'y_pct' => 4, 'w_pct' => 20, 'h_pct' => 5,
+      'text_runs' => [{ 'text' => 'Net Revenue' }] },
+    { 'id' => 'k1', 'kind' => 'chart', 'caption' => 'OV KPI Revenue', 'is_kpi' => true,
+      'chart_kind' => 'kpi', 'x_pct' => 0, 'y_pct' => 9, 'w_pct' => 20, 'h_pct' => 15,
+      'filters' => [], 'hidden_filters' => [], 'channels' => {}, 'formats' => {}, 'dual_axis' => false,
+      'ref_marks' => [], 'aggregations' => { '[Net Revenue]' => 'Sum' },
+      'rows_shelf' => { 'fields' => [] }, 'cols_shelf' => { 'fields' => [] },
+      'measures' => [{ 'column' => '[Net Revenue]', 'derivation' => 'Sum' }], 'calculations' => [] },
+    { 'id' => 'bH', 'kind' => 'chart', 'caption' => 'Rev by Region', 'chart_kind' => 'bar',
+      'mark_class' => 'Bar', 'x_pct' => 0, 'y_pct' => 30, 'w_pct' => 50, 'h_pct' => 30,
+      'filters' => [], 'hidden_filters' => [], 'channels' => {}, 'formats' => {}, 'dual_axis' => false,
+      'ref_marks' => [], 'aggregations' => { '[Region]' => 'None', '[Net Revenue]' => 'Sum' },
+      'rows_shelf' => { 'fields' => [{ 'caption' => 'Region', 'role' => 'dim' }] },
+      'cols_shelf' => { 'fields' => [{ 'caption' => 'Net Revenue', 'role' => 'measure' }] },
+      'measures' => [{ 'column' => '[Net Revenue]', 'derivation' => 'Sum' }], 'calculations' => [] },
+    { 'id' => 'bV', 'kind' => 'chart', 'caption' => 'Rev by Ship', 'chart_kind' => 'bar',
+      'mark_class' => 'Bar', 'x_pct' => 50, 'y_pct' => 30, 'w_pct' => 50, 'h_pct' => 30,
+      'filters' => [], 'hidden_filters' => [], 'channels' => {}, 'formats' => {}, 'dual_axis' => false,
+      'ref_marks' => [], 'aggregations' => { '[Ship]' => 'None', '[Net Revenue]' => 'Sum' },
+      'rows_shelf' => { 'fields' => [{ 'caption' => 'Net Revenue', 'role' => 'measure' }] },
+      'cols_shelf' => { 'fields' => [{ 'caption' => 'Ship', 'role' => 'dim' }] },
+      'measures' => [{ 'column' => '[Net Revenue]', 'derivation' => 'Sum' }], 'calculations' => [] }
+  ]
+}]
+META = { 'worksheets' => {}, 'shared_filters' => [], 'parameters' => [], 'column_aliases' => {},
+         'columns_by_guid' => {} }
+MMAP = {
+  '(?i)^Region$'      => { 'id' => 'm-region', 'name' => 'Region' },
+  '(?i)^Ship$'        => { 'id' => 'm-ship',   'name' => 'Ship' },
+  '(?i)^Net Revenue$' => { 'id' => 'm-rev',    'name' => 'Net Revenue' }
+}
+
+out = nil
+Dir.mktmpdir do |d|
+  File.write("#{d}/layout.json", JSON.dump(LAYOUT))
+  File.write("#{d}/meta.json",   JSON.dump(META))
+  File.write("#{d}/mm.json",     JSON.dump(MMAP))
+  File.write("#{d}/get-workbook.json",
+             JSON.dump('views' => { 'view' => [{ 'id' => 'vH', 'name' => 'Rev by Region' },
+                                                { 'id' => 'vV', 'name' => 'Rev by Ship' }] }))
+  Dir.mkdir("#{d}/views")
+  File.write("#{d}/views/vH.csv", "Region,Net Revenue\nWest,100\nEast,50\n")
+  File.write("#{d}/views/vV.csv", "Ship,Net Revenue\nAir,100\nGround,50\n")
+  o = "#{d}/specs.json"
+  `ruby #{BUILD} --tableau-dir #{d} --layout #{d}/layout.json --meta #{d}/meta.json --master-map #{d}/mm.json --master-element-id master --skip-dashboard-read unit-test --out #{o} 2>&1`
+  out = JSON.parse(File.read(o)) if File.exist?(o)
+end
+
+abort 'build produced no spec' unless out
+els = out.is_a?(Array) ? out : (out['elements'] || (out['pages'] || []).flat_map { |p| p['elements'] || [] })
+texts = els.select { |e| e['kind'] == 'text' }
+bars  = els.select { |e| e['kind'] == 'bar-chart' }
+bar_h = bars.find { |b| b['name'].to_s =~ /Region/ }
+bar_v = bars.find { |b| b['name'].to_s =~ /Ship/ }
+
+# (B) orphan KPI label dropped, section title kept
+text_bodies = texts.map { |t| (t['body'] || '').to_s }
+check(text_bodies.none? { |b| b =~ /Net Revenue/ && b !~ /Executive/ },
+      'orphan KPI label "Net Revenue" (above the KPI card) was DROPPED', fails)
+check(text_bodies.any? { |b| b =~ /Executive Overview/ },
+      'full-width section title "Orders — Executive Overview" was KEPT', fails)
+
+# (A) orientation
+check(!bar_h.nil? && bar_h['orientation'] == 'horizontal',
+      "dim-on-Rows bar → orientation:horizontal (got #{bar_h && bar_h['orientation'].inspect})", fails)
+check(!bar_v.nil? && bar_v['orientation'].nil?,
+      "dim-on-Cols bar → vertical (no orientation field) (got #{bar_v && bar_v['orientation'].inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — horizontal-bar orientation emitted + orphan KPI labels suppressed'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"; fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
Fixes from a fresh Cortex Code (CoCo) migration of *Orders Executive Overview* — the run that produced the stranded bottom band + vertical-instead-of-horizontal bars. **Verified end-to-end by re-running the real `build-charts-from-signals.rb` on CoCo's actual parsed inputs** (`~/tableau-migration/Orders-Executive-Overview/`), not just unit tests.

## Fixed

**#7 — orphan KPI-label text zones (the stray bottom band).** build-charts already dropped text zones matching a KPI *caption*, but a KPI card's label is the clean measure name (`"Net Revenue"`) while the scorecard's caption is internal (`"OV KPI Revenue"`) — so name-dedup missed all 5. Added **positional dedup**: a short text zone overlapping a KPI zone's column band, ~same width (not a full-width title), sitting just above it → dropped (the kpi-chart renders its own title).
> Real-data E2E: **7 text elements → 2** (5 orphan labels gone; page title + section title kept).

**#2 — horizontal bar orientation.** Tableau = dimension on Rows + measure on Cols ⇒ horizontal. The parser already tags shelf `role`; build-charts now emits `orientation: "horizontal"` (omit = vertical). Guards the shelf being a raw string vs Hash.
> Real-data E2E: **Region + Margin-by-Tier → horizontal, Gross-Rev-by-Ship stays vertical** — matches the source.

**#4 — refMark `label.visibility: "hidden"` is rejected.** Code already forces `"shown"`; corrected `refs/workbook-layout.md`, which wrongly claimed `hidden` was valid (it returns `Invalid value: object`), and documented the minimal-label workaround.

## Verification
- New offline regression `test-bar-orientation-kpi-dedup.rb` (4 assertions).
- Fixed a latent crash the change surfaced — shelf can be a **String**, not a Hash — which would have broken `test-param-metric-switch`.
- Full offline suite **51/51**, corpus **4/4**, governance green.
- **Live-schema check:** CoCo's real assembled workbook spec + the `orientation` field ⇒ `validate-spec.rb` **0 errors** (orientation round-trip is live-verified 2026-06-15 per `refs/workbook-layout.md`).

## Reported but NOT in this PR (need separate work / a design call)
- **#1** element naming — risk: breaks name-based parity/layout matching.
- **#3** refMark per-cell vs row-level `Avg` — nuanced formula semantics.
- **#5** master-map omits `Order Date`.
- **#6** stale parity-plan staleness guard (timestamp + freshness check).
- **#8** auto-seed `png-read.json` from the `.twb` — must reconcile with the vision gate (I'd auto-seed a *draft* the agent still verifies against the image, not replace it).
- **#9** layout wiped on spec re-PUT — `post-and-readback.rb` is a **shared** lib; needs the layout-preserving pattern (already used in `fidelity-loop.rb`) applied carefully via `shared/` + sync.

Happy to do any of these next — #6 and #9 are the highest-value of the remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)