### PR TITLE
Self-heal: auto-rebuild fresh when an auto-picked reuse DM fails the build

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/migrate-tableau.rb
@@ -123,6 +123,12 @@ HERE = __dir__
 $LOAD_PATH.unshift File.expand_path('lib', HERE)
 require 'coverage_gate' # build-charts coverage.json → consolidated report (bead beads-sigma-59mk)
 
+require 'rbconfig'
+# Snapshot ARGV before OptionParser consumes it — the reuse self-heal re-invokes
+# this orchestrator verbatim + `--skip-reuse-scan` (see the WorkbookBuildError
+# rescue). :recommended reuse comes from auto-pick, never a CLI arg, so the
+# snapshot carries no --reuse-dm to strip.
+ORIGINAL_ARGV = ARGV.dup.freeze
 opts = {}
 OptionParser.new do |o|
   o.banner = <<~BANNER
@@ -2423,6 +2429,30 @@ begin
   par_cmd += ['--update-id', update_wb] if update_wb
   p_log = sigma_run_wb!(par_cmd)
 rescue WorkbookBuildError => e
+  # ── SELF-HEAL: auto-picked reuse DM couldn't satisfy the workbook ──────────
+  # When the DM was AUTO-PICKED for reuse (opts[:reuse_dm] == :recommended, the
+  # orchestrator's choice — not an explicit user --reuse-dm <id>) and the build
+  # failed, rebuild a FRESH DM automatically instead of the exit-4 handoff. This
+  # closes the column-superset gate's KNOWN RESIDUAL: a reused DM can be a full
+  # column-superset yet lack a role-playing dimension alias the master needs
+  # (DATE_DIM as both Order + Return Date), which only surfaces at the pre-POST
+  # ref gate — after Phase 3 was skipped. A fresh DM is built from the workbook's
+  # own model, so it has exactly the structure the wb-spec needs. Re-invokes this
+  # orchestrator verbatim + --skip-reuse-scan (same --out → discovery is reused,
+  # so it's fast and creates no orphan: the ref gate is PRE-POST, nothing shipped).
+  # Fires once (SIGMA_SELFHEAL_RETRIED guard); an EXPLICIT --reuse-dm <id> is the
+  # user's decision and is respected (falls through to the handoff below).
+  if opts[:reuse_dm] == :recommended && ENV['SIGMA_SELFHEAL_RETRIED'].to_s.empty?
+    puts
+    puts "── SELF-HEAL: the auto-picked reuse DM (#{reuse_dm_id}) could not satisfy the"
+    puts "   workbook (#{e.message.lines.first&.strip}). Rebuilding a FRESH data model"
+    puts '   automatically (--skip-reuse-scan) — no manual step needed. ──'
+    Offramp.log(WORK, kind: 'reuse-selfheal', detail: "auto-picked DM #{reuse_dm_id} failed the build; rebuilding fresh") if defined?(Offramp)
+    ok = system({ 'SIGMA_SELFHEAL_RETRIED' => '1' }, RbConfig.ruby, File.expand_path(__FILE__),
+                *ORIGINAL_ARGV, '--skip-reuse-scan')
+    child = $?&.exitstatus
+    exit(ok ? 0 : (child.nil? ? 1 : child))
+  end
   failed = cull_failed_fields(e.captured_output,
                               (defined?(v_log) ? v_log : ''), (defined?(p_log) ? p_log : ''))
   # Fall back to the mechanically-known untranslatable fields when the log itself

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-reuse-selfheal.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-reuse-selfheal.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Wiring guard for the DM-reuse SELF-HEAL (2026-07-09).
+#
+# When a DM is AUTO-PICKED for reuse (opts[:reuse_dm] == :recommended) and the
+# workbook build fails (e.g. the reused DM is a full column-superset but lacks a
+# role-playing dimension alias the master needs — the KNOWN RESIDUAL of the
+# auto-pick column-superset gate), the orchestrator must rebuild a FRESH DM
+# automatically (re-invoke self + --skip-reuse-scan) instead of the exit-4
+# handoff — and ONLY for auto-picked reuse (an explicit --reuse-dm <id> is the
+# user's choice), ONCE (SIGMA_SELFHEAL_RETRIED guard). Behavioral proof is the
+# live E2E; this guards the wiring against silent removal/regression.
+#
+# Usage: ruby scripts/test-reuse-selfheal.rb
+
+DIR = __dir__
+src = File.read(File.join(DIR, 'migrate-tableau.rb'))
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+
+# Locate the WorkbookBuildError rescue and the self-heal block within it.
+rescue_idx = src.index('rescue WorkbookBuildError')
+check(!rescue_idx.nil?, 'WorkbookBuildError rescue present', fails)
+block = rescue_idx ? src[rescue_idx, 2800] : '' # self-heal block + reach the exit-4 handoff
+
+check(src.include?('ORIGINAL_ARGV = ARGV.dup'), 'ARGV snapshotted before OptionParser consumes it', fails)
+check(block.include?("opts[:reuse_dm] == :recommended"),
+      'self-heal gates on AUTO-PICKED reuse (:recommended), not an explicit --reuse-dm id', fails)
+check(block.include?("SIGMA_SELFHEAL_RETRIED"), 'self-heal is guarded against re-entry (fires once)', fails)
+check(block.include?("--skip-reuse-scan"), 'self-heal re-invokes with --skip-reuse-scan (fresh DM)', fails)
+check(block.include?('ORIGINAL_ARGV'), 'self-heal replays the original args', fails)
+check(block.include?('reuse-selfheal'), 'self-heal records an off-ramp event', fails)
+# The self-heal must come BEFORE the exit-4 handoff in the rescue body (search
+# the full source from the rescue, not the truncated window).
+heal_at = rescue_idx && src.index('SIGMA_SELFHEAL_RETRIED', rescue_idx)
+exit4_at = rescue_idx && src.index('exit 4', rescue_idx)
+check(heal_at && exit4_at && heal_at < exit4_at, 'self-heal branch precedes the exit-4 handoff', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end


### PR DESCRIPTION
Closes the KNOWN RESIDUAL documented in #325's DM-reuse column-superset gate.

**Problem:** a reused DM can be a full column-superset of the workbook's references yet still lack a **role-playing dimension alias** the master needs (e.g. `DATE_DIM` joined twice — Order Date + Return Date). Column-*name* coverage can't express "needs this table twice," so it passes the auto-pick gate, then fails the **pre-POST ref gate** — after Phase 3 (fresh DM build) was already skipped. Today that means an exit-4 handoff and a manual `--skip-reuse-scan` re-run (the exact friction hit on Orders Executive Overview).

**Fix:** when the DM was **auto-picked** for reuse (`opts[:reuse_dm] == :recommended` — the orchestrator's choice, not an explicit user `--reuse-dm <id>`) and the workbook build raises, the `WorkbookBuildError` rescue re-invokes the orchestrator verbatim + `--skip-reuse-scan`, building a fresh DM from the workbook's own model. Same `--out` ⇒ discovery is reused (fast); the ref gate is pre-POST so the failed attempt shipped nothing (no orphan). Fires **once** (`SIGMA_SELFHEAL_RETRIED` guard); an explicit `--reuse-dm <id>` is the user's decision and still gets the exit-4 handoff. Emits a `reuse-selfheal` off-ramp event.

**Validation:** wiring guard `test-reuse-selfheal.rb`; behavioral proof is a live E2E (Orders Executive Overview *without* `--skip-reuse-scan` now self-heals to green) — running before merge.

Full suite green (pre-existing env-only `test-calc-discovery` excepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)