### PR TITLE
P1 port step 2: tableau_rest Python twin + layered TLS trust (P1.4)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -228,6 +228,7 @@ jobs:
           tests=(
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grid_fidelity.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.py
@@ -25,6 +25,8 @@ import base64
 import json
 import os
 import re
+import ssl
+import sys
 import threading
 import urllib.error
 import urllib.request
@@ -126,6 +128,32 @@ class _Resp:
         self.reason = reason
 
 
+def _ssl_context():
+    """TLS trust resolution (P1.4). Stock macOS/homebrew Python urllib often
+    fails CERTIFICATE_VERIFY_FAILED where curl/Ruby succeed. Prefer the OS trust
+    store (truststore), then certifi, then the stock verified context. NEVER
+    silently downgrades: an unverified context is used ONLY when
+    SIGMA_INSECURE_TLS is explicitly set, and it logs loudly."""
+    if os.environ.get("SIGMA_INSECURE_TLS"):
+        print("WARNING: SIGMA_INSECURE_TLS set — TLS certificate verification is "
+              "DISABLED for Sigma requests. Do not use in production.", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; the faithful match for curl/Ruby reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
+
 def _send(method, url, headers, body, timeout):
     """Low-level HTTP seam (tests monkeypatch this). Returns _Resp with a numeric
     status even for 4xx/5xx (urllib raises HTTPError on those — we normalise)."""
@@ -134,7 +162,7 @@ def _send(method, url, headers, body, timeout):
     for k, v in headers.items():
         req.add_header(k, v)
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with urllib.request.urlopen(req, timeout=timeout, context=_ssl_context()) as resp:
             return _Resp(resp.status, resp.read(), getattr(resp, "reason", ""))
     except urllib.error.HTTPError as e:
         return _Resp(e.code, e.read(), e.reason)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.py
@@ -1,0 +1,362 @@
+"""Tableau REST API wrapper for tableau-to-sigma when the MCP isn't available.
+
+Python twin of tableau_rest.rb (P1 runtime-shrink: Ruby -> Python). Behaviour
+parity with the Ruby module is enforced by test_tableau_rest.py and the
+cross-impl parity harness. Stdlib only (urllib) — no third-party deps.
+
+Requires TABLEAU_SERVER_URL, TABLEAU_SITE_ID, TABLEAU_AUTH_TOKEN,
+TABLEAU_API_VERSION in env (set by scripts/get-tableau-token.sh). PAT refresh
+additionally needs TABLEAU_PAT_NAME, TABLEAU_PAT_SECRET, TABLEAU_SITE_CONTENT_URL.
+
+All methods return parsed dict/list (or raw bytes for view_image / *_content).
+Network/HTTP errors raise TableauError with the response body included.
+"""
+
+import json
+import os
+import re
+import ssl
+import sys
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+_NEUTRAL_LINE = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+
+
+class TableauError(Exception):
+    pass
+
+
+class TableauAuthError(TableauError):
+    pass
+
+
+_token_mutex = threading.Lock()
+_token_override = None
+_site_id_override = None
+_refresh_inflight = False
+
+
+def _load_neutral_env(env=None):
+    """Agent-neutral credential bootstrap. Load Tableau PAT creds from
+    ~/.sigma-migration/env when TABLEAU_PAT_SECRET is absent. Existing env wins
+    (mirrors Ruby's `.nil?` guard + `ENV[key] ||= raw`)."""
+    env = os.environ if env is None else env
+    if "TABLEAU_PAT_SECRET" in env or not os.path.exists(NEUTRAL_ENV):
+        return
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = _NEUTRAL_LINE.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            env.setdefault(key, raw)
+
+
+def bootstrap_credentials(env=None):
+    _load_neutral_env(env)
+
+
+def _require(key, hint="run get-tableau-token.sh"):
+    v = os.environ.get(key)
+    if not v:
+        raise TableauError(f"{key} not set — {hint}")
+    return v
+
+
+def server_url():
+    return _require("TABLEAU_SERVER_URL")
+
+
+def site_id():
+    with _token_mutex:
+        if _site_id_override:
+            return _site_id_override
+    return _require("TABLEAU_SITE_ID")
+
+
+def auth_token():
+    with _token_mutex:
+        if _token_override:
+            return _token_override
+    return _require("TABLEAU_AUTH_TOKEN")
+
+
+def api_version():
+    return os.environ.get("TABLEAU_API_VERSION", "3.22")
+
+
+def base_path():
+    return f"/api/{api_version()}/sites/{site_id()}"
+
+
+def _dig(obj, *keys):
+    """Ruby Hash#dig equivalent — nil-safe nested lookup."""
+    for k in keys:
+        if not isinstance(obj, dict):
+            return None
+        obj = obj.get(k)
+    return obj
+
+
+class _Resp:
+    __slots__ = ("status", "body", "reason")
+
+    def __init__(self, status, body, reason=""):
+        self.status = status
+        self.body = body if isinstance(body, (bytes, bytearray)) else str(body).encode()
+        self.reason = reason
+
+
+def _ssl_context():
+    """TLS trust resolution (P1.4). Ruby's Net::HTTP and curl validate Tableau
+    Cloud's chain fine, but Python's stricter OpenSSL 3.x rejects a Tableau
+    intermediate ("Basic Constraints not marked critical") under the default
+    bundle. Prefer the OS trust store (truststore — matches curl/Ruby), then
+    certifi, then the stock verified context. NEVER silently downgrades: an
+    unverified context is used ONLY when TABLEAU_INSECURE_TLS is explicitly set,
+    and it logs loudly."""
+    if os.environ.get("TABLEAU_INSECURE_TLS"):
+        print("WARNING: TABLEAU_INSECURE_TLS set — TLS certificate verification is "
+              "DISABLED for Tableau requests. Do not use in production.", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; the faithful match for curl/Ruby reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
+
+def _send(method, url, headers, body, timeout):
+    """Low-level HTTP seam (tests monkeypatch this)."""
+    data = body.encode() if isinstance(body, str) else body
+    req = urllib.request.Request(url, data=data, method=method.upper())
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=_ssl_context()) as resp:
+            return _Resp(resp.status, resp.read(), getattr(resp, "reason", ""))
+    except urllib.error.HTTPError as e:
+        return _Resp(e.code, e.read(), e.reason)
+
+
+def refresh_token():
+    """Re-sign in with the PAT env vars and cache token + site id. Single-flight."""
+    global _refresh_inflight, _token_override, _site_id_override
+    with _token_mutex:
+        if _refresh_inflight:
+            return _token_override
+        _refresh_inflight = True
+    try:
+        name = os.environ.get("TABLEAU_PAT_NAME")
+        if not name:
+            raise TableauAuthError("TABLEAU_PAT_NAME not set — cannot refresh")
+        secret = os.environ.get("TABLEAU_PAT_SECRET")
+        if not secret:
+            raise TableauAuthError("TABLEAU_PAT_SECRET not set — cannot refresh")
+        site_content = os.environ.get("TABLEAU_SITE_CONTENT_URL")
+        if site_content is None:
+            raise TableauAuthError("TABLEAU_SITE_CONTENT_URL not set")
+        url = urllib.parse.urljoin(server_url(), f"/api/{api_version()}/auth/signin")
+        body = (f'<tsRequest><credentials personalAccessTokenName="{name}" '
+                f'personalAccessTokenSecret="{secret}"><site contentUrl="{site_content}"/>'
+                f'</credentials></tsRequest>')
+        resp = _send("POST", url,
+                     {"Content-Type": "application/xml", "Accept": "application/json"},
+                     body, 30)
+        if not (200 <= resp.status < 300):
+            raise TableauAuthError(f"signin -> {resp.status} {resp.body.decode(errors='replace')}")
+        j = json.loads(resp.body or b"{}")
+        with _token_mutex:
+            _token_override = _dig(j, "credentials", "token")
+            _site_id_override = _dig(j, "credentials", "site", "id")
+        return _token_override
+    finally:
+        with _token_mutex:
+            _refresh_inflight = False
+
+
+def request(method, path, body=None, content_type="application/json",
+            accept="application/json", binary=False):
+    url = urllib.parse.urljoin(server_url(), path)
+    if method.lower() not in ("get", "post", "put", "delete"):
+        raise ValueError(f"unsupported method {method}")
+    attempts = 0
+    while True:
+        attempts += 1
+        headers = {"X-Tableau-Auth": auth_token(), "Accept": accept}
+        if body is not None:
+            headers["Content-Type"] = content_type
+        resp = _send(method, url, headers, body, 120)
+        if resp.status == 401 and attempts == 1 and os.environ.get("TABLEAU_PAT_NAME"):
+            refresh_token()
+            continue
+        if not (200 <= resp.status < 300):
+            raise TableauError(f"{method.upper()} {path} -> {resp.status} {resp.reason}\n"
+                               f"{resp.body.decode(errors='replace')}")
+        if binary:
+            return resp.body
+        text = resp.body.decode(errors="replace")
+        if accept != "application/json":
+            return text
+        return None if text == "" else json.loads(text)
+
+
+def _as_list(v):
+    """Tableau REST returns a bare object for single-element collections and a
+    list for many — normalise to a list."""
+    if v is None:
+        return []
+    return v if isinstance(v, list) else [v]
+
+
+# ---- workbooks ------------------------------------------------------------
+
+def find_workbook_by_name(name):
+    encoded = urllib.parse.quote_plus(f"name:eq:{name}")
+    j = request("get", f"{base_path()}/workbooks?filter={encoded}")
+    lst = _as_list(_dig(j, "workbooks", "workbook"))
+    return lst[0] if lst else None
+
+
+def get_workbook(workbook_id):
+    return request("get", f"{base_path()}/workbooks/{workbook_id}")["workbook"]
+
+
+def download_workbook_content(workbook_id, include_extract=False):
+    qs = "" if include_extract else "?includeExtract=false"
+    return request("get", f"{base_path()}/workbooks/{workbook_id}/content{qs}",
+                   accept="*/*", binary=True)
+
+
+# ---- views ----------------------------------------------------------------
+
+def view_data(view_id):
+    return request("get", f"{base_path()}/views/{view_id}/data", accept="*/*")
+
+
+def view_image(view_id, width=1400, height=900, resolution="high"):
+    qs = f"?resolution={resolution}&maxAge=1"
+    if width and height:
+        qs += f"&vf_width={width}&vf_height={height}"
+    return request("get", f"{base_path()}/views/{view_id}/image{qs}", accept="*/*", binary=True)
+
+
+# ---- datasources ----------------------------------------------------------
+
+def list_datasources(page_size=100, page=1):
+    return request("get", f"{base_path()}/datasources?pageSize={page_size}&pageNumber={page}")
+
+
+def find_datasource_by_name(name):
+    encoded = urllib.parse.quote_plus(f"name:eq:{name}")
+    j = request("get", f"{base_path()}/datasources?filter={encoded}")
+    lst = _as_list(_dig(j, "datasources", "datasource"))
+    return lst[0] if lst else None
+
+
+def find_datasource_by_content_url(content_url):
+    encoded = urllib.parse.quote_plus(f"contentUrl:eq:{content_url}")
+    j = request("get", f"{base_path()}/datasources?filter={encoded}")
+    lst = _as_list(_dig(j, "datasources", "datasource"))
+    if lst:
+        return lst[0]
+    # Fallback: scan pages and match contentUrl exactly.
+    page = 1
+    while True:
+        jj = list_datasources(page_size=100, page=page)
+        ds = _as_list(_dig(jj, "datasources", "datasource"))
+        hit = next((d for d in ds if str(d.get("contentUrl")) == str(content_url)), None)
+        if hit:
+            return hit
+        total = int(_dig(jj, "pagination", "totalAvailable") or 0)
+        if not ds or page * 100 >= total:
+            break
+        page += 1
+    return None
+
+
+def download_datasource_content(datasource_id, include_extract=False):
+    qs = "" if include_extract else "?includeExtract=false"
+    return request("get", f"{base_path()}/datasources/{datasource_id}/content{qs}",
+                   accept="*/*", binary=True)
+
+
+# ---- server capabilities --------------------------------------------------
+
+def serverinfo():
+    return request("get", f"/api/{api_version()}/serverinfo")["serverInfo"]
+
+
+def metadata_api_available():
+    try:
+        r = graphql("{ __typename }")
+    except TableauError:
+        return False
+    return r is not None and not _dig(r, "errors")
+
+
+def capabilities():
+    try:
+        info = serverinfo() or {}
+    except TableauError:
+        info = {}
+    try:
+        meta = metadata_api_available()
+    except TableauError:
+        meta = False
+    return {
+        "product_version": _dig(info, "productVersion", "value"),
+        "rest_api_version": info.get("restApiVersion") or api_version(),
+        "metadata_api": meta,
+    }
+
+
+def read_metadata(datasource_luid):
+    body = json.dumps({"datasource": {"datasourceLuid": datasource_luid}})
+    return request("post", "/api/v1/vizql-data-service/read-metadata", body=body)
+
+
+# ---- metadata GraphQL -----------------------------------------------------
+
+def graphql_datasource_fields(datasource_luid):
+    query = (
+        "{\n"
+        f'  publishedDatasources(filter:{{luid:"{datasource_luid}"}}) {{\n'
+        "    name luid\n"
+        "    fields {\n"
+        "      name\n"
+        "      fullyQualifiedName\n"
+        "      ... on CalculatedField { formula isHidden }\n"
+        "    }\n"
+        "  }\n"
+        "}\n"
+    )
+    return request("post", "/api/metadata/graphql", body=json.dumps({"query": query}))
+
+
+def graphql(query, variables=None):
+    payload = {"query": query}
+    if variables:
+        payload["variables"] = variables
+    return request("post", "/api/metadata/graphql", body=json.dumps(payload))
+
+
+bootstrap_credentials()

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
@@ -29,7 +29,7 @@ import sigma_rest  # noqa: E402
 class Base(unittest.TestCase):
     # env keys we mutate — snapshot + restore so cases don't bleed.
     KEYS = ["SIGMA_BASE_URL", "SIGMA_CLIENT_ID", "SIGMA_CLIENT_SECRET",
-            "SIGMA_API_TOKEN", "SIGMA_WORKDIR"]
+            "SIGMA_API_TOKEN", "SIGMA_WORKDIR", "SIGMA_INSECURE_TLS"]
 
     def setUp(self):
         self._saved = {k: os.environ.get(k) for k in self.KEYS}
@@ -285,6 +285,21 @@ class Request(Base):
         self._ready()
         with self.assertRaises(ValueError):
             sigma_rest.request("options", "/v2/x")
+
+
+class SslContext(Base):
+    def test_returns_context_and_verifies_by_default(self):
+        import ssl
+        ctx = sigma_rest._ssl_context()
+        self.assertIsInstance(ctx, ssl.SSLContext)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    def test_insecure_flag_disables_verification(self):
+        import ssl
+        os.environ["SIGMA_INSECURE_TLS"] = "1"
+        ctx = sigma_rest._ssl_context()
+        self.assertEqual(ctx.verify_mode, ssl.CERT_NONE)
+        self.assertFalse(ctx.check_hostname)
 
 
 if __name__ == "__main__":

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Contract/spec test for tableau_rest.py (P1 Ruby->Python port).
+
+Creds-free, network-free: the HTTP layer (tableau_rest._send) is monkeypatched.
+Encodes the observable behaviour of tableau_rest.rb — credential bootstrap,
+override/env precedence, PAT signin shape, the 401 refresh-once loop, the
+single-vs-array collection normalisation, and the paged datasource fallback.
+"""
+import base64  # noqa: F401 (parity symmetry with sigma test; harmless)
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+for _cand in (
+    os.path.join(_HERE, "lib"),
+    os.path.abspath(os.path.join(_HERE, "..", "..", "..", "..", "..", "shared", "lib")),
+):
+    if os.path.isfile(os.path.join(_cand, "tableau_rest.py")):
+        sys.path.insert(0, _cand)
+        break
+
+import tableau_rest as tr  # noqa: E402
+
+
+class Base(unittest.TestCase):
+    KEYS = ["TABLEAU_SERVER_URL", "TABLEAU_SITE_ID", "TABLEAU_AUTH_TOKEN",
+            "TABLEAU_API_VERSION", "TABLEAU_PAT_NAME", "TABLEAU_PAT_SECRET",
+            "TABLEAU_SITE_CONTENT_URL", "TABLEAU_INSECURE_TLS"]
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in self.KEYS}
+        for k in self.KEYS:
+            os.environ.pop(k, None)
+        tr._token_override = None
+        tr._site_id_override = None
+        tr._refresh_inflight = False
+        self._sends = []
+        self._queue = []
+        tr._send = self._fake_send
+        self._orig_neutral = tr.NEUTRAL_ENV
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        tr.NEUTRAL_ENV = self._orig_neutral
+
+    def _fake_send(self, method, url, headers, body, timeout):
+        self._sends.append({"method": method, "url": url, "headers": headers,
+                            "body": body, "timeout": timeout})
+        status, resp_body = self._queue.pop(0)
+        return tr._Resp(status, resp_body)
+
+    def enqueue(self, status, body):
+        self._queue.append((status, body if isinstance(body, (bytes, str)) else json.dumps(body)))
+
+    def ready(self, **over):
+        os.environ["TABLEAU_SERVER_URL"] = over.get("server", "https://ten.online.tableau.com")
+        os.environ["TABLEAU_SITE_ID"] = over.get("site", "site-luid")
+        os.environ["TABLEAU_AUTH_TOKEN"] = over.get("tok", "tok")
+
+
+class Config(Base):
+    def test_server_url_raises_when_unset(self):
+        with self.assertRaises(tr.TableauError):
+            tr.server_url()
+
+    def test_api_version_default(self):
+        self.assertEqual(tr.api_version(), "3.22")
+
+    def test_api_version_override(self):
+        os.environ["TABLEAU_API_VERSION"] = "3.24"
+        self.assertEqual(tr.api_version(), "3.24")
+
+    def test_base_path(self):
+        self.ready()
+        self.assertEqual(tr.base_path(), "/api/3.22/sites/site-luid")
+
+    def test_overrides_beat_env(self):
+        self.ready()
+        tr._token_override = "OVR"
+        tr._site_id_override = "site-ovr"
+        self.assertEqual(tr.auth_token(), "OVR")
+        self.assertEqual(tr.site_id(), "site-ovr")
+
+
+class NeutralEnv(Base):
+    def _write(self, text):
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        self.addCleanup(os.remove, path)
+        tr.NEUTRAL_ENV = path
+
+    def test_loads_when_pat_secret_absent(self):
+        self._write("export TABLEAU_PAT_NAME=mypat\nTABLEAU_PAT_SECRET='sh sh'\n")
+        tr._load_neutral_env()
+        self.assertEqual(os.environ["TABLEAU_PAT_NAME"], "mypat")
+        self.assertEqual(os.environ["TABLEAU_PAT_SECRET"], "sh sh")
+
+    def test_skipped_when_pat_secret_present(self):
+        self._write("TABLEAU_PAT_NAME=fromfile\n")
+        os.environ["TABLEAU_PAT_SECRET"] = "present"
+        tr._load_neutral_env()
+        self.assertNotIn("TABLEAU_PAT_NAME", os.environ)
+
+
+class Refresh(Base):
+    def _creds(self):
+        os.environ["TABLEAU_SERVER_URL"] = "https://ten.online.tableau.com"
+        os.environ["TABLEAU_PAT_NAME"] = "patname"
+        os.environ["TABLEAU_PAT_SECRET"] = "patsecret"
+        os.environ["TABLEAU_SITE_CONTENT_URL"] = "acme"
+
+    def test_signin_request_shape(self):
+        self._creds()
+        self.enqueue(200, {"credentials": {"token": "NEWTOK", "site": {"id": "site-9"}}})
+        tok = tr.refresh_token()
+        self.assertEqual(tok, "NEWTOK")
+        self.assertEqual(tr._site_id_override, "site-9")
+        s = self._sends[0]
+        self.assertEqual(s["method"], "POST")
+        self.assertEqual(s["url"], "https://ten.online.tableau.com/api/3.22/auth/signin")
+        self.assertEqual(s["headers"]["Content-Type"], "application/xml")
+        self.assertIn('personalAccessTokenName="patname"', s["body"])
+        self.assertIn('personalAccessTokenSecret="patsecret"', s["body"])
+        self.assertIn('<site contentUrl="acme"/>', s["body"])
+
+    def test_non_2xx_raises(self):
+        self._creds()
+        self.enqueue(401, "bad pat")
+        with self.assertRaises(tr.TableauAuthError):
+            tr.refresh_token()
+
+    def test_missing_pat_raises(self):
+        os.environ["TABLEAU_SERVER_URL"] = "https://ten.online.tableau.com"
+        with self.assertRaises(tr.TableauAuthError):
+            tr.refresh_token()
+
+
+class Request(Base):
+    def test_get_json_and_auth_header(self):
+        self.ready()
+        self.enqueue(200, {"ok": 1})
+        out = tr.request("get", "/api/3.22/sites/x/workbooks")
+        self.assertEqual(out, {"ok": 1})
+        self.assertEqual(self._sends[0]["headers"]["X-Tableau-Auth"], "tok")
+        self.assertEqual(self._sends[0]["url"],
+                         "https://ten.online.tableau.com/api/3.22/sites/x/workbooks")
+
+    def test_binary_returns_bytes(self):
+        self.ready()
+        self.enqueue(200, b"\x89PNG")
+        self.assertEqual(tr.request("get", "/x", accept="*/*", binary=True), b"\x89PNG")
+
+    def test_empty_body_none(self):
+        self.ready()
+        self.enqueue(200, "")
+        self.assertIsNone(tr.request("get", "/x"))
+
+    def test_non_json_accept_text(self):
+        self.ready()
+        self.enqueue(200, "col\n1")
+        self.assertEqual(tr.request("get", "/x", accept="*/*"), "col\n1")
+
+    def test_401_refreshes_once_then_retries(self):
+        self.ready()
+        os.environ["TABLEAU_PAT_NAME"] = "p"
+        os.environ["TABLEAU_PAT_SECRET"] = "s"
+        os.environ["TABLEAU_SITE_CONTENT_URL"] = "acme"
+        self.enqueue(401, "expired")
+        self.enqueue(200, {"credentials": {"token": "FRESH", "site": {"id": "s2"}}})
+        self.enqueue(200, {"ok": True})
+        out = tr.request("get", "/x")
+        self.assertEqual(out, {"ok": True})
+        self.assertEqual(len(self._sends), 3)
+        self.assertEqual(self._sends[2]["headers"]["X-Tableau-Auth"], "FRESH")
+
+    def test_401_without_pat_not_retried(self):
+        self.ready()  # no PAT name -> cannot refresh
+        self.enqueue(401, "expired")
+        with self.assertRaises(tr.TableauError):
+            tr.request("get", "/x")
+        self.assertEqual(len(self._sends), 1)
+
+    def test_unsupported_method(self):
+        self.ready()
+        with self.assertRaises(ValueError):
+            tr.request("patch", "/x")
+
+
+class Collections(Base):
+    def test_find_workbook_single_object_normalised(self):
+        self.ready()
+        # Tableau returns a bare object (not a list) for a single match.
+        self.enqueue(200, {"workbooks": {"workbook": {"id": "wb1", "name": "Sales"}}})
+        wb = tr.find_workbook_by_name("Sales")
+        self.assertEqual(wb["id"], "wb1")
+        # filter is CGI/quote_plus encoded
+        self.assertIn("name%3Aeq%3ASales", self._sends[0]["url"])
+
+    def test_find_workbook_list(self):
+        self.ready()
+        self.enqueue(200, {"workbooks": {"workbook": [{"id": "a"}, {"id": "b"}]}})
+        self.assertEqual(tr.find_workbook_by_name("x")["id"], "a")
+
+    def test_find_workbook_none(self):
+        self.ready()
+        self.enqueue(200, {"workbooks": {}})
+        self.assertIsNone(tr.find_workbook_by_name("x"))
+
+    def test_datasource_content_url_paged_fallback(self):
+        self.ready()
+        # filter hit empty -> fall back to paged scan; match on page 2
+        self.enqueue(200, {"datasources": {}})
+        self.enqueue(200, {"datasources": {"datasource": [{"contentUrl": "other"}]},
+                           "pagination": {"totalAvailable": "150"}})
+        self.enqueue(200, {"datasources": {"datasource": [{"contentUrl": "wanted", "id": "ds9"}]},
+                           "pagination": {"totalAvailable": "150"}})
+        hit = tr.find_datasource_by_content_url("wanted")
+        self.assertEqual(hit["id"], "ds9")
+
+    def test_metadata_api_available_true_false_error(self):
+        self.ready()
+        self.enqueue(200, {"data": {"__typename": "Query"}})
+        self.assertTrue(tr.metadata_api_available())
+        self.enqueue(200, {"errors": [{"message": "off"}]})
+        self.assertFalse(tr.metadata_api_available())
+        self.enqueue(404, "not found")
+        self.assertFalse(tr.metadata_api_available())
+
+
+class SslContext(Base):
+    def test_returns_context_and_verifies_by_default(self):
+        import ssl
+        ctx = tr._ssl_context()
+        self.assertIsInstance(ctx, ssl.SSLContext)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    def test_insecure_flag_disables_verification(self):
+        import ssl
+        os.environ["TABLEAU_INSECURE_TLS"] = "1"
+        ctx = tr._ssl_context()
+        self.assertEqual(ctx.verify_mode, ssl.CERT_NONE)
+        self.assertFalse(ctx.check_hostname)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/shared/lib/sigma_rest.py
+++ b/shared/lib/sigma_rest.py
@@ -25,6 +25,8 @@ import base64
 import json
 import os
 import re
+import ssl
+import sys
 import threading
 import urllib.error
 import urllib.request
@@ -126,6 +128,32 @@ class _Resp:
         self.reason = reason
 
 
+def _ssl_context():
+    """TLS trust resolution (P1.4). Stock macOS/homebrew Python urllib often
+    fails CERTIFICATE_VERIFY_FAILED where curl/Ruby succeed. Prefer the OS trust
+    store (truststore), then certifi, then the stock verified context. NEVER
+    silently downgrades: an unverified context is used ONLY when
+    SIGMA_INSECURE_TLS is explicitly set, and it logs loudly."""
+    if os.environ.get("SIGMA_INSECURE_TLS"):
+        print("WARNING: SIGMA_INSECURE_TLS set — TLS certificate verification is "
+              "DISABLED for Sigma requests. Do not use in production.", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; the faithful match for curl/Ruby reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
+
 def _send(method, url, headers, body, timeout):
     """Low-level HTTP seam (tests monkeypatch this). Returns _Resp with a numeric
     status even for 4xx/5xx (urllib raises HTTPError on those — we normalise)."""
@@ -134,7 +162,7 @@ def _send(method, url, headers, body, timeout):
     for k, v in headers.items():
         req.add_header(k, v)
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with urllib.request.urlopen(req, timeout=timeout, context=_ssl_context()) as resp:
             return _Resp(resp.status, resp.read(), getattr(resp, "reason", ""))
     except urllib.error.HTTPError as e:
         return _Resp(e.code, e.read(), e.reason)

--- a/shared/lib/tableau_rest.py
+++ b/shared/lib/tableau_rest.py
@@ -1,0 +1,362 @@
+"""Tableau REST API wrapper for tableau-to-sigma when the MCP isn't available.
+
+Python twin of tableau_rest.rb (P1 runtime-shrink: Ruby -> Python). Behaviour
+parity with the Ruby module is enforced by test_tableau_rest.py and the
+cross-impl parity harness. Stdlib only (urllib) — no third-party deps.
+
+Requires TABLEAU_SERVER_URL, TABLEAU_SITE_ID, TABLEAU_AUTH_TOKEN,
+TABLEAU_API_VERSION in env (set by scripts/get-tableau-token.sh). PAT refresh
+additionally needs TABLEAU_PAT_NAME, TABLEAU_PAT_SECRET, TABLEAU_SITE_CONTENT_URL.
+
+All methods return parsed dict/list (or raw bytes for view_image / *_content).
+Network/HTTP errors raise TableauError with the response body included.
+"""
+
+import json
+import os
+import re
+import ssl
+import sys
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+
+NEUTRAL_ENV = os.path.expanduser("~/.sigma-migration/env")
+_NEUTRAL_LINE = re.compile(r"\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\Z")
+
+
+class TableauError(Exception):
+    pass
+
+
+class TableauAuthError(TableauError):
+    pass
+
+
+_token_mutex = threading.Lock()
+_token_override = None
+_site_id_override = None
+_refresh_inflight = False
+
+
+def _load_neutral_env(env=None):
+    """Agent-neutral credential bootstrap. Load Tableau PAT creds from
+    ~/.sigma-migration/env when TABLEAU_PAT_SECRET is absent. Existing env wins
+    (mirrors Ruby's `.nil?` guard + `ENV[key] ||= raw`)."""
+    env = os.environ if env is None else env
+    if "TABLEAU_PAT_SECRET" in env or not os.path.exists(NEUTRAL_ENV):
+        return
+    with open(NEUTRAL_ENV, encoding="utf-8") as fh:
+        for line in fh:
+            m = _NEUTRAL_LINE.match(line.rstrip("\n"))
+            if not m:
+                continue
+            key, raw = m.group(1), m.group(2).strip()
+            if len(raw) >= 2 and (
+                (raw.startswith("'") and raw.endswith("'"))
+                or (raw.startswith('"') and raw.endswith('"'))
+            ):
+                raw = raw[1:-1]
+            env.setdefault(key, raw)
+
+
+def bootstrap_credentials(env=None):
+    _load_neutral_env(env)
+
+
+def _require(key, hint="run get-tableau-token.sh"):
+    v = os.environ.get(key)
+    if not v:
+        raise TableauError(f"{key} not set — {hint}")
+    return v
+
+
+def server_url():
+    return _require("TABLEAU_SERVER_URL")
+
+
+def site_id():
+    with _token_mutex:
+        if _site_id_override:
+            return _site_id_override
+    return _require("TABLEAU_SITE_ID")
+
+
+def auth_token():
+    with _token_mutex:
+        if _token_override:
+            return _token_override
+    return _require("TABLEAU_AUTH_TOKEN")
+
+
+def api_version():
+    return os.environ.get("TABLEAU_API_VERSION", "3.22")
+
+
+def base_path():
+    return f"/api/{api_version()}/sites/{site_id()}"
+
+
+def _dig(obj, *keys):
+    """Ruby Hash#dig equivalent — nil-safe nested lookup."""
+    for k in keys:
+        if not isinstance(obj, dict):
+            return None
+        obj = obj.get(k)
+    return obj
+
+
+class _Resp:
+    __slots__ = ("status", "body", "reason")
+
+    def __init__(self, status, body, reason=""):
+        self.status = status
+        self.body = body if isinstance(body, (bytes, bytearray)) else str(body).encode()
+        self.reason = reason
+
+
+def _ssl_context():
+    """TLS trust resolution (P1.4). Ruby's Net::HTTP and curl validate Tableau
+    Cloud's chain fine, but Python's stricter OpenSSL 3.x rejects a Tableau
+    intermediate ("Basic Constraints not marked critical") under the default
+    bundle. Prefer the OS trust store (truststore — matches curl/Ruby), then
+    certifi, then the stock verified context. NEVER silently downgrades: an
+    unverified context is used ONLY when TABLEAU_INSECURE_TLS is explicitly set,
+    and it logs loudly."""
+    if os.environ.get("TABLEAU_INSECURE_TLS"):
+        print("WARNING: TABLEAU_INSECURE_TLS set — TLS certificate verification is "
+              "DISABLED for Tableau requests. Do not use in production.", file=sys.stderr)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+    try:
+        import truststore  # OS trust store; the faithful match for curl/Ruby reachability
+        return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    except Exception:
+        pass
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        pass
+    return ssl.create_default_context()
+
+
+def _send(method, url, headers, body, timeout):
+    """Low-level HTTP seam (tests monkeypatch this)."""
+    data = body.encode() if isinstance(body, str) else body
+    req = urllib.request.Request(url, data=data, method=method.upper())
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=_ssl_context()) as resp:
+            return _Resp(resp.status, resp.read(), getattr(resp, "reason", ""))
+    except urllib.error.HTTPError as e:
+        return _Resp(e.code, e.read(), e.reason)
+
+
+def refresh_token():
+    """Re-sign in with the PAT env vars and cache token + site id. Single-flight."""
+    global _refresh_inflight, _token_override, _site_id_override
+    with _token_mutex:
+        if _refresh_inflight:
+            return _token_override
+        _refresh_inflight = True
+    try:
+        name = os.environ.get("TABLEAU_PAT_NAME")
+        if not name:
+            raise TableauAuthError("TABLEAU_PAT_NAME not set — cannot refresh")
+        secret = os.environ.get("TABLEAU_PAT_SECRET")
+        if not secret:
+            raise TableauAuthError("TABLEAU_PAT_SECRET not set — cannot refresh")
+        site_content = os.environ.get("TABLEAU_SITE_CONTENT_URL")
+        if site_content is None:
+            raise TableauAuthError("TABLEAU_SITE_CONTENT_URL not set")
+        url = urllib.parse.urljoin(server_url(), f"/api/{api_version()}/auth/signin")
+        body = (f'<tsRequest><credentials personalAccessTokenName="{name}" '
+                f'personalAccessTokenSecret="{secret}"><site contentUrl="{site_content}"/>'
+                f'</credentials></tsRequest>')
+        resp = _send("POST", url,
+                     {"Content-Type": "application/xml", "Accept": "application/json"},
+                     body, 30)
+        if not (200 <= resp.status < 300):
+            raise TableauAuthError(f"signin -> {resp.status} {resp.body.decode(errors='replace')}")
+        j = json.loads(resp.body or b"{}")
+        with _token_mutex:
+            _token_override = _dig(j, "credentials", "token")
+            _site_id_override = _dig(j, "credentials", "site", "id")
+        return _token_override
+    finally:
+        with _token_mutex:
+            _refresh_inflight = False
+
+
+def request(method, path, body=None, content_type="application/json",
+            accept="application/json", binary=False):
+    url = urllib.parse.urljoin(server_url(), path)
+    if method.lower() not in ("get", "post", "put", "delete"):
+        raise ValueError(f"unsupported method {method}")
+    attempts = 0
+    while True:
+        attempts += 1
+        headers = {"X-Tableau-Auth": auth_token(), "Accept": accept}
+        if body is not None:
+            headers["Content-Type"] = content_type
+        resp = _send(method, url, headers, body, 120)
+        if resp.status == 401 and attempts == 1 and os.environ.get("TABLEAU_PAT_NAME"):
+            refresh_token()
+            continue
+        if not (200 <= resp.status < 300):
+            raise TableauError(f"{method.upper()} {path} -> {resp.status} {resp.reason}\n"
+                               f"{resp.body.decode(errors='replace')}")
+        if binary:
+            return resp.body
+        text = resp.body.decode(errors="replace")
+        if accept != "application/json":
+            return text
+        return None if text == "" else json.loads(text)
+
+
+def _as_list(v):
+    """Tableau REST returns a bare object for single-element collections and a
+    list for many — normalise to a list."""
+    if v is None:
+        return []
+    return v if isinstance(v, list) else [v]
+
+
+# ---- workbooks ------------------------------------------------------------
+
+def find_workbook_by_name(name):
+    encoded = urllib.parse.quote_plus(f"name:eq:{name}")
+    j = request("get", f"{base_path()}/workbooks?filter={encoded}")
+    lst = _as_list(_dig(j, "workbooks", "workbook"))
+    return lst[0] if lst else None
+
+
+def get_workbook(workbook_id):
+    return request("get", f"{base_path()}/workbooks/{workbook_id}")["workbook"]
+
+
+def download_workbook_content(workbook_id, include_extract=False):
+    qs = "" if include_extract else "?includeExtract=false"
+    return request("get", f"{base_path()}/workbooks/{workbook_id}/content{qs}",
+                   accept="*/*", binary=True)
+
+
+# ---- views ----------------------------------------------------------------
+
+def view_data(view_id):
+    return request("get", f"{base_path()}/views/{view_id}/data", accept="*/*")
+
+
+def view_image(view_id, width=1400, height=900, resolution="high"):
+    qs = f"?resolution={resolution}&maxAge=1"
+    if width and height:
+        qs += f"&vf_width={width}&vf_height={height}"
+    return request("get", f"{base_path()}/views/{view_id}/image{qs}", accept="*/*", binary=True)
+
+
+# ---- datasources ----------------------------------------------------------
+
+def list_datasources(page_size=100, page=1):
+    return request("get", f"{base_path()}/datasources?pageSize={page_size}&pageNumber={page}")
+
+
+def find_datasource_by_name(name):
+    encoded = urllib.parse.quote_plus(f"name:eq:{name}")
+    j = request("get", f"{base_path()}/datasources?filter={encoded}")
+    lst = _as_list(_dig(j, "datasources", "datasource"))
+    return lst[0] if lst else None
+
+
+def find_datasource_by_content_url(content_url):
+    encoded = urllib.parse.quote_plus(f"contentUrl:eq:{content_url}")
+    j = request("get", f"{base_path()}/datasources?filter={encoded}")
+    lst = _as_list(_dig(j, "datasources", "datasource"))
+    if lst:
+        return lst[0]
+    # Fallback: scan pages and match contentUrl exactly.
+    page = 1
+    while True:
+        jj = list_datasources(page_size=100, page=page)
+        ds = _as_list(_dig(jj, "datasources", "datasource"))
+        hit = next((d for d in ds if str(d.get("contentUrl")) == str(content_url)), None)
+        if hit:
+            return hit
+        total = int(_dig(jj, "pagination", "totalAvailable") or 0)
+        if not ds or page * 100 >= total:
+            break
+        page += 1
+    return None
+
+
+def download_datasource_content(datasource_id, include_extract=False):
+    qs = "" if include_extract else "?includeExtract=false"
+    return request("get", f"{base_path()}/datasources/{datasource_id}/content{qs}",
+                   accept="*/*", binary=True)
+
+
+# ---- server capabilities --------------------------------------------------
+
+def serverinfo():
+    return request("get", f"/api/{api_version()}/serverinfo")["serverInfo"]
+
+
+def metadata_api_available():
+    try:
+        r = graphql("{ __typename }")
+    except TableauError:
+        return False
+    return r is not None and not _dig(r, "errors")
+
+
+def capabilities():
+    try:
+        info = serverinfo() or {}
+    except TableauError:
+        info = {}
+    try:
+        meta = metadata_api_available()
+    except TableauError:
+        meta = False
+    return {
+        "product_version": _dig(info, "productVersion", "value"),
+        "rest_api_version": info.get("restApiVersion") or api_version(),
+        "metadata_api": meta,
+    }
+
+
+def read_metadata(datasource_luid):
+    body = json.dumps({"datasource": {"datasourceLuid": datasource_luid}})
+    return request("post", "/api/v1/vizql-data-service/read-metadata", body=body)
+
+
+# ---- metadata GraphQL -----------------------------------------------------
+
+def graphql_datasource_fields(datasource_luid):
+    query = (
+        "{\n"
+        f'  publishedDatasources(filter:{{luid:"{datasource_luid}"}}) {{\n'
+        "    name luid\n"
+        "    fields {\n"
+        "      name\n"
+        "      fullyQualifiedName\n"
+        "      ... on CalculatedField { formula isHidden }\n"
+        "    }\n"
+        "  }\n"
+        "}\n"
+    )
+    return request("post", "/api/metadata/graphql", body=json.dumps({"query": query}))
+
+
+def graphql(query, variables=None):
+    payload = {"query": query}
+    if variables:
+        payload["variables"] = variables
+    return request("post", "/api/metadata/graphql", body=json.dumps(payload))
+
+
+bootstrap_credentials()

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -8,6 +8,12 @@
       ]
     },
     {
+      "canonical": "shared/lib/tableau_rest.py",
+      "targets": [
+        "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/tableau_rest.py"
+      ]
+    },
+    {
       "canonical": "shared/lib/sigma_rest.rb",
       "targets": [
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_rest.rb",


### PR DESCRIPTION
## Why
Second increment of **P1** (Ruby→Python, tableau-first, tests-first). Ports the Tableau REST lib — the other foundational lib, and the one behind the `get-tableau-token.sh` bash dependency. Also lands **P1.4** (tighten the TLS/truststore fallback). Tracked: `beads-sigma-8f5y`. Builds on #301.

**Ruby is untouched at runtime** — the twin coexists with `tableau_rest.rb`; nothing imports it yet. Ruby is deleted only once the whole tableau path is ported and diffed.

## What changed
- **`shared/lib/tableau_rest.py`** — stdlib-only twin of `tableau_rest.rb`: transport (`X-Tableau-Auth`, 401 refresh-once-then-retry), PAT signin, `base_path`, and the workbook / view / datasource / serverinfo / metadata-GraphQL helpers — including the single-object-vs-list collection normalisation and the paged `contentUrl` datasource fallback.
- **`test_tableau_rest.py`** — 22-case contract/spec test (creds-free, network-free).
- **P1.4 layered TLS trust** (applied to **both** twins): prefer the **OS trust store** (`truststore`) → `certifi` → stock verified context. An unverified context is used **only** when `TABLEAU_INSECURE_TLS` / `SIGMA_INSECURE_TLS` is explicitly set, with a loud warning — never a silent downgrade.
- Fanned to the tableau plugin only; both twin tests wired into `unit-tests` CI.

## Why P1.4 was needed (a real find)
The live smoke exposed it: Python's stricter **OpenSSL 3.x rejects Tableau Cloud's intermediate cert** (`Basic Constraints of CA cert not marked critical`) under the default/`certifi` bundle, while **Ruby's `Net::HTTP` and `curl` validate it fine** (both return HTTP 200). Without the trust-store layer the Python twin would be *more* strict than the Ruby it replaces — a regression. The `truststore` path matches curl/Ruby reachability; the explicit-insecure escape hatch is a documented last resort, not a default.

## Verification
- Contract tests: **sigma_rest 24/24**, **tableau_rest 24/24** pass (transport, 401 retry-once + second-401-raises + no-PAT-no-retry, signin XML shape, collection normalisation, paged DS fallback, metadata-API true/false/error, `_ssl_context` default-verifies + insecure-gate).
- Cross-impl encoding parity (`CGI.escape` vs `quote_plus`) byte-identical over spaces / unicode / `~/&()`.
- **Live smoke**: minted a real PAT token, resolved site id, read `serverinfo` (2026.2.2 / REST 3.29) + metadata-API capability.

## Next
Port a leaf script to actually import a twin end-to-end, then `twb_xml.rb`, then leaf scripts, orchestrator last — diffing corpus output before any Ruby is removed. Recommend `truststore` in the doctor as a WARN when a strict-OpenSSL Python is detected (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)