### PR TITLE
Windows portability strategy (ADR) + bash-free Node orchestration template

### DIFF
--- a/shared/examples/node-orchestration-template/README.md
+++ b/shared/examples/node-orchestration-template/README.md
@@ -1,0 +1,58 @@
+# Node orchestration template (bash-free, cross-platform)
+
+A minimal, runnable reference for **Phase 1** of
+[`../../refs/portability-strategy.md`](../../refs/portability-strategy.md): how a skill
+orchestrator should be written so it runs **identically on macOS, Linux, and native Windows
+PowerShell/cmd** — no bash, no `eval`, no `/tmp` literal, no `curl`, no `jq`, no `unzip` binary.
+
+New skills (and any substantial rewrite of an existing one) should follow this shape. It is the
+distilled version of the cognos-to-sigma Node orchestrator, with the one remaining bash dependency
+removed.
+
+## Run it
+
+```
+# proves the cross-platform primitives — NO Sigma credentials needed (safe in CI):
+node orchestrate.mjs --self-test
+
+# real run — shell-neutral auth then a live Sigma GET:
+python scripts/get_token.py --workdir <WORKDIR>   # identical in bash / PowerShell / cmd
+node orchestrate.mjs --workdir <WORKDIR>
+```
+
+Requires Node >= 18 (for global `fetch`). The zip helper additionally needs a real Python 3
+(resolved Store-stub-safe via `py_resolve`).
+
+## The patterns (and the anti-patterns they replace)
+
+| Concern | Do this | Instead of | Old hit |
+|---|---|---|---|
+| **Auth** | `lib/auth.mjs`: env → `<workdir>/auth.json` → helpful cross-shell error | `eval "$(get-token.sh)"`; `spawnSync('bash', ['-c', ...])` | `migrate-cognos.mjs:102` |
+| **Temp/work dir** | `lib/paths.mjs`: `os.tmpdir()` + `--workdir` | hardcoded `"/tmp/..."` | `pbi_exec.py:3`, `probe-controls.rb:81` |
+| **HTTP** | global `fetch` (`lib/sigma-rest.mjs`) | `curl` | `wb-rep.rb:409`, `verify_parity.py:26` |
+| **JSON** | native `JSON.parse` | `jq` | `wb-rep.rb:413-417` |
+| **Unzip** | `lib/extract-zip.mjs` → Python stdlib `zipfile` (or `fflate`) | `unzip` binary | `tableau-discover.rb:196` |
+| **Python interp** | `lib/py_resolve.mjs` (rejects the Windows Store stub) | bare `python3` | `test-telemetry-gate.rb:24` |
+
+### On zip specifically
+
+Node has **no** built-in zip-archive reader (`zlib` is gzip/deflate only). `lib/extract-zip.mjs`
+uses **Python's stdlib `zipfile`** — cross-platform, and Python is already a required runtime. If
+you are building a Node-only skill and want to drop the Python dependency, swap in a pure-JS lib
+(`fflate` / `yauzl`) — both are dependency-light with no native compilation.
+
+## Files
+
+- `orchestrate.mjs` — the entry point; `--self-test` and a real `--workdir` run.
+- `lib/auth.mjs` — shell-neutral credential load.
+- `lib/sigma-rest.mjs` — `fetch`-based REST client + arg parser.
+- `lib/paths.mjs` — cross-platform workdir/temp helpers.
+- `lib/py_resolve.mjs` — Store-stub-safe Python resolver (sibling of `shared/lib/py_resolve.rb`).
+- `lib/extract-zip.mjs` — cross-platform archive extraction.
+
+## Not shown (intentionally)
+
+This template is about the **portability seam**, not a full migration. Real converters are the
+esbuild-bundled `converter/*.mjs` (source of truth: `sigma-data-model-mcp/src/*.ts`) — call those,
+don't reimplement conversion here. Gates (`assert-doctor-ran.rb`, parity checks) still apply and
+compose on top of this shape.

--- a/shared/examples/node-orchestration-template/lib/auth.mjs
+++ b/shared/examples/node-orchestration-template/lib/auth.mjs
@@ -1,0 +1,40 @@
+// auth.mjs — SHELL-NEUTRAL Sigma credential load. No bash, no `eval`, no curl.
+//
+// This is the pattern that replaces `eval "$(get-token.sh)"` (bash-only) and the
+// `spawnSync('bash', ['-c', 'eval "$(get-token.sh)" ...'])` shim still living in
+// cognos-to-sigma/scripts/migrate-cognos.mjs:102. It works identically in bash,
+// PowerShell, and cmd.
+//
+// Resolution order (same contract as shared/lib/sigma_rest.rb):
+//   1. env SIGMA_API_TOKEN + SIGMA_BASE_URL           (already exported / CI secret)
+//   2. <workdir>/auth.json written by `python scripts/get_token.py --workdir <W>`
+//   3. fail with a cross-shell instruction (never a bash-only one)
+//
+// auth.json shape: { "token": "...", "baseUrl": "https://aws-api.sigmacomputing.com", ... }
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function loadSigmaAuth(workdir) {
+  let base = process.env.SIGMA_BASE_URL;
+  let token = process.env.SIGMA_API_TOKEN;
+
+  if (!token && workdir) {
+    const authPath = join(workdir, 'auth.json');
+    if (existsSync(authPath)) {
+      const a = JSON.parse(readFileSync(authPath, 'utf8'));
+      token = a.token || a.access_token || a.SIGMA_API_TOKEN;
+      base = base || a.baseUrl || a.base_url || a.SIGMA_BASE_URL;
+    }
+  }
+
+  if (!token || !base) {
+    // Deliberately shell-neutral: this instruction runs verbatim on Windows.
+    console.error(
+      'Missing Sigma credentials. Run this first (identical in bash / PowerShell / cmd):\n' +
+      '  python scripts/get_token.py --workdir <WORKDIR>\n' +
+      'then re-run with --workdir <WORKDIR>. (Or export SIGMA_API_TOKEN + SIGMA_BASE_URL.)',
+    );
+    process.exit(2);
+  }
+  return { base: base.replace(/\/$/, ''), token };
+}

--- a/shared/examples/node-orchestration-template/lib/extract-zip.mjs
+++ b/shared/examples/node-orchestration-template/lib/extract-zip.mjs
@@ -1,0 +1,28 @@
+// extract-zip.mjs — cross-platform archive extraction, the honest replacement for
+// shelling `unzip` (tableau-discover.rb:196, fetch-all-twbs.rb:223) which does not
+// exist on stock Windows.
+//
+// IMPORTANT: Node has NO built-in zip-archive reader (`zlib` is gzip/deflate only).
+// So the portable choices are:
+//   (a) Python's stdlib `zipfile` — cross-platform, and Python is already a required
+//       runtime. We resolve a real interpreter via py_resolve (Store-stub-safe).  ← used here
+//   (b) a pure-JS lib (`fflate` / `yauzl`) — no native compile, if you want to drop
+//       the Python dependency for a Node-only skill.
+//
+// This uses (a): one stdlib Python one-liner, no `unzip` binary, no temp script file.
+import { spawnSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { pythonArgv } from './py_resolve.mjs';
+
+export function extractZip(zipPath, destDir) {
+  mkdirSync(destDir, { recursive: true });
+  const PY = pythonArgv();
+  const code =
+    'import sys,zipfile;' +
+    'zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])';
+  const r = spawnSync(PY[0], [...PY.slice(1), '-c', code, zipPath, destDir], { encoding: 'utf8' });
+  if (r.status !== 0) {
+    throw new Error(`extractZip failed (${zipPath} → ${destDir}): ${r.stderr || r.stdout || 'unknown error'}`);
+  }
+  return destDir;
+}

--- a/shared/examples/node-orchestration-template/lib/paths.mjs
+++ b/shared/examples/node-orchestration-template/lib/paths.mjs
@@ -1,0 +1,20 @@
+// paths.mjs — cross-platform workdir/temp helpers. This is the replacement for the
+// ~48 hardcoded `/tmp/...` literals across the Ruby/Python scripts (e.g.
+// probe-controls.rb:81, pbi_exec.py:3, extract-pbir.py:37, build_workbook.py:339).
+//
+// `os.tmpdir()` resolves correctly on every OS (/tmp, /var/folders on macOS,
+// %TEMP% on Windows) — never hardcode "/tmp".
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdirSync } from 'node:fs';
+
+// Resolve a working dir: explicit --workdir wins, else a namespaced temp dir.
+export function resolveWorkdir(explicit, namespace = 'sigma-migration') {
+  const dir = explicit || join(tmpdir(), namespace);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function workPath(workdir, ...parts) {
+  return join(workdir, ...parts);
+}

--- a/shared/examples/node-orchestration-template/lib/py_resolve.mjs
+++ b/shared/examples/node-orchestration-template/lib/py_resolve.mjs
@@ -1,0 +1,34 @@
+// py_resolve.mjs — find a REAL Python interpreter, robust to the Windows Store
+// "App Execution Alias" stub (a zero-op shim under ...\WindowsApps\ that silently
+// does nothing when run non-interactively). JS sibling of shared/lib/py_resolve.rb.
+//
+//   import { pythonArgv } from './py_resolve.mjs';
+//   const PY = pythonArgv();                 // e.g. ['python3'] or ['py','-3']
+//   spawnSync(PY[0], [...PY.slice(1), script, ...args], opts);
+//
+// Returns an argv array (the Windows launcher is two tokens). Memoized per process.
+// Override with SIGMA_PYTHON / PYTHON.
+import { spawnSync } from 'node:child_process';
+
+let _pyArgv;
+
+export function pythonArgv() {
+  if (_pyArgv) return _pyArgv;
+  const isWin = process.platform === 'win32';
+  const real = (cand) => {
+    const v = spawnSync(cand[0], [...cand.slice(1), '--version'], { encoding: 'utf8' });
+    if (v.status !== 0 || !/Python\s+\d/i.test(`${v.stdout || ''}${v.stderr || ''}`)) return false;
+    if (isWin) { // reject an interpreter that lives under WindowsApps (the stub)
+      const e = spawnSync(cand[0], [...cand.slice(1), '-c', 'import sys; print(sys.executable)'], { encoding: 'utf8' });
+      if (e.status === 0 && /windowsapps/i.test(e.stdout || '')) return false;
+    }
+    return true;
+  };
+  for (const k of ['SIGMA_PYTHON', 'PYTHON']) {
+    const v = (process.env[k] || '').trim();
+    if (v && real(v.split(/\s+/))) return (_pyArgv = v.split(/\s+/));
+  }
+  const cands = isWin ? [['py', '-3'], ['python3'], ['python']] : [['python3'], ['python']];
+  for (const c of cands) { if (real(c)) return (_pyArgv = c); }
+  return (_pyArgv = isWin ? ['py', '-3'] : ['python3']); // let the caller's error path fire
+}

--- a/shared/examples/node-orchestration-template/lib/sigma-rest.mjs
+++ b/shared/examples/node-orchestration-template/lib/sigma-rest.mjs
@@ -1,0 +1,47 @@
+// sigma-rest.mjs — fetch-based Sigma REST helper. Zero unix-CLI dependency:
+// no curl (uses global fetch), no jq (uses native JSON). Cross-platform as-is.
+//
+// Improves on cognos-to-sigma/scripts/lib/sigma-rest.mjs by taking creds from the
+// shell-neutral auth.mjs loader instead of assuming an already-`eval`-ed env.
+import { loadSigmaAuth } from './auth.mjs';
+
+export function makeClient(workdir) {
+  const { base, token } = loadSigmaAuth(workdir);
+
+  async function api(method, path, body) {
+    const res = await fetch(base + path, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: body == null ? undefined : (typeof body === 'string' ? body : JSON.stringify(body)),
+    });
+    const text = await res.text();
+    let json = null;
+    try { json = JSON.parse(text); } catch { /* Sigma /spec POST can return YAML or empty */ }
+    return { status: res.status, ok: res.ok, text, json };
+  }
+
+  return { base, api };
+}
+
+// Sigma POST /spec returns JSON ({"workbookId":...}) OR YAML (workbookId: ...). Pull either.
+export function extractId(r, field) {
+  if (r.json && r.json[field]) return r.json[field];
+  const m = r.text.match(new RegExp(`${field}:\\s*"?([0-9a-f-]{36})`, 'i'));
+  return m ? m[1] : null;
+}
+
+// Tiny --flag parser: returns { flag: value | true }.
+export function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith('--')) continue;
+    const k = argv[i].slice(2);
+    const next = argv[i + 1];
+    out[k] = (next == null || next.startsWith('--')) ? true : (i++, next);
+  }
+  return out;
+}

--- a/shared/examples/node-orchestration-template/orchestrate.mjs
+++ b/shared/examples/node-orchestration-template/orchestrate.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// orchestrate.mjs — minimal, fully bash-free Node orchestration TEMPLATE.
+//
+// This is the convergence reference for Phase 1 of shared/refs/portability-strategy.md:
+// a skill orchestrator that runs identically on macOS, Linux, and native Windows
+// PowerShell/cmd — no bash, no eval, no /tmp literal, no curl, no jq, no `unzip`.
+//
+// Two modes:
+//   node orchestrate.mjs --self-test
+//       Exercises the cross-platform primitives (workdir, py_resolve, zip round-trip)
+//       and prints a PASS/FAIL report. Needs NO Sigma credentials — safe in CI.
+//   node orchestrate.mjs --workdir <W>
+//       Real run: shell-neutral auth (env or <W>/auth.json) → a live Sigma GET.
+//
+// Compare with cognos-to-sigma/scripts/migrate-cognos.mjs, which is the same shape but
+// still shells to bash for its token (migrate-cognos.mjs:102) — the one thing to fix.
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, existsSync } from 'node:fs';
+import { makeClient, parseArgs } from './lib/sigma-rest.mjs';
+import { resolveWorkdir, workPath } from './lib/paths.mjs';
+import { pythonArgv } from './lib/py_resolve.mjs';
+import { extractZip } from './lib/extract-zip.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+
+// ---- self-test: prove the cross-platform primitives, no creds needed ----
+if (a['self-test']) {
+  const results = [];
+  const check = (name, fn) => {
+    try { const detail = fn(); results.push({ name, ok: true, detail }); }
+    catch (e) { results.push({ name, ok: false, detail: e.message }); }
+  };
+
+  check('workdir resolves cross-platform (no /tmp literal)', () => {
+    const w = resolveWorkdir(null, 'sigma-template-selftest');
+    if (w.includes('/tmp/')) throw new Error(`workdir hardcoded /tmp: ${w}`);
+    return w;
+  });
+
+  check('py_resolve finds a real Python (Store-stub-safe)', () => {
+    const PY = pythonArgv();
+    const v = spawnSync(PY[0], [...PY.slice(1), '--version'], { encoding: 'utf8' });
+    if (v.status !== 0) throw new Error('no real python found');
+    return `${PY.join(' ')} → ${(v.stdout || v.stderr).trim()}`;
+  });
+
+  check('zip round-trip via Python stdlib (no `unzip` binary)', () => {
+    const w = resolveWorkdir(null, 'sigma-template-selftest');
+    const zip = workPath(w, 'sample.zip');
+    const dest = workPath(w, 'unzipped');
+    const PY = pythonArgv();
+    // build a tiny zip with stdlib, then extract it with our helper
+    const mk = spawnSync(PY[0], [...PY.slice(1), '-c',
+      'import sys,zipfile;z=zipfile.ZipFile(sys.argv[1],"w");z.writestr("hello.txt","hi");z.close()',
+      zip], { encoding: 'utf8' });
+    if (mk.status !== 0) throw new Error(`could not build sample zip: ${mk.stderr}`);
+    extractZip(zip, dest);
+    if (!existsSync(workPath(dest, 'hello.txt'))) throw new Error('extracted file missing');
+    return `${zip} → ${dest}/hello.txt`;
+  });
+
+  check('fetch is available (no curl dependency)', () => {
+    if (typeof fetch !== 'function') throw new Error('global fetch missing — need Node >= 18');
+    return `fetch present (Node ${process.version})`;
+  });
+
+  const pass = results.every((r) => r.ok);
+  for (const r of results) console.log(`${r.ok ? 'PASS' : 'FAIL'}  ${r.name}\n        ${r.detail}`);
+  console.log(`\n${pass ? 'ALL PASS' : 'FAILURES PRESENT'} — platform=${process.platform}, node=${process.version}`);
+  process.exit(pass ? 0 : 1);
+}
+
+// ---- real run: shell-neutral auth → a live Sigma call ----
+const workdir = resolveWorkdir(a.workdir, 'sigma-migration');
+const { base, api } = makeClient(workdir); // reads env → <workdir>/auth.json (never bash/eval)
+
+console.error(`[template] base=${base} workdir=${workdir}`);
+const me = await api('GET', '/v2/members?limit=1'); // harmless read to prove auth
+if (!me.ok) {
+  console.error(`Sigma call failed (HTTP ${me.status}): ${me.text.slice(0, 300)}`);
+  process.exit(1);
+}
+const out = workPath(workdir, 'orchestrate-result.json');
+writeFileSync(out, JSON.stringify({ base, status: me.status, sample: me.json }, null, 2));
+console.log(`OK — authenticated against ${base}; wrote ${out}`);

--- a/shared/refs/portability-strategy.md
+++ b/shared/refs/portability-strategy.md
@@ -1,0 +1,194 @@
+# Cross-platform / Windows portability strategy (ADR)
+
+**Status:** Proposed · **Date:** 2026-07-10 · **Scope:** `sigma-migration-skills`, `sigma-skills`, and the shared runtime.
+
+This is the decision record for how we make the migration skills run on Windows (and stay
+cross-platform), and why we are **not** rewriting them in Rust. It is the companion to the
+day-to-day setup guide in [`environment.md`](./environment.md) — that doc tells a user how to
+get running; this doc tells a contributor where we are headed and why.
+
+---
+
+## TL;DR
+
+- **The languages are not the problem.** Ruby (419 files) and Python (201 files) here are
+  ~99% standard library. There is no Gemfile; the only native gem (`nokogiri`) is optional with
+  a stdlib REXML fallback. Python's only real deps (`msal`, `requests`, `truststore`, `PyYAML`)
+  all ship Windows wheels. Native-compilation risk is ≈ zero.
+- **The connective tissue is the problem:** bash-only shell scripts, hardcoded `/tmp`, and
+  shell-outs to unix CLIs (`unzip`, `jq`, `curl`, `sips`, `aws`, `bash`), plus interpreter
+  naming (`python3` vs the Windows Store `python.exe` stub) and CRLF/BOM.
+- **Rust is rejected.** No performance case (this is I/O-bound REST orchestration), worst-case
+  ergonomics for LLM-authored/edited scripts, a ~150k-LOC rewrite of gate-hardened code, and it
+  does not fix a single one of the actual failures above.
+- **Direction: converge on Node/TypeScript incrementally**, because the hard logic (the
+  converters) already lives there (`sigma-data-model-mcp` → vendored `converter/*.mjs`), and Node
+  is already a required runtime on every migration. Fewer runtimes + no required bash is the goal.
+- **Do the cheap thing first.** We are ~70% of the way to "works on Windows" already. Finish the
+  shell-neutral hot path (self-scoped as "P1" in PR #299) before any rewrite of anything.
+
+---
+
+## Context
+
+The skills are invoked by an agent that reads `SKILL.md`, runs `scripts/*`, and frequently
+**edits those scripts mid-migration** to handle a given source. The runtime today is three
+languages glued with bash:
+
+| Layer | Language | Role |
+|---|---|---|
+| Converters (the hard logic) | **TypeScript** (`sigma-data-model-mcp`) | Parse Tableau/PBI/Qlik/etc. → Sigma spec. Vendored to skills as esbuild-bundled `converter/*.mjs`. Single source of truth. |
+| Orchestration / build / verify | **Ruby** (~105k LOC) + **Python** (~43k LOC) | REST calls, spec assembly, layout, gates, parity. |
+| Glue / auth / discovery | **bash** (57 `.sh`) | Token fetch, discovery lanes, env. |
+
+Field reports from Windows users (RubyInstaller / no-admin setups) surface as failures in the
+**glue**, not the language runtimes.
+
+---
+
+## What actually breaks on Windows
+
+In priority order, with representative hits found in a full-tree inventory (2026-07-10):
+
+1. **Bash as a *required* runtime.** 57 `.sh` scripts + bash-only idioms.
+   - `eval "$(get-token.sh)"` — has no cmd/PowerShell equivalent.
+   - Process substitution `< <(...)`, `paste -sd` — e.g. `sigma-skills` `verify-workbook.sh`.
+   - Ruby/Python that shell to bash: `migrate-thoughtspot.py:104`, `migrate-looker.py:176`
+     (`subprocess.run(["bash", "get-token.sh"])`).
+   - **Even the "Node-first" cognos orchestrator still bashes for its token:**
+     `cognos-to-sigma/.../migrate-cognos.mjs:102` runs `spawnSync('bash', ['-c', 'eval "$(get-token.sh)" ...'])`.
+2. **Hardcoded `/tmp`.** ~30 literal Ruby defaults + 18 Python files. Windows has no `/tmp`.
+   Examples: `probe-controls.rb:81`, `phase6-parity-pbi.rb:111` (`/tmp/pbiauth/cache.bin`),
+   `pbi_exec.py:3`, `extract-pbir.py:37`, `build_workbook.py:339`. The portable pattern
+   (`Dir.tmpdir` / `tempfile.gettempdir()`) is already used 160+ times elsewhere — these are the
+   stragglers.
+3. **Unix CLI shell-outs.**
+   - `unzip` — `.twbx`/`.twb` extraction (`tableau-discover.rb:196`, `fetch-all-twbs.rb:223`).
+   - `jq` — OpenAPI parsing (`sigma-workbooks/scripts/wb-rep.rb:413-417`, `validate-spec.sh`).
+   - `curl` — `wb-rep.rb:409`, `verify_parity.py:26`, PBI auth.
+   - `sips` — mac-only image scaling (2 sites); `aws` — QuickSight (works if AWS CLI v2 installed).
+4. **Interpreter naming.** `python3` vs `python` vs the Microsoft Store `python.exe`
+   App-Execution-Alias stub; POSIX venv layout `/tmp/pbiauth/bin/python` (Windows uses `Scripts\`).
+5. **CRLF / BOM.** `git core.autocrlf` mangles shebangs; BOM breaks JSON reads.
+
+None of these is a property of Ruby-vs-Python-vs-Rust. They are properties of *how the glue was
+written*.
+
+---
+
+## What already exists (do not rebuild)
+
+A large, coherent cross-platform layer is already in place (branch `feat/windows-env-doctor` →
+PRs #224/#251/#284/**#299**/#303/#306/#310):
+
+| Capability | Status | Where |
+|---|---|---|
+| OS-aware preflight **doctor** (bash + PowerShell), machine-readable `doctor.json`, enforced gate | Done; CI-smoke-tested on `windows-2022` | `shared/scripts/doctor.{sh,ps1}`, `assert-doctor-ran.rb` |
+| Store-stub-proof Python resolution | Done in Ruby **and** Node | `py_resolve.rb`, `lib/py_resolve.mjs` |
+| Shell-neutral token handoff (no `eval`) — the documented default | Done | `shared/scripts/get_token.py` → `auth.json` (0600); `sigma_rest.rb` reads env → `auth.json` → self-mint |
+| Bash-free Sigma + Tableau write path (in-process token mint) | Done | `migrate-tableau.rb` |
+| Windows footgun docs (Store stub, RubyInstaller, no-admin `fnm`, CRLF, truststore) | Done | [`environment.md`](./environment.md) |
+| Cross-platform converter engine | Done | `sigma-data-model-mcp/src/*.ts` → `converter/*.mjs` via `tools/vendor-converters.sh` |
+
+**Important nuance on "23 PowerShell files":** that is *one* file (`doctor.ps1`) mechanically
+fanned out by `tools/sync-shared.rb`, not 23 hand-maintained scripts. The only hand-kept PS↔bash
+pair is `doctor.{sh,ps1}`. **Do not** PowerShell-port the other 40 `.sh` files — that would create
+the dual-maintenance burden we currently do not have. Retire bash; don't mirror it.
+
+---
+
+## Options considered
+
+### A. "Add Windows helpers to every skill" (PowerShell twins everywhere)
+Partly right, partly a trap. The *spine* (doctor, shell-neutral tokens) is correct and mostly
+built. But porting every `.sh` to `.ps1` doubles maintenance forever and CI can only lint drift,
+not correctness. The right version of A is **eliminate bash, don't port it**.
+
+### B. Rewrite in Rust — **REJECTED**
+- **No performance case.** Every script is I/O-bound REST orchestration + JSON/XML/YAML munging.
+  There are zero CPU-bound hot paths. Rust's value proposition buys nothing here.
+- **Worst-case ergonomics for *this* codebase.** These scripts are authored and edited by the
+  agent mid-run (e.g. `build-charts-from-signals.rb` is 5,500 lines the model reasons over and
+  patches). Rust is the hardest mainstream language for an LLM to emit correctly in one shot
+  (lifetimes, borrow checker, strict types). We would trade a forgiving edit loop for a
+  compile-and-fight loop.
+- **~150k-LOC rewrite** (105k Ruby + 43k Python) of battle-tested, gate-hardened code —
+  re-litigating every fidelity fix and silent-drop workaround. Enormous regression surface, zero
+  user-visible benefit.
+- **It fixes nothing.** The breakage is bash/`/tmp`/`jq`/`unzip`; a Rust rewrite touches none of
+  it. Worse, it *regresses* our best current property — today there is **no** native compilation;
+  a Rust stack makes *everything* a per-OS compiled binary to build, sign, and ship.
+
+### C. Converge on Node/TypeScript incrementally — **CHOSEN**
+- The hard logic (converters) is **already** TS in the MCP; Node is **already** required on every
+  migration (the vendored `.mjs`).
+- Node is natively cross-platform: `os.tmpdir()` (no `/tmp`), `fetch` (no `curl`), native JSON
+  (no `jq`), one interpreter (no `python3`/Store-stub/venv-layout mess).
+- It collapses three runtimes toward one, deleting the largest section of the doctor and an entire
+  class of footguns — and it kills the **bilingual twin** maintenance we already carry
+  (`sigma_rest.rb` *and* `sigma_rest.py`).
+- It follows a trend already in the repo: cognos is already Node-first orchestration, and
+  `py_resolve` already has a `.mjs` twin.
+
+> **Accuracy note:** Node has **no** built-in zip-archive reader (`zlib` is gzip/deflate only).
+> The honest cross-platform replacement for shelling `unzip` is **Python's stdlib `zipfile`**
+> (already a required runtime, resolved via `py_resolve`) or a pure-JS lib (`fflate`/`yauzl`,
+> no native compile) — not "Node built-in." See the template's `lib/extract-zip.mjs`.
+
+---
+
+## Decision & phased plan
+
+**No big-bang rewrite in any language.** Convergence happens by natural churn, cheapest wins first.
+
+### Phase 0 — Finish "works on Windows" on the current stack (highest ROI; ~70% done)
+This is the "P1" already scoped in PR #299. Tracked as beads under the portability epic
+(`beads-sigma-*`, see the epic for the file:line backlog):
+- Retire bash as a *required* runtime: replace the ~40 non-doctor `.sh` helpers and the
+  `subprocess(["bash", …])` / `spawnSync('bash', …)` call sites with the `.py`/`.rb`/`.mjs` twin
+  that is already the pattern for `get_token`.
+- Sweep the ~48 `/tmp` literals → `Dir.tmpdir` / `tempfile.gettempdir()` / `os.tmpdir()`.
+- Replace `jq` (native JSON), `curl` (`net/http` / `urllib` / `fetch`); replace `unzip` with
+  Python `zipfile` (or `fflate`); make `sips` mac-only-optional or drop it.
+- Apply `PyResolve` uniformly (e.g. `test-telemetry-gate.rb:24` still hardcodes `python3`).
+- Fix the POSIX venv assumption (`bin/` → `Scripts\` fallback) in the PowerBI path.
+
+**Exit criterion:** the doctor's REQUIRED runtime list is Ruby + Python + Node — **not bash** —
+and a clean-Windows migration of one representative skill passes end-to-end in CI.
+
+### Phase 1 — Set direction: new work goes to Node/TS
+Freeze net-new Ruby/Python *orchestrators*. New skills and any substantial rewrite land in TS,
+colocated with the converter engine, using **cognos as the template** (and the
+[`node-orchestration-template`](../examples/node-orchestration-template/) in this repo as the
+minimal, bash-free reference). This also retires bilingual-twin maintenance over time.
+
+### Phase 2 — Opportunistic migration
+Port the highest-churn Ruby orchestrators to TS only when they are being substantially reworked
+anyway. Let churn do the heavy lifting; do not force a 150k-LOC event.
+
+---
+
+## Consequences
+
+- **Positive:** Windows unblocked without a rewrite; fewer runtimes; no bilingual twins; the
+  doctor shrinks; new work lands where the converters already are.
+- **Negative / cost:** a long-lived mixed-language period (Ruby + Python + Node coexist for a
+  while); Phase-1 discipline required to avoid adding new Ruby/Python orchestrators; contributors
+  must know the cross-platform primitives (documented in the template).
+- **Explicitly not chosen:** Rust (see B); PowerShell-porting every `.sh` (see A).
+
+---
+
+## The one-line summary
+
+The wrong path was **three runtimes glued with bash**, not Ruby the language. The fix is **fewer
+runtimes and no required bash**, converging on the Node/TS layer we already depend on — finish the
+shell-neutral work first (near-done), then let Node absorb orchestration over time.
+
+## References
+- [`environment.md`](./environment.md) — user setup + Windows footguns.
+- `shared/examples/node-orchestration-template/` — minimal bash-free Node orchestration reference.
+- `shared/scripts/doctor.{sh,ps1}`, `assert-doctor-ran.rb` — the preflight gate.
+- `shared/scripts/get_token.py`, `shared/lib/sigma_rest.rb` — shell-neutral auth.
+- `sigma-data-model-mcp/src/*.ts` + `tools/vendor-converters.sh` — the converter engine.
+- PR #299 — shell-neutral token + `doctor.json` gate + bash-free Sigma path (the P0 tier).


### PR DESCRIPTION
## What & why

TJ asked for a full analysis of the Windows pain in the migration skills (and sigma-skills): people on Windows keep hitting Ruby/Python issues — should we add Windows helpers everywhere, or rewrite in something cross-platform like Rust?

This PR lands the **decision record** plus a **runnable reference** for the recommended direction. No production skill is touched.

## Findings (grounded in a full-tree inventory)

- **The languages are not the problem.** Ruby is ~99% stdlib (no Gemfile; sole native gem `nokogiri` is optional w/ REXML fallback). Python's only real deps (`msal`/`requests`/`truststore`/`PyYAML`) all ship Windows wheels. Native-compile risk ≈ 0.
- **The glue is the problem:** 57 bash scripts, ~48 hardcoded `/tmp` literals, shell-outs to `unzip`/`jq`/`curl`/`sips`/`aws`/`bash`, and `python3` vs the Windows Store stub.
- **A lot of Windows work already exists** (doctor.sh/.ps1 + doctor.json gate, shell-neutral `get_token.py`→`auth.json`, in-process Tableau token mint, `py_resolve`) — the "23 .ps1 files" are one `doctor.ps1` fanned out, not 23 hand-maintained scripts.

## Recommendation

- **Reject Rust:** no perf case (I/O-bound REST orchestration), worst ergonomics for LLM-authored/edited scripts, ~150k-LOC rewrite of gate-hardened code, and it fixes none of the actual failures (which aren't language-level).
- **Converge on Node/TS incrementally** — that's already where the converters live and Node is already required.
- **Phase 0 first (cheapest):** finish retiring bash as a required runtime, sweep `/tmp`, drop `jq`/`curl`/`unzip`, apply `py_resolve` uniformly. Filed as beads under the portability epic.

## Contents

- `shared/refs/portability-strategy.md` — the ADR.
- `shared/examples/node-orchestration-template/` — minimal, **fully bash-free** Node orchestrator demonstrating the target patterns. `node orchestrate.mjs --self-test` passes with no credentials (CI-safe); verified locally (all PASS on darwin/node 22).

Note: even the "Node-first" cognos orchestrator still shells to bash for its token (`migrate-cognos.mjs:102`) — the template shows the fixed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)