### PR TITLE
Tier 1: catch multi-datasource collapse (gap-scan + pre-POST ref gate + droppage guard)

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -188,6 +188,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-zone-census.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-fill-gate.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-dedup.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-datasource-gap.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -189,6 +189,7 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-fill-gate.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-dedup.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-datasource-gap.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -245,6 +245,7 @@ which calc translation, which layout) — not orchestration.
 | `scripts/get_token.py` | Shell-neutral twin of `get-token.sh` (bash/PowerShell/cmd): writes `<WORK>/auth.json` (0600), read automatically by the scripts |
 | `scripts/doctor.sh` / `scripts/doctor.ps1` | Step-0 env check; writes `doctor.json` fingerprint the orchestrator gates on |
 | `scripts/assert-doctor-ran.rb` | 🚧 GATE — refuse to run without a passing `doctor.json` |
+| `scripts/assert-wb-refs-resolve.rb` | 🚧 GATE — every workbook `[Element/Column]` ref must exist in the live DM before POST (catches multi-datasource collapse → "Dependency not found"; waive `--skip-ref-check "<reason>"`) |
 | `scripts/setup-tableau.rb` | One-time Tableau PAT setup (only needed for PAT mode — see `refs/tableau-rest.md`) |
 | `scripts/get-tableau-token.sh` | One-shot signin → exports `TABLEAU_AUTH_TOKEN` + `TABLEAU_SITE_ID` |
 | `scripts/tableau-discover.rb` | PAT-mode Phase 1 discovery in one CLI: workbook + views + VDS metadata + GraphQL + .twb content. ONE unified fetch pool (default 5, `--pool N`, longest-job-first) with 429/timeout backoff + 401 re-mint; always writes per-task `timings.json`. Measured 61.8s → 13.7–18.9s on the 7-view reference workbook |

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-wb-refs-resolve.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-wb-refs-resolve.rb
@@ -1,0 +1,117 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# 🚧 GATE — every workbook-spec column reference must resolve against the LIVE
+# data model BEFORE the workbook is POSTed.
+#
+# The failure this prevents (MSP-Dashboard, 2026-07-08): the local converter
+# collapsed a multi-datasource workbook onto its primary datasource, so the DM
+# ended up with ~49 columns while the workbook spec still referenced ~599 —
+# every `[Master/<dropped column>]` formula then POSTed and Sigma rejected it
+# with "Dependency not found", one opaque error at a time, after the DM was
+# already created. This gate turns that into a single, clear, pre-POST report:
+# exactly which refs don't resolve and (usually) why (dropped datasource).
+#
+# It complements the multi-datasource gap (scan-workbook-gaps.rb) — that one
+# stops at gap-scan; this one is the safety net for anything that slips past it
+# (a collapse the gap scan didn't catch, a hand-edited spec, a stale cache).
+#
+# Column matching is GLOBAL + normalized (case/space-insensitive, trailing
+# "(suffix)" stripped) so Sigma's disambiguating label suffixes and element
+# renames don't cause false positives: a ref resolves if its column exists in
+# ANY element of the DM.
+#
+# Usage:
+#   ruby assert-wb-refs-resolve.rb --wb-spec <spec.json> \
+#     ( --dm-ids <dm-ids.json> | --dm-id <dataModelId> ) \
+#     [--skip-ref-check REASON]   # waive — REQUIRED reason; name it in your report
+#
+# Exit codes:
+#   0  all refs resolve (or waived)
+#   1  one or more refs do not resolve against the live DM
+#   2  usage error
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--wb-spec PATH')  { |v| opts[:spec] = v }
+  p.on('--dm-ids PATH')   { |v| opts[:dm_ids] = v }
+  p.on('--dm-id ID')      { |v| opts[:dm_id] = v }
+  p.on('--skip-ref-check REASON',
+       'waive the ref-resolution gate — REQUIRED reason; name it in your report') { |v| opts[:skip] = v }
+end.parse!
+
+if opts[:skip]
+  puts "[SKIP] workbook ref-resolution gate WAIVED (#{opts[:skip]}) — name this in your report."
+  exit 0
+end
+abort 'usage: --wb-spec PATH and (--dm-ids PATH | --dm-id ID)' unless opts[:spec] && (opts[:dm_ids] || opts[:dm_id])
+
+def norm(col)
+  s = col.to_s.strip.downcase
+  s = s.sub(/\s*\([^)]*\)\s*\z/, '') # drop a trailing "(disambiguating suffix)"
+  s.gsub(/\s+/, ' ')
+end
+
+# --- collect the DM's available column labels (normalized) -----------------
+available = Set.new
+if opts[:dm_ids]
+  idmap = JSON.parse(File.read(opts[:dm_ids], encoding: 'bom|utf-8'))
+  (idmap['pages'] || []).each do |pg|
+    (pg['elements'] || []).each do |el|
+      (el['columnLabels'] || []).each { |l| available << norm(l) }
+    end
+  end
+else
+  # Live fetch via the shared REST lib (self-mints a token).
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+  cols = (Sigma.request(:get, "/v2/dataModels/#{opts[:dm_id]}/columns") rescue { 'entries' => [] })
+  (cols['entries'] || []).each { |c| available << norm(c['label']) if c['label'] }
+end
+
+if available.empty?
+  warn '[FAIL] workbook ref-resolution gate — the live DM reports ZERO columns.'
+  warn '       The data model is empty/broken; do not POST the workbook against it.'
+  warn '       (This is the multi-datasource-collapse signature — see the gap report.)'
+  exit 1
+end
+
+# --- extract every [Element/Column] ref from the workbook spec --------------
+REF = /\[([^\]\/]+)\/([^\]]+)\]/.freeze
+refs = {} # normalized column -> {display, elements:Set}
+walk = lambda do |obj|
+  case obj
+  when Hash  then obj.each_value { |v| walk.call(v) }
+  when Array then obj.each { |v| walk.call(v) }
+  when String
+    obj.scan(REF) do |el, col|
+      k = norm(col)
+      (refs[k] ||= { display: col.strip, elements: Set.new })[:elements] << el.strip
+    end
+  end
+end
+walk.call(JSON.parse(File.read(opts[:spec], encoding: 'bom|utf-8')))
+
+unresolved = refs.reject { |k, _| available.include?(k) }
+
+if unresolved.empty?
+  puts "[PASS] workbook ref-resolution gate: all #{refs.size} referenced column(s) resolve " \
+       "against the live DM (#{available.size} columns)."
+  exit 0
+end
+
+warn "[FAIL] workbook ref-resolution gate — #{unresolved.size} of #{refs.size} referenced " \
+     "column(s) do NOT exist in the live DM (#{available.size} columns):"
+unresolved.values.first(40).each do |r|
+  warn "         ✗ #{r[:display]}   (referenced via #{r[:elements].to_a.map { |e| "[#{e}/…]" }.join(', ')})"
+end
+warn "         … and #{unresolved.size - 40} more." if unresolved.size > 40
+warn ''
+warn '       These refs would fail the workbook POST with "Dependency not found". The usual'
+warn '       cause is a MULTI-DATASOURCE workbook the local converter collapsed onto one'
+warn '       datasource (dropping the others\' columns) — see the multi_datasource gap report,'
+warn '       and build a multi-element DM (or land + repoint the missing sources) before POSTing.'
+warn '       Escape hatch (name it in your report): --skip-ref-check "<reason>".'
+exit 1

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -146,6 +146,7 @@ OptionParser.new do |o|
   o.on('--skip-reuse-scan')  {     opts[:skip_reuse] = true }
   o.on('--skip-dashboard-read REASON', 'waive the Phase 1d source dashboard-read gate — REQUIRED reason; name it in your report') { |v| opts[:skip_dashboard_read] = v }
   o.on('--skip-doctor-gate REASON', 'waive the Step-0 environment gate (doctor.json) — REQUIRED reason; name it in your report') { |v| opts[:skip_doctor_gate] = v }
+  o.on('--skip-ref-check REASON', 'waive the pre-POST workbook ref-resolution gate — REQUIRED reason; name it in your report') { |v| opts[:skip_ref_check] = v }
   o.on('--skip-extract-landing REASON', 'proceed although every datasource is an embedded file extract and no ' \
                                         'landing manifest was found (exit 17 otherwise) — you own the DM table paths') { |v| opts[:skip_extract_landing] = v }
   o.on('--skip-postpublish-guide REASON', 'waive the finalize gate that requires POSTPUBLISH_GUIDE.md when the ' \
@@ -2009,6 +2010,15 @@ wb_ids_path = File.join(WORK, 'wb-ids.json')
 begin
   v_log = run_wb!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'workbook',
                    '--dm-context', dm_ids_path, wb_spec_path])
+  # 🚧 Pre-POST ref-resolution gate: every [Element/Column] ref in the wb-spec must
+  # exist in the LIVE DM, or the POST fails one opaque "Dependency not found" at a
+  # time AFTER the DM is created (MSP-Dashboard 2026-07-08: multi-datasource
+  # collapse left 550 refs unresolvable). Catch it here with the full list; the
+  # WorkbookBuildError this raises routes to the friendly rebuild-against-DM handoff.
+  ref_cmd = ['ruby', File.join(HERE, 'assert-wb-refs-resolve.rb'),
+             '--wb-spec', wb_spec_path, '--dm-ids', dm_ids_path]
+  ref_cmd += ['--skip-ref-check', opts[:skip_ref_check]] if opts[:skip_ref_check]
+  run_wb!(ref_cmd)
   par_cmd = ['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
              '--spec', wb_spec_path, '--out', wb_ids_path, '--workdir', WORK]
   # PUT-append into the targeted existing workbook (instead of POST-create).

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -225,6 +225,27 @@ else
   warn "WARN: could not fetch /columns for type guard (got HTTP #{res.code}); skipping"
 end
 
+# DM column-DROPPAGE guard (MSP-Dashboard 2026-07-08): the type=error guard above
+# only catches columns that POSTed-then-errored. When a multi-datasource workbook
+# is collapsed onto its primary, the OTHER sources' columns are simply ABSENT from
+# the live DM (never posted) — no error type, so the guard above stays silent while
+# the spec declared hundreds more. Surface that gap loudly here; the pre-POST
+# ref-resolution gate (assert-wb-refs-resolve.rb) then hard-stops the workbook.
+if opts[:type] == 'datamodel' && res.is_a?(Net::HTTPSuccess)
+  declared = (spec['pages'] || []).sum { |p| (p['elements'] || []).sum { |e| (e['columns'] || []).size } }
+  live = (cols_json['entries'] || []).size
+  if declared > 20 && live < declared * 0.7
+    pct = ((1.0 - live.to_f / declared) * 100).round
+    warn "\n========================================"
+    warn "WARN — DM column DROPPAGE: spec declared #{declared} column(s), live DM has #{live} " \
+         "(#{pct}% absent, NOT type=error)."
+    warn 'This is the multi-datasource-collapse signature: columns from non-primary datasources'
+    warn 'were dropped. The workbook build will fail ref-resolution downstream. Verify the DM has'
+    warn 'one element per datasource (multi-element DM) before building the workbook.'
+    warn '========================================'
+  end
+end
+
 # Layout-quality lint (shared scripts/lib/layout_lint.rb — vendored byte-
 # identical, md5 discipline): fails loudly on raw-id element display names,
 # input controls outside the GridContainer bands of a banded page, and dead

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-workbook-gaps.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-workbook-gaps.rb
@@ -289,6 +289,47 @@ def detect_blends(xml)
   [features, { 'datasources' => ds_info.values, 'blends' => blends }]
 end
 
+# Detect the "N independent datasources feeding different worksheets" case —
+# DISTINCT from a Tableau blend (2 sources on ONE sheet, handled by
+# detect_blends). Here different sheets have different PRIMARY datasources. The
+# LOCAL converter (converter/tableau.mjs) collapses every worksheet onto the
+# primary datasource and silently drops the other sources' columns/calcs; the
+# workbook POST then fails with unresolved [Master/...] refs (see
+# MSP-Dashboard failure 2026-07-08). Emit an ❌-unhandled gap so migrate-tableau
+# HARD-STOPS at the gap gate with the table/sheet breakdown, instead of posting
+# a doomed DM. Fixed for real by the multi-element DM path (Tier 2).
+def detect_multi_datasource(xml)
+  return [nil, nil] if xml.nil?
+  ds_info = datasource_connections(xml)
+  return [nil, nil] if ds_info.size < 2
+  primaries = {} # ds_name -> [worksheets where it is the PRIMARY source]
+  xml.elements.each('//worksheet') do |ws|
+    ws_name = ws.attributes['name']
+    used = ws.elements.to_a('.//view/datasources/datasource')
+             .map { |d| d.attributes['name'] }.compact.select { |n| ds_info.key?(n) }
+    next if used.empty?
+    (primaries[used.first] ||= []) << ws_name
+  end
+  return [nil, nil] if primaries.size < 2 # single-primary workbook (incl. pure blends) — fine
+
+  detail = primaries.keys.map do |n|
+    { 'datasource'  => n,
+      'caption'     => ds_info[n]['caption'],
+      'connections' => ds_info[n]['connections'],
+      'worksheets'  => primaries[n].uniq.sort }
+  end
+  assigns = detail.map { |d| "#{d['caption']} → #{d['worksheets'].length} sheet(s)" }.join('; ')
+  blurb = "Workbook spans #{primaries.size} INDEPENDENT datasources across worksheets " \
+          "(#{assigns}). The local converter collapses all sheets onto the primary datasource " \
+          'and silently drops the other sources\' columns/calcs, so the workbook POST fails with ' \
+          'unresolved [Master/...] refs. This needs a MULTI-ELEMENT data model (one element per ' \
+          'datasource + relationships) or landing the extras and repointing — it is NOT a Tableau ' \
+          'blend. Per-datasource worksheet assignments are in the gaps JSON (multi_datasource).'
+  feat = { name: 'Multiple independent datasources (converter collapses to primary)',
+           status: :unhandled, count: primaries.size, blurb: blurb }
+  [feat, detail]
+end
+
 # --- Field-usage + calc-dependency analysis --------------------------------
 # Works purely from the .twb — no VDS/metadata graph needed. Produces field
 # statistics (source/calc/param split, used vs dead), calc classification
@@ -509,6 +550,8 @@ def main
   results.concat(detect_point_map_geo_role_gaps(content))
   blend_features, blend_plan = detect_blends(xml)
   results.concat(blend_features)
+  multi_ds_feature, multi_ds_detail = detect_multi_datasource(xml)
+  results << multi_ds_feature if multi_ds_feature
   md_path = out
   json_path = out.sub(/\.md$/, '.json')
 
@@ -533,6 +576,7 @@ def main
     'detected_features' => results.map { |r| r.transform_keys(&:to_s) }
   }
   json_payload['field_statistics'] = fields.reject { |k, _| k == 'components' } if fields
+  json_payload['multi_datasource'] = multi_ds_detail if multi_ds_detail
   File.write(json_path, JSON.pretty_generate(json_payload))
 
   if fields && !fields['components'].empty?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-datasource-gap.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-datasource-gap.rb
@@ -1,0 +1,84 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Offline test for detect_multi_datasource in scan-workbook-gaps.rb (Tier 1 #1,
+# MSP-Dashboard failure 2026-07-08): a workbook whose worksheets have DIFFERENT
+# primary datasources must be flagged ❌-unhandled (the local converter collapses
+# to the primary and drops the others), while single-primary workbooks and pure
+# blends must NOT be flagged.
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'twb_xml'
+# Requiring the script defines its functions without running main
+# ($PROGRAM_NAME guard). Silence any load-time noise.
+require_relative 'scan-workbook-gaps'
+
+FAILS = []
+def check(cond, msg)
+  puts((cond ? '  ok  ' : '  FAIL ') + msg)
+  FAILS << msg unless cond
+end
+
+def fires?(xml_str)
+  feat, detail = detect_multi_datasource(TwbXml.parse(xml_str))
+  [!feat.nil? && feat[:status] == :unhandled, detail]
+end
+
+# --- multi: two datasources, each the primary of a different worksheet -------
+multi = <<~XML
+  <?xml version='1.0'?>
+  <workbook><datasources>
+    <datasource name='sales' caption='Sales Funnel'><connection class='snowflake' server='x' dbname='EDNA'/></datasource>
+    <datasource name='sku' caption='SKU Master GA'><connection class='snowflake' server='x' dbname='BBBS'/></datasource>
+    <datasource name='Parameters'><connection class='sqlproxy'/></datasource>
+  </datasources>
+  <worksheet name='Funnel'><table><view><datasources><datasource name='sales'/></datasources></view></table></worksheet>
+  <worksheet name='SKUs'><table><view><datasources><datasource name='sku'/></datasources></view></table></worksheet>
+  </workbook>
+XML
+fired, detail = fires?(multi)
+check(fired, 'multi-datasource workbook is flagged unhandled')
+check(detail && detail.length == 2, "detail lists both datasources (got #{detail&.length})")
+check(detail && detail.map { |d| d['caption'] }.sort == ['SKU Master GA', 'Sales Funnel'],
+      'detail carries datasource captions')
+check(detail && detail.find { |d| d['caption'] == 'Sales Funnel' }['worksheets'] == ['Funnel'],
+      'detail maps each datasource to its worksheet(s)')
+
+# --- single primary (two sheets, same source): must NOT fire ----------------
+single = <<~XML
+  <?xml version='1.0'?>
+  <workbook><datasources>
+    <datasource name='sales' caption='Sales'><connection class='snowflake' server='x' dbname='EDNA'/></datasource>
+  </datasources>
+  <worksheet name='A'><table><view><datasources><datasource name='sales'/></datasources></view></table></worksheet>
+  <worksheet name='B'><table><view><datasources><datasource name='sales'/></datasources></view></table></worksheet>
+  </workbook>
+XML
+check(!fires?(single)[0], 'single-datasource workbook is NOT flagged')
+
+# --- Parameters-only second source: must NOT fire ---------------------------
+param = <<~XML
+  <?xml version='1.0'?>
+  <workbook><datasources>
+    <datasource name='sales' caption='Sales'><connection class='snowflake' server='x' dbname='EDNA'/></datasource>
+    <datasource name='Parameters'><connection class='sqlproxy'/></datasource>
+  </datasources>
+  <worksheet name='A'><table><view><datasources><datasource name='sales'/></datasources></view></table></worksheet>
+  </workbook>
+XML
+check(!fires?(param)[0], 'Parameters synthetic source does not count as a second datasource')
+
+# --- pure blend (both sources on ONE sheet → single primary): must NOT fire -
+blend = <<~XML
+  <?xml version='1.0'?>
+  <workbook><datasources>
+    <datasource name='sales' caption='Sales'><connection class='snowflake' server='x' dbname='EDNA'/></datasource>
+    <datasource name='sku' caption='SKU'><connection class='snowflake' server='x' dbname='EDNA'/></datasource>
+  </datasources>
+  <worksheet name='Blended'><table><view><datasources>
+    <datasource name='sales'/><datasource name='sku'/>
+  </datasources></view></table></worksheet>
+  </workbook>
+XML
+check(!fires?(blend)[0], 'single-sheet blend (one primary) is left to the blend detector, not flagged here')
+
+puts(FAILS.empty? ? "\nall multi-datasource-gap tests passed" : "\n#{FAILS.length} FAILED")
+exit(FAILS.empty? ? 0 : 1)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Offline test for assert-wb-refs-resolve.rb (Tier 1 #2). Drives the gate as a
+# subprocess against fixture wb-spec + dm-ids files. The MSP-Dashboard failure
+# (2026-07-08): a multi-datasource collapse left workbook [Master/...] refs
+# pointing at columns absent from the live DM; this gate must catch them BEFORE
+# the POST that would otherwise return an opaque "Dependency not found".
+require 'json'
+require 'tmpdir'
+
+GATE = File.join(__dir__, 'assert-wb-refs-resolve.rb')
+FAILS = []
+def check(cond, msg)
+  puts((cond ? '  ok  ' : '  FAIL ') + msg)
+  FAILS << msg unless cond
+end
+
+def run_gate(spec, dmids, *extra)
+  Dir.mktmpdir do |d|
+    File.write(File.join(d, 'wb.json'), JSON.generate(spec))
+    File.write(File.join(d, 'dm.json'), JSON.generate(dmids))
+    out = `ruby #{GATE} --wb-spec #{d}/wb.json --dm-ids #{d}/dm.json #{extra.join(' ')} 2>&1`
+    [$?.exitstatus, out]
+  end
+end
+
+DM = { 'dataModelId' => 'dm1', 'pages' => [{ 'elements' => [
+  { 'id' => 'e1', 'name' => 'Master',
+    'columnLabels' => ['Net Revenue', 'Region', 'Customer Id (CUSTOMER_DIM)'] }
+] }] }
+
+# all refs resolve (incl. suffix-normalized "Customer Id")
+rc, = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [
+  { 'formula' => 'Sum([Master/Net Revenue])' },
+  { 'formula' => '[Master/Customer Id]' }
+] }] }] }, DM)
+check(rc == 0, 'all-resolving spec passes (exit 0), suffix-normalized match works')
+
+# dropped columns (multi-DS collapse) → fail with exit 1
+rc, out = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [
+  { 'formula' => 'Sum([Master/Net Revenue])' },
+  { 'formula' => '[Master/Partner Name]' },
+  { 'formula' => '[SKU Master/Product Code]' }
+] }] }] }, DM)
+check(rc == 1, 'dropped-column refs fail (exit 1)')
+check(out.include?('Partner Name') && out.include?('Product Code'), 'names the unresolved columns')
+check(out.downcase.include?('multi-datasource'), 'points at the multi-datasource cause')
+
+# empty DM → fail
+rc, = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [{ 'formula' => '[Master/X]' }] }] }] },
+               { 'pages' => [{ 'elements' => [{ 'name' => 'Master', 'columnLabels' => [] }] }] })
+check(rc == 1, 'empty DM fails (exit 1)')
+
+# waiver → skip (exit 0)
+rc, = run_gate({ 'pages' => [{ 'elements' => [{ 'columns' => [{ 'formula' => '[Master/Partner Name]' }] }] }] },
+               DM, '--skip-ref-check', '"known, building manually"')
+check(rc == 0, '--skip-ref-check waives (exit 0)')
+
+puts(FAILS.empty? ? "\nall wb-refs-resolve tests passed" : "\n#{FAILS.length} FAILED")
+exit(FAILS.empty? ? 0 : 1)


### PR DESCRIPTION
## Why
Directly addresses a **multi-datasource workbook migration failure** from a field report: a workbook whose worksheets draw on several **independent** datasources (not a Tableau blend) — the local converter collapses onto the primary, drops the others' columns, and the workbook POST fails one opaque `Dependency not found` at a time, *after* the DM is already created.

## What (three honest, early stops)
1. **Gap-scan classification** (`scan-workbook-gaps.rb`) — detects ≥2 distinct **primary** datasources across worksheets → ❌-unhandled gap → `migrate-tableau` hard-stops at gap-scan (exit 11) with the datasource→sheet breakdown.
2. **Pre-POST ref-resolution gate** (`assert-wb-refs-resolve.rb`) — before the workbook POST, every `[Element/Column]` ref must resolve against the **live DM** `/columns` (global + normalized match). On a miss: FAIL with the exact unresolved list. Waive with `--skip-ref-check`.
3. **DM droppage guard** (`post-and-readback.rb`) — WARNs when the DM spec declared many more columns than the live DM has (the collapse signature).

## Verification
- `test-multi-datasource-gap.rb` (7 cases) + `test-wb-refs-resolve.rb` (6 cases), wired into CI. `check-shared` / lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)