### PR TITLE
fix(workbook): master-element selection + naming for extract/multi-element DMs (bead dn3z)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -205,6 +205,24 @@ def synthesize_view_from_signals(z, meta)
     dims << { 'guid' => g, 'role' => 'dim', 'derivation' => 'none' } if g && dims.none? { |f| f['guid'] == g }
   end
   headers = (dims.map(&field_header) + meas.map(&field_header)).compact
+  # Fallback for pie/detail marks: the dimension sits on the color/detail
+  # encoding (not rows/cols shelves, and `channels` may be empty), so the only
+  # signal is the zone's `aggregations` map — a "None"-aggregated column is the
+  # dim, anything with a real aggregator is the measure. Without this a pie/
+  # donut whose dim isn't shelf-bound gets "no dim+measure" and is dropped.
+  if headers.length < 2 && (aggs = z['aggregations']).is_a?(Hash) && !aggs.empty?
+    dcaps = []
+    mcaps = []
+    aggs.each do |col, agg|
+      g = guid_from_text(col.to_s)
+      next unless g
+      cap = (cbg[g] || {})['caption']
+      cap = g if cap.nil? || cap.to_s.empty?
+      (agg.to_s.casecmp('none').zero? ? dcaps : mcaps) << cap
+    end
+    fb = (dcaps + mcaps).compact
+    headers = fb if fb.length >= 2
+  end
   headers.length >= 2 ? { headers: headers } : nil
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-workbook-spec.rb
@@ -68,17 +68,40 @@ target = if opts[:dm_el_name]
            dm_elements.find { |e| e['name'] == opts[:dm_el_name] } ||
              abort("no DM element named #{opts[:dm_el_name].inspect}")
          else
-           # First non-dim-suffixed element, fallback to first
-           dm_elements.find { |e| !(e['name'] || '').end_with?(' Dim') } || dm_elements.first
+           # First non-dim-suffixed element, but only among elements that actually
+           # carry columns. The readback exposes columns via 'columnLabels'; an
+           # extract-landed (or multi-datasource) DM has NAMELESS master-shell
+           # elements with ZERO columns that must NOT be chosen — picking one
+           # aborts at 'no master columns to emit'. Skipping empty shells keeps
+           # the original "first non-dim" order for normal single-fact DMs.
+           width = ->(e) { (e['columnLabels'] || e['columns'] || []).size }
+           bearing = dm_elements.select { |e| width.call(e).positive? }
+           bearing = dm_elements if bearing.empty?
+           bearing.find { |e| !(e['name'] || '').end_with?(' Dim') } || bearing.first
          end
 dm_el_id   = target['id']
 dm_el_name = target['name']
-# A Custom SQL DM element is NAMELESS in the spec (rule 3: omit the element-level
-# name), but Sigma assigns it the name "Custom SQL" on the server. Without this
-# fallback the master column formula becomes an INVALID `[/Col]` (empty element
-# name) → the workbook POSTs but renders EMPTY (every published-DS / Custom-SQL-
-# sourced workbook). Use the server-assigned name so refs are `[Custom SQL/Col]`.
-dm_el_name = 'Custom SQL' if dm_el_name.to_s.strip.empty?
+# A DM element is often NAMELESS in the spec (rule 3: omit the element-level
+# name). Sigma then assigns a name on the server BY KIND, and the master column
+# formula must use that server name or it references a phantom element and the
+# workbook POSTs but renders EMPTY. Fetch the spec up front so we can both name
+# the element correctly and (in auto mode) read its columns.
+#   • warehouse-table  → the table's last path segment (e.g. an extract-landed
+#                        or direct-table element: MY_SCHEMA.MY_TABLE → "MY_TABLE")
+#   • everything else  → "Custom SQL" (SQL / published-DS elements)
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+spec = Sigma.request(:get, "/v2/dataModels/#{dm_id}/spec")
+el = spec['pages'].flat_map { |p| p['elements'] }.find { |e| e['id'] == dm_el_id }
+abort("DM element #{dm_el_id} not found in spec") unless el
+if dm_el_name.to_s.strip.empty?
+  src = el['source'] || {}
+  dm_el_name = if src['kind'] == 'warehouse-table' && !Array(src['path']).empty?
+                 Array(src['path']).last
+               else
+                 'Custom SQL'
+               end
+end
 
 # Master columns: either explicit from --master-cols or auto-passthrough from the DM element
 master_columns =
@@ -86,13 +109,6 @@ master_columns =
     cfg = YAML.safe_load(File.read(opts[:master_cols]))
     cfg['columns'] || abort('master-cols YAML missing `columns:` key')
   else
-    # Auto: pull the DM element's column DDL via REST (limited fields — name only)
-    # Sigma.request handles initial token fetch + 401-retry-with-refresh.
-    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
-    require 'sigma_rest'
-    spec = Sigma.request(:get, "/v2/dataModels/#{dm_id}/spec")
-    el = spec['pages'].flat_map { |p| p['elements'] }.find { |e| e['id'] == dm_el_id }
-    abort("DM element #{dm_el_id} not found in spec") unless el
     (el['columns'] || []).map do |c|
       nm = c['name'] || (c['formula'].to_s.match(/^\[[^\/]+\/([^\]]+)\]$/) || [nil, c['id']])[1]
       slug = nm.to_s.downcase.gsub(/\W+/, '-').sub(/-$/, '')

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -645,6 +645,16 @@ xml.elements.each('//worksheet') do |ws|
       field:  e.attributes['field']
     }
   end
+  # Alt/older form: the channel is the ELEMENT NAME, not an attr — e.g.
+  #   <encodings><color column='…Customer Value Tier…'/></encodings>
+  # (vs the newer <encoding attr='color' …/> above). Without this, a dimension
+  # on the color shelf (categorical bar coloring) is silently dropped.
+  ws.elements.each('.//encodings/*') do |e|
+    ch = e.name.to_s
+    next unless %w[color size shape detail label tooltip text].include?(ch)
+    next if channels.key?(ch) # newer form already captured this channel
+    channels[ch] = { column: e.attributes['column'], field: e.attributes['field'] }
+  end
 
   # Per-worksheet calculated fields. Tableau emits these as
   #   <column datatype='X' name='[Calc Name]' role='dimension|measure' type='...'>


### PR DESCRIPTION
## Summary

Two workbook-spec defects (plus two chart-fidelity fallbacks) surfaced by the **tsfast** CLI while migrating an embedded-extract **World Bank** workbook. All fixes are in the offline-deterministic skill scripts; verified against a live published data model.

Bead: `beads-sigma-dn3z`.

## Fixes

**1. `build-workbook-spec.rb` — master element selection & naming** (the blocker)

Extract-landed / multi-element DMs have *nameless* elements in the spec, which broke two assumptions:

- **Master picker grabbed a 0-column shell.** The default picker took the first element whose name didn't end in `' Dim'`; extract-landed and multi-datasource DMs carry nameless 0-col *shell* elements alongside the real warehouse-table elements, so it picked a shell and aborted at `no master columns to emit`. Now it considers only **column-bearing** elements (readback exposes the count via `columnLabels`), preserving the original first-non-dim order for ordinary single-fact DMs.
- **Nameless element defaulted to `"Custom SQL"`.** Sigma names a nameless *warehouse-table* element after its table (last path segment), so the `Custom SQL` fallback produced a dangling `[Custom SQL/col]` master passthrough → empty render. Name is now derived from `source.kind`: `warehouse-table` → `path.last`; everything else → `Custom SQL`.

**2. Chart-fidelity fallbacks**

- `build-charts-from-signals.rb` — recover a pie/detail mark's measure from the zone `aggregations` map when the dimension sits on the color/detail encoding (`channels` empty), instead of dropping the view offline.
- `parse-twb-layout.rb` — also parse the older element-form color encoding (`<encodings><color column='…'/>`) so color-by-dimension survives.

## Verification

- Master now sources the correct 12-col fact element on live DM `057743ff`; passthrough formulas resolve (`REGION`/`DATE` chart refs bind).
- No overlap with #319 (embedded-extract manifest remap); rebased clean onto latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)