### PR TITLE
doctor: WARN when Python OpenSSL 3.x lacks truststore (P1.4 companion)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 

--- a/shared/scripts/doctor.ps1
+++ b/shared/scripts/doctor.ps1
@@ -46,15 +46,35 @@ function Test-RealPython($exe, $pre) {
     return "$ver  ($where)"
   } catch { return $null }
 }
+$script:PyExe = $null; $script:PyPre = $null
 $py = Test-RealPython 'py' '-3'
-if ($py) { Ok "python - $py  [launcher: py -3]" }
+if ($py) { Ok "python - $py  [launcher: py -3]"; $script:PyExe = 'py'; $script:PyPre = '-3' }
 else {
   $py = Test-RealPython 'python' $null
-  if (-not $py) { $py = Test-RealPython 'python3' $null }
+  if ($py) { $script:PyExe = 'python' }
+  if (-not $py) { $py = Test-RealPython 'python3' $null; if ($py) { $script:PyExe = 'python3' } }
   if ($py) { Ok "python - $py" }
   else {
     Bad "no real Python (the 'python'/'python3' on PATH is likely the Microsoft Store alias stub)" `
         "Install Python from python.org (tick 'Add Python to PATH'), then use 'py -3'. OR disable the stub: Settings > Apps > Advanced app settings > App execution aliases > turn OFF python.exe / python3.exe. Re-run."
+  }
+}
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains under the default CA bundle (CERTIFICATE_VERIFY_FAILED where curl/Ruby
+# succeed). `truststore` (OS trust store) fixes it. WARN only when OpenSSL is
+# 3.x AND truststore is absent.
+if ($script:PyExe) {
+  $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
+  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
+    }
   }
 }
 

--- a/shared/scripts/doctor.ps1
+++ b/shared/scripts/doctor.ps1
@@ -67,14 +67,11 @@ else {
 # 3.x AND truststore is absent.
 if ($script:PyExe) {
   $pyArgs = @(); if ($script:PyPre) { $pyArgs += $script:PyPre }
-  & $script:PyExe @pyArgs -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    & $script:PyExe @pyArgs -c 'import truststore' 2>$null
-    if ($LASTEXITCODE -ne 0) {
-      $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
-      Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
-           "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
-    }
+  $probe = (& $script:PyExe @pyArgs -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>$null | Out-String).Trim()
+  if ($probe -eq 'TRUSTWARN') {
+    $fix = "$script:PyExe"; if ($script:PyPre) { $fix = "$script:PyExe $script:PyPre" }
+    Warn "python uses OpenSSL 3.x without 'truststore' - TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" `
+         "Fix: '$fix -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   }
 }
 

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -85,8 +85,9 @@ fi
 # CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
 # OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
 # absent — the exact combination that bites.
-if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
-  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+if [ -n "$PY_ARGV" ]; then
+  TLS_PROBE="$($PY_ARGV -c "import ssl,importlib.util as iu; print('TRUSTWARN' if ssl.OPENSSL_VERSION.startswith('OpenSSL 3') and iu.find_spec('truststore') is None else '')" 2>/dev/null)"
+  if [ "$TLS_PROBE" = "TRUSTWARN" ]; then
     warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
          "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -63,8 +63,9 @@ py_real() {
   case "$ver" in Python\ [0-9]*) : ;; *) return 1 ;; esac
   local where; where="$("$exe" "$@" -c 'import sys;print(sys.executable)' 2>/dev/null)" || return 1
   case "$(printf '%s' "$where" | tr 'A-Z' 'a-z')" in *windowsapps*) return 1 ;; esac
-  PY_DESC="$ver  ($where)"; PY_VER="$ver"; return 0
+  PY_DESC="$ver  ($where)"; PY_VER="$ver"; PY_ARGV="$exe${*:+ $*}"; return 0
 }
+PY_ARGV=""
 if   py_real py -3 ; then ok "python — $PY_DESC  [launcher: py -3]"
 elif py_real python3; then ok "python — $PY_DESC  [python3]"
 elif py_real python ; then ok "python — $PY_DESC  [python]"
@@ -74,6 +75,20 @@ else
         "Install Python from python.org (tick 'Add to PATH'), then use 'py -3', OR disable the stub: Settings → Apps → Advanced app settings → App execution aliases → turn OFF python.exe/python3.exe. Re-run."
   else
     bad "python3 not found" "macOS: 'brew install python'  •  Linux: 'apt-get install python3'."
+  fi
+fi
+
+# --- python TLS trust (P1.4) -----------------------------------------------
+# Python's OpenSSL 3.x is stricter than curl/Ruby and rejects some valid server
+# chains (e.g. Tableau Cloud's intermediate — "Basic Constraints not marked
+# critical") under the default CA bundle, so the Python REST path can fail
+# CERTIFICATE_VERIFY_FAILED where the Ruby path succeeds. `truststore` (uses the
+# OS trust store) fixes it. WARN only when OpenSSL is 3.x AND truststore is
+# absent — the exact combination that bites.
+if [ -n "$PY_ARGV" ] && $PY_ARGV -c 'import ssl,sys; sys.exit(0 if ssl.OPENSSL_VERSION.startswith("OpenSSL 3") else 1)' 2>/dev/null; then
+  if ! $PY_ARGV -c 'import truststore' 2>/dev/null; then
+    warn "python uses OpenSSL 3.x without 'truststore' — TLS verification may fail against some servers (e.g. Tableau Cloud) where curl/Ruby succeed" \
+         "Fix: '$PY_ARGV -m pip install truststore' (uses the OS trust store). Do NOT disable TLS verification."
   fi
 fi
 


### PR DESCRIPTION
## Why
Companion to #302's P1.4 TLS work. Python's OpenSSL 3.x rejects some valid server chains (notably **Tableau Cloud's intermediate cert** — `Basic Constraints not marked critical`) under the default CA bundle, failing `CERTIFICATE_VERIFY_FAILED` where curl/Ruby succeed. The Python REST twins prefer `truststore` (OS trust store) to match that reachability. This makes the doctor surface the gap *before* it bites.

## What
`doctor.sh` + `doctor.ps1` emit a **non-blocking WARN** when the resolved Python uses **OpenSSL 3.x AND `truststore` is absent** — the exact combination that fails — with the fix (`<python> -m pip install truststore`). Keyed narrowly so it doesn't fire on LibreSSL/OpenSSL-1.1 Pythons or when truststore is already present. Never suggests disabling TLS.

## Verification
- `doctor.sh` on macOS (OpenSSL 3.x, no truststore): WARN fires, exit 0, `doctor.json` still valid (`pass:true`).
- Keyed off `ssl.OPENSSL_VERSION` + `import truststore` probe via the resolved interpreter.
- `doctor.ps1` exercised by the `windows-smoke` CI job.
- Synced to all 22 doctor copies; `check-shared` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)