### PR TITLE
feat(gooddata): legacy GoodData Platform (classic /gdc) — discovery + assessment

### DIFF
--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/PRIVACY.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/PRIVACY.md
@@ -1,13 +1,16 @@
 # Privacy
 
-`gooddata-assessment` is **read-only** and **local**. It calls the GoodData
-declarative layout API (`GET /api/v1/layout/...`) with the user's own API token
-to read workspace metadata — dataset / metric / insight / dashboard definitions
-— and computes counts and complexity tags on the local machine.
+`gooddata-assessment` is **read-only** and **local**. For GoodData Cloud / .CN it
+calls the declarative layout API (`GET /api/v1/layout/...`) with the user's own
+API token; for the legacy Platform it calls the classic metadata API
+(`GET /gdc/md/{project}/query/...` + `/objects/get`) after an SST/TT login. Both
+read only metadata — dataset / metric / insight / report / dashboard definitions —
+and compute counts and complexity tags on the local machine.
 
 - No workspace data (warehouse rows / query results) is read or transmitted.
 - Nothing is written back to GoodData.
 - No definitions or credentials are sent anywhere except to the user's own
   GoodData host. Output (the readout) stays local.
-- The API token is read from the environment / `~/.gooddata_env` and is never
-  logged.
+- Credentials (Cloud API token, or Platform host/user/password/SST) are read from
+  the environment / `~/.gooddata_env` and are never logged. Platform SST/TT tokens
+  live only in memory for the duration of a run.

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/SKILL.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/SKILL.md
@@ -9,7 +9,8 @@ description: >-
   gooddata-to-sigma converter's actual coverage. Use when a user wants to scope
   a GoodData→Sigma migration, audit estate sprawl, or pick which dashboards to
   convert first. Read-only, all-free pre-scoping over the declarative workspace
-  export.
+  export. Also assesses the legacy GoodData Platform (classic /gdc, SST/TT auth)
+  and sweeps EVERY project a user can access under one domain in a single run.
 user-invocable: true
 ---
 
@@ -37,10 +38,31 @@ the declarative layout (no writes) and scores it against what
 
 ## Usage
 
+**GoodData Cloud / .CN** (Bearer API token, `/api/v1`):
+
 ```bash
 eval "$(../gooddata-to-sigma/scripts/get-token.sh)"
-python3 scripts/assess.py --workspace <id>     # or --all
+python3 scripts/assess.py --workspace <id>     # or --all (all workspaces in ONE org)
 ```
+
+**Legacy GoodData Platform** (classic `/gdc`, SST/TT auth) — different product,
+detected by a `help.gooddata.com/doc/enterprise` / `/gdc/...` footprint rather
+than `<org>.cloud.gooddata.com`:
+
+```bash
+export GOODDATA_PLATFORM_HOST=https://acme.on.gooddata.com
+export GOODDATA_PLATFORM_USER=...  GOODDATA_PLATFORM_PASSWORD=...
+python3 scripts/assess_platform.py --all       # EVERY project the user can access — one identity, one sweep
+python3 scripts/assess_platform.py --project <pid>
+```
+
+> **Multi-"instance" note.** On the Platform, "separate instances" are **projects
+> under one domain**, so `--all` sweeps them all from a single login — this is the
+> answer to "can one API pull across instances?" On **Cloud**, each org is a
+> separate host+token; there you re-point `GOODDATA_HOST`/`GOODDATA_TOKEN` and
+> re-run `assess.py --all` per org, then merge. Platform scoring reuses the same
+> MAQL translator as Cloud (classic refs are normalized first). See
+> `../gooddata-to-sigma/refs/gooddata-platform-api.md`.
 
 Usage telemetry (per-dashboard view counts) is the universal weak spot — it is
 not in the declarative model; note it as a manual input if needed.

--- a/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/assess_platform.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-assessment/scripts/assess_platform.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""assess_platform.py — legacy GoodData *Platform* estate readout (read-only).
+
+The Platform twin of assess.py. assess.py scores GoodData *Cloud* workspaces
+(Bearer token, /api/v1). This scores classic *Platform* projects (SST/TT flow,
+/gdc metadata API) and — crucially — sweeps EVERY project the logged-in user can
+access from ONE host + ONE identity. That is the multi-"instance" answer for
+Platform customers: classic instances are projects under a single domain, so a
+user with access to all of them is assessed in a single `--all` run. (Contrast
+Cloud, where each org is a separate host+token; there you loop credentials.)
+
+Scoring reuses the SAME MAQL translator as the converter (via
+discover_platform.normalize_maql -> maql.translate), so classic-dialect coverage
+is measured with real logic, not guessed.
+
+Usage:
+  export GOODDATA_PLATFORM_HOST=https://acme.on.gooddata.com
+  export GOODDATA_PLATFORM_USER=...   GOODDATA_PLATFORM_PASSWORD=...
+  python3 assess_platform.py --all                 # every accessible project
+  python3 assess_platform.py --project <pid>       # one project
+
+Status: built from docs, NOT yet run against a live Platform org. Classic reports
+/ dashboards do not carry Cloud `visualizationUrl`, so the viz-type histogram
+that assess.py prints for Cloud is replaced here by report / dashboard COUNTS;
+per-object widget-type tagging is a documented fast-follow once we see a live
+report definition.
+"""
+import argparse, os, sys
+
+# reuse the Platform client + normalizing extractor + shared MAQL translator
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "..", "gooddata-to-sigma", "scripts"))
+from platform_auth import PlatformClient          # noqa: E402
+from discover_platform import discover_project     # noqa: E402
+from maql import translate                          # noqa: E402
+
+
+def assess_project(c, pid):
+    layout = discover_project(c, pid)
+    an = layout["analytics"]
+    ds = layout["ldm"]["datasets"]
+    syms = layout["symbols"]
+
+    cats = {}
+    for m in an["metrics"]:
+        cat = translate(m["content"]["maql"], syms).get("category", "UNHANDLED")
+        cats[cat] = cats.get(cat, 0) + 1
+
+    nattr = sum(len(d["attributes"]) for d in ds)
+    nfact = sum(len(d["facts"]) for d in ds)
+    reports, legacy_dash, kpi_dash = (len(an["reports"]),
+                                      len(an["projectDashboards"]),
+                                      len(an["analyticalDashboards"]))
+
+    # per-project tag: hardest MAQL construct present drives the tag.
+    tag = ("MANUAL" if (cats.get("UNHANDLED")) else
+           "MANUAL" if (cats.get("CONTEXT") or cats.get("TIME_INTEL")) else
+           "HINT" if cats.get("WHERE") else
+           "AUTO")
+
+    print(f"\n=== {layout['project']['id']}  {layout['project']['title']} ===")
+    print(f"  datasets {len(ds)} | attributes {nattr} | facts {nfact} | metrics {len(an['metrics'])}")
+    print(f"  reports {reports} | legacy dashboards {legacy_dash} | KPI dashboards {kpi_dash}")
+    print(f"  MAQL coverage: {cats}")
+    print(f"  project tag: {tag}")
+    return {"id": pid, "title": layout["project"]["title"], "tag": tag,
+            "metrics": len(an["metrics"]), "cats": cats,
+            "reports": reports, "legacy_dash": legacy_dash, "kpi_dash": kpi_dash}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--project", help="assess a single project id")
+    ap.add_argument("--all", action="store_true", help="assess every accessible project")
+    a = ap.parse_args()
+
+    c = PlatformClient()
+    if a.project:
+        assess_project(c, a.project)
+        return
+    if not a.all:
+        sys.exit("--project <id> or --all required")
+
+    projects = c.projects()
+    print(f"Platform host {c.host}: {len(projects)} accessible project(s) — one identity, one sweep.")
+    rows = []
+    for p in projects:
+        try:
+            rows.append(assess_project(c, p["id"]))
+        except SystemExit as e:               # one project failing must not abort the estate
+            print(f"\n=== {p['id']}  {p['title']} ===\n  SKIPPED: {e}")
+
+    # estate roll-up
+    if rows:
+        by_tag = {}
+        for r in rows:
+            by_tag[r["tag"]] = by_tag.get(r["tag"], 0) + 1
+        tot_metrics = sum(r["metrics"] for r in rows)
+        print("\n" + "=" * 48)
+        print(f"ESTATE: {len(rows)} projects | {tot_metrics} metrics total")
+        print(f"  project tags: {by_tag}")
+        print("  migration order (AUTO first, then HINT, MANUAL):")
+        order = {"AUTO": 0, "HINT": 1, "MANUAL": 2}
+        for r in sorted(rows, key=lambda r: (order.get(r["tag"], 3), -r["metrics"])):
+            print(f"    [{r['tag']:6}] {r['id']:12} {r['title']}  "
+                  f"({r['metrics']} metrics, {r['reports']} reports)")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
@@ -10,8 +10,10 @@ description: >-
   and dashboards to pages + layout, ports user data filters (RLS) to Sigma user
   attributes, and verifies parity against the same warehouse. Translates what
   maps cleanly and flags what doesn't (compute-engine-only metrics, exotic MAQL
-  context, unsupported widgets) instead of emitting wrong logic. Legacy GoodData
-  Platform (/gdc/md classic) is out of scope for now — Cloud / .CN only.
+  context, unsupported widgets) instead of emitting wrong logic. Also handles the
+  legacy GoodData Platform (classic "bear", /gdc metadata API, SST/TT auth) for
+  discovery + assessment — one identity sweeps every project under a domain — with
+  DM/workbook conversion still Cloud-only (refs/gooddata-platform-api.md).
 user-invocable: true
 ---
 
@@ -37,7 +39,8 @@ and all data-model authoring to **sigma-data-models**.
 
 ## Read these first
 
-- `refs/gooddata-api.md` — declarative export API, auth, LDM + analytics shape.
+- `refs/gooddata-api.md` — Cloud/.CN declarative export API, auth, LDM + analytics shape.
+- `refs/gooddata-platform-api.md` — legacy Platform (`/gdc`) API, SST/TT auth, classic MAQL.
 - `refs/maql-mapping.md` — MAQL → Sigma formula contract (the hard part).
 - `refs/viz-type-mapping.md` — insight + dashboard → Sigma element mapping.
 - `refs/design-notes.md` — full architecture, parity, RLS, risks, build order.
@@ -123,6 +126,28 @@ opt-in escalate):
 
 ## Scope
 
-GoodData **Cloud / .CN** (`/api/v1` declarative API). Legacy **Platform**
-(`/gdc/md/{project}`, classic MAQL, MUF) is a documented fast-follow — see
-`design-notes.md` — not built.
+GoodData **Cloud / .CN** (`/api/v1` declarative API) — full path: discover → DM →
+workbook → parity → RLS.
+
+Legacy **GoodData Platform** (classic "bear", `/gdc`) — **discovery + assessment
+built; conversion not yet.** Different product, different API (SST/TT auth, `/gdc`
+metadata API, MUF). See `refs/gooddata-platform-api.md`. Use it when the customer's
+URLs/docs point at `help.gooddata.com/doc/enterprise` or a `/gdc/...` API rather
+than `<org>.cloud.gooddata.com` + `/api/v1`.
+
+```bash
+# Platform auth is SST/TT (username/password), NOT a Bearer token:
+export GOODDATA_PLATFORM_HOST=https://acme.on.gooddata.com
+export GOODDATA_PLATFORM_USER=...  GOODDATA_PLATFORM_PASSWORD=...
+python3 scripts/platform_auth.py --check                 # login + list accessible projects
+python3 scripts/discover_platform.py --list              # every project the user can see (one token)
+python3 scripts/discover_platform.py --project <pid>     # -> platform_layout.json (normalized to Cloud shape)
+```
+
+The classic multi-"instance" story: instances are **projects under one domain**, so
+one identity/token sweeps them all (`--list` / assessment `--all`) — unlike Cloud,
+where each org is a separate host+token. Classic MAQL is normalized into the same
+`maql.py` translator, so coverage scoring is shared. **Not built for Platform yet:**
+LDM→DM conversion (Platform data often isn't a customer-owned warehouse → parity
+caveat) and MUF→RLS extraction — both flagged as manual. Details + honest limits in
+`refs/gooddata-platform-api.md`.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/design-notes.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/design-notes.md
@@ -159,6 +159,14 @@ that fails the export). Keeps the migrated dashboard interactive, mirroring Good
 
 ## Scope note
 
-GoodData **Cloud / .CN** only for v0.1. Legacy **GoodData Platform**
-(`/gdc/md/{project}`, classic MAQL dialect, MUF) is a separate extraction client
-— documented fast-follow, not built.
+GoodData **Cloud / .CN** is the full path (discover → DM → workbook → parity → RLS).
+
+Legacy **GoodData Platform** (classic "bear", `/gdc` metadata API, SST/TT auth,
+classic MAQL dialect, MUF) now has a **discovery + assessment** path
+(`platform_auth.py`, `discover_platform.py`, `assess_platform.py`) — it enumerates
+every project a user can access under one domain and scores classic MAQL via the
+same `maql.py` translator (classic object-URI/identifier refs are normalized to
+`{type/id}` tokens first). **Still fast-follow for Platform:** LDM→DM conversion
+(Platform data is often GoodData's own datastore, not a customer warehouse → the
+same-warehouse parity assumption breaks) and MUF→RLS extraction. Full endpoint map
++ honest limits: `refs/gooddata-platform-api.md`.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/gooddata-api.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/gooddata-api.md
@@ -11,10 +11,12 @@
 |---|---|---|
 | **GoodData Cloud** (SaaS) | `/api/v1` REST + declarative layout | ✅ primary |
 | **GoodData.CN** (containerized) | same `/api/v1` + declarative layout | ✅ same code path |
-| **GoodData Platform** (classic / "bear", `/gdc/md/{project}`) | different REST, MUF user filters | ⏳ fast-follow only |
+| **GoodData Platform** (classic / "bear", `/gdc/md/{project}`) | different REST (SST/TT auth), MUF user filters | 🟡 discovery + assessment (see `gooddata-platform-api.md`) |
 
 Cloud and .CN share the API and the declarative model, so one client covers
-both. Classic Platform is a separate extraction client — deferred.
+both. Classic Platform is a **separate extraction client** — its own auth
+(SST/TT) and metadata API — now scaffolded for discovery + assessment; DM/workbook
+conversion is still Cloud-only. Full details: `gooddata-platform-api.md`.
 
 ## Auth
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/gooddata-platform-api.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/refs/gooddata-platform-api.md
@@ -1,0 +1,116 @@
+# GoodData *Platform* (classic "bear", `/gdc`) — extraction API
+
+> Source of truth: GoodData Platform / Legacy-Classic REST docs
+> (`help.gooddata.com/doc/enterprise` + `/classic`) and the `gooddata-java` /
+> `gooddata-http-client` SDKs. Endpoints below are **doc-verified**; the response
+> **shapes** (query/entries, objects/get wrappers, metric `content.expression`)
+> are **NOT yet exercised against a live Platform org** — confirm field paths on
+> first live run, same posture as `gooddata-api.md` for Cloud.
+
+## Platform vs Cloud — why this is a separate client
+
+| | GoodData **Cloud / .CN** | GoodData **Platform** (classic) |
+|---|---|---|
+| Docs | `gooddata.com/docs/cloud` | `help.gooddata.com/doc/enterprise` + `/classic` |
+| API root | `/api/v1` (declarative + entity) | `/gdc` (metadata API) |
+| Auth | `Authorization: Bearer <API token>` | **SST → TT** flow (below) |
+| Container | **organization** = one host, one token | **project** = one of many under ONE domain |
+| Multi-tenant | one org per host → loop hosts+tokens | many projects per host → **one token sweeps all** |
+| Metrics | `metrics[].content.maql`, `{fact/id}` refs | metric obj `content.expression`, `[<uri>]` refs |
+| RLS | user data filters / user attributes | **MUF** (mandatory user filters) |
+
+**The multi-"instance" question resolves here.** On the Platform, what a customer
+calls "separate instances" are **projects under a single domain**. A user with
+access to all of them is enumerated with **one identity, one token** — see
+`platform_auth.PlatformClient.projects()` and `assess_platform.py --all`. (On
+Cloud the opposite is true: each org is a separate host+token, so you loop
+credentials per org.)
+
+## Auth — SST / TT flow
+
+Every `/gdc` request **must** send a `User-Agent` header or it is rejected.
+
+```
+1. POST {HOST}/gdc/account/login
+   body: {"postUserLogin":{"login":"<email>","password":"<pw>","remember":0,"verify_level":2}}
+   -> SST in the `X-GDC-AuthSST` response header  (verify_level:2 = header token, not cookie)
+
+2. GET  {HOST}/gdc/account/token          header: X-GDC-AuthSST: <SST>
+   -> TT (Temporary Token) in the `X-GDC-AuthTT` response header. Short-lived (~10 min).
+
+3. Every metadata call:                    header: X-GDC-AuthTT: <TT>
+   On 401 -> mint a new TT from the SST and retry once.
+```
+
+`platform_auth.py` implements this (`PlatformClient`), env-driven:
+`GOODDATA_PLATFORM_HOST`, `GOODDATA_PLATFORM_USER` + `GOODDATA_PLATFORM_PASSWORD`
+(or a pre-obtained `GOODDATA_PLATFORM_SST`). `GOODDATA_TLS_VERIFY=1` forces strict
+TLS (default permissive, matching `discover.py`).
+
+> Bearer/personal-access tokens are a **Cloud** concept; the classic Platform is
+> SST/TT. If a given org exposes PATs, they slot in as an alternate `_login()`.
+
+## Projects (the "instance" list)
+
+```
+GET {HOST}/gdc/app/account/bootstrap            # -> current profile self-link
+GET {HOST}/gdc/account/profile/{profileId}/projects
+    -> { "projects": [ { "project": { "links": {"self": "/gdc/projects/{pid}"},
+                                        "meta": {"title": "..."} } } ] }
+GET {HOST}/gdc/projects/{pid}                    # project detail / title
+```
+
+## Per-project metadata
+
+```
+GET  {HOST}/gdc/md/{pid}/query/metrics            # -> query.entries[]{link,title,identifier,summary}
+GET  {HOST}/gdc/md/{pid}/query/facts
+GET  {HOST}/gdc/md/{pid}/query/attributes
+GET  {HOST}/gdc/md/{pid}/query/datasets
+GET  {HOST}/gdc/md/{pid}/query/reports
+GET  {HOST}/gdc/md/{pid}/query/projectdashboards      # legacy pixel-perfect tabs
+GET  {HOST}/gdc/md/{pid}/query/analyticaldashboards   # KPI dashboards
+GET  {HOST}/gdc/md/{pid}/obj/{objectId}               # single object detail
+POST {HOST}/gdc/md/{pid}/objects/get                  # bulk: {"get":{"items":[<uri>,...]}}
+     -> {"objects":{"items":[ {"<type>":{"content":..,"meta":{"uri","identifier","title"}}} ]}}
+```
+
+- A **metric** object: `content.expression` = classic MAQL; `content.format` = number format.
+- An **attribute** object: `content.displayForms[]` = its labels (display forms).
+- A **dataset** object: `content.attributes[]` + `content.facts[]` (object URIs) = its grain.
+- Bulk `objects/get` is the efficient path — pull all metric/attribute detail in
+  chunks of 50 rather than N single `obj/{id}` calls.
+
+## Classic MAQL → shared translator
+
+Classic MAQL references objects by **URI** (`[/gdc/md/{pid}/obj/N]`) or
+**identifier** (`[fact.sales.rev]`); Cloud MAQL uses typed tokens (`{fact/N}`).
+`discover_platform.normalize_maql()` rewrites classic refs into the Cloud token
+form (resolving display-form/label refs up to their parent attribute), so the
+**one** existing `maql.py` translator scores both dialects — no forked scorer.
+The `BY` / `BY ALL` / `WITHIN` / `FOR` / `WHERE` keyword surface is shared across
+dialects, so the AUTO / CONTEXT / TIME_INTEL / WHERE / UNHANDLED categories carry
+over directly.
+
+## MUF (row-level security) — fast-follow
+
+Mandatory User Filters are the Platform's RLS. Enumerate via
+`GET /gdc/md/{pid}/query/userfilters` and the per-user assignment resource; the
+filter expression is MAQL over an attribute. Maps to the same Sigma user-attribute
+RLS path the Cloud converter uses. **Extraction of MUF is not built yet** — flag
+RLS as a manual review item for Platform projects until it is.
+
+## Honest limitations (Platform, today)
+
+1. **Discovery + assessment only.** `convert.py` / `build_workbook.py` read the
+   **Cloud** LDM shape (`dataSourceTableId` → warehouse FQN). Platform projects
+   often store data in GoodData's own datastore/ADS, not a customer-owned
+   warehouse, so **same-warehouse parity may not hold** and DM conversion is not
+   wired for the Platform LDM. Treat Platform as: enumerate → assess → hand the
+   normalized layout to a human for the DM decision.
+2. **Reports vs insights.** Classic reports/dashboards don't carry a Cloud
+   `visualizationUrl`; the assessment reports COUNTS (reports / legacy dashboards
+   / KPI dashboards), not a per-widget viz-type histogram. Per-report widget-type
+   tagging needs a live report definition to model — fast-follow.
+3. **Not live-validated.** No live Platform org has been run. Every shape above is
+   defended with fallbacks; confirm on first run.

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/discover_platform.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/discover_platform.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""discover_platform.py — legacy GoodData *Platform* (classic /gdc) extraction.
+
+The Platform twin of discover.py. Where discover.py pulls a GoodData Cloud
+workspace via the declarative /api/v1/layout API + a Bearer token, this pulls a
+classic Platform *project* via the /gdc metadata API + the SST/TT flow
+(platform_auth.py), and NORMALIZES it into the SAME top-level shape discover.py
+emits — so the same downstream (maql.py translator, gap-scout, assessment) works
+unchanged.
+
+Key normalization: classic MAQL references objects by URI (`[/gdc/md/<pid>/obj/N]`)
+or identifier (`[fact.foo.bar]`). We rewrite each reference into the Cloud-style
+typed token maql.py understands — `{fact/N}` / `{attribute/N}` / `{metric/N}` —
+resolving display-form (label) refs up to their parent attribute. That lets the
+ONE existing translator score both dialects; we do not fork a second scorer.
+
+Usage:
+  export GOODDATA_PLATFORM_HOST=https://acme.on.gooddata.com
+  export GOODDATA_PLATFORM_USER=...   GOODDATA_PLATFORM_PASSWORD=...
+  python3 discover_platform.py --list                       # all accessible projects
+  python3 discover_platform.py --project <pid> [--out platform_layout.json]
+
+Status: built from the GoodData Platform metadata-API docs; endpoint SHAPES
+(query/entries, objects/get wrappers, metric content.expression) are doc-verified
+but NOT yet run against a live Platform org. The summary extractors defend against
+shape drift; confirm field paths on first live run (mirrors discover.py's own
+"confirm live" posture).
+"""
+import argparse, json, os, sys
+from platform_auth import PlatformClient
+from maql import translate
+
+# classic query resources -> our normalized bucket
+QUERY = {
+    "metrics": "metric",
+    "facts": "fact",
+    "attributes": "attribute",
+    "datasets": "dataSet",
+    "reports": "report",
+    "projectdashboards": "projectDashboard",
+    "analyticaldashboards": "analyticalDashboard",
+}
+
+
+def query_entries(c, pid, resource):
+    """GET /gdc/md/{pid}/query/{resource} -> list of entry dicts."""
+    data = c.get(f"/gdc/md/{pid}/query/{resource}")
+    return (data.get("query", {}) or {}).get("entries", []) or []
+
+
+def bulk_get(c, pid, uris):
+    """POST /gdc/md/{pid}/objects/get -> {uri: object-detail}. Chunked (server caps)."""
+    out = {}
+    uris = [u for u in uris if u]
+    for i in range(0, len(uris), 50):
+        chunk = uris[i:i + 50]
+        resp = c.post(f"/gdc/md/{pid}/objects/get", {"get": {"items": chunk}})
+        for item in ((resp.get("objects", {}) or {}).get("items", []) or []):
+            # item is {<wrapperKey>: {content, meta}}
+            for _wrapper, obj in item.items():
+                uri = (obj.get("meta", {}) or {}).get("uri")
+                if uri:
+                    out[uri] = obj
+    return out
+
+
+def _last(uri):
+    return uri.rstrip("/").split("/")[-1] if uri else None
+
+
+def build_ref_map(c, pid):
+    """Map every fact/attribute/metric (by URI *and* identifier) -> {kind,id,title}.
+
+    Display-form (label) URIs resolve to their PARENT attribute, so any label ref
+    in MAQL rewrites to `{attribute/<parentId>}` — exactly what maql.py expects.
+    """
+    ref = {}          # uri or identifier -> {"kind","id","title"}
+    syms = {"fact": {}, "attribute": {}, "metric": {}}
+
+    def add(kind, uri, ident, title):
+        oid = _last(uri)
+        rec = {"kind": kind, "id": oid, "title": title or oid}
+        if uri:   ref[uri] = rec
+        if ident: ref[ident] = rec
+        if oid:   syms[kind][oid] = rec["title"]
+
+    for res, kind in (("facts", "fact"), ("attributes", "attribute"), ("metrics", "metric")):
+        for e in query_entries(c, pid, res):
+            add(kind, e.get("link"), e.get("identifier"), e.get("title"))
+
+    # attribute display forms -> parent attribute (so label refs resolve)
+    attr_uris = [e.get("link") for e in query_entries(c, pid, "attributes")]
+    for uri, obj in bulk_get(c, pid, attr_uris).items():
+        parent = ref.get(uri)
+        if not parent:
+            continue
+        for df in (obj.get("content", {}) or {}).get("displayForms", []) or []:
+            meta = df.get("meta", {}) or {}
+            df_uri, df_ident = meta.get("uri"), meta.get("identifier")
+            if df_uri:   ref[df_uri] = parent
+            if df_ident: ref[df_ident] = parent
+    return ref, syms
+
+
+def normalize_maql(expr, ref):
+    """Rewrite classic `[<uri-or-identifier>]` refs -> Cloud `{kind/id}` tokens."""
+    if not expr:
+        return expr
+    import re
+
+    def sub(m):
+        inner = m.group(1).strip()
+        rec = ref.get(inner)
+        if not rec:
+            return m.group(0)          # leave unresolved -> translator tags UNHANDLED
+        return f"{{{rec['kind']}/{rec['id']}}}"
+
+    return re.sub(r"\[([^\]]+)\]", sub, expr)
+
+
+def discover_project(c, pid):
+    proj = c.get(f"/gdc/projects/{pid}")
+    title = (((proj.get("project") or {}).get("meta") or {}).get("title")) or pid
+
+    ref, syms = build_ref_map(c, pid)
+
+    # --- metrics: pull detail, normalize MAQL ---
+    metric_uris = [e.get("link") for e in query_entries(c, pid, "metrics")]
+    metrics = []
+    for uri, obj in bulk_get(c, pid, metric_uris).items():
+        content = obj.get("content", {}) or {}
+        meta = obj.get("meta", {}) or {}
+        raw = content.get("expression", "")
+        metrics.append({
+            "id": _last(uri),
+            "title": meta.get("title") or _last(uri),
+            "content": {
+                "maql": normalize_maql(raw, ref),
+                "expressionRaw": raw,
+                "format": content.get("format"),
+            },
+        })
+
+    # --- datasets: group attributes/facts (best-effort) ---
+    ds_uris = [e.get("link") for e in query_entries(c, pid, "datasets")]
+    datasets = []
+    for uri, obj in bulk_get(c, pid, ds_uris).items():
+        content = obj.get("content", {}) or {}
+        meta = obj.get("meta", {}) or {}
+
+        def resolve(uris, kind):
+            res = []
+            for u in uris or []:
+                r = ref.get(u)
+                if r and r["kind"] == kind:
+                    res.append({"id": r["id"], "title": r["title"]})
+            return res
+        datasets.append({
+            "id": _last(uri),
+            "title": meta.get("title") or _last(uri),
+            "attributes": resolve(content.get("attributes"), "attribute"),
+            "facts": resolve(content.get("facts"), "fact"),
+        })
+    if not datasets:      # fall back to a flat synthetic dataset so counts survive
+        datasets = [{
+            "id": "_all",
+            "title": "(ungrouped)",
+            "attributes": [{"id": i, "title": t} for i, t in syms["attribute"].items()],
+            "facts": [{"id": i, "title": t} for i, t in syms["fact"].items()],
+        }]
+
+    def simple(res):
+        return [{"id": _last(e.get("link")), "title": e.get("title")}
+                for e in query_entries(c, pid, res)]
+
+    return {
+        "product": "platform",
+        "host": c.host,
+        "project": {"id": pid, "title": title},
+        "ldm": {"datasets": datasets},
+        "analytics": {
+            "metrics": metrics,
+            "reports": simple("reports"),
+            "projectDashboards": simple("projectdashboards"),
+            "analyticalDashboards": simple("analyticaldashboards"),
+        },
+        "symbols": syms,
+    }
+
+
+def summarize(layout):
+    an = layout["analytics"]
+    ds = layout["ldm"]["datasets"]
+    nattr = sum(len(d["attributes"]) for d in ds)
+    nfact = sum(len(d["facts"]) for d in ds)
+    syms = layout["symbols"]
+    cats = {}
+    for m in an["metrics"]:
+        cat = translate(m["content"]["maql"], syms).get("category", "UNHANDLED")
+        cats[cat] = cats.get(cat, 0) + 1
+    print(f"\n=== {layout['project']['id']}  {layout['project']['title']} ===")
+    print(f"  datasets {len(ds)} | attributes {nattr} | facts {nfact} | metrics {len(an['metrics'])}")
+    print(f"  reports {len(an['reports'])} | legacy dashboards {len(an['projectDashboards'])}"
+          f" | KPI dashboards {len(an['analyticalDashboards'])}")
+    print(f"  MAQL coverage (via shared translator): {cats}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--list", action="store_true", help="list all accessible projects")
+    ap.add_argument("--project", help="project id to extract")
+    ap.add_argument("--out", default="platform_layout.json")
+    a = ap.parse_args()
+
+    c = PlatformClient()
+    if a.list:
+        for p in c.projects():
+            print(f"{p['id']}\t{p['title']}")
+        return
+    if not a.project:
+        sys.exit("--project <id> or --list required")
+
+    layout = discover_project(c, a.project)
+    summarize(layout)
+    with open(a.out, "w", encoding="utf-8") as fh:
+        json.dump(layout, fh, indent=2)
+    print(f"\n  wrote {a.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/platform_auth.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/platform_auth.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""platform_auth.py — legacy GoodData *Platform* (classic "bear", /gdc) auth.
+
+The Platform is a DIFFERENT product from GoodData Cloud / .CN (which uses a
+Bearer API token against /api/v1 — see discover.py + get_token.py). The classic
+Platform authenticates with the SST/TT flow:
+
+  1. POST /gdc/account/login  {postUserLogin: {login, password, verify_level:2}}
+       -> SST (SuperSecured Token) in the `X-GDC-AuthSST` response header.
+  2. GET  /gdc/account/token   (header X-GDC-AuthSST: <SST>)
+       -> TT (Temporary Token) in the `X-GDC-AuthTT` response header. TTs are
+          short-lived (~10 min); refresh from the SST on a 401.
+  3. Every subsequent /gdc call: header `X-GDC-AuthTT: <TT>`.
+
+IMPORTANT: the Platform REJECTS any request without a `User-Agent` header, so
+every call here sets one.
+
+This is the multi-instance answer for Platform customers: ONE host + ONE user
+identity can enumerate EVERY project that user can access (`--list`), because
+classic "instances" are projects under a single platform domain — unlike Cloud,
+where each org is a separate host+token. (See refs/gooddata-platform-api.md.)
+
+Credentials (env):
+  GOODDATA_PLATFORM_HOST      e.g. https://acme.on.gooddata.com  (or secure.gooddata.com)
+  GOODDATA_PLATFORM_USER      login email               ] username/password flow
+  GOODDATA_PLATFORM_PASSWORD  password                  ]
+  GOODDATA_PLATFORM_SST       pre-obtained SST          ] (alternative to user/pass)
+  GOODDATA_TLS_VERIFY=1       force strict TLS (default: permissive, like discover.py)
+
+CLI:
+  python3 platform_auth.py --check          # login, print profile + project count
+  python3 platform_auth.py --print-token    # print a fresh TT to stdout
+
+Status: built from GoodData Platform REST docs (SST/TT flow, /gdc/account/*),
+NOT yet exercised against a live Platform org. Header/body fallbacks are defensive
+precisely because the live shape must be confirmed on first run.
+"""
+import json, os, ssl, sys, urllib.request, urllib.error
+
+_UA = "sigma-gooddata-migration/1.0 (+platform)"
+
+_CTX = ssl.create_default_context()
+if os.environ.get("GOODDATA_TLS_VERIFY") != "1":
+    _CTX.check_hostname = False
+    _CTX.verify_mode = ssl.CERT_NONE
+
+
+def _host():
+    h = os.environ.get("GOODDATA_PLATFORM_HOST")
+    if not h:
+        sys.exit("GOODDATA_PLATFORM_HOST is required (e.g. https://acme.on.gooddata.com)")
+    return h.rstrip("/")
+
+
+class PlatformClient:
+    """Thin /gdc REST client with SST/TT auth and transparent TT refresh."""
+
+    def __init__(self):
+        self.host = _host()
+        self.sst = os.environ.get("GOODDATA_PLATFORM_SST")
+        self.tt = None
+
+    # --- low-level request ------------------------------------------------
+    def _raw(self, method, path, body=None, headers=None):
+        url = path if path.startswith("http") else self.host + path
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("User-Agent", _UA)          # Platform rejects requests without it
+        req.add_header("Accept", "application/json")
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        for k, v in (headers or {}).items():
+            req.add_header(k, v)
+        try:
+            resp = urllib.request.urlopen(req, timeout=60, context=_CTX)
+            raw = resp.read()
+            payload = json.loads(raw) if raw else {}
+            return resp, payload
+        except urllib.error.HTTPError as e:
+            raise e
+
+    # --- auth -------------------------------------------------------------
+    def _login(self):
+        """Exchange user/password for an SST (verify_level 2 -> header token)."""
+        if self.sst:
+            return
+        user = os.environ.get("GOODDATA_PLATFORM_USER")
+        pw = os.environ.get("GOODDATA_PLATFORM_PASSWORD")
+        if not (user and pw):
+            sys.exit("Set GOODDATA_PLATFORM_USER + GOODDATA_PLATFORM_PASSWORD, or "
+                     "GOODDATA_PLATFORM_SST directly.")
+        body = {"postUserLogin": {"login": user, "password": pw,
+                                  "remember": 0, "verify_level": 2}}
+        try:
+            resp, payload = self._raw("POST", "/gdc/account/login", body)
+        except urllib.error.HTTPError as e:
+            sys.exit(f"Platform login failed ({e.code}): "
+                     f"{e.read()[:300].decode(errors='replace')}")
+        # verify_level 2 returns the SST in the response header; some builds also
+        # echo it in the body. Header wins.
+        self.sst = (resp.headers.get("X-GDC-AuthSST")
+                    or (payload.get("userLogin", {}) or {}).get("token"))
+        if not self.sst:
+            sys.exit("Login succeeded but no SST returned (X-GDC-AuthSST). "
+                     "Confirm verify_level handling for this org.")
+
+    def _refresh_tt(self):
+        """Mint a fresh TT from the SST."""
+        self._login()
+        try:
+            resp, payload = self._raw("GET", "/gdc/account/token",
+                                      headers={"X-GDC-AuthSST": self.sst})
+        except urllib.error.HTTPError as e:
+            if e.code in (401, 403):
+                sys.exit("SST rejected while minting TT — SST expired or invalid; "
+                         "re-authenticate (check user/password).")
+            sys.exit(f"TT request failed ({e.code}): "
+                     f"{e.read()[:300].decode(errors='replace')}")
+        self.tt = (resp.headers.get("X-GDC-AuthTT")
+                   or (payload.get("userLogin", {}) or {}).get("token"))
+        if not self.tt:
+            sys.exit("Token endpoint returned no TT (X-GDC-AuthTT).")
+        return self.tt
+
+    def token(self):
+        return self.tt or self._refresh_tt()
+
+    # --- authenticated verbs (auto-refresh TT once on 401) ----------------
+    def get(self, path):
+        return self._call("GET", path)
+
+    def post(self, path, body):
+        return self._call("POST", path, body)
+
+    def _call(self, method, path, body=None):
+        for attempt in (1, 2):
+            tt = self.token()
+            try:
+                _, payload = self._raw(method, path, body,
+                                       headers={"X-GDC-AuthTT": tt})
+                return payload
+            except urllib.error.HTTPError as e:
+                if e.code == 401 and attempt == 1:
+                    self.tt = None          # expired TT -> refresh and retry once
+                    continue
+                sys.exit(f"{method} {path} -> {e.code}: "
+                         f"{e.read()[:300].decode(errors='replace')}")
+
+    # --- convenience ------------------------------------------------------
+    def profile_id(self):
+        """Resolve the logged-in account's profile id via the bootstrap resource."""
+        boot = self.get("/gdc/app/account/bootstrap")
+        prof = (((boot.get("bootstrapResource") or {}).get("accountSetting") or {})
+                .get("links") or {}).get("self", "")
+        return prof.rstrip("/").split("/")[-1] if prof else None
+
+    def projects(self):
+        """List every project the logged-in user can access.
+
+        Returns [{"id","title","uri"}]. This is the cross-'instance' sweep:
+        one token, all projects.
+        """
+        pid = self.profile_id()
+        if not pid:
+            sys.exit("Could not resolve profile id from bootstrap.")
+        data = self.get(f"/gdc/account/profile/{pid}/projects")
+        out = []
+        for entry in data.get("projects", []) or []:
+            p = entry.get("project", {})
+            uri = (p.get("links") or {}).get("self", "")
+            out.append({
+                "id": uri.rstrip("/").split("/")[-1] if uri else None,
+                "title": (p.get("meta") or {}).get("title"),
+                "uri": uri,
+            })
+        return out
+
+
+def main():
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true", help="login, print profile + project count")
+    ap.add_argument("--print-token", action="store_true", help="print a fresh TT")
+    a = ap.parse_args()
+    c = PlatformClient()
+    if a.print_token:
+        print(c.token()); return
+    if a.check or not (a.print_token):
+        pid = c.profile_id()
+        projs = c.projects()
+        print(f"host    : {c.host}")
+        print(f"profile : {pid}")
+        print(f"projects: {len(projs)} accessible")
+        for p in projs[:50]:
+            print(f"  - {p['id']}  {p['title']}")
+        if len(projs) > 50:
+            print(f"  … +{len(projs) - 50} more")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

A customer is on the **legacy GoodData Platform** (classic "bear", `/gdc` metadata API) — a different product from GoodData Cloud/.CN, which the skill already handles. Their team asked whether one API can pull across their multiple "instances." This adds a Platform path so the skill covers both products and answers that question concretely.

## What the API difference actually is

| | GoodData **Cloud / .CN** (already supported) | GoodData **Platform** (this PR) |
|---|---|---|
| Auth | `Authorization: Bearer <API token>` | **SST → TT** (username/password) |
| API | `/api/v1` declarative layout | `/gdc` metadata API |
| "Instances" | each **org** = separate host + token → loop creds per org | **projects under one domain** → **one identity sweeps all** |

The customer's "one API across instances, assuming the user has access" is **correct for the Platform** (projects under one domain), and the opposite of Cloud. This PR makes `--all` / `--list` do exactly that single-identity sweep.

## Added
- `scripts/platform_auth.py` — `PlatformClient` implementing the SST→TT flow (sets required `User-Agent`, auto-refreshes TT on 401), `--check` / `--print-token`, and `projects()` (cross-project enumeration).
- `scripts/discover_platform.py` — `--list` all accessible projects; `--project <pid>` → normalized `platform_layout.json`. Classic MAQL object-URI/identifier refs are rewritten into the Cloud `{type/id}` token form so the **existing `maql.py` translator scores both dialects** — no forked scorer.
- `gooddata-assessment/scripts/assess_platform.py` — `--all` sweeps every project the user can access (one login), per-project AUTO/HINT/MANUAL tag + estate roll-up / migration order; `--project` for one.
- `refs/gooddata-platform-api.md` — endpoint map, auth flow, MAQL normalization, MUF, honest limits.
- Scope/PRIVACY/design-notes/gooddata-api.md updated across both skills.

## Honest scope
Platform = **discovery + assessment only.** LDM→DM conversion and MUF→RLS are documented fast-follows (Platform data is often GoodData's own datastore, so the same-warehouse parity assumption breaks). **Not yet run against a live Platform org** — every `/gdc` shape is doc-verified with defensive fallbacks and validated offline against mocked `/gdc` responses (auth flow, project sweep, bulk `objects/get`, classic-MAQL normalization incl. `BY ALL` → CONTEXT flag, dataset grouping, estate roll-up all exercised).

Bead: beads-sigma-b1yz

🤖 Generated with [Claude Code](https://claude.com/claude-code)