### PR TITLE
portability(4alk.2): kill bash from token hot paths (thoughtspot/looker/cognos)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs
@@ -94,20 +94,24 @@ const hdr = (n, t) => console.log(`\n── Phase ${n}/${TOTAL} · ${t} ──`)
 const line = (m) => console.log(`   ${m}`);
 
 // ---------------------------------------------------------------------------
-// Sigma env bootstrap — same path as the per-phase scripts: get-token.sh
-// (which itself falls back to ~/.sigma-migration/env). All children inherit.
+// Sigma env bootstrap — shell-neutral (no bash, no `eval`): shells out to the
+// co-located get_token.py via a real Python interpreter (pythonArgv() — robust
+// to the Windows Store "App Execution Alias" python stub), which mints a
+// bearer (falling back to ~/.sigma-migration/env for creds) and writes
+// WORK/auth.json; read the token back from there. All children inherit via
+// process.env. Works identically on macOS/Linux/Windows.
 // ---------------------------------------------------------------------------
 function sigmaLogin() {
   if (process.env.SIGMA_API_TOKEN && process.env.SIGMA_BASE_URL) return;
-  const r = spawnSync('bash', ['-c',
-    `[ -f "$HOME/.sigma-migration/env" ] && . "$HOME/.sigma-migration/env"; ` +
-    `eval "$('${join(HERE, 'get-token.sh')}')" && env | grep '^SIGMA_'`], { encoding: 'utf8' });
+  const py = pythonArgv();
+  const r = spawnSync(py[0], [...py.slice(1), join(HERE, 'get_token.py'), '--workdir', WORK], { encoding: 'utf8' });
   if (r.status !== 0) die(`Sigma token bootstrap failed:\n${r.stderr || r.stdout}`);
-  for (const l of r.stdout.split('\n')) {
-    const m = l.match(/^(SIGMA_[A-Z_]+)=(.*)$/);
-    if (m) process.env[m[1]] = m[2];
-  }
-  if (!process.env.SIGMA_API_TOKEN) die('get-token.sh did not yield SIGMA_API_TOKEN');
+  const authPath = join(WORK, 'auth.json');
+  if (!existsSync(authPath)) die('get_token.py did not write auth.json');
+  const auth = JSON.parse(readFileSync(authPath, 'utf8'));
+  if (auth.SIGMA_API_TOKEN) process.env.SIGMA_API_TOKEN = auth.SIGMA_API_TOKEN;
+  if (auth.SIGMA_BASE_URL && !process.env.SIGMA_BASE_URL) process.env.SIGMA_BASE_URL = auth.SIGMA_BASE_URL;
+  if (!process.env.SIGMA_API_TOKEN) die('get_token.py did not yield SIGMA_API_TOKEN');
 }
 
 // Run a child, stream output indented; hard-fail unless allowFail.

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py
@@ -165,7 +165,15 @@ def run(cmd, env=None, cwd=None, check=True):
     return p.returncode, out
 
 
-def ensure_sigma_env():
+def ensure_sigma_env(workdir=None):
+    """Load ~/.sigma-migration/env and mint a bearer when SIGMA_API_TOKEN isn't
+    already exported.
+
+    Shell-neutral (no bash, no `eval`): shells out to the co-located
+    get_token.py with the SAME interpreter already running this script
+    (sys.executable — no PATH/py-launcher guessing needed), which writes
+    <workdir>/auth.json; read the token back from there. Works identically on
+    macOS/Linux/Windows."""
     env_file = os.path.expanduser("~/.sigma-migration/env")
     if os.path.exists(env_file):
         for line in open(env_file):
@@ -173,11 +181,19 @@ def ensure_sigma_env():
             if m and not os.environ.get(m.group(1)):
                 os.environ[m.group(1)] = m.group(2)
     if not os.environ.get("SIGMA_API_TOKEN") and os.environ.get("SIGMA_CLIENT_ID"):
-        p = subprocess.run(["bash", os.path.join(HERE, "get-token.sh")],
-                           capture_output=True, text=True)
-        m = re.search(r"export SIGMA_API_TOKEN=(\S+)", p.stdout or "")
-        if m:
-            os.environ["SIGMA_API_TOKEN"] = m.group(1)
+        wd = workdir or os.getcwd()
+        os.makedirs(wd, exist_ok=True)
+        p = subprocess.run([sys.executable, os.path.join(HERE, "get_token.py"),
+                            "--workdir", wd], capture_output=True, text=True)
+        if p.returncode != 0:
+            print(p.stderr or p.stdout, file=sys.stderr)
+        auth_path = os.path.join(wd, "auth.json")
+        if os.path.exists(auth_path):
+            auth = json.load(open(auth_path))
+            if auth.get("SIGMA_API_TOKEN"):
+                os.environ["SIGMA_API_TOKEN"] = auth["SIGMA_API_TOKEN"]
+            if auth.get("SIGMA_BASE_URL") and not os.environ.get("SIGMA_BASE_URL"):
+                os.environ["SIGMA_BASE_URL"] = auth["SIGMA_BASE_URL"]
 
 
 def sigma(method, path, body=None):
@@ -514,7 +530,7 @@ def main():
         a.lookml_dir = pulled
     lookml_dir = os.path.abspath(os.path.expanduser(a.lookml_dir))
     prefix = (a.name.strip() + " ") if a.name else ""
-    ensure_sigma_env()
+    ensure_sigma_env(wd)
     if not a.dry_run:
         missing = [v for v in ("SIGMA_BASE_URL", "SIGMA_API_TOKEN") if not os.environ.get(v)]
         if not a.reuse_dm and not os.environ.get("SIGMA_CONNECTION_ID"):

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py
@@ -91,9 +91,15 @@ def run(cmd, env=None, check=True):
     return p.returncode, out
 
 
-def ensure_sigma_env():
+def ensure_sigma_env(workdir=None):
     """Make the command truly one-command: load ~/.sigma-migration/env and mint a
-    bearer via get-token.sh when SIGMA_API_TOKEN isn't already exported."""
+    bearer when SIGMA_API_TOKEN isn't already exported.
+
+    Shell-neutral (no bash, no `eval`): shells out to the co-located
+    get_token.py with the SAME interpreter already running this script
+    (sys.executable — no PATH/py-launcher guessing needed), which writes
+    <workdir>/auth.json; read the token back from there. Works identically on
+    macOS/Linux/Windows."""
     env_file = os.path.expanduser("~/.sigma-migration/env")
     if os.path.exists(env_file):
         for line in open(env_file):
@@ -101,11 +107,19 @@ def ensure_sigma_env():
             if m and not os.environ.get(m.group(1)):
                 os.environ[m.group(1)] = m.group(2)
     if not os.environ.get("SIGMA_API_TOKEN") and os.environ.get("SIGMA_CLIENT_ID"):
-        p = subprocess.run(["bash", os.path.join(HERE, "get-token.sh")],
-                           capture_output=True, text=True)
-        m = re.search(r"export SIGMA_API_TOKEN=(\S+)", p.stdout or "")
-        if m:
-            os.environ["SIGMA_API_TOKEN"] = m.group(1)
+        wd = workdir or os.getcwd()
+        os.makedirs(wd, exist_ok=True)
+        p = subprocess.run([sys.executable, os.path.join(HERE, "get_token.py"),
+                            "--workdir", wd], capture_output=True, text=True)
+        if p.returncode != 0:
+            print(p.stderr or p.stdout, file=sys.stderr)
+        auth_path = os.path.join(wd, "auth.json")
+        if os.path.exists(auth_path):
+            auth = json.load(open(auth_path))
+            if auth.get("SIGMA_API_TOKEN"):
+                os.environ["SIGMA_API_TOKEN"] = auth["SIGMA_API_TOKEN"]
+            if auth.get("SIGMA_BASE_URL") and not os.environ.get("SIGMA_BASE_URL"):
+                os.environ["SIGMA_BASE_URL"] = auth["SIGMA_BASE_URL"]
 
 
 def resolve_folder():
@@ -320,7 +334,7 @@ def main():
         ap.error("--model or --model-tml required")
     offline = bool(a.model_tml)
     wd = migrate.resolve_workdir(a.workdir)
-    ensure_sigma_env()
+    ensure_sigma_env(wd)
     if not a.dry_run:
         missing = [v for v in ("SIGMA_BASE_URL", "SIGMA_API_TOKEN") if not os.environ.get(v)]
         if not a.reuse_dm and not os.environ.get("SIGMA_CONNECTION_ID"):


### PR DESCRIPTION
## Summary
Bounded slice of beads-sigma-4alk.2 ("retire bash as a REQUIRED runtime"): removes the 3 load-bearing `bash` shell-outs in converter orchestrator hot paths that mint the Sigma token, so those 3 paths run on native Windows without bash.

- `plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/migrate-thoughtspot.py` — `ensure_sigma_env()` no longer runs `subprocess.run(["bash", ".../get-token.sh"])`; it now invokes the co-located `get_token.py` with `sys.executable` (the interpreter already running the script — no PATH guessing) and reads the token back from `<workdir>/auth.json`.
- `plugins/looker-to-sigma/skills/looker-to-sigma/scripts/migrate-looker.py` — identical pattern.
- `plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/migrate-cognos.mjs` — `sigmaLogin()` no longer runs `spawnSync('bash', ['-c', 'eval "$(get-token.sh)" ...'])`; it now invokes `get_token.py` via `lib/py_resolve.mjs`'s `pythonArgv()` (robust to the Windows Store python stub) and reads `WORK/auth.json`.

All three now follow the same shell-neutral contract already used elsewhere in the repo: env vars win, else `<workdir>/auth.json` (written by `get_token.py`), else self-mint — matching `shared/lib/sigma_rest.rb`'s resolution order and the pattern documented in `shared/examples/node-orchestration-template/lib/auth.mjs`. Behavior on macOS is unchanged (same env vars end up set); on Windows these 3 sites no longer require a bash interpreter at all.

**Deferred (explicitly out of scope):** the remaining ~40 `.sh` helper scripts across the repo (including `get-token.sh` itself, which several other tools still shell out to) are untouched. This PR only retires the 3 call sites named in the bead; the rest of the bash-shell-out tail is tracked separately.

## Verification
- `python3 -m py_compile` on both `.py` files — clean.
- `node --check` on the `.mjs` file — clean.
- `ruby tools/check-shared.rb` — passes (none of the 3 edited files are canonical/shared-manifest entries, so no `sync-shared.rb` fan-out needed).
- Live end-to-end smoke test of all 3 bootstrap paths in this environment (real Sigma creds available): each successfully minted a token with `SIGMA_API_TOKEN` unset, via the new `get_token.py`/`pythonArgv()` path only — no `bash` process spawned, `auth.json` written and read back correctly.
- `grep` confirms no remaining `bash`/`get-token.sh` references in any of the 3 edited files (only explanatory comments mentioning "no bash" remain).

## Test plan
- [x] `python3 -m py_compile` both `.py` files
- [x] `node --check` the `.mjs` file
- [x] `ruby tools/check-shared.rb` passes
- [x] Live smoke test: token minted via new path with `SIGMA_API_TOKEN` unset, for all 3 sites
- [ ] Full pipeline run against a live Windows box (not available in this environment — deferred to whoever picks up the Windows validation pass for the epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)