### PR TITLE
Source-viz number format wins; DM auto-pick requires column-superset

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/find-or-pick-dm.rb
@@ -314,11 +314,25 @@ best = candidates.first
 second = candidates[1]
 
 # Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
-# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
-# workbook's source tables (table_match 1.0). Table coverage is the safety
-# invariant: a DM that sources every table the workbook needs can satisfy every
-# column ref through its element set, so reusing it is safe; a DM missing a table
-# is never auto-picked (its denorm view can't resolve the missing columns).
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
 #
 # We deliberately DO NOT block on a score tie here. A tie among table-covering
 # candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
@@ -343,7 +357,7 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
 ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
-auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables && !ambiguous_wide_tie)
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
 recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/find-or-pick-dm.rb
@@ -314,11 +314,25 @@ best = candidates.first
 second = candidates[1]
 
 # Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
-# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
-# workbook's source tables (table_match 1.0). Table coverage is the safety
-# invariant: a DM that sources every table the workbook needs can satisfy every
-# column ref through its element set, so reusing it is safe; a DM missing a table
-# is never auto-picked (its denorm view can't resolve the missing columns).
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
 #
 # We deliberately DO NOT block on a score tie here. A tie among table-covering
 # candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
@@ -343,7 +357,7 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
 ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
-auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables && !ambiguous_wide_tie)
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
 recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/find-or-pick-dm.rb
@@ -314,11 +314,25 @@ best = candidates.first
 second = candidates[1]
 
 # Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
-# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
-# workbook's source tables (table_match 1.0). Table coverage is the safety
-# invariant: a DM that sources every table the workbook needs can satisfy every
-# column ref through its element set, so reusing it is safe; a DM missing a table
-# is never auto-picked (its denorm view can't resolve the missing columns).
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
 #
 # We deliberately DO NOT block on a score tie here. A tie among table-covering
 # candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
@@ -343,7 +357,7 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
 ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
-auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables && !ambiguous_wide_tie)
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
 recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/find-or-pick-dm.rb
@@ -314,11 +314,25 @@ best = candidates.first
 second = candidates[1]
 
 # Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
-# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
-# workbook's source tables (table_match 1.0). Table coverage is the safety
-# invariant: a DM that sources every table the workbook needs can satisfy every
-# column ref through its element set, so reusing it is safe; a DM missing a table
-# is never auto-picked (its denorm view can't resolve the missing columns).
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
 #
 # We deliberately DO NOT block on a score tie here. A tie among table-covering
 # candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
@@ -343,7 +357,7 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
 ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
-auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables && !ambiguous_wide_tie)
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
 recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/find-or-pick-dm.rb
@@ -314,11 +314,25 @@ best = candidates.first
 second = candidates[1]
 
 # Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
-# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
-# workbook's source tables (table_match 1.0). Table coverage is the safety
-# invariant: a DM that sources every table the workbook needs can satisfy every
-# column ref through its element set, so reusing it is safe; a DM missing a table
-# is never auto-picked (its denorm view can't resolve the missing columns).
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
 #
 # We deliberately DO NOT block on a score tie here. A tie among table-covering
 # candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
@@ -343,7 +357,7 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
 ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
-auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables && !ambiguous_wide_tie)
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
 recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/find-or-pick-dm.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/find-or-pick-dm.rb
@@ -314,11 +314,25 @@ best = candidates.first
 second = candidates[1]
 
 # Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
-# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
-# workbook's source tables (table_match 1.0). Table coverage is the safety
-# invariant: a DM that sources every table the workbook needs can satisfy every
-# column ref through its element set, so reusing it is safe; a DM missing a table
-# is never auto-picked (its denorm view can't resolve the missing columns).
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
 #
 # We deliberately DO NOT block on a score tie here. A tie among table-covering
 # candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
@@ -343,7 +357,7 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
 ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
-auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables && !ambiguous_wide_tie)
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
 recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/find-or-pick-dm.rb
@@ -314,11 +314,25 @@ best = candidates.first
 second = candidates[1]
 
 # Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
-# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
-# workbook's source tables (table_match 1.0). Table coverage is the safety
-# invariant: a DM that sources every table the workbook needs can satisfy every
-# column ref through its element set, so reusing it is safe; a DM missing a table
-# is never auto-picked (its denorm view can't resolve the missing columns).
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
 #
 # We deliberately DO NOT block on a score tie here. A tie among table-covering
 # candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
@@ -343,7 +357,7 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
 ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
-auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables && !ambiguous_wide_tie)
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
 recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -3412,17 +3412,18 @@ layout.each do |dash|
     end
 
     meas_col_obj = { 'id' => "y-#{el_id}", 'name' => meas['name'], 'formula' => measure_formula }
-    # Format priority:
-    #   1. explicit `format` on the master-map entry
-    #   2. Tableau's own format string for this measure (zone.formats — only set
-    #      when --meta was provided)
+    # Format priority (source-fidelity order):
+    #   1. the worksheet's OWN Tableau format for this measure (zone.formats) —
+    #      the DISPLAY ground truth; the same measure can render at different
+    #      precision per sheet, and the DM's auto-inferred master format often
+    #      picks 2 decimals for a percent calc where the source shows 1 (65.04%
+    #      vs 65.0%). The source viz wins.
+    #   2. explicit `format` on the master-map entry (DM/curated)
     #   3. heuristic by header name
-    meas_col_obj['format'] = meas['format'] if meas['format'].is_a?(Hash)
-    if meas_col_obj['format'].nil?
-      tab_fmt = pick_tableau_format(z['formats'], meas_hdr) ||
-                pick_tableau_format(z['formats'], meas['name'])
-      meas_col_obj['format'] = tab_fmt if tab_fmt
-    end
+    tab_fmt = pick_tableau_format(z['formats'], meas_hdr) ||
+              pick_tableau_format(z['formats'], meas['name'])
+    meas_col_obj['format'] = tab_fmt
+    meas_col_obj['format'] ||= meas['format'] if meas['format'].is_a?(Hash)
     if meas_col_obj['format'].nil?
       meas_col_obj['format'] =
         case meas['name'].downcase

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/find-or-pick-dm.rb
@@ -314,11 +314,25 @@ best = candidates.first
 second = candidates[1]
 
 # Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
-# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
-# workbook's source tables (table_match 1.0). Table coverage is the safety
-# invariant: a DM that sources every table the workbook needs can satisfy every
-# column ref through its element set, so reusing it is safe; a DM missing a table
-# is never auto-picked (its denorm view can't resolve the missing columns).
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
 #
 # We deliberately DO NOT block on a score tie here. A tie among table-covering
 # candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
@@ -343,7 +357,7 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
 ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
-auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables && !ambiguous_wide_tie)
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
 recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/find-or-pick-dm.rb
@@ -314,11 +314,25 @@ best = candidates.first
 second = candidates[1]
 
 # Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
-# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
-# workbook's source tables (table_match 1.0). Table coverage is the safety
-# invariant: a DM that sources every table the workbook needs can satisfy every
-# column ref through its element set, so reusing it is safe; a DM missing a table
-# is never auto-picked (its denorm view can't resolve the missing columns).
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
 #
 # We deliberately DO NOT block on a score tie here. A tie among table-covering
 # candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
@@ -343,7 +357,7 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
 ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
-auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables && !ambiguous_wide_tie)
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
 recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie

--- a/shared/scripts/find-or-pick-dm.rb
+++ b/shared/scripts/find-or-pick-dm.rb
@@ -314,11 +314,25 @@ best = candidates.first
 second = candidates[1]
 
 # Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
-# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
-# workbook's source tables (table_match 1.0). Table coverage is the safety
-# invariant: a DM that sources every table the workbook needs can satisfy every
-# column ref through its element set, so reusing it is safe; a DM missing a table
-# is never auto-picked (its denorm view can't resolve the missing columns).
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
 #
 # We deliberately DO NOT block on a score tie here. A tie among table-covering
 # candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
@@ -343,7 +357,7 @@ best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
 # tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
 tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
 ambiguous_wide_tie   = tie_window_count >= 3 && !best_name_matches && !best_is_superset
-auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables && !ambiguous_wide_tie)
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
 
 # Standard recommend path keeps the old semantics (printed for human opt-in).
 recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie


### PR DESCRIPTION
Two follow-ups from the Orders Executive Overview E2E (both flagged as non-blockers when #324 merged).

## 1. Measure number format — source viz wins
The tier "Gross Margin %" bar rendered `,.2%` (65.04%) vs the source's `,.1%` (65.0%): the master-map entry format (DM auto-default — 2 decimals for a percent calc) had priority over the worksheet's own Tableau format (`p0.0%`). The worksheet format is the display ground truth (a measure can render at different precision per sheet), so the single-measure chart format priority is reordered: **source viz format → master-map → name heuristic.** Removes an RCF pass on this class of dashboard.

## 2. DM reuse auto-pick requires a column-superset
The auto-pick gate required only `table_match == 1.0` on the false premise "all tables present ⇒ all columns resolvable" — so a DM missing referenced columns (`col_match 0.8`) could still auto-pick (`0.2·1 + 0.7·0.8 ≈ 0.76 ≥ 0.55`) and then fail the pre-POST ref gate. Now auto-pick also requires `column_match == 1.0`; a DM missing any referenced column is **recommended for human opt-in but not silently reused.**

**Known residual (documented in code):** role-playing dimensions (a table aliased twice — e.g. `DATE_DIM` as Order + Return Date) can't be expressed by column-*name* coverage, so a DM with the table once is a full superset yet lacks the second alias. The pre-POST ref gate still catches it (exit-4 handoff). The proper fix is a **self-heal** (auto-rebuild fresh when an *auto-picked* DM fails the ref gate) — a larger control-flow change, tracked as a follow-up rather than rushed here.

Full suite green (pre-existing env-only `test-calc-discovery` excepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)