### PR TITLE
P1 leaf port: pick_destination.py twin (imports sigma_rest, live-parity)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -229,6 +229,7 @@ jobs:
             plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grid_fidelity.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_sigma_rest.py
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_tableau_rest.py
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_pick_destination.py
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/pick_destination.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/pick_destination.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Destination picker for the *-to-sigma migration skills (Python twin).
+
+Python port of pick-destination.rb (P1 Ruby->Python). Produces the folderId
+where a migrated data model + workbook should land. The SKILL drives the
+*asking*; this script just lists candidates and creates folders.
+
+    python pick_destination.py list
+        -> JSON { "workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}],
+                  "myDocuments": "<id>"|null }
+        Only folders the token can EDIT are returned. folderId in a DM/workbook POST
+        accepts either a workspace id (lands in the workspace root) or a folder id.
+
+    python pick_destination.py create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+        -> JSON { "id", "name", "parentId" }
+
+Env: SIGMA_BASE_URL + SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (or SIGMA_API_TOKEN).
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import sigma_rest  # noqa: E402
+
+
+def _get(path):
+    """GET returning a dict, swallowing errors to {} (mirrors Ruby `rescue {}`)."""
+    try:
+        return sigma_rest.request("get", path) or {}
+    except Exception:
+        return {}
+
+
+def my_documents_id():
+    # Only resolvable for a user-bound token; service-account tokens return None.
+    try:
+        uid = (_get("/v2/whoami") or {}).get("userId")
+        if not uid:
+            return None
+        entries = (_get(f"/v2/members/{uid}/files?typeFilters=folder&limit=500")
+                   or {}).get("entries") or []
+        hit = next((e for e in entries
+                    if e.get("name") == "My Documents" or e.get("path") == "My Documents"), None)
+        return hit and hit.get("id")
+    except Exception:
+        return None
+
+
+def cmd_list():
+    ws_entries = (_get("/v2/workspaces?limit=500") or {}).get("entries") or []
+    workspaces = [{"id": w.get("workspaceId") or w.get("id"), "name": w.get("name")}
+                  for w in ws_entries]
+    ws_name = {w["id"]: w["name"] for w in workspaces}
+    folder_entries = (_get("/v2/files?typeFilters=folder&limit=500") or {}).get("entries") or []
+    folders = [{"id": f.get("id"), "name": f.get("name"), "parentId": f.get("parentId"),
+                "parentName": ws_name.get(f.get("parentId"))}
+               for f in folder_entries if f.get("permission") == "edit"]
+    print(json.dumps({"workspaces": workspaces, "folders": folders,
+                      "myDocuments": my_documents_id()}, indent=2))
+
+
+def cmd_create(argv):
+    name = None
+    parent = None
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--name":
+            name = argv[i + 1] if i + 1 < len(argv) else None
+            i += 2
+        elif argv[i] == "--parent":
+            parent = argv[i + 1] if i + 1 < len(argv) else None
+            i += 2
+        else:
+            i += 1
+    if not name:
+        sys.exit("pick_destination create: --name is required")
+    if not parent:
+        parent = my_documents_id()
+    body = {"type": "folder", "name": name}
+    if parent:
+        body["parentId"] = parent
+    res = sigma_rest.request("post", "/v2/files", body=json.dumps(body))
+    print(json.dumps({"id": res.get("id"), "name": res.get("name"),
+                      "parentId": res.get("parentId")}, indent=2))
+
+
+def main(argv):
+    cmd = argv[0] if argv else None
+    if cmd in ("list", None):
+        cmd_list()
+    elif cmd == "create":
+        cmd_create(argv[1:])
+    else:
+        sys.exit("usage: pick_destination.py [list | create --name NAME [--parent ID]]")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_pick_destination.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test_pick_destination.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Contract test for pick_destination.py (P1 leaf port).
+
+Creds-free, network-free: sigma_rest.request is monkeypatched with canned API
+responses. Verifies the list shaping (workspace id fallback, edit-only folder
+filter, parentName join, myDocuments resolution) and create arg parsing / body.
+"""
+import io
+import json
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+sys.path.insert(0, os.path.join(_HERE, "lib"))
+import pick_destination as pd  # noqa: E402
+import sigma_rest  # noqa: E402
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self._orig = sigma_rest.request
+        self._routes = {}
+        self._posts = []
+        sigma_rest.request = self._fake
+        pd.sigma_rest = sigma_rest  # ensure the module ref points at our patched one
+
+    def tearDown(self):
+        sigma_rest.request = self._orig
+
+    def _fake(self, method, path, body=None, **kw):
+        if method == "post":
+            self._posts.append({"path": path, "body": body})
+            return self._routes.get(("post", path), {})
+        if ("get", path) in self._routes:
+            r = self._routes[("get", path)]
+            if isinstance(r, Exception):
+                raise r
+            return r
+        raise sigma_rest.SigmaError(f"unrouted GET {path}")
+
+    def route(self, method, path, resp):
+        self._routes[(method, path)] = resp
+
+    def run_main(self, argv):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            pd.main(argv)
+        return buf.getvalue()
+
+
+class ListCmd(Base):
+    def _base_routes(self):
+        self.route("get", "/v2/whoami", {"userId": "u1"})
+        self.route("get", "/v2/members/u1/files?typeFilters=folder&limit=500",
+                   {"entries": [{"id": "md1", "name": "My Documents"}]})
+        self.route("get", "/v2/workspaces?limit=500",
+                   {"entries": [{"workspaceId": "ws1", "name": "Sales"},
+                                {"id": "ws2", "name": "Ops"}]})
+        self.route("get", "/v2/files?typeFilters=folder&limit=500",
+                   {"entries": [
+                       {"id": "f1", "name": "Editable", "parentId": "ws1", "permission": "edit"},
+                       {"id": "f2", "name": "ReadOnly", "parentId": "ws1", "permission": "view"},
+                   ]})
+
+    def test_list_shape(self):
+        self._base_routes()
+        out = json.loads(self.run_main(["list"]))
+        # workspaceId falls back to id
+        self.assertEqual([w["id"] for w in out["workspaces"]], ["ws1", "ws2"])
+        # only edit-permission folders; parentName joined from workspaces
+        self.assertEqual(len(out["folders"]), 1)
+        self.assertEqual(out["folders"][0]["id"], "f1")
+        self.assertEqual(out["folders"][0]["parentName"], "Sales")
+        self.assertEqual(out["myDocuments"], "md1")
+
+    def test_default_argv_is_list(self):
+        self._base_routes()
+        self.assertEqual(self.run_main([]), self.run_main(["list"]))
+
+    def test_my_documents_none_for_service_token(self):
+        self.route("get", "/v2/whoami", {})  # no userId
+        self.route("get", "/v2/workspaces?limit=500", {"entries": []})
+        self.route("get", "/v2/files?typeFilters=folder&limit=500", {"entries": []})
+        out = json.loads(self.run_main(["list"]))
+        self.assertIsNone(out["myDocuments"])
+
+    def test_errors_swallowed_to_empty(self):
+        # whoami raises -> myDocuments None; workspaces raise -> empty lists
+        self.route("get", "/v2/whoami", sigma_rest.SigmaError("boom"))
+        self.route("get", "/v2/workspaces?limit=500", sigma_rest.SigmaError("boom"))
+        self.route("get", "/v2/files?typeFilters=folder&limit=500", sigma_rest.SigmaError("boom"))
+        out = json.loads(self.run_main(["list"]))
+        self.assertEqual(out, {"workspaces": [], "folders": [], "myDocuments": None})
+
+
+class CreateCmd(Base):
+    def test_create_with_parent(self):
+        self.route("post", "/v2/files", {"id": "new1", "name": "Migrated", "parentId": "ws1"})
+        out = json.loads(self.run_main(["create", "--name", "Migrated", "--parent", "ws1"]))
+        self.assertEqual(out, {"id": "new1", "name": "Migrated", "parentId": "ws1"})
+        self.assertEqual(json.loads(self._posts[0]["body"]),
+                         {"type": "folder", "name": "Migrated", "parentId": "ws1"})
+
+    def test_create_defaults_parent_to_my_documents(self):
+        self.route("get", "/v2/whoami", {"userId": "u1"})
+        self.route("get", "/v2/members/u1/files?typeFilters=folder&limit=500",
+                   {"entries": [{"id": "md1", "name": "My Documents"}]})
+        self.route("post", "/v2/files", {"id": "n", "name": "X", "parentId": "md1"})
+        self.run_main(["create", "--name", "X"])
+        self.assertEqual(json.loads(self._posts[0]["body"])["parentId"], "md1")
+
+    def test_create_requires_name(self):
+        with self.assertRaises(SystemExit):
+            self.run_main(["create", "--parent", "ws1"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Why
Third P1 increment — proves the Python REST twin (`sigma_rest.py`, from #301) works **end-to-end in a real leaf script**, and establishes the leaf-port pattern. Tracked: `beads-sigma-192c`. Builds on #301/#302/#303.

**Ruby untouched at runtime** — `pick-destination.rb` stays; the twin is parity-verified and CI-guarded but not yet wired into the orchestrator (that ports last, per the plan).

## What
- **`pick_destination.py`** — Python port of `pick-destination.rb`, imports `sigma_rest`: `list` (workspaces / edit-only folders / myDocuments) and `create` (folder).
- **`test_pick_destination.py`** — 7-case contract test (creds-free; `sigma_rest.request` mocked): workspaceId fallback, edit-only folder filter, parentName join, myDocuments resolution, errors→empty, create arg parsing + body + name-required.
- Wired into `unit-tests` CI.

## Verification
- 7/7 contract tests pass.
- **Live end-to-end parity**: `ruby pick-destination.rb list` and `python pick_destination.py list` return **byte-identical data** against the real org (8 workspaces, 39 folders, myDocuments resolved). Confirms the full seam: script → `sigma_rest.py` → live Sigma API.

## Next
Continue the leaf ports (diff each against Ruby), then `twb_xml.rb`, orchestrator last; only then delete the Ruby and shrink the doctor REQUIRED list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)