### PR TITLE
docs: verified Sigma cross-element filter spec surface (control vs UI-only trigger)

### DIFF
--- a/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/reference/specification/controls.md
@@ -358,5 +358,16 @@ Multiple controls on the same target compose with **AND** — selecting region "
 They are not the same and both are required:
 - `id` is the element ID used internally and in `layout.md`.
 - `controlId` is a human-facing handle used when referring to this control's value from formulas or downstream logic. Pick it to be meaningful (e.g., `RegionFilter`, `DateRange`).
+
+## Cross-element filters (click-to-filter) — what IS and ISN'T spec-authorable
+
+Sigma "cross-element filtering" (user interacts with one element, other elements filter) is a **3-part construct**: a *trigger* element + a *control* + a *target*. Only part of it lives in the workbook spec — verified live 2026-07-10.
+
+- **The control half IS spec-authorable** and is the whole filtering mechanism. Author a `control` whose `filters` bind the value to the target element(s) by `elementId` + `columnId` (exactly the shape above). Any element that sources the filtered element inherits the filter. This gives a fully working cross-element filter driven by the control (a dropdown / list / range picker). Proven: setting a list control's value collapsed the target chart to exactly the filtered rows.
+- **The click-to-trigger action is UI-only** — there is **no `action` / `sequence` / `setControlValue` node in the workbook spec**. The "click a bar/cell to set the control value" binding is configured in the UI (element → **Actions** tab → *Set control value*). So a spec can deliver the *filter*, but the *click-to-fire* gesture is a post-publish UI step. (This is why a Tableau `tsl-filter` action auto-converts only ~80%: the control + targets are emittable; the click binding is documented, not generated.)
+
+### Gotcha: list-control values are STRINGS — cast numeric filter columns
+
+A `list` control's parameter/filter **values are strings**. If the target column is **numeric** (e.g. an integer `period`, `year`, `store_id`), the filter throws `400 "Expecting string"` on the value and then a runtime **500 (type mismatch)** when applied. Cast the numeric dimension to text in the control's value-source column (e.g. a `Text([…/period])` column) and bind the control to that. Text columns filter cleanly with no cast. (Verified: a text `Team` control worked; a numeric `Period` control 500'd until cast.)
 </content>
 </invoke>

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-workbook-gaps.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/scan-workbook-gaps.rb
@@ -86,7 +86,7 @@ INVENTORY = [
 
   # MANUAL — non-translatable today; needs customer to do post-publish work
   { name: 'Dashboard filter / highlight / nav actions', pat: /command='tsc:tsl-(filter|highlight|navigate|set-action|parameter-action|url)'/,
-    status: :manual, blurb: 'Skill writes actions.md listing each action; customer wires Sigma cross-element filtering after publish.' },
+    status: :manual, blurb: 'tsl-filter → Sigma cross-element filter. FAITHFUL but ~80% automatable (verified 2026-07-10): the CONTROL half is spec-authorable — emit a list control whose filters bind {source:{kind:table,elementId},columnId} to the target element(s); elements sourcing the filtered element inherit it. The click-to-trigger is UI-ONLY (no action/setControlValue node in the workbook spec) — configured post-publish via the element Actions tab. GOTCHA: list-control values are STRINGS, so a NUMERIC filter column (period/year/id) 400s ("Expecting string") then 500s at query time — cast the numeric dim to text (Text([…])) in the control value-source column; text columns work as-is. Skill still writes actions.md for the click bindings. See sigma-workbooks controls.md "Cross-element filters".' },
   { name: 'Forecast / trendline model',                pat: /<forecast\b/,
     status: :manual, blurb: 'No Sigma forecast primitive; agent emits a note + Custom SQL option (beads-sigma-yi0).' },
   { name: 'Story points (sequential narrative)',       pat: /<story\b/,


### PR DESCRIPTION
## What

Documents the **verified** spec surface for Sigma cross-element filtering, discovered during a real Tableau→Sigma slice migration (2026-07-10). Docs-only; no behavior change.

## Why

The `tableau-to-sigma` gap scanner told users to "wire cross-element filtering after publish" without saying *what is automatable vs not*. A live migration nailed down the exact boundary, so the skills should carry it.

## Verified findings (end-to-end, live workbook + Snowflake oracle)

1. **Control half IS spec-authorable.** A `control` with a `filters` binding (`{source:{kind:table,elementId},columnId}`) is the entire filtering mechanism; elements sourcing the filtered element inherit it. Flip test: setting a list control's value collapsed the target chart to exactly the filtered rows (exact parity vs warehouse).
2. **Click-to-trigger is UI-only.** There is **no `action`/`sequence`/`setControlValue` node** anywhere in the workbook spec — the "click a bar/cell → set control value" gesture is configured in the UI (element → Actions tab). So a Tableau `tsl-filter` action auto-converts ~80%: control + targets emittable, click binding documented.
3. **Numeric filter columns break.** List-control values are strings — a numeric target column throws `400 "Expecting string"` then a runtime `500` type mismatch. Cast numeric filter dims to text; text columns work as-is.

## Changes

- `sigma-workbooks/reference/specification/controls.md` — new "Cross-element filters (click-to-filter)" section + the string-value gotcha.
- `tableau-to-sigma/scripts/scan-workbook-gaps.rb` — replace the vague `tsl-filter` blurb with the precise recipe.

## Scope / follow-ups

- Docs only — the `tsl-filter → control` **emitter** (auto-generate the controls) is a separate feature PR.
- The gap-scanner `:manual` → `faithful-manual`/`lossy` split is a separate change (touches classification + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)