### PR TITLE
tableau-to-sigma: bound the two un-timed hangs (migration 'stuck for hours')

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/discover-columns.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/discover-columns.rb
@@ -57,7 +57,24 @@ def http(method, path, body = nil)
     req['Content-Type'] = 'application/json'
     req.body = body
   end
-  res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
+  # Bound every call. Sigma's warehouse-catalog lookup/columns endpoints make the
+  # warehouse introspect the table; a cold warehouse or a very wide view (e.g. a
+  # 300+-column view) can otherwise leave this blocked with NO client-side cap —
+  # the "migration stuck for hours" hang. Fail loud instead of hanging forever.
+  # Override with SIGMA_HTTP_TIMEOUT (seconds) if a legitimately huge catalog read
+  # needs longer.
+  timeout = (ENV['SIGMA_HTTP_TIMEOUT'] || '90').to_i
+  begin
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true,
+                          open_timeout: [timeout, 30].min, read_timeout: timeout) do |h|
+      h.request(req)
+    end
+  rescue Net::OpenTimeout, Net::ReadTimeout, Timeout::Error => e
+    abort "TIMEOUT after #{timeout}s calling #{method.to_s.upcase} #{path} (#{e.class}). " \
+          "Sigma's warehouse catalog lookup did not return — often a cold warehouse or a very " \
+          "wide view. Retry, raise SIGMA_HTTP_TIMEOUT, or source this table via Custom SQL " \
+          "(SKILL.md Phase 1e.1) to skip per-column catalog introspection."
+  end
   [res.code.to_i, res.body]
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -1107,7 +1107,20 @@ mark('phase2-columns')
 # ---------------------------------------------------------------------------
 puts
 puts '── Phase 1 (join) · Tableau discovery lane ──'
-sleep 0.1 until lane_done.call
+# Bound the join so a wedged discovery lane (e.g. a Tableau REST call that never
+# returns) can't leave the whole migration "stuck" indefinitely. Generous default
+# for large sites; override with TABLEAU_LANE_TIMEOUT (seconds).
+_lane_timeout = (ENV['TABLEAU_LANE_TIMEOUT'] || '1800').to_i
+_lane_t0 = Time.now
+until lane_done.call
+  if Time.now - _lane_t0 > _lane_timeout
+    print_lane_log.call
+    abort "FATAL: Tableau discovery lane did not finish within #{_lane_timeout}s — likely a " \
+          "wedged Tableau REST call (see lane log above). Re-run, raise TABLEAU_LANE_TIMEOUT, " \
+          "or pass the .twb directly with --twb to skip live discovery."
+  end
+  sleep 0.1
+end
 mark('join-wait')
 print_lane_log.call
 unless lane[:status].success?


### PR DESCRIPTION
## What
A hackathon user reported the migration **"stuck on step 3/6 for hours."** That's a **hang, not slowness** — two calls had NO client-side timeout, so a stall wedged the whole run with no error.

## Root cause (two un-timed waits)
1. **`discover-columns.rb`** — `Net::HTTP.start(...)` had no `open_timeout`/`read_timeout`. Sigma's warehouse-catalog lookup (`/connection/{id}/lookup` + `/columns`) makes the warehouse introspect the table; a **cold warehouse or a very wide view (300+ columns)** can block forever. Runs once per table, right around the 2nd–3rd visible `Phase N/6` banner.
2. **`migrate-tableau.rb` Phase-1 lane join** — `sleep 0.1 until lane_done.call` was uncapped, so a wedged Tableau discovery lane (a REST call that never returns) hangs indefinitely.

## Change
- `discover-columns.rb`: bound every call (default **90s**, `SIGMA_HTTP_TIMEOUT` override); on timeout, abort loud with a Custom-SQL fallback hint instead of hanging.
- `migrate-tableau.rb`: bound the lane join (default **1800s**, `TABLEAU_LANE_TIMEOUT` override); on timeout, print the lane log and abort with guidance (`--twb` to skip live discovery).

Diagnostics only on the happy path — **no behavior change when calls return.** Both files `ruby -c` clean.

## Windows note (separate, for the user)
`core.autocrlf=true` mangles the shipped `.sh` files under Git Bash and can wedge the spawned token/discovery child (surfacing as the same hang). Have the user run `doctor.ps1` and set `git config --global core.autocrlf input`.

Bead: beads-sigma-sg7p

🤖 Generated with [Claude Code](https://claude.com/claude-code)
