### PR TITLE
Harden quicksight + shared chartCount stamp; verify-complete + THE ONE PATH

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -1080,8 +1080,13 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 begin
   _wd = opts[:tab]
+  # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
+  # reach here) so verify-complete.rb has a uniform element count across plugins.
+  _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
+  _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
   File.write(File.join(_wd, 'phase6-success.json'),
              JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'chartCount' => _cc,
                                   'gates' => 'all-pass',
                                   'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
   _pend = File.join(_wd, 'parity-pending.json')

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -1080,8 +1080,13 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 begin
   _wd = opts[:tab]
+  # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
+  # reach here) so verify-complete.rb has a uniform element count across plugins.
+  _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
+  _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
   File.write(File.join(_wd, 'phase6-success.json'),
              JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'chartCount' => _cc,
                                   'gates' => 'all-pass',
                                   'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
   _pend = File.join(_wd, 'parity-pending.json')

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -1080,8 +1080,13 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 begin
   _wd = opts[:tab]
+  # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
+  # reach here) so verify-complete.rb has a uniform element count across plugins.
+  _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
+  _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
   File.write(File.join(_wd, 'phase6-success.json'),
              JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'chartCount' => _cc,
                                   'gates' => 'all-pass',
                                   'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
   _pend = File.join(_wd, 'parity-pending.json')

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/SKILL.md
@@ -58,6 +58,20 @@ never guesses.
 
 ## The one command
 
+> ## ⛔ THE ONE PATH (do not improvise a workbook)
+> `migrate-qlik.rb` is the single entry point — it discovers the Qlik app, builds
+> the DM + workbook, and **only exits 0 when parity/layout/control pass with real
+> elements built**. Rules:
+> - **NEVER hand-drive the per-phase scripts, hand-author a DM/workbook JSON, or
+>   `curl`-POST to `/v2/workbooks` / lay out empty "placeholder" pages.** That
+>   bypasses parity + the element guard and ships an EMPTY workbook — the #1 way a
+>   migration fails. If you can't reach the Qlik app (no `qlik-cli` context /
+>   auth), **STOP and tell the user to authenticate** (`qlik context` / OAuth) —
+>   do not build a shell.
+> - **"Done" is a file on disk, not "pages exist."** Complete only when
+>   `ruby scripts/verify-complete.rb --workdir <WORK>` prints ✅ DONE (the run
+>   stamped `phase6-success.json` with real elements). An empty workbook is never done.
+
 ```bash
 eval "$(scripts/vendor/get-token.sh)"          # SIGMA_BASE_URL + SIGMA_API_TOKEN
 ruby scripts/migrate-qlik.rb \

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/migrate-qlik.rb
@@ -939,6 +939,25 @@ puts "CONTROLS    : #{control_ok ? 'GREEN' : 'RED'} — gate 7 control lint, #{c
      "#{ctl_violations.any? ? ", #{ctl_violations.size} violation(s)" : ''}"
 puts "freshness   : Qlik last reload #{app_meta['lastReloadTime'] || '?'} (#{stale_days} days ago)" if stale_days
 puts "warnings    : #{conv_warnings.size} converter, #{(wb_res['warnings'] || []).size} workbook-build" if conv_warnings.any? || (wb_res['warnings'] || []).any?
+# Empty-workbook guard + completion sentinel (parity with tableau/powerbi). A
+# workbook with 0 elements must never be "done" — require real elements, and
+# stamp a run-scoped success marker only on a genuine green so verify-complete.rb
+# (the done-check the SKILL points at) can't green an empty/hand-built result.
+n_elements = wb_res['elements'].to_i
+built_ok = parity_ok && layout_ok && control_ok && n_elements.positive?
+puts 'ELEMENTS    : 0 workbook elements built — EMPTY workbook, NOT done (investigate the build).' if n_elements.zero?
+begin
+  succ = File.join(WORK, 'phase6-success.json')
+  if built_ok
+    File.write(succ, JSON.pretty_generate('workbookId' => WB_ID, 'chartCount' => n_elements,
+                                          'gates' => 'parity+layout+control',
+                                          'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
+  elsif File.exist?(succ)
+    File.delete(succ)
+  end
+rescue StandardError
+  nil
+end
 puts '======================================='
 phase_summary
-exit(parity_ok && layout_ok && control_ok ? 0 : 3)
+exit(built_ok ? 0 : 3)

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/test-verify-complete.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the Qlik completion sentinel (2026-07-10).
+#
+# "Done" is a fact on disk: migrate-qlik.rb stamps phase6-success.json
+# (workbookId + chartCount + parity-pass) only on a real, non-empty, parity-
+# passing build; verify-complete.rb greens ONLY on that. Guards the exact PBI
+# failure where a blocked agent ships empty placeholder pages and calls it done.
+#
+# Usage: ruby scripts/test-verify-complete.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR = __dir__
+VC  = File.join(DIR, 'verify-complete.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+def run_vc(vc, wd, wb: nil)
+  cmd = ['ruby', vc, '--workdir', wd]; cmd += ['--workbook-id', wb] if wb
+  out = IO.popen(cmd, err: %i[child out], &:read)
+  [$?.exitstatus, out]
+end
+
+Dir.mktmpdir do |wd|
+  # 1) nothing → NOT DONE (2)
+  code, out = run_vc(VC, wd)
+  check(code == 2, "no marker => exit 2 (got #{code})", fails)
+  check(out.include?('NOT DONE') && out.include?('never hand-author'),
+        'empty-workdir message warns against hand-authoring', fails)
+
+  # 2) success marker with real charts → DONE (0)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'parity-pass',
+                           'generatedAt' => '2026-07-10T00:00:00Z'))
+  code, out = run_vc(VC, wd)
+  check(code == 0, "success + charts => exit 0 (got #{code})", fails)
+  check(out.include?('DONE') && out.include?('wb-1'), 'done message names the workbook', fails)
+
+  # 3) marker present but 0 charts → NOT DONE (3) (empty workbook)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 0))
+  code, = run_vc(VC, wd)
+  check(code == 3, "0-chart marker => exit 3 empty (got #{code})", fails)
+
+  # 4) workbook mismatch → exit 4
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9))
+  code, = run_vc(VC, wd, wb: 'wb-OTHER')
+  check(code == 4, "workbook mismatch => exit 4 (got #{code})", fails)
+end
+
+# 5) the orchestrator wires the empty-workbook guard + success stamp.
+mt = File.read(File.join(DIR, 'migrate-qlik.rb'))
+check(mt.include?('built_ok = parity_ok && layout_ok && control_ok && n_elements.positive?'),
+      'orchestrator requires real elements for a green (no empty pass)', fails)
+check(mt.include?('phase6-success.json'), 'orchestrator stamps the success sentinel', fails)
+# 6) SKILL carries THE ONE PATH / no-hand-drive directive.
+sk = File.read(File.join(DIR, '..', 'SKILL.md'))
+check(sk.include?('THE ONE PATH') && sk.downcase.include?('never hand-drive'),
+      'SKILL carries THE ONE PATH / no-hand-drive directive', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-complete.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/verify-complete.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-complete.rb — the single offline "is this migration actually done?" check.
+#
+# A Qlik→Sigma conversion is done ONLY when migrate-qlik.rb finished with a
+# real, parity-passing workbook — which it records by stamping
+# <workdir>/phase6-success.json (workbookId + chartCount + parity-pass) at exit 0.
+# An EMPTY / placeholder workbook (pages but no elements — the classic failure
+# where a blocked agent hand-builds a shell) never gets that marker, because the
+# orchestrator refuses to green a 0-element build. So "done" is a fact on disk,
+# not "the pages look right". Run this before claiming success or handing off.
+#
+# Usage:  ruby scripts/verify-complete.rb --workdir <dir> [--workbook-id <id>]
+#
+# Exit codes:
+#   0  DONE   — phase6-success.json present with chartCount > 0 (parity passed)
+#   2  NOT DONE — no success marker (conversion didn't complete / was hand-built)
+#   3  NOT DONE — marker present but 0 chart elements (empty workbook)
+#   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR') { |v| opts[:wd] = v }
+  p.on('--workbook-id ID') { |v| opts[:wb] = v }
+end.parse!(ARGV)
+abort 'FATAL: --workdir required' unless opts[:wd]
+
+succ = File.join(opts[:wd], 'phase6-success.json')
+unless File.exist?(succ)
+  warn '⛔ NOT DONE — no phase6-success.json in the workdir.'
+  warn '   The conversion did not complete a parity-passing build. If pages exist but are empty,'
+  warn '   they were NOT produced by a real migrate-qlik.rb run — re-run the orchestrator'
+  warn "   (never hand-author a workbook). Workdir checked: #{opts[:wd]}"
+  exit 2
+end
+
+sj = begin
+  JSON.parse(File.read(succ))
+rescue StandardError
+  {}
+end
+
+if sj['chartCount'].to_i <= 0
+  warn '⛔ NOT DONE — success marker present but 0 chart elements (empty workbook).'
+  exit 3
+end
+if opts[:wb] && !sj['workbookId'].to_s.empty? && sj['workbookId'] != opts[:wb]
+  warn "⛔ DONE marker is for a DIFFERENT workbook (#{sj['workbookId']}) than --workbook-id #{opts[:wb]}."
+  exit 4
+end
+
+puts '✅ DONE — migrate-qlik.rb built a parity-passing workbook for this run.'
+puts "   workbook : #{sj['workbookId']}"
+puts "   charts   : #{sj['chartCount']}"
+puts "   gates    : #{sj['gates']}"
+puts "   stamped  : #{sj['generatedAt']}"
+exit 0

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/SKILL.md
@@ -62,6 +62,18 @@ never guesses.
 
 ## One command (preferred): `scripts/migrate-quicksight.rb`
 
+> ## ⛔ THE ONE PATH (do not improvise a workbook)
+> `migrate-quicksight.rb` is the single entry point; it only exits 0 when the
+> `assert-phase6-ran` hard gate passes with real charts. Rules:
+> - **NEVER hand-drive the per-phase scripts, hand-author a DM/workbook JSON, or
+>   `curl`-POST to `/v2/workbooks` / lay out empty "placeholder" pages** — that
+>   bypasses parity + the gate and ships an EMPTY workbook (the #1 failure mode).
+>   If you can't reach QuickSight (no AWS creds / wrong `--profile`/`--region`),
+>   **STOP and tell the user to authenticate** — do not build a shell.
+> - **"Done" is a file on disk, not "pages exist."** Complete only when
+>   `ruby scripts/verify-complete.rb --workdir <WORK>` prints ✅ DONE (the gate
+>   stamped `phase6-success.json`). An empty workbook is never done.
+
 The single-process orchestrator chains every phase below — discover (live AWS or `--from-fixtures <dir>`), convert (**zero-config**: the self-contained `converter/quicksight.mjs` bundle vendored in the skill runs `convertQuickSightToSigma` locally via `node` — no clone, no npm, no MCP; a dev's `--mcp-dir`/`$QS_MCP_DIR` build still wins; refresh with `tools/vendor-converters.sh`; only if the bundle is also absent does `convert-model.rb --emit-mcp` gate + `--converted` resume apply), the **Phase 3.5 DM-reuse check** (`qs-dm-signature.py` + `find-or-pick-dm.rb`; **reuse-first** — auto-reuses an existing DM covering all the analysis's source tables, `--reuse-dm <id>` pins one, `--skip-reuse-check` forces build new), fixup `--folder-id` → validate → post-and-readback, workbook build, layout, then the **two-pass Phase 7 parity** (`phase6-parity-quicksight.rb` emits the per-chart query list and gates; write `parity-expected.json` + `parity-actuals.json` and re-run the SAME command — phases 1–5 skip automatically) and the `assert-phase6-ran.rb --workdir` hard gate:
 
 ```bash

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1080,8 +1080,13 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 begin
   _wd = opts[:tab]
+  # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
+  # reach here) so verify-complete.rb has a uniform element count across plugins.
+  _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
+  _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
   File.write(File.join(_wd, 'phase6-success.json'),
              JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'chartCount' => _cc,
                                   'gates' => 'all-pass',
                                   'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
   _pend = File.join(_wd, 'parity-pending.json')

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-verify-complete.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the QuickSight completion sentinel (2026-07-10).
+#
+# "Done" is a fact on disk: the shared assert-phase6-ran gate stamps
+# phase6-success.json (workbookId + chartCount + gates=all-pass) only on a real
+# parity-passing build; verify-complete.rb greens only on that. Tolerant: a stamp
+# with gates=all-pass is DONE even if chartCount is 0/absent (the gate already
+# enforced charts_total>0); only a 0-chart stamp with NO gate record is "empty".
+#
+# Usage: ruby scripts/test-verify-complete.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR = __dir__
+VC  = File.join(DIR, 'verify-complete.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+def run_vc(vc, wd, wb: nil)
+  cmd = ['ruby', vc, '--workdir', wd]; cmd += ['--workbook-id', wb] if wb
+  out = IO.popen(cmd, err: %i[child out], &:read)
+  [$?.exitstatus, out]
+end
+
+Dir.mktmpdir do |wd|
+  # 1) nothing → NOT DONE (2)
+  code, out = run_vc(VC, wd)
+  check(code == 2, "no marker => exit 2 (got #{code})", fails)
+  check(out.include?('never hand-author'), 'empty-workdir message warns against hand-authoring', fails)
+
+  # 2) shared-gate stamp (gates=all-pass, chartCount>0) → DONE (0)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'all-pass'))
+  code, out = run_vc(VC, wd)
+  check(code == 0, "gated stamp + charts => exit 0 (got #{code})", fails)
+  check(out.include?('DONE') && out.include?('wb-1'), 'done message names the workbook', fails)
+
+  # 3) TOLERANCE: chartCount 0/absent but gates=all-pass → still DONE (gate enforced >0)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'gates' => 'all-pass'))
+  code, = run_vc(VC, wd)
+  check(code == 0, "gated stamp w/o chartCount => exit 0 tolerant (got #{code})", fails)
+
+  # 4) 0 charts AND no gate record → NOT DONE empty (3)
+  File.write(File.join(wd, 'phase6-success.json'), JSON.generate('workbookId' => 'wb-1', 'chartCount' => 0))
+  code, = run_vc(VC, wd)
+  check(code == 3, "0-chart + no-gates => exit 3 empty (got #{code})", fails)
+
+  # 5) workbook mismatch → exit 4
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'all-pass'))
+  code, = run_vc(VC, wd, wb: 'wb-OTHER')
+  check(code == 4, "workbook mismatch => exit 4 (got #{code})", fails)
+end
+
+# 6) orchestrator invokes the shared gate; shared gate stamps chartCount; SKILL has THE ONE PATH.
+mt = File.read(File.join(DIR, 'migrate-quicksight.rb'))
+check(mt.include?('assert-phase6-ran.rb'), 'orchestrator invokes the assert-phase6-ran hard gate', fails)
+asrt = File.read(File.join(DIR, 'assert-phase6-ran.rb'))
+check(asrt.include?('phase6-success.json') && asrt.include?("'chartCount'"),
+      'shared gate stamps phase6-success.json with chartCount', fails)
+sk = File.read(File.join(DIR, '..', 'SKILL.md'))
+check(sk.include?('THE ONE PATH') && sk.downcase.include?('never hand-drive'),
+      'SKILL carries THE ONE PATH / no-hand-drive directive', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-complete.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/verify-complete.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-complete.rb — the single offline "is this migration actually done?" check.
+#
+# A QuickSight→Sigma conversion is done ONLY when migrate-quicksight.rb finished
+# with a real, parity-passing workbook — recorded by the assert-phase6-ran hard
+# gate stamping <workdir>/phase6-success.json (workbookId + chartCount +
+# gates=all-pass) at exit 0. An empty/placeholder workbook never gets that marker
+# (the gate fails charts_total<=0). "Done" is a fact on disk, not "pages look
+# right". Run before claiming success or handing off.
+#
+# Usage:  ruby scripts/verify-complete.rb --workdir <dir> [--workbook-id <id>]
+#
+# Exit codes:
+#   0  DONE   — phase6-success.json present (gates passed; chartCount > 0 when recorded)
+#   2  NOT DONE — no success marker (conversion didn't complete / was hand-built)
+#   3  NOT DONE — marker present but 0 chart elements AND no gate record (empty)
+#   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR') { |v| opts[:wd] = v }
+  p.on('--workbook-id ID') { |v| opts[:wb] = v }
+end.parse!(ARGV)
+abort 'FATAL: --workdir required' unless opts[:wd]
+
+succ = File.join(opts[:wd], 'phase6-success.json')
+unless File.exist?(succ)
+  warn '⛔ NOT DONE — no phase6-success.json in the workdir.'
+  warn '   The conversion did not complete a parity-passing build (assert-phase6-ran did not pass).'
+  warn '   If pages exist but are empty, they were NOT produced by a real migrate-quicksight.rb run —'
+  warn "   re-run the orchestrator (never hand-author a workbook). Workdir checked: #{opts[:wd]}"
+  exit 2
+end
+
+sj = begin
+  JSON.parse(File.read(succ))
+rescue StandardError
+  {}
+end
+
+# Tolerant empty-check: fail only when there are 0 charts AND no gate record. A
+# stamp from the shared assert-phase6-ran gate always carries gates=all-pass (the
+# gate enforced charts_total>0 to be stamped), so a missing/zero chartCount with
+# a gate record still means a real green.
+if sj['chartCount'].to_i <= 0 && sj['gates'].to_s.empty?
+  warn '⛔ NOT DONE — success marker present but 0 chart elements and no gate record (empty workbook).'
+  exit 3
+end
+if opts[:wb] && !sj['workbookId'].to_s.empty? && sj['workbookId'] != opts[:wb]
+  warn "⛔ DONE marker is for a DIFFERENT workbook (#{sj['workbookId']}) than --workbook-id #{opts[:wb]}."
+  exit 4
+end
+
+puts '✅ DONE — assert-phase6-ran passed the parity/gate suite for this run.'
+puts "   workbook : #{sj['workbookId']}"
+puts "   charts   : #{sj['chartCount']}"
+puts "   gates    : #{sj['gates']}"
+puts "   stamped  : #{sj['generatedAt']}"
+exit 0

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -1080,8 +1080,13 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 begin
   _wd = opts[:tab]
+  # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
+  # reach here) so verify-complete.rb has a uniform element count across plugins.
+  _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
+  _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
   File.write(File.join(_wd, 'phase6-success.json'),
              JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'chartCount' => _cc,
                                   'gates' => 'all-pass',
                                   'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
   _pend = File.join(_wd, 'parity-pending.json')

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -1080,8 +1080,13 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 begin
   _wd = opts[:tab]
+  # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
+  # reach here) so verify-complete.rb has a uniform element count across plugins.
+  _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
+  _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
   File.write(File.join(_wd, 'phase6-success.json'),
              JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'chartCount' => _cc,
                                   'gates' => 'all-pass',
                                   'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
   _pend = File.join(_wd, 'parity-pending.json')

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -1080,8 +1080,13 @@ end
 # gate can mint, closing the "agent narrates success without the gate" hole.
 begin
   _wd = opts[:tab]
+  # chartCount from parity-final.json (gate 1 already required charts_total > 0 to
+  # reach here) so verify-complete.rb has a uniform element count across plugins.
+  _pf = (JSON.parse(File.read(File.join(_wd, 'parity-final.json'))) rescue {})
+  _cc = (_pf['charts_total'] || _pf['charts_pass'] || 0).to_i
   File.write(File.join(_wd, 'phase6-success.json'),
              JSON.pretty_generate('workbookId' => (opts[:wb] || ''),
+                                  'chartCount' => _cc,
                                   'gates' => 'all-pass',
                                   'generatedAt' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')))
   _pend = File.join(_wd, 'parity-pending.json')


### PR DESCRIPTION
Fleet rollout of the guardrails, continued.

**Shared** (assert-phase6-ran.rb, synced to all plugins): the `phase6-success.json` stamp now carries `chartCount` (read from `parity-final.json`; gate 1 already required charts_total>0). Uniform element count for `verify-complete` fleet-wide. Additive + rescue-guarded.

**QuickSight** (MEDIUM — already runs the shared empty-guarded gate): add `verify-complete.rb` (tolerant of a gate stamp without chartCount) + the SKILL `THE ONE PATH` directive (never hand-drive/hand-author/curl-POST; STOP if AWS unreachable).

Tests green; shared drift clean. Live QS check to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)