### PR TITLE
tableau-to-sigma: remove customer identifiers from converter-fidelity scripts

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-wb-refs-resolve.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-wb-refs-resolve.rb
@@ -3,7 +3,7 @@
 # 🚧 GATE — every workbook-spec column reference must resolve against the LIVE
 # data model BEFORE the workbook is POSTed.
 #
-# The failure this prevents (MSP-Dashboard, 2026-07-08): the local converter
+# The failure this prevents (a real multi-datasource workbook): the local converter
 # collapsed a multi-datasource workbook onto its primary datasource, so the DM
 # ended up with ~49 columns while the workbook spec still referenced ~599 —
 # every `[Master/<dropped column>]` formula then POSTed and Sigma rejected it

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -225,7 +225,7 @@ else
   warn "WARN: could not fetch /columns for type guard (got HTTP #{res.code}); skipping"
 end
 
-# DM column-DROPPAGE guard (MSP-Dashboard 2026-07-08): the type=error guard above
+# DM column-DROPPAGE guard (a real multi-datasource workbook): the type=error guard above
 # only catches columns that POSTed-then-errored. When a multi-datasource workbook
 # is collapsed onto its primary, the OTHER sources' columns are simply ABSENT from
 # the live DM (never posted) — no error type, so the guard above stays silent while

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-workbook-gaps.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-workbook-gaps.rb
@@ -295,7 +295,7 @@ end
 # LOCAL converter (converter/tableau.mjs) collapses every worksheet onto the
 # primary datasource and silently drops the other sources' columns/calcs; the
 # workbook POST then fails with unresolved [Master/...] refs (see
-# MSP-Dashboard failure 2026-07-08). Emit an ❌-unhandled gap so migrate-tableau
+# a real multi-datasource workbook). Emit an ❌-unhandled gap so migrate-tableau
 # HARD-STOPS at the gap gate with the table/sheet breakdown, instead of posting
 # a doomed DM. Fixed for real by the multi-element DM path (Tier 2).
 def detect_multi_datasource(xml)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-datasource-gap.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-datasource-gap.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 # Offline test for detect_multi_datasource in scan-workbook-gaps.rb (Tier 1 #1,
-# MSP-Dashboard failure 2026-07-08): a workbook whose worksheets have DIFFERENT
+# a real multi-datasource workbook): a workbook whose worksheets have DIFFERENT
 # primary datasources must be flagged ❌-unhandled (the local converter collapses
 # to the primary and drops the others), while single-primary workbooks and pure
 # blends must NOT be flagged.
@@ -26,7 +26,7 @@ end
 multi = <<~XML
   <?xml version='1.0'?>
   <workbook><datasources>
-    <datasource name='sales' caption='Sales Funnel'><connection class='snowflake' server='x' dbname='EDNA'/></datasource>
+    <datasource name='sales' caption='Sales Funnel'><connection class='snowflake' server='x' dbname='WH'/></datasource>
     <datasource name='sku' caption='SKU Master GA'><connection class='snowflake' server='x' dbname='BBBS'/></datasource>
     <datasource name='Parameters'><connection class='sqlproxy'/></datasource>
   </datasources>
@@ -46,7 +46,7 @@ check(detail && detail.find { |d| d['caption'] == 'Sales Funnel' }['worksheets']
 single = <<~XML
   <?xml version='1.0'?>
   <workbook><datasources>
-    <datasource name='sales' caption='Sales'><connection class='snowflake' server='x' dbname='EDNA'/></datasource>
+    <datasource name='sales' caption='Sales'><connection class='snowflake' server='x' dbname='WH'/></datasource>
   </datasources>
   <worksheet name='A'><table><view><datasources><datasource name='sales'/></datasources></view></table></worksheet>
   <worksheet name='B'><table><view><datasources><datasource name='sales'/></datasources></view></table></worksheet>
@@ -58,7 +58,7 @@ check(!fires?(single)[0], 'single-datasource workbook is NOT flagged')
 param = <<~XML
   <?xml version='1.0'?>
   <workbook><datasources>
-    <datasource name='sales' caption='Sales'><connection class='snowflake' server='x' dbname='EDNA'/></datasource>
+    <datasource name='sales' caption='Sales'><connection class='snowflake' server='x' dbname='WH'/></datasource>
     <datasource name='Parameters'><connection class='sqlproxy'/></datasource>
   </datasources>
   <worksheet name='A'><table><view><datasources><datasource name='sales'/></datasources></view></table></worksheet>
@@ -70,8 +70,8 @@ check(!fires?(param)[0], 'Parameters synthetic source does not count as a second
 blend = <<~XML
   <?xml version='1.0'?>
   <workbook><datasources>
-    <datasource name='sales' caption='Sales'><connection class='snowflake' server='x' dbname='EDNA'/></datasource>
-    <datasource name='sku' caption='SKU'><connection class='snowflake' server='x' dbname='EDNA'/></datasource>
+    <datasource name='sales' caption='Sales'><connection class='snowflake' server='x' dbname='WH'/></datasource>
+    <datasource name='sku' caption='SKU'><connection class='snowflake' server='x' dbname='WH'/></datasource>
   </datasources>
   <worksheet name='Blended'><table><view><datasources>
     <datasource name='sales'/><datasource name='sku'/>

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 # Offline test for assert-wb-refs-resolve.rb (Tier 1 #2). Drives the gate as a
-# subprocess against fixture wb-spec + dm-ids files. The MSP-Dashboard failure
+# subprocess against fixture wb-spec + dm-ids files. The a real multi-datasource workbook
 # (2026-07-08): a multi-datasource collapse left workbook [Master/...] refs
 # pointing at columns absent from the live DM; this gate must catch them BEFORE
 # the POST that would otherwise return an opaque "Dependency not found".


### PR DESCRIPTION
Public-repo hygiene (no customer info in public artifacts): strips a customer workbook name and a warehouse/db codename from the multi-datasource gate scripts + tests added this cycle (`assert-wb-refs-resolve.rb`, `post-and-readback.rb`, `scan-workbook-gaps.rb`, `test-multi-datasource-gap.rb`, `test-wb-refs-resolve.rb`). Replaced with generic phrasing / placeholder db names. No behavior change; offline tests green.

Note: `migrate-tableau.rb` is sanitized in its own open PR; the converter source repo separately. A broader pre-existing identifier sprawl across the repo is flagged for a dedicated scrub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)