### PR TITLE
portability(4alk.4): uniform PyResolve + Windows venv layout fallback

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/SKILL.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/SKILL.md
@@ -69,6 +69,13 @@ python3 -m venv /tmp/pbiauth
 /tmp/pbiauth/bin/pip install -r scripts/requirements.txt   # msal, requests, truststore
 ```
 
+> **Windows:** the venv layout differs — use `Scripts\` instead of `bin/` (e.g.
+> `python -m venv \tmp\pbiauth` then `\tmp\pbiauth\Scripts\pip.exe install -r
+> scripts\requirements.txt`, and `\tmp\pbiauth\Scripts\python.exe` in place of
+> `/tmp/pbiauth/bin/python` everywhere below). The `powerbi-to-sigma` orchestrator
+> (`migrate-powerbi.rb`, `phase6-parity-pbi.rb`) already probes both layouts and
+> falls back to `PyResolve` — this note is only for the manual commands on this page.
+
 Auth reuses the working recipe documented in
 `powerbi-to-sigma/refs/connection.md`: well-known PowerBI Desktop public client
 `ea0616ba-638b-4df5-95b9-636659ae5121`, scope

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -306,8 +306,11 @@ signals_path = File.join(WORK, 'signals.json')
 # a real system Python via PyResolve (Windows Store-stub safe; the offline PBIR
 # parse is stdlib-only). PY_ARGV is an array so a multi-token launcher (`py -3`)
 # survives the splat below.
+# bead 4alk.4: venvs are POSIX bin/python OR Windows Scripts\python.exe — probe
+# both layouts per venv root rather than assuming bin/.
 py = opts[:python] || ENV['PBI_PY'] ||
-     [File.join(WORK, '.venv', 'bin', 'python'), '/tmp/pbiauth/bin/python']
+     [File.join(WORK, '.venv', 'bin', 'python'), File.join(WORK, '.venv', 'Scripts', 'python.exe'),
+      '/tmp/pbiauth/bin/python', '/tmp/pbiauth/Scripts/python.exe']
        .find { |p| File.exist?(p) }
 PY_ARGV = py ? [py] : PyResolve.argv
 if classic_rj

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
@@ -197,8 +197,10 @@ if opts[:emit]
   # venv, else a real system Python via PyResolve (Windows Store-stub safe; bead
   # 7o01 — see scripts/requirements.txt / run.sh bootstrap). py_argv is an array
   # so a multi-token launcher (`py -3`) survives the splat.
+  # bead 4alk.4: the venv is POSIX bin/python OR Windows Scripts\python.exe —
+  # probe both rather than assuming bin/.
   py = ENV['PBI_PY'] ||
-       (File.exist?('/tmp/pbiauth/bin/python') ? '/tmp/pbiauth/bin/python' : nil)
+       ['/tmp/pbiauth/bin/python', '/tmp/pbiauth/Scripts/python.exe'].find { |p| File.exist?(p) }
   py_argv = py ? [py] : PyResolve.argv
   out, err, st = Open3.capture3(*py_argv, HARNESS, opts[:ws], opts[:ds], stdin_data: JSON.dump(chart_dax))
   warn err unless err.empty?

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-conditional-formats.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-conditional-formats.rb
@@ -12,6 +12,7 @@
 
 require 'json'
 require_relative 'lib/pbi_conditional_formats'
+require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
 
 $fail = 0
 def ok(name, cond)
@@ -86,7 +87,10 @@ ok('leaf-name fallback resolves entity-mismatched target', res2['formats'].size 
 
 # --- 2. Python extractor: real PBIR bytes -> normalized CF records -------------
 require 'tempfile'
-py = ENV['PBI_PY'] || 'python3'
+# PBI_PY wins if set; else a real system Python via PyResolve (Windows Store-stub
+# safe). PyResolve.display is a shell-safe "tok1 tok2" string (e.g. "py -3") since
+# `py` is interpolated into a backtick command below, not splatted into argv.
+py = ENV['PBI_PY'] || PyResolve.display
 EXTRACTOR = File.join(__dir__, 'extract-pbir.py')
 def extract_cf(py, visual_json_path)
   Tempfile.create(['cf_extract', '.py']) do |f|

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-telemetry-gate.rb
@@ -7,6 +7,7 @@
 require 'json'
 require 'tmpdir'
 require 'rbconfig'
+require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
 
 GATE   = File.join(__dir__, 'assert-telemetry-ran.rb')
 REPORT = File.join(__dir__, 'report-telemetry.py')
@@ -21,7 +22,7 @@ end
 
 def report(dir, *extra)
   env = { 'SIGMA_CLIENT_ID' => 'testclient', 'SIGMA_BASE_URL' => 'https://api.au.aws.sigmacomputing.com' }
-  system(env, 'python3', REPORT, '--tool', 'tableau-to-sigma', '--workdir', dir, *extra,
+  system(env, *PyResolve.argv, REPORT, '--tool', 'tableau-to-sigma', '--workdir', dir, *extra,
          out: File::NULL, err: File::NULL)
 end
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb
@@ -232,7 +232,8 @@ when 'render'
   n = ledger['pass']
   out_png = File.join(opts[:dir], "rcf-pass-#{n}.png")
   renderer = File.join(HERE, 'sigma-export-png.py')
-  cmd_r = ['python3', renderer, '--workbook', ledger['workbook_id'],
+  require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
+  cmd_r = [*PyResolve.argv, renderer, '--workbook', ledger['workbook_id'],
            '--page', ledger['page_id'], '--out', out_png,
            '--w', opts[:width].to_s, '--h', opts[:height].to_s]
   ok = system(*cmd_r)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rls-wiring.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rls-wiring.rb
@@ -15,6 +15,7 @@
 
 require 'json'
 require 'tempfile'
+require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
 
 DIR = __dir__
 fails = []
@@ -53,7 +54,7 @@ security = [
 ]
 tmp = Tempfile.new(['security-', '.json'])
 tmp.write(JSON.generate(security)); tmp.close
-out = `python3 #{File.join(DIR, 'apply_sigma_rls.py').inspect} --from-security #{tmp.path.inspect} --print-plan 2>&1`
+out = `#{PyResolve.display} #{File.join(DIR, 'apply_sigma_rls.py').inspect} --from-security #{tmp.path.inspect} --print-plan 2>&1`
 ok = $?.success?
 tmp.unlink
 check(ok, 'print-plan exits 0 with no token / --dm-id (offline)', fails)

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-telemetry-gate.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-telemetry-gate.rb
@@ -7,6 +7,7 @@
 require 'json'
 require 'tmpdir'
 require 'rbconfig'
+require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
 
 GATE   = File.join(__dir__, 'assert-telemetry-ran.rb')
 REPORT = File.join(__dir__, 'report-telemetry.py')
@@ -21,7 +22,7 @@ end
 
 def report(dir, *extra)
   env = { 'SIGMA_CLIENT_ID' => 'testclient', 'SIGMA_BASE_URL' => 'https://api.au.aws.sigmacomputing.com' }
-  system(env, 'python3', REPORT, '--tool', 'tableau-to-sigma', '--workdir', dir, *extra,
+  system(env, *PyResolve.argv, REPORT, '--tool', 'tableau-to-sigma', '--workdir', dir, *extra,
          out: File::NULL, err: File::NULL)
 end
 

--- a/shared/scripts/test-telemetry-gate.rb
+++ b/shared/scripts/test-telemetry-gate.rb
@@ -7,6 +7,7 @@
 require 'json'
 require 'tmpdir'
 require 'rbconfig'
+require_relative 'lib/py_resolve' # real-Python resolver (Windows Store-stub safe)
 
 GATE   = File.join(__dir__, 'assert-telemetry-ran.rb')
 REPORT = File.join(__dir__, 'report-telemetry.py')
@@ -21,7 +22,7 @@ end
 
 def report(dir, *extra)
   env = { 'SIGMA_CLIENT_ID' => 'testclient', 'SIGMA_BASE_URL' => 'https://api.au.aws.sigmacomputing.com' }
-  system(env, 'python3', REPORT, '--tool', 'tableau-to-sigma', '--workdir', dir, *extra,
+  system(env, *PyResolve.argv, REPORT, '--tool', 'tableau-to-sigma', '--workdir', dir, *extra,
          out: File::NULL, err: File::NULL)
 end
 


### PR DESCRIPTION
## Summary
Part of the Windows-portability epic (see `shared/refs/portability-strategy.md` Phase 0, item: "Apply `PyResolve` uniformly... Fix the POSIX venv assumption (`bin/` -> `Scripts\` fallback) in the PowerBI path").

**Sites routed through `PyResolve`** (Windows Store-stub-safe resolver) — each of these lives in a skill dir that already has a `scripts/lib/py_resolve.rb` sibling:
- `shared/scripts/test-telemetry-gate.rb:24` — the explicitly-flagged hardcode (`system(env, 'python3', ...)` → `system(env, *PyResolve.argv, ...)`). This is the **canonical** copy; fanned via `tools/sync-shared.rb` to `powerbi-to-sigma` and `tableau-to-sigma`'s `test-telemetry-gate.rb`.
- `plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-conditional-formats.rb:89` — `py = ENV['PBI_PY'] || 'python3'` → `PyResolve.display` (a shell-safe joined string, since `py` is interpolated into a backtick command, not splatted).
- `plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/fidelity-loop.rb:235` — the `render` subcommand's `cmd_r = ['python3', ...]` → `[*PyResolve.argv, ...]`.
- `plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/test-rls-wiring.rb:56` — backtick `` `python3 ...` `` → `` `#{PyResolve.display} ...` ``.

**Windows venv-layout fallback** (`bin/python` → `Scripts\python.exe` probe), the other half of this bead:
- `plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb` — the `.venv` and legacy `/tmp/pbiauth` venv candidates now probe both `bin/python` and `Scripts/python.exe`.
- `plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb` — same fix for the legacy `/tmp/pbiauth` venv.
- `plugins/powerbi-to-sigma/skills/powerbi-assessment/SKILL.md` — this constructor is in code (fixed above), but the SKILL.md also documents the same path for manual copy-paste commands, so added a short Windows-equivalent note there.

**Deferred** — bare `python3` spawns found that do **not** have a `py_resolve` sibling in their own skill directory. Per instructions, not introducing new shared infra into files without existing access; listing for a follow-up bead instead:
- `plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/render-readout-html.rb:531`, `render-readout.rb:166`
- `plugins/quicksight-to-sigma/skills/quicksight-assessment/scripts/render-readout-html.rb:533`, `render-readout.rb:181`
- `plugins/cognos-to-sigma/skills/cognos-assessment/scripts/score-coverage.mjs:394` (the `cognos-to-sigma` skill has a `py_resolve.mjs` twin, but `cognos-assessment` is a separate skill dir with no local copy)

These are all `-assessment` skills invoking the shared `dup-dashboards.py` duplicate-detector; a real fix would mean deciding whether `py_resolve` becomes shared-manifest-governed for the assessment family (Ruby) and giving `cognos-assessment` its own `.mjs` copy — a small design call better made in its own bead/PR rather than folded in here.

## Test plan
- [x] `ruby -c` on all changed `.rb` files — all `Syntax OK`
- [x] No `.mjs` files changed (deferred sites listed above only)
- [x] `ruby tools/sync-shared.rb` propagated the canonical `test-telemetry-gate.rb` fix to both fanned copies; `ruby tools/check-shared.rb` passes (280 shared-file copies in sync, 1 allowlisted exception)
- [x] `ruby scripts/test-telemetry-gate.rb` (powerbi-to-sigma) — all 10 checks pass, exercising the real `PyResolve.argv`-routed `report-telemetry.py` invocation
- [x] `ruby scripts/test-conditional-formats.rb` (powerbi-to-sigma) — all checks pass, including the `PyResolve.display`-routed Python extractor
- [x] `ruby scripts/test-rls-wiring.rb` (tableau-to-sigma) — all checks pass, including the `PyResolve.display`-routed `apply_sigma_rls.py --print-plan`
- [x] `ruby scripts/fidelity-loop.rb init` + `render` (tableau-to-sigma) smoke-tested — reaches `sigma-export-png.py` via the resolved argv and fails only on missing `SIGMA_API_TOKEN` (expected offline), confirming the routing is live, not a NameError from the edit
- [x] `migrate-powerbi.rb --help` / `phase6-parity-pbi.rb --help` load cleanly with the new venv-probe list (no syntax/NameError regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)