### PR TITLE
tableau-to-sigma: re-vendor converter with nested-LOD translation (#1 fix)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
@@ -1,6 +1,6 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "82f997f",
+  "source_commit": "72f8549",
   "source_commit_date": "2026-07-08",
   "fast_xml_parser_version": "4.5.6",
   "artifact": "tableau.mjs",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
@@ -3124,6 +3124,15 @@ function tableauParseLOD(formula) {
   });
   return { _isLOD: true, lodType, dims, rawAgg, aggFunc, aggExpr, sigmaAgg };
 }
+function _stripOuterAggAroundLod(formula) {
+  const m = formula.trim().match(/^(SUM|MAX|MIN|AVG|COUNT|COUNTD|ATTR)\s*\(\s*(\{\s*(?:FIXED|INCLUDE|EXCLUDE)[\s\S]*\})\s*\)$/i);
+  if (!m)
+    return null;
+  const inner = m[2].trim();
+  if (!/^\{[\s\S]*\}$/.test(inner))
+    return null;
+  return { aggFunc: m[1].toUpperCase(), inner };
+}
 function _windowInnerToSql(expr) {
   let s = expr;
   s = s.replace(/\bZN\s*\(([^()]+)\)/gi, "$1");
@@ -5418,7 +5427,15 @@ ${joinSql}
         continue;
       }
       {
-        const lod = tableauParseLOD(formula);
+        let lod = tableauParseLOD(formula);
+        let lodOuterAgg = null;
+        if (!lod) {
+          const wrapped = _stripOuterAggAroundLod(formula);
+          if (wrapped) {
+            lod = tableauParseLOD(wrapped.inner);
+            lodOuterAgg = wrapped.aggFunc;
+          }
+        }
         if (lod) {
           const lodDimsResolved = [];
           let allFound = true;
@@ -5504,6 +5521,8 @@ ${suggestion}
             _ensureRelationship2(helperRes.signatureKey, dimResolved, relName);
             _addAggToHelper2(helperRes.signatureKey, alias, lod.aggFunc, lod.aggExpr, caption);
             warnings.push(`\u2705 LOD "${caption}" (${lod.lodType}) \u2192 helper "${helperRes.helper.name}" alias ${alias}`);
+            if (lodOuterAgg)
+              warnings.push(`\u2139 LOD "${caption}" was wrapped by ${lodOuterAgg}({\u2026}); emitted the row-level LOD value \u2014 apply ${lodOuterAgg} as the measure's aggregation in the workbook (verify the number vs source).`);
           }
           continue;
         }


### PR DESCRIPTION
Refreshes the local converter from `sigma-data-model-mcp@72f8549` (#95): LODs nested inside an outer aggregate (`MAX({FIXED…})` etc.) now translate to a GROUP-BY helper instead of being dropped or leaking raw `{ FIXED }` into the SQL — the **#1 enterprise blocker** from the field report.

Provenance `82f997f → 72f8549`. Verified: bundle carries the nested-LOD path; a nested `MAX({FIXED…})` builds a `kind:sql` helper with no raw `{FIXED}`; corpus **14/14**. Source change was live-API E2E'd (helper POSTs, LOD count column resolves as `integer`, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)