### PR TITLE
tableau-to-sigma: date-grain dim resolves to the BASE date column (fixes master/month-of-order-date)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -2732,9 +2732,14 @@ layout.each do |dash|
       dim_i   = ([0, 1, 2] - [mn_i, mv_i]).first
       dim_hdr = headers[dim_i].to_s.strip
       labels  = rows.map { |r| r[mn_i] }.compact.map(&:strip).reject(&:empty?).uniq
-      dimm = map_column(dim_hdr, mmap) ||
-             { 'id' => "m-#{dim_hdr.downcase.gsub(/\W+/, '-')}", 'name' => dim_hdr }
       mm_trunc = (hm = dim_hdr.match(/^(second|minute|hour|day|week|month|quarter|year) of /i)) && hm[1].downcase
+      # For a date-grain header the DateTrunc below must wrap the BASE date column
+      # ([Master/Order Date]); resolve the grain-stripped name FIRST so we don't
+      # bind the converter's broken passthrough "Month of Order Date" master column
+      # (formula [Fact/Month of Order Date] — no such fact column). See Path B.
+      mm_base_hdr = mm_trunc ? dim_hdr.sub(/^(?:second|minute|hour|day|week|month|quarter|year) of /i, '') : dim_hdr
+      dimm = (mm_trunc && map_column(mm_base_hdr, mmap)) || map_column(dim_hdr, mmap) ||
+             { 'id' => "m-#{dim_hdr.downcase.gsub(/\W+/, '-')}", 'name' => dim_hdr }
       el_id = "el-#{cap.downcase.gsub(/\W+/, '-')[0..40]}".sub(/-$/, '')
       mm_dim_formula =
         if mm_trunc == 'week'
@@ -2859,7 +2864,17 @@ layout.each do |dash|
     # formula (which would resolve to a non-existent column). dim_trunc below
     # still carries the grain. Strips only when the full header didn't match.
     dim_hdr_base = dim_hdr.sub(/^(?:second|minute|hour|day|week|month|quarter|year) of /i, '')
-    dim  = map_column(dim_hdr, mmap) || (dim_hdr_base != dim_hdr ? map_column(dim_hdr_base, mmap) : nil)
+    # When a grain prefix is present, resolve the BASE date column FIRST so the
+    # DateTrunc wraps [Master/Order Date]. Matching the full "Month of Order Date"
+    # first binds the converter's passthrough master column whose formula is
+    # [Fact/Month of Order Date] — a non-existent fact column — and DateTrunc then
+    # double-wraps a broken ref. The base "Order Date" is on the master via the
+    # reuse-union (#5); fall back to the full header only if the base isn't mapped.
+    dim = if dim_hdr_base != dim_hdr
+            map_column(dim_hdr_base, mmap) || map_column(dim_hdr, mmap)
+          else
+            map_column(dim_hdr, mmap)
+          end
     meas = map_column(meas_hdr, mmap)
     meas_unresolved = meas.nil?
     find_ws_calc = lambda do |hdr|

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-date-grain-base-ref.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-date-grain-base-ref.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+# Regression test: a date-grain dim header ("Month of Order Date") must resolve to
+# the BASE date column so DateTrunc wraps [Master/Order Date] — NOT the converter's
+# passthrough "Month of Order Date" master column (formula [Fact/Month of Order
+# Date], a non-existent fact column → renders empty / needs a --master-col override).
+# The base "Order Date" is on the master via the reuse-union (#5); build-charts must
+# prefer it for grain headers. Covers the "master/month of order date" defect.
+#
+# Usage: ruby scripts/test-date-grain-base-ref.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR   = __dir__
+BUILD = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+LAYOUT = [{
+  'dashboard' => 'D',
+  'zones' => [{
+    'id' => 'l1', 'kind' => 'chart', 'caption' => 'Revenue Trend', 'chart_kind' => 'line',
+    'mark_class' => 'Line', 'x_pct' => 0, 'y_pct' => 0, 'w_pct' => 100, 'h_pct' => 100,
+    'filters' => [], 'hidden_filters' => [], 'channels' => {}, 'formats' => {}, 'dual_axis' => false,
+    'ref_marks' => [], 'aggregations' => { '[Net Revenue]' => 'Sum' },
+    'rows_shelf' => { 'fields' => [] }, 'cols_shelf' => { 'fields' => [] },
+    'measures' => [{ 'column' => '[Net Revenue]', 'derivation' => 'Sum' }], 'calculations' => []
+  }]
+}]
+META = { 'worksheets' => {}, 'shared_filters' => [], 'parameters' => [], 'column_aliases' => {}, 'columns_by_guid' => {} }
+# Master-map AS IT LOOKS POST-#5: the base "Order Date" is present, AND the
+# converter's passthrough "Month of Order Date" is also present (the trap).
+MMAP = {
+  '(?i)^(?:(?:month|year|quarter|week|day) of )?Order Date$'          => { 'id' => 'm-order-date', 'name' => 'Order Date' },
+  '(?i)^(?:(?:month|year|quarter|week|day) of )?Month of Order Date$' => { 'id' => 'm-month-of-order-date', 'name' => 'Month of Order Date' },
+  '(?i)^Net Revenue$'                                                 => { 'id' => 'm-rev', 'name' => 'Net Revenue' }
+}
+
+out = nil
+Dir.mktmpdir do |d|
+  File.write("#{d}/layout.json", JSON.dump(LAYOUT))
+  File.write("#{d}/meta.json",   JSON.dump(META))
+  File.write("#{d}/mm.json",     JSON.dump(MMAP))
+  File.write("#{d}/get-workbook.json", JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => 'Revenue Trend' }] }))
+  Dir.mkdir("#{d}/views")
+  File.write("#{d}/views/v1.csv", "Month of Order Date,Net Revenue\n2024-01,100\n2024-02,50\n")
+  o = "#{d}/specs.json"
+  `ruby #{BUILD} --tableau-dir #{d} --layout #{d}/layout.json --meta #{d}/meta.json --master-map #{d}/mm.json --master-element-id master --skip-dashboard-read unit-test --out #{o} 2>&1`
+  out = JSON.parse(File.read(o)) if File.exist?(o)
+end
+
+abort 'build produced no spec' unless out
+els = out.is_a?(Array) ? out : (out['elements'] || (out['pages'] || []).flat_map { |p| p['elements'] || [] })
+line = els.find { |e| e['kind'] == 'line-chart' }
+xid  = line && line.dig('xAxis', 'columnId')
+xcol = line && (line['columns'] || []).find { |c| c['id'] == xid }
+f    = xcol && xcol['formula'].to_s
+
+check(!line.nil?, 'line chart built', fails)
+check(f == 'DateTrunc("month", [Master/Order Date])',
+      "x-axis wraps the BASE date column (got #{f.inspect})", fails)
+check(f !~ /Month of Order Date/,
+      'x-axis does NOT reference the broken passthrough [Master/Month of Order Date]', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — date-grain dim resolves to the base date column'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"; fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
## The bug you're still hitting

Even after #5 put `Order Date` on the master, a chart binned by **"Month of Order Date"** still emitted `DateTrunc("month", [Master/Month of Order Date])` — wrapping the converter's **passthrough** master column whose formula is `[Fact/Month of Order Date]` (a non-existent fact column). That renders empty and forces the manual `--master-col` override.

**Root cause:** both date-grain dim-resolution paths in `build-charts` matched the *full* "Month of Order Date" header first (binding the broken derived column) before falling back to the grain-stripped base.

**Fix:** when a grain prefix (`month/quarter/week/… of`) is present, resolve the **base** date column first (`[Master/Order Date]`, present via the #5 reuse-union), so `DateTrunc` wraps the real date. Applied to both paths; the refMark denominator inherits it.

Real-data (Orders Executive Overview, post-#5 master-map):
```
x-axis:  DateTrunc("month", [Master/Order Date])            (was [Master/Month of Order Date])
refMark: Sum([Master/Net Revenue]) / CountDistinct(DateTrunc("month", [Master/Order Date]))
```

## ⚠️ Why the earlier fixes looked like they "weren't landing"

The reports came from a checkout **not on updated `main`**:
- `~/sigma-migration-skills` is on another session's branch (`fix/tableau-discovery-hang-timeouts`) — **0 of the merged fixes on disk**.
- A fresh clone's local `main` was **behind `origin/main`**.

**#2/#3/#5/#7/#8 are all on `origin/main`** (#291/#292/#294 merged) and verified working from a clean `origin/main` worktree (text 7→2, horizontal bars, mark-level refMark). Runs must execute updated main: `git fetch origin && git checkout main && git reset --hard origin/main`.

## Verification
- `test-date-grain-base-ref.rb` (new). Full offline suite **56/56**; `check-shared` / `lint-skills` / `corpus` green. Plugin-local (no shared-sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)