### PR TITLE
tableau-to-sigma: master-map reuse-union (#5), mark-level refMark avg (#3), .twb draft-seed for png-read (#8)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-1-discover.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/phase-1-discover.md
@@ -105,7 +105,9 @@ If `get-view-data` returns 401 for a view, retry that view solo (the contention 
 
 > **🚧 GATE — read the dashboard image AND record what you saw in `png-read.json` before Phase 5.** The CSV headers tell you a chart's dimensions and measures; they do NOT tell you (a) the chart's *kind* (a `Category, Count` CSV could back a bar OR a pie OR a donut), (b) any text annotations (titles, section headers, footnotes), or (c) the filter shelf. Skipping the image read is the most common Phase 5 mistake — you ship a workbook that has the right numbers but is missing tiles the source dashboard actually rendered.
 >
-> This step was prose-only, so it got skipped under load. It is now gated: after Reading the dashboard PNG, write `<workdir>/png-read.json` capturing your interpretation, then confirm the gate:
+> **The orchestrator seeds a DRAFT for you.** `migrate-tableau.rb` auto-generates `png-read.json` from the `.twb` zone tree (chart kinds, titles, text zones, filter shelf) marked `"verified": false`. That draft does **not** satisfy the gate — the `.twb` can't tell bar-vs-pie for `automatic` marks, what text actually rendered, or the real filter shelf. So you **edit** the draft against the image rather than writing from scratch: Read the dashboard PNG, correct the tiles/text/filters, and set `"verified": true`.
+>
+> This step was prose-only, so it got skipped under load. It is now gated: after Reading the dashboard PNG, write (or verify+correct the seeded) `<workdir>/png-read.json`, then confirm the gate:
 >
 > ```bash
 > ruby scripts/assert-dashboard-read.rb --workdir /tmp/<name>
@@ -115,6 +117,7 @@ If `get-view-data` returns 401 for a view, retry that view solo (the contention 
 >
 > ```json
 > {
+>   "verified": true,
 >   "source_png": "views/<dashboardViewId>.png",
 >   "tiles": [
 >     { "title": "Revenue by Region", "kind": "bar-chart", "measures": ["Gross Revenue"] },
@@ -125,7 +128,7 @@ If `get-view-data` returns 401 for a view, retry that view solo (the contention 
 > }
 > ```
 >
-> `kind` must be a valid Sigma element kind (see the "Sigma spec supports:" list below). Set `text_elements` / `filter_shelf` to `[]` only after confirming from the image that the dashboard genuinely has none. Both build paths enforce this file: `build-charts-from-signals.rb` (Phase 5a) **refuses to build without it**, and the orchestrator (`migrate-tableau.rb`) hard-stops **before posting the data model** if it's missing. The Phase 6 gate sequence re-runs `assert-dashboard-read.rb` as a final belt. Genuinely can't read the PNG? Pass `--skip-dashboard-read "<reason>"` and name the waiver in your report.
+> `"verified": true` is REQUIRED to pass the gate when the file was seeded as a draft (`verified: false`); a hand-written file may omit the field. `kind` must be a valid Sigma element kind (see the "Sigma spec supports:" list below). Set `text_elements` / `filter_shelf` to `[]` only after confirming from the image that the dashboard genuinely has none. Both build paths enforce this file: `build-charts-from-signals.rb` (Phase 5a) **refuses to build without it**, and the orchestrator (`migrate-tableau.rb`) hard-stops **before posting the data model** if it's missing. The Phase 6 gate sequence re-runs `assert-dashboard-read.rb` as a final belt. Genuinely can't read the PNG? Pass `--skip-dashboard-read "<reason>"` and name the waiver in your report.
 
 **Phase 1d checklist — confirm before moving on:**
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -3550,10 +3550,30 @@ layout.each do |dash|
           fagg = tab_to_sigma_agg[rm['formula']]
           if fagg
             label_text = rm['label_type'] == 'custom' ? rm['label'] : "#{fagg} #{meas_name}"
+            # Mark-level vs row-level (bead: refmark-avg / finding #3). Tableau's
+            # reference line aggregates over the plotted MARKS (the per-bin
+            # aggregates), but Sigma evaluates a refMark formula over the raw
+            # ROWS — so `Avg([meas])` yields the row mean (e.g. $163/order), not
+            # the mean of the bars (e.g. mean of monthly sums ≈ $3,500). For an
+            # AVERAGE line the mark-level mean = Sum(meas) / <count of x-axis
+            # bins>; the bins are the chart's x grouping (dim_col_obj's formula:
+            # `[Master/Region]` or `DateTrunc("month", [Master/Order Date])`).
+            dim_grp = dim_col_obj && dim_col_obj['formula'].to_s
+            value_formula =
+              if fagg == 'Avg' && dim_grp && !dim_grp.strip.empty?
+                "Sum([Master/#{meas_name}]) / CountDistinct(#{dim_grp})"
+              else
+                "#{fagg}([Master/#{meas_name}])"
+              end
+            if fagg == 'Avg' && !(dim_grp && !dim_grp.strip.empty?)
+              warnings << "'#{cap}' average reference line fell back to ROW-LEVEL (couldn't resolve the x-axis grouping for a mark-level mean) — verify the line value vs Tableau at Phase 6f"
+            elsif %w[Min Max Median].include?(fagg)
+              warnings << "'#{cap}' #{fagg} reference line emitted ROW-LEVEL; Tableau computes it over the plotted marks — verify vs Tableau at Phase 6f (mark-level Min/Max/Median needs a windowed formula)"
+            end
             ref_emit << {
               'type'  => 'line',
               'axis'  => 'series',
-              'value' => { 'type' => 'formula', 'formula' => "#{fagg}([Master/#{meas_name}])" },
+              'value' => { 'type' => 'formula', 'formula' => value_formula },
               'label' => { 'visibility' => 'shown', 'text' => label_text }.compact
             }
           else

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/dashboard_read.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/dashboard_read.rb
@@ -47,6 +47,64 @@ module DashboardRead
     control text image container
   ].freeze
 
+  # parse-twb-layout chart_kind → a Sigma element kind, for the DRAFT seed only.
+  DRAFT_KIND = {
+    'bar' => 'bar-chart', 'line' => 'line-chart', 'area' => 'area-chart',
+    'pie' => 'pie-chart', 'scatter' => 'scatter-chart', 'kpi' => 'kpi-chart',
+    'pivot-table' => 'pivot-table', 'table' => 'table',
+    'map-region' => 'region-map', 'map-point' => 'point-map',
+    'automatic' => 'bar-chart', 'other' => 'bar-chart'
+  }.freeze
+
+  # Seed a DRAFT png-read.json from the .twb zone tree (dashboard-layout.json),
+  # so the agent EDITS a starting point instead of writing from scratch (finding
+  # #8). The draft is verified:false, so validate() still fails until the agent
+  # Reads the dashboard PNG and confirms/corrects it — the .twb can't tell
+  # bar-vs-pie for 'automatic' marks, what text actually rendered, or the filter
+  # shelf. Returns the written path, or nil if there's no zone tree to seed from.
+  def self.seed_from_layout(dir)
+    layout_path = File.join(dir, 'dashboard-layout.json')
+    return nil unless File.exist?(layout_path)
+
+    layout = (JSON.parse(File.read(layout_path)) rescue nil)
+    return nil unless layout
+
+    dashes = layout.is_a?(Array) ? layout : (layout['dashboards'] || [layout])
+    zones = dashes.flat_map { |d| d.is_a?(Hash) ? (d['zones'] || []) : [] }
+    tiles = []
+    text_elements = []
+    zones.each do |z|
+      if z['is_kpi'] || z['kind'] == 'chart'
+        tiles << { 'title' => z['caption'].to_s,
+                   'kind' => DRAFT_KIND[z['chart_kind'].to_s] || (z['is_kpi'] ? 'kpi-chart' : 'bar-chart') }
+      elsif %w[text title].include?(z['kind']) && z['text_runs']
+        t = z['text_runs'].map { |r| r['text'] }.join.strip
+        text_elements << t unless t.empty?
+      end
+    end
+
+    filter_shelf = []
+    meta_path = layout_path.sub(/\.json\z/, '-meta.json')
+    if File.exist?(meta_path)
+      meta = (JSON.parse(File.read(meta_path)) rescue {})
+      (meta['shared_filters'] || []).each do |f|
+        lbl = (f['caption'] || f['column'] || f['name']).to_s
+        filter_shelf << { 'label' => lbl } unless lbl.empty?
+      end
+    end
+
+    draft = {
+      'verified'      => false,
+      'seeded_from'   => 'twb-parse — UNVERIFIED. Read the dashboard PNG, correct tiles/text/filter_shelf, then set verified:true.',
+      'source_png'    => nil,
+      'tiles'         => tiles,
+      'text_elements' => text_elements,
+      'filter_shelf'  => filter_shelf
+    }
+    File.write(path(dir), JSON.pretty_generate(draft) + "\n")
+    path(dir)
+  end
+
   def self.path(dir)
     File.join(dir, 'png-read.json')
   end
@@ -67,6 +125,18 @@ module DashboardRead
       doc = JSON.parse(File.read(p))
     rescue JSON::ParserError => e
       return [false, ["#{p} is malformed JSON: #{e.message}"]]
+    end
+
+    # A DRAFT seeded from the .twb (seed_from_layout) carries verified:false. The
+    # .twb can't tell bar-vs-pie for 'automatic' marks, what text annotations
+    # rendered, or the filter shelf — so a draft does NOT satisfy the gate until
+    # the agent Reads the dashboard PNG, corrects it, and sets verified:true.
+    # (Hand-written png-read.json omit the field entirely — treated as verified.)
+    if doc['verified'] == false
+      return [false, ["#{p} is a DRAFT seeded from the .twb (\"verified\": false). Read the " \
+                      'dashboard PNG, correct the tiles/text/filter_shelf (esp. bar-vs-pie, ' \
+                      'annotations, and the filter shelf — the .twb cannot see these), then set ' \
+                      '"verified": true.']]
     end
 
     errs = []

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -918,6 +918,21 @@ module MechanicalSpecs
     cols = raw_cols.map { |c| [col_display(c), c['format'], label_for[c['id']]] }
     cols.sort_by! { |(dn, _, _)| (dn.to_s.include?('(') ? 1 : 0) }
     cols.each { |(dn, fmt, real_label)| add.call(dn, fmt, real_label) }
+    # Reuse-path completeness (bead: master-map omits reused-DM columns / finding #5).
+    # The columns above come from the .twb-derived CONVERTER fact element. When a
+    # DM is REUSED, its live fact element (real_labels = readback columnLabels) can
+    # carry columns the converter never enumerated — e.g. a raw "Order Date" the
+    # source only used via a "Month of Order Date" calc. Those were silently absent
+    # from the master-map, forcing a manual --master-col override. UNION every
+    # readback column not already covered so the master-map spans ALL fact columns.
+    # Dedup on the suffix-stripped bare name so a converter "Region" already isn't
+    # re-added as "Region (Store Dim)".
+    (real_labels || []).each do |lbl|
+      next if lbl.to_s.strip.empty?
+      bare = lbl.sub(/\s*\([^)]*\)\s*\z/, '').strip
+      next if bare.empty? || seen[bare.downcase]
+      add.call(lbl, nil, lbl)
+    end
     # FIXED-LOD helper surfacing (y9rd.10): a FIXED/INCLUDE/EXCLUDE LOD becomes a
     # separate grouped helper element related to the fact (rel named "FIXED <dims>"),
     # so its output measure (e.g. "Region Revenue LOD") is NOT a fact column and a

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -1517,21 +1517,31 @@ mark('folder-resolve')
 if opts[:skip_dashboard_read]
   line "dashboard-read gate WAIVED (--skip-dashboard-read: #{opts[:skip_dashboard_read]}) — name this in your report"
 elsif DashboardRead.expected?(WORK)
+  # Seed a DRAFT png-read.json from the .twb zone tree if none exists yet, so the
+  # agent EDITS a starting point instead of writing from scratch (finding #8). The
+  # draft is verified:false, so the gate below STILL requires the agent to Read
+  # the dashboard PNG and confirm/correct it — the .twb can't tell bar-vs-pie,
+  # text annotations, or the filter shelf.
+  unless File.exist?(DashboardRead.path(WORK))
+    seeded = DashboardRead.seed_from_layout(WORK)
+    line "seeded a DRAFT png-read.json from the .twb (#{DashboardRead.tile_count(WORK)} tile(s)) — must be verified against the dashboard PNG" if seeded
+  end
   dr_ok, dr_errs = DashboardRead.validate(WORK)
   unless dr_ok
     warn ''
     warn "[FAIL] Phase 1d source dashboard-read gate — #{DashboardRead.path(WORK)}"
     dr_errs.each { |e| warn "       - #{e}" }
     warn ''
-    warn '       The orchestrator cannot read images. Before it can build the workbook you must:'
+    warn '       A DRAFT png-read.json was seeded from the .twb parse. The orchestrator cannot read'
+    warn '       images, so before it can build the workbook you must:'
     warn "         1. Fetch the dashboard view PNG with mcp__tableau__get-view-image (solo) into #{WORK}/views/"
-    warn '         2. Read it and write png-read.json enumerating every tile (with its Sigma `kind`),'
-    warn '            text_elements, and filter_shelf — schema in SKILL.md Phase 1d.'
+    warn '         2. Read it, CORRECT the draft tiles/text_elements/filter_shelf (esp. bar-vs-pie, text'
+    warn '            annotations, and the filter shelf — the .twb cannot see these), and set "verified": true.'
     warn "         3. Re-run this command (discovery artifacts in #{WORK} are reused — no stray DM was posted)."
     warn '       Genuinely no PNG access? Re-run with --skip-dashboard-read "<reason>" (name it in your report).'
-    abort 'FATAL: Phase 1d dashboard-read not done — refusing to build a number-only dashboard.'
+    abort 'FATAL: Phase 1d dashboard-read not verified — refusing to build from an unverified .twb draft.'
   end
-  line "dashboard-read gate: #{DashboardRead.tile_count(WORK)} tile(s) enumerated (png-read.json)"
+  line "dashboard-read gate: #{DashboardRead.tile_count(WORK)} tile(s) verified (png-read.json)"
   RunState.stamp(WORK, 'phase-1d', note: 'source dashboard-read (png-read.json)')
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-master-map-reuse-union.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-master-map-reuse-union.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# Regression test for finding #5: on the DM-REUSE path, derive_master built the
+# master-map only from the .twb-derived CONVERTER fact columns, so a column that
+# exists on the reused DM's fact but not in the converter output (e.g. a raw
+# "Order Date" the source only used via a "Month of Order Date" calc) was silently
+# absent — forcing a manual --master-col override. derive_master must UNION the
+# real readback columns so the master-map spans ALL fact columns.
+#
+# Usage: ruby scripts/test-master-map-reuse-union.rb
+
+require_relative 'mechanical-specs'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Converter fact element MISSING "Order Date" (only the derived month calc used it).
+conv_fact = { 'name' => 'Order Fact', 'columns' => [
+  { 'id' => 'c1', 'name' => 'Net Revenue' },
+  { 'id' => 'c2', 'name' => 'Region' }
+] }
+# The REUSED DM's fact actually carries these columns (readback columnLabels).
+real_labels = ['Net Revenue', 'Region', 'Order Date', 'Order Date Key']
+
+d = MechanicalSpecs.derive_master(conv_fact, 'Order Fact', nil, real_labels, nil)
+names = d['master_columns'].map { |c| c['name'] }
+
+check(names.include?('Order Date'),
+      "master-map now includes the reused-DM-only column 'Order Date' (got #{names.inspect})", fails)
+check(names.include?('Net Revenue') && names.include?('Region'),
+      'converter columns still present', fails)
+check(names.count('Order Date') == 1 && names.uniq.length == names.length,
+      'no duplicate master columns', fails)
+
+od = d['master_columns'].find { |c| c['name'] == 'Order Date' }
+check(od && od['formula'] == '[Order Fact/Order Date]',
+      "Order Date formula refs the fact element (got #{od && od['formula'].inspect})", fails)
+
+# The mmap must carry a regex that matches an "Order Date" CSV header (so a chart
+# dim/param resolves without a manual --master-col).
+matched = d['mmap'].keys.any? { |rx| 'Order Date' =~ Regexp.new(rx) }
+check(matched, "mmap has a regex matching the 'Order Date' header", fails)
+
+# Suffix-dedup: a converter 'Region' must NOT be re-added as 'Region (Store Dim)'.
+d2 = MechanicalSpecs.derive_master(conv_fact, 'Order Fact', nil,
+                                   ['Net Revenue', 'Region (Store Dim)', 'Order Date'], nil)
+n2 = d2['master_columns'].map { |c| c['name'] }
+check(!n2.include?('Region (Store Dim)'),
+      "a suffixed dup of an existing converter column is NOT re-added (got #{n2.inspect})", fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — reused-DM fact columns are unioned into the master-map'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"; fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-png-read-draft-seed.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-png-read-draft-seed.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+# Regression test for finding #8: the orchestrator can't read images, so it now
+# SEEDS a draft png-read.json from the .twb zone tree (removing the write-from-
+# scratch friction) — but the draft is verified:false, so the gate STILL requires
+# the agent to Read the dashboard PNG and set verified:true (the .twb can't tell
+# bar-vs-pie, text annotations, or the filter shelf). This preserves the vision
+# gate while addressing the friction.
+#
+# Usage: ruby scripts/test-png-read-draft-seed.rb
+
+require 'json'
+require 'tmpdir'
+require_relative 'lib/dashboard_read'
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+LAYOUT = [{
+  'dashboard' => 'Exec',
+  'zones' => [
+    { 'id' => 'k1', 'kind' => 'chart', 'caption' => 'KPI Revenue', 'is_kpi' => true, 'chart_kind' => 'kpi' },
+    { 'id' => 'b1', 'kind' => 'chart', 'caption' => 'Rev by Region', 'chart_kind' => 'bar' },
+    { 'id' => 'a1', 'kind' => 'chart', 'caption' => 'Auto Tile', 'chart_kind' => 'automatic' },
+    { 'id' => 't1', 'kind' => 'text', 'text_runs' => [{ 'text' => 'Executive Overview' }] }
+  ]
+}]
+META = { 'shared_filters' => [{ 'caption' => 'Order Date' }] }
+
+Dir.mktmpdir do |d|
+  File.write("#{d}/dashboard-layout.json", JSON.dump(LAYOUT))
+  File.write("#{d}/dashboard-layout-meta.json", JSON.dump(META))
+
+  p = DashboardRead.seed_from_layout(d)
+  check(!p.nil? && File.exist?(p), 'seed_from_layout wrote a draft png-read.json', fails)
+  doc = JSON.parse(File.read(p))
+
+  check(doc['verified'] == false, 'draft is verified:false', fails)
+  check(doc['tiles'].size == 3, "3 chart tiles seeded (got #{doc['tiles'].size})", fails)
+  check(doc['tiles'].any? { |t| t['title'] == 'KPI Revenue' && t['kind'] == 'kpi-chart' }, 'KPI → kpi-chart', fails)
+  check(doc['tiles'].any? { |t| t['title'] == 'Rev by Region' && t['kind'] == 'bar-chart' }, 'bar → bar-chart', fails)
+  check(doc['tiles'].any? { |t| t['title'] == 'Auto Tile' && t['kind'] == 'bar-chart' }, "automatic → bar-chart (verify vs PNG)", fails)
+  check(doc['text_elements'].include?('Executive Overview'), 'text zone → text_elements', fails)
+  check(doc['filter_shelf'].any? { |f| f['label'] == 'Order Date' }, 'shared_filter → filter_shelf', fails)
+
+  ok, errs = DashboardRead.validate(d)
+  check(!ok && errs.first.to_s =~ /DRAFT|verified/, 'gate REJECTS the unverified draft', fails)
+
+  doc['verified'] = true
+  File.write(p, JSON.pretty_generate(doc))
+  ok2, = DashboardRead.validate(d)
+  check(ok2, 'gate PASSES once verified:true', fails)
+end
+
+# A hand-written png-read.json WITHOUT a `verified` field stays valid (back-compat).
+Dir.mktmpdir do |d|
+  File.write(DashboardRead.path(d), JSON.dump(
+    'tiles' => [{ 'title' => 'X', 'kind' => 'bar-chart' }], 'text_elements' => [], 'filter_shelf' => []
+  ))
+  ok, = DashboardRead.validate(d)
+  check(ok, 'hand-written file without a verified field is still accepted (back-compat)', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS — .twb draft seeded; gate still requires visual verification'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"; fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-refmark-mark-level.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-refmark-mark-level.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+# Regression test for finding #3: a Tableau AVERAGE reference line averages the
+# plotted MARKS (per-bin aggregates), but Sigma evaluates a refMark formula over
+# raw ROWS — so Avg([meas]) gave the row mean, not the mean of the bars. For an
+# average line the mark-level mean = Sum(meas) / CountDistinct(<x-axis bins>).
+#
+# Deterministic + offline: runs the ACTUAL build-charts-from-signals.rb on a bar
+# zone with an average reference mark and asserts the emitted refMark formula.
+#
+# Usage: ruby scripts/test-refmark-mark-level.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR   = __dir__
+BUILD = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+LAYOUT = [{
+  'dashboard' => 'D',
+  'zones' => [{
+    'id' => 'b1', 'kind' => 'chart', 'caption' => 'Rev by Region', 'chart_kind' => 'bar',
+    'mark_class' => 'Bar', 'x_pct' => 0, 'y_pct' => 0, 'w_pct' => 100, 'h_pct' => 100,
+    'filters' => [], 'hidden_filters' => [], 'channels' => {}, 'formats' => {}, 'dual_axis' => false,
+    'aggregations' => { '[Region]' => 'None', '[Net Revenue]' => 'Sum' },
+    'rows_shelf' => { 'fields' => [{ 'caption' => 'Net Revenue', 'role' => 'measure' }] },
+    'cols_shelf' => { 'fields' => [{ 'caption' => 'Region', 'role' => 'dim' }] },
+    'measures' => [{ 'column' => '[Net Revenue]', 'derivation' => 'Sum' }], 'calculations' => [],
+    'ref_marks' => [{ 'kind' => 'line', 'formula' => 'average', 'label_type' => 'auto' }]
+  }]
+}]
+META = { 'worksheets' => {}, 'shared_filters' => [], 'parameters' => [], 'column_aliases' => {}, 'columns_by_guid' => {} }
+MMAP = {
+  '(?i)^Region$'      => { 'id' => 'm-region', 'name' => 'Region' },
+  '(?i)^Net Revenue$' => { 'id' => 'm-rev',    'name' => 'Net Revenue' }
+}
+
+out = nil
+Dir.mktmpdir do |d|
+  File.write("#{d}/layout.json", JSON.dump(LAYOUT))
+  File.write("#{d}/meta.json",   JSON.dump(META))
+  File.write("#{d}/mm.json",     JSON.dump(MMAP))
+  File.write("#{d}/get-workbook.json", JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => 'Rev by Region' }] }))
+  Dir.mkdir("#{d}/views")
+  File.write("#{d}/views/v1.csv", "Region,Net Revenue\nWest,100\nEast,50\n")
+  o = "#{d}/specs.json"
+  `ruby #{BUILD} --tableau-dir #{d} --layout #{d}/layout.json --meta #{d}/meta.json --master-map #{d}/mm.json --master-element-id master --skip-dashboard-read unit-test --out #{o} 2>&1`
+  out = JSON.parse(File.read(o)) if File.exist?(o)
+end
+
+abort 'build produced no spec' unless out
+els = out.is_a?(Array) ? out : (out['elements'] || (out['pages'] || []).flat_map { |p| p['elements'] || [] })
+bar = els.find { |e| e['kind'] == 'bar-chart' }
+rm  = bar && (bar['refMarks'] || []).first
+f   = rm && rm.dig('value', 'formula').to_s
+
+check(!rm.nil?, 'an average reference mark was emitted as a refMark', fails)
+check(f =~ /\ASum\(\[Master\/Net Revenue\]\)\s*\/\s*CountDistinct\(/,
+      "average line is MARK-LEVEL: Sum(meas)/CountDistinct(bins) (got #{f.inspect})", fails)
+check(f.include?('CountDistinct([Master/Region])'),
+      "denominator counts the x-axis bins (Region) (got #{f.inspect})", fails)
+check(f !~ /\AAvg\(/,
+      'NOT the old row-level Avg([meas])', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — average reference line translated to a mark-level mean'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"; fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
The last batch of findings from the live CoCo run — each verified **end-to-end on the real run data** and covered by an offline regression test.

## #5 — master-map omitted reused-DM columns (e.g. `Order Date`)
`derive_master` built the master-map from the `.twb`-derived **converter** fact columns only. On the DM-**reuse** path the live fact carries columns the converter never enumerated (a raw `Order Date` the source used only via a `Month of Order Date` calc) → absent from the map → a manual `--master-col` override. Now it **unions** every readback column not already covered (dedup on the suffix-stripped bare name, so a converter `Region` isn't re-added as `Region (Store Dim)`).
> Confirmed against the DM you linked: its fact `columnLabels` *does* include `Order Date`. Test: `test-master-map-reuse-union.rb`.

## #3 — reference-line average was row-level, not mark-level
Tableau's average line means the plotted **marks** (per-bin aggregates); Sigma evaluates a refMark formula over raw **rows**, so `Avg([meas])` gave ~$163/order, not the mean of the monthly bars (~$3,500). Now emits `Sum(meas)/CountDistinct(<x-axis grouping>)` for the average case (denominator = the chart's own x grouping), with a WARN for Min/Max/Median (still row-level — verify at Phase 6f).
> Real-data E2E: the OV Revenue Trend now emits `Sum([Master/Net Revenue]) / CountDistinct(DateTrunc("month", [Master/Month of Order Date]))` — exactly your prescription. Test: `test-refmark-mark-level.rb`.

## #8 — png-read gate reconciled with "the orchestrator can't see images"
`migrate-tableau.rb` now **seeds a draft** `png-read.json` from the `.twb` zone tree (tiles + text + filter shelf) so the agent **edits** a starting point instead of writing from scratch — **but** the draft is `verified: false`, so the gate **still** requires the agent to Read the dashboard PNG and set `verified: true`. The `.twb` can't tell bar-vs-pie for `automatic` marks, text annotations, or the real filter shelf, so this keeps the vision gate that prevents the "right numbers, missing tiles" escape while removing the friction. Hand-written files without the field stay valid (back-compat).
> Real-data E2E on CoCo's `.twb`: draft seeds 9 tiles; gate rejects until verified. Test: `test-png-read-draft-seed.rb`.

## #1 — won't fix
The source titles genuinely *are* "OV KPI Revenue" (faithful reproduction, not a bug), and renaming risks breaking the name-based `--rename` matching that parity + layout depend on — cosmetic gain, real risk. A customer who wants cleaner names renames post-migration.

## Verification
- Full offline suite **53/53** (3 new tests), `check-shared` / `lint-skills` / `corpus` green.
- All touched files are plugin-local (no shared-sync).

This closes out the CoCo findings: **#2/#4/#7 (PR #291), #6/#9 (PR #292), #5/#3/#8 (this), #1 won't-fix.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)