### PR TITLE
tableau: loud zero-join guard for the noun/collection model

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
@@ -1,6 +1,6 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "4edc45a",
+  "source_commit": "a98e6b7",
   "source_commit_date": "2026-07-07",
   "fast_xml_parser_version": "4.5.6",
   "artifact": "tableau.mjs",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
@@ -4423,8 +4423,10 @@ function convertTableauToSigma(xmlContent, options = {}) {
           const eqExprs = [];
           for (const oe of asArray(rel.expression || []))
             collectEqs(oe, eqExprs);
-          if (eqExprs.length === 0)
+          if (eqExprs.length === 0) {
+            warnings.push(`\u26A0 Relationship ${firstEntry.cleanName} \u2192 ${secondEntry.cleanName} carries no serialized join key \u2014 Tableau auto-matches these at query time; Sigma needs an explicit key. NOT wired: pick a join key and wire manually (LEFT from fact\u2192dim), and verify the dimension is unique on the key to avoid measure fan-out.`);
             continue;
+          }
           const isPhysical = (op) => /^\[[^\]]+\]$/.test(op.trim());
           const keys = [];
           let skippedComputed = 0;
@@ -4462,6 +4464,11 @@ function convertTableauToSigma(xmlContent, options = {}) {
             name: secondEntry.cleanName
           });
           warnings.push(`\u2139 Relationship ${firstEntry.cleanName} \u2192 ${secondEntry.cleanName} wired on ${keys.length} physical key(s).`);
+        }
+        const joinableEls = elements.filter((e) => e.source?.kind === "warehouse-table" || e.source?.kind === "sql");
+        const wiredRelCount = elements.reduce((n, e) => n + (e.relationships?.length || 0), 0);
+        if (joinableEls.length > 1 && wiredRelCount === 0) {
+          warnings.push(relsList.length === 0 ? `\u26A0 Tableau logical (relationship / noun) datasource: ${joinableEls.length} tables but NO relationships were serialized in <object-graph> \u2014 nothing to derive a join key from (Tableau matches these at query time). The DM is a set of disconnected tables. Pick an explicit join key for each table pair and wire relationships manually (LEFT from fact\u2192dim), and verify each dimension is unique on the key to avoid measure fan-out.` : `\u26A0 Tableau logical (relationship / noun) datasource: ${joinableEls.length} tables and ${relsList.length} relationship(s), but 0 could be wired \u2014 all lacked a physical equality key (auto-matched or computed-only; see per-relationship warnings above). The DM is a set of disconnected tables. Pick an explicit join key per pair and wire manually (LEFT from fact\u2192dim); verify dimension uniqueness on the key.`);
         }
         elements.sort((a, b) => {
           const aR = !!a.relationships?.length;


### PR DESCRIPTION
## What
Loud **zero-join guard** for the Tableau logical **relationship (noun) model** (`type='collection'`). The 2020.2+ noun model can leave **no serialized join key** — Tableau matches the tables at query time. Two shapes reached the converter and dropped **silently**, yielding a disconnected data model with no signal why (the hackathon "tables but no joins" symptom):

1. an `<object-graph>` relationship with an empty `<expression>` (`eqExprs.length === 0`) — auto-matched, no key stored
2. no `<relationships>` block at all

## Change
Both now emit warnings instead of silently producing an unjoined DM (mirrors the BOBJ zero-join guard):
- **per-relationship:** "carries no serialized join key … NOT wired"
- **aggregate:** multi-table + 0 wired relationships → one loud, cause-specific warning (nothing-serialized vs. none-could-be-wired) with guidance (LEFT fact→dim, verify dimension uniqueness).

Warnings-only — **no change to emitted model for valid inputs.**

## Test
- Unit: 29/29 object-model tests (3 new: empty-expression, no-relationships-block, wired-key no-false-positive control).
- Live E2E (CSA.TJ.ORDER_FACT + CUSTOMER_DIM noun `.twb`): keyed variant → relationship wired → POST 200 → derived view query returns real joined rows (Consumer 406 / Corporate 174 / Home Office 155 / 26 null = unmatched fact rows preserved, LEFT semantics). No-key variant → both guards fire, 0 relationships. Test DM cleaned up.

Bead: beads-sigma-bybc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
