### PR TITLE
v3 Week 0: doctor version-drift gate + agent-vision fingerprint + telemetry design metrics

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -40,6 +40,10 @@ jobs:
     timeout-minutes: 12
     env:
       TS_SKILL: plugins/tableau-to-sigma/skills/tableau-to-sigma
+      # CI is a shallow checkout — the version-drift probe is meaningless here and
+      # rev-list against a grafted origin/main is unreliable. Skip it explicitly
+      # (the doctors also auto-skip on a shallow clone).
+      SIGMA_SKIP_VERSION_CHECK: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-assessment/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/sigma_telemetry.py
@@ -122,6 +122,7 @@ def report_migration(
     client_agent: str = None,
     run_id: str = None,
     doctor: dict = None,
+    design: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -179,6 +180,21 @@ def report_migration(
             "sandbox_hint": doctor.get("sandbox_hint"),
             "pass":         doctor.get("pass"),
             "runtimes":     sorted(k for k, v in rt.items() if v),
+            # version-drift + agent-capability fingerprint (v3 §2.1/§2.2)
+            "behind_count": doctor.get("behind_count"),
+            "agent_vision": doctor.get("agent_vision"),
+            "model_hint":   doctor.get("model_hint"),
+        }
+
+    # Design-fidelity metrics (v3 §2.4) — makes the design half of cross-user
+    # variance visible in telemetry (not just the environment half). Coarse: a
+    # waiver bit, a pass count, a rubric score, a gate verdict. No customer data.
+    if design:
+        payload["design"] = {
+            "layout_fill_waived":   design.get("layout_fill_waived"),
+            "rcf_passes":           design.get("rcf_passes"),
+            "fidelity_rubric_score": design.get("fidelity_rubric_score"),
+            "visual_gate":          design.get("visual_gate"),
         }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/report-telemetry.py
@@ -67,6 +67,16 @@ parser.add_argument('--failure-stage', default=None,
                     choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
                     help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
+# Design-fidelity metrics (v3 §2.4) — the design half of cross-user variance.
+parser.add_argument('--layout-fill-waived', dest='layout_fill_waived', action='store_true',
+                    help='the auto layout-fill gate was waived (--skip-layout-fill) for this run')
+parser.add_argument('--rcf-passes', type=int, default=None,
+                    help='number of render-compare-fix passes performed')
+parser.add_argument('--rubric-score', type=float, default=None,
+                    help='fidelity rubric score for the run')
+parser.add_argument('--visual-gate', default=None,
+                    choices=['pass', 'fail', 'not-executable'],
+                    help='visual gate verdict (not-executable = driving agent lacked vision)')
 args = parser.parse_args()
 
 
@@ -118,6 +128,17 @@ def _load_doctor(workdir):
 
 _doctor = _load_doctor(getattr(args, 'workdir', None))
 
+# Design metrics: explicit flags win; otherwise leave None (absent from payload).
+_design = None
+if (args.layout_fill_waived or args.rcf_passes is not None
+        or args.rubric_score is not None or args.visual_gate is not None):
+    _design = {
+        'layout_fill_waived': args.layout_fill_waived,
+        'rcf_passes': args.rcf_passes,
+        'fidelity_rubric_score': args.rubric_score,
+        'visual_gate': args.visual_gate,
+    }
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -127,6 +148,7 @@ sent = report_migration(
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
     doctor=_doctor,
+    design=_design,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/sigma_telemetry.py
@@ -122,6 +122,7 @@ def report_migration(
     client_agent: str = None,
     run_id: str = None,
     doctor: dict = None,
+    design: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -179,6 +180,21 @@ def report_migration(
             "sandbox_hint": doctor.get("sandbox_hint"),
             "pass":         doctor.get("pass"),
             "runtimes":     sorted(k for k, v in rt.items() if v),
+            # version-drift + agent-capability fingerprint (v3 §2.1/§2.2)
+            "behind_count": doctor.get("behind_count"),
+            "agent_vision": doctor.get("agent_vision"),
+            "model_hint":   doctor.get("model_hint"),
+        }
+
+    # Design-fidelity metrics (v3 §2.4) — makes the design half of cross-user
+    # variance visible in telemetry (not just the environment half). Coarse: a
+    # waiver bit, a pass count, a rubric score, a gate verdict. No customer data.
+    if design:
+        payload["design"] = {
+            "layout_fill_waived":   design.get("layout_fill_waived"),
+            "rcf_passes":           design.get("rcf_passes"),
+            "fidelity_rubric_score": design.get("fidelity_rubric_score"),
+            "visual_gate":          design.get("visual_gate"),
         }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/report-telemetry.py
@@ -67,6 +67,16 @@ parser.add_argument('--failure-stage', default=None,
                     choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
                     help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
+# Design-fidelity metrics (v3 §2.4) — the design half of cross-user variance.
+parser.add_argument('--layout-fill-waived', dest='layout_fill_waived', action='store_true',
+                    help='the auto layout-fill gate was waived (--skip-layout-fill) for this run')
+parser.add_argument('--rcf-passes', type=int, default=None,
+                    help='number of render-compare-fix passes performed')
+parser.add_argument('--rubric-score', type=float, default=None,
+                    help='fidelity rubric score for the run')
+parser.add_argument('--visual-gate', default=None,
+                    choices=['pass', 'fail', 'not-executable'],
+                    help='visual gate verdict (not-executable = driving agent lacked vision)')
 args = parser.parse_args()
 
 
@@ -118,6 +128,17 @@ def _load_doctor(workdir):
 
 _doctor = _load_doctor(getattr(args, 'workdir', None))
 
+# Design metrics: explicit flags win; otherwise leave None (absent from payload).
+_design = None
+if (args.layout_fill_waived or args.rcf_passes is not None
+        or args.rubric_score is not None or args.visual_gate is not None):
+    _design = {
+        'layout_fill_waived': args.layout_fill_waived,
+        'rcf_passes': args.rcf_passes,
+        'fidelity_rubric_score': args.rubric_score,
+        'visual_gate': args.visual_gate,
+    }
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -127,6 +148,7 @@ sent = report_migration(
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
     doctor=_doctor,
+    design=_design,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-assessment/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/sigma_telemetry.py
@@ -122,6 +122,7 @@ def report_migration(
     client_agent: str = None,
     run_id: str = None,
     doctor: dict = None,
+    design: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -179,6 +180,21 @@ def report_migration(
             "sandbox_hint": doctor.get("sandbox_hint"),
             "pass":         doctor.get("pass"),
             "runtimes":     sorted(k for k, v in rt.items() if v),
+            # version-drift + agent-capability fingerprint (v3 §2.1/§2.2)
+            "behind_count": doctor.get("behind_count"),
+            "agent_vision": doctor.get("agent_vision"),
+            "model_hint":   doctor.get("model_hint"),
+        }
+
+    # Design-fidelity metrics (v3 §2.4) — makes the design half of cross-user
+    # variance visible in telemetry (not just the environment half). Coarse: a
+    # waiver bit, a pass count, a rubric score, a gate verdict. No customer data.
+    if design:
+        payload["design"] = {
+            "layout_fill_waived":   design.get("layout_fill_waived"),
+            "rcf_passes":           design.get("rcf_passes"),
+            "fidelity_rubric_score": design.get("fidelity_rubric_score"),
+            "visual_gate":          design.get("visual_gate"),
         }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/report-telemetry.py
@@ -67,6 +67,16 @@ parser.add_argument('--failure-stage', default=None,
                     choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
                     help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
+# Design-fidelity metrics (v3 §2.4) — the design half of cross-user variance.
+parser.add_argument('--layout-fill-waived', dest='layout_fill_waived', action='store_true',
+                    help='the auto layout-fill gate was waived (--skip-layout-fill) for this run')
+parser.add_argument('--rcf-passes', type=int, default=None,
+                    help='number of render-compare-fix passes performed')
+parser.add_argument('--rubric-score', type=float, default=None,
+                    help='fidelity rubric score for the run')
+parser.add_argument('--visual-gate', default=None,
+                    choices=['pass', 'fail', 'not-executable'],
+                    help='visual gate verdict (not-executable = driving agent lacked vision)')
 args = parser.parse_args()
 
 
@@ -118,6 +128,17 @@ def _load_doctor(workdir):
 
 _doctor = _load_doctor(getattr(args, 'workdir', None))
 
+# Design metrics: explicit flags win; otherwise leave None (absent from payload).
+_design = None
+if (args.layout_fill_waived or args.rcf_passes is not None
+        or args.rubric_score is not None or args.visual_gate is not None):
+    _design = {
+        'layout_fill_waived': args.layout_fill_waived,
+        'rcf_passes': args.rcf_passes,
+        'fidelity_rubric_score': args.rubric_score,
+        'visual_gate': args.visual_gate,
+    }
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -127,6 +148,7 @@ sent = report_migration(
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
     doctor=_doctor,
+    design=_design,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-assessment/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/sigma_telemetry.py
@@ -122,6 +122,7 @@ def report_migration(
     client_agent: str = None,
     run_id: str = None,
     doctor: dict = None,
+    design: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -179,6 +180,21 @@ def report_migration(
             "sandbox_hint": doctor.get("sandbox_hint"),
             "pass":         doctor.get("pass"),
             "runtimes":     sorted(k for k, v in rt.items() if v),
+            # version-drift + agent-capability fingerprint (v3 §2.1/§2.2)
+            "behind_count": doctor.get("behind_count"),
+            "agent_vision": doctor.get("agent_vision"),
+            "model_hint":   doctor.get("model_hint"),
+        }
+
+    # Design-fidelity metrics (v3 §2.4) — makes the design half of cross-user
+    # variance visible in telemetry (not just the environment half). Coarse: a
+    # waiver bit, a pass count, a rubric score, a gate verdict. No customer data.
+    if design:
+        payload["design"] = {
+            "layout_fill_waived":   design.get("layout_fill_waived"),
+            "rcf_passes":           design.get("rcf_passes"),
+            "fidelity_rubric_score": design.get("fidelity_rubric_score"),
+            "visual_gate":          design.get("visual_gate"),
         }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/report-telemetry.py
@@ -67,6 +67,16 @@ parser.add_argument('--failure-stage', default=None,
                     choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
                     help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
+# Design-fidelity metrics (v3 §2.4) — the design half of cross-user variance.
+parser.add_argument('--layout-fill-waived', dest='layout_fill_waived', action='store_true',
+                    help='the auto layout-fill gate was waived (--skip-layout-fill) for this run')
+parser.add_argument('--rcf-passes', type=int, default=None,
+                    help='number of render-compare-fix passes performed')
+parser.add_argument('--rubric-score', type=float, default=None,
+                    help='fidelity rubric score for the run')
+parser.add_argument('--visual-gate', default=None,
+                    choices=['pass', 'fail', 'not-executable'],
+                    help='visual gate verdict (not-executable = driving agent lacked vision)')
 args = parser.parse_args()
 
 
@@ -118,6 +128,17 @@ def _load_doctor(workdir):
 
 _doctor = _load_doctor(getattr(args, 'workdir', None))
 
+# Design metrics: explicit flags win; otherwise leave None (absent from payload).
+_design = None
+if (args.layout_fill_waived or args.rcf_passes is not None
+        or args.rubric_score is not None or args.visual_gate is not None):
+    _design = {
+        'layout_fill_waived': args.layout_fill_waived,
+        'rcf_passes': args.rcf_passes,
+        'fidelity_rubric_score': args.rubric_score,
+        'visual_gate': args.visual_gate,
+    }
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -127,6 +148,7 @@ sent = report_migration(
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
     doctor=_doctor,
+    design=_design,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/sigma_telemetry.py
@@ -122,6 +122,7 @@ def report_migration(
     client_agent: str = None,
     run_id: str = None,
     doctor: dict = None,
+    design: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -179,6 +180,21 @@ def report_migration(
             "sandbox_hint": doctor.get("sandbox_hint"),
             "pass":         doctor.get("pass"),
             "runtimes":     sorted(k for k, v in rt.items() if v),
+            # version-drift + agent-capability fingerprint (v3 §2.1/§2.2)
+            "behind_count": doctor.get("behind_count"),
+            "agent_vision": doctor.get("agent_vision"),
+            "model_hint":   doctor.get("model_hint"),
+        }
+
+    # Design-fidelity metrics (v3 §2.4) — makes the design half of cross-user
+    # variance visible in telemetry (not just the environment half). Coarse: a
+    # waiver bit, a pass count, a rubric score, a gate verdict. No customer data.
+    if design:
+        payload["design"] = {
+            "layout_fill_waived":   design.get("layout_fill_waived"),
+            "rcf_passes":           design.get("rcf_passes"),
+            "fidelity_rubric_score": design.get("fidelity_rubric_score"),
+            "visual_gate":          design.get("visual_gate"),
         }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/report-telemetry.py
@@ -67,6 +67,16 @@ parser.add_argument('--failure-stage', default=None,
                     choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
                     help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
+# Design-fidelity metrics (v3 §2.4) — the design half of cross-user variance.
+parser.add_argument('--layout-fill-waived', dest='layout_fill_waived', action='store_true',
+                    help='the auto layout-fill gate was waived (--skip-layout-fill) for this run')
+parser.add_argument('--rcf-passes', type=int, default=None,
+                    help='number of render-compare-fix passes performed')
+parser.add_argument('--rubric-score', type=float, default=None,
+                    help='fidelity rubric score for the run')
+parser.add_argument('--visual-gate', default=None,
+                    choices=['pass', 'fail', 'not-executable'],
+                    help='visual gate verdict (not-executable = driving agent lacked vision)')
 args = parser.parse_args()
 
 
@@ -118,6 +128,17 @@ def _load_doctor(workdir):
 
 _doctor = _load_doctor(getattr(args, 'workdir', None))
 
+# Design metrics: explicit flags win; otherwise leave None (absent from payload).
+_design = None
+if (args.layout_fill_waived or args.rcf_passes is not None
+        or args.rubric_score is not None or args.visual_gate is not None):
+    _design = {
+        'layout_fill_waived': args.layout_fill_waived,
+        'rcf_passes': args.rcf_passes,
+        'fidelity_rubric_score': args.rubric_score,
+        'visual_gate': args.visual_gate,
+    }
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -127,6 +148,7 @@ sent = report_migration(
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
     doctor=_doctor,
+    design=_design,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-assessment/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/sigma_telemetry.py
@@ -122,6 +122,7 @@ def report_migration(
     client_agent: str = None,
     run_id: str = None,
     doctor: dict = None,
+    design: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -179,6 +180,21 @@ def report_migration(
             "sandbox_hint": doctor.get("sandbox_hint"),
             "pass":         doctor.get("pass"),
             "runtimes":     sorted(k for k, v in rt.items() if v),
+            # version-drift + agent-capability fingerprint (v3 §2.1/§2.2)
+            "behind_count": doctor.get("behind_count"),
+            "agent_vision": doctor.get("agent_vision"),
+            "model_hint":   doctor.get("model_hint"),
+        }
+
+    # Design-fidelity metrics (v3 §2.4) — makes the design half of cross-user
+    # variance visible in telemetry (not just the environment half). Coarse: a
+    # waiver bit, a pass count, a rubric score, a gate verdict. No customer data.
+    if design:
+        payload["design"] = {
+            "layout_fill_waived":   design.get("layout_fill_waived"),
+            "rcf_passes":           design.get("rcf_passes"),
+            "fidelity_rubric_score": design.get("fidelity_rubric_score"),
+            "visual_gate":          design.get("visual_gate"),
         }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/report-telemetry.py
@@ -67,6 +67,16 @@ parser.add_argument('--failure-stage', default=None,
                     choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
                     help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
+# Design-fidelity metrics (v3 §2.4) — the design half of cross-user variance.
+parser.add_argument('--layout-fill-waived', dest='layout_fill_waived', action='store_true',
+                    help='the auto layout-fill gate was waived (--skip-layout-fill) for this run')
+parser.add_argument('--rcf-passes', type=int, default=None,
+                    help='number of render-compare-fix passes performed')
+parser.add_argument('--rubric-score', type=float, default=None,
+                    help='fidelity rubric score for the run')
+parser.add_argument('--visual-gate', default=None,
+                    choices=['pass', 'fail', 'not-executable'],
+                    help='visual gate verdict (not-executable = driving agent lacked vision)')
 args = parser.parse_args()
 
 
@@ -118,6 +128,17 @@ def _load_doctor(workdir):
 
 _doctor = _load_doctor(getattr(args, 'workdir', None))
 
+# Design metrics: explicit flags win; otherwise leave None (absent from payload).
+_design = None
+if (args.layout_fill_waived or args.rcf_passes is not None
+        or args.rubric_score is not None or args.visual_gate is not None):
+    _design = {
+        'layout_fill_waived': args.layout_fill_waived,
+        'rcf_passes': args.rcf_passes,
+        'fidelity_rubric_score': args.rubric_score,
+        'visual_gate': args.visual_gate,
+    }
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -127,6 +148,7 @@ sent = report_migration(
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
     doctor=_doctor,
+    design=_design,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/sigma_telemetry.py
@@ -122,6 +122,7 @@ def report_migration(
     client_agent: str = None,
     run_id: str = None,
     doctor: dict = None,
+    design: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -179,6 +180,21 @@ def report_migration(
             "sandbox_hint": doctor.get("sandbox_hint"),
             "pass":         doctor.get("pass"),
             "runtimes":     sorted(k for k, v in rt.items() if v),
+            # version-drift + agent-capability fingerprint (v3 §2.1/§2.2)
+            "behind_count": doctor.get("behind_count"),
+            "agent_vision": doctor.get("agent_vision"),
+            "model_hint":   doctor.get("model_hint"),
+        }
+
+    # Design-fidelity metrics (v3 §2.4) — makes the design half of cross-user
+    # variance visible in telemetry (not just the environment half). Coarse: a
+    # waiver bit, a pass count, a rubric score, a gate verdict. No customer data.
+    if design:
+        payload["design"] = {
+            "layout_fill_waived":   design.get("layout_fill_waived"),
+            "rcf_passes":           design.get("rcf_passes"),
+            "fidelity_rubric_score": design.get("fidelity_rubric_score"),
+            "visual_gate":          design.get("visual_gate"),
         }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/report-telemetry.py
@@ -67,6 +67,16 @@ parser.add_argument('--failure-stage', default=None,
                     choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
                     help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
+# Design-fidelity metrics (v3 §2.4) — the design half of cross-user variance.
+parser.add_argument('--layout-fill-waived', dest='layout_fill_waived', action='store_true',
+                    help='the auto layout-fill gate was waived (--skip-layout-fill) for this run')
+parser.add_argument('--rcf-passes', type=int, default=None,
+                    help='number of render-compare-fix passes performed')
+parser.add_argument('--rubric-score', type=float, default=None,
+                    help='fidelity rubric score for the run')
+parser.add_argument('--visual-gate', default=None,
+                    choices=['pass', 'fail', 'not-executable'],
+                    help='visual gate verdict (not-executable = driving agent lacked vision)')
 args = parser.parse_args()
 
 
@@ -118,6 +128,17 @@ def _load_doctor(workdir):
 
 _doctor = _load_doctor(getattr(args, 'workdir', None))
 
+# Design metrics: explicit flags win; otherwise leave None (absent from payload).
+_design = None
+if (args.layout_fill_waived or args.rcf_passes is not None
+        or args.rubric_score is not None or args.visual_gate is not None):
+    _design = {
+        'layout_fill_waived': args.layout_fill_waived,
+        'rcf_passes': args.rcf_passes,
+        'fidelity_rubric_score': args.rubric_score,
+        'visual_gate': args.visual_gate,
+    }
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -127,6 +148,7 @@ sent = report_migration(
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
     doctor=_doctor,
+    design=_design,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-assessment/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-doctor-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-doctor-ran.rb
@@ -72,6 +72,21 @@ rt = d['runtimes'] || {}
 env_desc = "os=#{d['os']} shell=#{d['shell']} sandbox=#{d['sandbox_hint']} " \
            "runtimes=[#{rt.select { |_, v| v }.keys.join(',')}]"
 
+# Version-drift hard gate (v3 §2.1). A plugin many commits behind origin/main is
+# missing the fidelity layer — the #1 measured cause of "looks better on another
+# machine". WARN lives in the doctor; the orchestrator preflight BLOCKS above a
+# threshold. Override with SIGMA_MAX_BEHIND; waive with --skip-doctor-gate.
+threshold = (ENV['SIGMA_MAX_BEHIND'] || '50').to_i
+behind = d['behind_count']
+if behind.is_a?(Integer) && behind > threshold
+  warn "[FAIL] environment gate — skill is #{behind} commit(s) behind origin/main " \
+       "(> #{threshold}); the installed build (#{d['skill_sha']}) is missing fidelity-layer fixes."
+  warn '       Update the skill checkout: git pull (or reinstall the plugin), re-run the'
+  warn '       doctor, then retry. Tune the bar with SIGMA_MAX_BEHIND=<n>.'
+  warn '       Escape hatch (name it in your report): --skip-doctor-gate "<reason>".'
+  exit 1
+end
+
 if d['pass']
   puts "[PASS] environment gate — doctor.json OK (#{env_desc}). Source: #{path}"
   exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_telemetry.py
@@ -122,6 +122,7 @@ def report_migration(
     client_agent: str = None,
     run_id: str = None,
     doctor: dict = None,
+    design: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -179,6 +180,21 @@ def report_migration(
             "sandbox_hint": doctor.get("sandbox_hint"),
             "pass":         doctor.get("pass"),
             "runtimes":     sorted(k for k, v in rt.items() if v),
+            # version-drift + agent-capability fingerprint (v3 §2.1/§2.2)
+            "behind_count": doctor.get("behind_count"),
+            "agent_vision": doctor.get("agent_vision"),
+            "model_hint":   doctor.get("model_hint"),
+        }
+
+    # Design-fidelity metrics (v3 §2.4) — makes the design half of cross-user
+    # variance visible in telemetry (not just the environment half). Coarse: a
+    # waiver bit, a pass count, a rubric score, a gate verdict. No customer data.
+    if design:
+        payload["design"] = {
+            "layout_fill_waived":   design.get("layout_fill_waived"),
+            "rcf_passes":           design.get("rcf_passes"),
+            "fidelity_rubric_score": design.get("fidelity_rubric_score"),
+            "visual_gate":          design.get("visual_gate"),
         }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/report-telemetry.py
@@ -67,6 +67,16 @@ parser.add_argument('--failure-stage', default=None,
                     choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
                     help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
+# Design-fidelity metrics (v3 §2.4) — the design half of cross-user variance.
+parser.add_argument('--layout-fill-waived', dest='layout_fill_waived', action='store_true',
+                    help='the auto layout-fill gate was waived (--skip-layout-fill) for this run')
+parser.add_argument('--rcf-passes', type=int, default=None,
+                    help='number of render-compare-fix passes performed')
+parser.add_argument('--rubric-score', type=float, default=None,
+                    help='fidelity rubric score for the run')
+parser.add_argument('--visual-gate', default=None,
+                    choices=['pass', 'fail', 'not-executable'],
+                    help='visual gate verdict (not-executable = driving agent lacked vision)')
 args = parser.parse_args()
 
 
@@ -118,6 +128,17 @@ def _load_doctor(workdir):
 
 _doctor = _load_doctor(getattr(args, 'workdir', None))
 
+# Design metrics: explicit flags win; otherwise leave None (absent from payload).
+_design = None
+if (args.layout_fill_waived or args.rcf_passes is not None
+        or args.rubric_score is not None or args.visual_gate is not None):
+    _design = {
+        'layout_fill_waived': args.layout_fill_waived,
+        'rcf_passes': args.rcf_passes,
+        'fidelity_rubric_score': args.rubric_score,
+        'visual_gate': args.visual_gate,
+    }
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -127,6 +148,7 @@ sent = report_migration(
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
     doctor=_doctor,
+    design=_design,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/sigma_telemetry.py
@@ -122,6 +122,7 @@ def report_migration(
     client_agent: str = None,
     run_id: str = None,
     doctor: dict = None,
+    design: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -179,6 +180,21 @@ def report_migration(
             "sandbox_hint": doctor.get("sandbox_hint"),
             "pass":         doctor.get("pass"),
             "runtimes":     sorted(k for k, v in rt.items() if v),
+            # version-drift + agent-capability fingerprint (v3 §2.1/§2.2)
+            "behind_count": doctor.get("behind_count"),
+            "agent_vision": doctor.get("agent_vision"),
+            "model_hint":   doctor.get("model_hint"),
+        }
+
+    # Design-fidelity metrics (v3 §2.4) — makes the design half of cross-user
+    # variance visible in telemetry (not just the environment half). Coarse: a
+    # waiver bit, a pass count, a rubric score, a gate verdict. No customer data.
+    if design:
+        payload["design"] = {
+            "layout_fill_waived":   design.get("layout_fill_waived"),
+            "rcf_passes":           design.get("rcf_passes"),
+            "fidelity_rubric_score": design.get("fidelity_rubric_score"),
+            "visual_gate":          design.get("visual_gate"),
         }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/report-telemetry.py
@@ -67,6 +67,16 @@ parser.add_argument('--failure-stage', default=None,
                     choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
                     help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
+# Design-fidelity metrics (v3 §2.4) — the design half of cross-user variance.
+parser.add_argument('--layout-fill-waived', dest='layout_fill_waived', action='store_true',
+                    help='the auto layout-fill gate was waived (--skip-layout-fill) for this run')
+parser.add_argument('--rcf-passes', type=int, default=None,
+                    help='number of render-compare-fix passes performed')
+parser.add_argument('--rubric-score', type=float, default=None,
+                    help='fidelity rubric score for the run')
+parser.add_argument('--visual-gate', default=None,
+                    choices=['pass', 'fail', 'not-executable'],
+                    help='visual gate verdict (not-executable = driving agent lacked vision)')
 args = parser.parse_args()
 
 
@@ -118,6 +128,17 @@ def _load_doctor(workdir):
 
 _doctor = _load_doctor(getattr(args, 'workdir', None))
 
+# Design metrics: explicit flags win; otherwise leave None (absent from payload).
+_design = None
+if (args.layout_fill_waived or args.rcf_passes is not None
+        or args.rubric_score is not None or args.visual_gate is not None):
+    _design = {
+        'layout_fill_waived': args.layout_fill_waived,
+        'rcf_passes': args.rcf_passes,
+        'fidelity_rubric_score': args.rubric_score,
+        'visual_gate': args.visual_gate,
+    }
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -127,6 +148,7 @@ sent = report_migration(
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
     doctor=_doctor,
+    design=_design,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.

--- a/shared/lib/sigma_telemetry.py
+++ b/shared/lib/sigma_telemetry.py
@@ -122,6 +122,7 @@ def report_migration(
     client_agent: str = None,
     run_id: str = None,
     doctor: dict = None,
+    design: dict = None,
     endpoint: str = TELEMETRY_ENDPOINT,
     timeout: int = 5,
 ) -> bool:
@@ -179,6 +180,21 @@ def report_migration(
             "sandbox_hint": doctor.get("sandbox_hint"),
             "pass":         doctor.get("pass"),
             "runtimes":     sorted(k for k, v in rt.items() if v),
+            # version-drift + agent-capability fingerprint (v3 §2.1/§2.2)
+            "behind_count": doctor.get("behind_count"),
+            "agent_vision": doctor.get("agent_vision"),
+            "model_hint":   doctor.get("model_hint"),
+        }
+
+    # Design-fidelity metrics (v3 §2.4) — makes the design half of cross-user
+    # variance visible in telemetry (not just the environment half). Coarse: a
+    # waiver bit, a pass count, a rubric score, a gate verdict. No customer data.
+    if design:
+        payload["design"] = {
+            "layout_fill_waived":   design.get("layout_fill_waived"),
+            "rcf_passes":           design.get("rcf_passes"),
+            "fidelity_rubric_score": design.get("fidelity_rubric_score"),
+            "visual_gate":          design.get("visual_gate"),
         }
 
     print("\nReporting anonymous migration telemetry (no customer data sent):")

--- a/shared/scripts/doctor.ps1
+++ b/shared/scripts/doctor.ps1
@@ -118,7 +118,10 @@ if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
   $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
   if ($isRepo) {
     $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
-    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+    # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+    # grafted origin/main returns a bogus count (a false "hundreds behind").
+    $shallow = (& git -C $here rev-parse --is-shallow-repository 2>$null)
+    if ($shallow -ne 'true' -and -not $env:SIGMA_SKIP_VERSION_CHECK) {
       & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
       $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
       if ($bc -match '^\d+$') { $behindCount = [int]$bc }

--- a/shared/scripts/doctor.ps1
+++ b/shared/scripts/doctor.ps1
@@ -107,6 +107,41 @@ if ((Test-Path $envFile) -or $env:SIGMA_API_TOKEN -or $env:SIGMA_CLIENT_ID) {
   Warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once, or set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET."
 }
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A pinned plugin install never self-updates; a stale SHA silently ships
+# pre-fidelity-layer output. Record {skill_sha, behind_count}; the orchestrator
+# preflight FAILs above a threshold. Bounded, best-effort fetch; skip with
+# SIGMA_SKIP_VERSION_CHECK=1.
+$skillSha = ""; $behindCount = $null
+$here = $PSScriptRoot
+if ($here -and (Get-Command git -ErrorAction SilentlyContinue)) {
+  $isRepo = (& git -C $here rev-parse --git-dir 2>$null)
+  if ($isRepo) {
+    $skillSha = (& git -C $here rev-parse --short HEAD 2>$null)
+    if (-not $env:SIGMA_SKIP_VERSION_CHECK) {
+      & git -C $here -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>$null
+      $bc = (& git -C $here rev-list --count HEAD..origin/main 2>$null)
+      if ($bc -match '^\d+$') { $behindCount = [int]$bc }
+    }
+    if ($null -eq $behindCount) {
+      if ($skillSha) { Ok "skill version $skillSha (drift check skipped/offline)" }
+    } elseif ($behindCount -gt 0) {
+      Warn "skill is $behindCount commit(s) behind origin/main (installed $skillSha) - you may be missing fidelity-layer fixes" `
+           "Update: 'git -C ""$here"" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+    } else {
+      Ok "skill version $skillSha (current with origin/main)"
+    }
+  }
+}
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# Vision is asserted by the caller (a vision-capable session sets
+# SIGMA_AGENT_VISION=true); default false so the visual gate fails LOUDLY
+# rather than accepting a blind attestation.
+$agentVision = $false
+if ($env:SIGMA_AGENT_VISION -in @('true', '1', 'yes', 'TRUE', 'True')) { $agentVision = $true }
+$modelHint = if ($env:SIGMA_MODEL_HINT) { $env:SIGMA_MODEL_HINT } else { "" }
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Same contract as doctor.sh: lets the preflight GATE refuse to proceed on a
 # broken environment, and lets telemetry group failures by environment class.
@@ -131,6 +166,10 @@ $doctor = [ordered]@{
   runtimes     = [ordered]@{ ruby = $rubyOk; python = $pyOk; node = $nodeOk; bash = [bool](Get-Command bash -ErrorAction SilentlyContinue) }
   versions     = [ordered]@{ ruby = "$rubyV"; python = "$pyV"; node = "$nodeV" }
   sandbox_hint = $sandbox
+  skill_sha    = "$skillSha"
+  behind_count = $behindCount
+  agent_vision = $agentVision
+  model_hint   = "$modelHint"
   pass         = ($script:Fail -eq 0)
   failures     = @($script:Failures)
 }

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -133,6 +133,37 @@ else
   warn "no Sigma credentials found" "Run 'ruby scripts/setup.rb' once (writes ~/.sigma-migration/env), or export SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET."
 fi
 
+# --- skill version drift (v3 §2.1) -----------------------------------------
+# A plugin install pins a git SHA and never self-updates; running a stale SHA
+# silently ships pre-fidelity-layer output. Record {skill_sha, behind_count};
+# the orchestrator preflight FAILs above a threshold. Bounded, best-effort
+# fetch (stalled network capped ~6s); skip with SIGMA_SKIP_VERSION_CHECK=1.
+SKILL_SHA=""; BEHIND_COUNT="null"
+if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
+  SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+    git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
+    _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
+    case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac
+  fi
+  if [ "$BEHIND_COUNT" = "null" ]; then
+    [ -n "$SKILL_SHA" ] && ok "skill version $SKILL_SHA (drift check skipped/offline)"
+  elif [ "$BEHIND_COUNT" -gt 0 ] 2>/dev/null; then
+    warn "skill is ${BEHIND_COUNT} commit(s) behind origin/main (installed $SKILL_SHA) — you may be missing fidelity-layer fixes" \
+         "Update: 'git -C \"$HERE\" pull' (or reinstall the plugin). SIGMA_SKIP_VERSION_CHECK=1 skips this probe."
+  else
+    ok "skill version $SKILL_SHA (current with origin/main)"
+  fi
+fi
+
+# --- agent capability fingerprint (v3 §2.2) --------------------------------
+# The doctor can't introspect the driving agent, so vision is asserted by the
+# caller: a vision-capable session exports SIGMA_AGENT_VISION=true. Default
+# false so the visual gate (D5) fails LOUDLY rather than accepting a blind
+# attestation. model_hint is free-form (e.g. "claude-opus-4-8").
+case "${SIGMA_AGENT_VISION:-}" in true|1|yes|TRUE|True) AGENT_VISION=true ;; *) AGENT_VISION=false ;; esac
+MODEL_HINT="${SIGMA_MODEL_HINT:-}"
+
 # --- machine-readable fingerprint (doctor.json) ----------------------------
 # Written so (a) the run-state / preflight GATE can refuse to proceed on a
 # broken environment instead of letting the agent improvise, and (b) telemetry
@@ -169,6 +200,10 @@ write_doctor_json() {
     printf '"runtimes":{"ruby":%s,"python":%s,"node":%s,"bash":true},' "$RUBY_OK" "$PY_OK" "$NODE_OK"
     printf '"versions":{"ruby":"%s","python":"%s","node":"%s"},' "$(jstr "$RUBY_V")" "$(jstr "$PY_VER")" "$(jstr "$NODE_V")"
     printf '"sandbox_hint":"%s",' "$(jstr "$SANDBOX_HINT")"
+    printf '"skill_sha":"%s",' "$(jstr "$SKILL_SHA")"
+    printf '"behind_count":%s,' "$BEHIND_COUNT"
+    printf '"agent_vision":%s,' "$AGENT_VISION"
+    printf '"model_hint":"%s",' "$(jstr "$MODEL_HINT")"
     printf '"pass":%s,' "$PASS_BOOL"
     printf '"failures":[%s]' "$fj"
     printf '}\n'

--- a/shared/scripts/doctor.sh
+++ b/shared/scripts/doctor.sh
@@ -141,7 +141,10 @@ fi
 SKILL_SHA=""; BEHIND_COUNT="null"
 if command -v git >/dev/null 2>&1 && git -C "$HERE" rev-parse --git-dir >/dev/null 2>&1; then
   SKILL_SHA="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || true)"
-  if [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
+  # Skip on a SHALLOW clone (CI checkout, some installs): rev-list against a
+  # grafted origin/main returns a bogus count (a false "hundreds behind").
+  _shallow="$(git -C "$HERE" rev-parse --is-shallow-repository 2>/dev/null)"
+  if [ "$_shallow" != "true" ] && [ -z "${SIGMA_SKIP_VERSION_CHECK:-}" ]; then
     git -C "$HERE" -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=6 fetch --quiet origin 2>/dev/null
     _bc="$(git -C "$HERE" rev-list --count HEAD..origin/main 2>/dev/null || true)"
     case "$_bc" in ''|*[!0-9]*) BEHIND_COUNT="null" ;; *) BEHIND_COUNT="$_bc" ;; esac

--- a/shared/scripts/report-telemetry.py
+++ b/shared/scripts/report-telemetry.py
@@ -67,6 +67,16 @@ parser.add_argument('--failure-stage', default=None,
                     choices=['auth', 'convert', 'spec_post', 'query_validate', 'other'],
                     help='When --failed: coarse stage the migration broke at (no messages or stack traces)')
 parser.add_argument('--workdir',  default=None, help='Run directory; the telemetry marker is written here for the gate')
+# Design-fidelity metrics (v3 §2.4) — the design half of cross-user variance.
+parser.add_argument('--layout-fill-waived', dest='layout_fill_waived', action='store_true',
+                    help='the auto layout-fill gate was waived (--skip-layout-fill) for this run')
+parser.add_argument('--rcf-passes', type=int, default=None,
+                    help='number of render-compare-fix passes performed')
+parser.add_argument('--rubric-score', type=float, default=None,
+                    help='fidelity rubric score for the run')
+parser.add_argument('--visual-gate', default=None,
+                    choices=['pass', 'fail', 'not-executable'],
+                    help='visual gate verdict (not-executable = driving agent lacked vision)')
 args = parser.parse_args()
 
 
@@ -118,6 +128,17 @@ def _load_doctor(workdir):
 
 _doctor = _load_doctor(getattr(args, 'workdir', None))
 
+# Design metrics: explicit flags win; otherwise leave None (absent from payload).
+_design = None
+if (args.layout_fill_waived or args.rcf_passes is not None
+        or args.rubric_score is not None or args.visual_gate is not None):
+    _design = {
+        'layout_fill_waived': args.layout_fill_waived,
+        'rcf_passes': args.rcf_passes,
+        'fidelity_rubric_score': args.rubric_score,
+        'visual_gate': args.visual_gate,
+    }
+
 sent = report_migration(
     tool=args.tool,
     sigma_base=os.environ.get('SIGMA_BASE_URL', 'https://aws-api.sigmacomputing.com'),
@@ -127,6 +148,7 @@ sent = report_migration(
     mode=mode,
     failure_stage=(args.failure_stage if args.failed else None),
     doctor=_doctor,
+    design=_design,
 )
 # Honest marker (handoff FIX 3): "sent" ONLY when the POST actually landed (2xx);
 # otherwise "skipped" so the audit record never claims a delivery that failed.


### PR DESCRIPTION
## Why
Implements **v3 §2.1 / §2.2 / §2.4** — the "Week 0, before the next event" slice — by extending the `doctor.json` + telemetry we already ship (#299). Targets v3's **#1 measured root cause**: a pinned plugin running hundreds of commits behind `origin/main` silently ships pre-fidelity-layer output (the test machine was 412 behind). Tracked: `beads-sigma-u815`.

## What
- **§2.1 version drift** — `doctor.sh` + `doctor.ps1` record `{skill_sha, behind_count}` via a bounded, best-effort `git fetch` (stalled network capped ~6s; skip with `SIGMA_SKIP_VERSION_CHECK=1`). WARN when behind>0. **`assert-doctor-ran.rb` (the orchestrator preflight) FAILs when `behind_count > SIGMA_MAX_BEHIND` (default 50)** — waivable with `--skip-doctor-gate`.
- **§2.2 agent capability** — `doctor.json` records `{agent_vision, model_hint}` from `SIGMA_AGENT_VISION` / `SIGMA_MODEL_HINT`. Default `agent_vision=false` so the visual gate can fail loudly rather than accept a blind attestation (D5 builds on this).
- **§2.4 telemetry** — `report_migration` gains `design={layout_fill_waived, rcf_passes, fidelity_rubric_score, visual_gate}`; the doctor fingerprint is extended with `behind_count/agent_vision/model_hint`. `report-telemetry.py` exposes the flags.

## Verification
- `doctor.json` valid with new fields on macOS; version line shows `current with origin/main` (behind 0) live.
- Gate: **blocks at behind=100, passes at ≤50 and when offline (`null`)**, honors `SIGMA_MAX_BEHIND=5`.
- Vision fields: `SIGMA_AGENT_VISION=true` + `SIGMA_MODEL_HINT` land correctly.
- Telemetry payload carries both fingerprints; `test-telemetry-gate.rb` green; synced to all copies (`check-shared` clean).
- `doctor.ps1` exercised by the `windows-smoke` CI job.

## Scope
Plumbing only — the `design` metrics are wired end-to-end into telemetry but the orchestrator populating `layout_fill_waived`/`rcf_passes` at finalize comes with D3/D5 (when those metrics exist). Ruby untouched elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)