### PR TITLE
Harden microstrategy: close vacuous-parity escape + THE ONE PATH

### DIFF
--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/SKILL.md
@@ -17,6 +17,15 @@ user-invocable: true
 > `bash scripts/doctor.sh` (macOS/Linux/Git Bash) or `powershell -ExecutionPolicy Bypass -File scripts\doctor.ps1` (Windows).
 > It checks Ruby/Python/Node/bash and flags the Python "Store stub" + CRLF with exact fixes. Details: `refs/environment.md`.
 
+> ## ⛔ THE ONE PATH (do not ship an unverified/empty workbook)
+> Convert with `convert.py`, POST its specs, then verify with `verify_parity.py`. Rules:
+> - **NEVER hand-author a DM/workbook JSON and `curl`-POST it, and never ship empty
+>   "placeholder" pages.** Post only what `convert.py` produces. If MicroStrategy is
+>   unreachable (no session), **STOP and tell the user to authenticate** — don't build a shell.
+> - **`verify_parity.py` must be GREEN with REAL reports before you're done.** It now
+>   **refuses a vacuous pass** — an `expected_parity.json` with 0 reports is "NOT
+>   parity-clean" (exit 1), never a silent green. An empty/placeholder workbook is never done.
+
 ## Preflight the workbook spec before POST (mandatory)
 
 Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test_parity_guard.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/test_parity_guard.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Regression test for the microstrategy verify_parity empty-check guard (2026-07-10).
+
+Before: verify_parity.py with an empty expected_parity.json ({}) left all_green
+True (the compare loop is skipped) and exited 0 — an empty/placeholder workbook
+passed vacuously. The guard rejects 0 expected reports BEFORE any Sigma API call.
+Offline: a dummy token clears the import-time token check; the guard fires before
+the network.
+
+    python3 scripts/test_parity_guard.py
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+VP = os.path.join(HERE, "verify_parity.py")
+fails = []
+
+
+def check(cond, msg):
+    print(f"  {'PASS' if cond else 'FAIL'}  {msg}")
+    if not cond:
+        fails.append(msg)
+
+
+with tempfile.TemporaryDirectory() as d:
+    empty = os.path.join(d, "empty.json")
+    json.dump({}, open(empty, "w"))
+    env = dict(os.environ, SIGMA_API_TOKEN="dummy")  # clears the import-time token check
+    r = subprocess.run([sys.executable, VP, "--expected", empty, "--workbook-id", "wb-x"],
+                       capture_output=True, text=True, env=env)
+    check(r.returncode != 0, f"empty expected_parity.json => non-zero exit (got {r.returncode})")
+    check("NOT parity-clean" in (r.stdout + r.stderr), "prints the 0-reports NOT-parity-clean message")
+    # guard must fire BEFORE the Sigma API call (no spec GET attempted)
+    check("spec GET failed" not in (r.stdout + r.stderr), "guard fires before any Sigma API call")
+
+print()
+if fails:
+    print(f"{len(fails)} FAILURE(S):")
+    for f in fails:
+        print(f"  - {f}")
+    sys.exit(1)
+print("ALL PASS")

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify_parity.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/verify_parity.py
@@ -84,6 +84,13 @@ def main():
     args = ap.parse_args()
 
     expected = json.load(open(args.expected))
+    # Empty-check guard: 0 expected reports means nothing to verify — the loop
+    # below is skipped, all_green stays True, and an empty/placeholder workbook
+    # passes vacuously. A migration with nothing to compare is not parity-clean.
+    if not expected:
+        raise SystemExit("⛔ NOT parity-clean — expected_parity.json has 0 reports: nothing to "
+                         "verify. An empty/placeholder workbook cannot pass parity. Capture the "
+                         "MicroStrategy ground-truth values and re-run.")
     key_cols_by_report = {}
     if os.path.exists(args.keys):
         key_cols_by_report = json.load(open(args.keys))


### PR DESCRIPTION
microstrategy was HIGH: `verify_parity.py` left all_green=True on an empty `expected_parity.json` (loop skipped) → exit 0, so an empty workbook passed vacuously (its only real gate — the vendored assert-phase6-ran is orphaned).

- `verify_parity.py`: 0 expected reports → `NOT parity-clean` / exit 1, before any Sigma API call.
- SKILL `THE ONE PATH`: post only convert.py output; never curl-POST placeholders; STOP if MSTR unreachable.

**Offline E2E**: converted `fixtures/bundle.json` → real workbook (3 pages, 18 elements, intact); `verify_parity` empty → exit 1 (hole closed). Test `test_parity_guard.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)