### PR TITLE
tableau-to-sigma: re-vendor converter with virtual-field drop (#8)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
@@ -1,6 +1,6 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "72f8549",
+  "source_commit": "a0baa58",
   "source_commit_date": "2026-07-08",
   "fast_xml_parser_version": "4.5.6",
   "artifact": "tableau.mjs",

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
@@ -3133,6 +3133,9 @@ function _stripOuterAggAroundLod(formula) {
     return null;
   return { aggFunc: m[1].toUpperCase(), inner };
 }
+function _isTableauVirtualField(name) {
+  return (name || "").replace(/^\[|\]$/g, "").trim().startsWith(":");
+}
 function _windowInnerToSql(expr) {
   let s = expr;
   s = s.replace(/\bZN\s*\(([^()]+)\)/gi, "$1");
@@ -4264,7 +4267,7 @@ function convertTableauToSigma(xmlContent, options = {}) {
       const columns = [], order = [];
       for (const col of asArray(rootRelation?.columns?.column || [])) {
         const key = attr(col, "name").toUpperCase();
-        if (!key)
+        if (!key || _isTableauVirtualField(attr(col, "name")))
           continue;
         const id = sigmaInodeId(key);
         columns.push({ id, formula: `[${tableName}/${sigmaDisplayName(key)}]` });
@@ -4292,7 +4295,7 @@ function convertTableauToSigma(xmlContent, options = {}) {
           const columns = [], order = [];
           for (const col of asArray(t.rel?.columns?.column || [])) {
             const key = attr(col, "name").toUpperCase();
-            if (!key)
+            if (!key || _isTableauVirtualField(attr(col, "name")))
               continue;
             const id = sigmaInodeId(key);
             columns.push({ id, formula: `[${tableName}/${sigmaDisplayName(key)}]` });


### PR DESCRIPTION
Refresh the local converter from `sigma-data-model-mcp@a0baa58` (#96): `[:Measure Names]` / `[:Measure Values]` are no longer emitted as DM columns. Provenance `72f8549 → a0baa58`; corpus 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)