### PR TITLE
Harden looker + thoughtspot + gooddata: verify-complete + THE ONE PATH (finish the fleet)

### DIFF
--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/SKILL.md
@@ -55,6 +55,18 @@ conversion leaves your machine.
 
 ## Phases
 
+> ## ⛔ THE ONE PATH (do not ship an unverified/empty workbook)
+> Run the phases below **in order** and finish with **Phase 4 (`verify-warehouse.rb`)**. Rules:
+> - **NEVER hand-author a DM/workbook JSON off this flow, and never ship empty
+>   "placeholder" pages.** POST only the specs `convert.py` / `build_workbook.py`
+>   produce. If GoodData isn't reachable (no token), **STOP and tell the user to
+>   authenticate** (`get-token.sh`) — don't build a shell.
+> - **`verify-warehouse.rb` must PASS (exit 0) with REAL elements before you're
+>   done** — it fails when an element returns no rows / errors AND when there are
+>   **0 elements** (`total > 0` guard), so an empty/placeholder workbook cannot
+>   pass. Running it is mandatory, not optional. "Done" is that gate green, not
+>   "pages exist."
+
 **Phase 0 — Assess.** Run the `gooddata-assessment` skill for an inventory +
 readiness readout before committing to a conversion.
 

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test-verify-guards.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/test-verify-guards.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Guard test for gooddata's empty-workbook protection + THE ONE PATH (2026-07-10).
+# verify-warehouse.rb must fail an empty workbook (total > 0 guard), and the SKILL
+# must funnel to THE ONE PATH (no hand-author). Source-level assertions.
+DIR = __dir__
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+vw = File.read(File.join(DIR, 'verify-warehouse.rb'))
+check(vw.include?('total > 0'), 'verify-warehouse fails an empty workbook (total > 0 guard)', fails)
+check(vw.include?("status == 'PASS' ? 0 : 2") || vw.include?('exit(status'), 'verify-warehouse exits non-zero on FAIL', fails)
+sk = File.read(File.join(DIR, '..', 'SKILL.md'))
+check(sk.include?('THE ONE PATH'), 'SKILL carries THE ONE PATH directive', fails)
+check(sk.downcase.include?('never hand-author') && sk.include?('must PASS'),
+      'directive forbids hand-authoring + mandates verify-warehouse PASS', fails)
+puts
+if fails.empty? then puts 'ALL PASS' else puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1 end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/SKILL.md
@@ -70,6 +70,18 @@ offline-only path that normalizes into the same contract.
 
 ## ONE COMMAND (preferred): migrate-looker.py
 
+> ## ⛔ THE ONE PATH (do not improvise a workbook)
+> `migrate-looker.py` is the single entry point; it only reaches GREEN when the
+> `assert-phase6-ran` hard gate passes with real charts. Rules:
+> - **NEVER hand-drive the per-phase scripts, hand-author a DM/workbook JSON, or
+>   `curl`-POST to `/v2/workbooks` / lay out empty "placeholder" pages** — that
+>   bypasses parity + the gate and ships an EMPTY workbook (the #1 failure mode).
+>   If Looker isn't reachable (no `~/.looker/looker.ini` / API creds), **STOP and
+>   tell the user to authenticate** — do not build a shell.
+> - **"Done" is a file on disk, not "pages exist."** Complete only when
+>   `ruby scripts/verify-complete.rb --workdir <WORK>` prints ✅ DONE (the gate
+>   stamped `phase6-success.json`). An empty workbook is never done.
+
 The whole pipeline — parse → **RLS gate** → convert → **DM-reuse check** → DM
 POST + readback → workbook build (layout inline) → **source-freshness
 preflight** → **scripted parity + hard gate** — as a single command (mirrors

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/test-verify-complete.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the Looker completion sentinel (2026-07-10).
+#
+# "Done" is a fact on disk: the shared assert-phase6-ran gate stamps
+# phase6-success.json (workbookId + chartCount + gates=all-pass) only on a real
+# parity-passing build; verify-complete.rb greens only on that. Tolerant: a stamp
+# with gates=all-pass is DONE even if chartCount is 0/absent (the gate already
+# enforced charts_total>0); only a 0-chart stamp with NO gate record is "empty".
+#
+# Usage: ruby scripts/test-verify-complete.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR = __dir__
+VC  = File.join(DIR, 'verify-complete.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+def run_vc(vc, wd, wb: nil)
+  cmd = ['ruby', vc, '--workdir', wd]; cmd += ['--workbook-id', wb] if wb
+  out = IO.popen(cmd, err: %i[child out], &:read)
+  [$?.exitstatus, out]
+end
+
+Dir.mktmpdir do |wd|
+  # 1) nothing → NOT DONE (2)
+  code, out = run_vc(VC, wd)
+  check(code == 2, "no marker => exit 2 (got #{code})", fails)
+  check(out.include?('never hand-author'), 'empty-workdir message warns against hand-authoring', fails)
+
+  # 2) shared-gate stamp (gates=all-pass, chartCount>0) → DONE (0)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'all-pass'))
+  code, out = run_vc(VC, wd)
+  check(code == 0, "gated stamp + charts => exit 0 (got #{code})", fails)
+  check(out.include?('DONE') && out.include?('wb-1'), 'done message names the workbook', fails)
+
+  # 3) TOLERANCE: chartCount 0/absent but gates=all-pass → still DONE (gate enforced >0)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'gates' => 'all-pass'))
+  code, = run_vc(VC, wd)
+  check(code == 0, "gated stamp w/o chartCount => exit 0 tolerant (got #{code})", fails)
+
+  # 4) 0 charts AND no gate record → NOT DONE empty (3)
+  File.write(File.join(wd, 'phase6-success.json'), JSON.generate('workbookId' => 'wb-1', 'chartCount' => 0))
+  code, = run_vc(VC, wd)
+  check(code == 3, "0-chart + no-gates => exit 3 empty (got #{code})", fails)
+
+  # 5) workbook mismatch → exit 4
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'all-pass'))
+  code, = run_vc(VC, wd, wb: 'wb-OTHER')
+  check(code == 4, "workbook mismatch => exit 4 (got #{code})", fails)
+end
+
+# 6) orchestrator invokes the shared gate; shared gate stamps chartCount; SKILL has THE ONE PATH.
+mt = File.read(File.join(DIR, 'migrate-looker.py'))
+check(mt.include?('assert-phase6-ran.rb'), 'orchestrator invokes the assert-phase6-ran hard gate', fails)
+asrt = File.read(File.join(DIR, 'assert-phase6-ran.rb'))
+check(asrt.include?('phase6-success.json') && asrt.include?("'chartCount'"),
+      'shared gate stamps phase6-success.json with chartCount', fails)
+sk = File.read(File.join(DIR, '..', 'SKILL.md'))
+check(sk.include?('THE ONE PATH') && sk.downcase.include?('never hand-drive'),
+      'SKILL carries THE ONE PATH / no-hand-drive directive', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-complete.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/verify-complete.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-complete.rb — the single offline "is this migration actually done?" check.
+#
+# A Looker→Sigma conversion is done ONLY when migrate-looker.rb finished
+# with a real, parity-passing workbook — recorded by the assert-phase6-ran hard
+# gate stamping <workdir>/phase6-success.json (workbookId + chartCount +
+# gates=all-pass) at exit 0. An empty/placeholder workbook never gets that marker
+# (the gate fails charts_total<=0). "Done" is a fact on disk, not "pages look
+# right". Run before claiming success or handing off.
+#
+# Usage:  ruby scripts/verify-complete.rb --workdir <dir> [--workbook-id <id>]
+#
+# Exit codes:
+#   0  DONE   — phase6-success.json present (gates passed; chartCount > 0 when recorded)
+#   2  NOT DONE — no success marker (conversion didn't complete / was hand-built)
+#   3  NOT DONE — marker present but 0 chart elements AND no gate record (empty)
+#   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR') { |v| opts[:wd] = v }
+  p.on('--workbook-id ID') { |v| opts[:wb] = v }
+end.parse!(ARGV)
+abort 'FATAL: --workdir required' unless opts[:wd]
+
+succ = File.join(opts[:wd], 'phase6-success.json')
+unless File.exist?(succ)
+  warn '⛔ NOT DONE — no phase6-success.json in the workdir.'
+  warn '   The conversion did not complete a parity-passing build (assert-phase6-ran did not pass).'
+  warn '   If pages exist but are empty, they were NOT produced by a real migrate-looker.rb run —'
+  warn "   re-run the orchestrator (never hand-author a workbook). Workdir checked: #{opts[:wd]}"
+  exit 2
+end
+
+sj = begin
+  JSON.parse(File.read(succ))
+rescue StandardError
+  {}
+end
+
+# Tolerant empty-check: fail only when there are 0 charts AND no gate record. A
+# stamp from the shared assert-phase6-ran gate always carries gates=all-pass (the
+# gate enforced charts_total>0 to be stamped), so a missing/zero chartCount with
+# a gate record still means a real green.
+if sj['chartCount'].to_i <= 0 && sj['gates'].to_s.empty?
+  warn '⛔ NOT DONE — success marker present but 0 chart elements and no gate record (empty workbook).'
+  exit 3
+end
+if opts[:wb] && !sj['workbookId'].to_s.empty? && sj['workbookId'] != opts[:wb]
+  warn "⛔ DONE marker is for a DIFFERENT workbook (#{sj['workbookId']}) than --workbook-id #{opts[:wb]}."
+  exit 4
+end
+
+puts '✅ DONE — assert-phase6-ran passed the parity/gate suite for this run.'
+puts "   workbook : #{sj['workbookId']}"
+puts "   charts   : #{sj['chartCount']}"
+puts "   gates    : #{sj['gates']}"
+puts "   stamped  : #{sj['generatedAt']}"
+exit 0

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/SKILL.md
@@ -45,6 +45,21 @@ context (curl uses the system store and works).
 
 ## ONE COMMAND (preferred): migrate-thoughtspot.py
 
+> ## ⛔ THE ONE PATH (do not improvise a workbook)
+> **Use `migrate-thoughtspot.py`** — it runs the `assert-phase6-ran` hard gate, so
+> it only reaches GREEN with real charts. Rules:
+> - **Prefer the one command over the manual `migrate.py` per-phase path** (below):
+>   the manual path does not run the completion gate, so it can leave an unverified
+>   or empty result. If you must run phases by hand, you MUST still finish with
+>   parity + `assert-phase6-ran.rb` and `verify-complete.rb`.
+> - **Never hand-drive the per-phase scripts as a cold shortcut, never hand-author
+>   a DM/workbook JSON and `curl`-POST it, and never lay out empty "placeholder"
+>   pages.** If ThoughtSpot isn't reachable (no `TS_HOST`/`TS_TOKEN`), **STOP and
+>   tell the user to authenticate** — do not build a shell.
+> - **"Done" is a file on disk.** Complete only when
+>   `ruby scripts/verify-complete.rb --workdir <WORK>` prints ✅ DONE (the gate
+>   stamped `phase6-success.json`). An empty workbook is never done.
+
 The whole pipeline — discover → DM-reuse check → convert → DM → workbooks →
 layout → **source-freshness preflight** → **scripted parity + hard gate** — as a
 single command (mirrors qlik-to-sigma's `migrate-qlik.rb`). Gates are never

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test-verify-complete.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/test-verify-complete.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Regression test for the ThoughtSpot completion sentinel (2026-07-10).
+#
+# "Done" is a fact on disk: the shared assert-phase6-ran gate stamps
+# phase6-success.json (workbookId + chartCount + gates=all-pass) only on a real
+# parity-passing build; verify-complete.rb greens only on that. Tolerant: a stamp
+# with gates=all-pass is DONE even if chartCount is 0/absent (the gate already
+# enforced charts_total>0); only a 0-chart stamp with NO gate record is "empty".
+#
+# Usage: ruby scripts/test-verify-complete.rb
+
+require 'json'
+require 'tmpdir'
+
+DIR = __dir__
+VC  = File.join(DIR, 'verify-complete.rb')
+fails = []
+def check(c, m, fails) fails << m unless c; puts "  #{c ? 'PASS' : 'FAIL'}  #{m}" end
+def run_vc(vc, wd, wb: nil)
+  cmd = ['ruby', vc, '--workdir', wd]; cmd += ['--workbook-id', wb] if wb
+  out = IO.popen(cmd, err: %i[child out], &:read)
+  [$?.exitstatus, out]
+end
+
+Dir.mktmpdir do |wd|
+  # 1) nothing → NOT DONE (2)
+  code, out = run_vc(VC, wd)
+  check(code == 2, "no marker => exit 2 (got #{code})", fails)
+  check(out.include?('never hand-author'), 'empty-workdir message warns against hand-authoring', fails)
+
+  # 2) shared-gate stamp (gates=all-pass, chartCount>0) → DONE (0)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'all-pass'))
+  code, out = run_vc(VC, wd)
+  check(code == 0, "gated stamp + charts => exit 0 (got #{code})", fails)
+  check(out.include?('DONE') && out.include?('wb-1'), 'done message names the workbook', fails)
+
+  # 3) TOLERANCE: chartCount 0/absent but gates=all-pass → still DONE (gate enforced >0)
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'gates' => 'all-pass'))
+  code, = run_vc(VC, wd)
+  check(code == 0, "gated stamp w/o chartCount => exit 0 tolerant (got #{code})", fails)
+
+  # 4) 0 charts AND no gate record → NOT DONE empty (3)
+  File.write(File.join(wd, 'phase6-success.json'), JSON.generate('workbookId' => 'wb-1', 'chartCount' => 0))
+  code, = run_vc(VC, wd)
+  check(code == 3, "0-chart + no-gates => exit 3 empty (got #{code})", fails)
+
+  # 5) workbook mismatch → exit 4
+  File.write(File.join(wd, 'phase6-success.json'),
+             JSON.generate('workbookId' => 'wb-1', 'chartCount' => 9, 'gates' => 'all-pass'))
+  code, = run_vc(VC, wd, wb: 'wb-OTHER')
+  check(code == 4, "workbook mismatch => exit 4 (got #{code})", fails)
+end
+
+# 6) orchestrator invokes the shared gate; shared gate stamps chartCount; SKILL has THE ONE PATH.
+mt = File.read(File.join(DIR, 'migrate-thoughtspot.py'))
+check(mt.include?('assert-phase6-ran.rb'), 'orchestrator invokes the assert-phase6-ran hard gate', fails)
+asrt = File.read(File.join(DIR, 'assert-phase6-ran.rb'))
+check(asrt.include?('phase6-success.json') && asrt.include?("'chartCount'"),
+      'shared gate stamps phase6-success.json with chartCount', fails)
+sk = File.read(File.join(DIR, '..', 'SKILL.md'))
+check(sk.include?('THE ONE PATH') && sk.downcase.include?('never hand-drive'),
+      'SKILL carries THE ONE PATH / no-hand-drive directive', fails)
+
+puts
+if fails.empty?
+  puts 'ALL PASS'
+else
+  puts "#{fails.size} FAILURE(S):"; fails.each { |f| puts "  - #{f}" }; exit 1
+end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-complete.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/verify-complete.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# verify-complete.rb — the single offline "is this migration actually done?" check.
+#
+# A ThoughtSpot→Sigma conversion is done ONLY when migrate-thoughtspot.rb finished
+# with a real, parity-passing workbook — recorded by the assert-phase6-ran hard
+# gate stamping <workdir>/phase6-success.json (workbookId + chartCount +
+# gates=all-pass) at exit 0. An empty/placeholder workbook never gets that marker
+# (the gate fails charts_total<=0). "Done" is a fact on disk, not "pages look
+# right". Run before claiming success or handing off.
+#
+# Usage:  ruby scripts/verify-complete.rb --workdir <dir> [--workbook-id <id>]
+#
+# Exit codes:
+#   0  DONE   — phase6-success.json present (gates passed; chartCount > 0 when recorded)
+#   2  NOT DONE — no success marker (conversion didn't complete / was hand-built)
+#   3  NOT DONE — marker present but 0 chart elements AND no gate record (empty)
+#   4  DONE-BUT-MISMATCH — success marker is for a different workbook than asked
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workdir DIR') { |v| opts[:wd] = v }
+  p.on('--workbook-id ID') { |v| opts[:wb] = v }
+end.parse!(ARGV)
+abort 'FATAL: --workdir required' unless opts[:wd]
+
+succ = File.join(opts[:wd], 'phase6-success.json')
+unless File.exist?(succ)
+  warn '⛔ NOT DONE — no phase6-success.json in the workdir.'
+  warn '   The conversion did not complete a parity-passing build (assert-phase6-ran did not pass).'
+  warn '   If pages exist but are empty, they were NOT produced by a real migrate-thoughtspot.rb run —'
+  warn "   re-run the orchestrator (never hand-author a workbook). Workdir checked: #{opts[:wd]}"
+  exit 2
+end
+
+sj = begin
+  JSON.parse(File.read(succ))
+rescue StandardError
+  {}
+end
+
+# Tolerant empty-check: fail only when there are 0 charts AND no gate record. A
+# stamp from the shared assert-phase6-ran gate always carries gates=all-pass (the
+# gate enforced charts_total>0 to be stamped), so a missing/zero chartCount with
+# a gate record still means a real green.
+if sj['chartCount'].to_i <= 0 && sj['gates'].to_s.empty?
+  warn '⛔ NOT DONE — success marker present but 0 chart elements and no gate record (empty workbook).'
+  exit 3
+end
+if opts[:wb] && !sj['workbookId'].to_s.empty? && sj['workbookId'] != opts[:wb]
+  warn "⛔ DONE marker is for a DIFFERENT workbook (#{sj['workbookId']}) than --workbook-id #{opts[:wb]}."
+  exit 4
+end
+
+puts '✅ DONE — assert-phase6-ran passed the parity/gate suite for this run.'
+puts "   workbook : #{sj['workbookId']}"
+puts "   charts   : #{sj['chartCount']}"
+puts "   gates    : #{sj['gates']}"
+puts "   stamped  : #{sj['generatedAt']}"
+exit 0


### PR DESCRIPTION
The last three (MED/MED-LOW) — they already block empty on the orchestrator path (looker/thoughtspot run the shared gate; gooddata's verify-warehouse fails total==0), so this is purely **additive**: the funnel + a done-check.

- **looker** + **thoughtspot**: `verify-complete.rb` (tolerant of the shared gate stamp) + `THE ONE PATH` directive. thoughtspot's also steers off the ungated manual `migrate.py`.
- **gooddata**: `THE ONE PATH` directive making `verify-warehouse.rb` mandatory (it already fails empty via total>0).

Tests green; shared drift clean. Completes the fleet — every plugin now has the single-entry directive + an empty/vacuous-parity guard + a completion check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)