### PR TITLE
Harden powerbi-to-sigma: single entry point, device-code connect prompt, empty-workbook guard, completion gate

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/SKILL.md
@@ -10,6 +10,37 @@ user-invocable: true
 > `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
 > It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
 
+> ## ⛔ STEP 1 — THE ONE PATH (do not improvise a workbook)
+> This conversion runs through **one orchestrator** that builds every chart and
+> **verifies each one's data against Power BI before it's done**:
+> ```
+> ruby scripts/migrate-powerbi.rb --tmsl <model.bim> --pbir <report-bundle.json> --connection <id> --out <WORK>
+> ```
+> - **You need the model (TMSL) + report layout (PBIR) first. Get them by
+>   CONNECTING to Power BI — do NOT ask the user to hand them over and do NOT
+>   proceed without them.** Run the device-code login (no Entra app):
+>   ```
+>   python scripts/fabric-extract.py --report "<report name>" [--workspace "<ws id|name>"] \
+>     --out-dir <WORK> --report-out-dir <WORK> --report-bundle <WORK>/report-bundle.json
+>   ```
+>   It prints a **device code + `https://microsoft.com/devicelogin`** — tell the
+>   user to open that URL and enter the code (one sign-in; token caches). Then run
+>   the orchestrator with the extracted `--tmsl`/`--pbir`. Full recipe: `refs/connection.md`.
+> - **NEVER hand-author a workbook JSON and `curl`-POST it to `/v2/workbooks`, and
+>   never lay out empty "placeholder" pages.** That bypasses the DAX conversion,
+>   chart build, and parity gate and ships an EMPTY workbook (invented page names,
+>   no elements) — the #1 way this migration fails. If you cannot extract the
+>   model (no Fabric access / not published), **STOP and tell the user you need to
+>   connect to Power BI (device-code) or that the report must be published** — do
+>   not fall back to a hand-built shell.
+> - **"Done" is not "pages exist."** The migration is complete only when
+>   `ruby scripts/verify-complete.rb --workdir <WORK>` prints ✅ DONE — i.e. the
+>   `assert-phase6-ran` parity gate passed with real chart elements. An empty or
+>   placeholder workbook is never done, no matter how it looks.
+> - Small/older models (e.g. running on Haiku): if the report is large or complex,
+>   say so and confirm scope with the user before building — don't silently
+>   degrade to a partial shell.
+
 ## Preflight the workbook spec before POST (mandatory)
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/fabric-extract.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/fabric-extract.py
@@ -78,7 +78,12 @@ def main():
         print("NO_SEMANTIC_MODEL found in any accessible workspace.", flush=True)
         sys.exit(4)
     if model and not ARGS.model_name:
-        print("[note] no --model-name given — defaulting to the first model found", flush=True)
+        if ARGS.report:
+            print("[note] no --model-name given — bound the report's own semantic model "
+                  "(via datasetId; falls back to first model only if that lookup fails)", flush=True)
+        else:
+            print("[note] no --model-name given and no --report to bind against — "
+                  "defaulting to the FIRST model in the workspace; pass --model-name to be sure", flush=True)
     if model:
         print(f"[TARGET] ws='{ws.get('name')}' model='{model.get('name')}' id={model['id']}", flush=True)
     if report:

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -152,10 +152,23 @@ if opts[:print_converter]
   exit 0
 end
 
-abort 'missing --tmsl' unless opts[:tmsl]
-abort "--tmsl not found: #{opts[:tmsl]}" unless opts[:tmsl] && File.exist?(opts[:tmsl])
-abort 'missing --pbir' unless opts[:pbir]
-abort "--pbir not found: #{opts[:pbir]}" unless File.exist?(opts[:pbir])
+# The orchestrator REQUIRES the extracted model (TMSL) + report layout (PBIR).
+# When they're missing, the failure mode we must prevent is an agent improvising
+# a hand-built empty workbook. So the remediation is explicit: CONNECT to Power
+# BI via device-code and extract them — never hand-author a spec.
+CONNECT_HINT = <<~HINT.freeze
+  Extract them by CONNECTING to Power BI (device-code login, no Entra app):
+      python scripts/fabric-extract.py --report "<report name>" [--workspace "<ws id|name>"] \\
+        --out-dir <WORK> --report-out-dir <WORK> --report-bundle <WORK>/report-bundle.json
+  It prints a device code + https://microsoft.com/devicelogin — the USER signs in
+  once, then re-run this command with the extracted --tmsl (model.bim) + --pbir
+  (report-bundle.json). See refs/connection.md. Do NOT hand-author a workbook spec
+  or proceed without the model — if you can't extract it, STOP and tell the user.
+HINT
+abort "FATAL: missing --tmsl (the Power BI semantic model, TMSL/model.bim).\n#{CONNECT_HINT}" unless opts[:tmsl]
+abort "FATAL: --tmsl not found: #{opts[:tmsl]}\n#{CONNECT_HINT}" unless File.exist?(opts[:tmsl])
+abort "FATAL: missing --pbir (the Power BI report layout / PBIR bundle).\n#{CONNECT_HINT}" unless opts[:pbir]
+abort "FATAL: --pbir not found: #{opts[:pbir]}\n#{CONNECT_HINT}" unless File.exist?(opts[:pbir])
 # intake.rb (front-door) caches the resolved connection in <out>/connection.json; honor it
 # when --connection is omitted so the agent need not re-pass the id it just resolved.
 opts[:conn] ||= (JSON.parse(File.read(File.join(opts[:out], 'connection.json')))['connection_id'] rescue nil) if opts[:out]
@@ -1481,5 +1494,30 @@ if fresh_ok
        "#{freshness['credsSuspect'] ? ' — REFRESH FAILING (creds)' : ''}"
 end
 puts "ENHANCE     : #{enhance_line}" if enhance_line
+# Empty-workbook guard + completion sentinel. parity_ok is VACUOUSLY true when no
+# chart elements were built (0 cols, 0 divergent) — an empty/placeholder workbook
+# would otherwise exit 0 and look "done" (the exact PBI failure: pages, no
+# elements). Require real elements, and stamp a run-scoped success marker only on
+# a genuine pass so verify-complete.rb (the done-check the SKILL points at) can't
+# green an empty result.
+built_ok = parity_ok && chart_els.size.positive?
+if chart_els.size.zero?
+  puts 'ELEMENTS    : 0 chart elements built — EMPTY workbook, NOT a complete migration.'
+  puts '              Parity is vacuous with no elements. Do NOT report success: re-extract the'
+  puts '              report layout (--pbir) or investigate why no visuals were produced. Never'
+  puts '              hand-author placeholder pages to fill it.'
+end
+begin
+  succ = File.join(WORK, 'phase6-success.json')
+  if built_ok
+    File.write(succ, JSON.pretty_generate('workbookId' => wb_id, 'chartCount' => chart_els.size,
+                                          'gates' => 'parity-pass',
+                                          'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  elsif File.exist?(succ)
+    File.delete(succ) # a prior success marker is stale if this run isn't green
+  end
+rescue StandardError
+  nil # sentinel bookkeeping never fails the run
+end
 puts '======================================='
-exit(parity_ok ? 0 : 3)
+exit(built_ok ? 0 : 3)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_fabric.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_fabric.py
@@ -306,16 +306,10 @@ def resolve_targets(tok, model_name=None, workspace=None, report=None,
         scope = [ws] if ws else wss
         model = rep = None
         m_ws = r_ws = ws
-        if model_name:
-            for w in scope:
-                m = _match(w["models"], model_name)
-                if m:
-                    model, m_ws = m, w
-                    break
-            if not model:
-                return None
-        elif scope and scope[0]["models"]:
-            model, m_ws = scope[0]["models"][0], scope[0]
+        # Resolve the report FIRST so that, absent an explicit --model-name, we can
+        # bind the model the report ACTUALLY uses (its datasetId) instead of the
+        # workspace's first model — a silent mismatch that converts the WRONG model
+        # (observed: --report "Superstore Overview" pulled "Workforce KitchenSink").
         if report:
             for w in scope:
                 rr = _match(w["reports"], report)
@@ -324,6 +318,32 @@ def resolve_targets(tok, model_name=None, workspace=None, report=None,
                     break
             if not rep:
                 return None
+        if model_name:
+            for w in scope:
+                m = _match(w["models"], model_name)
+                if m:
+                    model, m_ws = m, w
+                    break
+            if not model:
+                return None
+        elif rep:
+            # Bind the report's own semantic model (GET reports/{id} -> datasetId).
+            dsid = report_dataset_id((r_ws or {}).get("id"), rep["id"])
+            if dsid:
+                for w in scope:
+                    m = next((mm for mm in w["models"] if mm.get("id") == dsid), None)
+                    if m:
+                        model, m_ws = m, w
+                        break
+                if not model:  # dataset not in the enumerated estate — use its id directly
+                    model, m_ws = {"id": dsid, "name": None}, r_ws
+            if not model and scope and scope[0]["models"]:
+                log("[model] WARNING: could not bind the report to its dataset (datasetId "
+                    "unavailable) — falling back to the workspace's FIRST model. Pass "
+                    "--model-name if this converts the wrong model.")
+                model, m_ws = scope[0]["models"][0], scope[0]
+        elif scope and scope[0]["models"]:
+            model, m_ws = scope[0]["models"][0], scope[0]
         return {"workspace": m_ws or r_ws, "model": model,
                 "report": rep, "report_workspace": r_ws}
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-verify-complete.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the Power BI completion sentinel (2026-07-10).
+#
+# "Done" is a fact on disk: migrate-powerbi.rb stamps phase6-success.json
+# (workbookId + chartCount + parity-pass) only on a real, non-empty, parity-
+# passing build; verify-complete.rb greens ONLY on that. Guards the exact PBI
+# failure where a blocked agent ships empty placeholder pages and calls it done.
+#
+# Usage: ruby scripts/test-verify-complete.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR = __dir__
+VC  = File.join(DIR, 'verify-complete.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+def run_vc(vc, wd, wb: nil)
+  cmd = ['ruby', vc, '--workdir', wd]; cmd += ['--workbook-id', wb] if wb
+  out = IO.popen(cmd, err: %i[child out], &:read)
+  [$?.exitstatus, out]
+end
+
+Dir.mktmpdir do |wd|
+  # 1) nothing → NOT DONE (2)
+  code, out = run_vc(VC, wd)
+  check(code == 2, "no marker => exit 2 (got #{code})", fails)
+  check(out.include?('NOT DONE') && out.include?('never hand-author'),
+        'empty-workdir message warns against hand-authoring', fails)
+
+  # 2) success marker with real charts → DONE (0)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'parity-pass',
+                           'generatedAt' => '2026-07-10T00:00:00Z'))
+  code, out = run_vc(VC, wd)
+  check(code == 0, "success + charts => exit 0 (got #{code})", fails)
+  check(out.include?('DONE') && out.include?('wb-1'), 'done message names the workbook', fails)
+
+  # 3) marker present but 0 charts → NOT DONE (3) (empty workbook)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 0))
+  code, = run_vc(VC, wd)
+  check(code == 3, "0-chart marker => exit 3 empty (got #{code})", fails)
+
+  # 4) workbook mismatch → exit 4
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9))
+  code, = run_vc(VC, wd, wb: 'wb-OTHER')
+  check(code == 4, "workbook mismatch => exit 4 (got #{code})", fails)
+end
+
+# 5) the orchestrator wires the empty-workbook guard + success stamp.
+mt = File.read(File.join(DIR, 'migrate-powerbi.rb'))
+check(mt.include?('built_ok = parity_ok && chart_els.size.positive?'),
+      'orchestrator requires real elements for a green (no vacuous empty pass)', fails)
+check(mt.include?('phase6-success.json'), 'orchestrator stamps the success sentinel', fails)
+# 6) missing-input aborts point at the device-code connect, not a bare "missing".
+check(mt.include?('fabric-extract.py') && mt.include?('microsoft.com/devicelogin'),
+      'missing --tmsl/--pbir abort prompts device-code Power BI connect', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-complete.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/verify-complete.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-complete.rb — the single offline "is this migration actually done?" check.
+#
+# A Power BI→Sigma conversion is done ONLY when migrate-powerbi.rb finished with a
+# real, parity-passing workbook — which it records by stamping
+# <workdir>/phase6-success.json (workbookId + chartCount + parity-pass) at exit 0.
+# An EMPTY / placeholder workbook (pages but no elements — the classic failure
+# where a blocked agent hand-builds a shell) never gets that marker, because the
+# orchestrator refuses to green a 0-element build. So "done" is a fact on disk,
+# not "the pages look right". Run this before claiming success or handing off.
+#
+# Usage:  ruby scripts/verify-complete.rb --workdir <dir> [--workbook-id <id>]
+#
+# Exit codes:
+#   0  DONE   — phase6-success.json present with chartCount > 0 (parity passed)
+#   2  NOT DONE — no success marker (conversion didn't complete / was hand-built)
+#   3  NOT DONE — marker present but 0 chart elements (empty workbook)
+#   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR') { |v| opts[:wd] = v }
+  p.on('--workbook-id ID') { |v| opts[:wb] = v }
+end.parse!(ARGV)
+abort 'FATAL: --workdir required' unless opts[:wd]
+
+succ = File.join(opts[:wd], 'phase6-success.json')
+unless File.exist?(succ)
+  warn '⛔ NOT DONE — no phase6-success.json in the workdir.'
+  warn '   The conversion did not complete a parity-passing build. If pages exist but are empty,'
+  warn '   they were NOT produced by a real migrate-powerbi.rb run — re-run the orchestrator'
+  warn "   (never hand-author a workbook). Workdir checked: #{opts[:wd]}"
+  exit 2
+end
+
+sj = begin
+  JSON.parse(File.read(succ))
+rescue StandardError
+  {}
+end
+
+if sj['chartCount'].to_i <= 0
+  warn '⛔ NOT DONE — success marker present but 0 chart elements (empty workbook).'
+  exit 3
+end
+if opts[:wb] && !sj['workbookId'].to_s.empty? && sj['workbookId'] != opts[:wb]
+  warn "⛔ DONE marker is for a DIFFERENT workbook (#{sj['workbookId']}) than --workbook-id #{opts[:wb]}."
+  exit 4
+end
+
+puts '✅ DONE — migrate-powerbi.rb built a parity-passing workbook for this run.'
+puts "   workbook : #{sj['workbookId']}"
+puts "   charts   : #{sj['chartCount']}"
+puts "   gates    : #{sj['gates']}"
+puts "   stamped  : #{sj['generatedAt']}"
+exit 0


### PR DESCRIPTION
## Why
A live customer session (Claude Code, **Haiku 4.5**) loaded `powerbi-to-sigma`, couldn't extract the TMSL from Fabric, then **abandoned the pipeline and hand-authored a workbook JSON + `curl`-POSTed empty placeholder pages** — bypassing DAX conversion, chart build, and the parity gate — and declared success. Result: empty canvas, invented page names (6 made-up vs the source's 17), no elements. `powerbi-to-sigma` had **none** of the guardrails added to `tableau-to-sigma` (#324/#326), so nothing funneled the agent or caught the empty result.

## What
1. **SKILL.md "STEP 1 — THE ONE PATH"**: always run `migrate-powerbi.rb`; to get the TMSL+PBIR, **CONNECT to Power BI via device-code** (`fabric-extract.py` → prints a code for `microsoft.com/devicelogin`); **never hand-author a workbook JSON or `curl`-POST placeholder pages**; if you can't extract the model, **STOP and tell the user** (do not improvise a shell). "Done" == `verify-complete.rb` exits 0.
2. **Actionable missing-input aborts**: `--tmsl`/`--pbir` missing now prints the exact device-code connect command + "do NOT hand-author," instead of a bare `missing --tmsl` that invited the improvisation.
3. **Empty-workbook guard** (closes a real hole): `parity_ok` is *vacuously* true with 0 chart elements, so an empty workbook would `exit 0` and look done. Now `built_ok = parity_ok && chart_els > 0` — a 0-element build fails (exit 3).
4. **Completion sentinel**: the orchestrator stamps `<WORK>/phase6-success.json` (workbookId + chartCount) only on a genuine green; `verify-complete.rb` greens only on that with charts > 0.

## Validation
- `test-verify-complete.rb` (4 sentinel states + orchestrator wiring + device-code abort). Full powerbi suite **14/14**; shared drift clean (all edits powerbi-local).
- Live-checked: a missing-`--tmsl` run now prints the device-code connect prompt.
- Cold-subagent E2E (funneling: does a blocked agent connect/stop vs hand-author) — running before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)