### PR TITLE
tableau: converge Ruby translator with TS on WEEK + lock fail-closed contract (tt3z.4)

### DIFF
--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/build-charts-from-signals.rb
@@ -435,6 +435,15 @@ def translate_row_level_calc(formula, mmap, columns_by_guid = {})
   s = s.gsub(/\bIIF\s*\(/i, 'If(')
   s = s.gsub(/\bIFNULL\s*\(/i, 'Coalesce(')
   s = s.gsub(/\bABS\s*\(/i, 'Abs(')
+  # Date-part extracts — align with the TS TABLEAU_FUNC_MAP so a row-level date
+  # calc auto-translates instead of failing the residue check and dropping to a
+  # manual warning (bead tt3z.4). WEEK has NO Sigma Week() fn — it maps to
+  # DatePart("week", …) exactly like formulas.ts (bead tt3z.2). Run before the
+  # single→double-quote pass; "week" is already double-quoted here.
+  s = s.gsub(/\bWEEK\s*\(/i, 'DatePart("week", ')
+  s = s.gsub(/\bYEAR\s*\(/i, 'Year(').gsub(/\bMONTH\s*\(/i, 'Month(').gsub(/\bDAY\s*\(/i, 'Day(')
+  s = s.gsub(/\bQUARTER\s*\(/i, 'Quarter(').gsub(/\bHOUR\s*\(/i, 'Hour(')
+  s = s.gsub(/\bMINUTE\s*\(/i, 'Minute(').gsub(/\bSECOND\s*\(/i, 'Second(')
   s = s.gsub(/'([^']*)'/) { %("#{Regexp.last_match(1)}") } # remaining single-quoted strings
   out = s.gsub(/\[([^\/\]]+)\]/) do
     cap = Regexp.last_match(1).strip
@@ -444,7 +453,7 @@ def translate_row_level_calc(formula, mmap, columns_by_guid = {})
   residue = out.dup
   residue.gsub!(/"(?:\\.|[^"\\])*"/, '1')
   residue.gsub!(/\[Master\/[^\]]+\]/, '1')
-  residue.gsub!(/\b(DateDiff|DateAdd|DateTrunc|DatePart|Today|Now|If|Coalesce|Abs)\b/, '')
+  residue.gsub!(/\b(DateDiff|DateAdd|DateTrunc|DatePart|Today|Now|If|Coalesce|Abs|Year|Month|Day|Quarter|Hour|Minute|Second)\b/, '')
   return nil unless residue =~ %r{\A[\s()+\-*/.,\d!=<>]*\z}
   out
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-row-level-date-translation.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-row-level-date-translation.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+# Cross-path consistency + fail-closed guard for the Ruby formula translator
+# (bead beads-sigma-tt3z.4). The TS path (formulas.ts::tableauFormulaToSigma) and
+# this Ruby path (build-charts-from-signals.rb) had drifted:
+#   - TS: fail-OPEN until B1 — unmapped fns passed through verbatim (silent break).
+#         Fixed by the B1 catch-all (warns).
+#   - Ruby: fail-CLOSED — a residue validator returns nil on any unmapped
+#         construct and the caller warns loudly. So the dangerous silent
+#         passthrough never existed here. This test LOCKS that contract.
+# It also locks the WEEK → DatePart("week", …) fix (Sigma has no Week(), bead
+# tt3z.2) now mirrored on the Ruby path, plus the sibling date-part extracts.
+#
+# Usage:  ruby scripts/test-row-level-date-translation.rb
+DIR = __dir__
+src = File.read(File.join(DIR, 'build-charts-from-signals.rb'))
+o = Object.new
+# map_column needs the full mmap infra; nil is fine here — refs fall back to the
+# raw caption inside [Master/…], which is all the residue validator inspects.
+o.define_singleton_method(:map_column) { |_cap, _mmap| nil }
+defsrc = src.match(/^def translate_row_level_calc\b.*?\n^end$/m)
+abort 'test bug: could not extract translate_row_level_calc' unless defsrc
+o.instance_eval(defsrc[0])
+
+fails = []
+def check(cond, msg, fails)
+  fails << msg unless cond
+  puts "  #{cond ? 'PASS' : 'FAIL'}  #{msg}"
+end
+
+puts 'WEEK / date-part extracts (consistency with formulas.ts)'
+week = o.translate_row_level_calc('WEEK([Order Date])', {}, {})
+check(week&.include?('DatePart("week"'), "WEEK([Order Date]) → DatePart(\"week\", …)  (got #{week.inspect})", fails)
+check(week && !week.match?(/\bWEEK\s*\(/i), '  no residual WEEK( passthrough', fails)
+
+{ 'YEAR' => 'Year', 'MONTH' => 'Month', 'QUARTER' => 'Quarter' }.each do |tab, sig|
+  out = o.translate_row_level_calc("#{tab}([Order Date])", {}, {})
+  check(out&.include?("#{sig}("), "#{tab}([Order Date]) → #{sig}(…)  (got #{out.inspect})", fails)
+end
+
+puts 'fail-closed guarantee (never emit an unmapped Tableau fn verbatim)'
+%w[FINDNTH([Path]) CHAR([Code]) MAKEDATETIME([D])].each do |f|
+  out = o.translate_row_level_calc(f, {}, {})
+  check(out.nil?, "#{f} → nil (rejected, caller warns) — got #{out.inspect}", fails)
+end
+
+# a fully-mapped row-level calc still translates (no over-rejection)
+ok = o.translate_row_level_calc('DATEDIFF(\'day\', [Start], [End])', {}, {})
+check(ok&.include?('DateDiff("day"'), "DATEDIFF still translates (got #{ok.inspect})", fails)
+
+puts(fails.empty? ? "\nALL PASS" : "\n#{fails.size} FAILED")
+exit(fails.empty? ? 0 : 1)


### PR DESCRIPTION
## Investigation outcome
The two Tableau-formula translators had drifted — but **not in the dangerous way** the bead assumed:

| path | behavior on an unmapped function |
|---|---|
| **TS** `formulas.ts::tableauFormulaToSigma` | was fail-**open** (verbatim passthrough → silent break); fixed by the B1 catch-all (`sigma-data-model-mcp#99`) |
| **Ruby** `build-charts-from-signals.rb` | already fail-**closed** — a residue validator returns `nil` on any unmapped construct and the caller warns loudly |

So the silent-passthrough hazard never existed on the Ruby path. The real drift is **coverage**: the Ruby row-level path *rejected* `WEEK`/`YEAR`/`MONTH`/`QUARTER`/`HOUR`/`MINUTE`/`SECOND` calcs (→ manual fallback) that the TS path translates.

## Change
- Adds those date-part extracts to `translate_row_level_calc`, with **`WEEK` → `DatePart("week", …)`** exactly matching the TS WEEK fix (`sigma-data-model-mcp#100`; Sigma has no `Week()`).
- The fail-closed residue validator is unchanged (still guards correctness).

## Test
Adds `scripts/test-row-level-date-translation.rb` — locks (a) WEEK/date-part consistency with TS, and (b) the **fail-closed guarantee** (`FINDNTH`/`CHAR`/`MAKEDATETIME` → `nil`, never verbatim). Existing `test-table-calc-translation.rb` still green; `ruby -c` clean.

## Follow-up
Full single-translator convergence (Ruby shelling to the TS translator) is a larger architectural change, noted for later — this closes the concrete WEEK drift and locks the safety contract on both paths.

Bead: `beads-sigma-tt3z.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)