### PR TITLE
Hackathon follow-ups: SQL-identifier preflight, DM element quarantine, converter-fix regression pins

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -190,6 +190,9 @@ jobs:
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-layout-dedup.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-multi-datasource-gap.rb
             plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-wb-refs-resolve.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-sql-quoting.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-sql-ident-check.rb
+            plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-quarantine.rb
             plugins/tableau-to-sigma/skills/tableau-assessment/scripts/test-predicted-parity.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-dax-restructure.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -129,6 +129,14 @@
 #      <workdir>/POSTPUBLISH_GUIDE.md does not exist. Run
 #      scripts/build-postpublish-guide.rb to generate the user handoff guide.
 #      Escape hatch: --skip-postpublish-guide "<reason>".
+#  17  Deferred DM elements unresolved (gate 12) — <workdir>/deferred-elements.json
+#      is non-empty: post-and-readback.rb --quarantine-on-failure removed broken
+#      element(s) at DM POST time to save the rest, so the LIVE data model is
+#      PARTIAL. Resolve the deferred elements and re-POST: fix each element spec
+#      in the file, restore it into the DM spec, PUT it back (post-and-readback
+#      --update-id <dmId>), then delete the file. Escape hatch:
+#      --accept-deferred-elements "<reason>" (knowingly shipping a partial DM —
+#      name it AND the dropped elements in your migration report).
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -168,6 +176,7 @@ OptionParser.new do |p|
   p.on('--skip-layout-fill REASON', 'waive gate 8c (layout fill / grid coverage) — REQUIRED reason string. Use ONLY when a sparse/partial page is intentional. The reason MUST be named in your migration report.') { |v| opts[:skip_layout_fill] = v }
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
   p.on('--skip-postpublish-guide REASON', 'waive gate 11 (post-publish interactivity guide) — REQUIRED reason string. Use ONLY when the source dashboard actions are genuinely not worth a handoff guide. The reason MUST be named in your migration report.') { |v| opts[:skip_postpublish] = v }
+  p.on('--accept-deferred-elements REASON', 'waive gate 12 (deferred/quarantined DM elements) — REQUIRED reason string. Use ONLY when knowingly shipping a PARTIAL data model; the reason AND the dropped elements MUST be named in your migration report.') { |v| opts[:accept_deferred] = v }
   p.on('--require-fidelity-ledger', 'gate 8d (OPT-IN, off by default): require an RCF fidelity-ledger.json (Phase 5g) with zero UNRESOLVED spec-fixable deltas. Adopters (tableau-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_fidelity] = true }
   p.on('--fidelity-ledger PATH', 'gate 8d: path to the RCF ledger (default: <workdir>/fidelity-ledger.json)') { |v| opts[:fidelity_ledger] = v }
   p.on('--accept-residuals LIST', 'gate 8d: comma-separated ledger entry ids/indices to WAIVE as accepted residuals (name them in the report)') { |v| opts[:accept_residuals] = v.split(',').map(&:strip) }
@@ -1003,6 +1012,44 @@ else
     warn '       Escape hatch: --skip-postpublish-guide "<reason>" (name it in your migration report).'
     exit 16
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 12 — deferred DM elements (exit 17). post-and-readback.rb
+# --quarantine-on-failure saves a DM POST killed by one broken element by
+# moving the offender(s) to <workdir>/deferred-elements.json and re-POSTing the
+# rest (hackathon Rec5). That DM is PARTIAL by construction — declaring GREEN
+# on it would silently ship a data model missing elements. Non-empty file →
+# hard FAIL until the elements are fixed + re-POSTed (then delete the file).
+# No file / empty deferred list → OK. Escape: --accept-deferred-elements
+# "<reason>" (recorded as a waiver; name it + the dropped elements in the report).
+# ---------------------------------------------------------------------------
+deferred_path = File.join(opts[:tab], 'deferred-elements.json')
+if opts[:accept_deferred]
+  record_waiver.call('--accept-deferred-elements', 'gate 12 (deferred/quarantined DM elements)', opts[:accept_deferred])
+elsif File.exist?(deferred_path)
+  ddoc = JSON.parse(File.read(deferred_path)) rescue nil
+  deferred = ddoc.is_a?(Hash) ? Array(ddoc['deferred']) : (ddoc.is_a?(Array) ? ddoc : nil)
+  if deferred.nil?
+    warn "[FAIL] gate 12: #{deferred_path} is malformed (expected {\"deferred\":[...]} or a bare array)."
+    warn '       Fix or delete the file (delete ONLY if every quarantined element was restored + re-POSTed).'
+    exit 17
+  elsif deferred.any?
+    names = deferred.map { |d| d.is_a?(Hash) ? (d.dig('element', 'name') || d.dig('element', 'id') || '(unnamed)') : d.to_s }
+    warn "[FAIL] gate 12: #{deferred.size} DM element(s) still deferred (quarantined at POST time) — the live"
+    warn '       data model is PARTIAL. Resolve the deferred elements and re-POST:'
+    names.each { |n| warn "         - #{n}" }
+    warn "       Fix each element spec in #{deferred_path}, restore it into the DM spec,"
+    warn '       PUT it back (ruby scripts/post-and-readback.rb --type datamodel --update-id <dmId> ...),'
+    warn '       then delete the file and re-run this gate.'
+    warn '       Escape hatch (knowingly shipping a partial DM): --accept-deferred-elements "<reason>"'
+    warn '       (name it AND the dropped elements in your migration report).'
+    exit 17
+  else
+    puts "[OK] gate 12: deferred-elements.json present but empty — all quarantined elements resolved"
+  end
+else
+  puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -129,6 +129,14 @@
 #      <workdir>/POSTPUBLISH_GUIDE.md does not exist. Run
 #      scripts/build-postpublish-guide.rb to generate the user handoff guide.
 #      Escape hatch: --skip-postpublish-guide "<reason>".
+#  17  Deferred DM elements unresolved (gate 12) — <workdir>/deferred-elements.json
+#      is non-empty: post-and-readback.rb --quarantine-on-failure removed broken
+#      element(s) at DM POST time to save the rest, so the LIVE data model is
+#      PARTIAL. Resolve the deferred elements and re-POST: fix each element spec
+#      in the file, restore it into the DM spec, PUT it back (post-and-readback
+#      --update-id <dmId>), then delete the file. Escape hatch:
+#      --accept-deferred-elements "<reason>" (knowingly shipping a partial DM —
+#      name it AND the dropped elements in your migration report).
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -168,6 +176,7 @@ OptionParser.new do |p|
   p.on('--skip-layout-fill REASON', 'waive gate 8c (layout fill / grid coverage) — REQUIRED reason string. Use ONLY when a sparse/partial page is intentional. The reason MUST be named in your migration report.') { |v| opts[:skip_layout_fill] = v }
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
   p.on('--skip-postpublish-guide REASON', 'waive gate 11 (post-publish interactivity guide) — REQUIRED reason string. Use ONLY when the source dashboard actions are genuinely not worth a handoff guide. The reason MUST be named in your migration report.') { |v| opts[:skip_postpublish] = v }
+  p.on('--accept-deferred-elements REASON', 'waive gate 12 (deferred/quarantined DM elements) — REQUIRED reason string. Use ONLY when knowingly shipping a PARTIAL data model; the reason AND the dropped elements MUST be named in your migration report.') { |v| opts[:accept_deferred] = v }
   p.on('--require-fidelity-ledger', 'gate 8d (OPT-IN, off by default): require an RCF fidelity-ledger.json (Phase 5g) with zero UNRESOLVED spec-fixable deltas. Adopters (tableau-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_fidelity] = true }
   p.on('--fidelity-ledger PATH', 'gate 8d: path to the RCF ledger (default: <workdir>/fidelity-ledger.json)') { |v| opts[:fidelity_ledger] = v }
   p.on('--accept-residuals LIST', 'gate 8d: comma-separated ledger entry ids/indices to WAIVE as accepted residuals (name them in the report)') { |v| opts[:accept_residuals] = v.split(',').map(&:strip) }
@@ -1003,6 +1012,44 @@ else
     warn '       Escape hatch: --skip-postpublish-guide "<reason>" (name it in your migration report).'
     exit 16
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 12 — deferred DM elements (exit 17). post-and-readback.rb
+# --quarantine-on-failure saves a DM POST killed by one broken element by
+# moving the offender(s) to <workdir>/deferred-elements.json and re-POSTing the
+# rest (hackathon Rec5). That DM is PARTIAL by construction — declaring GREEN
+# on it would silently ship a data model missing elements. Non-empty file →
+# hard FAIL until the elements are fixed + re-POSTed (then delete the file).
+# No file / empty deferred list → OK. Escape: --accept-deferred-elements
+# "<reason>" (recorded as a waiver; name it + the dropped elements in the report).
+# ---------------------------------------------------------------------------
+deferred_path = File.join(opts[:tab], 'deferred-elements.json')
+if opts[:accept_deferred]
+  record_waiver.call('--accept-deferred-elements', 'gate 12 (deferred/quarantined DM elements)', opts[:accept_deferred])
+elsif File.exist?(deferred_path)
+  ddoc = JSON.parse(File.read(deferred_path)) rescue nil
+  deferred = ddoc.is_a?(Hash) ? Array(ddoc['deferred']) : (ddoc.is_a?(Array) ? ddoc : nil)
+  if deferred.nil?
+    warn "[FAIL] gate 12: #{deferred_path} is malformed (expected {\"deferred\":[...]} or a bare array)."
+    warn '       Fix or delete the file (delete ONLY if every quarantined element was restored + re-POSTed).'
+    exit 17
+  elsif deferred.any?
+    names = deferred.map { |d| d.is_a?(Hash) ? (d.dig('element', 'name') || d.dig('element', 'id') || '(unnamed)') : d.to_s }
+    warn "[FAIL] gate 12: #{deferred.size} DM element(s) still deferred (quarantined at POST time) — the live"
+    warn '       data model is PARTIAL. Resolve the deferred elements and re-POST:'
+    names.each { |n| warn "         - #{n}" }
+    warn "       Fix each element spec in #{deferred_path}, restore it into the DM spec,"
+    warn '       PUT it back (ruby scripts/post-and-readback.rb --type datamodel --update-id <dmId> ...),'
+    warn '       then delete the file and re-run this gate.'
+    warn '       Escape hatch (knowingly shipping a partial DM): --accept-deferred-elements "<reason>"'
+    warn '       (name it AND the dropped elements in your migration report).'
+    exit 17
+  else
+    puts "[OK] gate 12: deferred-elements.json present but empty — all quarantined elements resolved"
+  end
+else
+  puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -129,6 +129,14 @@
 #      <workdir>/POSTPUBLISH_GUIDE.md does not exist. Run
 #      scripts/build-postpublish-guide.rb to generate the user handoff guide.
 #      Escape hatch: --skip-postpublish-guide "<reason>".
+#  17  Deferred DM elements unresolved (gate 12) — <workdir>/deferred-elements.json
+#      is non-empty: post-and-readback.rb --quarantine-on-failure removed broken
+#      element(s) at DM POST time to save the rest, so the LIVE data model is
+#      PARTIAL. Resolve the deferred elements and re-POST: fix each element spec
+#      in the file, restore it into the DM spec, PUT it back (post-and-readback
+#      --update-id <dmId>), then delete the file. Escape hatch:
+#      --accept-deferred-elements "<reason>" (knowingly shipping a partial DM —
+#      name it AND the dropped elements in your migration report).
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -168,6 +176,7 @@ OptionParser.new do |p|
   p.on('--skip-layout-fill REASON', 'waive gate 8c (layout fill / grid coverage) — REQUIRED reason string. Use ONLY when a sparse/partial page is intentional. The reason MUST be named in your migration report.') { |v| opts[:skip_layout_fill] = v }
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
   p.on('--skip-postpublish-guide REASON', 'waive gate 11 (post-publish interactivity guide) — REQUIRED reason string. Use ONLY when the source dashboard actions are genuinely not worth a handoff guide. The reason MUST be named in your migration report.') { |v| opts[:skip_postpublish] = v }
+  p.on('--accept-deferred-elements REASON', 'waive gate 12 (deferred/quarantined DM elements) — REQUIRED reason string. Use ONLY when knowingly shipping a PARTIAL data model; the reason AND the dropped elements MUST be named in your migration report.') { |v| opts[:accept_deferred] = v }
   p.on('--require-fidelity-ledger', 'gate 8d (OPT-IN, off by default): require an RCF fidelity-ledger.json (Phase 5g) with zero UNRESOLVED spec-fixable deltas. Adopters (tableau-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_fidelity] = true }
   p.on('--fidelity-ledger PATH', 'gate 8d: path to the RCF ledger (default: <workdir>/fidelity-ledger.json)') { |v| opts[:fidelity_ledger] = v }
   p.on('--accept-residuals LIST', 'gate 8d: comma-separated ledger entry ids/indices to WAIVE as accepted residuals (name them in the report)') { |v| opts[:accept_residuals] = v.split(',').map(&:strip) }
@@ -1003,6 +1012,44 @@ else
     warn '       Escape hatch: --skip-postpublish-guide "<reason>" (name it in your migration report).'
     exit 16
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 12 — deferred DM elements (exit 17). post-and-readback.rb
+# --quarantine-on-failure saves a DM POST killed by one broken element by
+# moving the offender(s) to <workdir>/deferred-elements.json and re-POSTing the
+# rest (hackathon Rec5). That DM is PARTIAL by construction — declaring GREEN
+# on it would silently ship a data model missing elements. Non-empty file →
+# hard FAIL until the elements are fixed + re-POSTed (then delete the file).
+# No file / empty deferred list → OK. Escape: --accept-deferred-elements
+# "<reason>" (recorded as a waiver; name it + the dropped elements in the report).
+# ---------------------------------------------------------------------------
+deferred_path = File.join(opts[:tab], 'deferred-elements.json')
+if opts[:accept_deferred]
+  record_waiver.call('--accept-deferred-elements', 'gate 12 (deferred/quarantined DM elements)', opts[:accept_deferred])
+elsif File.exist?(deferred_path)
+  ddoc = JSON.parse(File.read(deferred_path)) rescue nil
+  deferred = ddoc.is_a?(Hash) ? Array(ddoc['deferred']) : (ddoc.is_a?(Array) ? ddoc : nil)
+  if deferred.nil?
+    warn "[FAIL] gate 12: #{deferred_path} is malformed (expected {\"deferred\":[...]} or a bare array)."
+    warn '       Fix or delete the file (delete ONLY if every quarantined element was restored + re-POSTed).'
+    exit 17
+  elsif deferred.any?
+    names = deferred.map { |d| d.is_a?(Hash) ? (d.dig('element', 'name') || d.dig('element', 'id') || '(unnamed)') : d.to_s }
+    warn "[FAIL] gate 12: #{deferred.size} DM element(s) still deferred (quarantined at POST time) — the live"
+    warn '       data model is PARTIAL. Resolve the deferred elements and re-POST:'
+    names.each { |n| warn "         - #{n}" }
+    warn "       Fix each element spec in #{deferred_path}, restore it into the DM spec,"
+    warn '       PUT it back (ruby scripts/post-and-readback.rb --type datamodel --update-id <dmId> ...),'
+    warn '       then delete the file and re-run this gate.'
+    warn '       Escape hatch (knowingly shipping a partial DM): --accept-deferred-elements "<reason>"'
+    warn '       (name it AND the dropped elements in your migration report).'
+    exit 17
+  else
+    puts "[OK] gate 12: deferred-elements.json present but empty — all quarantined elements resolved"
+  end
+else
+  puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -129,6 +129,14 @@
 #      <workdir>/POSTPUBLISH_GUIDE.md does not exist. Run
 #      scripts/build-postpublish-guide.rb to generate the user handoff guide.
 #      Escape hatch: --skip-postpublish-guide "<reason>".
+#  17  Deferred DM elements unresolved (gate 12) — <workdir>/deferred-elements.json
+#      is non-empty: post-and-readback.rb --quarantine-on-failure removed broken
+#      element(s) at DM POST time to save the rest, so the LIVE data model is
+#      PARTIAL. Resolve the deferred elements and re-POST: fix each element spec
+#      in the file, restore it into the DM spec, PUT it back (post-and-readback
+#      --update-id <dmId>), then delete the file. Escape hatch:
+#      --accept-deferred-elements "<reason>" (knowingly shipping a partial DM —
+#      name it AND the dropped elements in your migration report).
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -168,6 +176,7 @@ OptionParser.new do |p|
   p.on('--skip-layout-fill REASON', 'waive gate 8c (layout fill / grid coverage) — REQUIRED reason string. Use ONLY when a sparse/partial page is intentional. The reason MUST be named in your migration report.') { |v| opts[:skip_layout_fill] = v }
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
   p.on('--skip-postpublish-guide REASON', 'waive gate 11 (post-publish interactivity guide) — REQUIRED reason string. Use ONLY when the source dashboard actions are genuinely not worth a handoff guide. The reason MUST be named in your migration report.') { |v| opts[:skip_postpublish] = v }
+  p.on('--accept-deferred-elements REASON', 'waive gate 12 (deferred/quarantined DM elements) — REQUIRED reason string. Use ONLY when knowingly shipping a PARTIAL data model; the reason AND the dropped elements MUST be named in your migration report.') { |v| opts[:accept_deferred] = v }
   p.on('--require-fidelity-ledger', 'gate 8d (OPT-IN, off by default): require an RCF fidelity-ledger.json (Phase 5g) with zero UNRESOLVED spec-fixable deltas. Adopters (tableau-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_fidelity] = true }
   p.on('--fidelity-ledger PATH', 'gate 8d: path to the RCF ledger (default: <workdir>/fidelity-ledger.json)') { |v| opts[:fidelity_ledger] = v }
   p.on('--accept-residuals LIST', 'gate 8d: comma-separated ledger entry ids/indices to WAIVE as accepted residuals (name them in the report)') { |v| opts[:accept_residuals] = v.split(',').map(&:strip) }
@@ -1003,6 +1012,44 @@ else
     warn '       Escape hatch: --skip-postpublish-guide "<reason>" (name it in your migration report).'
     exit 16
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 12 — deferred DM elements (exit 17). post-and-readback.rb
+# --quarantine-on-failure saves a DM POST killed by one broken element by
+# moving the offender(s) to <workdir>/deferred-elements.json and re-POSTing the
+# rest (hackathon Rec5). That DM is PARTIAL by construction — declaring GREEN
+# on it would silently ship a data model missing elements. Non-empty file →
+# hard FAIL until the elements are fixed + re-POSTed (then delete the file).
+# No file / empty deferred list → OK. Escape: --accept-deferred-elements
+# "<reason>" (recorded as a waiver; name it + the dropped elements in the report).
+# ---------------------------------------------------------------------------
+deferred_path = File.join(opts[:tab], 'deferred-elements.json')
+if opts[:accept_deferred]
+  record_waiver.call('--accept-deferred-elements', 'gate 12 (deferred/quarantined DM elements)', opts[:accept_deferred])
+elsif File.exist?(deferred_path)
+  ddoc = JSON.parse(File.read(deferred_path)) rescue nil
+  deferred = ddoc.is_a?(Hash) ? Array(ddoc['deferred']) : (ddoc.is_a?(Array) ? ddoc : nil)
+  if deferred.nil?
+    warn "[FAIL] gate 12: #{deferred_path} is malformed (expected {\"deferred\":[...]} or a bare array)."
+    warn '       Fix or delete the file (delete ONLY if every quarantined element was restored + re-POSTed).'
+    exit 17
+  elsif deferred.any?
+    names = deferred.map { |d| d.is_a?(Hash) ? (d.dig('element', 'name') || d.dig('element', 'id') || '(unnamed)') : d.to_s }
+    warn "[FAIL] gate 12: #{deferred.size} DM element(s) still deferred (quarantined at POST time) — the live"
+    warn '       data model is PARTIAL. Resolve the deferred elements and re-POST:'
+    names.each { |n| warn "         - #{n}" }
+    warn "       Fix each element spec in #{deferred_path}, restore it into the DM spec,"
+    warn '       PUT it back (ruby scripts/post-and-readback.rb --type datamodel --update-id <dmId> ...),'
+    warn '       then delete the file and re-run this gate.'
+    warn '       Escape hatch (knowingly shipping a partial DM): --accept-deferred-elements "<reason>"'
+    warn '       (name it AND the dropped elements in your migration report).'
+    exit 17
+  else
+    puts "[OK] gate 12: deferred-elements.json present but empty — all quarantined elements resolved"
+  end
+else
+  puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -129,6 +129,14 @@
 #      <workdir>/POSTPUBLISH_GUIDE.md does not exist. Run
 #      scripts/build-postpublish-guide.rb to generate the user handoff guide.
 #      Escape hatch: --skip-postpublish-guide "<reason>".
+#  17  Deferred DM elements unresolved (gate 12) — <workdir>/deferred-elements.json
+#      is non-empty: post-and-readback.rb --quarantine-on-failure removed broken
+#      element(s) at DM POST time to save the rest, so the LIVE data model is
+#      PARTIAL. Resolve the deferred elements and re-POST: fix each element spec
+#      in the file, restore it into the DM spec, PUT it back (post-and-readback
+#      --update-id <dmId>), then delete the file. Escape hatch:
+#      --accept-deferred-elements "<reason>" (knowingly shipping a partial DM —
+#      name it AND the dropped elements in your migration report).
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -168,6 +176,7 @@ OptionParser.new do |p|
   p.on('--skip-layout-fill REASON', 'waive gate 8c (layout fill / grid coverage) — REQUIRED reason string. Use ONLY when a sparse/partial page is intentional. The reason MUST be named in your migration report.') { |v| opts[:skip_layout_fill] = v }
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
   p.on('--skip-postpublish-guide REASON', 'waive gate 11 (post-publish interactivity guide) — REQUIRED reason string. Use ONLY when the source dashboard actions are genuinely not worth a handoff guide. The reason MUST be named in your migration report.') { |v| opts[:skip_postpublish] = v }
+  p.on('--accept-deferred-elements REASON', 'waive gate 12 (deferred/quarantined DM elements) — REQUIRED reason string. Use ONLY when knowingly shipping a PARTIAL data model; the reason AND the dropped elements MUST be named in your migration report.') { |v| opts[:accept_deferred] = v }
   p.on('--require-fidelity-ledger', 'gate 8d (OPT-IN, off by default): require an RCF fidelity-ledger.json (Phase 5g) with zero UNRESOLVED spec-fixable deltas. Adopters (tableau-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_fidelity] = true }
   p.on('--fidelity-ledger PATH', 'gate 8d: path to the RCF ledger (default: <workdir>/fidelity-ledger.json)') { |v| opts[:fidelity_ledger] = v }
   p.on('--accept-residuals LIST', 'gate 8d: comma-separated ledger entry ids/indices to WAIVE as accepted residuals (name them in the report)') { |v| opts[:accept_residuals] = v.split(',').map(&:strip) }
@@ -1003,6 +1012,44 @@ else
     warn '       Escape hatch: --skip-postpublish-guide "<reason>" (name it in your migration report).'
     exit 16
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 12 — deferred DM elements (exit 17). post-and-readback.rb
+# --quarantine-on-failure saves a DM POST killed by one broken element by
+# moving the offender(s) to <workdir>/deferred-elements.json and re-POSTing the
+# rest (hackathon Rec5). That DM is PARTIAL by construction — declaring GREEN
+# on it would silently ship a data model missing elements. Non-empty file →
+# hard FAIL until the elements are fixed + re-POSTed (then delete the file).
+# No file / empty deferred list → OK. Escape: --accept-deferred-elements
+# "<reason>" (recorded as a waiver; name it + the dropped elements in the report).
+# ---------------------------------------------------------------------------
+deferred_path = File.join(opts[:tab], 'deferred-elements.json')
+if opts[:accept_deferred]
+  record_waiver.call('--accept-deferred-elements', 'gate 12 (deferred/quarantined DM elements)', opts[:accept_deferred])
+elsif File.exist?(deferred_path)
+  ddoc = JSON.parse(File.read(deferred_path)) rescue nil
+  deferred = ddoc.is_a?(Hash) ? Array(ddoc['deferred']) : (ddoc.is_a?(Array) ? ddoc : nil)
+  if deferred.nil?
+    warn "[FAIL] gate 12: #{deferred_path} is malformed (expected {\"deferred\":[...]} or a bare array)."
+    warn '       Fix or delete the file (delete ONLY if every quarantined element was restored + re-POSTed).'
+    exit 17
+  elsif deferred.any?
+    names = deferred.map { |d| d.is_a?(Hash) ? (d.dig('element', 'name') || d.dig('element', 'id') || '(unnamed)') : d.to_s }
+    warn "[FAIL] gate 12: #{deferred.size} DM element(s) still deferred (quarantined at POST time) — the live"
+    warn '       data model is PARTIAL. Resolve the deferred elements and re-POST:'
+    names.each { |n| warn "         - #{n}" }
+    warn "       Fix each element spec in #{deferred_path}, restore it into the DM spec,"
+    warn '       PUT it back (ruby scripts/post-and-readback.rb --type datamodel --update-id <dmId> ...),'
+    warn '       then delete the file and re-run this gate.'
+    warn '       Escape hatch (knowingly shipping a partial DM): --accept-deferred-elements "<reason>"'
+    warn '       (name it AND the dropped elements in your migration report).'
+    exit 17
+  else
+    puts "[OK] gate 12: deferred-elements.json present but empty — all quarantined elements resolved"
+  end
+else
+  puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/check-sql-idents.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/check-sql-idents.rb
@@ -1,0 +1,124 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# check-sql-idents — preflight the Custom SQL (kind:"sql") elements of a DM
+# spec against LIVE warehouse catalog columns, BEFORE the POST (hackathon F2:
+# emitted SQL referenced CUSTOMER_SFDC_ID unquoted while the actual Snowflake
+# column is "Customer SFDC ID" — a compile error that only surfaced at POST).
+#
+# Offline + pure: reads the spec and the column JSONs you already fetched
+# (scripts/discover-columns.rb output, or any {"columns":[{"name":...}]} /
+# ["NAME", ...] file). No network, no creds.
+#
+# Usage:
+#   ruby scripts/check-sql-idents.rb --dm-spec <workdir>/dm-spec.json \
+#     --columns DEAL_FACTS=<workdir>/columns-DEAL_FACTS.json \
+#     [--columns OTHER_TABLE=path.json ...]
+#
+#   Table keys match the LAST path segment of the SQL's FROM/JOIN refs,
+#   case-insensitively. Fetch each file first with e.g.:
+#     ruby scripts/discover-columns.rb --connection-id <id> \
+#       --table-path DB.SCHEMA.DEAL_FACTS --out columns-DEAL_FACTS.json
+#
+# Exit codes:
+#   0  every kind:"sql" element's identifiers resolve against the catalog
+#   1  unknown identifier(s) found — per-element fix list printed
+#   2  usage / input error (missing file, malformed JSON, no --columns)
+#
+# List the tables a spec references (to know what to fetch):
+#   ruby scripts/check-sql-idents.rb --dm-spec dm-spec.json --list-tables
+
+require 'json'
+require 'optparse'
+require_relative 'lib/sql_ident_check'
+
+opts = { columns: {} }
+OptionParser.new do |p|
+  p.on('--dm-spec PATH') { |v| opts[:spec] = v }
+  p.on('--columns PAIR', 'TABLE=path-to-columns-json (repeatable)') do |v|
+    t, path = v.split('=', 2)
+    abort "bad --columns #{v.inspect} — expected TABLE=path.json" if t.to_s.empty? || path.to_s.empty?
+    opts[:columns][t] = path
+  end
+  p.on('--list-tables', 'print the base tables the spec\'s SQL references, then exit') { opts[:list] = true }
+end.parse!
+abort 'missing --dm-spec' unless opts[:spec]
+abort("dm-spec not found: #{opts[:spec]}") unless File.exist?(opts[:spec])
+
+spec = begin
+  JSON.parse(File.read(opts[:spec], encoding: 'UTF-8'))
+rescue JSON::ParserError => e
+  warn "malformed dm-spec JSON: #{e.message}"
+  exit 2
+end
+
+sql_els = SqlIdentCheck.sql_elements(spec)
+if sql_els.empty?
+  puts 'no kind:"sql" elements in the spec — nothing to preflight'
+  exit 0
+end
+
+if opts[:list]
+  tables = SqlIdentCheck.referenced_tables(spec)
+  puts "#{sql_els.size} kind:\"sql\" element(s) reference #{tables.size} base table(s):"
+  tables.each { |t| puts "  #{t}" }
+  puts 'Fetch each with discover-columns.rb, then re-run with --columns TABLE=path.json.'
+  exit 0
+end
+
+if opts[:columns].empty?
+  warn 'no --columns supplied — run with --list-tables to see what to fetch, then pass'
+  warn '  --columns TABLE=columns.json for each referenced table.'
+  exit 2
+end
+
+# Accept discover-columns.rb output ({"columns":[{"name":..}]}), a bare
+# ["NAME", ...] array, or [{"name": ...}] — be liberal in what we read.
+columns_by_table = {}
+opts[:columns].each do |table, path|
+  unless File.exist?(path)
+    warn "columns file not found for #{table}: #{path}"
+    exit 2
+  end
+  doc = begin
+    JSON.parse(File.read(path, encoding: 'UTF-8'))
+  rescue JSON::ParserError => e
+    warn "malformed columns JSON for #{table} (#{path}): #{e.message}"
+    exit 2
+  end
+  cols = doc.is_a?(Hash) ? doc['columns'] : doc
+  names = Array(cols).map { |c| c.is_a?(Hash) ? (c['name'] || c['label']) : c }.compact.map(&:to_s)
+  if names.empty?
+    warn "no column names readable for #{table} in #{path} (expected {\"columns\":[{\"name\":..}]} or [\"NAME\",...])"
+    exit 2
+  end
+  columns_by_table[table] = names
+end
+
+bad_total = 0
+sql_els.each do |el|
+  res = SqlIdentCheck.check(el['statement'], columns_by_table)
+  if res[:ok]
+    puts "OK   #{el['name']} (page #{el['page']}) — identifiers resolve"
+    next
+  end
+  bad_total += res[:unknown].size
+  puts "FAIL #{el['name']} (page #{el['page']}, id #{el['id']}) — #{res[:unknown].size} unknown identifier(s):"
+  res[:unknown].each do |u|
+    shown = u[:quoted] ? %("#{u[:identifier]}") : u[:identifier]
+    fix = u[:suggestion] ? " → #{u[:suggestion]}" : ' → no catalog match (typo? wrong table? missing --columns?)'
+    scope = u[:table] ? " [#{u[:table]}]" : ''
+    puts "  #{shown}#{scope}#{fix}"
+  end
+end
+
+if bad_total.zero?
+  puts "all #{sql_els.size} kind:\"sql\" element(s) clean — identifiers match the live catalog"
+  exit 0
+else
+  puts
+  puts "#{bad_total} unknown identifier(s). Apply the quoted fixes above to each element's"
+  puts 'source.statement in the DM spec (double-quote spaced/mixed-case Snowflake columns),'
+  puts 'then re-run this preflight before POSTing.'
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/dm_quarantine.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/dm_quarantine.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+#
+# dm_quarantine — pure element-quarantine logic for a failed / partially-broken
+# DM POST (hackathon Rec5: ONE broken element must not lose the other N-1).
+#
+# The field regression: a DM spec with 5 elements where one view element carried
+# 300 dependency-not-found column refs. The whole POST failed, and the tester
+# hand-stripped elements to get a partial DM up. This module mechanizes that:
+# identify the offending element(s) from (a) the API error text or (b) the
+# post-POST /columns type=error census, remove them from the spec, and hand the
+# caller a deferred-elements record to persist. The DM that results is PARTIAL
+# by definition — post-and-readback.rb exits with a DISTINCT code and
+# assert-phase6-ran.rb refuses GREEN while deferred-elements.json is non-empty.
+#
+# Pure Ruby, stdlib only, NO network — every function takes plain Hashes so the
+# offline tests (scripts/test-dm-quarantine.rb) can drive it without an API.
+module DmQuarantine
+  module_function
+
+  # Distinct exit code for "quarantined + partial DM posted" — chosen unused:
+  # post-and-readback.rb already uses 1 (abort), 2 (type=error columns),
+  # 3 (layout lint), 4 (control lint). Documented in that script's header.
+  EXIT_QUARANTINED = 6
+
+  # All elements of a DM spec → [{page_id:, el:}].
+  def spec_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| { page_id: pg['id'], el: el } }
+    end
+  end
+
+  # (a) Attribute a failed-POST API error to specific spec element(s).
+  # Returns { ids: [element-id...], reasons: { id => "why" } } — empty ids when
+  # the error names nothing attributable (caller must then fail loudly and
+  # quarantine NOTHING; a blind guess would hide real breakage).
+  #
+  # Heuristics tuned to how Sigma DM POST errors surface today (message text in
+  # the JSON/YAML body — post-and-readback parses it and aborts with .inspect):
+  #   1. "[Element/...]" / "[Element/Rel/Col]" refs (dependency-not-found class)
+  #      → blame the element(s) whose column formulas CONTAIN that reference,
+  #        falling back to formulas referencing the same "[Element/" prefix.
+  #   2. an element NAME or spec element ID mentioned verbatim → that element.
+  #   3. "invalid identifier 'X'" (SQL compile class) → the kind:"sql"
+  #      element(s) whose statement contains X.
+  def offending_from_error(spec, error_payload)
+    text = error_payload.is_a?(String) ? error_payload : JSON.generate(error_payload)
+    els = spec_elements(spec)
+    ids = []
+    reasons = {}
+    blame = lambda do |el, why|
+      id = el['id']
+      next if id.nil?
+      ids << id unless ids.include?(id)
+      reasons[id] ||= why
+    end
+
+    # 1. bracketed refs like [Name/Col] (or deeper) in the error text.
+    text.scan(/\[([^\[\]\/]+)\/([^\[\]]+)\]/).each do |el_name, rest|
+      ref = "[#{el_name}/#{rest}]"
+      holders = els.select do |h|
+        (h[:el]['columns'] || []).any? { |c| c['formula'].to_s.include?(ref) }
+      end
+      holders = els.select do |h|
+        (h[:el]['columns'] || []).any? { |c| c['formula'].to_s.include?("[#{el_name}/") }
+      end if holders.empty?
+      # A base warehouse-table element's [TABLE/Col] formulas are SELF-refs
+      # (normal); the same text in a view/sql element is a cross-element
+      # dependency. When both match, blame the dependents, never the base —
+      # quarantining the base would gut every surviving element.
+      if holders.size > 1
+        dependents = holders.reject { |h| h[:el].dig('source', 'kind') == 'warehouse-table' }
+        holders = dependents if dependents.any?
+      end
+      holders = holders.reject { |h| (h[:el]['name'] || '') == el_name } if holders.size > 1
+      holders.each { |h| blame.call(h[:el], "column formula references unresolved #{ref}") }
+    end
+
+    # 2. element names / ids mentioned verbatim. Bracket refs are rule 1's
+    #    territory — strip them first so "[Deal Facts/…]" doesn't read as a
+    #    mention of the base element. Longest names first, and each match is
+    #    CONSUMED so "Deal Facts" can't re-match inside "Deal Facts View".
+    mention_text = text.gsub(/\[([^\[\]\/]+)\/([^\[\]]+)\]/, ' ')
+    els.sort_by { |h| -(h[:el]['name'].to_s.length) }.each do |h|
+      nm = h[:el]['name'].to_s
+      id = h[:el]['id'].to_s
+      if !id.empty? && mention_text.include?(id)
+        mention_text = mention_text.gsub(id, ' ')
+        blame.call(h[:el], 'element id named in the API error')
+      elsif nm.length >= 4 && mention_text.match?(/(?<![A-Za-z0-9_])#{Regexp.escape(nm)}(?![A-Za-z0-9_])/)
+        mention_text = mention_text.gsub(/(?<![A-Za-z0-9_])#{Regexp.escape(nm)}(?![A-Za-z0-9_])/, ' ')
+        blame.call(h[:el], 'element name named in the API error')
+      end
+    end
+
+    # 3. SQL compile errors naming an identifier → the sql element carrying it.
+    text.scan(/invalid identifier\s+'?"?([A-Za-z0-9_ ]+)"?'?/i).flatten.uniq.each do |ident|
+      els.each do |h|
+        stmt = h[:el].dig('source', 'statement').to_s
+        next if stmt.empty?
+        blame.call(h[:el], "SQL compile error: invalid identifier '#{ident}'") if stmt.include?(ident)
+      end
+    end
+
+    { ids: ids, reasons: reasons }
+  end
+
+  # (b) Attribute post-POST /columns type=error entries (live census) to SPEC
+  # element ids. Live element ids can differ from spec ids, so the caller maps
+  # live id → element NAME via the readback spec and passes those names here.
+  # Entries whose elementId matches a spec id directly are also honored.
+  def offending_from_error_columns(spec, error_columns, live_names_by_id = {})
+    els = spec_elements(spec)
+    ids = []
+    reasons = {}
+    Array(error_columns).each do |c|
+      live_id = c['elementId'].to_s
+      target = els.find { |h| h[:el]['id'] == live_id }
+      if target.nil? && (nm = live_names_by_id[live_id])
+        target = els.find { |h| h[:el]['name'] == nm }
+      end
+      next unless target
+      id = target[:el]['id']
+      ids << id unless ids.include?(id)
+      reasons[id] ||= "live column #{(c['label'] || c['columnId']).inspect} resolved to type=error"
+    end
+    { ids: ids, reasons: reasons }
+  end
+
+  # Remove the named elements from a DEEP COPY of the spec. Also drops
+  # relationships (on surviving elements) that target a removed element — a
+  # dangling relationship would just re-fail the re-POST. Returns
+  #   { spec: <cleaned>, deferred: [{pageId:, reason:, element:, removedRelationships: []}] }
+  # deferred[] is what post-and-readback persists to deferred-elements.json.
+  def quarantine(spec, ids, reasons = {})
+    cleaned = JSON.parse(JSON.generate(spec)) # deep copy
+    removed = []
+    (cleaned['pages'] || []).each do |pg|
+      keep = []
+      (pg['elements'] || []).each do |el|
+        if ids.include?(el['id'])
+          removed << { 'pageId' => pg['id'], 'reason' => reasons[el['id']] || 'quarantined',
+                       'element' => el, 'removedRelationships' => [] }
+        else
+          keep << el
+        end
+      end
+      pg['elements'] = keep
+    end
+    (cleaned['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el['relationships'].is_a?(Array)
+        dangling, kept = el['relationships'].partition { |r| ids.include?(r['targetElementId']) }
+        next if dangling.empty?
+        el['relationships'] = kept
+        el.delete('relationships') if kept.empty?
+        holder = removed.find { |d| d['element']['id'] == dangling.first['targetElementId'] } || removed.first
+        holder['removedRelationships'].concat(dangling.map { |r| r.merge('sourceElementId' => el['id']) }) if holder
+      end
+    end
+    { spec: cleaned, deferred: removed }
+  end
+
+  # The persisted deferred-elements.json document.
+  def deferred_doc(deferred, data_model_id: nil, spec_path: nil)
+    { 'dataModelId' => data_model_id, 'spec' => spec_path,
+      'note' => 'PARTIAL DM — these elements were quarantined at POST time. Fix them, restore into the spec, re-POST, then delete this file. assert-phase6-ran.rb blocks GREEN while it is non-empty.',
+      'deferred' => deferred }.compact
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sql_ident_check.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sql_ident_check.rb
@@ -1,0 +1,309 @@
+# frozen_string_literal: true
+#
+# sql_ident_check — Custom-SQL identifier preflight for kind:"sql" DM elements.
+#
+# WHY (hackathon field report, F2 class): the converter historically emitted
+# Custom SQL referencing UPPER_SNAKE identifiers (CUSTOMER_SFDC_ID) when the
+# actual warehouse column is spaced/mixed-case ("Customer SFDC ID") — a
+# Snowflake "invalid identifier" compile error that only surfaces at DM POST,
+# after minutes of pipeline. This module checks a statement's column
+# identifiers against the LIVE catalog columns (the caller fetches those, e.g.
+# via scripts/discover-columns.rb) BEFORE the POST, and proposes the quoted
+# fix: CUSTOMER_SFDC_ID → "Customer SFDC ID".
+#
+# SCOPE (deliberate): this is a tokenizer good enough for the converter's
+# emission patterns — bare identifiers, double-quoted identifiers, and
+# table-alias prefixes (__f."Deal Value", d.STAGE_NAME) across SELECT / WHERE /
+# GROUP BY / HAVING / ON / ORDER BY / QUALIFY / OVER clauses, WITH CTEs and
+# derived-table subqueries. It is NOT a SQL parser; exotic SQL should go
+# through the warehouse's own EXPLAIN.
+#
+# Matching semantics (Snowflake resolution rules):
+#   - quoted "X"  → OK iff an actual column equals X CASE-EXACTLY.
+#   - bare   X    → OK iff an actual column equals X or upcase(X) exactly
+#                   (unquoted identifiers fold to upper case).
+#   - otherwise   → unknown; if an actual column NORMALIZES to the same
+#                   upper-snake key (non-alphanumerics → _), suggest the
+#                   double-quoted exact name.
+#
+# Pure Ruby, stdlib only, no network. Callers: scripts/check-sql-idents.rb
+# (CLI) and offline tests (scripts/test-sql-ident-check.rb).
+module SqlIdentCheck
+  module_function
+
+  # Words that can appear in identifier position but are never warehouse
+  # columns. Function names are excluded structurally (token followed by "(") —
+  # this list covers keywords and argument-position soup (DATE_TRUNC parts
+  # arrive as string literals, already stripped).
+  KEYWORDS = %w[
+    SELECT FROM WHERE GROUP BY HAVING ORDER ASC DESC LIMIT OFFSET FETCH FIRST
+    NEXT ROWS ROW ONLY AS ON USING JOIN INNER LEFT RIGHT FULL OUTER CROSS
+    NATURAL LATERAL AND OR NOT IN IS NULL TRUE FALSE CASE WHEN THEN ELSE END
+    DISTINCT ALL UNION EXCEPT INTERSECT WITH OVER PARTITION QUALIFY WINDOW
+    BETWEEN LIKE ILIKE RLIKE SIMILAR TO EXISTS ANY SOME CAST INTERVAL
+    CURRENT_DATE CURRENT_TIME CURRENT_TIMESTAMP LOCALTIME LOCALTIMESTAMP
+    PRECEDING FOLLOWING UNBOUNDED CURRENT RANGE GROUPS EXCLUDE TIES OTHERS
+    ASOF MATCH_CONDITION PIVOT UNPIVOT SAMPLE TABLESAMPLE TOP ESCAPE VALUES
+  ].to_h { |k| [k, true] }.freeze
+
+  # Upper-snake normalization matching the converter's alias scheme
+  # ("Customer SFDC ID" → CUSTOMER_SFDC_ID).
+  def normalize(name)
+    name.to_s.gsub(/[^A-Za-z0-9]+/, '_').gsub(/\A_+|_+\z/, '').upcase
+  end
+
+  Token = Struct.new(:kind, :value) # kind: :word | :quoted | :punct
+
+  # Tokenize a statement: strips line/block comments and single-quoted string
+  # literals; yields double-quoted identifiers (:quoted, inner value with ""
+  # unescaped), bare words (:word), and single-char punctuation (:punct).
+  # Numbers are dropped (GROUP BY 1 ordinals are never column refs).
+  def tokenize(sql)
+    s = sql.to_s.dup
+    s = s.gsub(/--[^\n]*/, ' ').gsub(%r{/\*.*?\*/}m, ' ')
+    tokens = []
+    i = 0
+    while i < s.length
+      c = s[i]
+      case c
+      when '"'
+        j = i + 1
+        buf = +''
+        while j < s.length
+          if s[j] == '"' && s[j + 1] == '"'
+            buf << '"'
+            j += 2
+          elsif s[j] == '"'
+            break
+          else
+            buf << s[j]
+            j += 1
+          end
+        end
+        tokens << Token.new(:quoted, buf)
+        i = j + 1
+      when "'"
+        j = i + 1
+        j += (s[j] == "'" && s[j + 1] == "'" ? 2 : 1) while j < s.length && !(s[j] == "'" && s[j + 1] != "'")
+        i = j + 1
+      when /[A-Za-z_]/
+        j = i
+        j += 1 while j < s.length && s[j] =~ /[A-Za-z0-9_$]/
+        tokens << Token.new(:word, s[i...j])
+        i = j
+      when /[0-9]/
+        j = i
+        j += 1 while j < s.length && s[j] =~ /[0-9.eE+\-]/ && !(s[j] =~ /[+\-]/ && s[j - 1] !~ /[eE]/)
+        i = j
+      when /\s/
+        i += 1
+      else
+        tokens << Token.new(:punct, c)
+        i += 1
+      end
+    end
+    tokens
+  end
+
+  # Structural scan → {
+  #   idents:  [{name:, quoted:, alias: <tbl-alias|nil>}, ...]  candidate COLUMN refs
+  #   aliases: { "OUTPUT_ALIAS" => true, ... }   names defined by AS / CTEs (upcased)
+  #   tables:  [{name:, alias:}]                 FROM/JOIN base tables (last path part)
+  # }
+  def scan(sql)
+    tokens = tokenize(sql)
+    idents  = []
+    defined = {}
+    tables  = []
+    i = 0
+    while i < tokens.length
+      t = tokens[i]
+      nxt = tokens[i + 1]
+      up = t.kind == :word ? t.value.upcase : nil
+
+      # WITH <cte> AS (   /   ), <cte> AS (
+      if up == 'WITH' || (t.kind == :punct && t.value == ',' && nxt && tokens[i + 2] && tokens[i + 2].kind == :word && tokens[i + 2].value.upcase == 'AS' && tokens[i + 3] && tokens[i + 3].value == '(')
+        cte = up == 'WITH' ? nxt : nxt
+        if cte && (cte.kind == :word || cte.kind == :quoted) &&
+           tokens[i + 2] && tokens[i + 2].kind == :word && tokens[i + 2].value.upcase == 'AS'
+          defined[cte.value.upcase] = true
+          i += 3
+          next
+        end
+      end
+
+      # AS <name> — output alias / derived-table alias: defined, never checked.
+      if up == 'AS' && nxt && (nxt.kind == :word || nxt.kind == :quoted)
+        defined[nxt.value.upcase] = true
+        i += 2
+        next
+      end
+
+      # FROM/JOIN <table-ref> [alias] — capture the base table + its alias,
+      # skip the path tokens entirely. FROM ( → derived table; its trailing
+      # alias is caught by the ") word" rule below.
+      if %w[FROM JOIN].include?(up)
+        j = i + 1
+        if tokens[j] && tokens[j].kind == :punct && tokens[j].value == '('
+          i = j # fall through; subquery scanned as part of the stream
+          next
+        end
+        parts = []
+        while tokens[j] && (tokens[j].kind == :word || tokens[j].kind == :quoted)
+          parts << tokens[j].value
+          break unless tokens[j + 1] && tokens[j + 1].kind == :punct && tokens[j + 1].value == '.'
+          j += 2
+        end
+        if parts.any?
+          tbl = { name: parts.last, alias: nil }
+          k = j + 1
+          if tokens[k] && tokens[k].kind == :word && tokens[k].value.upcase == 'AS' && tokens[k + 1]
+            tbl[:alias] = tokens[k + 1].value
+            k += 2
+          elsif tokens[k] && tokens[k].kind == :word && !KEYWORDS[tokens[k].value.upcase]
+            tbl[:alias] = tokens[k].value
+            k += 1
+          end
+          defined[tbl[:alias].upcase] = true if tbl[:alias]
+          tables << tbl
+          i = k
+          next
+        end
+      end
+
+      # ") <word>" — derived-table alias (e.g. ") __base", ") t"): defined.
+      if t.kind == :punct && t.value == ')' && nxt && nxt.kind == :word &&
+         !KEYWORDS[nxt.value.upcase] && !(tokens[i + 2] && tokens[i + 2].kind == :punct && tokens[i + 2].value == '(')
+        defined[nxt.value.upcase] = true
+        i += 2
+        next
+      end
+
+      # <alias> . <ident>  — table-qualified column ref.
+      if (t.kind == :word || t.kind == :quoted) && nxt && nxt.kind == :punct && nxt.value == '.' &&
+         tokens[i + 2] && (tokens[i + 2].kind == :word || tokens[i + 2].kind == :quoted)
+        col = tokens[i + 2]
+        after = tokens[i + 3]
+        source_pos = after && after.kind == :word && after.value.upcase == 'AS'
+        # function call like alias.fn( never occurs in emitted SQL; treat as column
+        idents << { name: col.value, quoted: col.kind == :quoted, alias: t.value,
+                    source_pos: source_pos }
+        i += 3
+        next
+      end
+
+      # bare word: keyword? function (followed by "(")? else candidate column.
+      # `X AS ...` marks X as SOURCE-position: it must be checked even when an
+      # output alias shares its name (the `CUSTOMER_SFDC_ID AS CUSTOMER_SFDC_ID`
+      # bug shape must not self-whitelist).
+      if t.kind == :word
+        if KEYWORDS[up] || (nxt && nxt.kind == :punct && nxt.value == '(')
+          i += 1
+          next
+        end
+        idents << { name: t.value, quoted: false, alias: nil,
+                    source_pos: nxt && nxt.kind == :word && nxt.value.upcase == 'AS' }
+        i += 1
+        next
+      end
+
+      # standalone quoted ident: candidate column (unless followed by "(").
+      if t.kind == :quoted
+        unless nxt && nxt.kind == :punct && nxt.value == '('
+          idents << { name: t.value, quoted: true, alias: nil,
+                      source_pos: nxt && nxt.kind == :word && nxt.value.upcase == 'AS' }
+        end
+        i += 1
+        next
+      end
+
+      i += 1
+    end
+    { idents: idents, aliases: defined, tables: tables }
+  end
+
+  # Check one statement against catalog columns.
+  #
+  #   statement        — the kind:"sql" element's SQL text
+  #   columns_by_table — { "DEAL_FACTS" => ["Customer Ref ID", ...], ... }
+  #                      (table keys matched case-insensitively on the LAST
+  #                      path segment; values are the LIVE column names)
+  #
+  # Returns { ok:, unknown: [{identifier:, quoted:, table:, suggestion:}], tables: [...] }
+  #   suggestion is the ready-to-paste fix, e.g. %q{"Customer Ref ID"}, or nil.
+  def check(statement, columns_by_table)
+    scanned = scan(statement)
+    norm_tables = {}
+    (columns_by_table || {}).each { |t, cols| norm_tables[t.to_s.split('.').last.upcase] = Array(cols).map(&:to_s) }
+    all_cols = norm_tables.values.flatten
+    alias_to_table = {}
+    scanned[:tables].each do |t|
+      key = t[:name].to_s.upcase
+      alias_to_table[t[:alias].to_s.upcase] = key if t[:alias] && norm_tables.key?(key)
+    end
+
+    unknown = []
+    seen = {}
+    scanned[:idents].each do |ref|
+      name = ref[:name]
+      next if name.empty?
+      qualified_to_catalog = ref[:alias] && alias_to_table.key?(ref[:alias].to_s.upcase)
+      # An output alias / CTE / derived-table name may be REFERENCED later
+      # (outer SELECT, GROUP BY) — skip those occurrences. But an identifier in
+      # SOURCE position (left of AS) or qualified to a real catalog table is a
+      # column read and is always checked.
+      next if scanned[:aliases][name.upcase] && !ref[:source_pos] && !qualified_to_catalog
+      cols =
+        if qualified_to_catalog
+          norm_tables[alias_to_table[ref[:alias].to_s.upcase]]
+        else
+          all_cols
+        end
+      next if cols.empty? # no catalog supplied for this scope — can't judge
+      ok =
+        if ref[:quoted]
+          cols.include?(name) # case-exact
+        else
+          cols.include?(name) || cols.include?(name.upcase)
+        end
+      next if ok
+      key = "#{ref[:quoted] ? '"' : ''}#{name}"
+      next if seen[key]
+      seen[key] = true
+      suggestion = nil
+      if ref[:quoted]
+        exact_ci = cols.find { |c| c.casecmp?(name) }
+        suggestion = %("#{exact_ci}") if exact_ci
+      end
+      suggestion ||= begin
+        n = normalize(name)
+        hit = cols.find { |c| normalize(c) == n }
+        hit ? %("#{hit}") : nil
+      end
+      unknown << { identifier: name, quoted: ref[:quoted],
+                   table: ref[:alias] ? alias_to_table[ref[:alias].to_s.upcase] : nil,
+                   suggestion: suggestion }
+    end
+    { ok: unknown.empty?, unknown: unknown, tables: scanned[:tables].map { |t| t[:name] } }
+  end
+
+  # All kind:"sql" elements of a DM spec → [{page:, name:, id:, statement:}].
+  def sql_elements(dm_spec)
+    out = []
+    (dm_spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        next unless el.dig('source', 'kind') == 'sql'
+        out << { 'page' => pg['name'] || pg['id'], 'name' => el['name'] || el['id'],
+                 'id' => el['id'], 'statement' => el.dig('source', 'statement').to_s }
+      end
+    end
+    out
+  end
+
+  # Base tables referenced by every kind:"sql" element (last path segment,
+  # upcased, deduped) — what the caller must supply --columns for.
+  def referenced_tables(dm_spec)
+    sql_elements(dm_spec).flat_map { |e| scan(e['statement'])[:tables].map { |t| t[:name].to_s.upcase } }
+                         .reject { |t| t.start_with?('__') }.uniq
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -1808,6 +1808,27 @@ unless reuse_dm_id
   _, dvst = run!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'datamodel', dm_spec_path],
                  allow_fail: mechanical)
   line 'DM validate-spec flagged issues (advisory in mechanical mode — live POST is the gate)' if mechanical && !dvst.success?
+  # Custom-SQL identifier preflight (hackathon F2 class): a kind:"sql" element
+  # whose statement references CUSTOMER_SFDC_ID unquoted while the live column
+  # is "Customer SFDC ID" compiles only at POST time (Snowflake "invalid
+  # identifier"). The catalog fetch needs connection context this orchestrator
+  # doesn't have inline, so we print the exact copy-paste preflight instead of
+  # auto-running it — run it if the POST below fails with a SQL compile error.
+  begin
+    require_relative 'lib/sql_ident_check'
+    _sql_tables = SqlIdentCheck.referenced_tables(JSON.parse(File.read(dm_spec_path, encoding: 'UTF-8')))
+    if _sql_tables.any?
+      line "DM spec contains Custom SQL element(s) referencing: #{_sql_tables.join(', ')}"
+      line 'If the POST fails with a SQL compile error (invalid identifier), preflight the identifiers:'
+      _sql_tables.each do |t|
+        line "  ruby #{File.join(HERE, 'discover-columns.rb')} --connection-id #{opts[:conn]} --table-path #{db}.#{schema}.#{t} --out #{File.join(WORK, "columns-#{t}.json")}"
+      end
+      line "  ruby #{File.join(HERE, 'check-sql-idents.rb')} --dm-spec #{dm_spec_path} " +
+           _sql_tables.map { |t| "--columns #{t}=#{File.join(WORK, "columns-#{t}.json")}" }.join(' ')
+    end
+  rescue StandardError => e
+    line "WARN: sql-ident preflight hint unavailable (#{e.class}: #{e.message})"
+  end
   sigma_run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
               '--spec', dm_spec_path, '--out', dm_ids_path, '--workdir', WORK])
   dm_ids = JSON.parse(File.read(dm_ids_path))
@@ -2160,7 +2181,8 @@ mark('phase5-layout')
 # layout can be reviewed against refs/layout-visual-qa.md AND compared to the
 # source Tableau dashboard — the cross-converter visual-QA gate. Page ids come
 # from the LOCAL wb-spec.json (deterministic; the live /spec readback is flaky
-# and returns YAML); token via get-token.sh inside sigma_run!. Non-fatal — a
+# and returns YAML); token minted IN-PROCESS (Sigma.refresh_token!) and injected
+# into the child env by sigma_run! — no get-token.sh subshell (#299/#310). Non-fatal — a
 # transient export failure must not sink a green migration; the REVIEW is the gate.
 # ---------------------------------------------------------------------------
 hdr('5b', 'Visual QA')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/post-and-readback.rb
@@ -4,6 +4,19 @@
 #
 # Usage:
 #   ruby post-and-readback.rb --type datamodel|workbook --spec <spec.json> --out <id-map.json>
+#
+# Exit codes:
+#   0  posted + readback clean
+#   1  hard failure (abort) — POST/PUT rejected, nothing recoverable
+#   2  column(s) resolved to type=error on the live DM/workbook
+#   3  workbook layout lint violations
+#   4  workbook control lint violations
+#   6  DATAMODEL QUARANTINED (only with --quarantine-on-failure): one or more
+#      broken elements were removed to <workdir>/deferred-elements.json and the
+#      REMAINING spec re-POSTed once. The DM is PARTIAL — the migration may NOT
+#      be declared GREEN while deferred-elements.json is non-empty
+#      (assert-phase6-ran.rb enforces this). Fix the deferred elements, restore
+#      them into the spec, re-POST, then delete the file.
 
 require 'net/http'
 require 'uri'
@@ -23,6 +36,7 @@ OptionParser.new do |p|
   p.on('--skip-control-lint') { opts[:skip_control_lint] = true }
   p.on('--control-scope P', 'control-scope.json sidecar (default: <workdir>/control-scope.json if present)') { |v| opts[:control_scope] = v }
   p.on('--update-id ID', 'PUT the spec to this existing workbook/DM id instead of POSTing a new one (retry-safe; avoids orphan workbooks). For workbooks, if omitted, the last id in posted-workbooks.jsonl is reused automatically.') { |v| opts[:update_id] = v }
+  p.on('--quarantine-on-failure', 'DATAMODEL only: when the POST fails naming specific element(s), or the post-POST column census resolves specific elements to type=error, move those elements to <workdir>/deferred-elements.json, re-POST ONCE without them, and exit 6 (PARTIAL DM — never GREEN until the file is resolved). Default (no flag): fail loudly, quarantine nothing.') { opts[:quarantine] = true }
 end.parse!
 %i[type spec out].each { |k| abort("missing --#{k}") unless opts[k] }
 opts[:workdir] ||= File.dirname(File.expand_path(opts[:spec]))
@@ -31,6 +45,11 @@ FileUtils.mkdir_p(opts[:workdir])
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'sigma_rest'
+require 'dm_quarantine'
+
+QUARANTINE = opts[:quarantine] && opts[:type] == 'datamodel'
+DEFERRED_PATH = File.join(opts[:workdir], 'deferred-elements.json')
+warn 'NOTE: --quarantine-on-failure only applies to --type datamodel; ignored.' if opts[:quarantine] && opts[:type] != 'datamodel'
 
 BASE = ENV.fetch('SIGMA_BASE_URL')
 
@@ -137,7 +156,31 @@ if update_id
 else
   resp = http(:post, POST_PATH, File.read(opts[:spec]))
   parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
-  oid = parsed[ID_FIELD] or abort("POST failed: #{parsed.inspect}")
+  oid = parsed.is_a?(Hash) ? parsed[ID_FIELD] : nil
+  # Rec5 quarantine (opt-in): a POST killed by ONE broken element must not lose
+  # the other N-1. If the API error names attributable element(s), defer them
+  # to <workdir>/deferred-elements.json and re-POST ONCE without them. If the
+  # error is not attributable, fail loudly exactly as before.
+  if oid.nil? && QUARANTINE
+    spec_doc = JSON.parse(File.read(opts[:spec]))
+    found = DmQuarantine.offending_from_error(spec_doc, resp.body.to_s)
+    if found[:ids].any?
+      q = DmQuarantine.quarantine(spec_doc, found[:ids], found[:reasons])
+      $quarantined = q[:deferred]
+      File.write(DEFERRED_PATH, JSON.pretty_generate(
+        DmQuarantine.deferred_doc(q[:deferred], spec_path: File.expand_path(opts[:spec]))))
+      cleaned_path = File.join(opts[:workdir], 'dm-spec.quarantined.json')
+      File.write(cleaned_path, JSON.pretty_generate(q[:spec]))
+      warn "QUARANTINE: POST failed naming #{found[:ids].size} element(s) — deferred to #{DEFERRED_PATH}; re-POSTing ONCE without them (#{cleaned_path})"
+      found[:ids].each { |id| warn "  - #{id}: #{found[:reasons][id]}" }
+      resp = http(:post, POST_PATH, File.read(cleaned_path))
+      parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+      oid = parsed.is_a?(Hash) ? parsed[ID_FIELD] : nil
+      abort("POST failed AGAIN after quarantining #{found[:ids].size} element(s) — not a single-element failure. " \
+            "Deferred file kept for forensics: #{DEFERRED_PATH}. Error: #{parsed.inspect}") if oid.nil?
+    end
+  end
+  abort("POST failed: #{parsed.inspect}") if oid.nil?
   warn "POST ok: #{ID_FIELD}=#{oid}"
 
   # Append the new ID to the per-conversion log. Newline-delimited JSON so
@@ -151,21 +194,59 @@ else
 end
 
 # Read back
-spec = JSON.parse(http(:get, format(GET_PATH, oid), accept_json: true).body)
-
 # Fetch the resolved /columns BEFORE writing the id-map so we can attach the
 # AUTHORITATIVE per-element column labels (the suffixed display names Sigma
 # assigns to disambiguate joined-dim columns — e.g. "Customer Id (CUSTOMER_DIM)").
 # derive_master needs these to emit master-column formulas that actually resolve.
 # (Same response is reused below for the error-type guard — one round trip.)
+# Wrapped in a lambda because the quarantine path below may PUT a cleaned spec
+# and needs a SECOND readback of the final live state.
 columns_path = opts[:type] == 'datamodel' ?
   "/v2/dataModels/#{oid}/columns" :
   "/v2/workbooks/#{oid}/columns"
-cols_res = http(:get, columns_path, accept_json: true)
-cols_json = cols_res.is_a?(Net::HTTPSuccess) ? (JSON.parse(cols_res.body) rescue { 'entries' => [] }) : nil
-labels_by_el = Hash.new { |h, k| h[k] = [] }
-(cols_json && cols_json['entries'] || []).each do |c|
-  labels_by_el[c['elementId']] << c['label'] if c['elementId'] && c['label']
+readback = lambda do
+  spec = JSON.parse(http(:get, format(GET_PATH, oid), accept_json: true).body)
+  cols_res = http(:get, columns_path, accept_json: true)
+  cols_json = cols_res.is_a?(Net::HTTPSuccess) ? (JSON.parse(cols_res.body) rescue { 'entries' => [] }) : nil
+  labels_by_el = Hash.new { |h, k| h[k] = [] }
+  (cols_json && cols_json['entries'] || []).each do |c|
+    labels_by_el[c['elementId']] << c['label'] if c['elementId'] && c['label']
+  end
+  [spec, cols_res, cols_json, labels_by_el]
+end
+spec, cols_res, cols_json, labels_by_el = readback.call
+
+# Rec5 quarantine, census leg (opt-in, datamodel only): the POST succeeded but
+# specific live element(s) resolved columns to type=error. Defer those elements,
+# PUT the cleaned spec back to the SAME DM id (no orphan), and re-read once.
+# $quarantined.nil? enforces the re-POST-ONCE contract: if the POST leg already
+# quarantined and errors REMAIN, fail loudly (exit 2) instead of looping.
+if QUARANTINE && $quarantined.nil? && cols_res.is_a?(Net::HTTPSuccess)
+  census_errors = (cols_json['entries'] || []).select { |c| c.dig('type', 'type') == 'error' }
+  if census_errors.any?
+    spec_doc = JSON.parse(File.read(opts[:spec]))
+    # live element id → name, so census elementIds map back onto spec elements
+    live_names = {}
+    (spec['pages'] || []).each { |p| (p['elements'] || []).each { |e| live_names[e['id']] = e['name'] } }
+    found = DmQuarantine.offending_from_error_columns(spec_doc, census_errors, live_names)
+    if found[:ids].any?
+      q = DmQuarantine.quarantine(spec_doc, found[:ids], found[:reasons])
+      $quarantined = Array($quarantined) + q[:deferred]
+      File.write(DEFERRED_PATH, JSON.pretty_generate(
+        DmQuarantine.deferred_doc($quarantined, data_model_id: oid, spec_path: File.expand_path(opts[:spec]))))
+      cleaned_path = File.join(opts[:workdir], 'dm-spec.quarantined.json')
+      File.write(cleaned_path, JSON.pretty_generate(q[:spec]))
+      warn "QUARANTINE: column census flagged #{found[:ids].size} element(s) — deferred to #{DEFERRED_PATH}; " \
+           "re-PUTting the remaining spec to #{ID_FIELD}=#{oid} (#{cleaned_path})"
+      found[:ids].each { |id| warn "  - #{id}: #{found[:reasons][id]}" }
+      put_res = http(:put, format(GET_PATH, oid), File.read(cleaned_path))
+      abort("re-PUT after quarantine failed (HTTP #{put_res.code}): #{put_res.body.to_s[0, 500]} — " \
+            "deferred file kept: #{DEFERRED_PATH}") unless put_res.is_a?(Net::HTTPSuccess)
+      spec, cols_res, cols_json, labels_by_el = readback.call
+    else
+      warn 'QUARANTINE: column census has type=error entries but none map to a spec element — nothing quarantined (failing loudly below).'
+    end
+  end
 end
 
 out = {
@@ -215,6 +296,7 @@ if res.is_a?(Net::HTTPSuccess)
     warn 'Fix these formulas before continuing — Phase 6 parity would fail downstream.'
     warn 'Common causes: typo in a column ref, IsIn() / non-existent function, window'
     warn 'aggregate in a calc column (use a Custom SQL element instead — see Phase 3).'
+    warn "NOTE: errors persist AFTER quarantining #{Array($quarantined).size} element(s) — see #{DEFERRED_PATH}." if $quarantined
     warn '========================================'
     exit(2)
   else
@@ -244,6 +326,30 @@ if opts[:type] == 'datamodel' && res.is_a?(Net::HTTPSuccess)
     warn 'one element per datasource (multi-element DM) before building the workbook.'
     warn '========================================'
   end
+end
+
+# Rec5 quarantine final report: the (re-)POST succeeded and the census is clean,
+# but only because broken element(s) were REMOVED. The DM is PARTIAL — exit with
+# the distinct code so no caller mistakes this for a full green POST.
+if $quarantined && Array($quarantined).any?
+  File.write(DEFERRED_PATH, JSON.pretty_generate(
+    DmQuarantine.deferred_doc($quarantined, data_model_id: oid, spec_path: File.expand_path(opts[:spec]))))
+  names = Array($quarantined).map { |d| d.dig('element', 'name') || d.dig('element', 'id') }
+  warn "\n================================================================"
+  warn "PARTIAL DM — #{names.size} element(s) QUARANTINED (exit #{DmQuarantine::EXIT_QUARANTINED})"
+  warn "================================================================"
+  Array($quarantined).each do |d|
+    warn "  - #{d.dig('element', 'name') || d.dig('element', 'id')}: #{d['reason']}"
+  end
+  warn "The remaining elements posted cleanly to #{ID_FIELD}=#{oid}, but the DM is"
+  warn "INCOMPLETE. Fix each element spec in:"
+  warn "  #{DEFERRED_PATH}"
+  warn 'restore it into the DM spec, re-POST (PUT --update-id), and delete the file.'
+  warn 'The migration may NOT be declared GREEN while deferred-elements.json is'
+  warn 'non-empty — assert-phase6-ran.rb blocks it (escape: --accept-deferred-elements'
+  warn '"<reason>", which must be named in the migration report).'
+  warn '================================================================'
+  exit(DmQuarantine::EXIT_QUARANTINED)
 end
 
 # Layout-quality lint (shared scripts/lib/layout_lint.rb — vendored byte-

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-quarantine.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-dm-quarantine.rb
@@ -1,0 +1,154 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Offline test for the Rec5 element-quarantine ("don't lose the other 4
+# elements"): scripts/lib/dm_quarantine.rb pure functions + the
+# assert-phase6-ran.rb gate 12 (deferred-elements.json blocks GREEN, exit 17).
+# Deterministic — no network, no live Sigma API.
+#
+# Usage:  ruby scripts/test-dm-quarantine.rb
+
+require 'json'
+require 'tmpdir'
+require 'open3'
+require 'rbconfig'
+require_relative 'lib/dm_quarantine'
+
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+Q = DmQuarantine
+GATE = File.join(__dir__, 'assert-phase6-ran.rb')
+
+# A 4-element DM shaped like the field regression: warehouse fact, a 2-column
+# LOD SQL helper, a derived view whose formulas reference base+helper, and an
+# unrelated healthy dim. Fact carries the relationship to the helper.
+def spec_fixture
+  {
+    'name' => 'Pipeline Deals', 'schemaVersion' => 1,
+    'pages' => [{ 'id' => 'pg1', 'name' => 'Page 1', 'elements' => [
+      { 'id' => 'el-fact', 'kind' => 'table', 'name' => 'Deal Facts',
+        'source' => { 'kind' => 'warehouse-table', 'path' => %w[ANALYTICS SALES DEAL_FACTS] },
+        'columns' => [{ 'id' => 'c1', 'formula' => '[DEAL_FACTS/Customer Ref Id]' },
+                      { 'id' => 'c2', 'formula' => '[DEAL_FACTS/Deal Value]' }],
+        'relationships' => [{ 'id' => 'r1', 'targetElementId' => 'el-helper',
+                              'keys' => [{ 'sourceColumnId' => 'c1', 'targetColumnId' => 'h1' }] }] },
+      { 'id' => 'el-helper', 'kind' => 'table', 'name' => 'DEAL_FACTS FIXED CUSTOMER_REF_ID',
+        'source' => { 'kind' => 'sql', 'statement' => 'SELECT CUSTOMER_SFDC_ID, COUNT(1) AS N FROM ANALYTICS.SALES.DEAL_FACTS GROUP BY 1' },
+        'columns' => [{ 'id' => 'h1', 'formula' => '[Custom SQL/CUSTOMER_REF_ID]' }] },
+      { 'id' => 'el-view', 'kind' => 'table', 'name' => 'Deal Facts View',
+        'source' => { 'kind' => 'table', 'elementId' => 'el-fact' },
+        'columns' => [{ 'id' => 'v1', 'formula' => '[Deal Facts/Customer Ref Id]' },
+                      { 'id' => 'v2', 'formula' => '[Deal Facts/FIXED Customer Ref ID/Max West]' }] },
+      { 'id' => 'el-dim', 'kind' => 'table', 'name' => 'Account Dim',
+        'source' => { 'kind' => 'warehouse-table', 'path' => %w[ANALYTICS SALES ACCOUNT_DIM] },
+        'columns' => [{ 'id' => 'd1', 'formula' => '[ACCOUNT_DIM/Account Name]' }] }
+    ] }]
+  }
+end
+
+puts 'Part A — offending_from_error: dependency-not-found refs blame the DEPENDENT'
+err = '{"code":"bad_request","message":"Dependency not found: [Deal Facts/Customer Ref Id] ' \
+      '(and 299 more) while compiling element"}'
+found = Q.offending_from_error(spec_fixture, err)
+check(found[:ids].include?('el-view'), 'view (holder of the broken refs) blamed', fails)
+check(!found[:ids].include?('el-fact'), 'base fact NOT blamed for its own self-refs', fails)
+
+puts 'Part B — offending_from_error: element name / SQL identifier attribution'
+found = Q.offending_from_error(spec_fixture, 'Element "Deal Facts View" failed to compile')
+check(found[:ids] == ['el-view'], "name mention → el-view (got #{found[:ids].inspect})", fails)
+found = Q.offending_from_error(spec_fixture, "SQL compilation error: invalid identifier 'CUSTOMER_SFDC_ID'")
+check(found[:ids] == ['el-helper'], "invalid identifier → the sql element (got #{found[:ids].inspect})", fails)
+found = Q.offending_from_error(spec_fixture, 'internal server error, request id 12345')
+check(found[:ids].empty?, 'unattributable error → NOTHING quarantined (fail-loud contract)', fails)
+
+puts 'Part C — offending_from_error_columns: live census → spec elements'
+census = [{ 'elementId' => 'el-view', 'columnId' => 'v2', 'label' => 'Max West', 'type' => { 'type' => 'error' } }]
+found = Q.offending_from_error_columns(spec_fixture, census)
+check(found[:ids] == ['el-view'], 'direct spec-id match', fails)
+census = [{ 'elementId' => 'live-9x', 'columnId' => 'v2', 'label' => 'Max West', 'type' => { 'type' => 'error' } }]
+found = Q.offending_from_error_columns(spec_fixture, census, { 'live-9x' => 'Deal Facts View' })
+check(found[:ids] == ['el-view'], 'server-assigned live id maps back via element NAME', fails)
+found = Q.offending_from_error_columns(spec_fixture, census, {})
+check(found[:ids].empty?, 'unmappable live id → nothing quarantined', fails)
+
+puts 'Part D — quarantine: removes offenders, keeps the rest, drops dangling rels'
+src = spec_fixture
+q = Q.quarantine(src, ['el-helper'], { 'el-helper' => 'SQL compile error' })
+kept_ids = q[:spec]['pages'][0]['elements'].map { |e| e['id'] }
+check(kept_ids == %w[el-fact el-view el-dim], "helper removed, other 3 kept (got #{kept_ids.inspect})", fails)
+fact2 = q[:spec]['pages'][0]['elements'].find { |e| e['id'] == 'el-fact' }
+check(!fact2.key?('relationships'), 'dangling fact→helper relationship dropped from the cleaned spec', fails)
+check(q[:deferred].size == 1 && q[:deferred][0]['element']['id'] == 'el-helper', 'deferred record carries the full element spec', fails)
+check(q[:deferred][0]['reason'] == 'SQL compile error', 'deferred record carries the reason', fails)
+check(q[:deferred][0]['removedRelationships'].size == 1 &&
+      q[:deferred][0]['removedRelationships'][0]['sourceElementId'] == 'el-fact',
+      'removed relationship recorded for restoration', fails)
+check(src['pages'][0]['elements'].size == 4 && src['pages'][0]['elements'][0].key?('relationships'),
+      'original spec untouched (deep copy)', fails)
+doc = Q.deferred_doc(q[:deferred], data_model_id: 'dm-123', spec_path: '/x/dm-spec.json')
+check(doc['dataModelId'] == 'dm-123' && doc['deferred'].size == 1 && doc['note'].include?('PARTIAL'),
+      'deferred_doc shape (id + note + deferred[])', fails)
+
+puts 'Part E — gate 12 (assert-phase6-ran.rb): deferred-elements.json blocks GREEN'
+# Workdir that passes every default gate (mirrors test-assert-phase6-gates.rb).
+def base_workdir(dir)
+  File.write(File.join(dir, 'parity-final.json'), JSON.pretty_generate(
+    'workbook_id' => 'wb-test', 'mode' => 'strict', 'status' => 'PASS',
+    'charts_total' => 2, 'charts_pass' => 2, 'charts_fail' => 0,
+    'pass_names' => %w[KPI Trend], 'fail_names' => [],
+    'visual_checked' => true, 'visual_verdict' => 'pass', 'agent_vision' => true))
+  File.binwrite(File.join(dir, 'sigma-render.png'), "\x89PNG\r\n\x1a\n".b + ("\x00".b * 6000))
+  File.write(File.join(dir, 'telemetry-sent.json'), JSON.generate('status' => 'sent', 'tool' => 'test'))
+end
+
+def run_gate(dir, *args)
+  env = { 'SIGMA_BASE_URL' => nil, 'SIGMA_API_TOKEN' => nil }
+  Open3.capture3(env, RbConfig.ruby, GATE, '--workdir', dir, *args)
+end
+
+Dir.mktmpdir do |dir|
+  base_workdir(dir)
+  out, _e, st = run_gate(dir)
+  check(st.success? && out.include?('gate 12: no deferred-elements.json'),
+        'no deferred file → gate 12 OK, all gates pass', fails)
+
+  File.write(File.join(dir, 'deferred-elements.json'), JSON.pretty_generate(
+    Q.deferred_doc(q[:deferred], data_model_id: 'dm-123')))
+  out, err, st = run_gate(dir)
+  check(st.exitstatus == 17, "non-empty deferred → exit 17 (got #{st.exitstatus})", fails)
+  check(err.include?('resolve the deferred elements and re-POST') || err.downcase.include?('resolve the deferred'),
+        'failure text says to resolve the deferred elements and re-POST', fails)
+  check(err.include?('DEAL_FACTS FIXED CUSTOMER_REF_ID'), 'failure names the deferred element', fails)
+  check(!out.include?('all gates pass'), 'GREEN clearance withheld', fails)
+
+  out, _e, st = run_gate(dir, '--accept-deferred-elements', 'customer accepted partial DM for pilot')
+  check(st.success?, 'waiver → gates pass', fails)
+  check(out.include?('--accept-deferred-elements') && out.include?('WAIVED'),
+        'waiver recorded loudly (never silent)', fails)
+  waivers = JSON.parse(File.read(File.join(dir, 'waivers.json'))) rescue []
+  check(waivers.any? { |w| w['flag'] == '--accept-deferred-elements' }, 'waiver persisted to waivers.json', fails)
+
+  File.write(File.join(dir, 'deferred-elements.json'), JSON.pretty_generate('deferred' => []))
+  out, _e, st = run_gate(dir)
+  check(st.success? && out.include?('all quarantined elements resolved'),
+        'EMPTY deferred list → gate 12 OK (resolved)', fails)
+
+  File.write(File.join(dir, 'deferred-elements.json'), '{not json')
+  _o, err, st = run_gate(dir)
+  check(st.exitstatus == 17 && err.include?('malformed'), 'malformed deferred file → exit 17, stated', fails)
+end
+
+puts 'Part F — shared twin in sync (md5 discipline)'
+require 'digest'
+local  = Digest::MD5.file(GATE).hexdigest
+shared = Digest::MD5.file(File.expand_path('../../../../../shared/scripts/assert-phase6-ran.rb', __dir__)).hexdigest
+check(local == shared, 'scripts/assert-phase6-ran.rb byte-identical to shared/scripts twin (run tools/sync-shared.rb)', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixtures/lod-spaced-columns.twb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixtures/lod-spaced-columns.twb
@@ -1,0 +1,90 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!-- Minimal synthetic fixture for LOD-helper SQL identifier quoting (F2) and
+     derived-view source binding (F3) verification — invented, neutral names;
+     no customer data. The warehouse table DEAL_FACTS carries SPACED/mixed-case
+     physical column names ("Customer Ref ID", "Region View", "Deal Value") in
+     both the relation projection and the metadata-records remote-names, plus
+     one already-upper-snake column (STAGE_NAME). Calculation_1 is a FIXED LOD
+     wrapped in MAX() so the converter emits a GROUP-BY SQL helper element and
+     a relationship from the base fact (which then yields the derived
+     "... View" element with [element/col] formulas). -->
+<workbook source-build='2023.1.0' version='18.1'>
+  <datasources>
+    <datasource caption='Pipeline Deals' name='federated.deals1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='wh.example.snowflakecomputing.com' name='snowflake.conn1'>
+            <connection class='snowflake' dbname='ANALYTICS' schema='SALES' server='wh.example.snowflakecomputing.com' warehouse='COMPUTE_WH' />
+          </named-connection>
+        </named-connections>
+        <relation connection='snowflake.conn1' name='DEAL_FACTS' table='[SALES].[DEAL_FACTS]' type='table'>
+          <columns>
+            <column name='Customer Ref ID' datatype='string' />
+            <column name='Region View' datatype='string' />
+            <column name='Deal Value' datatype='real' />
+            <column name='STAGE_NAME' datatype='string' />
+          </columns>
+        </relation>
+        <metadata-records>
+          <metadata-record class='column'>
+            <remote-name>Customer Ref ID</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[Customer Ref ID]</local-name>
+            <parent-name>[DEAL_FACTS]</parent-name>
+            <remote-alias>Customer Ref ID</remote-alias>
+            <local-type>string</local-type>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>Region View</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[Region View]</local-name>
+            <parent-name>[DEAL_FACTS]</parent-name>
+            <remote-alias>Region View</remote-alias>
+            <local-type>string</local-type>
+          </metadata-record>
+          <metadata-record class='measure'>
+            <remote-name>Deal Value</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[Deal Value]</local-name>
+            <parent-name>[DEAL_FACTS]</parent-name>
+            <remote-alias>Deal Value</remote-alias>
+            <local-type>real</local-type>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>STAGE_NAME</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[STAGE_NAME]</local-name>
+            <parent-name>[DEAL_FACTS]</parent-name>
+            <remote-alias>STAGE_NAME</remote-alias>
+            <local-type>string</local-type>
+          </metadata-record>
+        </metadata-records>
+      </connection>
+      <column caption='Customer Ref ID' datatype='string' name='[Customer Ref ID]' role='dimension' type='nominal' />
+      <column caption='Region View' datatype='string' name='[Region View]' role='dimension' type='nominal' />
+      <column caption='Deal Value' datatype='real' name='[Deal Value]' role='measure' type='quantitative' />
+      <column caption='Stage Name' datatype='string' name='[STAGE_NAME]' role='dimension' type='nominal' />
+      <column caption='Max West Deals Per Customer' datatype='integer' name='[Calculation_1]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='MAX({ FIXED [Customer Ref ID] : COUNT(IF [Region View]=&quot;West&quot; AND [Deal Value]&lt;&gt;0 THEN 1 END) })' />
+      </column>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='West Deals by Customer'>
+      <table>
+        <view>
+          <datasource-dependencies datasource='federated.deals1'>
+            <column caption='Customer Ref ID' datatype='string' name='[Customer Ref ID]' role='dimension' type='nominal' />
+            <column caption='Stage Name' datatype='string' name='[STAGE_NAME]' role='dimension' type='nominal' />
+            <column caption='Max West Deals Per Customer' datatype='integer' name='[Calculation_1]' role='measure' type='quantitative'>
+              <calculation class='tableau' formula='MAX({ FIXED [Customer Ref ID] : COUNT(IF [Region View]=&quot;West&quot; AND [Deal Value]&lt;&gt;0 THEN 1 END) })' />
+            </column>
+          </datasource-dependencies>
+        </view>
+        <rows>[federated.deals1].[none:Customer Ref ID:nk]</rows>
+        <cols>[federated.deals1].[usr:Calculation_1:qk]</cols>
+        <panes><pane><mark class='Bar' /></pane></panes>
+      </table>
+    </worksheet>
+  </worksheets>
+</workbook>

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-sql-quoting.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-sql-quoting.rb
@@ -1,0 +1,92 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression pin for two hackathon field-report findings against the VENDORED
+# converter (converter/tableau.mjs) — deterministic + offline (node, no network):
+#
+#   F2 — LOD-helper Custom SQL must DOUBLE-QUOTE spaced/mixed-case warehouse
+#        identifiers ("Customer Ref ID"), never emit them upper-snaked unquoted
+#        (CUSTOMER_REF_ID → Snowflake "invalid identifier" compile error).
+#        Fixed by the #313 re-vendor (physToRealQuoted/qFact from
+#        metadata-record remote-names); this test keeps it fixed.
+#
+#   F3 — the derived "<Fact> View" element's `source.elementId` must point at
+#        the BASE fact element (warehouse-table), never at the narrow LOD
+#        GROUP-BY helper it references through a relationship (the wrong-source
+#        binding produced 300+ dependency-not-found errors at DM POST).
+#
+# Fixture: scripts/test-fixtures/lod-spaced-columns.twb — one Snowflake table
+# with spaced/mixed-case physical columns + a MAX({FIXED ...}) calc that forces
+# the converter to emit (a) an LOD SQL helper and (b) a derived view element.
+#
+# Usage:  ruby scripts/test-lod-sql-quoting.rb
+
+require 'json'
+require 'tmpdir'
+require_relative 'mechanical-specs'
+
+HERE = __dir__
+VENDORED = File.expand_path('../converter/tableau.mjs', HERE)
+FIXTURE  = File.join(HERE, 'test-fixtures', 'lod-spaced-columns.twb')
+
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+abort "vendored converter missing: #{VENDORED}" unless File.exist?(VENDORED)
+abort "fixture missing: #{FIXTURE}" unless File.exist?(FIXTURE)
+
+model = nil
+Dir.mktmpdir do |dir|
+  conv = MechanicalSpecs.run_converter(
+    twb_path: FIXTURE, conn: 'conn-test-1', db: 'ANALYTICS', schema: 'SALES',
+    mcp_build: VENDORED, workdir: dir)
+  model = conv['model']
+end
+
+els = (model['pages'] || []).flat_map { |p| p['elements'] || [] }
+fact   = els.find { |e| e.dig('source', 'kind') == 'warehouse-table' }
+helper = els.find { |e| e.dig('source', 'kind') == 'sql' }
+view   = els.find { |e| e.dig('source', 'kind') == 'table' && e.dig('source', 'elementId') }
+
+puts 'Part A — structure: fact + LOD helper + derived view all emitted'
+check(!fact.nil?,   'warehouse-table fact element emitted', fails)
+check(!helper.nil?, 'LOD GROUP-BY SQL helper element emitted', fails)
+check(!view.nil?,   'derived "<Fact> View" element emitted', fails)
+exit 1 unless fails.empty?
+
+sql = helper.dig('source', 'statement').to_s
+
+puts 'Part B — F2: spaced/mixed-case identifiers are double-quoted in the helper SQL'
+check(sql.include?('"Customer Ref ID" AS CUSTOMER_REF_ID'),
+      'GROUP-BY dim emitted as "Customer Ref ID" AS CUSTOMER_REF_ID', fails)
+check(sql.include?('"Region View"'), 'agg expr quotes "Region View"', fails)
+check(sql.include?('"Deal Value"'),  'agg expr quotes "Deal Value"', fails)
+# The BUG signature: an upper-snaked identifier used UNQUOTED as a source
+# column (allowed only as an output alias after AS / a table-path segment).
+check(sql !~ /SELECT\s+CUSTOMER_REF_ID\b/i,
+      'no bare CUSTOMER_REF_ID as a SELECT source identifier', fails)
+check(sql !~ /\bREGION_VIEW\b/ && sql !~ /\bDEAL_VALUE\b/,
+      'no upper-snaked unquoted REGION_VIEW / DEAL_VALUE anywhere in the SQL', fails)
+check(sql.include?('FROM ANALYTICS.SALES.DEAL_FACTS'), 'FROM is the fully-qualified base table', fails)
+check(sql =~ /GROUP BY 1\b/, 'GROUP BY by ordinal', fails)
+
+puts 'Part C — F3: derived view sources the BASE fact, not the LOD helper'
+check(view.dig('source', 'elementId') == fact['id'],
+      "view source.elementId == fact id (got #{view.dig('source', 'elementId').inspect}, fact=#{fact['id'].inspect}, helper=#{helper['id'].inspect})", fails)
+check(view.dig('source', 'elementId') != helper['id'],
+      'view source.elementId is NOT the LOD helper', fails)
+view_formulas = (view['columns'] || []).map { |c| c['formula'] }
+check(view_formulas.any? { |f| f =~ %r{\A\[DEAL_FACTS/[^/\]]+\]\z} },
+      'view columns reference base-table names ([DEAL_FACTS/...])', fails)
+check(view_formulas.any? { |f| f =~ %r{\A\[DEAL_FACTS/FIXED [^/\]]+/} },
+      'helper agg surfaced through the relationship path ([DEAL_FACTS/FIXED .../...])', fails)
+rel = (fact['relationships'] || []).find { |r| r['targetElementId'] == helper['id'] }
+check(!rel.nil? && (rel['keys'] || []).any?, 'fact → helper relationship with keys exists', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-sql-ident-check.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-sql-ident-check.rb
@@ -1,0 +1,135 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Offline unit test for scripts/lib/sql_ident_check.rb + the check-sql-idents.rb
+# CLI (hackathon F2 guard: unquoted upper-snake identifiers vs spaced/mixed-case
+# live Snowflake columns). Deterministic — no network, no creds.
+#
+# Usage:  ruby scripts/test-sql-ident-check.rb
+
+require 'json'
+require 'tmpdir'
+require 'open3'
+require 'rbconfig'
+require_relative 'lib/sql_ident_check'
+
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+S = SqlIdentCheck
+
+# Live catalog: spaced/mixed-case names (the field-report class) + upper-snake.
+CATALOG = {
+  'DEAL_FACTS' => ['Customer Ref ID', 'Region View', 'Deal Value', 'STAGE_NAME'],
+  'ACCOUNT_DIM' => ['Account Name', 'ACCOUNT_ID']
+}.freeze
+
+puts 'Part A — the F2 bug shape: unquoted upper-snake vs spaced live columns'
+bug_sql = 'SELECT CUSTOMER_REF_ID, COUNT(CASE WHEN REGION_VIEW=\'West\' AND DEAL_VALUE<>0 THEN 1 END) AS N ' \
+          'FROM ANALYTICS.SALES.DEAL_FACTS GROUP BY 1'
+res = S.check(bug_sql, CATALOG)
+check(!res[:ok], 'bug SQL flagged not-ok', fails)
+names = res[:unknown].map { |u| u[:identifier] }
+check(names.include?('CUSTOMER_REF_ID'), 'CUSTOMER_REF_ID reported unknown', fails)
+check(names.include?('REGION_VIEW') && names.include?('DEAL_VALUE'), 'REGION_VIEW + DEAL_VALUE reported', fails)
+sug = res[:unknown].to_h { |u| [u[:identifier], u[:suggestion]] }
+check(sug['CUSTOMER_REF_ID'] == '"Customer Ref ID"', 'quoted-fix suggestion CUSTOMER_REF_ID → "Customer Ref ID"', fails)
+check(sug['REGION_VIEW'] == '"Region View"', 'quoted-fix suggestion REGION_VIEW → "Region View"', fails)
+
+puts 'Part B — the FIXED emission passes clean'
+good_sql = %{SELECT "Customer Ref ID" AS CUSTOMER_REF_ID, COUNT(CASE WHEN "Region View"='West' AND "Deal Value"<>0 THEN 1 END) AS MAX_WEST } +
+           'FROM ANALYTICS.SALES.DEAL_FACTS GROUP BY 1'
+res = S.check(good_sql, CATALOG)
+check(res[:ok], "correctly-quoted LOD helper SQL is clean (got #{res[:unknown].inspect})", fails)
+check(S.check('SELECT STAGE_NAME AS STAGE_NAME FROM DEAL_FACTS', CATALOG)[:ok],
+      'bare upper-snake identifier matching a real upper-snake column is clean', fails)
+
+puts 'Part C — quoted identifiers are case-EXACT'
+res = S.check('SELECT "CUSTOMER REF ID" FROM DEAL_FACTS', CATALOG)
+check(!res[:ok], 'quoted wrong-case identifier flagged', fails)
+check(res[:unknown].first[:suggestion] == '"Customer Ref ID"',
+      'case-exact fix suggested for wrong-case quoted ident', fails)
+check(S.check('SELECT "Customer Ref ID" FROM DEAL_FACTS', CATALOG)[:ok], 'exact-case quoted ident clean', fails)
+
+puts 'Part D — self-aliased bug shape must not self-whitelist'
+res = S.check('SELECT CUSTOMER_REF_ID AS CUSTOMER_REF_ID FROM DEAL_FACTS', CATALOG)
+check(!res[:ok], 'CUSTOMER_REF_ID AS CUSTOMER_REF_ID still flagged (source position)', fails)
+
+puts 'Part E — output aliases / CTEs / derived tables are not false-positives'
+wrapped = %{SELECT "Customer Ref ID" AS CUSTOMER_REF_ID, SUM("Deal Value") AS TOTAL_VALUE FROM (
+SELECT d."Customer Ref ID", d."Deal Value" FROM ANALYTICS.SALES.DEAL_FACTS d
+) __base GROUP BY 1}
+check(S.check(wrapped, CATALOG)[:ok], 'subquery wrap + derived alias __base clean', fails)
+cte = 'WITH base AS (SELECT "Region View" AS RV, SUM("Deal Value") AS DV FROM DEAL_FACTS GROUP BY 1) ' \
+      'SELECT RV, DV, SUM(DV) OVER (PARTITION BY RV) AS W FROM base'
+check(S.check(cte, CATALOG)[:ok], 'window-helper CTE: inner aliases referenced outside are clean', fails)
+
+puts 'Part F — table-alias prefixes resolve per-table'
+joined = 'SELECT __f."Customer Ref ID" AS CUSTOMER_REF_ID, __d0."Account Name" AS ACCOUNT_NAME ' \
+         'FROM ANALYTICS.SALES.DEAL_FACTS __f LEFT JOIN ANALYTICS.SALES.ACCOUNT_DIM __d0 ' \
+         'ON __f.STAGE_NAME = __d0.ACCOUNT_ID GROUP BY 1, 2'
+check(S.check(joined, CATALOG)[:ok], 'alias-qualified refs check against the right table', fails)
+wrong = 'SELECT __d0."Customer Ref ID" FROM ANALYTICS.SALES.ACCOUNT_DIM __d0'
+res = S.check(wrong, CATALOG)
+check(!res[:ok], 'a column qualified to the WRONG table is flagged', fails)
+check(res[:unknown].first[:table] == 'ACCOUNT_DIM', 'wrong-table finding names the scoped table', fails)
+
+puts 'Part G — misc: literals, functions, comments, no-catalog scope'
+check(S.check("SELECT DATE_TRUNC('month', \"Deal Value\") AS M FROM DEAL_FACTS -- CUSTOMER_REF_ID\n", CATALOG)[:ok],
+      'string literals, function names and comments are ignored', fails)
+check(S.check('SELECT ANYTHING FROM T', {})[:ok],
+      'empty catalog → cannot judge → clean (caller must supply columns)', fails)
+
+puts 'Part H — spec helpers'
+spec = { 'pages' => [{ 'name' => 'Page 1', 'elements' => [
+  { 'id' => 'el1', 'name' => 'LOD Helper', 'kind' => 'table',
+    'source' => { 'kind' => 'sql', 'statement' => bug_sql } },
+  { 'id' => 'el2', 'name' => 'Base', 'kind' => 'table',
+    'source' => { 'kind' => 'warehouse-table', 'path' => %w[ANALYTICS SALES DEAL_FACTS] } }
+] }] }
+els = S.sql_elements(spec)
+check(els.size == 1 && els.first['name'] == 'LOD Helper', 'sql_elements picks only kind:"sql"', fails)
+check(S.referenced_tables(spec) == ['DEAL_FACTS'], "referenced_tables → DEAL_FACTS (got #{S.referenced_tables(spec).inspect})", fails)
+
+puts 'Part I — CLI end-to-end (exit codes + fix list)'
+Dir.mktmpdir do |dir|
+  spec_path = File.join(dir, 'dm-spec.json')
+  File.write(spec_path, JSON.pretty_generate(spec))
+  cols_path = File.join(dir, 'columns-DEAL_FACTS.json')
+  File.write(cols_path, JSON.pretty_generate(
+    'path' => %w[ANALYTICS SALES DEAL_FACTS],
+    'columns' => CATALOG['DEAL_FACTS'].map { |n| { 'name' => n, 'type' => 'text' } }))
+  cli = File.join(__dir__, 'check-sql-idents.rb')
+
+  out, _e, st = Open3.capture3(RbConfig.ruby, cli, '--dm-spec', spec_path, '--list-tables')
+  check(st.success? && out.include?('DEAL_FACTS'), '--list-tables prints the referenced table', fails)
+
+  out, _e, st = Open3.capture3(RbConfig.ruby, cli, '--dm-spec', spec_path, '--columns', "DEAL_FACTS=#{cols_path}")
+  check(st.exitstatus == 1, 'bug spec → exit 1', fails)
+  check(out.include?('CUSTOMER_REF_ID → "Customer Ref ID"'), 'CLI prints the quoted-fix line', fails)
+  check(out.include?('LOD Helper'), 'CLI names the offending element', fails)
+
+  fixed = JSON.parse(JSON.generate(spec))
+  fixed['pages'][0]['elements'][0]['source']['statement'] = good_sql
+  File.write(spec_path, JSON.pretty_generate(fixed))
+  _o, _e, st = Open3.capture3(RbConfig.ruby, cli, '--dm-spec', spec_path, '--columns', "DEAL_FACTS=#{cols_path}")
+  check(st.success?, 'fixed spec → exit 0', fails)
+
+  no_sql = { 'pages' => [{ 'elements' => [spec['pages'][0]['elements'][1]] }] }
+  File.write(spec_path, JSON.pretty_generate(no_sql))
+  out, _e, st = Open3.capture3(RbConfig.ruby, cli, '--dm-spec', spec_path, '--columns', "DEAL_FACTS=#{cols_path}")
+  check(st.success? && out.include?('nothing to preflight'), 'spec without sql elements → exit 0, stated', fails)
+
+  # sql elements present but no --columns supplied → usage error with guidance
+  File.write(spec_path, JSON.pretty_generate(spec))
+  _o, e2, st = Open3.capture3(RbConfig.ruby, cli, '--dm-spec', spec_path)
+  check(st.exitstatus == 2 && e2.include?('--list-tables'), 'sql elements but no --columns → exit 2 with guidance', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -129,6 +129,14 @@
 #      <workdir>/POSTPUBLISH_GUIDE.md does not exist. Run
 #      scripts/build-postpublish-guide.rb to generate the user handoff guide.
 #      Escape hatch: --skip-postpublish-guide "<reason>".
+#  17  Deferred DM elements unresolved (gate 12) — <workdir>/deferred-elements.json
+#      is non-empty: post-and-readback.rb --quarantine-on-failure removed broken
+#      element(s) at DM POST time to save the rest, so the LIVE data model is
+#      PARTIAL. Resolve the deferred elements and re-POST: fix each element spec
+#      in the file, restore it into the DM spec, PUT it back (post-and-readback
+#      --update-id <dmId>), then delete the file. Escape hatch:
+#      --accept-deferred-elements "<reason>" (knowingly shipping a partial DM —
+#      name it AND the dropped elements in your migration report).
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -168,6 +176,7 @@ OptionParser.new do |p|
   p.on('--skip-layout-fill REASON', 'waive gate 8c (layout fill / grid coverage) — REQUIRED reason string. Use ONLY when a sparse/partial page is intentional. The reason MUST be named in your migration report.') { |v| opts[:skip_layout_fill] = v }
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
   p.on('--skip-postpublish-guide REASON', 'waive gate 11 (post-publish interactivity guide) — REQUIRED reason string. Use ONLY when the source dashboard actions are genuinely not worth a handoff guide. The reason MUST be named in your migration report.') { |v| opts[:skip_postpublish] = v }
+  p.on('--accept-deferred-elements REASON', 'waive gate 12 (deferred/quarantined DM elements) — REQUIRED reason string. Use ONLY when knowingly shipping a PARTIAL data model; the reason AND the dropped elements MUST be named in your migration report.') { |v| opts[:accept_deferred] = v }
   p.on('--require-fidelity-ledger', 'gate 8d (OPT-IN, off by default): require an RCF fidelity-ledger.json (Phase 5g) with zero UNRESOLVED spec-fixable deltas. Adopters (tableau-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_fidelity] = true }
   p.on('--fidelity-ledger PATH', 'gate 8d: path to the RCF ledger (default: <workdir>/fidelity-ledger.json)') { |v| opts[:fidelity_ledger] = v }
   p.on('--accept-residuals LIST', 'gate 8d: comma-separated ledger entry ids/indices to WAIVE as accepted residuals (name them in the report)') { |v| opts[:accept_residuals] = v.split(',').map(&:strip) }
@@ -1003,6 +1012,44 @@ else
     warn '       Escape hatch: --skip-postpublish-guide "<reason>" (name it in your migration report).'
     exit 16
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 12 — deferred DM elements (exit 17). post-and-readback.rb
+# --quarantine-on-failure saves a DM POST killed by one broken element by
+# moving the offender(s) to <workdir>/deferred-elements.json and re-POSTing the
+# rest (hackathon Rec5). That DM is PARTIAL by construction — declaring GREEN
+# on it would silently ship a data model missing elements. Non-empty file →
+# hard FAIL until the elements are fixed + re-POSTed (then delete the file).
+# No file / empty deferred list → OK. Escape: --accept-deferred-elements
+# "<reason>" (recorded as a waiver; name it + the dropped elements in the report).
+# ---------------------------------------------------------------------------
+deferred_path = File.join(opts[:tab], 'deferred-elements.json')
+if opts[:accept_deferred]
+  record_waiver.call('--accept-deferred-elements', 'gate 12 (deferred/quarantined DM elements)', opts[:accept_deferred])
+elsif File.exist?(deferred_path)
+  ddoc = JSON.parse(File.read(deferred_path)) rescue nil
+  deferred = ddoc.is_a?(Hash) ? Array(ddoc['deferred']) : (ddoc.is_a?(Array) ? ddoc : nil)
+  if deferred.nil?
+    warn "[FAIL] gate 12: #{deferred_path} is malformed (expected {\"deferred\":[...]} or a bare array)."
+    warn '       Fix or delete the file (delete ONLY if every quarantined element was restored + re-POSTed).'
+    exit 17
+  elsif deferred.any?
+    names = deferred.map { |d| d.is_a?(Hash) ? (d.dig('element', 'name') || d.dig('element', 'id') || '(unnamed)') : d.to_s }
+    warn "[FAIL] gate 12: #{deferred.size} DM element(s) still deferred (quarantined at POST time) — the live"
+    warn '       data model is PARTIAL. Resolve the deferred elements and re-POST:'
+    names.each { |n| warn "         - #{n}" }
+    warn "       Fix each element spec in #{deferred_path}, restore it into the DM spec,"
+    warn '       PUT it back (ruby scripts/post-and-readback.rb --type datamodel --update-id <dmId> ...),'
+    warn '       then delete the file and re-run this gate.'
+    warn '       Escape hatch (knowingly shipping a partial DM): --accept-deferred-elements "<reason>"'
+    warn '       (name it AND the dropped elements in your migration report).'
+    exit 17
+  else
+    puts "[OK] gate 12: deferred-elements.json present but empty — all quarantined elements resolved"
+  end
+else
+  puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -129,6 +129,14 @@
 #      <workdir>/POSTPUBLISH_GUIDE.md does not exist. Run
 #      scripts/build-postpublish-guide.rb to generate the user handoff guide.
 #      Escape hatch: --skip-postpublish-guide "<reason>".
+#  17  Deferred DM elements unresolved (gate 12) — <workdir>/deferred-elements.json
+#      is non-empty: post-and-readback.rb --quarantine-on-failure removed broken
+#      element(s) at DM POST time to save the rest, so the LIVE data model is
+#      PARTIAL. Resolve the deferred elements and re-POST: fix each element spec
+#      in the file, restore it into the DM spec, PUT it back (post-and-readback
+#      --update-id <dmId>), then delete the file. Escape hatch:
+#      --accept-deferred-elements "<reason>" (knowingly shipping a partial DM —
+#      name it AND the dropped elements in your migration report).
 #
 # Prints a per-gate summary to stdout regardless of exit code.
 
@@ -168,6 +176,7 @@ OptionParser.new do |p|
   p.on('--skip-layout-fill REASON', 'waive gate 8c (layout fill / grid coverage) — REQUIRED reason string. Use ONLY when a sparse/partial page is intentional. The reason MUST be named in your migration report.') { |v| opts[:skip_layout_fill] = v }
   p.on('--skip-telemetry-gate REASON', 'waive gate 10 (telemetry consent decision) — REQUIRED reason string. Use ONLY when the run genuinely cannot prompt (e.g. unattended CI). The reason MUST be named in your migration report.') { |v| opts[:skip_telemetry] = v }
   p.on('--skip-postpublish-guide REASON', 'waive gate 11 (post-publish interactivity guide) — REQUIRED reason string. Use ONLY when the source dashboard actions are genuinely not worth a handoff guide. The reason MUST be named in your migration report.') { |v| opts[:skip_postpublish] = v }
+  p.on('--accept-deferred-elements REASON', 'waive gate 12 (deferred/quarantined DM elements) — REQUIRED reason string. Use ONLY when knowingly shipping a PARTIAL data model; the reason AND the dropped elements MUST be named in your migration report.') { |v| opts[:accept_deferred] = v }
   p.on('--require-fidelity-ledger', 'gate 8d (OPT-IN, off by default): require an RCF fidelity-ledger.json (Phase 5g) with zero UNRESOLVED spec-fixable deltas. Adopters (tableau-to-sigma) pass this; other converters are unaffected until they do.') { opts[:require_fidelity] = true }
   p.on('--fidelity-ledger PATH', 'gate 8d: path to the RCF ledger (default: <workdir>/fidelity-ledger.json)') { |v| opts[:fidelity_ledger] = v }
   p.on('--accept-residuals LIST', 'gate 8d: comma-separated ledger entry ids/indices to WAIVE as accepted residuals (name them in the report)') { |v| opts[:accept_residuals] = v.split(',').map(&:strip) }
@@ -1003,6 +1012,44 @@ else
     warn '       Escape hatch: --skip-postpublish-guide "<reason>" (name it in your migration report).'
     exit 16
   end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 12 — deferred DM elements (exit 17). post-and-readback.rb
+# --quarantine-on-failure saves a DM POST killed by one broken element by
+# moving the offender(s) to <workdir>/deferred-elements.json and re-POSTing the
+# rest (hackathon Rec5). That DM is PARTIAL by construction — declaring GREEN
+# on it would silently ship a data model missing elements. Non-empty file →
+# hard FAIL until the elements are fixed + re-POSTed (then delete the file).
+# No file / empty deferred list → OK. Escape: --accept-deferred-elements
+# "<reason>" (recorded as a waiver; name it + the dropped elements in the report).
+# ---------------------------------------------------------------------------
+deferred_path = File.join(opts[:tab], 'deferred-elements.json')
+if opts[:accept_deferred]
+  record_waiver.call('--accept-deferred-elements', 'gate 12 (deferred/quarantined DM elements)', opts[:accept_deferred])
+elsif File.exist?(deferred_path)
+  ddoc = JSON.parse(File.read(deferred_path)) rescue nil
+  deferred = ddoc.is_a?(Hash) ? Array(ddoc['deferred']) : (ddoc.is_a?(Array) ? ddoc : nil)
+  if deferred.nil?
+    warn "[FAIL] gate 12: #{deferred_path} is malformed (expected {\"deferred\":[...]} or a bare array)."
+    warn '       Fix or delete the file (delete ONLY if every quarantined element was restored + re-POSTed).'
+    exit 17
+  elsif deferred.any?
+    names = deferred.map { |d| d.is_a?(Hash) ? (d.dig('element', 'name') || d.dig('element', 'id') || '(unnamed)') : d.to_s }
+    warn "[FAIL] gate 12: #{deferred.size} DM element(s) still deferred (quarantined at POST time) — the live"
+    warn '       data model is PARTIAL. Resolve the deferred elements and re-POST:'
+    names.each { |n| warn "         - #{n}" }
+    warn "       Fix each element spec in #{deferred_path}, restore it into the DM spec,"
+    warn '       PUT it back (ruby scripts/post-and-readback.rb --type datamodel --update-id <dmId> ...),'
+    warn '       then delete the file and re-run this gate.'
+    warn '       Escape hatch (knowingly shipping a partial DM): --accept-deferred-elements "<reason>"'
+    warn '       (name it AND the dropped elements in your migration report).'
+    exit 17
+  else
+    puts "[OK] gate 12: deferred-elements.json present but empty — all quarantined elements resolved"
+  end
+else
+  puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
 puts "[OK] all gates pass — conversion may declare GREEN"


### PR DESCRIPTION
## What this is

Closes out the hackathon field report (Windows/Cortex, two enterprise workbooks, DM POST failures). Triage first: **six of its eight findings were already fixed on main** — LOD raw syntax (#313), `:Measure Names` (#314), Custom-SQL FROM repoint (#315), Windows ESM (#284), bash-free tokens (#299/#310), and the 18-minute discovery re-runs (discovery-stamp reuse). This PR covers the rest.

## What's in it

**1. Empirical verification of the two unconfirmed findings — both already FIXED, now regression-pinned.**
Fixture `.twb` (spaced/mixed-case remote-names + nested `MAX({FIXED …})`) run through the current vendored converter:
- Identifier quoting: emits `SELECT "Customer Ref ID" AS CUSTOMER_REF_ID, … FROM ANALYTICS.SALES.DEAL_FACTS GROUP BY 1` — correctly quoted (#313's `physToRealQuoted`).
- View-source binding: the derived view element sources the base fact element, not the 2-column LOD helper.
`test-lod-sql-quoting.rb` + the fixture pin both verdicts so future converter re-vendors can't silently regress them. No converter escalations needed.

**2. Catalog-backed SQL-identifier preflight** (`lib/sql_ident_check.rb` + `check-sql-idents.rb`) — version-independent guard: extracts identifiers from `kind:sql` statements, checks them against real catalog columns, reports mismatches with the exact quoted-name fix (`CUSTOMER_REF_ID → "Customer Ref ID"`). The orchestrator prints the copy-paste command at DM-validate whenever sql elements are present.

**3. DM element quarantine** (the report's rec #5 — the tester hand-stripped elements to salvage a partial DM). `post-and-readback.rb --quarantine-on-failure` (datamodel path): attributable POST/census failures defer the offending elements to `deferred-elements.json`, re-POST the remainder ONCE, exit 6 with a loud PARTIAL report. Default behavior unchanged (fail-loud, no quarantine). New shared gate 12 (exit 17): non-empty `deferred-elements.json` blocks GREEN — `--accept-deferred-elements "<reason>"` escape, waiver-recorded; synced to all plugin twins.

**4.** Stale comment fix (`migrate-tableau.rb` still described bash token minting).

## Judgment calls for review
- Dependency-error blame prefers dependent view/sql elements over the base table (quarantining the base would gut the DM); unattributable errors quarantine nothing.
- Census→spec element matching is by NAME (server reassigns ids on POST).

## Tests
69/70 ruby suites green (sole failure: pre-existing `test-calc-discovery.rb`, needs live token); python + doctor suites green; governance (drift/lint/variants/conformance) green; three new tests added to the CI allow-list; hygiene grep clean (neutral fixture names only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)