### PR TITLE
tableau-to-sigma: don't double the dashboard title (source banner + synthetic)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -4182,24 +4182,32 @@ end
 # ---- Title text element ----
 # If --title given, emit a text element. If --title omitted AND the parser
 # found a title/text zone, infer the dashboard name from the parser output.
+#
+# The source's OWN top title zone (a text/title zone near the top carrying
+# run-level formatting) is emitted faithfully as a styled `text-<id>` element
+# (B4 path) and placed at the top. Synthesizing a second "# <name>" title here
+# then DOUBLES the title — the dashboard shows it at the top AND again in the
+# stray text band (the "title top + bottom" duplicate). So skip the synthetic
+# title WHENEVER the source has its own top title zone — regardless of whether
+# --title was passed. (migrate-tableau always passes --title, which is exactly
+# why the old `opts[:title].nil?`-only guard never fired and the title doubled.)
+source_has_top_title = layout.any? do |dash|
+  (dash['zones'] || []).any? do |z|
+    %w[title text].include?(z['kind']) && (z['y_pct'] || 100) < 10 && z['text_runs']
+  end
+end
 auto_title = nil
-if opts[:title].nil?
+if opts[:title].nil? && !source_has_top_title
   layout.each do |dash|
     top = dash['zones'].select { |z| %w[title text].include?(z['kind']) && (z['y_pct'] || 100) < 10 }
     next if top.empty?
-    # B4 (gap ubr5.8): a top text/title zone that carries run-level formatting
-    # is the dashboard's OWN hero title — it is emitted faithfully as a styled
-    # `text-<id>` element (black-on-canvas, at its position). Do NOT ALSO
-    # synthesize the white dashboard-name title here: the two double up, and the
-    # synthetic one (white, meant for the dark header band) renders invisibly
-    # over a light canvas when the composed layout has no dark band. Only
-    # synthesize when the top zone is a BARE title with no styled runs for B4.
-    next if top.any? { |z| z['text_runs'] }
     auto_title = dash['dashboard']
     break
   end
 end
-title_text = opts[:title] || auto_title
+# Source banner wins: when it exists, the styled text-<id> element IS the title
+# (placed at its own top geometry by the layout stage), so emit no synthetic one.
+title_text = source_has_top_title ? nil : (opts[:title] || auto_title)
 
 extras = []
 if title_text
@@ -4964,16 +4972,28 @@ elsif opts[:pages_mode] == :dashboard
     next if els.nil? || els.empty?
     els.each { |e| e.delete('_worksheet'); e.delete('_dashboard') }
     d_slug = dash_name.to_s.downcase.gsub(/\W+/, '-')[0..30].sub(/-$/, '')
-    page_extras = [{
-      'id'   => "title-#{d_slug}",
-      'kind' => 'text',
-      # Theme-default colour: the layout builder now emits a colored header band
-      # only when the source has one (else the title sits on the canvas, where
-      # forced-white would be invisible).
-      'body' => "# #{dash_name}"
-    }]
+    # Skip the synthetic "# <dashboard>" title when this dashboard has its OWN top
+    # title zone (a styled text/title zone near the top) — that zone is already
+    # emitted in styled_text_by_dash and placed at the top by the layout stage, so
+    # a synthetic one DOUBLES the title (renders at the top AND again in the stray
+    # text band — the reported "title top + bottom" duplicate). The source banner
+    # (richer, e.g. "Orders — Executive Overview") wins.
+    dash_has_top_title = (layout.find { |d| d['dashboard'] == dash_name } || {})['zones']
+                         &.any? { |z| %w[title text].include?(z['kind']) && (z['y_pct'] || 100) < 10 && z['text_runs'] }
+    page_extras = []
+    unless dash_has_top_title
+      page_extras << {
+        'id'   => "title-#{d_slug}",
+        'kind' => 'text',
+        # Theme-default colour: the layout builder now emits a colored header band
+        # only when the source has one (else the title sits on the canvas, where
+        # forced-white would be invisible).
+        'body' => "# #{dash_name}"
+      }
+    end
     # B4: this dashboard's styled static-text elements (subtitle/annotations/
-    # credit/section headers). Placed by the layout stage at their zone geometry.
+    # credit/section headers) — incl. the source's own top title banner. Placed by
+    # the layout stage at their zone geometry.
     styled_text_by_dash[dash_name].each { |e| page_extras << e.reject { |k, _| k == '_dashboard' } }
     ctl_rewrites = {}
     param_control_ids = param_controls.map { |c| c['controlId'] }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-no-double-title.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-no-double-title.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+# Regression test: when the source dashboard has its OWN top title banner (a
+# styled text zone near the top), build-charts must NOT also synthesize a
+# "# <dashboard>" title — that renders the title TWICE (at the top AND in a stray
+# text band, the reported "title top + bottom" duplicate). Covers both the
+# --page-per-dashboard path (which migrate-tableau uses, and which unconditionally
+# emitted title-<slug>) and the single-page path.
+#
+# Usage: ruby scripts/test-no-double-title.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR   = __dir__
+BUILD = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+# Dashboard WITH its own styled top title banner ("Orders — Executive Overview").
+LAYOUT = [{
+  'dashboard' => 'Executive Overview',
+  'zones' => [
+    { 'id' => 'banner', 'kind' => 'text', 'x_pct' => 0, 'y_pct' => 0, 'w_pct' => 100, 'h_pct' => 4,
+      'text_runs' => [{ 'text' => 'Orders — Executive Overview' }] },
+    { 'id' => 'b1', 'kind' => 'chart', 'caption' => 'Rev by Region', 'chart_kind' => 'bar',
+      'mark_class' => 'Bar', 'x_pct' => 0, 'y_pct' => 10, 'w_pct' => 100, 'h_pct' => 40,
+      'filters' => [], 'hidden_filters' => [], 'channels' => {}, 'formats' => {}, 'dual_axis' => false,
+      'ref_marks' => [], 'aggregations' => { '[Region]' => 'None', '[Net Revenue]' => 'Sum' },
+      'rows_shelf' => { 'fields' => [{ 'caption' => 'Net Revenue', 'role' => 'measure' }] },
+      'cols_shelf' => { 'fields' => [{ 'caption' => 'Region', 'role' => 'dim' }] },
+      'measures' => [{ 'column' => '[Net Revenue]', 'derivation' => 'Sum' }], 'calculations' => [] }
+  ]
+}]
+META = { 'worksheets' => {}, 'shared_filters' => [], 'parameters' => [], 'column_aliases' => {}, 'columns_by_guid' => {} }
+MMAP = {
+  '(?i)^Region$'      => { 'id' => 'm-region', 'name' => 'Region' },
+  '(?i)^Net Revenue$' => { 'id' => 'm-rev',    'name' => 'Net Revenue' }
+}
+
+def run_build(build, mode_flag)
+  out = nil
+  Dir.mktmpdir do |d|
+    File.write("#{d}/layout.json", JSON.dump(LAYOUT))
+    File.write("#{d}/meta.json",   JSON.dump(META))
+    File.write("#{d}/mm.json",     JSON.dump(MMAP))
+    File.write("#{d}/get-workbook.json", JSON.dump('views' => { 'view' => [{ 'id' => 'v1', 'name' => 'Rev by Region' }] }))
+    Dir.mkdir("#{d}/views")
+    File.write("#{d}/views/v1.csv", "Region,Net Revenue\nWest,100\n")
+    o = "#{d}/specs.json"
+    `ruby #{build} --tableau-dir #{d} --layout #{d}/layout.json --meta #{d}/meta.json --master-map #{d}/mm.json --master-element-id master #{mode_flag} --title "Executive Overview" --skip-dashboard-read unit-test --out #{o} 2>&1`
+    out = JSON.parse(File.read(o)) if File.exist?(o)
+  end
+  out
+end
+
+def texts(out)
+  return [] unless out
+  els = out.is_a?(Array) ? out : (out['elements'] || (out['pages'] || []).flat_map { |p| p['elements'] || [] })
+  els.select { |e| e['kind'] == 'text' }
+end
+
+# --page-per-dashboard (the orchestrator's mode).
+td = texts(run_build(BUILD, '--page-per-dashboard'))
+check(td.length == 1, "page-per-dashboard: exactly ONE title text element (got #{td.length}: #{td.map { |t| (t['body'] || '')[0, 25] }})", fails)
+check(td.none? { |t| t['body'].to_s =~ /\A#\s*Executive Overview\s*\z/ },
+      'page-per-dashboard: NO synthetic "# Executive Overview" (the duplicate)', fails)
+check(td.any? { |t| t['body'].to_s.include?('Orders — Executive Overview') },
+      'page-per-dashboard: the source banner is kept as the title', fails)
+
+# single-page path.
+ts = texts(run_build(BUILD, ''))
+check(ts.length == 1, "single-page: exactly ONE title text element (got #{ts.length})", fails)
+check(ts.none? { |t| t['body'].to_s =~ /\A#\s*Executive Overview\s*\z/ },
+      'single-page: NO synthetic "# Executive Overview"', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS — source top-title banner suppresses the synthetic title (no double)'
+  exit 0
+else
+  puts "FAILURES (#{fails.length}):"; fails.each { |f| puts "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
## The bug in your screenshots
"Orders — Executive Overview" rendered **twice** — as the title at the top *and* as a stray text element at the bottom.

**Cause:** the dashboard's own top title banner (a styled text zone at y≈0) is emitted faithfully as a `text-<id>` element, **and** build-charts *also* synthesized a `# <dashboard>` title. The de-dup guard that suppresses the synthetic title only ran when `--title` was **omitted** — but `migrate-tableau` always passes `--title`, so it never fired. And in `--page-per-dashboard` mode (the orchestrator's mode) a **second** code path emitted `title-<slug>` unconditionally.

**Fix (both paths):** when a dashboard has its own top title zone, skip the synthetic title. The source banner (richer — "Orders — Executive Overview") wins, and the layout places it at its own top geometry → **one** title at the top, **no** stray bottom text band.

## Verified on your real run
Text elements **2 → 1** — only the source banner remains; the synthetic `# Executive Overview` duplicate is gone.

`test-no-double-title.rb` (page-per-dashboard + single-page). Full offline suite **57/57**; `check-shared` / `lint-skills` / `corpus` green. Plugin-local.

Note: with no synthetic title consuming the header slot, the layout's `resolve_leaf` places the source banner at its zone geometry (top) rather than the leftover bottom band. A re-run from updated `main` will show the title once, at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)