### PR TITLE
fix(tableau): auto-translate conditional-inner FIXED LODs in workbook builder

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -474,8 +474,19 @@ end
 #     this path, and single-level LODs never reach the chain path.
 def parse_fixed_lod(formula, columns_by_guid = {})
   s = formula.to_s.gsub(/\s+/, ' ').strip
-  m = s.match(/\A\{\s*FIXED\s+(\[[^\]]+\](?:\s*,\s*\[[^\]]+\])*)\s*:\s*(SUM|AVG|MIN|MAX|MEDIAN|COUNTD|COUNT)\s*\(\s*\[([^\]]+)\]\s*\)\s*\}\z/i)
+  # The inner aggregate argument is captured greedily (.+) rather than as a bare
+  # [col], so a CONDITIONAL / expression inner (e.g. the last-sold-date pattern
+  # MAX(IF [Units] > 0 THEN [Date] END)) is ACCEPTED here instead of silently
+  # dropping to a generic "translate manually" warning (bead: conditional-inner
+  # FIXED LODs missed the auto-helper). The \z anchor forces the trailing ')}',
+  # so the greedy body backtracks to the last ')'.
+  m = s.match(/\A\{\s*FIXED\s+(\[[^\]]+\](?:\s*,\s*\[[^\]]+\])*)\s*:\s*(SUM|AVG|MIN|MAX|MEDIAN|COUNTD|COUNT)\s*\((.+)\)\s*\}\z/i)
   return nil unless m
+  inner = m[3].strip
+  # NESTED {FIXED…{FIXED…}} stays DISJOINT from this path (see the dispatch note
+  # above): it routes through decompose_nested_fixed (helper-element chain). The
+  # loosened inner would otherwise match the outer of a nest — reject it here.
+  return nil if inner =~ /\{\s*(?:FIXED|INCLUDE|EXCLUDE)\b/i
   resolve = lambda do |ref|
     if ref =~ /\A[0-9a-f\-]{36}\z/i
       info = columns_by_guid[ref]
@@ -485,9 +496,21 @@ def parse_fixed_lod(formula, columns_by_guid = {})
     end
   end
   dims = m[1].scan(/\[([^\]]+)\]/).flatten.map { |d| resolve.call(d) }
-  meas = resolve.call(m[3])
-  return nil if dims.empty? || dims.any?(&:nil?) || meas.nil?
-  { 'dims' => dims, 'agg' => m[2].upcase, 'measure' => meas }
+  return nil if dims.empty? || dims.any?(&:nil?)
+  out = { 'dims' => dims, 'agg' => m[2].upcase }
+  if (bare = inner.match(/\A\[([^\]]+)\]\z/))
+    # Bare-column inner — unchanged behaviour: expose 'measure' (+ display label).
+    meas = resolve.call(bare[1])
+    return nil if meas.nil?
+    out['measure'] = meas
+    out['label']   = meas
+  else
+    # Conditional / expression inner — the caller resolves it to a Sigma formula
+    # via lod_inner_ref; 'label' is the raw inner for warning messages.
+    out['inner_expr'] = inner
+    out['label']      = inner
+  end
+  out
 end
 
 # Parse a RELATIVE LOD — {INCLUDE [dims]: AGG([m])} or {EXCLUDE [dims]: AGG([m])}
@@ -534,6 +557,26 @@ LOD_INNER_AGG = {
   'MEDIAN' => 'Median', 'COUNTD' => 'CountDistinct',
   'COUNT' => 'CountIf(IsNotNull(%s))'
 }.freeze
+
+# Resolve a FIXED LOD's inner aggregate into the Sigma expression the helper's
+# inner grouping aggregates over. A bare-column inner ('measure') maps to a
+# single [Master/<col>] ref (unchanged). A conditional/expression inner
+# ('inner_expr', e.g. IF [Units] > 0 THEN [Date] END) is translated to a Sigma
+# formula over master columns via the shared dim/row-level calc translators
+# (IF/CASE…END → nested If()/Switch(); arithmetic/date fns via row-level). The
+# caller then wraps the result in the LOD aggregate (render_agg). Returns nil
+# when the inner uses constructs we can't safely auto-emit — the caller falls
+# back to a loud, specific warning (author a DM Custom SQL element) rather than
+# building a broken helper.
+def lod_inner_ref(lod, mmap, columns_by_guid = {})
+  if lod['measure']
+    m = map_column(lod['measure'], mmap)
+    "[Master/#{m ? m['name'] : lod['measure']}]"
+  elsif lod['inner_expr']
+    translate_dim_calc(lod['inner_expr'], mmap, columns_by_guid) ||
+      translate_row_level_calc(lod['inner_expr'], mmap, columns_by_guid)
+  end
+end
 
 # Build the hidden two-level grouped helper element for a FIXED LOD (see the
 # block comment above). Returns [element_hash, src_name, stage2_col_name].
@@ -2432,12 +2475,12 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
   two_stage_formula = nil
   ws_calc_lod = (z['calculations'] || []).find { |c| norm.call(c['name']) == norm.call(field_cap) }
   lod = ws_calc_lod && parse_fixed_lod(ws_calc_lod['formula'], meta['columns_by_guid'] || {})
-  if lod
+  lod_ref = lod && lod_inner_ref(lod, mmap, meta['columns_by_guid'] || {})
+  if lod && lod_ref
     # FIXED-LOD KPI → two-level helper (constant outer key), Max() the outer calc.
     map_name = ->(capn) { (m = map_column(capn, mmap)) ? m['name'] : capn }
     inner_keys = lod['dims'].map { |d| n = map_name.call(d); { 'name' => n, 'formula' => "[Master/#{n}]" } }
-    meas_name = map_name.call(lod['measure'])
-    value_formula = render_agg(LOD_INNER_AGG[lod['agg']], "[Master/#{meas_name}]")
+    value_formula = render_agg(LOD_INNER_AGG[lod['agg']], lod_ref)
     stage2 = SHELF_AGG_FOR_PREFIX[deriv] || 'Avg'
     helper, src_name, s2_name = build_two_stage_helper(
       el_id: el_id, master_id: opts[:master_id], value_name: field_cap.to_s.strip,
@@ -2445,8 +2488,14 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
     data_elements << helper
     source_eid = helper['id']
     two_stage_formula = "Max([#{src_name}/#{s2_name}])"
-    warnings << "'#{cap}' KPI measure '#{field_cap}' is a FIXED LOD ({FIXED #{lod['dims'].join(', ')} : #{lod['agg']}(#{lod['measure']})}) — " \
+    warnings << "'#{cap}' KPI measure '#{field_cap}' is a FIXED LOD ({FIXED #{lod['dims'].join(', ')} : #{lod['agg']}(#{lod['label']})}) — " \
                 "auto-built hidden grouped helper '#{src_name}' (inner grain = FIXED dims, 2nd-stage #{stage2}) ⚠ verify in Sigma"
+  elsif lod && lod_ref.nil?
+    # Parsed as a FIXED LOD but the conditional/expression inner can't be safely
+    # auto-translated — point at the data-model Custom SQL path (loud, specific).
+    warnings << "'#{cap}' KPI measure '#{field_cap}' is a FIXED LOD with a conditional/expression inner " \
+                "(#{lod['agg']}(#{lod['label']})) that can't be auto-translated to a workbook helper — implement it as a " \
+                "data-model Custom SQL element: #{lod['agg']}(CASE …) OVER (PARTITION BY #{lod['dims'].join(', ')}). See refs/phase-3-datamodel.md."
   elsif %w[avg average].include?(deriv) && master['formula'].nil? && master['grain'] && ws_calc_lod.nil?
     # Grain-aware average (bead AvgLTR): Avg of a dim-table measure — Tableau
     # evaluates it at the DIM table's native grain (all dim rows, incl. entities
@@ -3136,20 +3185,20 @@ layout.each do |dash|
       # through decompose_nested_fixed (helper-element chain, -lod-chains.json
       # sidecar) in the calc loop below; the agent wires the chain manually.
       lod_parse = lod_calc && parse_fixed_lod(lod_calc['formula'], meta['columns_by_guid'] || {})
-      if lod_parse
+      lod_ref = lod_parse && lod_inner_ref(lod_parse, mmap, meta['columns_by_guid'] || {})
+      if lod_parse && lod_ref
         # FIXED LOD → two-level grouped helper: inner = FIXED dims computing
         # the LOD aggregate, outer = the chart's plotted dims computing the
         # second-stage aggregate; chart Max()es the replicated outer calc.
         map_name = ->(capn) { (mm = map_column(capn, mmap)) ? mm['name'] : capn }
         inner_keys = lod_parse['dims'].map { |d| n = map_name.call(d); { 'name' => n, 'formula' => "[Master/#{n}]" } }
-        lod_meas = map_name.call(lod_parse['measure'])
         value_name = header_base(meas_hdr)
         outer_dims = [{ 'name' => dim['name'], 'formula' => dim_formula }]
         outer_dims << { 'name' => color_col_obj['name'], 'formula' => color_col_obj['formula'] } if color_col_obj
         stage2 = (SIGMA_AGG[agg_label] unless %w[None User].include?(agg_label.to_s)) || 'Avg'
         helper, src_name, s2_name = build_two_stage_helper(
           el_id: el_id, master_id: opts[:master_id], value_name: value_name,
-          value_formula: render_agg(LOD_INNER_AGG[lod_parse['agg']], "[Master/#{lod_meas}]"),
+          value_formula: render_agg(LOD_INNER_AGG[lod_parse['agg']], lod_ref),
           inner_keys: inner_keys, outer_dims: outer_dims, stage2_agg: stage2)
         data_elements << helper
         chart_source_eid = helper['id']
@@ -3157,9 +3206,16 @@ layout.each do |dash|
         color_col_obj['formula'] = "[#{src_name}/#{color_col_obj['name']}]" if color_col_obj
         measure_formula = "Max([#{src_name}/#{s2_name}])"
         warnings << "'#{cap}' measure '#{meas_hdr}' is a FIXED LOD ({FIXED #{lod_parse['dims'].join(', ')} : " \
-                    "#{lod_parse['agg']}(#{lod_parse['measure']})}) — auto-built hidden grouped helper '#{src_name}' " \
+                    "#{lod_parse['agg']}(#{lod_parse['label']})}) — auto-built hidden grouped helper '#{src_name}' " \
                     "(inner grain = FIXED dims, 2nd-stage #{stage2} at chart grain) ⚠ exact iff the chart dims are " \
                     'functionally dependent on the FIXED dims — verify in Sigma'
+      elsif lod_parse && lod_ref.nil?
+        # FIXED LOD whose conditional/expression inner isn't auto-translatable —
+        # steer to the data-model Custom SQL path instead of silently degrading.
+        warnings << "'#{cap}' measure '#{meas_hdr}' is a FIXED LOD with a conditional/expression inner " \
+                    "(#{lod_parse['agg']}(#{lod_parse['label']})) that can't be auto-translated to a workbook helper — " \
+                    "implement it as a data-model Custom SQL element: #{lod_parse['agg']}(CASE …) " \
+                    "OVER (PARTITION BY #{lod_parse['dims'].join(', ')}). See refs/phase-3-datamodel.md."
       elsif (rel = lod_calc && parse_relative_lod(lod_calc['formula'], meta['columns_by_guid'] || {}))
         # INCLUDE / EXCLUDE LOD — relative to the chart's VIEW grain.
         map_name = ->(capn) { (mm = map_column(capn, mmap)) ? mm['name'] : capn }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-conditional-inner.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-conditional-inner.rb
@@ -1,0 +1,114 @@
+#!/usr/bin/env ruby
+# Regression test for CONDITIONAL / EXPRESSION-inner FIXED LODs in the workbook
+# auto-helper path (bead: conditional-inner FIXED LODs silently missed the
+# auto-translate). The canonical case is the "last-sold date" recency LOD:
+#
+#   { FIXED [Retailer Store ID], [Product Name] : MAX(IF [Sales Units] > 0 THEN [Date] END) }
+#
+# Before the fix parse_fixed_lod's inner was anchored to a bare [col], so MAX(IF
+# … END) returned nil and the measure dropped to a generic "translate manually"
+# warning. Now the inner is captured generically, translated via the shared
+# dim/row-level calc translators, and wrapped in the LOD aggregate.
+#
+# Deterministic + offline. Exercises the shipped function bodies verbatim
+# (extracted + instance_eval'd over a map_column stub), like
+# test-param-swap-translation.rb.
+#
+# Usage:  ruby scripts/test-lod-conditional-inner.rb
+
+DIR   = __dir__
+BUILD = File.join(DIR, 'build-charts-from-signals.rb')
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+src = File.read(BUILD)
+defs = %w[render_agg parse_fixed_lod lod_inner_ref translate_dim_calc
+          translate_row_level_calc].map do |fn|
+  m = src.match(/^def #{Regexp.escape(fn)}\b.*?\nend\n/m)
+  abort "test bug: could not extract def #{fn} from build-charts-from-signals.rb" unless m
+  m[0]
+end.join("\n")
+
+# LOD_INNER_AGG is a top-level constant the callers use to wrap the inner ref.
+LOD_INNER_AGG = {
+  'SUM' => 'Sum', 'AVG' => 'Avg', 'MIN' => 'Min', 'MAX' => 'Max',
+  'MEDIAN' => 'Median', 'COUNTD' => 'CountDistinct',
+  'COUNT' => 'CountIf(IsNotNull(%s))'
+}.freeze
+
+mod = Object.new
+# map_column stub: known captions map to a same-named column; unknown -> nil
+# (translators then keep the caption verbatim).
+mod.instance_eval(<<~STUB + defs)
+  KNOWN = %w[Sales\\ Units Date Net\\ Revenue Retailer\\ Store\\ ID Product\\ Name Order\\ Id]
+  def map_column(cap, _mmap)
+    c = cap.to_s.strip
+    KNOWN.include?(c) ? { 'id' => "m-\#{c}", 'name' => c } : nil
+  end
+STUB
+
+mmap = {} # unused by the stub, but the signatures expect it
+
+# ---- 1. The prospect's conditional MAX-of-date LOD --------------------------
+puts 'Part 1 — conditional MAX-of-date FIXED LOD (last-sold date)'
+f1 = '{ FIXED [Retailer Store ID], [Product Name] : MAX(IF [Sales Units] > 0 THEN [Date] END) }'
+lod = mod.parse_fixed_lod(f1, {})
+check(!lod.nil?, 'parses (no longer nil for a conditional inner)', fails)
+check(lod && lod['dims'] == ['Retailer Store ID', 'Product Name'], 'dims are the FIXED keys', fails)
+check(lod && lod['agg'] == 'MAX', 'outer aggregate is MAX', fails)
+check(lod && lod['measure'].nil? && lod['inner_expr'], 'exposes inner_expr, not measure', fails)
+ref = lod && mod.lod_inner_ref(lod, mmap, {})
+check(ref == 'If([Master/Sales Units] > 0, [Master/Date], Null)',
+      "inner translates to Sigma If() over master cols (got: #{ref.inspect})", fails)
+vf = ref && mod.render_agg(LOD_INNER_AGG[lod['agg']], ref)
+check(vf == 'Max(If([Master/Sales Units] > 0, [Master/Date], Null))',
+      "value formula wraps the inner in Max() (got: #{vf.inspect})", fails)
+
+# ---- 2. Bare-column FIXED LOD — unchanged behaviour -------------------------
+puts 'Part 2 — bare-column FIXED LOD (regression: existing path unchanged)'
+lod2 = mod.parse_fixed_lod('{ FIXED [Retailer Store ID] : SUM([Net Revenue]) }', {})
+check(lod2 && lod2['measure'] == 'Net Revenue', "still exposes 'measure' for a bare column", fails)
+ref2 = lod2 && mod.lod_inner_ref(lod2, mmap, {})
+check(ref2 == '[Master/Net Revenue]', "bare inner -> single [Master/col] ref (got: #{ref2.inspect})", fails)
+vf2 = ref2 && mod.render_agg(LOD_INNER_AGG[lod2['agg']], ref2)
+check(vf2 == 'Sum([Master/Net Revenue])', 'bare value formula is Sum([Master/Net Revenue])', fails)
+
+# ---- 3. Nested FIXED stays disjoint (routes to decompose_nested_fixed) ------
+puts 'Part 3 — nested FIXED must NOT be claimed here'
+nested = '{ FIXED [Retailer Store ID] : SUM({ FIXED [Product Name] : SUM([Net Revenue]) }) }'
+check(mod.parse_fixed_lod(nested, {}).nil?, 'nested {FIXED{FIXED}} returns nil', fails)
+
+# ---- 4. GUID refs in dims and inner resolve via columns_by_guid -------------
+puts 'Part 4 — GUID refs resolve to captions'
+cbg = {
+  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' => { 'caption' => 'Retailer Store ID' },
+  'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' => { 'caption' => 'Sales Units' },
+  'cccccccc-cccc-cccc-cccc-cccccccccccc' => { 'caption' => 'Date' }
+}
+fg = '{ FIXED [aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa] : ' \
+     'MAX(IF [bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb] > 0 THEN [cccccccc-cccc-cccc-cccc-cccccccccccc] END) }'
+lodg = mod.parse_fixed_lod(fg, cbg)
+check(lodg && lodg['dims'] == ['Retailer Store ID'], 'dim GUID resolves to caption', fails)
+refg = lodg && mod.lod_inner_ref(lodg, mmap, cbg)
+check(refg == 'If([Master/Sales Units] > 0, [Master/Date], Null)',
+      "inner GUIDs resolve to master refs (got: #{refg.inspect})", fails)
+
+# ---- 5. Untranslatable inner -> nil ref (caller warns loudly) ---------------
+puts 'Part 5 — untranslatable inner returns nil (routes to DM Custom SQL warning)'
+lodx = mod.parse_fixed_lod('{ FIXED [Retailer Store ID] : MAX(REGEXP_EXTRACT([Order Id], "x")) }', {})
+check(!lodx.nil?, 'still parses the LOD shell', fails)
+check(lodx && mod.lod_inner_ref(lodx, mmap, {}).nil?,
+      'inner with an unsupported function yields nil ref', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "FAILURES (#{fails.size}):"
+  fails.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-conditional-inner.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-lod-conditional-inner.rb
@@ -53,7 +53,7 @@ STUB
 
 mmap = {} # unused by the stub, but the signatures expect it
 
-# ---- 1. The prospect's conditional MAX-of-date LOD --------------------------
+# ---- 1. Conditional MAX-of-date LOD (last-sold date) ------------------------
 puts 'Part 1 — conditional MAX-of-date FIXED LOD (last-sold date)'
 f1 = '{ FIXED [Retailer Store ID], [Product Name] : MAX(IF [Sales Units] > 0 THEN [Date] END) }'
 lod = mod.parse_fixed_lod(f1, {})


### PR DESCRIPTION
## Problem

The workbook builder (`build-charts-from-signals.rb`) auto-translates a `{FIXED …}` LOD plotted as a measure into a hidden two-level grouped helper element. But `parse_fixed_lod` anchored the inner aggregate to a **bare column** — `AGG([col])` — so any **conditional / expression inner** returned `nil` and the measure silently dropped to a generic "translate manually" warning.

The canonical miss is the last-sold-date recency pattern:

```
{ FIXED [Retailer Store ID], [Product Name] : MAX(IF [Sales Units] > 0 THEN [Date] END) }
```

This is a likely root cause of field reports that "Claude can't recreate LODs." Notably, the **data-model** converter (`tableau.mjs`) already handles the same LOD fine via a `kind:"sql"` `GROUP BY` / `OVER (PARTITION BY …)` element — only the Ruby workbook path had the gap.

## Fix

- **`parse_fixed_lod`**: loosen the inner capture from a bare `[col]` to any expression (`(.+)`, greedy + `\z`-anchored so it backtracks to the trailing `)}`), with a **nested-`{FIXED}` guard** so the disjoint `decompose_nested_fixed` (helper-chain) dispatch is preserved. Returns `'measure'` for a bare inner (**unchanged**) or `'inner_expr'` otherwise, plus a `'label'` for warnings.
- **`lod_inner_ref`** (new): resolves the inner to a Sigma ref — bare → `[Master/col]`; expression → `translate_dim_calc` (IF/CASE…END → nested `If()`/`Switch()`) `||` `translate_row_level_calc` (arithmetic/date/IIF); `nil` when untranslatable.
- Both call sites (KPI + chart) wrap the ref via `render_agg(LOD_INNER_AGG[agg], ref)`. So `MAX(IF [Units]>0 THEN [Date] END)` → `Max(If([Master/Sales Units] > 0, [Master/Date], Null))`.
- When the inner **parses but isn't translatable**, emit a **specific** warning steering to a DM Custom SQL element (`AGG(CASE …) OVER (PARTITION BY dims)`) instead of silently degrading.

## Tests

- New `test-lod-conditional-inner.rb` (5 parts): conditional MAX-of-date, bare-column regression (byte-identical output), nested-FIXED stays `nil`, GUID-ref resolution, untranslatable-inner → `nil` ref.
- Existing `test-param-swap-translation`, `test-param-metric-switch`, `test-table-calc-translation`, `test-aggregate-dimension` all still pass. Shared-file-copy pre-commit gate passes.

Bead: beads-sigma-4wy8

🤖 Generated with [Claude Code](https://claude.com/claude-code)