### PR TITLE
Harden cognos: close vacuous-parity escape + THE ONE PATH (dashboards must verify)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/SKILL.md
@@ -53,6 +53,20 @@ of emitting wrong logic.
 
 ## One command (orchestrated path)
 
+> ## ⛔ THE ONE PATH (do not ship an unverified/empty workbook)
+> `migrate-cognos.mjs` is the entry point. Rules:
+> - **NEVER hand-author a DM/workbook JSON and `curl`-POST it, and never ship
+>   empty "placeholder" pages.** Post only what the converter produces. If Cognos
+>   is unreachable (no CA session), **STOP and tell the user to authenticate** —
+>   don't build a shell.
+> - **Dashboards ARE hand-authored** (the converter doesn't do exploration JSON —
+>   see `refs/dashboard-migration.md`). That is the one sanctioned hand-authored
+>   path — but it is NOT exempt from verification: a hand-authored dashboard must
+>   still pass `assert-parity.mjs --check` **GREEN with real comparisons**.
+> - **"Done" requires parity GREEN with real values.** `assert-parity.mjs --check`
+>   now **refuses a vacuous pass** — 0 expected values is "NOT parity-clean" (exit
+>   1), never "0/0 GREEN". An empty/placeholder workbook is never done.
+
 ```bash
 node scripts/migrate-cognos.mjs \
   --module <module.json> --report <report.xml> \

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/assert-parity.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/assert-parity.mjs
@@ -36,6 +36,15 @@ if (a.check) {
   const actual = JSON.parse(readFileSync(a.actual, 'utf8'));
   const expected = JSON.parse(readFileSync(a.expected, 'utf8'));
   const tol = Number(a.tol ?? 0.01);
+  // Empty-check guard: 0 expected values means there is NOTHING to verify — the
+  // old loop printed "PARITY GREEN: 0/0" and exited 0, so an empty/placeholder
+  // workbook (or empty {} in/out) passed vacuously. A migration with nothing to
+  // compare is not parity-clean.
+  if (Object.keys(expected).length === 0) {
+    console.error('⛔ NOT parity-clean — 0 expected values: nothing to verify. An empty/placeholder '
+      + 'workbook cannot pass parity. Build the elements + capture the source numbers, then re-run.');
+    process.exit(1);
+  }
   const rows = []; let fail = 0;
   for (const k of Object.keys(expected)) {
     const e = Number(expected[k]), av = Number(actual[k]);

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-parity-guard.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-parity-guard.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Regression test for the cognos assert-parity empty-check guard (2026-07-10).
+//
+// Before: `assert-parity.mjs --check` with an empty `expected` ({}) printed
+// "PARITY GREEN: 0/0" and exited 0 — so an empty/placeholder workbook (or empty
+// in/out) passed vacuously. The guard refuses 0 comparisons. Offline (pure JS).
+//
+//   node scripts/test-parity-guard.mjs
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const AP = join(HERE, 'assert-parity.mjs');
+const d = mkdtempSync(join(tmpdir(), 'cog-'));
+const fails = [];
+const check = (cond, msg) => { console.log(`  ${cond ? 'PASS' : 'FAIL'}  ${msg}`); if (!cond) fails.push(msg); };
+
+function run(expected, actual) {
+  const ef = join(d, 'e.json'), af = join(d, 'a.json');
+  writeFileSync(ef, JSON.stringify(expected));
+  writeFileSync(af, JSON.stringify(actual));
+  try {
+    execFileSync('node', [AP, '--check', '--expected', ef, '--actual', af], { stdio: 'pipe' });
+    return 0;
+  } catch (e) { return e.status ?? 1; }
+}
+
+// 1) real non-empty matching → GREEN (exit 0) — happy path intact.
+check(run({ Revenue: 1000, Orders: 50 }, { Revenue: 1000, Orders: 50 }) === 0,
+  'real matching values => exit 0 (GREEN, not broken)');
+// 2) empty expected → NOT clean (exit 1) — vacuous-green hole closed.
+check(run({}, {}) === 1, 'empty expected => exit 1 (no vacuous 0/0 GREEN)');
+// 3) a genuine mismatch still fails (sanity).
+check(run({ Revenue: 1000 }, { Revenue: 5 }) === 1, 'mismatch => exit 1');
+
+console.log();
+if (fails.length) { console.log(`${fails.length} FAILURE(S):`); fails.forEach((f) => console.log(`  - ${f}`)); process.exit(1); }
+console.log('ALL PASS');


### PR DESCRIPTION
cognos was HIGH: `assert-parity.mjs --check` with empty `expected` printed 'PARITY GREEN: 0/0' → exit 0 (empty workbook passed vacuously). Also the sanctioned hand-authored dashboard path had no gate.

- `assert-parity.mjs`: 0 expected values → NOT parity-clean / exit 1.
- SKILL `THE ONE PATH`: post only converter output; never curl-POST placeholders; STOP if Cognos unreachable; **hand-authored dashboards must still pass `assert-parity --check` GREEN with real comparisons**.

Offline test `test-parity-guard.mjs` (real→0, empty→1, mismatch→1). Converter untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)