### PR TITLE
Harden agent guardrails: fail-closed cred gate, completion sentinel, single entry point, off-ramp observability

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -1073,5 +1073,22 @@ else
   puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
+# Completion sentinel — stamp a run-scoped success marker keyed to the workbook
+# and clear any PASS-1 pending marker. verify-complete.rb (the offline done-check
+# the SKILL points agents at) reports GREEN only when this file exists for the
+# workbook and no parity-pending.json remains. This makes "done" a token only the
+# gate can mint, closing the "agent narrates success without the gate" hole.
+begin
+  _wd = opts[:tab]
+  File.write(File.join(_wd, 'phase6-success.json'),
+             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'gates' => 'all-pass',
+                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _pend = File.join(_wd, 'parity-pending.json')
+  File.delete(_pend) if File.exist?(_pend)
+rescue StandardError
+  # never fail the gate on sentinel bookkeeping
+end
+
 puts "[OK] all gates pass — conversion may declare GREEN"
 exit 0

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -1073,5 +1073,22 @@ else
   puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
+# Completion sentinel — stamp a run-scoped success marker keyed to the workbook
+# and clear any PASS-1 pending marker. verify-complete.rb (the offline done-check
+# the SKILL points agents at) reports GREEN only when this file exists for the
+# workbook and no parity-pending.json remains. This makes "done" a token only the
+# gate can mint, closing the "agent narrates success without the gate" hole.
+begin
+  _wd = opts[:tab]
+  File.write(File.join(_wd, 'phase6-success.json'),
+             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'gates' => 'all-pass',
+                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _pend = File.join(_wd, 'parity-pending.json')
+  File.delete(_pend) if File.exist?(_pend)
+rescue StandardError
+  # never fail the gate on sentinel bookkeeping
+end
+
 puts "[OK] all gates pass — conversion may declare GREEN"
 exit 0

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -1073,5 +1073,22 @@ else
   puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
+# Completion sentinel — stamp a run-scoped success marker keyed to the workbook
+# and clear any PASS-1 pending marker. verify-complete.rb (the offline done-check
+# the SKILL points agents at) reports GREEN only when this file exists for the
+# workbook and no parity-pending.json remains. This makes "done" a token only the
+# gate can mint, closing the "agent narrates success without the gate" hole.
+begin
+  _wd = opts[:tab]
+  File.write(File.join(_wd, 'phase6-success.json'),
+             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'gates' => 'all-pass',
+                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _pend = File.join(_wd, 'parity-pending.json')
+  File.delete(_pend) if File.exist?(_pend)
+rescue StandardError
+  # never fail the gate on sentinel bookkeeping
+end
+
 puts "[OK] all gates pass — conversion may declare GREEN"
 exit 0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1073,5 +1073,22 @@ else
   puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
+# Completion sentinel — stamp a run-scoped success marker keyed to the workbook
+# and clear any PASS-1 pending marker. verify-complete.rb (the offline done-check
+# the SKILL points agents at) reports GREEN only when this file exists for the
+# workbook and no parity-pending.json remains. This makes "done" a token only the
+# gate can mint, closing the "agent narrates success without the gate" hole.
+begin
+  _wd = opts[:tab]
+  File.write(File.join(_wd, 'phase6-success.json'),
+             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'gates' => 'all-pass',
+                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _pend = File.join(_wd, 'parity-pending.json')
+  File.delete(_pend) if File.exist?(_pend)
+rescue StandardError
+  # never fail the gate on sentinel bookkeeping
+end
+
 puts "[OK] all gates pass — conversion may declare GREEN"
 exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/QUICKSTART.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/QUICKSTART.md
@@ -74,8 +74,8 @@ Sigma SEs, technical CSMs, and migration partners running 1:1 Tableau-to-Sigma c
   <li>How to invoke the <code>tableau-to-sigma</code> skill from Claude Code with a single dashboard URL.</li>
   <li>What each conversion phase does — discovery, gap scan, DM reuse check, spec build, parity verification.</li>
   <li>How to read the gap report and accept / override the proposed Sigma translations.</li>
-  <li>How the four hard-gate checks (parity ran, no orphans, no runtime errors, layout applied) prevent silent regressions.</li>
-  <li>When to fall back to a hand-written layout vs the auto-layout from <code>build-dashboard-layout.rb</code>.</li>
+  <li>How the finalize hard gate (<code>assert-phase6-ran.rb</code> — a stack of ~15 independent checks: parity ran, no orphans, no runtime errors, layout applied + filled, controls wired, visual verdict recorded, fidelity ledger clean, telemetry, …) prevents silent regressions, and why a clean PASS 1 is <em>not</em> "done".</li>
+  <li>Why you drive the whole conversion through the <strong>one orchestrator command</strong> (<code>migrate-tableau.rb</code>) rather than running the per-phase scripts by hand.</li>
 </ul>
 
 ### What You'll Build
@@ -93,7 +93,7 @@ Duration: 5
 
 <ul>
   <li><strong><code>tableau-assessment</code></strong> — <em>Phase 0: scoping</em>. Point it at a Tableau Cloud site and it inventories everything in ~90 seconds — environment counts, licenses, datasource mix, refresh history, per-workbook usage, per-workbook complexity (via a <code>.twb</code> gap-scan), and a value/cost-ranked migration shortlist. Run this BEFORE you commit to a conversion plan; the output tells you which workbooks convert clean today, which need redesign, and which to leave on Tableau. Complements (does not replace) Hakkoda's deeper Assessment App. Also emits the cluster plan that <code>tableau-to-sigma</code> consumes for batch runs.</li>
-  <li><strong><code>tableau-to-sigma</code></strong> — <em>Phases 1–6: the conversion</em>. The subject of this QuickStart. Takes a single workbook URL (or a cluster plan from <code>tableau-assessment</code>) and produces a live Sigma workbook with verified parity. Hardened against the four most-common silent regressions via a four-gate finalize check.</li>
+  <li><strong><code>tableau-to-sigma</code></strong> — <em>Phases 1–6: the conversion</em>. The subject of this QuickStart. Takes a single workbook URL (or a cluster plan from <code>tableau-assessment</code>) and produces a live Sigma workbook with verified parity. Hardened against the most-common silent regressions via the <code>assert-phase6-ran.rb</code> finalize hard gate.</li>
   <li><strong><code>tableau-vds-to-cdw</code></strong> — <em>Phase 0.5: data landing, when needed</em>. Extracts a published Tableau datasource via the VizQL Data Service (VDS) API and lands it in your cloud warehouse — Snowflake (stored procedure + External Access Integration) or Databricks (serverless notebook on Unity Catalog), optionally scheduled for ongoing refresh. Reach for this when a customer's data lives <em>only</em> inside Tableau (extracts, Tableau Prep outputs, Web Data Connector feeds) and isn't already in the warehouse Sigma reads. Sigma needs warehouse-native data; this skill is the bridge.</li>
 </ul>
 
@@ -172,6 +172,38 @@ Your agent should respond with the skill's preamble — a short summary of phase
 ![Footer](assets/sigma_footer.png)
 <!-- END OF SECTION -->
 
+## **The one command (read this before the phases)**
+Duration: 2
+
+In practice you do **not** run the phase scripts by hand. The skill has a single
+entry point — the orchestrator — that chains every phase below in one process and
+self-gates:
+
+```console
+ruby scripts/migrate-tableau.rb --workbook "Orders Overview" --connection <sigma-connection-id>
+```
+
+It runs discovery → gap gate → DM (build or reuse) → workbook → layout → two-pass
+parity → cleanup, stamping run-state as it goes, and **stops with an exact
+next-command message** anywhere your judgment is needed (read the source PNG,
+collect pivot actuals, resolve an untranslatable field). The phase-by-phase
+sections that follow exist so you understand *what the one command is doing* and
+can pick up from an orchestrator STOP — they are a **map, not a menu**. Running
+individual scripts à la carte instead of the orchestrator is the most common way
+a conversion drifts (the run-state audit silently no-ops when bypassed).
+
+Two rules that keep a run honest:
+
+- **PASS 1 ends at exit 12 — that is not "done."** It means "collect actuals, then
+  run the printed `--finalize` command," which runs the `assert-phase6-ran.rb`
+  hard gate. Exit 0 there is the only green.
+- **Confirm completion with one offline check, not by eyeballing HTTP 200s:**
+  `ruby scripts/verify-complete.rb --workdir <WORK>` must print ✅ DONE. Until it
+  does, the migration is not finished.
+
+![Footer](assets/sigma_footer.png)
+<!-- END OF SECTION -->
+
 ## **Phase 1 — Discovery**
 Duration: 10
 
@@ -191,10 +223,10 @@ Claude resolves the URL to a workbook LUID and runs `scripts/tableau-discover.rb
   <li><strong>Dashboard PNG</strong> — fetched solo after the CSVs to avoid VizQL session contention</li>
 </ul>
 
-The output lands in `/tmp/<workbook-slug>/`:
+The output lands in `~/tableau-migration/<slug>/`:
 
 ```console
-/tmp/orders-conv/
+~/tableau-migration/orders-conv/
   get-workbook.json
   workbook-content.twb
   ds-metadata.json
@@ -281,13 +313,13 @@ After the workbook POST + readback, Claude builds and applies the layout:
 
 ```console
 ruby scripts/build-dashboard-layout.rb \
-  --layout /tmp/<name>/dashboard-layout.json \
-  --wb-ids /tmp/<name>/wb-ids.json \
-  --out /tmp/<name>/layout.xml
+  --layout ~/tableau-migration/<slug>/dashboard-layout.json \
+  --wb-ids ~/tableau-migration/<slug>/wb-ids.json \
+  --out ~/tableau-migration/<slug>/layout.xml
 
 ruby scripts/put-layout.rb \
   --workbook <workbook-id> \
-  --layout /tmp/<name>/layout.xml
+  --layout ~/tableau-migration/<slug>/layout.xml
 ```
 
 `build-dashboard-layout.rb` walks each Tableau zone, converts its `x_pct` / `y_pct` / `w_pct` / `h_pct` into Sigma 24-column grid spans, and stretches adjacent tiles to close gaps where Tableau had legend or filter zones Sigma doesn't render. **Skipping this step makes Sigma render every tile in a single-column auto-stack** — the regression the hard gate catches.
@@ -308,10 +340,10 @@ The conversion is not complete until every chart's Sigma values match Tableau's 
 </ul>
 
 ```console
-ruby scripts/phase6-parity.rb --tableau /tmp/<name> --workbook-id <id>
+ruby scripts/phase6-parity.rb --tableau ~/tableau-migration/<slug> --workbook-id <id>
 # ... agent collects actuals via mcp__sigma-mcp-v2__query ...
-ruby scripts/phase6-parity.rb --tableau /tmp/<name> --finalize \
-  --actuals /tmp/<name>/parity-actuals.json
+ruby scripts/phase6-parity.rb --tableau ~/tableau-migration/<slug> --finalize \
+  --actuals ~/tableau-migration/<slug>/parity-actuals.json
 ```
 
 ![tts_parity_pass](assets/tts_parity_pass.png)
@@ -328,7 +360,7 @@ The conversion is gated by `scripts/assert-phase6-ran.rb`, which checks **four**
 </ol>
 
 ```console
-ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name>
+ruby scripts/assert-phase6-ran.rb --tableau ~/tableau-migration/<slug>
 ```
 
 ![tts_hard_gate](assets/tts_hard_gate.png)
@@ -352,7 +384,7 @@ on any shift. See the SKILL.md "Phase E (opt-in) — Enhance" section.
 Duration: 5
 
 <ul>
-  <li><strong>Three workbooks in My Documents.</strong> POST is create-only; each retry creates a new workbook. Run <code>ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/&lt;name&gt;</code> to delete all-but-the-most-recent ID via <code>DELETE /v2/files/{id}</code>.</li>
+  <li><strong>Three workbooks in My Documents.</strong> POST is create-only; each retry creates a new workbook. Run <code>ruby scripts/cleanup-orphan-workbooks.rb --workdir ~/tableau-migration/&lt;slug&gt;</code> to delete all-but-the-most-recent ID via <code>DELETE /v2/files/{id}</code>.</li>
   <li><strong>Single-column auto-stack layout.</strong> Sigma's server auto-generates a left-half stacked layout when a workbook is POSTed without one. <code>assert-phase6-ran.rb</code> gate 4 catches this; fix by running <code>build-dashboard-layout.rb</code> + <code>put-layout.rb</code>.</li>
   <li><strong>Chart renders blank in Sigma but spec compiled.</strong> A column resolved to <code>type=error</code> — typo'd ref, <code>IsIn()</code>, a window function in a calc column. Run <code>verify-workbook.rb</code> for the diagnostic; <code>mcp__sigma-mcp-v2__describe</code> on the element shows which column is broken.</li>
   <li><strong>Pivot table appears as a flat table.</strong> Verify <code>parse-twb-layout.rb</code> emitted <code>chart_kind: pivot-table</code>. If it emitted <code>table</code> instead, the source worksheet had dims on only one shelf — that's a flat detail list, not a crosstab.</li>

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -25,6 +25,31 @@ user-invocable: true
 > Windows use the no-admin path in `refs/environment.md` (#5), and let the **user** run it.
 > Details: `refs/environment.md`.
 
+> ## ⛔ STEP 1 — THE ONE PATH (there is a single entry point; do not improvise one)
+> After the doctor, **always run the orchestrator** — it chains every phase
+> (discover → gates → DM → workbook → layout → two-pass parity → cleanup) in one
+> process and self-gates:
+> ```
+> ruby scripts/migrate-tableau.rb --workbook "<name>" --connection <id>
+> ```
+> - **Do NOT hand-drive the per-phase scripts, and do NOT hand-author DM/workbook
+>   JSON, UNLESS an orchestrator STOP message explicitly routes you there** (e.g.
+>   "CONVERTER STOP", the exit-4 workbook handoff). The per-phase table further
+>   down is a **map for understanding and recovery, not a menu** — picking scripts
+>   off it à la carte is the #1 way runs go inconsistent (the run-state audit
+>   silently no-ops when you bypass the orchestrator).
+> - **"Done" is not something you decide — it is a file on disk.** The migration
+>   is complete **only** when this exits 0:
+>   ```
+>   ruby scripts/verify-complete.rb --workdir <WORK>
+>   ```
+>   A clean **PASS 1 (exit 12) is NOT done** — it means "run `--finalize`". Never
+>   report success, hand off, or write a completion summary until
+>   `verify-complete.rb` prints ✅ DONE. Nothing else counts as green.
+> - **Credentials:** if you are **not** on Claude Code, the orchestrator will stop
+>   at step 0 telling you to run `ruby scripts/setup.rb` once — that is expected;
+>   do it (in a real terminal) rather than working around the auth error.
+
 > **Model fit & vision requirements — `refs/model-fit.md`.** Design fidelity depends on
 > the driving agent, not just the environment. One-line rule: **pixel-fidelity claims
 > require image input; very-large workbooks on non-top-tier models require asking the
@@ -233,9 +258,14 @@ Optional `--enhance [--enhance-accept <ids|all-low-risk>]` runs Phase E
 
 ## Scripts
 
-The conversion is driven by `scripts/*.rb`. Each script encapsulates one mechanical
-phase. You compose them; the agent's role is judgment (which DM/workbook shape,
-which calc translation, which layout) — not orchestration.
+The conversion is driven by `scripts/*.rb`. **`migrate-tableau.rb` composes them
+for you** (see STEP 1 at the top) — it is the orchestrator and the only entry
+point you run cold. Each other script encapsulates one mechanical phase; you
+invoke one **directly only when an orchestrator STOP message tells you to**
+(recovery/handoff), never as an à-la-carte alternative to the one command. The
+agent's role is judgment (which DM/workbook shape, which calc translation, which
+layout) inside that spine — not re-orchestrating it by hand. The table below is
+the map of what the orchestrator runs.
 
 | Script | Purpose |
 |---|---|
@@ -507,8 +537,11 @@ ruby scripts/assert-dashboard-read.rb --workdir <WORK>                  # 🚧 P
 ruby scripts/assert-run-state.rb --workdir <WORK>                       # 🚧 phase-chain ledger audit
 ruby scripts/assert-phase6-ran.rb --workdir <WORK> --workbook-id <wb>   # 🚧 hard gate — must exit 0
 ```
-**A conversion is NOT done until `assert-phase6-ran.rb` exits 0.** Full detail
-(raw-warehouse mode, triage, visual checklist): `refs/phase-6-parity.md`.
+**A conversion is NOT done until `assert-phase6-ran.rb` exits 0** (which stamps
+`<WORK>/phase6-success.json`). Confirm it before claiming success with the single
+offline check — `ruby scripts/verify-complete.rb --workdir <WORK>` must print
+✅ DONE / exit 0. Full detail (raw-warehouse mode, triage, visual checklist):
+`refs/phase-6-parity.md`.
 
 ### Phase 5g — RCF (render-compare-fix) fidelity loop — `refs/phase-5g-rcf.md`
 After the workbook renders, iterate composition to convergence: `fidelity-loop.rb render`

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/SKILL.md
@@ -270,6 +270,8 @@ the map of what the orchestrator runs.
 | Script | Purpose |
 |---|---|
 | `scripts/migrate-tableau.rb` | **The one command** — chains the whole scripted spine (gap gate → DM-reuse scan → DM → workbook → layout → two-pass parity → cleanup + census gate) and stops with exact instructions where agent judgment is required. See "One command" above. |
+| `scripts/verify-complete.rb` | **The single offline "are we done?" check** — exit 0 / ✅ DONE only when `phase6-success.json` is present (stamped by `assert-phase6-ran.rb` exit 0) and no `parity-pending.json` remains. A clean PASS 1 (exit 12) reports NOT DONE. Also prints the run's off-ramp trail. Run before claiming success. |
+| `scripts/lib/offramp.rb` + `offramps.jsonl` | **Observability trail** — every point a run leaves the golden path (cred/doctor waiver, PASS-1 stop, converter-stop, workbook-handoff, degraded fast path, manual-spec) appends a structured record to `<WORK>/offramps.jsonl`. Read it (or `verify-complete.rb`) to pinpoint *where* a run defected. |
 | `scripts/setup.rb` | One-time Sigma credential setup |
 | `scripts/get-token.sh` | Exchange `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` for `SIGMA_API_TOKEN` (~1h TTL) — **bash only** |
 | `scripts/get_token.py` | Shell-neutral twin of `get-token.sh` (bash/PowerShell/cmd): writes `<WORK>/auth.json` (0600), read automatically by the scripts |

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -1073,5 +1073,22 @@ else
   puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
+# Completion sentinel — stamp a run-scoped success marker keyed to the workbook
+# and clear any PASS-1 pending marker. verify-complete.rb (the offline done-check
+# the SKILL points agents at) reports GREEN only when this file exists for the
+# workbook and no parity-pending.json remains. This makes "done" a token only the
+# gate can mint, closing the "agent narrates success without the gate" hole.
+begin
+  _wd = opts[:tab]
+  File.write(File.join(_wd, 'phase6-success.json'),
+             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'gates' => 'all-pass',
+                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _pend = File.join(_wd, 'parity-pending.json')
+  File.delete(_pend) if File.exist?(_pend)
+rescue StandardError
+  # never fail the gate on sentinel bookkeeping
+end
+
 puts "[OK] all gates pass — conversion may declare GREEN"
 exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/auto-parity-plan.rb
@@ -148,6 +148,26 @@ def normalize(s)
   s.to_s.downcase.gsub(/[^a-z0-9]/, '')
 end
 
+# Auto-bridge the display-title rename. Sigma tiles are named by their worksheet
+# display_title ("Net Revenue"), but Tableau views are keyed by the worksheet
+# caption/nickname ("OV KPI Revenue"). Seed the caption→display_title map from the
+# dashboard-layout zones so parity matches WITHOUT a manual --rename (explicit
+# --rename still wins). Keeps parity matching in lockstep with the element namer.
+_dl_path = File.join(opts[:tab], 'dashboard-layout.json')
+if File.exist?(_dl_path)
+  begin
+    _dl = JSON.parse(File.read(_dl_path))
+    (_dl.is_a?(Array) ? _dl : (_dl['dashboards'] || [_dl])).each do |d|
+      (d['zones'] || []).each do |z|
+        cap = z['caption'].to_s; dt = z['display_title'].to_s.strip
+        opts[:renames][cap] ||= dt unless cap.empty? || dt.empty? || cap == dt
+      end
+    end
+  rescue StandardError
+    nil # best-effort; fall back to name==name matching
+  end
+end
+
 # Build reverse-rename map: tableau-name → sigma-name was the input;
 # we want sigma-name → tableau-name for lookup.
 rev_renames = opts[:renames].each_with_object({}) { |(k, v), h| h[v] = k }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -140,6 +140,16 @@ SIGMA_KIND = {
   'other'         => 'bar-chart'
 }.freeze
 
+# The human display name for a built tile: the source-displayed worksheet title
+# (parse-twb-layout's `display_title`, from the worksheet <title> run — e.g.
+# "Net Revenue") when present, else the worksheet nickname/caption ("OV KPI
+# Revenue"). One source of truth so every tile builder names elements the way the
+# source labels them, not by internal sheet name.
+def tile_title(zone, fallback)
+  t = zone && zone['display_title']
+  t && !t.to_s.strip.empty? ? t.to_s.strip : fallback
+end
+
 # ---- Tableau derivation → Sigma aggregation function name ----
 SIGMA_AGG = {
   'Sum'    => 'Sum',
@@ -2361,7 +2371,7 @@ def build_pivot_element(z, meta, mmap, opts, warnings, data_elements = [])
   {
     'id'        => el_id,
     'kind'      => 'pivot-table',
-    'name'      => cap,
+    'name'      => tile_title(z, cap),
     'source'    => source,
     'columns'   => cols_array,
     'values'    => values_arr,
@@ -2638,7 +2648,7 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
   element = {
     'id'      => el_id,
     'kind'    => 'kpi-chart',
-    'name'    => cap,
+    'name'    => tile_title(z, cap),
     'source'  => { 'kind' => 'table', 'elementId' => source_eid },
     'columns' => [measure_col],
     # value.columnId, NOT value.id — the live API 400s with
@@ -2663,7 +2673,10 @@ def build_kpi_element(z, meta, mmap, opts, warnings, data_elements = [])
   # composition stage (B1/B2 region cards) sets it when it actually places a KPI
   # into a tint. So we set label + fontSize only and leave the default card.
   if z['kpi_value_font_size']
-    element['name'] = z['kpi_label'] if z['kpi_label'] && !z['kpi_label'].to_s.strip.empty?
+    # kpi_label (BAN scorecard label) only when the source has no displayed title
+    # — the worksheet <title> (already applied above) is the more authoritative name.
+    element['name'] = z['kpi_label'] if z['kpi_label'] && !z['kpi_label'].to_s.strip.empty? &&
+                                        z['display_title'].to_s.strip.empty?
     element['value']['fontSize'] = z['kpi_value_font_size']
     # The BAN's side annotation (e.g. "40% of U.S. total") is driven by a dynamic
     # Tableau calc token that can't be reproduced as static text; emitting the
@@ -2899,7 +2912,7 @@ layout.each do |dash|
       end
       if y_cols.any?
         element = {
-          'id' => el_id, 'kind' => SIGMA_KIND[z['chart_kind']] || 'line-chart', 'name' => cap,
+          'id' => el_id, 'kind' => SIGMA_KIND[z['chart_kind']] || 'line-chart', 'name' => tile_title(z, cap),
           'source' => { 'kind' => 'table', 'elementId' => opts[:master_id] },
           'columns' => [dim_col_obj] + y_cols,
           'xAxis' => { 'columnId' => dim_col_obj['id'] },
@@ -3518,7 +3531,7 @@ layout.each do |dash|
       money_fmt = { 'kind' => 'number', 'formatString' => '$,.0f', 'currencySymbol' => '$' }
       num_fmt = ->(n) { n.to_s.downcase =~ /(revenue|profit|cost|sales|amount|spend)/ ? money_fmt : { 'kind' => 'number', 'formatString' => ',.0f' } }
       element = {
-        'id' => el_id, 'kind' => 'scatter-chart', 'name' => cap,
+        'id' => el_id, 'kind' => 'scatter-chart', 'name' => tile_title(z, cap),
         'source' => { 'kind' => 'table', 'elementId' => src_id },
         'columns' => [
           { 'id' => "c-#{el_id}", 'name' => dim['name'], 'formula' => "[#{src_name}/#{dim['name']}]" },
@@ -3583,7 +3596,7 @@ layout.each do |dash|
     element = {
       'id'      => el_id,
       'kind'    => kind,
-      'name'    => cap,
+      'name'    => tile_title(z, cap),
       'source'  => { 'kind' => 'table', 'elementId' => chart_source_eid },
       'columns' => [dim_col_obj, meas_col_obj]
     }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -442,19 +442,10 @@ def build_page_from_tree(dashboard, page, opts)
   # E1: flat zones carry chart_kind + plot signals (tree nodes don't) — the
   # per-kind row floor resolves through this map.
   zone_by_id  = (dashboard['zones'] || []).each_with_object({}) { |z, h| h[z['id']] = z if z['id'] }
-  title_el    = page['elements'].find { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('title') }
-  # Fall back to the source's own TOP-BANNER text (a text element whose zone sits
-  # at y≈0 spanning most of the width) as the title. Otherwise we'd both fabricate
-  # a page-name H1 banner AND place that source title separately in the body — the
-  # duplicate-title bug. Topmost qualifying text element wins. (Marked placed in the
-  # header branch below so the body pass doesn't re-emit it.)
-  if title_el.nil?
-    zid = ->(e) { e['id'].to_s.sub(/\Atext-/, '') }
-    title_el = page['elements'].select { |e| e['kind'] == 'text' }
-                               .map { |e| [e, zone_by_id[zid.call(e)]] }
-                               .select { |_e, z| z && z['y_pct'].to_f < 12 && z['w_pct'].to_f >= 40 }
-                               .min_by { |_e, z| z['y_pct'].to_f }&.first
-  end
+  # Dedicated title-* element, else the source's own top banner (shared detector,
+  # used by the synthesis path too) — avoids the fabricate-H1-alongside-source-
+  # title duplicate-title bug. (Marked placed in the header branch below.)
+  title_el    = detect_header_title_el(page, zone_by_id)
 
   ctx = { page_id: page['id'], renames: opts[:renames], els_by_name: els_by_name,
           ctl_by_name: ctl_by_name, els_by_id: els_by_id, title_el: title_el, title_used: false,
@@ -565,12 +556,32 @@ end
 # build_page_for_dashboard (+ min_row_expansions).
 SECTION_TEXT_MIN_W_PCT = 60.0 # a text zone at least this wide separates sections
 
+# The source dashboard's title element, resolved identically for BOTH layout
+# paths (geometry `build_page_from_tree` and synthesis `build_page_synthesized`).
+# Prefer a dedicated `title-*` element; otherwise fall back to the source's own
+# TOP-BANNER text (a text zone at y≈0 spanning most of the width). Using the
+# source title as the header — instead of fabricating a page-name H1 alongside it
+# — is what prevents the duplicate-title bug. Previously only the geometry path
+# had the fallback, so synthesized pages shipped two titles. Shared here so the
+# two paths cannot drift again.
+def detect_header_title_el(page, zone_by_id)
+  title_el = page['elements'].find { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('title') }
+  return title_el if title_el
+  zid = ->(e) { e['id'].to_s.sub(/\Atext-/, '') }
+  page['elements'].select { |e| e['kind'] == 'text' }
+                  .map { |e| [e, zone_by_id[zid.call(e)]] }
+                  .select { |_e, z| z && z['y_pct'].to_f < 12 && z['w_pct'].to_f >= 40 }
+                  .min_by { |_e, z| z['y_pct'].to_f }&.first
+end
+
 def build_page_synthesized(dashboard, page, opts, structure)
   zones       = dashboard['zones'] || []
   els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
   els_by_id   = page['elements'].each_with_object({}) { |e, h| h[e['id']] = e if e['id'] }
-  # Pin the header title to the dedicated title element (see build_page_from_tree).
-  title_el    = page['elements'].find { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('title') }
+  # Header title: dedicated title-* element, else the source's own top banner
+  # (shared detector) — NOT a fabricated page-name H1 alongside the source title.
+  zone_by_id  = zones.each_with_object({}) { |z, h| h[z['id']] = z if z['id'] }
+  title_el    = detect_header_title_el(page, zone_by_id)
   page_rows   = opts[:page_rows]
   placed      = []
   extra_els   = []
@@ -857,9 +868,11 @@ end
 def build_page_for_dashboard(dashboard, page, opts)
   chart_zones = dashboard['zones'].select { |z| z['kind'] == 'chart' && z['caption'] }
   els_by_name = page['elements'].each_with_object({}) { |e, h| h[e['name']] = e if e['name'] }
-  # Pin to the dedicated title element (see build_page_from_tree) so a B4
-  # styled-text element isn't mistaken for the header title.
-  title_el = page['elements'].find { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('title') }
+  # Dedicated title-* element, else the source's own top banner (shared detector,
+  # same as the tree + synthesis paths) — no fabricated page-name H1 alongside a
+  # source title.
+  zone_by_id = (dashboard['zones'] || []).each_with_object({}) { |z, h| h[z['id']] = z if z['id'] }
+  title_el = detect_header_title_el(page, zone_by_id)
   ctl_els  = page['elements'].select { |e| e['kind'] == 'control' }
 
   # Per-dashboard copy of the band tuning — auto-fit must not leak between

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-dashboard-layout.rb
@@ -520,7 +520,7 @@ def build_page_from_tree(dashboard, page, opts)
   # element made it into ctx[:placed]. Header band excluded from the fill rects.
   content_zones = ZoneCensus.content_zones(dashboard['zones'])
   placed = content_zones.count do |z|
-    e = els_by_name[opts[:renames][z['caption']] || z['caption']]
+    e = els_by_name[zone_el_name(z, opts[:renames])]
     e && ctx[:placed].include?(e['id'])
   end
   fill = ZoneCensus.grid_fill_pct(content_rects, opts[:page_cols], page_rows)
@@ -564,6 +564,20 @@ SECTION_TEXT_MIN_W_PCT = 60.0 # a text zone at least this wide separates section
 # — is what prevents the duplicate-title bug. Previously only the geometry path
 # had the fallback, so synthesized pages shipped two titles. Shared here so the
 # two paths cannot drift again.
+# Resolve the Sigma element NAME a source zone maps to. Tiles are now named by
+# the worksheet display_title (human title, e.g. "Net Revenue"), NOT the caption/
+# nickname ("OV KPI Revenue"), so zone→element matching must prefer display_title
+# (after any explicit --rename), falling back to the caption (still == the name
+# when the worksheet had no custom title). This keeps the layout + parity matchers
+# in lockstep with the element namer — changing the display name in one place must
+# not silently drop every tile from the layout.
+def zone_el_name(z, renames)
+  explicit = renames && renames[z['caption']]
+  return explicit if explicit
+  dt = z['display_title'].to_s.strip
+  dt.empty? ? z['caption'] : dt
+end
+
 def detect_header_title_el(page, zone_by_id)
   title_el = page['elements'].find { |e| e['kind'] == 'text' && e['id'].to_s.start_with?('title') }
   return title_el if title_el
@@ -666,7 +680,7 @@ def build_page_synthesized(dashboard, page, opts, structure)
   resolve_zone_el = lambda do |z|
     case z['kind'].to_s
     when 'chart'
-      el = els_by_name[opts[:renames][z['caption']] || z['caption']]
+      el = els_by_name[zone_el_name(z, opts[:renames])]
       el && el['id']
     when 'text', 'title'
       el = els_by_id["text-#{z['id']}"]
@@ -847,7 +861,7 @@ def build_page_synthesized(dashboard, page, opts, structure)
 
   content_zones = ZoneCensus.content_zones(zones)
   placed_count = content_zones.count do |z|
-    e = els_by_name[opts[:renames][z['caption']] || z['caption']]
+    e = els_by_name[zone_el_name(z, opts[:renames])]
     e && placed.include?(e['id'])
   end
   rects = []
@@ -894,7 +908,7 @@ def build_page_for_dashboard(dashboard, page, opts)
   end
 
   chart_layouts = chart_zones.map do |z|
-    lookup_name = o[:renames][z['caption']] || z['caption']
+    lookup_name = zone_el_name(z, o[:renames])
     el = els_by_name[lookup_name]
     if el.nil?
       warn "WARN: no Sigma element matched zone caption #{z['caption'].inspect} on page #{page['name'].inspect}" \
@@ -997,7 +1011,7 @@ def build_page_for_dashboard(dashboard, page, opts)
   #          furniture (header band, styled-text band) excluded from the fill
   #          numerator.
   content_zones = ZoneCensus.content_zones(dashboard['zones'])
-  placed = content_zones.count { |z| els_by_name[o[:renames][z['caption']] || z['caption']] }
+  placed = content_zones.count { |z| els_by_name[zone_el_name(z, o[:renames])] }
   content_rects = bands.flat_map { |b| b.map { |i| [i[1], i[2], i[3] + band_offset, i[4] + band_offset] } }
   content_rects << [1, o[:page_cols] + 1, 1 + HEADER_ROWS, 1 + HEADER_ROWS + ctl_rows] if ctl_els.length.positive?
   fill = ZoneCensus.grid_fill_pct(content_rects, o[:page_cols], o[:page_rows])

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/offramp.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/offramp.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+#
+# offramp.rb — record every point where a run LEAVES the golden path.
+#
+# The hard part of debugging inconsistent agent runs is not "did it fail" but
+# "WHERE did it leave the rails" — which gate was waived, which stop was hit,
+# which degraded mode was taken. Those off-ramps were previously scattered across
+# prose warnings and a couple of ad-hoc files. This appends a structured line to
+# <WORK>/offramps.jsonl at each one, so a single file answers "where did this run
+# defect?" post-hoc (and verify-complete.rb surfaces the trail).
+#
+# Kinds (stable strings — group on these in telemetry):
+#   cred-gate-waived     SIGMA_SKIP_CRED_GATE used — creds unresolved, run may die at first API call
+#   doctor-gate-waived   --skip-doctor-gate / SIGMA_SKIP_DOCTOR_GATE used
+#   pass1-stop           PASS 1 ended at exit 12 (parity + gates NOT run yet)
+#   converter-stop       converter unavailable / refused — routed to a fallback
+#   workbook-handoff     workbook build raised (exit 4) — untranslatable fields handed off
+#   degraded-fastpath    --yes fast path proceeded with missing discovery artifacts
+#   gate-waived          an assert-phase6-ran gate waived (mirrored from waivers.json)
+#
+# Never fatal: bookkeeping must not break a run.
+
+require 'json'
+
+module Offramp
+  module_function
+
+  def log(work, kind:, reason: nil, detail: nil)
+    return unless work && Dir.exist?(work.to_s)
+    rec = { 'kind' => kind, 'reason' => reason, 'detail' => detail,
+            'at' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ') }.reject { |_, v| v.nil? }
+    File.open(File.join(work, 'offramps.jsonl'), 'a') { |f| f.puts(JSON.generate(rec)) }
+    warn "   ↪ off-ramp recorded: #{kind}#{reason ? " (#{reason})" : ''} → #{File.join(work, 'offramps.jsonl')}"
+  rescue StandardError
+    # bookkeeping only — never fail the run
+  end
+
+  # Read the trail back (array of records, oldest first). Empty on any error.
+  def trail(work)
+    path = File.join(work.to_s, 'offramps.jsonl')
+    return [] unless File.exist?(path)
+    # map + compact (not filter_map — that is Ruby 2.7+; the skills target 2.6).
+    File.readlines(path).map { |l| JSON.parse(l) rescue nil }.compact
+  rescue StandardError
+    []
+  end
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/mechanical-specs.rb
@@ -239,7 +239,11 @@ module MechanicalSpecs
 
   def synthesize_fixed_lods!(model, fact, twb_text, colmap = {}, discriminator: nil)
     return {} unless model && fact && twb_text
-    return 0 unless fact.dig('source', 'kind') == 'warehouse-table'
+    # Must return the SAME type ({}) as every other exit — the caller does
+    # world_lod_map.any?, and `0.any?` is a NoMethodError that crashes the run.
+    # This fires whenever the plotted fact is a DERIVED VIEW (source kind 'sql'/
+    # 'table', e.g. a Virtual-Connection-backed workbook), not a raw table.
+    return {} unless fact.dig('source', 'kind') == 'warehouse-table'
     path = fact.dig('source', 'path') || []
     conn = fact.dig('source', 'connectionId')
     return {} if path.size < 3 || conn.to_s.empty?

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -303,6 +303,46 @@ if !_creds_ok && _cred_skip && !_cred_skip.to_s.empty?
 end
 Offramp.log(WORK, kind: 'doctor-gate-waived', reason: _dg_skip.to_s) if _dg_skip && !_dg_skip.to_s.empty?
 
+# 🚧 Step-0 TABLEAU CREDENTIAL GATE (fail-closed). Tableau auth is a SECOND,
+# separate system from Sigma — and its absence was the #1 recurring blocker: the
+# orchestrated discovery lane signs in via PAT REST (tableau_rest.rb), so when
+# TABLEAU_PAT_* aren't in the env (people run setup.rb for Sigma but not
+# setup-tableau.rb; non-Claude-Code harnesses don't auto-load them) the run
+# starts and dies DEEP in discovery with an opaque "could not mint a Tableau
+# token / end of file reached" that a low-context agent flails against. Resolve
+# it HERE instead. Only required when FRESH discovery will run — skip on
+# --finalize (no discovery) and when discovery is being REUSED (stamp present),
+# and skip if the agent is driving discovery through the Tableau MCP
+# (SIGMA_TABLEAU_VIA_MCP=1). Waive with SIGMA_SKIP_TABLEAU_GATE="<reason>".
+_tab_skip     = ENV['SIGMA_SKIP_TABLEAU_GATE']
+_tab_via_mcp  = ENV['SIGMA_TABLEAU_VIA_MCP'].to_s == '1'
+_tab_reuse    = File.exist?(File.join(WORK, 'discovery-stamp.json'))
+_tab_needed   = !opts[:finalize] && !_tab_reuse && !_tab_via_mcp
+# Contents check, not mere existence: the neutral file often has Sigma creds
+# (setup.rb) but NOT Tableau (setup-tableau.rb) — the exact gap that let runs
+# start and fail deep. Require the Tableau PAT to actually be present.
+_tab_creds_ok = (!ENV['TABLEAU_PAT_NAME'].to_s.empty? && !ENV['TABLEAU_PAT_SECRET'].to_s.empty?) ||
+                (File.exist?(_neutral_env) && File.read(_neutral_env).include?('TABLEAU_PAT_SECRET'))
+if _tab_needed && !_tab_creds_ok && (_tab_skip.nil? || _tab_skip.to_s.empty?)
+  abort <<~MSG
+    FATAL: no Tableau credentials resolvable — discovery would fail at the Tableau
+    sign-in (the "could not mint a Tableau token" / "end of file reached" error).
+    Tableau auth is SEPARATE from Sigma: running setup.rb configures Sigma only.
+    Fix it ONCE, in a real terminal:
+        ruby scripts/setup-tableau.rb    # writes the Tableau PAT to ~/.sigma-migration/env
+    …or export TABLEAU_PAT_NAME + TABLEAU_PAT_SECRET + TABLEAU_SITE_CONTENT_URL
+    (+ TABLEAU_SERVER_URL) into this environment. If you are driving discovery via
+    the Tableau MCP tools instead of a PAT, re-run with SIGMA_TABLEAU_VIA_MCP=1.
+    (If sign-in fails even WITH creds set, that is a network/TLS-proxy issue
+    reaching your Tableau server, not a missing-cred issue — check connectivity.)
+    Then re-run this exact command.  (Waive: SIGMA_SKIP_TABLEAU_GATE="<reason>".)
+  MSG
+end
+if _tab_needed && !_tab_creds_ok && _tab_skip && !_tab_skip.to_s.empty?
+  warn "WARN: Tableau credential gate waived (SIGMA_SKIP_TABLEAU_GATE=#{_tab_skip})."
+  Offramp.log(WORK, kind: 'tableau-gate-waived', reason: _tab_skip.to_s)
+end
+
 # ── Design-consistency advisory readout (doctor.json) ────────────────────────
 # The hard gate above proves the environment passed; these two are the silent
 # DESIGN-variance killers the gate does not block on — surface them at every

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -111,6 +111,7 @@ require_relative 'lib/scout_gate'
 require_relative 'lib/dashboard_read'
 require_relative 'lib/recipe_multimetric'
 require_relative 'lib/run_state'
+require_relative 'lib/offramp' # structured "where did this run leave the golden path" trail
 require_relative 'lib/fast_path' # FAST-PATH routing + BOM-tolerant JSON reads
 require_relative 'lib/sigma_rest' # in-process Sigma token minting (no bash/eval)
 require_relative 'lib/tableau_rest' # in-process Tableau token minting (Windows-safe; no bash/eval)
@@ -180,6 +181,9 @@ OptionParser.new do |o|
   o.on('--dm-spec PATH', 'agent-authored data-model spec JSON (fresh DM build through the gated spine)') { |v| opts[:dm_spec] = File.expand_path(v) }
   o.on('--wb-spec PATH', 'agent-authored workbook spec JSON (re-enters the gated spine). With an explicit ' \
                          '--reuse-dm <id> this takes the FAST PATH (see banner).') { |v| opts[:wb_spec] = File.expand_path(v) }
+  o.on('--allow-manual-spec REASON', 'deliberately hand-author --dm-spec/--wb-spec COLD (no prior ' \
+                                     'orchestrator STOP). Normally the orchestrator authorizes this path; ' \
+                                     'this waives that requirement — named in the report.') { |v| opts[:allow_manual_spec] = v }
   o.on('--out DIR')          { |v| opts[:out]     = File.expand_path(v) }
   o.on('--answers JSON')     { |v| opts[:answers] = v }
   o.on('--yes')              {     opts[:yes]     = true }
@@ -293,7 +297,11 @@ if !_creds_ok && (_cred_skip.nil? || _cred_skip.to_s.empty?)
     (Genuinely offline/no-Sigma run? Re-run with SIGMA_SKIP_CRED_GATE="<reason>".)
   MSG
 end
-warn "WARN: credential gate waived (SIGMA_SKIP_CRED_GATE=#{_cred_skip}) — Sigma calls will fail if reached." if !_creds_ok && _cred_skip && !_cred_skip.to_s.empty?
+if !_creds_ok && _cred_skip && !_cred_skip.to_s.empty?
+  warn "WARN: credential gate waived (SIGMA_SKIP_CRED_GATE=#{_cred_skip}) — Sigma calls will fail if reached."
+  Offramp.log(WORK, kind: 'cred-gate-waived', reason: _cred_skip.to_s)
+end
+Offramp.log(WORK, kind: 'doctor-gate-waived', reason: _dg_skip.to_s) if _dg_skip && !_dg_skip.to_s.empty?
 
 # ── Design-consistency advisory readout (doctor.json) ────────────────────────
 # The hard gate above proves the environment passed; these two are the silent
@@ -716,6 +724,30 @@ end
 # Set-Content -Encoding UTF8 prepends a BOM plain JSON.parse rejects).
 # ---------------------------------------------------------------------------
 if opts[:dm_spec] || opts[:wb_spec]
+  # 🚧 Manual-spec authorization gate (P1). Hand-authored specs must be a ROUTED
+  # fallback, not a cold default — cold hand-authoring is the #1 way a run skips
+  # the converter + gated spine. Accept --dm-spec/--wb-spec only when: (a) an
+  # orchestrator STOP emitted <WORK>/manual-path-authorized.json, (b) --reuse-dm
+  # carries an EXPLICIT id (the documented exit-4 fast-path re-entry against an
+  # already-posted DM), or (c) an explicit --allow-manual-spec "<reason>" waiver.
+  _ms_token  = File.exist?(File.join(WORK, 'manual-path-authorized.json'))
+  _ms_reuse  = opts[:reuse_dm] && opts[:reuse_dm] != :recommended
+  _ms_waiver = opts[:allow_manual_spec].to_s
+  unless _ms_token || _ms_reuse || !_ms_waiver.empty?
+    abort <<~MSG
+      FATAL: --dm-spec/--wb-spec (hand-authored specs) is a ROUTED fallback, not a cold
+      entry point. No orchestrator STOP is on record for this workdir
+      (#{File.join(WORK, 'manual-path-authorized.json')} is absent) and no --reuse-dm <id>
+      was given. Start with the one command so the converter + gates actually run:
+          ruby scripts/migrate-tableau.rb --workbook "<name>" --connection <id>
+      If it STOPS (CONVERTER STOP / workbook handoff) it authorizes this path and prints
+      the exact --dm-spec/--wb-spec (or --reuse-dm --wb-spec) re-run.
+      Deliberately hand-authoring anyway? Re-run adding --allow-manual-spec "<reason>".
+    MSG
+  end
+  Offramp.log(WORK, kind: 'manual-spec',
+              reason: (!_ms_waiver.empty? ? "waiver: #{_ms_waiver}" : (_ms_token ? 'authorized-by-stop' : 'reuse-dm-id')))
+
   # The workbook spec is always agent-authored on this path.
   abort 'FATAL: --wb-spec is required for the agent-authored manual path ' \
         '(pair it with --dm-spec for a fresh build, or --reuse-dm for an existing model).' \
@@ -780,6 +812,8 @@ if FASTPATH
     line '  --yes: Tableau discovery is NOT re-run. Layout falls back to a stacked page and the'
     line '  parity plan may be unbuildable — restore the workdir (or re-run without --yes to'
     line '  re-fetch) before relying on the Phase 6 gates.'
+    Offramp.log(WORK, kind: 'degraded-fastpath',
+                detail: "#{FAST[:degraded].size} missing discovery artifact(s): #{FAST[:degraded].join(', ')}")
   else
     line "discovery artifacts present in #{WORK} — reused for layout + parity as normal"
   end
@@ -1066,6 +1100,17 @@ if mechanical
   else
     sleep 0.1 until lane_done.call # reap the background lane before aborting
     print_lane_log.call
+    # Authorize the option-2 agent-authored-spec re-entry (the re-run passes
+    # --dm-spec/--wb-spec; the manual-spec gate requires this token or refuses a
+    # cold hand-author).
+    begin
+      File.write(File.join(WORK, 'manual-path-authorized.json'),
+                 JSON.pretty_generate('via' => 'converter-stop',
+                                      'at' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+    rescue StandardError
+      # best-effort
+    end
+    Offramp.log(WORK, kind: 'converter-stop', reason: 'no converter backend configured')
     abort <<~MSG
       ==================== CONVERTER STOP (no backend) ====================
       No mechanical Tableau→Sigma converter is configured, and hosted conversion was not
@@ -2368,6 +2413,18 @@ rescue WorkbookBuildError => e
   puts '          straight to the workbook layer — see --help.)'
   puts '   The data model is posted and ready to attach either way. A conversion is NOT done'
   puts '   until scripts/assert-phase6-ran.rb exits 0 — that hard gate applies on both paths.'
+  # Authorize the hand-authoring re-entry: this STOP is the ONLY sanctioned way to
+  # reach --wb-spec/--dm-spec. The token lets the re-run's manual-spec gate pass
+  # (a COLD hand-author with no prior orchestrator run is refused).
+  begin
+    File.write(File.join(WORK, 'manual-path-authorized.json'),
+               JSON.pretty_generate('via' => 'workbook-handoff', 'dataModelId' => dm_id,
+                                    'fields' => failed,
+                                    'at' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  rescue StandardError
+    # best-effort
+  end
+  Offramp.log(WORK, kind: 'workbook-handoff', detail: "untranslatable field(s): #{names}")
   mark('phase4-workbook')
   phase_summary
   exit 4
@@ -2650,6 +2707,7 @@ begin
 rescue StandardError
   # best-effort — never fail the run on sentinel bookkeeping
 end
+Offramp.log(WORK, kind: 'pass1-stop', detail: "workbook #{wb_id} — parity + gates not yet run")
 puts
 puts '⛔ NOT DONE — this is PASS 1 of 2. Do NOT report success or hand off yet.'
 puts '   To confirm completion at any point, run (exit 0 == done, nothing else counts):'

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -268,6 +268,33 @@ unless system(*_dg_cmd)
         'or re-run with --skip-doctor-gate "<reason>".'
 end
 
+# 🚧 Step-0 CREDENTIAL GATE (fail-closed). The doctor treats missing creds as a
+# warning, so a harness that does NOT auto-load ~/.claude/settings.json (Coco,
+# Cursor, plain shell) can sail past it and then die at the FIRST Sigma API call
+# with an opaque auth error — which a low-context agent misreads as a TASK
+# failure and improvises around (hand-rolled curl, self-writing creds, a
+# hallucinated token). Resolve creds HERE, before any Tableau/discovery work, and
+# stop with the exact remediation if they're absent. Waive only for genuinely
+# offline runs with SIGMA_SKIP_CRED_GATE="<reason>".
+_cred_skip = ENV['SIGMA_SKIP_CRED_GATE']
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+_creds_ok = !ENV['SIGMA_API_TOKEN'].to_s.empty? ||
+            (!ENV['SIGMA_CLIENT_ID'].to_s.empty? && !ENV['SIGMA_CLIENT_SECRET'].to_s.empty?) ||
+            File.exist?(_neutral_env)
+if !_creds_ok && (_cred_skip.nil? || _cred_skip.to_s.empty?)
+  abort <<~MSG
+    FATAL: no Sigma credentials resolvable — the run would fail at the first API call.
+    This almost always means you are NOT on Claude Code (which auto-loads
+    ~/.claude/settings.json). Other harnesses (Coco, Cursor, plain shell) do not,
+    so the neutral credential file is REQUIRED. Fix it ONCE, in a real terminal:
+        ruby scripts/setup.rb        # writes ~/.sigma-migration/env
+    …or export SIGMA_CLIENT_ID + SIGMA_CLIENT_SECRET (and SIGMA_BASE_URL) into the
+    environment this orchestrator runs in. Then re-run this exact command.
+    (Genuinely offline/no-Sigma run? Re-run with SIGMA_SKIP_CRED_GATE="<reason>".)
+  MSG
+end
+warn "WARN: credential gate waived (SIGMA_SKIP_CRED_GATE=#{_cred_skip}) — Sigma calls will fail if reached." if !_creds_ok && _cred_skip && !_cred_skip.to_s.empty?
+
 # ── Design-consistency advisory readout (doctor.json) ────────────────────────
 # The hard gate above proves the environment passed; these two are the silent
 # DESIGN-variance killers the gate does not block on — surface them at every
@@ -2606,6 +2633,27 @@ puts finalize_cmd
 puts '(--finalize runs phase6 finalize + orphan cleanup + the census-aware'
 puts ' assert-phase6-ran hard gate; exit 0 there is the ONLY green exit.)'
 puts 'PHASE E     : requested (--enhance) — runs at --finalize AFTER all gates are green' if opts[:enhance]
+puts '=================================================================='
+
+# Completion sentinel (run-scoped). PASS 1 is NOT a done state: the gate suite
+# lives in --finalize. Drop a pending marker keyed to this workbook and CLEAR any
+# stale success marker from a prior run, so verify-complete.rb (the sole done-
+# check the SKILL points at) reports NOT DONE until --finalize's hard gate stamps
+# phase6-success.json. This is the structural backstop for the "agent stops at
+# PASS 1 and narrates success" failure mode.
+begin
+  File.write(File.join(WORK, 'parity-pending.json'),
+             JSON.pretty_generate('workbookId' => wb_id, 'dataModelId' => dm_id,
+                                  'stage' => 'pass1', 'note' => 'parity + gates NOT run — run --finalize'))
+  _succ = File.join(WORK, 'phase6-success.json')
+  File.delete(_succ) if File.exist?(_succ)
+rescue StandardError
+  # best-effort — never fail the run on sentinel bookkeeping
+end
+puts
+puts '⛔ NOT DONE — this is PASS 1 of 2. Do NOT report success or hand off yet.'
+puts '   To confirm completion at any point, run (exit 0 == done, nothing else counts):'
+puts "     ruby scripts/verify-complete.rb --workdir #{WORK}"
 puts '=================================================================='
 mark('phase6-pass1')
 phase_summary

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/parse-twb-layout.rb
@@ -415,6 +415,25 @@ end
 # value + side annotation). Runs mirror zone_text_fields' shape (Æ = U+00C6
 # line-break sentinel); `ref`=true marks a dynamic <[…]> field/measure token.
 KPI_BAN_MIN_FONT = 16
+# The worksheet's DISPLAYED title (shown above the viz on a dashboard) — the
+# source of the human element name ("Net Revenue"), distinct from the worksheet
+# NAME/nickname ("OV KPI Revenue"). Path: layout-options/title/formatted-text.
+# Custom text only: a DEFAULT title is the "<Sheet Name>" field token (or the
+# element is absent), which we skip so the builder falls back to the nickname.
+# Concatenates runs (a title can be multi-span).
+def worksheet_display_title(ws)
+  t = ws.elements['layout-options/title'] || ws.elements['title']
+  return nil unless t
+  ft = t.elements['formatted-text']
+  return nil unless ft
+  # .elements.to_a('run') / .text — supported by BOTH backends of twb_xml
+  # (the Nokogiri shim and the REXML fallback); get_elements is REXML-only.
+  txt = ft.elements.to_a('run').map { |r| r.text.to_s }.join.strip
+  return nil if txt.empty?
+  return nil if txt =~ /\A<[^<>]+>\z/ # "<Sheet Name>" / field-token default
+  txt
+end
+
 def parse_customized_label(ws)
   cl = ws.elements['.//customized-label']
   return nil unless cl
@@ -828,6 +847,9 @@ xml.elements.each('//worksheet') do |ws|
     cols_shelf:       cols_shelf,
     is_crosstab:      is_crosstab,
     is_kpi:           is_kpi,
+    # The source-displayed worksheet title → human element name (falls back to
+    # the nickname when the title is default/absent). See worksheet_display_title.
+    display_title:        worksheet_display_title(ws),
     # Phase-1 B3: KPI composite signals (nil unless a BAN scorecard label exists)
     kpi_label:            kpi_ban && kpi_ban['label'],
     kpi_value_font_size:  kpi_ban && kpi_ban['value_font_size'],
@@ -1201,6 +1223,8 @@ xml.elements.each('//dashboard') do |d|
       'h_pct'        => pct(z.attributes['h']),
       'chart_kind'   => chart_kind,
       'chart_kind_inferred' => chart_kind_inferred,
+      # Source-displayed worksheet title → human element name (nil = use nickname).
+      'display_title' => ws_meta&.dig(:display_title),
       'mark_class'   => ws_meta&.dig(:mark_class),
       'geo_role'     => ws_meta&.dig(:geo_role),
       # New per-worksheet signal fields (nil for non-chart zones)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the step-0 fail-closed CREDENTIAL gate (2026-07-09).
+#
+# A harness that does not auto-load ~/.claude/settings.json (Coco, Cursor, plain
+# shell) reaches the first Sigma call with no creds and dies with an opaque auth
+# error a low-context agent improvises around. migrate-tableau.rb now resolves
+# creds at step 0 and STOPS with the setup.rb remediation when none are present.
+#
+# This drives the orchestrator with HOME pointed at an empty tmp dir (so
+# ~/.sigma-migration/env cannot resolve) and the cred env vars cleared, and
+# asserts it aborts AT the gate (before any network) with the actionable message.
+# The doctor gate is waived so the run reaches the cred gate deterministically.
+#
+# Usage: ruby scripts/test-cred-gate.rb
+
+require 'tmpdir'
+DIR = __dir__
+MT  = File.join(DIR, 'migrate-tableau.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+# Run with a hard timeout+kill: cases that PASS the cred gate proceed toward
+# discovery (network) and must not hang the test — we only need the early output
+# to confirm the cred abort did/didn't fire.
+def run_no_creds(mt, home, work, extra_env = {}, timeout: 20)
+  env = {
+    'HOME' => home, 'SIGMA_SKIP_DOCTOR_GATE' => 'test',
+    'SIGMA_API_TOKEN' => nil, 'SIGMA_CLIENT_ID' => nil,
+    'SIGMA_CLIENT_SECRET' => nil, 'SIGMA_SKIP_CRED_GATE' => nil
+  }.merge(extra_env)
+  cmd = ['ruby', mt, '--workbook-id', 'wb-x', '--connection', 'conn-x', '--out', work]
+  io = IO.popen(env, cmd, err: %i[child out])
+  pid = io.pid
+  out = +''
+  begin
+    reader = Thread.new { out << io.read.to_s }
+    killed = reader.join(timeout).nil?
+    if killed
+      Process.kill('KILL', pid) rescue nil
+      reader.join(2)
+    end
+    Process.wait(pid) rescue nil
+  ensure
+    io.close rescue nil
+  end
+  [$?&.exitstatus, out]
+end
+
+Dir.mktmpdir do |home|
+  Dir.mktmpdir do |work|
+    # (1) No creds anywhere => abort at the gate with the remediation.
+    code, out = run_no_creds(MT, home, work)
+    check(code != 0, "no creds => nonzero exit (got #{code})", fails)
+    check(out.include?('no Sigma credentials resolvable'), 'prints the fail-closed cred message', fails)
+    check(out.include?('scripts/setup.rb'), 'names the setup.rb remediation', fails)
+    check(out.include?('Claude Code'), 'explains the non-Claude-Code harness cause', fails)
+
+    # (2) Waiver env set => does NOT abort on creds (proceeds past the gate).
+    code, out = run_no_creds(MT, home, work, 'SIGMA_SKIP_CRED_GATE' => 'offline-test')
+    check(!out.include?('no Sigma credentials resolvable'),
+          'SIGMA_SKIP_CRED_GATE waives the fail-closed abort', fails)
+
+    # (3) Client creds present in env => passes the cred gate (no cred abort).
+    code, out = run_no_creds(MT, home, work,
+                             'SIGMA_CLIENT_ID' => 'id-123', 'SIGMA_CLIENT_SECRET' => 'secret-456')
+    check(!out.include?('no Sigma credentials resolvable'),
+          'env client creds satisfy the gate', fails)
+  end
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-cred-gate.rb
@@ -27,7 +27,11 @@ def run_no_creds(mt, home, work, extra_env = {}, timeout: 20)
   env = {
     'HOME' => home, 'SIGMA_SKIP_DOCTOR_GATE' => 'test',
     'SIGMA_API_TOKEN' => nil, 'SIGMA_CLIENT_ID' => nil,
-    'SIGMA_CLIENT_SECRET' => nil, 'SIGMA_SKIP_CRED_GATE' => nil
+    'SIGMA_CLIENT_SECRET' => nil, 'SIGMA_SKIP_CRED_GATE' => nil,
+    # Clear Tableau creds too so cases abort at a gate (no network) and the
+    # Tableau gate is exercised hermetically.
+    'TABLEAU_PAT_NAME' => nil, 'TABLEAU_PAT_SECRET' => nil,
+    'SIGMA_SKIP_TABLEAU_GATE' => nil, 'SIGMA_TABLEAU_VIA_MCP' => nil
   }.merge(extra_env)
   cmd = ['ruby', mt, '--workbook-id', 'wb-x', '--connection', 'conn-x', '--out', work]
   io = IO.popen(env, cmd, err: %i[child out])
@@ -61,11 +65,34 @@ Dir.mktmpdir do |home|
     check(!out.include?('no Sigma credentials resolvable'),
           'SIGMA_SKIP_CRED_GATE waives the fail-closed abort', fails)
 
-    # (3) Client creds present in env => passes the cred gate (no cred abort).
+    # (3) Client creds present in env => passes the SIGMA cred gate (no Sigma abort).
     code, out = run_no_creds(MT, home, work,
                              'SIGMA_CLIENT_ID' => 'id-123', 'SIGMA_CLIENT_SECRET' => 'secret-456')
     check(!out.include?('no Sigma credentials resolvable'),
-          'env client creds satisfy the gate', fails)
+          'env client creds satisfy the Sigma gate', fails)
+
+    # ---- Tableau gate (reached once the Sigma gate is satisfied) --------------
+    sigma = { 'SIGMA_CLIENT_ID' => 'id-123', 'SIGMA_CLIENT_SECRET' => 'secret-456' }
+
+    # (4) Sigma ok, Tableau absent, fresh discovery => Tableau abort + remediation.
+    code, out = run_no_creds(MT, home, work, sigma)
+    check(out.include?('no Tableau credentials resolvable'), 'Tableau gate fires when PAT absent', fails)
+    check(out.include?('setup-tableau.rb'), 'names the setup-tableau.rb remediation', fails)
+
+    # (5) SIGMA_TABLEAU_VIA_MCP=1 => Tableau gate skipped (MCP-driven discovery).
+    code, out = run_no_creds(MT, home, work, sigma.merge('SIGMA_TABLEAU_VIA_MCP' => '1'))
+    check(!out.include?('no Tableau credentials resolvable'), 'SIGMA_TABLEAU_VIA_MCP=1 skips the Tableau gate', fails)
+
+    # (6) discovery-stamp present (reuse) => Tableau gate skipped.
+    File.write(File.join(work, 'discovery-stamp.json'), '{}')
+    code, out = run_no_creds(MT, home, work, sigma)
+    check(!out.include?('no Tableau credentials resolvable'), 'reused discovery (stamp present) skips the Tableau gate', fails)
+    File.delete(File.join(work, 'discovery-stamp.json'))
+
+    # (7) Tableau PAT present in env => Tableau gate passes.
+    code, out = run_no_creds(MT, home, work,
+                             sigma.merge('TABLEAU_PAT_NAME' => 'pat', 'TABLEAU_PAT_SECRET' => 'sec'))
+    check(!out.include?('no Tableau credentials resolvable'), 'env Tableau PAT satisfies the gate', fails)
   end
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-display-title-match.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-display-title-match.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for zone→element matching after the display-title rename
+# (2026-07-09). Tiles are named by the worksheet display_title ("Net Revenue"),
+# not the caption/nickname ("OV KPI Revenue"). The layout builder must match a
+# zone to its Sigma element by display_title (via zone_el_name) — a live E2E
+# regression dropped ALL 9 tiles (0/9 placed, collapsed layout) because the
+# matcher still keyed on caption after the namer changed to display_title. This
+# drives build-dashboard-layout on a fixture where caption ≠ display_title = the
+# element name and asserts the tiles are PLACED (not DROPPED).
+#
+# Usage: ruby scripts/test-display-title-match.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR   = __dir__
+BUILD = File.join(DIR, 'build-dashboard-layout.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+LAYOUT = [{
+  'dashboard' => 'D', 'is_story' => false, 'zone_tree' => nil, 'brand_palette' => [],
+  'zones' => [
+    { 'id' => '10', 'kind' => 'chart', 'caption' => 'OV Rev', 'display_title' => 'Net Revenue',
+      'x_pct' => 0.0, 'y_pct' => 10.0, 'w_pct' => 50.0, 'h_pct' => 40.0, 'chart_kind' => 'bar' },
+    { 'id' => '11', 'kind' => 'chart', 'caption' => 'OV Marg', 'display_title' => 'Gross Margin %',
+      'x_pct' => 50.0, 'y_pct' => 10.0, 'w_pct' => 50.0, 'h_pct' => 40.0, 'chart_kind' => 'bar' }
+  ]
+}]
+# Elements named by display_title (what the fixed builder emits), NOT the caption.
+WBIDS = { 'workbookId' => 'wb-x', 'pages' => [
+  { 'id' => 'page-data', 'name' => 'Data', 'elements' => [{ 'id' => 'master', 'kind' => 'table', 'name' => 'Master' }] },
+  { 'id' => 'page-dash-1', 'name' => 'D', 'elements' => [
+    { 'id' => 'el-rev',  'kind' => 'bar-chart', 'name' => 'Net Revenue' },
+    { 'id' => 'el-marg', 'kind' => 'bar-chart', 'name' => 'Gross Margin %' }
+  ] }
+] }
+
+Dir.mktmpdir do |d|
+  lf = File.join(d, 'layout.json'); wf = File.join(d, 'wb-ids.json'); out = File.join(d, 'out.xml')
+  File.write(lf, JSON.generate(LAYOUT)); File.write(wf, JSON.generate(WBIDS))
+  log = `ruby #{BUILD} --layout #{lf} --wb-ids #{wf} --out #{out} 2>&1`
+  xml = File.exist?(out) ? File.read(out) : ''
+
+  check(!log.include?('DROPPED'), "no tile DROPPED warning (matcher found both by display_title)\n#{log}", fails)
+  check(xml.include?('el-rev'),  'el-rev (name "Net Revenue") placed in the layout', fails)
+  check(xml.include?('el-marg'), 'el-marg (name "Gross Margin %") placed in the layout', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixed-lod-synth.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-fixed-lod-synth.rb
@@ -97,6 +97,24 @@ factnoyear = { 'id' => 'f2', 'kind' => 'table', 'name' => 'X',
 check(MechanicalSpecs.synthesize_fixed_lods!({ 'pages' => [{ 'elements' => [factnoyear] }] }, factnoyear, TWB, COLMAP).empty?,
       'fact without a Year key -> 0 (safe skip)', fails)
 
+# Part E2 — DERIVED-VIEW fact (source kind != 'warehouse-table') must return a
+# Hash ({}), NOT Integer 0. The caller does world_lod_map.any?, and 0.any? is a
+# NoMethodError that crashed the whole run on Virtual-Connection-backed workbooks
+# (found by the live Orders Executive Overview E2E, 2026-07-09).
+%w[sql table].each do |dkind|
+  dview = { 'id' => 'dv', 'kind' => 'table', 'name' => 'Order Fact View',
+            'source' => { 'kind' => dkind, 'statement' => 'SELECT ...' },
+            'columns' => [{ 'id' => 'y', 'formula' => '[V/Year]' }] }
+  r = MechanicalSpecs.synthesize_fixed_lods!({ 'pages' => [{ 'elements' => [dview] }] }, dview, TWB, COLMAP)
+  check(r.is_a?(Hash) && r.empty?, "derived-view fact (kind=#{dkind}) -> {} not 0 (no .any? crash)", fails)
+  begin
+    r.any?
+    check(true, "derived-view result responds to .any? (kind=#{dkind})", fails)
+  rescue NoMethodError
+    check(false, "derived-view result crashes on .any? (kind=#{dkind}) — the return-0 bug", fails)
+  end
+end
+
 puts 'Part F — retain_columns! adds recipe point-in-time cols the converter dropped'
 rfact = {
   'id' => 'rf', 'kind' => 'table', 'name' => 'F',

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-manual-spec-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-manual-spec-gate.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the manual-spec authorization gate (2026-07-09, P1).
+#
+# Hand-authored --dm-spec/--wb-spec must be a ROUTED fallback, not a cold entry
+# point (cold hand-authoring is the #1 way a run skips the converter + gated
+# spine). migrate-tableau.rb accepts them only when: an orchestrator STOP emitted
+# <WORK>/manual-path-authorized.json, OR --reuse-dm carries an explicit id, OR
+# --allow-manual-spec "<reason>" is passed. Otherwise it refuses and routes back
+# to the one command.
+#
+# Drives migrate-tableau.rb with a fresh HOME + client creds present (so it clears
+# the step-0 cred gate) and asserts the manual-spec gate's behavior. The gate
+# aborts before any network, so cases are fast; a timeout guards the authorized
+# cases that proceed toward work.
+#
+# Usage: ruby scripts/test-manual-spec-gate.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR = __dir__
+MT  = File.join(DIR, 'migrate-tableau.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+def run(mt, home, work, args, extra_env = {}, timeout: 20)
+  env = {
+    'HOME' => home, 'SIGMA_SKIP_DOCTOR_GATE' => 'test',
+    'SIGMA_CLIENT_ID' => 'id-123', 'SIGMA_CLIENT_SECRET' => 'sec-456',
+    'SIGMA_API_TOKEN' => nil
+  }.merge(extra_env)
+  cmd = ['ruby', mt, '--workbook', 'WB', '--connection', 'c1', '--out', work] + args
+  io = IO.popen(env, cmd, err: %i[child out]); pid = io.pid; out = +''
+  t = Thread.new { out << io.read.to_s }
+  if t.join(timeout).nil?
+    Process.kill('KILL', pid) rescue nil; t.join(2)
+  end
+  Process.wait(pid) rescue nil
+  io.close rescue nil
+  out
+end
+
+Dir.mktmpdir do |home|
+  # a minimal valid wb-spec so the gate is what's under test (not a missing file)
+  Dir.mktmpdir do |work|
+    wb = File.join(work, 'wb-spec.json')
+    File.write(wb, JSON.generate('pages' => [{ 'id' => 'p', 'elements' => [] }]))
+
+    # (1) COLD --wb-spec (no token, no reuse-dm, no waiver) => refused + routed.
+    out = run(MT, home, work, ['--wb-spec', wb])
+    check(out.include?('ROUTED fallback, not a cold'), 'cold hand-author is refused', fails)
+    check(out.include?('migrate-tableau.rb --workbook'), 'refusal routes back to the one command', fails)
+
+    # (2) --allow-manual-spec waiver => NOT refused on manual-spec grounds.
+    out = run(MT, home, work, ['--wb-spec', wb, '--allow-manual-spec', 'intentional'])
+    check(!out.include?('ROUTED fallback, not a cold'), '--allow-manual-spec waives the gate', fails)
+
+    # (3) orchestrator STOP token present => NOT refused.
+    File.write(File.join(work, 'manual-path-authorized.json'), JSON.generate('via' => 'converter-stop'))
+    out = run(MT, home, work, ['--wb-spec', wb])
+    check(!out.include?('ROUTED fallback, not a cold'), 'manual-path-authorized.json admits the path', fails)
+    File.delete(File.join(work, 'manual-path-authorized.json'))
+
+    # (4) explicit --reuse-dm <id> (fast-path re-entry) => NOT refused.
+    out = run(MT, home, work, ['--wb-spec', wb, '--reuse-dm', 'dm-abc123'])
+    check(!out.include?('ROUTED fallback, not a cold'), 'explicit --reuse-dm id admits the path', fails)
+  end
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-offramp.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-offramp.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the off-ramp observability trail (2026-07-09).
+#
+# Every point where a run leaves the golden path (cred waiver, PASS-1 stop,
+# converter-stop, workbook-handoff, degraded fast path, manual-spec) appends a
+# structured record to <WORK>/offramps.jsonl, and verify-complete.rb surfaces the
+# trail under its verdict. This proves the logger appends + reads back, is never
+# fatal, and that verify-complete prints the trail. Offline.
+#
+# Usage: ruby scripts/test-offramp.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR = __dir__
+require_relative 'lib/offramp'
+VC = File.join(DIR, 'verify-complete.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+Dir.mktmpdir do |wd|
+  # append two off-ramps
+  Offramp.log(wd, kind: 'pass1-stop', detail: 'workbook wb-1')
+  Offramp.log(wd, kind: 'cred-gate-waived', reason: 'offline-test')
+  trail = Offramp.trail(wd)
+  check(trail.size == 2, "trail has both records (got #{trail.size})", fails)
+  check(trail[0]['kind'] == 'pass1-stop' && trail[1]['reason'] == 'offline-test', 'records preserve kind/reason', fails)
+  check(trail.all? { |r| r['at'] =~ /\d{4}-\d\d-\d\dT/ }, 'each record carries a timestamp', fails)
+
+  # never fatal on a bad workdir
+  begin
+    Offramp.log('/no/such/dir/really', kind: 'x')
+    check(true, 'logging to a missing dir does not raise', fails)
+  rescue StandardError => e
+    check(false, "logging to a missing dir raised: #{e.class}", fails)
+  end
+  check(Offramp.trail('/no/such/dir').empty?, 'trail of a missing dir is empty', fails)
+
+  # verify-complete surfaces the trail under a NOT-DONE verdict
+  File.write(File.join(wd, 'parity-pending.json'), JSON.generate('workbookId' => 'wb-1', 'stage' => 'pass1'))
+  out = IO.popen(['ruby', VC, '--workdir', wd], err: %i[child out], &:read)
+  check(out.include?('off-ramps taken this run'), 'verify-complete prints the off-ramp trail header', fails)
+  check(out.include?('pass1-stop') && out.include?('cred-gate-waived'), 'trail lists the recorded off-ramps', fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-verify-complete.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the run-scoped completion sentinel (2026-07-09).
+#
+# "Done" must be a fact on disk, not a narration. verify-complete.rb reports
+# GREEN only when phase6-success.json is present AND no parity-pending.json
+# remains — the two markers PASS 1 (exit 12) and assert-phase6-ran.rb (exit 0)
+# maintain. This drives verify-complete.rb across the four states. Offline.
+#
+# Usage: ruby scripts/test-verify-complete.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR = __dir__
+VC  = File.join(DIR, 'verify-complete.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+def run_vc(vc, wd, wb: nil)
+  cmd = ['ruby', vc, '--workdir', wd]
+  cmd += ['--workbook-id', wb] if wb
+  out = IO.popen(cmd, err: %i[child out], &:read)
+  [$?.exitstatus, out]
+end
+
+Dir.mktmpdir do |wd|
+  # State 1 — PASS 1 only (pending present) => exit 3, NOT DONE
+  File.write(File.join(wd, 'parity-pending.json'),
+             JSON.generate('workbookId' => 'wb-1', 'stage' => 'pass1'))
+  code, out = run_vc(VC, wd)
+  check(code == 3, "PASS-1 pending => exit 3 (got #{code})", fails)
+  check(out.include?('NOT DONE') && out.downcase.include?('pass 1'), 'pending message names PASS 1', fails)
+
+  # State 2 — nothing (no markers) => exit 2, NOT DONE (gate never ran)
+  File.delete(File.join(wd, 'parity-pending.json'))
+  code, = run_vc(VC, wd)
+  check(code == 2, "no markers => exit 2 (got #{code})", fails)
+
+  # State 3 — success present, no pending => exit 0, DONE
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'gates' => 'all-pass',
+                           'generatedAt' => '2026-07-09T00:00:00Z'))
+  code, out = run_vc(VC, wd)
+  check(code == 0, "success + no pending => exit 0 (got #{code})", fails)
+  check(out.include?('DONE') && out.include?('wb-1'), 'done message names the workbook', fails)
+
+  # State 3b — --workbook-id match still passes
+  code, = run_vc(VC, wd, wb: 'wb-1')
+  check(code == 0, "success + matching --workbook-id => exit 0 (got #{code})", fails)
+
+  # State 4 — success is for a DIFFERENT workbook than asked => exit 4
+  code, = run_vc(VC, wd, wb: 'wb-OTHER')
+  check(code == 4, "success but workbook mismatch => exit 4 (got #{code})", fails)
+
+  # State 5 — a fresh PASS 1 after a success must FLIP back to NOT DONE
+  # (exit-12 writes pending AND deletes the stale success marker; simulate both).
+  File.write(File.join(wd, 'parity-pending.json'), JSON.generate('workbookId' => 'wb-1', 'stage' => 'pass1'))
+  File.delete(File.join(wd, 'phase6-success.json'))
+  code, = run_vc(VC, wd)
+  check(code == 3, "re-run PASS 1 flips DONE back to NOT DONE (got #{code})", fails)
+end
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-worksheet-title.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-worksheet-title.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for worksheet-title → element display name (2026-07-09).
+#
+# Element titles came out as worksheet NICKNAMES ("OV KPI Revenue") instead of
+# the source-DISPLAYED worksheet title ("Net Revenue"), because parse-twb-layout
+# never extracted the worksheet <title> run. This drives parse-twb-layout on a
+# minimal .twb and asserts: (a) a CUSTOM worksheet <title> is extracted to
+# display_title on both the worksheet meta and the dashboard zone; (b) a DEFAULT
+# title (the "<Sheet Name>" field token) is skipped (nil) so the builder falls
+# back to the nickname; (c) build-charts' tile_title consumes display_title.
+#
+# Usage: ruby scripts/test-worksheet-title.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR   = __dir__
+PARSE = File.join(DIR, 'parse-twb-layout.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+TWB = <<~XML
+  <?xml version='1.0' encoding='utf-8' ?>
+  <workbook>
+    <worksheets>
+      <worksheet name='OV KPI Revenue'>
+        <layout-options><title><formatted-text><run>Net Revenue</run></formatted-text></title></layout-options>
+        <table><view><datasources/></view></table>
+      </worksheet>
+      <worksheet name='Plain Sheet'>
+        <layout-options><title><formatted-text><run>&lt;Sheet Name&gt;</run></formatted-text></title></layout-options>
+        <table><view><datasources/></view></table>
+      </worksheet>
+    </worksheets>
+    <dashboards>
+      <dashboard name='D'>
+        <zones><zone id='1' name='OV KPI Revenue' x='0' y='0' w='100000' h='100000'><zone id='2' name='OV KPI Revenue' param='vizic'/></zone></zones>
+      </dashboard>
+    </dashboards>
+  </workbook>
+XML
+
+Dir.mktmpdir do |d|
+  twb = File.join(d, 'wb.twb')
+  out = File.join(d, 'layout.json')
+  File.write(twb, TWB)
+  system('ruby', PARSE, twb, out, out: File::NULL, err: File::NULL)
+
+  meta = JSON.parse(File.read(out.sub(/\.json$/, '-meta.json')))
+  ws = meta['worksheets'] || {}
+  check(ws.dig('OV KPI Revenue', 'display_title') == 'Net Revenue',
+        "custom worksheet <title> extracted (got #{ws.dig('OV KPI Revenue', 'display_title').inspect})", fails)
+  check(ws.dig('Plain Sheet', 'display_title').nil?,
+        "default '<Sheet Name>' token skipped -> nil (got #{ws.dig('Plain Sheet', 'display_title').inspect})", fails)
+
+  doc = JSON.parse(File.read(out))
+  dashes = doc.is_a?(Array) ? doc : (doc['dashboards'] || [doc])
+  zone = dashes.flat_map { |x| x['zones'] || [] }.find { |z| z['caption'] == 'OV KPI Revenue' }
+  check(zone && zone['display_title'] == 'Net Revenue',
+        "display_title threaded onto the dashboard zone (got #{zone && zone['display_title'].inspect})", fails)
+end
+
+# tile_title (build-charts) prefers display_title, else falls back to the nickname.
+BUILD = File.join(DIR, 'build-charts-from-signals.rb')
+src = File.read(BUILD)
+check(src.include?('def tile_title'), 'build-charts defines tile_title helper', fails)
+check(src.scan(/tile_title\(z, cap\)/).size >= 3, 'tile_title applied at multiple element-name sites', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-complete.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-complete.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-complete.rb — the SINGLE offline "are we actually done?" check.
+#
+# The migration is a two-pass design: PASS 1 (migrate-tableau.rb) ends at exit 12
+# with parity + the hard-gate suite still PENDING; only PASS 2 (--finalize) runs
+# assert-phase6-ran.rb, whose exit 0 is the one legitimate GREEN. A low-context
+# agent can mistake a clean PASS-1 (DM + workbook POSTed, HTTP 200s) for "done"
+# and stop before the gates ever fire. This script makes "done" a fact on disk,
+# not a narration:
+#
+#   * PASS 1 writes   <workdir>/parity-pending.json  and clears the success marker
+#   * assert-phase6-ran.rb (at --finalize, exit 0) writes <workdir>/phase6-success.json
+#     and clears the pending marker
+#
+# So the ONLY state that reports GREEN here is: success marker present, no pending
+# marker. The SKILL's definition of done is "verify-complete.rb exits 0" —
+# nothing else counts. It is fully offline (reads two files); run it before
+# claiming completion or handing off.
+#
+# Usage:  ruby scripts/verify-complete.rb --workdir <dir> [--workbook-id <id>]
+#
+# Exit codes:
+#   0  DONE   — phase6-success.json present (and matches --workbook-id if given)
+#   2  NOT DONE — the hard gate never stamped success (finalize not run / failed)
+#   3  NOT DONE — still at PASS 1 (parity-pending.json present); run --finalize
+#   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR') { |v| opts[:wd] = v }
+  p.on('--workbook-id ID') { |v| opts[:wb] = v }
+end.parse!(ARGV)
+abort 'FATAL: --workdir required' unless opts[:wd]
+
+wd       = opts[:wd]
+pending  = File.join(wd, 'parity-pending.json')
+success  = File.join(wd, 'phase6-success.json')
+
+def load(path)
+  JSON.parse(File.read(path))
+rescue StandardError
+  {}
+end
+
+if File.exist?(pending)
+  pj = load(pending)
+  warn '⛔ NOT DONE — still at PASS 1 (parity + hard gates have not run).'
+  warn "   workbook: #{pj['workbookId'] || '?'}   stage: #{pj['stage'] || '?'}"
+  warn '   Collect parity actuals, then run the --finalize command PASS 1 printed,'
+  warn '   which runs assert-phase6-ran.rb (the only path to GREEN).'
+  exit 3
+end
+
+unless File.exist?(success)
+  warn '⛔ NOT DONE — no phase6-success.json in the workdir.'
+  warn '   The hard-gate suite (assert-phase6-ran.rb) has not passed for this run.'
+  warn "   Run PASS 1, then --finalize. Workdir checked: #{wd}"
+  exit 2
+end
+
+sj = load(success)
+if opts[:wb] && !sj['workbookId'].to_s.empty? && sj['workbookId'] != opts[:wb]
+  warn "⛔ DONE marker is for a DIFFERENT workbook (#{sj['workbookId']}) than --workbook-id #{opts[:wb]}."
+  warn '   You are likely looking at a stale workdir or the wrong run.'
+  exit 4
+end
+
+puts '✅ DONE — assert-phase6-ran.rb passed all gates for this run.'
+puts "   workbook : #{sj['workbookId']}"
+puts "   gates    : #{sj['gates']}"
+puts "   stamped  : #{sj['generatedAt']}"
+exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-complete.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/verify-complete.rb
@@ -29,6 +29,24 @@
 
 require 'json'
 require 'optparse'
+require_relative 'lib/offramp'
+
+# Print the off-ramp trail + any gate waivers for this workdir — the "where did
+# this run leave the golden path" readout. Advisory; shown under every verdict.
+def print_offramps(wd)
+  trail = Offramp.trail(wd)
+  waivers = begin
+    JSON.parse(File.read(File.join(wd, 'waivers.json')))
+  rescue StandardError
+    nil
+  end
+  wv = waivers.is_a?(Array) ? waivers : (waivers.is_a?(Hash) ? (waivers['waivers'] || []) : [])
+  return if trail.empty? && wv.empty?
+  warn ''
+  warn "   off-ramps taken this run (#{trail.size} logged, #{wv.size} gate waiver(s)) — where it left the golden path:"
+  trail.each { |r| warn "     • #{r['kind']}#{r['reason'] ? " — #{r['reason']}" : ''}#{r['detail'] ? " (#{r['detail']})" : ''}" }
+  warn "     • #{wv.size} assert-phase6-ran gate waiver(s) — see waivers.json" unless wv.empty?
+end
 
 opts = {}
 OptionParser.new do |p|
@@ -53,6 +71,7 @@ if File.exist?(pending)
   warn "   workbook: #{pj['workbookId'] || '?'}   stage: #{pj['stage'] || '?'}"
   warn '   Collect parity actuals, then run the --finalize command PASS 1 printed,'
   warn '   which runs assert-phase6-ran.rb (the only path to GREEN).'
+  print_offramps(wd)
   exit 3
 end
 
@@ -60,6 +79,7 @@ unless File.exist?(success)
   warn '⛔ NOT DONE — no phase6-success.json in the workdir.'
   warn '   The hard-gate suite (assert-phase6-ran.rb) has not passed for this run.'
   warn "   Run PASS 1, then --finalize. Workdir checked: #{wd}"
+  print_offramps(wd)
   exit 2
 end
 
@@ -74,4 +94,5 @@ puts '✅ DONE — assert-phase6-ran.rb passed all gates for this run.'
 puts "   workbook : #{sj['workbookId']}"
 puts "   gates    : #{sj['gates']}"
 puts "   stamped  : #{sj['generatedAt']}"
+print_offramps(wd) # even a GREEN run can carry waivers/degradations — surface them
 exit 0

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -1073,5 +1073,22 @@ else
   puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
+# Completion sentinel — stamp a run-scoped success marker keyed to the workbook
+# and clear any PASS-1 pending marker. verify-complete.rb (the offline done-check
+# the SKILL points agents at) reports GREEN only when this file exists for the
+# workbook and no parity-pending.json remains. This makes "done" a token only the
+# gate can mint, closing the "agent narrates success without the gate" hole.
+begin
+  _wd = opts[:tab]
+  File.write(File.join(_wd, 'phase6-success.json'),
+             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'gates' => 'all-pass',
+                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _pend = File.join(_wd, 'parity-pending.json')
+  File.delete(_pend) if File.exist?(_pend)
+rescue StandardError
+  # never fail the gate on sentinel bookkeeping
+end
+
 puts "[OK] all gates pass — conversion may declare GREEN"
 exit 0

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -1073,5 +1073,22 @@ else
   puts '[OK] gate 12: no deferred-elements.json — no DM elements were quarantined'
 end
 
+# Completion sentinel — stamp a run-scoped success marker keyed to the workbook
+# and clear any PASS-1 pending marker. verify-complete.rb (the offline done-check
+# the SKILL points agents at) reports GREEN only when this file exists for the
+# workbook and no parity-pending.json remains. This makes "done" a token only the
+# gate can mint, closing the "agent narrates success without the gate" hole.
+begin
+  _wd = opts[:tab]
+  File.write(File.join(_wd, 'phase6-success.json'),
+             JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'gates' => 'all-pass',
+                                  'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  _pend = File.join(_wd, 'parity-pending.json')
+  File.delete(_pend) if File.exist?(_pend)
+rescue StandardError
+  # never fail the gate on sentinel bookkeeping
+end
+
 puts "[OK] all gates pass — conversion may declare GREEN"
 exit 0


### PR DESCRIPTION
## Why
A skill audit (3 parallel investigations) explained why agents with less context than the author go off the rails — skip gates/phases, declare done early, hand-author, improvise past errors — inconsistently across Claude Code/Mac and Coco/Windows despite the same Opus model. Root cause is **not a fragile pipeline** (the pipeline is well-gated and resumable) but **three seams where the guardrail was prose, not code**, plus the correction that **same model ≠ same environment** (the harness controls cred loading, shell, permissions, cwd).

## What
**P0 — close the three seams**
1. **Fail-closed credential gate** (`migrate-tableau.rb` step 0). The doctor treats missing creds as a *warning*, so a non-Claude-Code harness sails past and dies at the first Sigma call with an opaque auth error the agent improvises around. Now the orchestrator stops before any work with the exact `setup.rb` remediation (waivable via `SIGMA_SKIP_CRED_GATE`).
2. **Run-scoped completion sentinel.** "Done" is now a file on disk. PASS 1 (exit 12) writes `parity-pending.json` + clears any stale success + prints a NOT-DONE banner; `assert-phase6-ran.rb` (shared) stamps `phase6-success.json` on exit 0 + clears pending. New **`verify-complete.rb`** is the single offline done-check the SKILL points at.
3. **Doc singularity.** SKILL.md gains a top "STEP 1 — THE ONE PATH" directive and demotes the per-phase table to a map, not a menu; QUICKSTART leads with the one command and purges POSIX-only `/tmp/<name>` → `~/tableau-migration/<slug>` (Windows parity).

**P1 — gate cold hand-authoring.** `--dm-spec/--wb-spec` accepted only via an orchestrator STOP token (`manual-path-authorized.json`), an explicit `--reuse-dm <id>`, or `--allow-manual-spec "<reason>"`. Closes the largest defection surface.

**P2 — off-ramp observability** (answers "hard to pinpoint where agents go wrong"). `lib/offramp.rb` logs every departure from the golden path to `<WORK>/offramps.jsonl`; `verify-complete.rb` surfaces the trail.

## Validation
- **Two cold-subagent E2Es** (context-free agents given only the skill): (A) simulated fresh non-Claude-Code laptop, no creds → funneled to the one command, **stopped cleanly at the cred gate** (no orphans, no improvisation); (B) a "looks-finished" PASS-1 workdir → correctly concluded **NOT DONE** via `verify-complete.rb`, not fooled by the live workbook/URL.
- **Live confirmation:** ran the real `assert-phase6-ran.rb` against a live workbook to exit 0 → stamped `phase6-success.json`, `verify-complete` flipped to ✅ DONE, stale pending cleared.
- New tests: `test-verify-complete.rb`, `test-cred-gate.rb`, `test-offramp.rb`, `test-manual-spec-gate.rb`. Full suite 84/84 (pre-existing env-only `test-calc-discovery` excepted). Shared `assert-phase6-ran.rb` synced to all plugins; drift gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)