### PR TITLE
tableau-to-sigma: mint Tableau token in-process (Windows-safe)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -247,7 +247,8 @@ which calc translation, which layout) — not orchestration.
 | `scripts/assert-doctor-ran.rb` | 🚧 GATE — refuse to run without a passing `doctor.json` |
 | `scripts/assert-wb-refs-resolve.rb` | 🚧 GATE — every workbook `[Element/Column]` ref must exist in the live DM before POST (catches multi-datasource collapse → "Dependency not found"; waive `--skip-ref-check "<reason>"`) |
 | `scripts/setup-tableau.rb` | One-time Tableau PAT setup (only needed for PAT mode — see `refs/tableau-rest.md`) |
-| `scripts/get-tableau-token.sh` | One-shot signin → exports `TABLEAU_AUTH_TOKEN` + `TABLEAU_SITE_ID` |
+| `scripts/get-tableau-token.sh` | One-shot signin → exports `TABLEAU_AUTH_TOKEN` + `TABLEAU_SITE_ID` — **bash only** |
+| `scripts/get-tableau-token.py` | Shell-neutral twin (bash/PowerShell/cmd) for hand-driven Tableau REST. The orchestrator mints the Tableau token in-process (no bash) so it no longer calls either. |
 | `scripts/tableau-discover.rb` | PAT-mode Phase 1 discovery in one CLI: workbook + views + VDS metadata + GraphQL + .twb content. ONE unified fetch pool (default 5, `--pool N`, longest-job-first) with 429/timeout backoff + 401 re-mint; always writes per-task `timings.json`. Measured 61.8s → 13.7–18.9s on the 7-view reference workbook |
 | `scripts/scan-workbook-gaps.rb` | **Phase 0a (mandatory):** scan a `.twb` and emit `gaps-report.md` + `gaps.json` categorising every feature into ✅ auto / ⚠️ hint / 🛠 manual / ❌ unhandled. Run BEFORE any other phase. Also detects multi-datasource **data blends** (secondary `datasource-dependencies` + linking fields) and writes `blend-plan.json` with a per-blend route — same-warehouse-repoint / materialize-via-vds / flag-unreachable (decision tree: `refs/blending.md`). |
 | `scripts/gap-scout.md` | **Phase 0a-scout:** subagent prompt + protocol for resolving ❌ Unhandled gaps. Main agent spawns one scout per gap via the Agent tool. |
@@ -352,6 +353,11 @@ process).
 | **MCP** — fallback | No PAT can be provisioned, and `mcp__tableau__*` tools are loaded in the session | None — host handles auth |
 
 **PAT mode in one command:**
+
+> **`migrate-tableau.rb` needs no token step** — it mints the Tableau token
+> **in-process** (Ruby, no bash/`eval`), so the orchestrated path works as-is on
+> Windows/PowerShell. The block below is only for **hand-driven** Tableau REST.
+> Shell-neutral: `python scripts/get-tableau-token.py --print-token`. bash:
 
 ```bash
 eval "$(scripts/get-tableau-token.sh)"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-tableau-token.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-tableau-token.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""get-tableau-token.py — shell-neutral Tableau token minting (stdlib only).
+
+The cross-shell twin of get-tableau-token.sh (Windows/PowerShell token fix). The bash
+version signs in via curl + sources ~/.sigma-migration/env, which fails on
+Windows (PowerShell env vars don't reach the bash subprocess and $HOME isn't
+set). This mints the same PAT signin token over pure Python (via the
+tableau_rest twin) so it works identically in bash, PowerShell, and cmd:
+
+    python scripts/get-tableau-token.py --print-token     # bare token to stdout
+    python scripts/get-tableau-token.py --print-export    # bash: eval "$(...)"
+    python scripts/get-tableau-token.py                   # default: bash exports
+
+NOTE: the migrate-tableau.rb orchestrator no longer needs this — it mints the
+Tableau token IN-PROCESS (Ruby tableau_rest) and injects it into child env, the
+Windows-safe path. This script is for hand-driven Tableau REST calls.
+
+Requires TABLEAU_SERVER_URL + PAT creds (TABLEAU_PAT_NAME / TABLEAU_PAT_SECRET /
+TABLEAU_SITE_CONTENT_URL) in the env or ~/.sigma-migration/env (setup-tableau.rb).
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import tableau_rest as tr  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Tableau REST token (shell-neutral).")
+    ap.add_argument("--print-token", action="store_true", help="print the bare auth token")
+    ap.add_argument("--print-export", action="store_true",
+                    help='print `export TABLEAU_AUTH_TOKEN=...` lines (bash eval compatibility)')
+    args = ap.parse_args()
+
+    try:
+        tr.refresh_token()  # PAT signin, in-process
+        token, site, server, ver = tr.auth_token(), tr.site_id(), tr.server_url(), tr.api_version()
+    except tr.TableauError as e:
+        print(f"FATAL: Tableau signin failed — {e}\n"
+              "  Check TABLEAU_SERVER_URL + PAT creds (run: ruby scripts/setup-tableau.rb).",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if args.print_token:
+        print(token)
+        return
+    # default + --print-export: bash-eval-compatible exports (matches get-tableau-token.sh)
+    print(f"export TABLEAU_AUTH_TOKEN='{token}'")
+    print(f"export TABLEAU_SITE_ID='{site}'")
+    print(f"export TABLEAU_SERVER_URL='{server}'")
+    print(f"export TABLEAU_API_VERSION='{ver}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -89,6 +89,7 @@ require_relative 'lib/scout_gate'
 require_relative 'lib/dashboard_read'
 require_relative 'lib/run_state'
 require_relative 'lib/sigma_rest' # in-process Sigma token minting (no bash/eval)
+require_relative 'lib/tableau_rest' # in-process Tableau token minting (Windows-safe; no bash/eval)
 require_relative 'hydrate-custom-sql'
 
 $stdout.sync = true # progress lines interleave correctly when piped/captured
@@ -291,6 +292,38 @@ end
 # Wrap a command so a Sigma token is live for it (injected via child env).
 def sigma_run!(cmd, allow_fail: false)
   run!(cmd, allow_fail: allow_fail, env: { 'SIGMA_API_TOKEN' => sigma_token! })
+end
+
+# Mint a fresh Tableau token IN-PROCESS (pure Ruby via tableau_rest) and return
+# the env a child needs, instead of `bash -c "eval \"$(get-tableau-token.sh)\""`.
+# On Windows the bash path fails — PowerShell env vars don't propagate into the
+# bash subprocess and $HOME isn't set, so get-tableau-token.sh can't source
+# ~/.sigma-migration/env (a Windows/PowerShell subprocess token failure). Ruby's Tableau.refresh_token!
+# resolves the neutral cred file via Ruby's own ~ expansion and mints over
+# net/http — no shell involved. Falls back to a pre-set TABLEAU_AUTH_TOKEN when
+# no PAT creds are available to refresh (parity with a hand-minted token).
+def tableau_env
+  begin
+    Tableau.refresh_token! # fresh PAT signin, in-process
+  rescue Tableau::Error
+    raise if ENV['TABLEAU_AUTH_TOKEN'].to_s.empty? # nothing to fall back on
+  end
+  {
+    'TABLEAU_SERVER_URL'  => (Tableau.server_url  rescue ENV['TABLEAU_SERVER_URL']),
+    'TABLEAU_SITE_ID'     => (Tableau.site_id     rescue ENV['TABLEAU_SITE_ID']),
+    'TABLEAU_AUTH_TOKEN'  => (Tableau.auth_token  rescue ENV['TABLEAU_AUTH_TOKEN']),
+    'TABLEAU_API_VERSION' => (Tableau.api_version rescue (ENV['TABLEAU_API_VERSION'] || '3.22')),
+  }.compact
+rescue StandardError => e
+  abort "FATAL: could not mint a Tableau token in-process: #{e.message}\n" \
+        '  Check Tableau creds (run: ruby scripts/setup-tableau.rb), or set TABLEAU_AUTH_TOKEN.'
+end
+
+# Run a Ruby child script with a live Tableau token injected via env — the
+# Windows-safe, bash-free replacement for
+# `run!(['bash','-c',"eval \"$(get-tableau-token.sh)\" && <cmd>"])`.
+def tableau_run!(cmd, allow_fail: false)
+  run!(cmd, allow_fail: allow_fail, env: tableau_env)
 end
 
 # Raised when the MECHANICAL WORKBOOK layer (build / validate / POST) fails after
@@ -607,9 +640,9 @@ probe_rb << if opts[:wb_id]
               "h = Tableau.find_workbook_by_name(#{opts[:wb_name].inspect}) or abort 'no workbook'; wb = Tableau.get_workbook(h['id']); "
             end
 probe_rb << "puts JSON.generate({ 'id' => wb['id'], 'updatedAt' => wb['updatedAt'] })"
-probe_quoted = "'" + probe_rb.gsub("'") { "'\\''" } + "'"
-probe_out, probe_st = Open3.capture2e('bash', '-c',
-                                      "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && ruby -e #{probe_quoted}")
+# Run ruby directly with the Tableau token injected via env (Windows-safe) —
+# no bash, no `eval "$(get-tableau-token.sh)"`, no shell-quoting of the script.
+probe_out, probe_st = Open3.capture2e(tableau_env, RbConfig.ruby, '-e', probe_rb)
 probe = (JSON.parse(probe_out.lines.last.to_s) rescue nil) if probe_st.success?
 stamp = (JSON.parse(File.read(stamp_path)) rescue nil)
 reuse_discovery = probe && stamp &&
@@ -646,10 +679,13 @@ else
   # Gap scan runs in the lane as soon as its input (the .twb) is ready — i.e.
   # right after discovery lands it. Scan failure is tolerated (same as before);
   # discovery failure is the lane's exit code.
-  lane_cmd = "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && #{disc_sh}; rc=$?; " \
+  # Token injected via env (Windows-safe); bash still orchestrates the lane
+  # (rc capture + conditional gap scan) but no longer sources creds via a
+  # fragile `eval "$(get-tableau-token.sh)"` that breaks under PowerShell/$HOME.
+  lane_cmd = "#{disc_sh}; rc=$?; " \
              "if [ $rc -eq 0 ] && [ -f '#{twb}' ]; then #{scan_sh} || true; fi; exit $rc"
   lane = { started: Time.now, status: nil }
-  lane[:pid] = Process.spawn('bash', '-c', lane_cmd, %i[out err] => [disc_log, 'a'])
+  lane[:pid] = Process.spawn(tableau_env, 'bash', '-c', lane_cmd, %i[out err] => [disc_log, 'a'])
   line "Tableau discovery + gap scan: BACKGROUND lane (pid #{lane[:pid]}, log #{File.basename(disc_log)})"
   line 'Sigma-side phases 1.6 + 2 run concurrently; lanes join before discovery output is consumed.'
 end
@@ -977,14 +1013,12 @@ if mechanical
     hcsql = File.join(WORK, 'hydrate-custom-sql.json')
     if wb_luid || true # resolution + GraphQL both need a Tableau token; get-*-token guards if absent
       # PRIMARY — REST content chase (covers table + Custom SQL PDSes).
-      run!(['bash', '-c', "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && " +
-            ['ruby', File.join(HERE, 'resolve-published-ds.rb'), '--twb', twb, '--out', pds_json]
-              .map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')], allow_fail: true)
+      tableau_run!(['ruby', File.join(HERE, 'resolve-published-ds.rb'), '--twb', twb, '--out', pds_json],
+                   allow_fail: true)
       # FALLBACK — GraphQL Custom SQL blocks (only helps the text case).
       if wb_luid
-        run!(['bash', '-c', "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && " +
-              ['ruby', File.join(HERE, 'extract-custom-sql.rb'), '--workbook-luid', wb_luid, '--twb', twb, '--out', hcsql]
-                .map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')], allow_fail: true)
+        tableau_run!(['ruby', File.join(HERE, 'extract-custom-sql.rb'), '--workbook-luid', wb_luid, '--twb', twb, '--out', hcsql],
+                     allow_fail: true)
       end
     end
     hyd_twb = File.join(WORK, 'workbook-hydrated.twb')
@@ -1238,9 +1272,7 @@ if wb_luid
   cf = ['ruby', File.join(HERE, 'extract-calc-fields.rb'),
         '--workbook-luid', wb_luid, '--out', calc_path]
   cf += ['--twb', twb] if have_twb
-  _, st = run!(['bash', '-c',
-                "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && " +
-                cf.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')], allow_fail: true)
+  _, st = tableau_run!(cf, allow_fail: true)
   if File.exist?(calc_path)
     cfj = JSON.parse(File.read(calc_path)) rescue {}
     calcs = cfj['calcs'] || []
@@ -1282,9 +1314,7 @@ csql_path = File.join(WORK, 'custom-sql.json')
 if wb_luid && have_twb
   csql_cmd = ['ruby', File.join(HERE, 'extract-custom-sql.rb'),
               '--workbook-luid', wb_luid, '--twb', twb, '--out', csql_path]
-  run!(['bash', '-c',
-        "eval \"$(#{File.join(HERE, 'get-tableau-token.sh')})\" && " +
-        csql_cmd.map { |a| "'" + a.gsub("'", "'\\''") + "'" }.join(' ')], allow_fail: true)
+  tableau_run!(csql_cmd, allow_fail: true)
   custom_sql = (JSON.parse(File.read(csql_path)) rescue []) if File.exist?(csql_path)
   custom_sql = [] unless custom_sql.is_a?(Array)
 end
@@ -2012,7 +2042,7 @@ begin
                    '--dm-context', dm_ids_path, wb_spec_path])
   # 🚧 Pre-POST ref-resolution gate: every [Element/Column] ref in the wb-spec must
   # exist in the LIVE DM, or the POST fails one opaque "Dependency not found" at a
-  # time AFTER the DM is created (MSP-Dashboard 2026-07-08: multi-datasource
+  # time AFTER the DM is created (a multi-datasource enterprise workbook: multi-datasource
   # collapse left 550 refs unresolvable). Catch it here with the full list; the
   # WorkbookBuildError this raises routes to the friendly rebuild-against-DM handoff.
   ref_cmd = ['ruby', File.join(HERE, 'assert-wb-refs-resolve.rb'),


### PR DESCRIPTION
## Why
`migrate-tableau.rb` still shelled `bash -c "eval \"$(get-tableau-token.sh)\""` at 5 sites to put a Tableau token in each child's env. On **Windows** that fails — PowerShell env vars don't propagate into the bash subprocess and `$HOME` isn't set, so `get-tableau-token.sh` can't source `~/.sigma-migration/env` (reported by a Windows/PowerShell user). #299 fixed the **Sigma** side in-process; this does the **Tableau** side.

## What
- **`tableau_env` / `tableau_run!`** mint the Tableau token **in-process** via the Ruby `tableau_rest` lib (net/http PAT signin — Ruby resolves `~` itself, no `$HOME`/bash dependency) and inject `TABLEAU_AUTH_TOKEN`/`SITE_ID`/`SERVER_URL`/`API_VERSION` into the child env. Falls back to a pre-set `TABLEAU_AUTH_TOKEN` when there are no PAT creds to refresh.
- **All 5 bash-eval token sites converted**: the workbook probe runs `ruby` directly (Open3 + env, no bash/quoting); `resolve-published-ds` / `extract-custom-sql` (×2) / `extract-calc-fields` use `tableau_run!`; the background discovery lane still uses Git Bash for orchestration but gets its token via env. The orchestrator now has a **single** `bash -c` (that lane), token-injected.
- **`scripts/get-tableau-token.py`** — shell-neutral twin for hand-driven Tableau REST (wraps `tableau_rest.py`; inherits truststore/insecure TLS handling). SKILL.md updated: the orchestrated path needs no token step.

## Verification
- **Live**: `tableau_env` mints a real token in-process (no bash); a child sees `TABLEAU_AUTH_TOKEN` via env. `get-tableau-token.py --print-token` returns the token.
- Orchestrator syntax OK; offline tableau tests green; `lint-skills` / `check-shared` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)