### PR TITLE
portability(4alk.3): replace jq/curl/unzip/sips shell-outs

### DIFF
--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb
@@ -401,20 +401,80 @@ def cmd_summarize(args)
 end
 
 OPENAPI_CACHE = '/tmp/sigma-api.json'.freeze
+OPENAPI_URL = 'https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json'.freeze
+
+# Depth-first pre-order walk over every Hash node reachable from `node`
+# (mirrors jq's `.. | objects`): yields the node itself, then recurses into
+# each Hash/Array value it contains, in place, so "first match wins" callers
+# see nodes in the same order jq's `first(...)` would.
+def walk_openapi_objects(node, &blk)
+  return unless node.is_a?(Hash) || node.is_a?(Array)
+  if node.is_a?(Hash)
+    blk.call(node)
+    node.each_value { |v| walk_openapi_objects(v, &blk) }
+  else
+    node.each { |v| walk_openapi_objects(v, &blk) }
+  end
+end
+
+# True when `node` is the schema for element/control kind `k` — either
+# directly (properties.kind.enum == [k]) or via an allOf branch. Mirrors the
+# jq selector this replaced:
+#   (.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]
+def openapi_kind_match?(node, k)
+  return true if node.dig('properties', 'kind', 'enum') == [k]
+  Array(node['allOf']).any? { |a| a.is_a?(Hash) && a.dig('properties', 'kind', 'enum') == [k] }
+end
+
+# Plain Net::HTTP::Get.new(uri) + start does not follow redirects (unlike
+# `curl` without `-L`); the docs host serves this URL via a 308, so this is
+# needed for the fetch below to actually land on the JSON.
+def http_get_following_redirects(url, limit = 5)
+  die 'too many HTTP redirects fetching OpenAPI' if limit.zero?
+  uri = URI(url)
+  res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 120) { |h| h.get(uri) }
+  res.is_a?(Net::HTTPRedirection) ? http_get_following_redirects(res['location'], limit - 1) : res
+end
+
 def cmd_capabilities(args)
   kind = field = nil
   if (i = args.index('--kind')) then kind = args[i + 1]; args.slice!(i, 2); end
   if (i = args.index('--field')) then field = args[i + 1]; args.slice!(i, 2); end
   unless File.exist?(OPENAPI_CACHE)
-    system('curl', '-sf', 'https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json', '-o', OPENAPI_CACHE) or die 'failed to fetch OpenAPI'
+    res = http_get_following_redirects(OPENAPI_URL)
+    die "failed to fetch OpenAPI (HTTP #{res.code})" unless res.code.to_i.between?(200, 299)
+    File.write(OPENAPI_CACHE, res.body)
   end
-  sel = %q{first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))}
+  spec = JSON.parse(File.read(OPENAPI_CACHE))
+
   if kind.nil?
-    system('jq', '-r', '[.. | objects | select(.properties.kind.enum) | .properties.kind.enum[0]] | unique[]', OPENAPI_CACHE)
-  elsif field.nil?
-    system('jq', '-r', '--arg', 'k', kind, "#{sel} | [.allOf[]?.properties // .properties | keys[]] | unique[]", OPENAPI_CACHE)
+    # jq: [.. | objects | select(.properties.kind.enum) | .properties.kind.enum[0]] | unique[]
+    kinds = []
+    walk_openapi_objects(spec) do |n|
+      enum = n.dig('properties', 'kind', 'enum')
+      kinds << enum[0] if enum
+    end
+    puts kinds.compact.uniq.sort
+    return
+  end
+
+  match = nil
+  walk_openapi_objects(spec) { |n| match ||= n if openapi_kind_match?(n, kind) }
+  die "no schema found for kind=#{kind}" unless match
+
+  if field.nil?
+    # jq: [.allOf[]?.properties // .properties | keys[]] | unique[]
+    branches = Array(match['allOf']).map { |a| a['properties'] }.compact
+    branches = [match['properties'] || {}] if branches.empty?
+    puts branches.flat_map(&:keys).uniq.sort
   else
-    system('jq', '--arg', 'k', kind, "[#{sel} | .. | objects | select(.properties[\"#{field}\"]) | .properties[\"#{field}\"]] | .[0]", OPENAPI_CACHE)
+    # jq: [.. | objects | select(.properties["field"]) | .properties["field"]] | .[0]
+    found = nil
+    walk_openapi_objects(match) do |n|
+      next unless found.nil?
+      found = n['properties'][field] if n['properties'].is_a?(Hash) && n['properties'].key?(field)
+    end
+    puts found.nil? ? 'null' : JSON.pretty_generate(found)
   end
 end
 

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify_parity.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/verify_parity.py
@@ -19,16 +19,29 @@ Env: SISENSE_BASE_URL/SISENSE_API_TOKEN; `snow` CLI connection (default "tj").
 Usage: python3 verify_parity.py <checks.json> [--snow-conn tj]
 checks.json: [{"label","datasource","jaql":[...],"snowflake_sql","tol":0.01}]
 """
-import json, os, subprocess, sys
+import json, os, ssl, subprocess, sys, urllib.error, urllib.request
 
 def sisense_jaql(datasource, metadata):
     ds = datasource.replace(" ", "%20").replace("(", "%28").replace(")", "%29")
-    out = subprocess.run(["curl", "-sk", "--max-time", "120", "-X", "POST",
-        f'{os.environ["SISENSE_BASE_URL"].rstrip("/")}/api/datasources/{ds}/jaql',
-        "-H", f'Authorization: Bearer {os.environ["SISENSE_API_TOKEN"]}',
-        "-H", "Content-Type: application/json",
-        "-d", json.dumps({"datasource": datasource, "metadata": metadata})],
-        capture_output=True, text=True).stdout
+    url = f'{os.environ["SISENSE_BASE_URL"].rstrip("/")}/api/datasources/{ds}/jaql'
+    payload = json.dumps({"datasource": datasource, "metadata": metadata}).encode("utf-8")
+    req = urllib.request.Request(url, data=payload, method="POST", headers={
+        "Authorization": f'Bearer {os.environ["SISENSE_API_TOKEN"]}',
+        "Content-Type": "application/json",
+    })
+    # NOTE: the original `curl -sk` skipped TLS verification (-k), which is
+    # commonly needed against on-prem Sisense deployments on self-signed certs.
+    # Preserved here (not tightened) so existing setups don't silently break;
+    # if this ever needs to be strict, gate it behind an env var instead of
+    # flipping the default.
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    try:
+        with urllib.request.urlopen(req, timeout=120, context=ctx) as resp:
+            out = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        out = e.read().decode("utf-8")
     d = json.loads(out)
     if d.get("error"):
         return ("ERROR", d.get("details"))

--- a/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/fetch-all-twbs.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-assessment/scripts/fetch-all-twbs.rb
@@ -31,6 +31,19 @@ require 'net/http'
 require 'uri'
 $LOAD_PATH.unshift File.expand_path('../../tableau-to-sigma/scripts/lib', __dir__)
 require 'tableau_rest'
+require 'py_resolve'
+
+# Cross-platform replacement for shelling `unzip` (not present on stock
+# Windows): Ruby has no stdlib zip reader, so this delegates to Python's
+# stdlib `zipfile` via a Store-stub-safe interpreter (see lib/py_resolve.rb,
+# shared across the tableau-to-sigma plugin's skills).
+def unzip_extract(zip_path, dest_dir)
+  require 'open3'
+  code = 'import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])'
+  _out, err, status = Open3.capture3(*PyResolve.argv, '-c', code, zip_path, dest_dir)
+  warn "  unzip failed for #{zip_path}: #{err.strip[0, 300]}" if !status.success? && !err.to_s.strip.empty?
+  status.success?
+end
 
 opts = { threads: 12, refresh_min: 60, limit: nil, force: false, exclude_projects: ['Personal Space'] }
 OptionParser.new do |p|
@@ -220,8 +233,7 @@ unzip_queue.each do |luid, r|
   next if File.exist?(twb_path) && File.size(twb_path) > 0
   tmp = File.join(twb_dir, "_unpack_#{luid}")
   FileUtils.mkdir_p(tmp)
-  unless system('unzip', '-o', '-q', r['path'], '-d', tmp)
-    warn "  unzip failed for #{r['path']} (is the unzip command available?)"
+  unless unzip_extract(r['path'], tmp)
     FileUtils.rm_rf(tmp)
     next
   end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/export-zone-images.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/export-zone-images.rb
@@ -32,6 +32,7 @@
 require 'json'
 require 'fileutils'
 require 'optparse'
+require 'rbconfig'
 
 # ---------------------------------------------------------------------------
 # CLI
@@ -56,17 +57,34 @@ abort "ERROR: layout file not found: #{opts[:layout]}" unless File.exist?(opts[:
 # ---------------------------------------------------------------------------
 # Detect image tool
 # ---------------------------------------------------------------------------
+# sips is macOS-only (not present on Windows/Linux) and its own presence check
+# used to be a shell string relying on POSIX-only redirection (`>/dev/null
+# 2>&1`), which is not portable to cmd.exe. Gate the probe on the host OS and
+# use array-form `system` (bypasses the shell entirely, so no redirection
+# syntax is needed) — on non-macOS this skips straight to the ImageMagick
+# fallback with a one-line note instead of attempting/failing on `sips`.
+MACOS = RbConfig::CONFIG['host_os'] =~ /darwin/i ? true : false
+
+def tool_available?(*cmd)
+  system(*cmd, out: File::NULL, err: File::NULL)
+rescue StandardError
+  false
+end
+
 TOOL =
-  if system('sips --version >/dev/null 2>&1')
+  if MACOS && tool_available?('sips', '--version')
     :sips
-  elsif system('convert -version >/dev/null 2>&1')
+  elsif tool_available?('convert', '-version')
     :imagemagick_convert
-  elsif system('magick -version >/dev/null 2>&1')
+  elsif tool_available?('magick', '-version')
     :imagemagick_magick
   else
+    warn 'NOTE: sips is macOS-only and this is not macOS — skipping straight to ImageMagick (also not found).' unless MACOS
     abort "ERROR: no image-cropping tool found.\n" \
           "  macOS: sips is built-in (/usr/bin/sips) — it should be present.\n" \
-          "  Linux: install imagemagick (apt install imagemagick / brew install imagemagick)."
+          "  Linux: install ImageMagick (apt install imagemagick / brew install imagemagick).\n" \
+          "  Windows: install ImageMagick (choco install imagemagick / winget install ImageMagick.ImageMagick) " \
+          'and ensure `magick` is on PATH.'
   end
 warn "Image tool: #{TOOL}"
 

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/tableau-discover.rb
@@ -61,6 +61,19 @@ require 'thread'
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'tableau_rest'
+require 'py_resolve'
+
+# Cross-platform replacement for shelling `unzip` (not present on stock
+# Windows): Ruby has no stdlib zip reader, so this delegates to Python's
+# stdlib `zipfile` via a Store-stub-safe interpreter (see lib/py_resolve.rb).
+# Returns true/false like the old `system('unzip', ...)` call did.
+def unzip_extract(zip_path, dest_dir)
+  require 'open3'
+  code = 'import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])'
+  _out, err, status = Open3.capture3(*PyResolve.argv, '-c', code, zip_path, dest_dir)
+  warn "  unzip failed for #{zip_path}: #{err.strip[0, 300]}" if !status.success? && !err.to_s.strip.empty?
+  status.success?
+end
 
 opts = { fetch_view_images: 'dashboard-only', pool: 5 }
 OptionParser.new do |o|
@@ -193,8 +206,8 @@ unless opts[:skip_content]
         log "wrote workbook-content.twbx  (#{bytes.bytesize} bytes)"
         require 'tmpdir'
         Dir.mktmpdir do |tmp|
-          unless system('unzip', '-o', '-q', twbx_path, '-d', tmp)
-            log '.twbx auto-unzip failed (unzip command not available?); leaving .twbx in place'
+          unless unzip_extract(twbx_path, tmp)
+            log '.twbx auto-unzip failed; leaving .twbx in place'
           else
             inner = Dir.glob(File.join(tmp, '**', '*.twb')).first
             if inner


### PR DESCRIPTION
## Summary

Part of the Windows-portability epic (`beads-sigma-4alk`, ADR: `shared/refs/portability-strategy.md`). Replaces the identified shell-outs to unix CLIs that don't exist on stock Windows.

| Site | Old | New | Verification |
|---|---|---|---|
| `sigma-workbooks/scripts/wb-rep.rb` (`cmd_capabilities`) — OpenAPI parsing | `system('jq', ...)` × 3, `system('curl', ...)` | `Net::HTTP` (with redirect-following — the docs host 308-redirects this URL, and plain `Net::HTTP.get` doesn't follow redirects like curl does) + `JSON.parse` + a small recursive Hash/Array walker replacing the 3 jq pipelines | Ran the old jq pipelines and the new Ruby against an identical synthetic OpenAPI fixture (kind-listing, field-listing-with/without-allOf, field-lookup) — byte-identical output on all 5 cases. Live fetch could not be exercised end-to-end from this sandbox: the real URL currently 308s to a path that itself returns HTTP 500 upstream (a pre-existing, unrelated issue with the vendor docs site, not introduced by this change) |
| `sisense-to-sigma/scripts/verify_parity.py` (`sisense_jaql`) | `subprocess.run(["curl", "-sk", ...])` | `urllib.request` with an unverified SSL context (preserves `-k`'s insecure behavior — commonly needed for on-prem self-signed certs — rather than silently tightening it) | `python3 -m py_compile` |
| `tableau-to-sigma/scripts/tableau-discover.rb:196`, `tableau-assessment/scripts/fetch-all-twbs.rb:223` — `.twbx` extraction | `system('unzip', ...)` | New `unzip_extract` helper: Python stdlib `zipfile` via the existing Store-stub-safe `py_resolve.rb` (Ruby has no stdlib zip reader) | `ruby -c`; end-to-end test creating a real `.twbx`-style zip and extracting it through the helper — inner file recovered byte-for-byte |
| `tableau-to-sigma/scripts/export-zone-images.rb` — image crop tool detection | `system('sips --version >/dev/null 2>&1')` (shell string, POSIX-only redirection syntax) | Probe gated on `RbConfig::CONFIG['host_os']` (only attempts `sips` on macOS) + array-form `system(..., out: File::NULL, err: File::NULL)` (no shell involved). Falls through to the existing ImageMagick (`convert`/`magick`) path with a one-line note on non-macOS instead of attempting/failing on `sips` | `ruby -c`; smoke-ran the script (argument-validation path) |

## Deferred

- **`sigma-workbooks/scripts/validate-spec.sh`** still shells `jq` (plus a `yq`/PyYAML fallback dance) for its formula-qualification check. No compatible Ruby/Python equivalent exists in this skill — the similarly-named `validate-spec.rb` in `tableau-to-sigma`/`powerbi-to-sigma`/`quicksight-to-sigma` is a different, incompatible validator built for their DM+workbook two-file pipeline (`--type datamodel|workbook`, `--dm-context`), not a drop-in replacement. Porting the jq logic to Ruby and updating every doc reference (`SKILL.md`, `reference/workflows/*.md`, the per-agent generated variants) is a larger, separate change than a mechanical CLI swap — left as a follow-up rather than guessing at a rewrite under this bead's scope.

## Test plan
- [x] `ruby -c` on all changed `.rb` files
- [x] `python3 -m py_compile` on the changed `.py` file
- [x] `ruby tools/check-shared.rb` passes (no shared-manifest files touched — `wb-rep.rb` is not shared-listed; `py_resolve.rb` was reused via existing cross-skill `$LOAD_PATH` reach, not duplicated)
- [x] `wb-rep.rb capabilities` (all 3 modes) verified byte-identical to real `jq` output on a synthetic OpenAPI fixture
- [x] `unzip_extract` verified end-to-end against a real zip archive
- [x] `export-zone-images.rb` smoke-run (tool-detection path unchanged in behavior on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)