### PR TITLE
tableau: vendor B1 silent-passthrough guard (mcp-sync)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/PROVENANCE.json
@@ -1,9 +1,8 @@
 {
   "source_repo": "twells89/sigma-data-model-mcp",
-  "source_commit": "cc3e81a",
-  "source_commit_date": "2026-07-08",
-  "fast_xml_parser_version": "4.5.6",
-  "artifact": "tableau.mjs",
+  "source_commit": "c33e5bd",
+  "source_commit_date": "2026-07-10",
   "bundler": "esbuild --bundle --format=esm --platform=node",
-  "note": "Self-contained bundled artifact, not source. Refresh with scripts/dev/vendor-converter.sh after the converter changes."
+  "vendored_modules": "tableau.mjs",
+  "note": "Self-contained bundled artifacts, not source. Refresh with tools/vendor-converters.sh after the converter repo changes."
 }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/converter/tableau.mjs
@@ -2932,6 +2932,21 @@ function tableauFormulaToSigma(formula, warnings) {
   if (warnings && TABLEAU_TABLE_CALC_TOKEN_RE.test(f)) {
     warnings.push(`\u26A0 Table-calc function embedded in a larger expression \u2014 NOT translated in place. Untranslated fragment: ${f.slice(0, 120)}`);
   }
+  if (warnings) {
+    const masked = f.replace(/"[^"]*"/g, '""').replace(/\[[^\]]*\]/g, "[]");
+    const unmapped = /* @__PURE__ */ new Set();
+    const scan = /\b([A-Z][A-Z0-9_]+)\s*\(/g;
+    let mm;
+    while ((mm = scan.exec(masked)) !== null) {
+      const fn = mm[1];
+      if (TABLEAU_TABLE_CALC_TOKEN_RE.test(fn + "("))
+        continue;
+      unmapped.add(fn);
+    }
+    if (unmapped.size) {
+      warnings.push(`\u26A0 Unmapped Tableau function(s) passed through unconverted: ${[...unmapped].join(", ")} \u2014 no validated Sigma equivalent yet. Rewrite manually; left as-is they error at query time.`);
+    }
+  }
   return f.trim();
 }
 function tableauIsAggregate(formula) {


### PR DESCRIPTION
Re-vendors `converter/tableau.mjs` from `sigma-data-model-mcp@c33e5bd` so the skill's bundled converter carries the **B1 silent-passthrough guard**.

Companion to source PR **twells89/sigma-data-model-mcp#99**. Unmapped Tableau functions (`FINDNTH`, `CHAR`, `MAKEDATETIME`, `MODEL_QUANTILE`, trig family) now raise a loud warning instead of reaching Sigma as invalid verbatim syntax that fails only at query time.

Bundle regenerated via `tools/vendor-converters.sh` — diff is the esbuild output (+15 lines) plus the PROVENANCE SHA stamp. Re-vendor from `main` once #99 merges.

Bead: `beads-sigma-tt3z.1` (epic `tt3z`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)