### PR TITLE
Cross-user consistency P0: shell-neutral token + doctor.json gate + bash-free Sigma path

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -30,6 +30,61 @@ jobs:
         # vendored bundle and only uses a local build via an explicit env/flag.
         run: ./corpus/converter-default-test.sh
 
+  windows-smoke:
+    name: windows PowerShell path (doctor.ps1 + offline corpus)
+    # Proves the Windows/PowerShell path works BEFORE an event does (P0.4):
+    # doctor.ps1 runs, emits a valid + passing doctor.json, and the offline
+    # local-converter corpus converts. Creds-free, network-free. Runtimes are
+    # pinned via setup-* so a runner-image change can't flip doctor's result.
+    runs-on: windows-2022
+    timeout-minutes: 12
+    env:
+      TS_SKILL: plugins/tableau-to-sigma/skills/tableau-to-sigma
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: doctor.ps1 runs and writes a passing doctor.json
+        shell: pwsh
+        run: |
+          $wd = Join-Path $env:RUNNER_TEMP 'wd'
+          New-Item -ItemType Directory -Force -Path $wd | Out-Null
+          powershell -ExecutionPolicy Bypass -File "$env:TS_SKILL\scripts\doctor.ps1" -WorkDir $wd
+          if ($LASTEXITCODE -ne 0) { throw "doctor.ps1 exited $LASTEXITCODE (a REQUIRED runtime is missing)" }
+          $j = Get-Content (Join-Path $wd 'doctor.json') -Raw | ConvertFrom-Json
+          Write-Host "doctor.json -> os=$($j.os) shell=$($j.shell) pass=$($j.pass)"
+          if (-not $j.pass) { throw "doctor.json pass=false: $($j.failures -join '; ')" }
+          foreach ($r in 'ruby','python','node') {
+            if (-not $j.runtimes.$r) { throw "doctor.json runtimes.$r is false" }
+          }
+
+      - name: get_token.py imports + parses under Windows Python
+        shell: pwsh
+        run: |
+          python "$env:TS_SKILL\scripts\get_token.py" --help
+          if ($LASTEXITCODE -ne 0) { throw "get_token.py --help exited $LASTEXITCODE" }
+
+      - name: assert-doctor-ran gate passes on the emitted doctor.json
+        shell: pwsh
+        run: |
+          $wd = Join-Path $env:RUNNER_TEMP 'wd'
+          ruby "$env:TS_SKILL\scripts\assert-doctor-ran.rb" --workdir $wd
+          if ($LASTEXITCODE -ne 0) { throw "assert-doctor-ran gate failed on a passing doctor.json" }
+
+      - name: offline corpus conversion (local converter) under Git Bash
+        shell: bash
+        run: |
+          ./corpus/run-corpus.sh --check
+          ./corpus/converter-default-test.sh
+
   script-syntax:
     name: syntax-check every script (ruby -c / py_compile / bash -n)
     runs-on: ubuntu-24.04

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -82,8 +82,11 @@ jobs:
       - name: offline corpus conversion (local converter) under Git Bash
         shell: bash
         run: |
+          # Proves the offline local-converter path converts on Windows.
+          # (converter-default-test.sh is NOT run here — its dev-override path
+          # assertions compare Unix-style paths and don't port to Windows drive
+          # letters / backslashes; it runs on the ubuntu 'corpus' job instead.)
           ./corpus/run-corpus.sh --check
-          ./corpus/converter-default-test.sh
 
   script-syntax:
     name: syntax-check every script (ruby -c / py_compile / bash -n)

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ __pycache__/
 .DS_Store
 node_modules/
 
+# Live-credential handoff artifacts written into a run's workdir by
+# get_token.py / doctor — never commit (auth.json holds a live bearer token).
+auth.json
+doctor.json
+
 # Generated at vendor/release time by tools/stamp-version.rb (do not commit)
 shared/lib/VERSION
 plugins/*/skills/*/scripts/lib/VERSION

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get_token.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
@@ -121,6 +121,7 @@ def report_migration(
     environment: str = None,
     client_agent: str = None,
     run_id: str = None,
+    doctor: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -166,6 +167,19 @@ def report_migration(
         "client_agent":     client_agent or _client_agent(),
         "run_id":           run_id or uuid.uuid4().hex,
     }
+
+    # Environment fingerprint from doctor.json (P0.3) — lets an event's failures
+    # be grouped by environment CLASS (os/shell/sandbox/which-runtimes-present)
+    # instead of anecdotes. Coarse only: no host names, no file paths, no PII.
+    if doctor:
+        rt = doctor.get("runtimes") or {}
+        payload["doctor"] = {
+            "os":           doctor.get("os"),
+            "shell":        doctor.get("shell"),
+            "sandbox_hint": doctor.get("sandbox_hint"),
+            "pass":         doctor.get("pass"),
+            "runtimes":     sorted(k for k, v in rt.items() if v),
+        }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
     for k, v in payload.items():

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
@@ -100,6 +100,23 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
+# Environment fingerprint (P0.3): prefer <workdir>/doctor.json, fall back to the
+# stable ~/.sigma-migration/doctor.json the doctor always writes.
+def _load_doctor(workdir):
+    candidates = []
+    if workdir:
+        candidates.append(os.path.join(workdir, 'doctor.json'))
+    candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
+    for p in candidates:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            continue
+    return None
+
+_doctor = _load_doctor(getattr(args, 'workdir', None))
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -108,6 +125,7 @@ sent = report_migration(
     success=not args.failed,
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
+    doctor=_doctor,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
@@ -109,7 +109,8 @@ def _load_doctor(workdir):
     candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
     for p in candidates:
         try:
-            with open(p, encoding='utf-8') as fh:
+            # utf-8-sig strips a UTF-8 BOM if present (Windows PowerShell writes one).
+            with open(p, encoding='utf-8-sig') as fh:
                 return json.load(fh)
         except (OSError, ValueError):
             continue

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get_token.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
@@ -121,6 +121,7 @@ def report_migration(
     environment: str = None,
     client_agent: str = None,
     run_id: str = None,
+    doctor: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -166,6 +167,19 @@ def report_migration(
         "client_agent":     client_agent or _client_agent(),
         "run_id":           run_id or uuid.uuid4().hex,
     }
+
+    # Environment fingerprint from doctor.json (P0.3) — lets an event's failures
+    # be grouped by environment CLASS (os/shell/sandbox/which-runtimes-present)
+    # instead of anecdotes. Coarse only: no host names, no file paths, no PII.
+    if doctor:
+        rt = doctor.get("runtimes") or {}
+        payload["doctor"] = {
+            "os":           doctor.get("os"),
+            "shell":        doctor.get("shell"),
+            "sandbox_hint": doctor.get("sandbox_hint"),
+            "pass":         doctor.get("pass"),
+            "runtimes":     sorted(k for k, v in rt.items() if v),
+        }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
     for k, v in payload.items():

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
@@ -100,6 +100,23 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
+# Environment fingerprint (P0.3): prefer <workdir>/doctor.json, fall back to the
+# stable ~/.sigma-migration/doctor.json the doctor always writes.
+def _load_doctor(workdir):
+    candidates = []
+    if workdir:
+        candidates.append(os.path.join(workdir, 'doctor.json'))
+    candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
+    for p in candidates:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            continue
+    return None
+
+_doctor = _load_doctor(getattr(args, 'workdir', None))
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -108,6 +125,7 @@ sent = report_migration(
     success=not args.failed,
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
+    doctor=_doctor,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
@@ -109,7 +109,8 @@ def _load_doctor(workdir):
     candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
     for p in candidates:
         try:
-            with open(p, encoding='utf-8') as fh:
+            # utf-8-sig strips a UTF-8 BOM if present (Windows PowerShell writes one).
+            with open(p, encoding='utf-8-sig') as fh:
                 return json.load(fh)
         except (OSError, ValueError):
             continue

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get_token.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
@@ -121,6 +121,7 @@ def report_migration(
     environment: str = None,
     client_agent: str = None,
     run_id: str = None,
+    doctor: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -166,6 +167,19 @@ def report_migration(
         "client_agent":     client_agent or _client_agent(),
         "run_id":           run_id or uuid.uuid4().hex,
     }
+
+    # Environment fingerprint from doctor.json (P0.3) — lets an event's failures
+    # be grouped by environment CLASS (os/shell/sandbox/which-runtimes-present)
+    # instead of anecdotes. Coarse only: no host names, no file paths, no PII.
+    if doctor:
+        rt = doctor.get("runtimes") or {}
+        payload["doctor"] = {
+            "os":           doctor.get("os"),
+            "shell":        doctor.get("shell"),
+            "sandbox_hint": doctor.get("sandbox_hint"),
+            "pass":         doctor.get("pass"),
+            "runtimes":     sorted(k for k, v in rt.items() if v),
+        }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
     for k, v in payload.items():

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
@@ -100,6 +100,23 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
+# Environment fingerprint (P0.3): prefer <workdir>/doctor.json, fall back to the
+# stable ~/.sigma-migration/doctor.json the doctor always writes.
+def _load_doctor(workdir):
+    candidates = []
+    if workdir:
+        candidates.append(os.path.join(workdir, 'doctor.json'))
+    candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
+    for p in candidates:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            continue
+    return None
+
+_doctor = _load_doctor(getattr(args, 'workdir', None))
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -108,6 +125,7 @@ sent = report_migration(
     success=not args.failed,
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
+    doctor=_doctor,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
@@ -109,7 +109,8 @@ def _load_doctor(workdir):
     candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
     for p in candidates:
         try:
-            with open(p, encoding='utf-8') as fh:
+            # utf-8-sig strips a UTF-8 BOM if present (Windows PowerShell writes one).
+            with open(p, encoding='utf-8-sig') as fh:
                 return json.load(fh)
         except (OSError, ValueError):
             continue

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get_token.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
@@ -121,6 +121,7 @@ def report_migration(
     environment: str = None,
     client_agent: str = None,
     run_id: str = None,
+    doctor: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -166,6 +167,19 @@ def report_migration(
         "client_agent":     client_agent or _client_agent(),
         "run_id":           run_id or uuid.uuid4().hex,
     }
+
+    # Environment fingerprint from doctor.json (P0.3) — lets an event's failures
+    # be grouped by environment CLASS (os/shell/sandbox/which-runtimes-present)
+    # instead of anecdotes. Coarse only: no host names, no file paths, no PII.
+    if doctor:
+        rt = doctor.get("runtimes") or {}
+        payload["doctor"] = {
+            "os":           doctor.get("os"),
+            "shell":        doctor.get("shell"),
+            "sandbox_hint": doctor.get("sandbox_hint"),
+            "pass":         doctor.get("pass"),
+            "runtimes":     sorted(k for k, v in rt.items() if v),
+        }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
     for k, v in payload.items():

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
@@ -100,6 +100,23 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
+# Environment fingerprint (P0.3): prefer <workdir>/doctor.json, fall back to the
+# stable ~/.sigma-migration/doctor.json the doctor always writes.
+def _load_doctor(workdir):
+    candidates = []
+    if workdir:
+        candidates.append(os.path.join(workdir, 'doctor.json'))
+    candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
+    for p in candidates:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            continue
+    return None
+
+_doctor = _load_doctor(getattr(args, 'workdir', None))
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -108,6 +125,7 @@ sent = report_migration(
     success=not args.failed,
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
+    doctor=_doctor,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
@@ -109,7 +109,8 @@ def _load_doctor(workdir):
     candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
     for p in candidates:
         try:
-            with open(p, encoding='utf-8') as fh:
+            # utf-8-sig strips a UTF-8 BOM if present (Windows PowerShell writes one).
+            with open(p, encoding='utf-8-sig') as fh:
                 return json.load(fh)
         except (OSError, ValueError):
             continue

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get_token.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
@@ -121,6 +121,7 @@ def report_migration(
     environment: str = None,
     client_agent: str = None,
     run_id: str = None,
+    doctor: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -166,6 +167,19 @@ def report_migration(
         "client_agent":     client_agent or _client_agent(),
         "run_id":           run_id or uuid.uuid4().hex,
     }
+
+    # Environment fingerprint from doctor.json (P0.3) — lets an event's failures
+    # be grouped by environment CLASS (os/shell/sandbox/which-runtimes-present)
+    # instead of anecdotes. Coarse only: no host names, no file paths, no PII.
+    if doctor:
+        rt = doctor.get("runtimes") or {}
+        payload["doctor"] = {
+            "os":           doctor.get("os"),
+            "shell":        doctor.get("shell"),
+            "sandbox_hint": doctor.get("sandbox_hint"),
+            "pass":         doctor.get("pass"),
+            "runtimes":     sorted(k for k, v in rt.items() if v),
+        }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
     for k, v in payload.items():

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
@@ -100,6 +100,23 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
+# Environment fingerprint (P0.3): prefer <workdir>/doctor.json, fall back to the
+# stable ~/.sigma-migration/doctor.json the doctor always writes.
+def _load_doctor(workdir):
+    candidates = []
+    if workdir:
+        candidates.append(os.path.join(workdir, 'doctor.json'))
+    candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
+    for p in candidates:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            continue
+    return None
+
+_doctor = _load_doctor(getattr(args, 'workdir', None))
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -108,6 +125,7 @@ sent = report_migration(
     success=not args.failed,
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
+    doctor=_doctor,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
@@ -109,7 +109,8 @@ def _load_doctor(workdir):
     candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
     for p in candidates:
         try:
-            with open(p, encoding='utf-8') as fh:
+            # utf-8-sig strips a UTF-8 BOM if present (Windows PowerShell writes one).
+            with open(p, encoding='utf-8-sig') as fh:
                 return json.load(fh)
         except (OSError, ValueError):
             continue

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
@@ -121,6 +121,7 @@ def report_migration(
     environment: str = None,
     client_agent: str = None,
     run_id: str = None,
+    doctor: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -166,6 +167,19 @@ def report_migration(
         "client_agent":     client_agent or _client_agent(),
         "run_id":           run_id or uuid.uuid4().hex,
     }
+
+    # Environment fingerprint from doctor.json (P0.3) — lets an event's failures
+    # be grouped by environment CLASS (os/shell/sandbox/which-runtimes-present)
+    # instead of anecdotes. Coarse only: no host names, no file paths, no PII.
+    if doctor:
+        rt = doctor.get("runtimes") or {}
+        payload["doctor"] = {
+            "os":           doctor.get("os"),
+            "shell":        doctor.get("shell"),
+            "sandbox_hint": doctor.get("sandbox_hint"),
+            "pass":         doctor.get("pass"),
+            "runtimes":     sorted(k for k, v in rt.items() if v),
+        }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
     for k, v in payload.items():

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
@@ -100,6 +100,23 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
+# Environment fingerprint (P0.3): prefer <workdir>/doctor.json, fall back to the
+# stable ~/.sigma-migration/doctor.json the doctor always writes.
+def _load_doctor(workdir):
+    candidates = []
+    if workdir:
+        candidates.append(os.path.join(workdir, 'doctor.json'))
+    candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
+    for p in candidates:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            continue
+    return None
+
+_doctor = _load_doctor(getattr(args, 'workdir', None))
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -108,6 +125,7 @@ sent = report_migration(
     success=not args.failed,
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
+    doctor=_doctor,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
@@ -109,7 +109,8 @@ def _load_doctor(workdir):
     candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
     for p in candidates:
         try:
-            with open(p, encoding='utf-8') as fh:
+            # utf-8-sig strips a UTF-8 BOM if present (Windows PowerShell writes one).
+            with open(p, encoding='utf-8-sig') as fh:
                 return json.load(fh)
         except (OSError, ValueError):
             continue

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get_token.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get_token.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
@@ -121,6 +121,7 @@ def report_migration(
     environment: str = None,
     client_agent: str = None,
     run_id: str = None,
+    doctor: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -166,6 +167,19 @@ def report_migration(
         "client_agent":     client_agent or _client_agent(),
         "run_id":           run_id or uuid.uuid4().hex,
     }
+
+    # Environment fingerprint from doctor.json (P0.3) — lets an event's failures
+    # be grouped by environment CLASS (os/shell/sandbox/which-runtimes-present)
+    # instead of anecdotes. Coarse only: no host names, no file paths, no PII.
+    if doctor:
+        rt = doctor.get("runtimes") or {}
+        payload["doctor"] = {
+            "os":           doctor.get("os"),
+            "shell":        doctor.get("shell"),
+            "sandbox_hint": doctor.get("sandbox_hint"),
+            "pass":         doctor.get("pass"),
+            "runtimes":     sorted(k for k, v in rt.items() if v),
+        }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
     for k, v in payload.items():

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
@@ -100,6 +100,23 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
+# Environment fingerprint (P0.3): prefer <workdir>/doctor.json, fall back to the
+# stable ~/.sigma-migration/doctor.json the doctor always writes.
+def _load_doctor(workdir):
+    candidates = []
+    if workdir:
+        candidates.append(os.path.join(workdir, 'doctor.json'))
+    candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
+    for p in candidates:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            continue
+    return None
+
+_doctor = _load_doctor(getattr(args, 'workdir', None))
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -108,6 +125,7 @@ sent = report_migration(
     success=not args.failed,
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
+    doctor=_doctor,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
@@ -109,7 +109,8 @@ def _load_doctor(workdir):
     candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
     for p in candidates:
         try:
-            with open(p, encoding='utf-8') as fh:
+            # utf-8-sig strips a UTF-8 BOM if present (Windows PowerShell writes one).
+            with open(p, encoding='utf-8-sig') as fh:
                 return json.load(fh)
         except (OSError, ValueError):
             continue

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get_token.py
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get_token.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -52,16 +52,47 @@ that mirrors the Tableau dashboard layout as closely as possible.
 
 ---
 
-## Step 0 — Front door: resolve the connection once (`scripts/intake.rb`)
+## Step 0 — Environment doctor (MANDATORY — the orchestrator gates on it)
+
+Run the environment doctor FIRST. It reports missing runtimes with per-OS fixes
+**and** writes a machine-readable `doctor.json` fingerprint (to
+`~/.sigma-migration/doctor.json`, and to `<WORK>/doctor.json` when `--workdir` is
+given). `migrate-tableau.rb` refuses to start until a **passing** `doctor.json`
+exists — so a broken environment stops here with an explicit fix instead of the
+run improvising around a missing runtime (the #1 cause of cross-user drift).
+
+macOS / Linux / Git-Bash:
+```bash
+bash scripts/doctor.sh --workdir <WORK>
+```
+
+Windows PowerShell:
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1 -WorkDir <WORK>
+```
+
+If the doctor cannot pass in your environment (e.g. a Cowork sandbox missing a
+runtime) and you must proceed anyway, waive the gate explicitly and name it in
+your report: `migrate-tableau.rb … --skip-doctor-gate "<reason>"`.
+
+## Step 0.1 — Front door: resolve the connection once (`scripts/intake.rb`)
 
 Before the run, resolve the Sigma warehouse connection a SINGLE time so no phase
 free-searches `/v2/connections` (the token sink):
 
 ```bash
-eval "$(scripts/get-token.sh)"
 ruby scripts/intake.rb --workdir <WORK> --tool tableau-to-sigma --mode live \
   [--connection <id>] [--name <connection-name-substring>] [--source "<workbook name>"]
 ```
+
+> **Credentials are shell-neutral now.** The Ruby/Python scripts mint Sigma
+> tokens themselves from `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` (env or
+> `~/.sigma-migration/env`) and auto-refresh on expiry — no `eval` step needed,
+> in any shell. If you hand-drive a raw `curl` and want an explicit token, mint
+> one the same way in every shell (bash, PowerShell, cmd):
+> `python scripts/get_token.py --workdir <WORK>` writes `<WORK>/auth.json`
+> (mode 0600), which the scripts read automatically. (`eval "$(scripts/get-token.sh)"`
+> still works in bash for muscle memory.)
 
 It caches `<WORK>/connection.json` (the orchestrator reads it when `--connection` is
 omitted — just point `--out` at the same `<WORK>`) and writes `intake.json` (run-start +
@@ -72,8 +103,8 @@ multiple connections it lists them and asks you to pick — it never guesses.
 ## One command (orchestrated path)
 
 ```bash
-eval "$(scripts/get-token.sh)"
 # PASS 1 — discover → gap gate → DM-reuse scan → DM → workbook → layout → parity plan
+# (mints its Sigma token in-process — no `eval`/bash token step, works in any shell)
 ruby scripts/migrate-tableau.rb \
   --workbook "<name>" --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID> \
   [--db CSA --schema TJ] [--name '<prefix>'] [--row-scale 1.5] \
@@ -202,7 +233,10 @@ which calc translation, which layout) — not orchestration.
 |---|---|
 | `scripts/migrate-tableau.rb` | **The one command** — chains the whole scripted spine (gap gate → DM-reuse scan → DM → workbook → layout → two-pass parity → cleanup + census gate) and stops with exact instructions where agent judgment is required. See "One command" above. |
 | `scripts/setup.rb` | One-time Sigma credential setup |
-| `scripts/get-token.sh` | Exchange `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` for `SIGMA_API_TOKEN` (~1h TTL) |
+| `scripts/get-token.sh` | Exchange `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` for `SIGMA_API_TOKEN` (~1h TTL) — **bash only** |
+| `scripts/get_token.py` | Shell-neutral twin of `get-token.sh` (bash/PowerShell/cmd): writes `<WORK>/auth.json` (0600), read automatically by the scripts |
+| `scripts/doctor.sh` / `scripts/doctor.ps1` | Step-0 env check; writes `doctor.json` fingerprint the orchestrator gates on |
+| `scripts/assert-doctor-ran.rb` | 🚧 GATE — refuse to run without a passing `doctor.json` |
 | `scripts/setup-tableau.rb` | One-time Tableau PAT setup (only needed for PAT mode — see `refs/tableau-rest.md`) |
 | `scripts/get-tableau-token.sh` | One-shot signin → exports `TABLEAU_AUTH_TOKEN` + `TABLEAU_SITE_ID` |
 | `scripts/tableau-discover.rb` | PAT-mode Phase 1 discovery in one CLI: workbook + views + VDS metadata + GraphQL + .twb content. ONE unified fetch pool (default 5, `--pool N`, longest-job-first) with 429/timeout backoff + 401 re-mint; always writes per-task `timings.json`. Measured 61.8s → 13.7–18.9s on the 7-view reference workbook |
@@ -275,16 +309,22 @@ Required env vars:
 - `SIGMA_CLIENT_ID`
 - `SIGMA_CLIENT_SECRET`
 
-Fetch a token at the start of each phase that needs one:
+Fetch a token at the start of each phase that needs one. **Shell-neutral (works
+in bash, PowerShell, cmd):**
 
-```bash
-eval "$(scripts/get-token.sh)"
+```
+python scripts/get_token.py --workdir <WORK>
 ```
 
-> Tokens live ~1 hour. Re-run when a curl returns 401. Never use
-> `TOKEN=$(eval "$(scripts/get-token.sh)")` — `$()` creates a subshell where
-> the exported var dies immediately. Keep eval + curl in the same `bash -c '...'`
-> invocation.
+This writes `<WORK>/auth.json` (mode 0600); every Ruby/Python script reads it
+automatically (explicit `SIGMA_API_TOKEN` in the env still wins). Tokens live
+~1 hour — re-run when a call returns 401.
+
+> **bash-only alternative:** `eval "$(scripts/get-token.sh)"` still works in
+> bash. But never use `TOKEN=$(eval "$(scripts/get-token.sh)")` — `$()` creates a
+> subshell where the exported var dies immediately; keep eval + curl in the same
+> `bash -c '...'`. PowerShell/cmd cannot run this idiom at all — use
+> `get_token.py` there.
 
 > **Inline Python inside bash — DON'T.** Triple-nested escapes (`f"...{e.get(\\\"name\\\")}..."` inside `python3 -c "..."` inside `bash -c '...'`) silently break. Instead **always write a `.py` file with `Write` and call it via `python3 file.py`.** Same rule for any inline script over ~5 lines: write it to disk, then exec. It's not slower, it's deterministic, and the file becomes a reusable artifact. (Same applies to Ruby — prefer `ruby file.rb` over `ruby -e '...'`.)
 
@@ -479,7 +519,7 @@ Row/column security is **never silently dropped and never silently ported** — 
 2. **Gate (opt-in/out, default _Port_).** Show a plain-English summary of each detected rule + recommended Sigma mapping, then ask: **Port** (recommended) / **Customize** (review per-rule attribute/team mapping + username-to-email reconciliation) / **Skip** (migrated model shows ALL rows to everyone). Reuse-first: existing Sigma user attributes/teams are matched before creating new ones.
 3. **Provision + apply** with the shared engine:
    ```bash
-   eval "$(scripts/get-token.sh)"
+   python scripts/get_token.py --workdir <WORK>   # shell-neutral; writes <WORK>/auth.json (read automatically)
    python3 scripts/apply_sigma_rls.py --from-security security.json --dm-id <dataModelId>            # plan only (default)
    python3 scripts/apply_sigma_rls.py --from-security security.json --dm-id <dataModelId> --provision --apply
    ```

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/apply_sigma_rls.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/apply_sigma_rls.py
@@ -63,10 +63,30 @@ import urllib.request
 BASE = os.environ.get("SIGMA_BASE_URL")
 TOK = os.environ.get("SIGMA_API_TOKEN")
 
+# Shell-neutral token handoff: if the token isn't in the env (e.g. PowerShell,
+# where `eval "$(get-token.sh)"` can't run), read it from auth.json written by
+# `python scripts/get_token.py --workdir <WORK>`. Env always wins.
+if not TOK:
+    for _p in (
+        os.path.join(os.environ["SIGMA_WORKDIR"], "auth.json") if os.environ.get("SIGMA_WORKDIR") else None,
+        os.path.join(os.getcwd(), "auth.json"),
+    ):
+        if _p and os.path.exists(_p):
+            try:
+                with open(_p, encoding="utf-8") as _fh:
+                    _a = json.load(_fh)
+                TOK = TOK or _a.get("SIGMA_API_TOKEN")
+                BASE = BASE or _a.get("SIGMA_BASE_URL")
+                break
+            except (OSError, ValueError):
+                pass
+
 
 def api(method, path, body=None):
     if not BASE or not TOK:
-        sys.exit("SIGMA_BASE_URL / SIGMA_API_TOKEN unset — run: eval \"$(scripts/get-token.sh)\"")
+        sys.exit("SIGMA_BASE_URL / SIGMA_API_TOKEN unset — run: "
+                 "python scripts/get_token.py --workdir <WORK>  (any shell), "
+                 "or eval \"$(scripts/get-token.sh)\" (bash only)")
     data = json.dumps(body).encode() if body is not None else None
     req = urllib.request.Request(
         BASE + path, data=data, method=method,

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-doctor-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-doctor-ran.rb
@@ -59,7 +59,9 @@ unless path
 end
 
 begin
-  d = JSON.parse(File.read(path))
+  # 'bom|utf-8' strips a UTF-8 BOM if present — Windows PowerShell writes one and
+  # JSON.parse otherwise fails with "unexpected token".
+  d = JSON.parse(File.read(path, encoding: 'bom|utf-8'))
 rescue JSON::ParserError => e
   warn "[FAIL] environment gate — doctor.json at #{path} is unreadable: #{e.message}"
   remediate

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-doctor-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-doctor-ran.rb
@@ -1,0 +1,81 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# 🚧 GATE — refuse to proceed on an unverified / broken environment.
+#
+# The mandatory Step-0 environment check (doctor.sh / doctor.ps1) writes a
+# machine-readable doctor.json fingerprint. This turns "run the doctor first"
+# from prose into a real gate: if the doctor never ran, or ran and FAILED, the
+# pipeline stops here with the exact remediation — instead of the agent
+# improvising around a missing runtime, which is the #1 source of cross-user
+# inconsistency at multi-user events.
+#
+# doctor.json is looked up in this order:
+#   1. <workdir>/doctor.json         (when --workdir is given)
+#   2. ~/.sigma-migration/doctor.json (the stable location doctor always writes)
+#
+# Usage:
+#   ruby scripts/assert-doctor-ran.rb [--workdir DIR]
+#     [--skip-doctor-gate REASON]   # waive — REQUIRED reason; name it in your report
+#
+# Exit codes:
+#   0  doctor.json present and pass:true (or waived)
+#   1  doctor.json missing, unreadable, or pass:false
+#   2  usage error
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR') { |v| opts[:dir] = v }
+  p.on('--tableau DIR', 'alias of --workdir') { |v| opts[:dir] = v }
+  p.on('--skip-doctor-gate REASON',
+       'waive the environment gate — REQUIRED reason string; name it in your report') do |v|
+    opts[:skip] = v
+  end
+end.parse!
+
+if opts[:skip]
+  puts "[SKIP] environment gate WAIVED (#{opts[:skip]}) — name this in your report."
+  exit 0
+end
+
+home_doctor = File.expand_path('~/.sigma-migration/doctor.json')
+candidates = []
+candidates << File.join(opts[:dir], 'doctor.json') if opts[:dir]
+candidates << home_doctor
+path = candidates.find { |p| File.exist?(p) }
+
+def remediate
+  warn '       Run the environment doctor FIRST, then re-run:'
+  warn '         macOS/Linux/Git-Bash:  bash scripts/doctor.sh'
+  warn '         Windows PowerShell:    powershell -ExecutionPolicy Bypass -File scripts\\doctor.ps1'
+  warn '       Escape hatch (name it in your report): --skip-doctor-gate "<reason>".'
+end
+
+unless path
+  warn '[FAIL] environment gate — no doctor.json found (the Step-0 environment check never ran).'
+  remediate
+  exit 1
+end
+
+begin
+  d = JSON.parse(File.read(path))
+rescue JSON::ParserError => e
+  warn "[FAIL] environment gate — doctor.json at #{path} is unreadable: #{e.message}"
+  remediate
+  exit 1
+end
+
+rt = d['runtimes'] || {}
+env_desc = "os=#{d['os']} shell=#{d['shell']} sandbox=#{d['sandbox_hint']} " \
+           "runtimes=[#{rt.select { |_, v| v }.keys.join(',')}]"
+
+if d['pass']
+  puts "[PASS] environment gate — doctor.json OK (#{env_desc}). Source: #{path}"
+  exit 0
+end
+
+warn "[FAIL] environment gate — the environment doctor reported blocking failures (#{env_desc}):"
+Array(d['failures']).each { |f| warn "         ✗ #{f}" }
+remediate
+exit 1

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get_token.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
@@ -121,6 +121,7 @@ def report_migration(
     environment: str = None,
     client_agent: str = None,
     run_id: str = None,
+    doctor: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -166,6 +167,19 @@ def report_migration(
         "client_agent":     client_agent or _client_agent(),
         "run_id":           run_id or uuid.uuid4().hex,
     }
+
+    # Environment fingerprint from doctor.json (P0.3) — lets an event's failures
+    # be grouped by environment CLASS (os/shell/sandbox/which-runtimes-present)
+    # instead of anecdotes. Coarse only: no host names, no file paths, no PII.
+    if doctor:
+        rt = doctor.get("runtimes") or {}
+        payload["doctor"] = {
+            "os":           doctor.get("os"),
+            "shell":        doctor.get("shell"),
+            "sandbox_hint": doctor.get("sandbox_hint"),
+            "pass":         doctor.get("pass"),
+            "runtimes":     sorted(k for k, v in rt.items() if v),
+        }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
     for k, v in payload.items():

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -85,6 +85,7 @@ require 'set'
 require_relative 'lib/scout_gate'
 require_relative 'lib/dashboard_read'
 require_relative 'lib/run_state'
+require_relative 'lib/sigma_rest' # in-process Sigma token minting (no bash/eval)
 require_relative 'hydrate-custom-sql'
 
 $stdout.sync = true # progress lines interleave correctly when piped/captured
@@ -141,6 +142,7 @@ OptionParser.new do |o|
   o.on('--reuse-dm [ID]')    { |v| opts[:reuse_dm] = v || :recommended }
   o.on('--skip-reuse-scan')  {     opts[:skip_reuse] = true }
   o.on('--skip-dashboard-read REASON', 'waive the Phase 1d source dashboard-read gate — REQUIRED reason; name it in your report') { |v| opts[:skip_dashboard_read] = v }
+  o.on('--skip-doctor-gate REASON', 'waive the Step-0 environment gate (doctor.json) — REQUIRED reason; name it in your report') { |v| opts[:skip_doctor_gate] = v }
   o.on('--row-scale F', Float) { |v| opts[:row_scale] = v }
   o.on('--master-col PAIR', "'Name=<Sigma formula>' — extra master column (repeatable). The resume path " \
                             'for the exit-4 handoff when a chart dim is a master-level calc the mechanical ' \
@@ -215,6 +217,19 @@ slug = (opts[:wb_name] || opts[:wb_id]).gsub(/[^A-Za-z0-9_-]/, '-').squeeze('-')
 WORK = opts[:out] || File.expand_path("~/tableau-migration/#{slug}")
 FileUtils.mkdir_p(File.join(WORK, 'views'))
 
+# 🚧 Step-0 environment GATE. The doctor writes a doctor.json fingerprint; this
+# refuses to run on an env that never passed the doctor, instead of letting the
+# pipeline improvise around a missing runtime (the #1 source of cross-user
+# inconsistency at multi-user events). Waive with --skip-doctor-gate "<reason>"
+# or SIGMA_SKIP_DOCTOR_GATE=<reason>. Runs before every path (pass-1 + finalize).
+_dg_skip = opts[:skip_doctor_gate] || ENV['SIGMA_SKIP_DOCTOR_GATE']
+_dg_cmd = ['ruby', File.join(HERE, 'assert-doctor-ran.rb'), '--workdir', WORK]
+_dg_cmd += ['--skip-doctor-gate', _dg_skip] if _dg_skip && !_dg_skip.to_s.empty?
+unless system(*_dg_cmd)
+  abort 'FATAL: environment gate failed — run the doctor first (see remediation above), ' \
+        'or re-run with --skip-doctor-gate "<reason>".'
+end
+
 TOTAL = 6
 def hdr(n, title)
   puts; puts "── Phase #{n}/#{TOTAL} · #{title} ──"
@@ -245,17 +260,27 @@ end
 # Run a child command, indenting its output. token_env: prepend a fresh
 # Sigma/Tableau token via the skill's get-token scripts so long runs survive
 # the ~1h token TTL.
-def run!(cmd, allow_fail: false)
-  out, st = Open3.capture2e(*cmd)
+def run!(cmd, allow_fail: false, env: nil)
+  out, st = env ? Open3.capture2e(env, *cmd) : Open3.capture2e(*cmd)
   out.each_line { |l| puts "   #{l.rstrip}" } unless out.strip.empty?
   abort "FATAL: command failed (#{st.exitstatus}): #{cmd.join(' ')}" unless st.success? || allow_fail
   [out, st]
 end
 
-# Wrap a command so a Sigma token is live for it (eval get-token.sh first).
+# Mint a fresh Sigma bearer token IN-PROCESS (pure Ruby net/http via the Sigma
+# lib) — no bash, no `eval "$(get-token.sh)"`, so this works identically under
+# PowerShell / cmd / a Cowork sandbox. Refreshed per call to match the old
+# per-call get-token.sh behaviour, so a long run never carries a stale token.
+def sigma_token!
+  Sigma.refresh_token!
+rescue StandardError => e
+  abort "FATAL: could not mint a Sigma token: #{e.message}\n" \
+        '  Check SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET (run: ruby scripts/setup.rb).'
+end
+
+# Wrap a command so a Sigma token is live for it (injected via child env).
 def sigma_run!(cmd, allow_fail: false)
-  joined = cmd.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')
-  run!(['bash', '-c', "eval \"$(#{File.join(HERE, 'get-token.sh')})\" && #{joined}"], allow_fail: allow_fail)
+  run!(cmd, allow_fail: allow_fail, env: { 'SIGMA_API_TOKEN' => sigma_token! })
 end
 
 # Raised when the MECHANICAL WORKBOOK layer (build / validate / POST) fails after
@@ -272,8 +297,8 @@ end
 
 # Like run!, but on failure raises WorkbookBuildError (catchable) instead of
 # abort()ing the process. Captures the child output for field-name mining.
-def run_wb!(cmd)
-  out, st = Open3.capture2e(*cmd)
+def run_wb!(cmd, env: nil)
+  out, st = env ? Open3.capture2e(env, *cmd) : Open3.capture2e(*cmd)
   out.each_line { |l| puts "   #{l.rstrip}" } unless out.strip.empty?
   raise WorkbookBuildError.new("command failed (#{st.exitstatus}): #{cmd.join(' ')}", out) unless st.success?
   out
@@ -281,8 +306,7 @@ end
 
 # sigma_run! variant that raises WorkbookBuildError instead of aborting.
 def sigma_run_wb!(cmd)
-  joined = cmd.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')
-  run_wb!(['bash', '-c', "eval \"$(#{File.join(HERE, 'get-token.sh')})\" && #{joined}"])
+  run_wb!(cmd, env: { 'SIGMA_API_TOKEN' => sigma_token! })
 end
 
 # Pull likely-offending field/column names out of a failed workbook build/POST log.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
@@ -100,6 +100,23 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
+# Environment fingerprint (P0.3): prefer <workdir>/doctor.json, fall back to the
+# stable ~/.sigma-migration/doctor.json the doctor always writes.
+def _load_doctor(workdir):
+    candidates = []
+    if workdir:
+        candidates.append(os.path.join(workdir, 'doctor.json'))
+    candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
+    for p in candidates:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            continue
+    return None
+
+_doctor = _load_doctor(getattr(args, 'workdir', None))
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -108,6 +125,7 @@ sent = report_migration(
     success=not args.failed,
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
+    doctor=_doctor,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
@@ -109,7 +109,8 @@ def _load_doctor(workdir):
     candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
     for p in candidates:
         try:
-            with open(p, encoding='utf-8') as fh:
+            # utf-8-sig strips a UTF-8 BOM if present (Windows PowerShell writes one).
+            with open(p, encoding='utf-8-sig') as fh:
                 return json.load(fh)
         except (OSError, ValueError):
             continue

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get_token.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get_token.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
@@ -121,6 +121,7 @@ def report_migration(
     environment: str = None,
     client_agent: str = None,
     run_id: str = None,
+    doctor: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -166,6 +167,19 @@ def report_migration(
         "client_agent":     client_agent or _client_agent(),
         "run_id":           run_id or uuid.uuid4().hex,
     }
+
+    # Environment fingerprint from doctor.json (P0.3) — lets an event's failures
+    # be grouped by environment CLASS (os/shell/sandbox/which-runtimes-present)
+    # instead of anecdotes. Coarse only: no host names, no file paths, no PII.
+    if doctor:
+        rt = doctor.get("runtimes") or {}
+        payload["doctor"] = {
+            "os":           doctor.get("os"),
+            "shell":        doctor.get("shell"),
+            "sandbox_hint": doctor.get("sandbox_hint"),
+            "pass":         doctor.get("pass"),
+            "runtimes":     sorted(k for k, v in rt.items() if v),
+        }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
     for k, v in payload.items():

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
@@ -100,6 +100,23 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
+# Environment fingerprint (P0.3): prefer <workdir>/doctor.json, fall back to the
+# stable ~/.sigma-migration/doctor.json the doctor always writes.
+def _load_doctor(workdir):
+    candidates = []
+    if workdir:
+        candidates.append(os.path.join(workdir, 'doctor.json'))
+    candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
+    for p in candidates:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            continue
+    return None
+
+_doctor = _load_doctor(getattr(args, 'workdir', None))
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -108,6 +125,7 @@ sent = report_migration(
     success=not args.failed,
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
+    doctor=_doctor,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
@@ -109,7 +109,8 @@ def _load_doctor(workdir):
     candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
     for p in candidates:
         try:
-            with open(p, encoding='utf-8') as fh:
+            # utf-8-sig strips a UTF-8 BOM if present (Windows PowerShell writes one).
+            with open(p, encoding='utf-8-sig') as fh:
                 return json.load(fh)
         except (OSError, ValueError):
             continue

--- a/shared/lib/sigma_rest.rb
+++ b/shared/lib/sigma_rest.rb
@@ -39,6 +39,28 @@ if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
   end
 end
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/shared/lib/sigma_rest.rb
+++ b/shared/lib/sigma_rest.rb
@@ -52,7 +52,7 @@ if ENV['SIGMA_API_TOKEN'].nil?
   _auth_path = _auth_candidates.find { |p| File.exist?(p) }
   if _auth_path
     begin
-      _auth = JSON.parse(File.read(_auth_path))
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
       ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
       ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
     rescue JSON::ParserError

--- a/shared/lib/sigma_telemetry.py
+++ b/shared/lib/sigma_telemetry.py
@@ -121,6 +121,7 @@ def report_migration(
     environment: str = None,
     client_agent: str = None,
     run_id: str = None,
+    doctor: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -166,6 +167,19 @@ def report_migration(
         "client_agent":     client_agent or _client_agent(),
         "run_id":           run_id or uuid.uuid4().hex,
     }
+
+    # Environment fingerprint from doctor.json (P0.3) — lets an event's failures
+    # be grouped by environment CLASS (os/shell/sandbox/which-runtimes-present)
+    # instead of anecdotes. Coarse only: no host names, no file paths, no PII.
+    if doctor:
+        rt = doctor.get("runtimes") or {}
+        payload["doctor"] = {
+            "os":           doctor.get("os"),
+            "shell":        doctor.get("shell"),
+            "sandbox_hint": doctor.get("sandbox_hint"),
+            "pass":         doctor.get("pass"),
+            "runtimes":     sorted(k for k, v in rt.items() if v),
+        }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")
     for k, v in payload.items():

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -253,6 +253,23 @@
       ]
     },
     {
+      "canonical": "shared/scripts/get_token.py",
+      "targets": [
+        "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get_token.py",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get_token.py",
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get_token.py",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get_token.py",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get_token.py",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get_token.py",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get_token.py",
+        "plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get_token.py",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get_token.py",
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get_token.py",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get_token.py",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get_token.py"
+      ]
+    },
+    {
       "canonical": "shared/scripts/setup.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/setup.rb",

--- a/shared/scripts/doctor.ps1
+++ b/shared/scripts/doctor.ps1
@@ -10,10 +10,15 @@
 #
 # REQUIRED: ruby (*-to-sigma orchestrators), python (looker/thoughtspot/mstr/
 # sisense + discovery), node (vendored converters/*.mjs), bash (get-token.sh).
+#
+#   -WorkDir <dir>  also drop doctor.json there (always also written to
+#                   ~/.sigma-migration/doctor.json).
+param([string]$WorkDir = "")
 
 $script:Pass = 0; $script:Fail = 0; $script:Warn = 0
+$script:Failures = @()
 function Ok([string]$m)        { Write-Host "  [OK] $m" -ForegroundColor Green;  $script:Pass++ }
-function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++ }
+function Bad([string]$m,$fix)  { Write-Host "  [X]  $m" -ForegroundColor Red;    Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Fail++; $script:Failures += $m }
 function Warn([string]$m,$fix) { Write-Host "  [!]  $m" -ForegroundColor Yellow; Write-Host "       -> $fix" -ForegroundColor DarkGray; $script:Warn++ }
 
 Write-Host "Environment doctor - host: windows (PowerShell)`n"
@@ -84,6 +89,44 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
 } else {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
+# broken environment, and lets telemetry group failures by environment class.
+# Human output above is unchanged. Always ~/.sigma-migration/doctor.json; also
+# -WorkDir if given.
+$rubyOk = [bool](Get-Command ruby -ErrorAction SilentlyContinue)
+$rubyV  = if ($rubyOk) { (& ruby -e 'print RUBY_VERSION' 2>$null) } else { "" }
+$nodeOk = [bool](Get-Command node -ErrorAction SilentlyContinue)
+$nodeV  = if ($nodeOk) { (& node --version 2>$null) } else { "" }
+$pyDesc = Test-RealPython 'py' '-3'
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python' $null }
+if (-not $pyDesc) { $pyDesc = Test-RealPython 'python3' $null }
+$pyOk = [bool]$pyDesc
+$pyV  = if ($pyOk) { ($pyDesc -split '  ')[0] } else { "" }
+
+$sandbox = "none"
+if ($env:CLAUDE_CODE_REMOTE -or $env:COWORK -or $env:CODESPACES) { $sandbox = "remote-sandbox" }
+
+$doctor = [ordered]@{
+  os           = "windows"
+  shell        = "powershell"
+  runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
+  versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
+  sandbox_hint = $sandbox
+  pass         = ($script:Fail -eq 0)
+  failures     = @($script:Failures)
+}
+$json = $doctor | ConvertTo-Json -Compress -Depth 5
+function Write-DoctorJson([string]$dest) {
+  try {
+    $dir = Split-Path -Parent $dest
+    if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+  } catch { }
+}
+Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")
+if ($WorkDir) { Write-DoctorJson (Join-Path $WorkDir "doctor.json") }
 
 Write-Host "`nSummary: $script:Pass ok, $script:Warn warning(s), $script:Fail missing/blocking."
 if ($script:Fail -eq 0) { Write-Host "Environment looks good - proceed."; exit 0 }

--- a/shared/scripts/doctor.ps1
+++ b/shared/scripts/doctor.ps1
@@ -122,7 +122,10 @@ function Write-DoctorJson([string]$dest) {
   try {
     $dir = Split-Path -Parent $dest
     if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-    Set-Content -Path $dest -Value $json -Encoding UTF8 -NoNewline
+    # UTF-8 WITHOUT BOM. Windows PowerShell 5.1's `Set-Content -Encoding UTF8`
+    # prepends a BOM, which makes Ruby's JSON.parse (the gate reader) fail with
+    # "unexpected token". Write via .NET so it's BOM-less on both 5.1 and 7.
+    [System.IO.File]::WriteAllText($dest, $json, (New-Object System.Text.UTF8Encoding($false)))
   } catch { }
 }
 Write-DoctorJson (Join-Path $env:USERPROFILE ".sigma-migration\doctor.json")

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -18,9 +18,21 @@
 #   - bash   : get-token.sh / *-auth.sh (Sigma token minting)
 set -u
 
+# --workdir DIR: also drop doctor.json here (in addition to the stable
+# ~/.sigma-migration/doctor.json). Everything else is positional-agnostic.
+WORKDIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --workdir=*) WORKDIR="${1#*=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
 PASS=0; FAIL=0; WARN=0
+FAILURES=()
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n     ↳ %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
 warn() { printf '  \033[33m!\033[0m %s\n     ↳ %s\n' "$1" "$2"; WARN=$((WARN+1)); }
 
 case "$(uname -s 2>/dev/null)" in
@@ -51,7 +63,7 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
 }
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
@@ -104,6 +116,50 @@ if [ -f "$HOME/.sigma-migration/env" ] || [ -n "${SIGMA_API_TOKEN:-}" ] || [ -n 
 else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
+
+# --- machine-readable fingerprint (doctor.json) ----------------------------
+# Written so (a) the run-state / preflight GATE can refuse to proceed on a
+# broken environment instead of letting the agent improvise, and (b) telemetry
+# can group next event's failures by environment class. Human output above is
+# unchanged. Always to ~/.sigma-migration/doctor.json; also to <WORKDIR> if given.
+jstr() { local s="${1:-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+RUBY_OK=false; RUBY_V=""
+if command -v ruby >/dev/null 2>&1; then RUBY_OK=true; RUBY_V="$(ruby -e 'print RUBY_VERSION' 2>/dev/null || true)"; fi
+NODE_OK=false; NODE_V=""
+if command -v node >/dev/null 2>&1; then NODE_OK=true; NODE_V="$(node --version 2>/dev/null || true)"; fi
+PY_OK=false; PY_VER="${PY_VER:-}"
+if py_real py -3 || py_real python3 || py_real python; then PY_OK=true; fi
+
+case "$OS" in windows-bash) SHELL_KIND="git-bash" ;; *) SHELL_KIND="bash" ;; esac
+SANDBOX_HINT="none"
+[ -f /.dockerenv ] && SANDBOX_HINT="container"
+[ -n "${CLAUDE_CODE_REMOTE:-}${COWORK:-}${CODESPACES:-}" ] && SANDBOX_HINT="remote-sandbox"
+[ "$FAIL" -eq 0 ] && PASS_BOOL=true || PASS_BOOL=false
+
+fj=""
+for f in "${FAILURES[@]:-}"; do
+  [ -z "$f" ] && continue
+  fj="${fj:+$fj,}\"$(jstr "$f")\""
+done
+
+write_doctor_json() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")" 2>/dev/null || return 0
+  {
+    printf '{'
+    printf '"os":"%s",' "$(jstr "$OS")"
+    printf '"shell":"%s",' "$(jstr "$SHELL_KIND")"
+    printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
+    printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
+    printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"pass":%s,' "$PASS_BOOL"
+    printf '"failures":[%s]' "$fj"
+    printf '}\n'
+  } > "$dest" 2>/dev/null || true
+}
+write_doctor_json "$HOME/.sigma-migration/doctor.json"
+[ -n "$WORKDIR" ] && write_doctor_json "$WORKDIR/doctor.json"
 
 echo
 echo "Summary: $PASS ok, $WARN warning(s), $FAIL missing/blocking."

--- a/shared/scripts/get_token.py
+++ b/shared/scripts/get_token.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+The cross-shell twin of get-token.sh. Where get-token.sh prints
+`export SIGMA_API_TOKEN=...` (a bash idiom that cannot run in PowerShell /
+cmd), this writes the token to <WORK>/auth.json so EVERY shell — bash,
+PowerShell, cmd, or an agent driving any of them — uses the exact same
+invocation:
+
+    python scripts/get_token.py --workdir <WORK>        # writes <WORK>/auth.json (0600)
+    python scripts/get_token.py --print-export          # bash: eval "$(...)" compatibility
+    python scripts/get_token.py --print-token           # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by shared/lib/sigma_rest.rb (env vars still win) and MUST be
+covered by .gitignore — it holds a live bearer token.
+
+Credential resolution mirrors get-token.sh exactly:
+  explicit env (SIGMA_CLIENT_ID/SECRET/BASE_URL)
+    -> ~/.sigma-migration/env  (the neutral cred file setup.rb writes)
+    -> actionable error.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+
+
+def _load_neutral_env():
+    """If Sigma creds aren't already in the environment, load them from the
+    neutral cred file written by setup.rb. Existing env always wins — mirrors
+    the `ENV[key] ||= raw` behaviour of sigma_rest.rb."""
+    if os.environ.get("SIGMA_CLIENT_ID") or not os.path.exists(NEUTRAL_ENV):
+        return
+    line_re = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = line_re.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            os.environ.setdefault(key, raw)
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    _load_neutral_env()
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env),\n"
+            "  or set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the environment."
+        )
+
+    # Pre-flight sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+    # settings.json where SIGMA_CLIENT_SECRET was a COPY of SIGMA_CLIENT_ID.
+    # Sigma returns the opaque "client secret provided is invalid" and nothing
+    # else runs. Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it in ~/.sigma-migration/env (and in\n"
+            "~/.claude/settings.json if it lives there too), then re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/shared/scripts/report-telemetry.py
+++ b/shared/scripts/report-telemetry.py
@@ -100,6 +100,23 @@ if args.declined:
     _write_marker(args.workdir, {'status': 'declined', 'tool': args.tool})
     sys.exit(0)
 
+# Environment fingerprint (P0.3): prefer <workdir>/doctor.json, fall back to the
+# stable ~/.sigma-migration/doctor.json the doctor always writes.
+def _load_doctor(workdir):
+    candidates = []
+    if workdir:
+        candidates.append(os.path.join(workdir, 'doctor.json'))
+    candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
+    for p in candidates:
+        try:
+            with open(p, encoding='utf-8') as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            continue
+    return None
+
+_doctor = _load_doctor(getattr(args, 'workdir', None))
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -108,6 +125,7 @@ sent = report_migration(
     success=not args.failed,
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
+    doctor=_doctor,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/shared/scripts/report-telemetry.py
+++ b/shared/scripts/report-telemetry.py
@@ -109,7 +109,8 @@ def _load_doctor(workdir):
     candidates.append(os.path.expanduser('~/.sigma-migration/doctor.json'))
     for p in candidates:
         try:
-            with open(p, encoding='utf-8') as fh:
+            # utf-8-sig strips a UTF-8 BOM if present (Windows PowerShell writes one).
+            with open(p, encoding='utf-8-sig') as fh:
                 return json.load(fh)
         except (OSError, ValueError):
             continue


### PR DESCRIPTION
## Why
Skills behave inconsistently across users at multi-user events (Cowork remote sandboxes, Windows/PowerShell). This ships the **P0 tier** of the cross-user consistency plan — no runtime porting, low risk, in-spirit with the repo's own GATE/vendoring conventions. Tracked: `beads-sigma-agad`.

## What changed

**P0.1 — shell-neutral credential handoff** (kills the `eval "$(get-token.sh)"` idiom PowerShell/cmd can't run)
- New `shared/scripts/get_token.py` (stdlib): mints the Sigma token, writes `<WORK>/auth.json` (mode 0600). Identical invocation in every shell.
- `sigma_rest.rb` reads `auth.json` (precedence: explicit env token → `auth.json` → client-cred self-mint).
- `apply_sigma_rls.py` gains the same `auth.json` fallback.
- `auth.json`/`doctor.json` `.gitignore`d; `get-token.sh` still works.

**P0.3 — doctor fingerprint + hard gate**
- `doctor.sh` + `doctor.ps1` write `doctor.json` `{os, shell, runtimes, versions, sandbox_hint, pass, failures[]}` to `~/.sigma-migration/` (and `--workdir`).
- New `assert-doctor-ran.rb` GATE; `migrate-tableau.rb` preflight refuses to start without a passing `doctor.json` (escape hatch: `--skip-doctor-gate "<reason>"`). Turns "run the doctor first" from prose into a real gate — stops agents improvising past a broken env (the #1 inconsistency source).
- Telemetry (`report-telemetry.py` + `sigma_telemetry.py`) appends the doctor fingerprint so next event's failures group by **environment class**, not anecdotes.

**P0.2 — remove load-bearing bash from the Sigma token path**
- `migrate-tableau.rb` `sigma_run!`/`sigma_run_wb!` mint the token **in-process** (pure Ruby via the Sigma lib) and inject via child env — no `bash -c`, no eval subshell.
- `tableau-to-sigma` SKILL.md hot path made shell-neutral (Step-0 doctor with bash + PowerShell variants; token step no longer needs `eval`).

## Scope / honest caveats
- **bash is still REQUIRED** (Tableau discovery lanes + `get-tableau-token.sh`) — the doctor's REQUIRED list is deliberately **unchanged**. Shrinking it to Python+Node is **P1** (Ruby→Python port), not here. So a PowerShell-only Windows box with no Ruby still won't run tableau end-to-end; this PR's payoff is Cowork/mac/linux consistency, killing the eval-subshell footgun, and making every failure loud + attributable.
- Follow-ups (not in this PR): P0.4 `windows-latest` CI; P0.2 sweep of the remaining 24 SKILLs; P1 runtime shrink; P2 Cowork inventory.

## Verification
- E2E: `get_token.py` → `auth.json` (0600) → Ruby `Sigma` lib reads it; explicit env token correctly wins.
- `doctor.sh` emits valid JSON on macOS bash 3.2; gate blocks (exit 1) with no `doctor.json`, passes with one; `--skip-doctor-gate` waives.
- In-process `sigma_run!` delivers a valid token to a child process, no bash.
- Telemetry payload carries the coarse fingerprint (ruby/bash excluded when absent).
- `tools/check-shared.rb`, `tools/lint-skills.rb`, `test-telemetry-gate.rb`, `test-intake.rb` all green; canonical files fanned out via `sync-shared.rb`.
- `doctor.ps1` reviewed by hand (no local pwsh) — will be covered by the P0.4 Windows CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)