### PR TITLE
tableau-to-sigma: infer flat detail tables (not bars) for Automatic-mark sheets

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -297,31 +297,43 @@ MEASURE_PREFIXES = %w[sum avg min max count countd cntd median stdev stdevp var 
 DATE_TRUNC_PREFIXES = %w[yr qr mn wk dy hr mi sc mdy md qd ymd y q m d w h s].freeze
 
 # Classify a single shelf-field bracketed spec like "none:GUID:qk" or "sum:GUID:qk"
-# or "REGION" (no prefix). Returns [:dim | :measure | :measure_names, derivation_or_nil].
+# or "REGION" (no prefix).
+# Returns [:dim | :measure | :measure_names | :skip, derivation_or_nil, discrete_bool].
+#
+# The trailing type code encodes the pill's data role: `qk`/`ok` = CONTINUOUS
+# (green — a measure that draws a bar/line axis), `nk` = DISCRETE (blue — renders
+# as a text header, never an axis). Dimensions are always discrete; a MEASURE can
+# be either. A discrete measure (e.g. `[usr:Calc:nk]`) is a text-table cell, not a
+# bar — so we surface `discrete` for the chart-kind inference to honor.
+# An optional trailing `:N` is a duplicate-instance index (the same field placed
+# twice on the shelves), NOT part of the type code — strip it before reading the
+# code, or a field like `[usr:Calc:nk:1]` slips past the matcher and is mis-typed
+# as a dimension.
 def classify_shelf_field(field_str)
-  return [:skip, nil] if field_str.nil? || field_str.strip.empty?
+  return [:skip, nil, false] if field_str.nil? || field_str.strip.empty?
   fs = field_str.strip
   # Bare "[Measure Names]" or ".[Measure Names]" → placeholder
-  return [:measure_names, nil] if fs =~ /\bMeasure\s*Names\b/i
+  return [:measure_names, nil, false] if fs =~ /\bMeasure\s*Names\b/i
   # Extract the inner spec — the last `[...]` segment
   spec = fs[/\[([^\[\]]*)\]\s*$/, 1] || fs
-  # Aggregation/trunc prefix form: "prefix:GUID:type"
-  if (m = spec.match(/^([a-z]+):.*?:[a-z]+$/i))
+  # Aggregation/trunc prefix form: "prefix:GUID:type" (+ optional ":N" instance)
+  if (m = spec.match(/^([a-z]+):.*?:([a-z]+)(?::\d+)?$/i))
     pref = m[1].downcase
-    return [:measure, pref] if MEASURE_PREFIXES.include?(pref)
-    return [:dim, pref]     if DATE_TRUNC_PREFIXES.include?(pref)
-    return [:dim, pref]     if pref == 'none'
-    return [:dim, pref]     # unknown prefix → conservative dim
+    discrete = m[2].downcase.start_with?('n')   # nk → discrete; qk/ok → continuous
+    return [:measure, pref, discrete] if MEASURE_PREFIXES.include?(pref)
+    return [:dim, pref, false]        if DATE_TRUNC_PREFIXES.include?(pref)
+    return [:dim, pref, false]        if pref == 'none'
+    return [:dim, pref, false]        # unknown prefix → conservative dim
   end
   # No prefix → dim (e.g. "[REGION]")
-  [:dim, nil]
+  [:dim, nil, false]
 end
 
 # Parse a `<rows>` or `<cols>` shelf string into a structured summary.
 def parse_shelf(shelf_str)
   out = { 'raw' => shelf_str, 'fields' => [], 'dim_count' => 0,
-          'measure_count' => 0, 'has_measure_names' => false,
-          'has_measure_values' => false }
+          'measure_count' => 0, 'cont_measure_count' => 0,
+          'has_measure_names' => false, 'has_measure_values' => false }
   return out if shelf_str.nil? || shelf_str.strip.empty?
   # The Measure-VALUES pill (`[Multiple Values]` / `[Measure Values]`) signals
   # measures placed on this shelf as a VISUAL encoding (bar lengths / line
@@ -341,7 +353,7 @@ def parse_shelf(shelf_str)
     # parens, so this is safe for flat and ≥2-level nested shelves alike.)
     raw_field = f.strip.gsub(/\A[(\s]+/, '').gsub(/[)\s]+\z/, '')
     next if raw_field.empty?
-    role, deriv = classify_shelf_field(raw_field)
+    role, deriv, discrete = classify_shelf_field(raw_field)
     case role
     when :dim
       out['dim_count'] += 1
@@ -349,8 +361,9 @@ def parse_shelf(shelf_str)
                          'guid' => guid_from_param(raw_field) }
     when :measure
       out['measure_count'] += 1
+      out['cont_measure_count'] += 1 unless discrete
       out['fields'] << { 'raw' => raw_field, 'role' => 'measure', 'derivation' => deriv,
-                         'guid' => guid_from_param(raw_field) }
+                         'discrete' => discrete, 'guid' => guid_from_param(raw_field) }
     when :measure_names
       out['has_measure_names'] = true
       out['fields'] << { 'raw' => raw_field, 'role' => 'measure-names' }
@@ -900,27 +913,30 @@ def infer_automatic_kind(meta)
   fields = (rs['fields'] || []) + (cs['fields'] || [])
   dims = fields.select { |f| f['role'] == 'dim' }
   meas = fields.select { |f| f['role'] == 'measure' }
+  # Only CONTINUOUS measures draw an axis (bar length / line value). A DISCRETE
+  # measure (blue pill, type code `nk`) renders as a text cell — for chart-kind
+  # inference it behaves like "no measure on the axis." (Zero-dim + a measure is
+  # already claimed as a KPI upstream, so we only reach here for dim-bearing
+  # sheets.)
+  cont_meas = meas.reject { |f| f['discrete'] }
   has_date_dim = dims.any? { |f| DATE_GRAIN_DERIV.include?(f['derivation'].to_s.downcase) }
   has_measure_values = rs['has_measure_values'] || cs['has_measure_values']
-  # 1) continuous date dimension + a measure → time-series LINE
-  return 'line' if has_date_dim && !meas.empty?
-  # 2) a measure on BOTH axes (rows AND cols), ≤1 dim → SCATTER
-  return 'scatter' if rs['measure_count'].to_i >= 1 && cs['measure_count'].to_i >= 1 && dims.size <= 1
-  # 3) flat detail TABLE: dimension(s) present but NO measure sits on an axis
-  #    shelf (measures live on the Marks/Text card, or the sheet is a pure
-  #    dimension list) and no Measure-VALUES encoding pill. A bar needs a
-  #    continuous measure axis; with none, Tableau's default "Automatic" mark
-  #    renders a text grid, not bars — so route to a Sigma `table` instead of
-  #    blindly defaulting to bar-chart. This is what rescues the common case of
-  #    a detail table left on the default mark (never flipped to "Text"), which
-  #    the Text/Square and crosstab/KPI heuristics above don't claim.
-  #    LIMITATION: does NOT catch a table built by making a measure DISCRETE
-  #    (blue pill) on a shelf — that still reports role=measure here, so it
-  #    reads as a bar. Those remain chart_kind_inferred → verified against the
-  #    PNG in Phase 5g. (Kept narrow on purpose to avoid demoting real bars.)
-  return 'table' if !dims.empty? && meas.empty? && !has_measure_values
-  # 4) categorical dim(s) + measure → BAR (Tableau's default for cat × measure)
-  return 'bar' if !dims.empty? && !meas.empty?
+  # 1) continuous date dimension + a continuous measure → time-series LINE
+  return 'line' if has_date_dim && !cont_meas.empty?
+  # 2) a continuous measure on BOTH axes (rows AND cols), ≤1 dim → SCATTER
+  return 'scatter' if rs['cont_measure_count'].to_i >= 1 && cs['cont_measure_count'].to_i >= 1 && dims.size <= 1
+  # 3) flat detail TABLE: dimension(s) present but NO continuous measure sits on
+  #    an axis (measures live on the Marks/Text card, are DISCRETE blue pills, or
+  #    the sheet is a pure dimension list) and no Measure-VALUES encoding pill. A
+  #    bar needs a continuous measure axis; with none, Tableau's default
+  #    "Automatic" mark renders a text grid, not bars — so route to a Sigma
+  #    `table` instead of blindly defaulting to bar-chart. Rescues detail tables
+  #    left on the default mark (never flipped to "Text"), including the discrete-
+  #    measure-on-a-shelf idiom, which the Text/Square and crosstab/KPI
+  #    heuristics above don't claim.
+  return 'table' if !dims.empty? && cont_meas.empty? && !has_measure_values
+  # 4) categorical dim(s) + continuous measure → BAR (Tableau's default)
+  return 'bar' if !dims.empty? && !cont_meas.empty?
   'bar'
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -901,11 +901,25 @@ def infer_automatic_kind(meta)
   dims = fields.select { |f| f['role'] == 'dim' }
   meas = fields.select { |f| f['role'] == 'measure' }
   has_date_dim = dims.any? { |f| DATE_GRAIN_DERIV.include?(f['derivation'].to_s.downcase) }
+  has_measure_values = rs['has_measure_values'] || cs['has_measure_values']
   # 1) continuous date dimension + a measure → time-series LINE
   return 'line' if has_date_dim && !meas.empty?
   # 2) a measure on BOTH axes (rows AND cols), ≤1 dim → SCATTER
   return 'scatter' if rs['measure_count'].to_i >= 1 && cs['measure_count'].to_i >= 1 && dims.size <= 1
-  # 3) categorical dim(s) + measure → BAR (Tableau's default for cat × measure)
+  # 3) flat detail TABLE: dimension(s) present but NO measure sits on an axis
+  #    shelf (measures live on the Marks/Text card, or the sheet is a pure
+  #    dimension list) and no Measure-VALUES encoding pill. A bar needs a
+  #    continuous measure axis; with none, Tableau's default "Automatic" mark
+  #    renders a text grid, not bars — so route to a Sigma `table` instead of
+  #    blindly defaulting to bar-chart. This is what rescues the common case of
+  #    a detail table left on the default mark (never flipped to "Text"), which
+  #    the Text/Square and crosstab/KPI heuristics above don't claim.
+  #    LIMITATION: does NOT catch a table built by making a measure DISCRETE
+  #    (blue pill) on a shelf — that still reports role=measure here, so it
+  #    reads as a bar. Those remain chart_kind_inferred → verified against the
+  #    PNG in Phase 5g. (Kept narrow on purpose to avoid demoting real bars.)
+  return 'table' if !dims.empty? && meas.empty? && !has_measure_values
+  # 4) categorical dim(s) + measure → BAR (Tableau's default for cat × measure)
   return 'bar' if !dims.empty? && !meas.empty?
   'bar'
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-automatic-chart-kind.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-automatic-chart-kind.rb
@@ -42,6 +42,7 @@ GR = '[33b6c718-9b55-3dc0-9698-d1d57fac0f90]' # Gross Revenue (measure)
 NP = '[a1111111-0000-0000-0000-000000000001]' # Net Profit (measure)
 OD = '[c2ec6b07-897e-39ab-9422-aa895d35a627]' # Order Date (date dim)
 RG = '[d73055c0-9ed1-347d-8f8e-05a48ce2c8a8]' # Region (categorical dim)
+CT = '[b2222222-0000-0000-0000-000000000002]' # Category (categorical dim)
 
 TWB = <<~XML
   <?xml version='1.0' encoding='utf-8' ?>
@@ -52,18 +53,23 @@ TWB = <<~XML
         <column caption='Net Profit' name='#{NP}' datatype='real' role='measure' />
         <column caption='Order Date ' name='#{OD}' datatype='date' role='dimension' />
         <column caption='Region' name='#{RG}' datatype='string' role='dimension' />
+        <column caption='Category' name='#{CT}' datatype='string' role='dimension' />
       </datasource>
     </datasources>
     <worksheets>
       #{ws('Trend',   "[federated.x].[sum:#{GR[1..-2]}:qk]", "[federated.x].[tmn:#{OD[1..-2]}:qk]")}
       #{ws('ByRegion', "[federated.x].[sum:#{GR[1..-2]}:qk]", "[federated.x].[none:#{RG[1..-2]}:nk]")}
       #{ws('Scatter', "[federated.x].[sum:#{NP[1..-2]}:qk]", "[federated.x].[sum:#{GR[1..-2]}:qk]")}
+      #{ws('DetailList', "[federated.x].[none:#{RG[1..-2]}:nk] / [federated.x].[none:#{CT[1..-2]}:nk]", "")}
+      #{ws('MultiMeasBar', "[federated.x].[none:#{RG[1..-2]}:nk]", "[Multiple Values]")}
     </worksheets>
     <dashboards>
       <dashboard name='Dash'><zones>
         <zone id='1' name='Trend' x='0' y='0' w='33000' h='100000' />
         <zone id='2' name='ByRegion' x='33000' y='0' w='33000' h='100000' />
         <zone id='3' name='Scatter' x='66000' y='0' w='34000' h='100000' />
+        <zone id='4' name='DetailList' x='0' y='100000' w='50000' h='100000' />
+        <zone id='5' name='MultiMeasBar' x='50000' y='100000' w='50000' h='100000' />
       </zones></dashboard>
     </dashboards>
   </workbook>
@@ -89,6 +95,10 @@ check(kind(by_name, 'Scatter') == 'scatter',
       "Automatic + measure on both axes → scatter (got #{kind(by_name, 'Scatter').inspect})", fails)
 check((by_name['Trend'] || {})['chart_kind_inferred'] == true,
       'inferred-automatic kinds carry chart_kind_inferred:true (→ image confirmation)', fails)
+check(kind(by_name, 'DetailList') == 'table',
+      "Automatic + dims only, no measure axis → table (got #{kind(by_name, 'DetailList').inspect})", fails)
+check(kind(by_name, 'MultiMeasBar') == 'bar',
+      "Automatic + dim + [Multiple Values] pill → stays bar, not table (got #{kind(by_name, 'MultiMeasBar').inspect})", fails)
 
 puts
 if fails.empty?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-automatic-chart-kind.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-automatic-chart-kind.rb
@@ -62,6 +62,8 @@ TWB = <<~XML
       #{ws('Scatter', "[federated.x].[sum:#{NP[1..-2]}:qk]", "[federated.x].[sum:#{GR[1..-2]}:qk]")}
       #{ws('DetailList', "[federated.x].[none:#{RG[1..-2]}:nk] / [federated.x].[none:#{CT[1..-2]}:nk]", "")}
       #{ws('MultiMeasBar', "[federated.x].[none:#{RG[1..-2]}:nk]", "[Multiple Values]")}
+      #{ws('DiscreteMeasTable', "[federated.x].[none:#{RG[1..-2]}:nk] / [federated.x].[sum:#{GR[1..-2]}:nk]", "")}
+      #{ws('DiscreteBAN', "[federated.x].[usr:#{GR[1..-2]}:nk:1]", "")}
     </worksheets>
     <dashboards>
       <dashboard name='Dash'><zones>
@@ -70,6 +72,8 @@ TWB = <<~XML
         <zone id='3' name='Scatter' x='66000' y='0' w='34000' h='100000' />
         <zone id='4' name='DetailList' x='0' y='100000' w='50000' h='100000' />
         <zone id='5' name='MultiMeasBar' x='50000' y='100000' w='50000' h='100000' />
+        <zone id='6' name='DiscreteMeasTable' x='0' y='200000' w='50000' h='100000' />
+        <zone id='7' name='DiscreteBAN' x='50000' y='200000' w='50000' h='100000' />
       </zones></dashboard>
     </dashboards>
   </workbook>
@@ -99,6 +103,10 @@ check(kind(by_name, 'DetailList') == 'table',
       "Automatic + dims only, no measure axis → table (got #{kind(by_name, 'DetailList').inspect})", fails)
 check(kind(by_name, 'MultiMeasBar') == 'bar',
       "Automatic + dim + [Multiple Values] pill → stays bar, not table (got #{kind(by_name, 'MultiMeasBar').inspect})", fails)
+check(kind(by_name, 'DiscreteMeasTable') == 'table',
+      "Automatic + dim + DISCRETE measure (nk) on shelf → table, not bar (got #{kind(by_name, 'DiscreteMeasTable').inspect})", fails)
+check(kind(by_name, 'DiscreteBAN') == 'kpi',
+      "Automatic + zero-dim discrete measure w/ :N instance index → kpi (got #{kind(by_name, 'DiscreteBAN').inspect})", fails)
 
 puts
 if fails.empty?


### PR DESCRIPTION
## Why

Asked: *why does the skill sometimes convert Tableau tables to bar charts?*

Root cause: a worksheet's Sigma element kind is derived from its `<mark class>`. Tableau's **default mark is "Automatic"**, and `infer_automatic_kind()` in `parse-twb-layout.rb` had branches for line / scatter / bar but **no `table` branch** — so any Automatic-mark sheet carrying a dimension fell through to `bar`. A detail table left on the default mark (never flipped to "Text") shipped as a bar chart. `SIGMA_KIND` compounds it with `automatic`/`other` → `bar-chart` as the hard fallback.

## Fix (two commits)

**1. Flat-table branch.** Automatic mark + dimension(s) + **no measure on an axis shelf** + no Measure-VALUES pill → `table`. A bar needs a continuous measure axis; with none, Tableau renders a text grid, so `table` matches the real render. Reuses the existing `chart_kind='table'` path (identical to an explicit Text/Square mark → `kind='table'` → table builder), so no new downstream code.

**2. Continuity-aware — catches the discrete-measure idiom.** A Tableau measure's shelf spec carries a type code: `qk`/`ok` = **continuous** (green, draws an axis), `nk` = **discrete** (blue, renders as text). Verified against real `.twb`s (Partner Landscape, DDMX OKR, Superstore) where discrete measures appear as `[usr:Calc:nk]`. Inference now counts only **continuous** measures as axis measures, so a detail table built by making its measure *discrete* on a shelf → `table` (previously the escape hatch the first commit couldn't reach).

Also fixes a **pre-existing bug** in `classify_shelf_field`: the type-code regex didn't allow the optional trailing `:N` duplicate-instance index, so `[usr:Calc:nk:1]` slipped past and was mis-typed as a dimension. Now correctly a (discrete) measure — which also lets a zero-dim discrete-measure BAN resolve to `kpi`.

**Guards against demoting real bars:** the `[Multiple Values]`/`[Measure Values]` pill keeps multi-measure bars as bars; a continuous measure on the axis still → bar/line/scatter.

## Tests

Extends `test-automatic-chart-kind.rb` (all pass):
- `DetailList` (dims only) → `table`
- `MultiMeasBar` (`[Multiple Values]` pill) → stays `bar` (guard)
- `DiscreteMeasTable` (dim + `nk` measure) → `table`
- `DiscreteBAN` (zero-dim `nk` measure w/ `:N` index) → `kpi`

Full tableau suite green (57 pass; the one nonzero test is live-creds-gated, unrelated). Skill-only change — the vendored MCP/browser converter has no chart-kind logic, so no sync needed.

## Residual limitation

Detection is shelf-signal based; anything still ambiguous stays `chart_kind_inferred=true` → flagged for the Phase 5g PNG parity check.