### PR TITLE
powerbi-to-sigma: auto-emit PBI number abbreviation, KPI centering, presentation tables

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/style-fidelity.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/style-fidelity.md
@@ -13,6 +13,8 @@ captures the signals, the builder emits the Sigma equivalents. No UI editing.
 | Card value color | card visual `objects.labels[].properties.color` | `rec['value_color']` |
 | Matrix/tableEx totals | matrix/tableEx default (honor explicit `total.show=false`) | `rec['show_totals']` |
 | Data-label toggle | `objects.labels.show` | `rec['data_labels']` (pre-existing) |
+| Number display units | `objects.labels/callout[].properties.labelDisplayUnits` (absent ⇒ PBI default `Auto`) | `rec['display_units']` (`auto`/`none`/`thousands`/…) |
+| Card callout alignment | `objects.callout/labels[].properties.alignment` | `rec['value_align']` |
 
 ## What's emitted (build-workbook-from-pbir.rb)
 
@@ -26,10 +28,11 @@ PBI colors by legend order, so donut/pie slices and multi-series charts line up.
 Unknown/absent theme → PBI's current default (`CY24SU10`).
 
 ### 2. KPI card fidelity
-A PBI card renders a big value in the theme accent with a gray caption **below** it.
-The KPI emit reproduces that: `value.color` = `rec['value_color']` (or the palette
-accent), `name` = `{text, color:{kind:theme, ref:colors-textNeutral}}`, and
-`layout.titleOrient: bottom`.
+A PBI card renders a big value in the theme accent with a gray caption **below** it,
+**centered** in the card. The KPI emit reproduces that: `value.color` =
+`rec['value_color']` (or the palette accent), `name` = `{text, color:{kind:theme,
+ref:colors-textNeutral}}`, `layout.titleOrient: bottom`, and `layout.anchor`
+(centered by default — see §6). All handled by `lib/pbi_style.rb`.
 
 ### 3. Pivot grand totals
 PBI matrices/tableEx show a **Grand Total** row by default. A grouped Sigma `table`
@@ -54,17 +57,87 @@ donut/pie (per-element `color.scheme` is silently dropped there — the workbook
 `Coalesce([dim], "(Blank)")`, which both matches PBI's label and sorts ahead of
 letters (`(` < `A`) — so every slice gets the color PBI gave it.
 
-## 5. Number "K"/thousands — known approximation (NOT auto-transformed)
-PBI "display units: Thousands, 0 dp" (`$121K`, `$8K`) is **fixed** thousands scaling.
-Sigma's compact `formatString` uses d3 `s` = **significant figures**, so:
-- `$,.2s` renders `$121,347` → `$120K` (2 sig figs drops the 1) and `$8,358` → `$8.4K`.
-- No d3 `formatString` reproduces PBI's whole-thousands-K across all magnitudes.
+## 5. Number abbreviation ("K"/"M") — now auto-emitted (`lib/pbi_style.rb`)
+PBI cards and charts default to **display units "Auto"**, which abbreviates large
+values (`$126K`, `$1.2M`). PBI *serializes `labelDisplayUnits` only when non-default*,
+so an **absent** signal means Auto ⇒ abbreviate. The builder honors this:
 
-The exact match is a display hack — divide the measure by 1000 and add a literal `K`
-suffix (`Sum(...)/1000`, `format: {prefix:"$", suffix:"K", formatString:",.0f"}` →
-`$121K`). It changes the value's semantics (now in thousands), so the converter does
-**not** apply it silently — it emits the standard format and this is the documented
-gotcha. Apply the hack per-KPI in the UI if a pixel match is required.
+- `rec['display_units']` absent (`nil`) or anything but `none` → **abbreviate** the
+  element's **measure** columns; explicit `none` → keep full precision.
+- **KPI** value columns → `$,.3s` (3 sig figs keeps a 6-digit value honest:
+  `$125,916` → `$126k`, not `$130k`). **Chart** data labels → `$,.2s` (denser).
+- Currency `$` prefix is preserved; **percents/ratios are never abbreviated**
+  (`.1%` untouched, and an *unformatted* ratio like a bare YoY% is left alone —
+  abbreviating `0.26` → `260m` would be wrong).
+- An unformatted **sibling** measure (e.g. a "Prior Year" column with no format)
+  inherits the element's currency so it abbreviates consistently with its peers.
+- **Tables keep full precision** — PBI matrices/tableEx show full numbers
+  (`$17,581`), so `table`/`pivot-table` measure columns are **not** abbreviated.
+
+**Known approximation (irreducible via `formatString`):** Sigma's compact format is
+d3 `s` notation — **lowercase** `k`/`M` and **significant-figures** based, so it can't
+reproduce PBI's *uppercase whole-thousands* exactly (`$84,760` → `$84.8k`, where PBI
+shows `$85K`). The only exact match is the divide-by-1000 + literal-`K`-suffix hack,
+which changes the value's semantics (now stored in thousands) and breaks tooltips/axes
+— so the builder emits the honest `s` format and this residual is documented, not
+silently hacked. (Prior versions skipped abbreviation entirely; the compact `s` form
+is a strictly closer match and is now the default.)
+
+## 6. KPI card alignment (`layout.anchor`)
+PBI stat cards center their callout. The KPI emit sets `layout.anchor` from
+`rec['value_align']` (`left`→`start`, `right`→`end`, `center`→`middle`), defaulting to
+**`middle`** when PBI didn't specify — centered stat cards are the house default for
+migrations and match the common PBI card look. Set an explicit PBI alignment to
+override. (`PbiStyle.kpi_anchor`.)
+
+## 7. Presentation table style (`tableStyle`)
+PBI matrices/tableEx read as roomy, lightly-ruled "presentation" tables, not Sigma's
+dense spreadsheet grid. Every migrated `table`/`pivot-table` gets
+`tableStyle: {preset: presentation, cellSpacing: medium, gridLines: horizontal,
+banding: shown}` (does not clobber an explicitly-set style).
+(`PbiStyle.presentation_table!`.)
+
+## 8. Other PBIR-derived formats — roadmap (what else the report file carries)
+The PBIR encodes more visual style than we port today. Prioritized by value ×
+reliability (all mechanical reads of `visual.objects[...].properties`):
+
+| Signal | PBIR source | Sigma target | Status |
+|---|---|---|---|
+| Decimal precision | `labelPrecision` | `formatString` `.Nf` decimals | planned |
+| Legend position | `legend.position` (`Top`/`Right`/…) | chart legend `position` | planned (`show` already ported) |
+| Axis titles / visibility | `categoryAxis/valueAxis.showAxisTitle`, `.titleText`, `.show` | chart axis `title`, `visibility` | planned |
+| Explicit series colors | `dataPoint[].properties.fill` per series | `color.scheme` (bar/line/combo) | partial (theme palette by order) |
+| Title font / size / color | `title.properties.{fontSize,fontColor,alignment}` | element `titleFont` / `themeOverrides.titleFont` | planned |
+| Y-axis gridlines | `valueAxis.gridlineShow` | chart gridlines | planned |
+| Negative-number / currency-symbol / separators | number-format structured props | `format` structured fields (`prefix`,`currencySymbol`,…) | planned |
+| Total label / subtotal toggles | matrix `subTotals`, `total.label` | pivot `totals` | partial |
+| Page/canvas background | `section.objects.background` | `themeOverrides.colorOverrides.backgroundCanvas` | planned |
+
+Conditional formatting (background/font scales, rules, data bars) is **already**
+ported (`rec['conditional_formats']` → Sigma `conditionalFormats`).
+
+## 9. Recovering style the PBIR omits — the PNG fallback
+Some style never reaches the PBIR: it's a **theme default** PBI doesn't serialize
+(the `$126K` abbreviation is exactly this — `labelDisplayUnits` was absent), a
+report-theme JSON we can't resolve to hex, or an org theme applied at view time. When
+a signal is absent, the **source render** is ground truth. The Phase-5e compare
+already exports the PBI pages (`export-pbi-pages.py`, PNG→PDF fallback); that image
+can also be **sampled** to recover style the file dropped:
+
+| Recover from PNG | How | Feeds |
+|---|---|---|
+| KPI accent / series palette (hex) | sample dominant non-neutral pixels in each KPI value / chart mark region | `value.color`, `themeOverrides.categoricalScheme` |
+| Whether values are abbreviated + case | OCR/needle a KPI tile: does it read `$126K` vs `$125,916`? | confirm `display_units` when `nil` |
+| Value/label alignment | centroid of the value text within its card bbox | `layout.anchor` |
+| Data-label / legend presence | detect label glyphs / legend swatches in the render | confirm `data_labels`/`legend` when `nil` |
+
+Design: a `pbi-style-from-png.py` enrichment that runs **only when the PBIR signal is
+`nil`** and a source render exists — it never overrides an explicit PBIR value, and it
+degrades to the documented defaults when no render is available (as here: this
+tenant's `ExportToFile` 404s, so we relied on the `nil`→abbreviate/centered defaults).
+**Not yet implemented** — the color path (sampling the KPI accent + categorical
+palette) is the highest-value first cut, since theme-hex is the least reliable PBIR
+signal.
 
 ## 6. Conditional formatting (table / matrix)
 PBI table & matrix conditional formatting (`objects.values[]` backColor/fontColor +
@@ -103,3 +176,8 @@ isn't in the migrated table, and the two non-mappable modes, are recorded to
 - Cold builder run emits `themeName`/`themeOverrides` (CY24SU10 palette), KPI
   `value.color`+`titleOrient`, donut `Coalesce(..., "(Blank)")`, and the tableEx→pivot
   totals re-expression — 0 dropped/degraded in coverage.
+- §5–§7 (`lib/pbi_style.rb`): `scripts/test-pbi-style.rb` (26 assertions, offline)
+  pins the abbreviation/anchor/presentation logic. Live-verified on the Retail
+  Performance & Trends workbook (2026-07-10): KPIs render `$126k` / `$84.8k` centered,
+  chart labels `$37k`/`$49k`, and the Region table in the presentation preset — matching
+  the PBI source (POST → `GET /spec` round-trip → PNG export compared to the source).

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/build-workbook-from-pbir.rb
@@ -50,6 +50,7 @@ require 'json'
 require 'optparse'
 require_relative 'lib/layout'
 require_relative 'lib/pbi_theme'
+require_relative 'lib/pbi_style'
 require_relative 'lib/pbi_conditional_formats'
 include SigmaLayout
 
@@ -917,8 +918,11 @@ def build_element(rec, fields, masters, extra_data = [])
         col = { 'id' => "#{kid}-v", 'formula' => measure_formula(fs), 'name' => qr_leaf(qr) }
         apply_fmt(col, qr, fields, vfmts)
         e = { 'id' => kid, 'kind' => 'kpi-chart', 'name' => qr_leaf(qr),
-              'columns' => [col], 'value' => { 'columnId' => "#{kid}-v" } }
+              'columns' => [col], 'value' => { 'columnId' => "#{kid}-v" },
+              'layout' => { 'titleOrient' => 'bottom', 'anchor' => PbiStyle.kpi_anchor(rec['value_align']) } }
         e['source'] = { 'elementId' => master_id, 'kind' => 'table' } if master_id
+        # Style fidelity: abbreviate the card value (early return skips the tail).
+        PbiStyle.abbreviate_measures!(e, rec['display_units'], 'kpi-chart')
         e
       end
     end
@@ -938,7 +942,10 @@ def build_element(rec, fields, masters, extra_data = [])
     el['value']['color'] = rec['value_color'] || $pbi_accent
     el['name'] = { 'text' => qr_leaf(qr, 'Value'),
                    'color' => { 'kind' => 'theme', 'ref' => 'colors-textNeutral' } }
-    el['layout'] = { 'titleOrient' => 'bottom' }
+    # Style fidelity: caption below the value (titleOrient), and CENTER the card
+    # contents (anchor) — PBI stat cards center; overridable from a PBI alignment
+    # signal. Abbreviation of the value column happens in the shared tail below.
+    el['layout'] = { 'titleOrient' => 'bottom', 'anchor' => PbiStyle.kpi_anchor(rec['value_align']) }
   when 'region-map'
     loc = (b['Category'] || b['Location'] || []).first
     meas = (b['Y'] || b['Values'] || []).first
@@ -1354,6 +1361,14 @@ def build_element(rec, fields, masters, extra_data = [])
 
   # Controls reference a master column; they carry no columns array of their own.
   el['columns'] = cols unless el['kind'] == 'control'
+  # Style fidelity (refs/style-fidelity.md §5-7) — applied AFTER columns are
+  # attached so the measure-column formats exist to rewrite:
+  #   §5 number abbreviation — KPI/chart measure columns render compact ("$126k")
+  #       to match PBI's default "Auto" display units (tables keep full precision).
+  #   §7 presentation table style — PBI matrices/tableEx read as roomy tables.
+  # (KPI anchor §6 is set in the kpi-chart branch, next to titleOrient.)
+  PbiStyle.abbreviate_measures!(el, rec['display_units'], el['kind'])
+  PbiStyle.presentation_table!(el, el['kind'])
   # bead miu7: never ship an unresolved literal-ref column (type=error). Drop it
   # and prune its references — the tile degrades honestly into coverage instead.
   drop_unresolved_columns!(el, rec, kind) unless el['kind'] == 'control'

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
@@ -358,6 +358,45 @@ def _card_value_color(visual):
     return None
 
 
+_DISPLAY_UNITS = {
+    "0": "auto", "1": "none", "1000": "thousands", "1000000": "millions",
+    "1000000000": "billions", "1000000000000": "trillions",
+}
+
+
+def _display_units(visual):
+    """PBI number display units (objects.labels/callout/calloutValue[].properties.
+    labelDisplayUnits) -> 'auto'|'none'|'thousands'|'millions'|... or None.
+
+    PBI serializes this only when NON-default, so None means the report is on the
+    default 'Auto' (which abbreviates large values, e.g. '$126K'). The builder
+    treats None/anything-but-'none' as abbreviate; explicit 'none' = full
+    precision. (Style fidelity §5.)"""
+    objs = visual.get("objects", {}) or {}
+    for key in ("labels", "callout", "calloutValue", "dataLabels"):
+        for item in objs.get(key, []) or []:
+            props = (item or {}).get("properties", {}) or {}
+            du = _literal(props.get("labelDisplayUnits"))
+            if du is not None:
+                return _DISPLAY_UNITS.get(str(du).split(".")[0], "auto")
+    return None
+
+
+def _card_alignment(visual):
+    """PBI card callout horizontal alignment (objects.callout/labels[].properties.
+    alignment | horizontalAlignment) -> 'left'|'center'|'right' or None. The
+    builder maps it to the Sigma kpi-chart layout.anchor; None -> centered
+    default (PBI stat cards center). (Style fidelity §6.)"""
+    objs = visual.get("objects", {}) or {}
+    for key in ("callout", "calloutValue", "labels", "general"):
+        for item in objs.get(key, []) or []:
+            props = (item or {}).get("properties", {}) or {}
+            a = _literal(props.get("alignment") or props.get("horizontalAlignment"))
+            if a:
+                return str(a).lower()
+    return None
+
+
 def _show_totals(visual, vtype):
     """PBI matrix/tableEx show a Grand Total by default -> True; honor an explicit
     off toggle -> False. Non-table visuals -> None (irrelevant)."""
@@ -625,6 +664,13 @@ def extract(pbir_dir):
                 # Sigma pivot-table totals:{showGrandTotals} (builder re-expresses a
                 # grouped table as a pivot when set).
                 "show_totals": _show_totals(visual, vtype),
+                # style fidelity §5: PBI number display units (None = default
+                # 'Auto' = abbreviate). Builder emits compact d3 `s` format on
+                # KPI/chart measure columns to match PBI's "$126K" look.
+                "display_units": _display_units(visual),
+                # style fidelity §6: PBI card callout alignment -> KPI layout.anchor
+                # (None = centered default).
+                "value_align": _card_alignment(visual),
                 # table/matrix conditional formatting (background/font color-scales,
                 # rules, field-value measures, data bars) -> Sigma conditionalFormats.
                 "conditional_formats": _conditional_formats(visual, vtype),

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_style.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/pbi_style.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+# pbi_style.rb — style-fidelity transforms shared by build-workbook-from-pbir.rb
+# and its tests. Pure functions over the Sigma element hash + the PBI `rec`
+# signals; NO API, NO creds. Tested by scripts/test-pbi-style.rb.
+#
+# Three transforms live here (see refs/style-fidelity.md §5-7):
+#   1. Number abbreviation — PBI cards/charts default to display-units "Auto"
+#      (compact "$126K"); Sigma defaults to full ("$125,916"). We emit d3
+#      compact `s` notation on KPI/chart MEASURE columns so the migrated look
+#      matches. Tables keep full precision (PBI tables do too).
+#   2. KPI card alignment — PBI stat cards center their callout; we center by
+#      default via layout.anchor (overridable from a PBI alignment signal).
+#   3. Table presentation preset — PBI matrices/tableEx read as roomy
+#      "presentation" tables, not the dense spreadsheet grid Sigma defaults to.
+module PbiStyle
+  # A roomier, lighter table look that matches how source BI tools render
+  # dashboard tables (verified round-trips + renders live 2026-06-24).
+  PRESENTATION_TABLE_STYLE = {
+    'preset'      => 'presentation',
+    'cellSpacing' => 'medium',
+    'gridLines'   => 'horizontal',
+    'banding'     => 'shown'
+  }.freeze
+
+  KPI_KIND    = 'kpi-chart'
+  CHART_KINDS = %w[kpi-chart bar-chart line-chart area-chart combo-chart donut-chart pie-chart].freeze
+  TABLE_KINDS = %w[table pivot-table].freeze
+
+  # d3 `s` precision: KPIs carry one big value → 3 sig figs keeps 6-digit values
+  # honest ($125,916 → $126k, not $130k); chart data labels are denser → 2.
+  KPI_PRECISION   = 3
+  CHART_PRECISION = 2
+
+  module_function
+
+  # PBI serializes labelDisplayUnits only when NON-default. Absent (nil) = the
+  # PBI default "Auto", which abbreviates. Explicit "none" = full precision.
+  # Everything else (auto/thousands/millions/…) abbreviates.
+  def abbreviates?(display_units)
+    display_units.to_s.strip.downcase != 'none'
+  end
+
+  # PBI card callout alignment → Sigma kpi-chart layout.anchor.
+  # Default (no signal) = 'middle': stat cards read best centered, and it's the
+  # requested house default for PBI migrations. An explicit PBI alignment wins.
+  def kpi_anchor(value_align = nil)
+    case value_align.to_s.strip.downcase
+    when 'left'  then 'start'
+    when 'right' then 'end'
+    when 'center', 'middle' then 'middle'
+    else 'middle'
+    end
+  end
+
+  # The measure (value) column ids of a built element, by binding — the columns
+  # whose numbers should abbreviate. Dimensions are never abbreviated.
+  def measure_col_ids(el)
+    ids = []
+    ids << el.dig('value', 'columnId') if el.dig('value', 'columnId') # kpi-chart
+    ids << el.dig('value', 'id')       if el.dig('value', 'id')       # pie/donut
+    Array(el.dig('yAxis', 'columnIds')).each do |y|                   # bar/line/area/combo
+      ids << (y.is_a?(Hash) ? y['columnId'] : y)
+    end
+    ids.compact.uniq
+  end
+
+  # Rewrite a measure column's format to compact `s` notation, preserving a `$`
+  # currency prefix. Skips percents (never abbreviate a ratio). Returns the new
+  # format hash, or nil to leave the column untouched.
+  #   existing "$,.0f"  + currency → "$,.<p>s"
+  #   existing ",.0f"   (plain)    → ",.<p>s"
+  #   no format, currency sibling  → "$,.<p>s"
+  #   no format, no currency clue  → nil  (can't classify — e.g. a bare ratio)
+  def compact_format(existing, precision, currency_sibling)
+    fs = existing.is_a?(Hash) ? existing['formatString'].to_s : ''
+    return nil if fs.include?('%')                       # percent — leave alone
+    if fs.start_with?('$')
+      { 'kind' => 'number', 'formatString' => "$,.#{precision}s" }
+    elsif !fs.empty?
+      { 'kind' => 'number', 'formatString' => ",.#{precision}s" }
+    elsif currency_sibling
+      { 'kind' => 'number', 'formatString' => "$,.#{precision}s" }
+    end
+  end
+
+  # Abbreviate every measure column of a KPI/chart element in place.
+  # No-op unless the element is a KPI/chart and PBI's display units abbreviate.
+  def abbreviate_measures!(el, display_units, kind = nil)
+    kind ||= el['kind']
+    return el unless CHART_KINDS.include?(kind)
+    return el unless abbreviates?(display_units)
+
+    precision = kind == KPI_KIND ? KPI_PRECISION : CHART_PRECISION
+    ids  = measure_col_ids(el)
+    cols = el['columns'] || []
+    # If any measure column is currency, treat the whole element as currency so
+    # an unformatted sibling (e.g. a "Prior Year" column) picks up the `$` too.
+    currency_sibling = ids.any? do |cid|
+      c = cols.find { |x| x['id'] == cid }
+      c && c['format'].is_a?(Hash) && c.dig('format', 'formatString').to_s.start_with?('$')
+    end
+    ids.each do |cid|
+      col = cols.find { |x| x['id'] == cid }
+      next unless col
+      f = compact_format(col['format'], precision, currency_sibling)
+      col['format'] = f if f
+    end
+    el
+  end
+
+  # Add the presentation table style to a table/pivot-table (does not clobber an
+  # already-set tableStyle).
+  def presentation_table!(el, kind = nil)
+    kind ||= el['kind']
+    return el unless TABLE_KINDS.include?(kind)
+    el['tableStyle'] ||= PRESENTATION_TABLE_STYLE.dup
+    el
+  end
+end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-style.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-pbi-style.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# test-pbi-style.rb — regression test for lib/pbi_style.rb (style fidelity §5-7:
+# number abbreviation, KPI anchor, presentation table). Offline: no API, no creds.
+# Run: ruby scripts/test-pbi-style.rb
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'pbi_style'
+
+$fail = 0
+def ok(name, cond); puts((cond ? "  ok  " : "FAIL  ") + name); $fail += 1 unless cond; end
+def fmt(el, cid); (el['columns'].find { |c| c['id'] == cid } || {}).dig('format', 'formatString'); end
+
+S = PbiStyle
+
+# --- abbreviates? : nil/auto/thousands abbreviate; explicit 'none' does not ----
+ok('abbreviates? nil (PBI default Auto)', S.abbreviates?(nil) == true)
+ok('abbreviates? auto',                   S.abbreviates?('auto') == true)
+ok('abbreviates? thousands',              S.abbreviates?('thousands') == true)
+ok('abbreviates? none = full precision',  S.abbreviates?('none') == false)
+
+# --- kpi_anchor : center by default; explicit PBI alignment wins ---------------
+ok('kpi_anchor nil -> middle',   S.kpi_anchor(nil) == 'middle')
+ok('kpi_anchor left -> start',   S.kpi_anchor('left') == 'start')
+ok('kpi_anchor right -> end',    S.kpi_anchor('right') == 'end')
+ok('kpi_anchor center -> middle', S.kpi_anchor('center') == 'middle')
+
+# --- compact_format : preserve $, skip %, classify unformatted by sibling ------
+ok('compact $ currency -> $,.3s', S.compact_format({ 'formatString' => '$,.0f' }, 3, false) == { 'kind' => 'number', 'formatString' => '$,.3s' })
+ok('compact plain number -> ,.2s', S.compact_format({ 'formatString' => ',.0f' }, 2, false) == { 'kind' => 'number', 'formatString' => ',.2s' })
+ok('compact percent -> nil (never abbreviate a ratio)', S.compact_format({ 'formatString' => '.1%' }, 3, false).nil?)
+ok('compact unformatted + currency sibling -> $,.2s', S.compact_format(nil, 2, true) == { 'kind' => 'number', 'formatString' => '$,.2s' })
+ok('compact unformatted + no currency clue -> nil', S.compact_format(nil, 2, false).nil?)
+
+# --- measure_col_ids : value.columnId (kpi) / value.id (donut) / yAxis ---------
+kpi  = { 'kind' => 'kpi-chart', 'value' => { 'columnId' => 'v' } }
+bar  = { 'kind' => 'bar-chart', 'yAxis' => { 'columnIds' => ['y0', { 'columnId' => 'y1', 'type' => 'line' }] } }
+donut = { 'kind' => 'donut-chart', 'value' => { 'id' => 'dv' } }
+ok('measure_col_ids kpi',   S.measure_col_ids(kpi) == ['v'])
+ok('measure_col_ids bar (string + hash)', S.measure_col_ids(bar) == %w[y0 y1])
+ok('measure_col_ids donut', S.measure_col_ids(donut) == ['dv'])
+
+# --- abbreviate_measures! : the KPI + chart transforms end-to-end --------------
+kpi_el = {
+  'kind' => 'kpi-chart', 'value' => { 'columnId' => 'v' },
+  'columns' => [{ 'id' => 'v', 'format' => { 'kind' => 'number', 'formatString' => '$,.0f' } }]
+}
+S.abbreviate_measures!(kpi_el, nil, 'kpi-chart')
+ok('KPI currency value -> $,.3s (precision 3)', fmt(kpi_el, 'v') == '$,.3s')
+
+pct_kpi = {
+  'kind' => 'kpi-chart', 'value' => { 'columnId' => 'v' },
+  'columns' => [{ 'id' => 'v', 'format' => { 'kind' => 'number', 'formatString' => '.1%' } }]
+}
+S.abbreviate_measures!(pct_kpi, nil, 'kpi-chart')
+ok('KPI percent value untouched', fmt(pct_kpi, 'v') == '.1%')
+
+# bar with a formatted currency measure + an UNFORMATTED prior-year sibling:
+# the sibling inherits the element's currency and both go to $,.2s (chart precision).
+bar_el = {
+  'kind' => 'bar-chart', 'yAxis' => { 'columnIds' => %w[y0 y1] },
+  'columns' => [
+    { 'id' => 'x' },                                                    # dim, must stay untouched
+    { 'id' => 'y0', 'format' => { 'kind' => 'number', 'formatString' => '$,.0f' } },
+    { 'id' => 'y1' }                                                    # unformatted PY column
+  ]
+}
+S.abbreviate_measures!(bar_el, nil, 'bar-chart')
+ok('bar currency measure -> $,.2s',        fmt(bar_el, 'y0') == '$,.2s')
+ok('bar unformatted sibling -> $,.2s',     fmt(bar_el, 'y1') == '$,.2s')
+ok('bar dimension column untouched',       (bar_el['columns'].find { |c| c['id'] == 'x' }).key?('format') == false)
+
+# display_units 'none' -> no abbreviation (full precision honored)
+full_el = {
+  'kind' => 'kpi-chart', 'value' => { 'columnId' => 'v' },
+  'columns' => [{ 'id' => 'v', 'format' => { 'kind' => 'number', 'formatString' => '$,.0f' } }]
+}
+S.abbreviate_measures!(full_el, 'none', 'kpi-chart')
+ok('display_units none keeps full $,.0f', fmt(full_el, 'v') == '$,.0f')
+
+# tables never abbreviate (PBI tables show full numbers too)
+tbl_el = {
+  'kind' => 'pivot-table', 'values' => ['c1'],
+  'columns' => [{ 'id' => 'c1', 'format' => { 'kind' => 'number', 'formatString' => '$,.0f' } }]
+}
+S.abbreviate_measures!(tbl_el, nil, 'pivot-table')
+ok('pivot-table values NOT abbreviated', fmt(tbl_el, 'c1') == '$,.0f')
+
+# --- presentation_table! -------------------------------------------------------
+t = { 'kind' => 'table' }; S.presentation_table!(t, 'table')
+ok('table gets presentation tableStyle', t.dig('tableStyle', 'preset') == 'presentation')
+k = { 'kind' => 'kpi-chart' }; S.presentation_table!(k, 'kpi-chart')
+ok('kpi-chart gets NO tableStyle', !k.key?('tableStyle'))
+pre = { 'kind' => 'pivot-table', 'tableStyle' => { 'preset' => 'spreadsheet' } }
+S.presentation_table!(pre, 'pivot-table')
+ok('existing tableStyle not clobbered', pre.dig('tableStyle', 'preset') == 'spreadsheet')
+
+puts $fail.zero? ? "\nall pbi-style tests passed" : "\n#{$fail} FAILED"
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
## Why
The PBI→Sigma style-fidelity layer reproduced **data + layout** but read as "the right charts, plain":

- KPIs/charts showed **full numbers** (`$125,916`) where PBI abbreviates (`$126K`)
- KPI cards were **left-aligned** where PBI **centers** them
- Migrated tables used Sigma's dense **spreadsheet** grid vs PBI's roomy **presentation** look

`style-fidelity.md §5` was an explicit punt ("number K/thousands — NOT auto-transformed"). This closes the gap and matches PBI far more closely, driven off the report file.

## What
New **`lib/pbi_style.rb`** (pure, offline, unit-tested by **`test-pbi-style.rb`** — 26 assertions):

- **§5 Number abbreviation** — KPI/chart **measure** columns emit compact d3 `s` (KPI `$,.3s` → `$126k`; chart `$,.2s` → `$37k`), governed by PBI display units. PBI serializes `labelDisplayUnits` only when non-default, so **absent ⇒ "Auto" ⇒ abbreviate**; explicit `none` ⇒ full precision. Percents/ratios are **never** abbreviated; an unformatted sibling (e.g. a Prior-Year column) inherits the element's currency. **Tables keep full precision** (PBI tables do too).
- **§6 KPI alignment** — `layout.anchor` from PBI card alignment, **default centered**.
- **§7 Presentation tables** — `tableStyle: {preset: presentation, …}` on migrated `table`/`pivot-table`.

`extract-pbir.py` adds `_display_units` + `_card_alignment` → `rec['display_units']`, `rec['value_align']`. `build-workbook-from-pbir.rb` applies the transforms centrally after columns attach (single **and** multiRowCard KPI paths covered).

## Known residual (documented, not hacked)
d3 `s` is **lowercase** + **significant-figures**, so PBI's uppercase whole-thousands (`$85K`) can't be matched exactly (`$84.8k`) without the semantics-changing `/1000` + literal-`K` hack — so we emit the honest `s` format. `style-fidelity.md §8` adds a **roadmap** of other PBIR-derived formats; **§9** designs a **PNG-fallback** to recover style the PBIR omits (theme-default colors, abbreviation when `labelDisplayUnits` is absent).

## Verification
- `scripts/test-pbi-style.rb` — 26 assertions, green. Full `powerbi-to-sigma` test suite green; ruby/python syntax clean; shared-file gate passes.
- **Live-verified** on the *Retail Performance & Trends* workbook (2026-07-10): extract → build → `validate-spec` (0 errors) → the emitted spec produces KPIs `$126k`/`$84.8k` **centered**, chart labels `$37k`/`$49k`, and the Region table in the **presentation** preset — matching the PBI source (POST → `GET /spec` round-trip → PNG export compared to source).

Bead: beads-sigma-6awz