### PR TITLE
kvza.4: shared documentation-grounding infra (coverage-catalog loader + matrix generator)

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/gen-coverage-matrix.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/gen-coverage-matrix.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""gen-coverage-matrix.py — generate refs/<skill>-coverage.md FROM the JSON
+catalogs (refs/catalogs/*.json), so the human-readable coverage matrix can never
+drift from the machine-loaded single source of truth (beads-sigma-kvza).
+
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md --check     # exit 1 if the file is stale
+
+One table per dimension, five columns (the handoff's shape):
+  | construct | doc ref | Sigma target | sigma_verified (y/n·date) | on-unmapped |
+
+Stdlib only; Windows-safe.
+"""
+import argparse
+import json
+import os
+import sys
+
+DIM_ORDER = ["viz-kind", "number-format", "aggregation", "control"]
+DIM_TITLE = {
+    "viz-kind": "Visualization / chart kind",
+    "number-format": "Number format",
+    "aggregation": "Aggregation",
+    "control": "Control / filter",
+}
+
+
+def _md_escape(s):
+    return str(s).replace("|", "\\|").replace("\n", " ")
+
+
+def _verified_cell(r):
+    sv = r.get("sigma_verified") or {}
+    status = sv.get("status", "n")
+    if status == "y":
+        return "✅ y · %s" % sv.get("date", "?")
+    return "🟡 n"
+
+
+def _target_cell(r):
+    sig = r.get("sigma")
+    if sig is None and r.get("sigma_if") is None:
+        return "— (no Sigma equivalent)"
+    parts = []
+    if sig is not None:
+        parts.append("`%s`" % _md_escape(sig))
+    if r.get("sigma_if"):
+        parts.append("if→`%s`" % _md_escape(r["sigma_if"]))
+    return " ".join(parts) if parts else "—"
+
+
+def _doc_cell(r):
+    ref = r.get("doc_ref", "")
+    return "[doc](%s)" % ref if ref.startswith("http") else _md_escape(ref or "—")
+
+
+def render(catalogs, skill):
+    cats = {}
+    for fn in sorted(os.listdir(catalogs)):
+        if fn.endswith(".json"):
+            cats[fn[:-5]] = json.load(open(os.path.join(catalogs, fn)))
+    order = [d for d in DIM_ORDER if d in cats] + [d for d in sorted(cats) if d not in DIM_ORDER]
+
+    out = []
+    out.append("# %s → Sigma — dashboard classifier coverage matrix" % skill.capitalize())
+    out.append("")
+    out.append("> **GENERATED — do not edit by hand.** Regenerate with "
+               "`python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs "
+               "--skill %s --out refs/%s-coverage.md`. The JSON catalogs in "
+               "`refs/catalogs/` are the single source of truth; the classifier "
+               "(`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them "
+               "via `shared/lib/coverage_catalog.py`. A no-drift test asserts this "
+               "file matches the catalogs." % (skill, skill))
+    out.append("")
+    out.append("Every documented source construct maps to a real, current Sigma target "
+               "or a loud fallback — no silent wrong-defaults, no name-substring "
+               "guessing (beads-sigma-kvza).")
+    out.append("")
+    out.append("**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at "
+               "**query time** in a live migration (no `type=error` column) on the date "
+               "shown; 🟡 n = target is documented but not yet query-verified.")
+    out.append("")
+    total = sum(len(c.get("rows", [])) for c in cats.values())
+    ver = sum(1 for c in cats.values() for r in c.get("rows", [])
+              if (r.get("sigma_verified") or {}).get("status") == "y")
+    out.append("**Coverage:** %d documented constructs across %d dimensions; "
+               "%d live-verified." % (total, len(cats), ver))
+    out.append("")
+
+    for dim in order:
+        c = cats[dim]
+        out.append("## %s" % DIM_TITLE.get(dim, dim))
+        out.append("")
+        if c.get("description"):
+            out.append("_%s_" % c["description"])
+            out.append("")
+        if c.get("authoritative_doc"):
+            out.append("Authoritative source: <%s>" % c["authoritative_doc"])
+            out.append("")
+        out.append("| construct | doc ref | Sigma target | sigma_verified | on-unmapped |")
+        out.append("|---|---|---|---|---|")
+        for r in c.get("rows", []):
+            notes = r.get("notes")
+            src = "`%s`" % _md_escape(r["source"])
+            onun = _md_escape(r.get("on_unmapped", c.get("on_unmapped_default", "")))
+            row = "| %s | %s | %s | %s | %s |" % (
+                src, _doc_cell(r), _target_cell(r), _verified_cell(r), onun)
+            out.append(row)
+            if notes:
+                out.append("| | | | | _%s_ |" % _md_escape(notes))
+        out.append("")
+
+    out.append("---")
+    out.append("_Compositional constructs that do not serialize to a flat table "
+               "(Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask "
+               "parsers, count-on-joined-view) stay as cited predicates in the "
+               "classifier; this matrix covers the enumerable maps._")
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--catalogs", required=True)
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if --out is stale vs the catalogs (no write)")
+    a = ap.parse_args()
+    text = render(a.catalogs, a.skill)
+    if a.check:
+        cur = open(a.out).read() if os.path.exists(a.out) else ""
+        if cur != text:
+            sys.stderr.write("STALE: %s does not match refs/catalogs — regenerate.\n" % a.out)
+            sys.exit(1)
+        print("OK: %s matches the catalogs." % a.out)
+        return
+    open(a.out, "w").write(text)
+    print("wrote %s (%d bytes)" % (a.out, len(text)))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/coverage_catalog.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""coverage_catalog.py — load a documentation-grounded mapping catalog and
+resolve source constructs to Sigma targets, LOUDLY on a miss.
+
+The single source of truth for a classifier's mappings is a JSON catalog under
+the skill's ``refs/catalogs/<dimension>.json``. Each catalog is an envelope::
+
+    {
+      "dimension": "number-format",
+      "source_tool": "looker",
+      "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+      "on_unmapped_default": "warn+skip",
+      "rows": [
+        {"source": "usd_0", "sigma": "$,.0f",
+         "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+         "sigma_verified": {"status": "y", "date": "2026-07-13"},
+         "on_unmapped": "warn+skip",
+         "notes": "..."}
+      ]
+    }
+
+Rows are indexed by ``source`` (normalized: trimmed + lowercased — every one of
+the four classifier dimensions keys on lowercase tokens). ``resolve()`` returns
+the row dict or ``None``. The classifier MUST honor a ``None`` by warning +
+skipping/placeholdering — never by emitting a silent wrong default.
+``resolve_or_warn()`` enforces that: it appends a standardized warning to the
+caller's ``warnings`` list and returns ``None`` on a miss.
+
+Stdlib only (json/os); Windows-safe (os.path). Mirrors the beads-sigma-93ps
+design contract: the catalog is language-neutral data; this loader is the thin
+resolver. See refs/<skill>-coverage.md (generated FROM the catalogs) for the
+human-readable, cited coverage matrix.
+"""
+import json
+import os
+
+MISS = None  # sentinel: resolve() returns None when a source key is absent
+
+
+class Catalog:
+    """A single loaded mapping dimension (viz-kind / number-format / aggregation
+    / control), indexed by source construct."""
+
+    def __init__(self, data, path):
+        self.path = path
+        self.filename = os.path.basename(path)
+        self.dimension = data.get("dimension") or os.path.splitext(self.filename)[0]
+        self.source_tool = data.get("source_tool", "")
+        self.authoritative_doc = data.get("authoritative_doc", "")
+        self.on_unmapped_default = data.get("on_unmapped_default", "warn+skip")
+        self.rows = data.get("rows", [])
+        self._by_source = {}
+        for r in self.rows:
+            k = r.get("source")
+            if k is None:
+                continue
+            self._by_source[self._norm(k)] = r
+
+    @staticmethod
+    def _norm(k):
+        return str(k).strip().lower()
+
+    def resolve(self, source_key):
+        """Return the full catalog row for ``source_key``, or ``None`` on a miss."""
+        if source_key is None:
+            return None
+        return self._by_source.get(self._norm(source_key))
+
+    def target(self, source_key):
+        """Return just the Sigma target string for ``source_key`` (row['sigma']),
+        or ``None`` on a miss. Convenience for the common case."""
+        row = self.resolve(source_key)
+        return row.get("sigma") if row else None
+
+    def resolve_or_warn(self, source_key, warnings, *, context=""):
+        """Resolve ``source_key``; on a miss append a standardized LOUD warning to
+        ``warnings`` and return ``None``. The caller must then skip/placeholder —
+        this makes the loud fallback mandatory and uniform across classifiers."""
+        row = self.resolve(source_key)
+        if row is not None:
+            return row
+        where = " (%s)" % context if context else ""
+        warnings.append(
+            "⚠ %s: no documented %s mapping for '%s'%s — %s. "
+            "Add a cited row to refs/catalogs/%s if this is a real construct."
+            % (self.dimension, self.source_tool or "source", source_key, where,
+               self.on_unmapped_default, self.filename)
+        )
+        return None
+
+    def sources(self):
+        """All (normalized) source keys the catalog covers."""
+        return list(self._by_source.keys())
+
+    def unverified(self):
+        """Rows whose Sigma target is not yet live-verified
+        (``sigma_verified.status`` != 'y'). Used to gate a PR / stamp progress."""
+        return [r for r in self.rows
+                if (r.get("sigma_verified") or {}).get("status") != "y"]
+
+
+def load(catalog_dir, dimension):
+    """Load ``<catalog_dir>/<dimension>.json``. Fails LOUDLY if absent — a
+    classifier with no catalog must not silently guess."""
+    path = os.path.join(catalog_dir, dimension + ".json")
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            "coverage catalog missing: %s — the classifier requires a "
+            "documentation-grounded catalog for '%s'; refusing to guess."
+            % (path, dimension)
+        )
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return Catalog(data, path)
+
+
+def load_all(catalog_dir):
+    """Load every ``*.json`` catalog in ``catalog_dir``, keyed by dimension name."""
+    if not os.path.isdir(catalog_dir):
+        raise FileNotFoundError("coverage catalog dir missing: %s" % catalog_dir)
+    out = {}
+    for fn in sorted(os.listdir(catalog_dir)):
+        if fn.endswith(".json"):
+            out[fn[:-5]] = load(catalog_dir, fn[:-5])
+    return out
+
+
+def default_catalog_dir(script_file):
+    """Given a builder's ``__file__`` (in scripts/), return its sibling
+    ``refs/catalogs`` dir. Keeps callers from hand-rolling the ``..`` walk."""
+    scripts_dir = os.path.dirname(os.path.abspath(script_file))
+    return os.path.normpath(os.path.join(scripts_dir, "..", "refs", "catalogs"))

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-coverage-matrix.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-coverage-matrix.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""gen-coverage-matrix.py — generate refs/<skill>-coverage.md FROM the JSON
+catalogs (refs/catalogs/*.json), so the human-readable coverage matrix can never
+drift from the machine-loaded single source of truth (beads-sigma-kvza).
+
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md --check     # exit 1 if the file is stale
+
+One table per dimension, five columns (the handoff's shape):
+  | construct | doc ref | Sigma target | sigma_verified (y/n·date) | on-unmapped |
+
+Stdlib only; Windows-safe.
+"""
+import argparse
+import json
+import os
+import sys
+
+DIM_ORDER = ["viz-kind", "number-format", "aggregation", "control"]
+DIM_TITLE = {
+    "viz-kind": "Visualization / chart kind",
+    "number-format": "Number format",
+    "aggregation": "Aggregation",
+    "control": "Control / filter",
+}
+
+
+def _md_escape(s):
+    return str(s).replace("|", "\\|").replace("\n", " ")
+
+
+def _verified_cell(r):
+    sv = r.get("sigma_verified") or {}
+    status = sv.get("status", "n")
+    if status == "y":
+        return "✅ y · %s" % sv.get("date", "?")
+    return "🟡 n"
+
+
+def _target_cell(r):
+    sig = r.get("sigma")
+    if sig is None and r.get("sigma_if") is None:
+        return "— (no Sigma equivalent)"
+    parts = []
+    if sig is not None:
+        parts.append("`%s`" % _md_escape(sig))
+    if r.get("sigma_if"):
+        parts.append("if→`%s`" % _md_escape(r["sigma_if"]))
+    return " ".join(parts) if parts else "—"
+
+
+def _doc_cell(r):
+    ref = r.get("doc_ref", "")
+    return "[doc](%s)" % ref if ref.startswith("http") else _md_escape(ref or "—")
+
+
+def render(catalogs, skill):
+    cats = {}
+    for fn in sorted(os.listdir(catalogs)):
+        if fn.endswith(".json"):
+            cats[fn[:-5]] = json.load(open(os.path.join(catalogs, fn)))
+    order = [d for d in DIM_ORDER if d in cats] + [d for d in sorted(cats) if d not in DIM_ORDER]
+
+    out = []
+    out.append("# %s → Sigma — dashboard classifier coverage matrix" % skill.capitalize())
+    out.append("")
+    out.append("> **GENERATED — do not edit by hand.** Regenerate with "
+               "`python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs "
+               "--skill %s --out refs/%s-coverage.md`. The JSON catalogs in "
+               "`refs/catalogs/` are the single source of truth; the classifier "
+               "(`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them "
+               "via `shared/lib/coverage_catalog.py`. A no-drift test asserts this "
+               "file matches the catalogs." % (skill, skill))
+    out.append("")
+    out.append("Every documented source construct maps to a real, current Sigma target "
+               "or a loud fallback — no silent wrong-defaults, no name-substring "
+               "guessing (beads-sigma-kvza).")
+    out.append("")
+    out.append("**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at "
+               "**query time** in a live migration (no `type=error` column) on the date "
+               "shown; 🟡 n = target is documented but not yet query-verified.")
+    out.append("")
+    total = sum(len(c.get("rows", [])) for c in cats.values())
+    ver = sum(1 for c in cats.values() for r in c.get("rows", [])
+              if (r.get("sigma_verified") or {}).get("status") == "y")
+    out.append("**Coverage:** %d documented constructs across %d dimensions; "
+               "%d live-verified." % (total, len(cats), ver))
+    out.append("")
+
+    for dim in order:
+        c = cats[dim]
+        out.append("## %s" % DIM_TITLE.get(dim, dim))
+        out.append("")
+        if c.get("description"):
+            out.append("_%s_" % c["description"])
+            out.append("")
+        if c.get("authoritative_doc"):
+            out.append("Authoritative source: <%s>" % c["authoritative_doc"])
+            out.append("")
+        out.append("| construct | doc ref | Sigma target | sigma_verified | on-unmapped |")
+        out.append("|---|---|---|---|---|")
+        for r in c.get("rows", []):
+            notes = r.get("notes")
+            src = "`%s`" % _md_escape(r["source"])
+            onun = _md_escape(r.get("on_unmapped", c.get("on_unmapped_default", "")))
+            row = "| %s | %s | %s | %s | %s |" % (
+                src, _doc_cell(r), _target_cell(r), _verified_cell(r), onun)
+            out.append(row)
+            if notes:
+                out.append("| | | | | _%s_ |" % _md_escape(notes))
+        out.append("")
+
+    out.append("---")
+    out.append("_Compositional constructs that do not serialize to a flat table "
+               "(Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask "
+               "parsers, count-on-joined-view) stay as cited predicates in the "
+               "classifier; this matrix covers the enumerable maps._")
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--catalogs", required=True)
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if --out is stale vs the catalogs (no write)")
+    a = ap.parse_args()
+    text = render(a.catalogs, a.skill)
+    if a.check:
+        cur = open(a.out).read() if os.path.exists(a.out) else ""
+        if cur != text:
+            sys.stderr.write("STALE: %s does not match refs/catalogs — regenerate.\n" % a.out)
+            sys.exit(1)
+        print("OK: %s matches the catalogs." % a.out)
+        return
+    open(a.out, "w").write(text)
+    print("wrote %s (%d bytes)" % (a.out, len(text)))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/coverage_catalog.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""coverage_catalog.py — load a documentation-grounded mapping catalog and
+resolve source constructs to Sigma targets, LOUDLY on a miss.
+
+The single source of truth for a classifier's mappings is a JSON catalog under
+the skill's ``refs/catalogs/<dimension>.json``. Each catalog is an envelope::
+
+    {
+      "dimension": "number-format",
+      "source_tool": "looker",
+      "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+      "on_unmapped_default": "warn+skip",
+      "rows": [
+        {"source": "usd_0", "sigma": "$,.0f",
+         "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+         "sigma_verified": {"status": "y", "date": "2026-07-13"},
+         "on_unmapped": "warn+skip",
+         "notes": "..."}
+      ]
+    }
+
+Rows are indexed by ``source`` (normalized: trimmed + lowercased — every one of
+the four classifier dimensions keys on lowercase tokens). ``resolve()`` returns
+the row dict or ``None``. The classifier MUST honor a ``None`` by warning +
+skipping/placeholdering — never by emitting a silent wrong default.
+``resolve_or_warn()`` enforces that: it appends a standardized warning to the
+caller's ``warnings`` list and returns ``None`` on a miss.
+
+Stdlib only (json/os); Windows-safe (os.path). Mirrors the beads-sigma-93ps
+design contract: the catalog is language-neutral data; this loader is the thin
+resolver. See refs/<skill>-coverage.md (generated FROM the catalogs) for the
+human-readable, cited coverage matrix.
+"""
+import json
+import os
+
+MISS = None  # sentinel: resolve() returns None when a source key is absent
+
+
+class Catalog:
+    """A single loaded mapping dimension (viz-kind / number-format / aggregation
+    / control), indexed by source construct."""
+
+    def __init__(self, data, path):
+        self.path = path
+        self.filename = os.path.basename(path)
+        self.dimension = data.get("dimension") or os.path.splitext(self.filename)[0]
+        self.source_tool = data.get("source_tool", "")
+        self.authoritative_doc = data.get("authoritative_doc", "")
+        self.on_unmapped_default = data.get("on_unmapped_default", "warn+skip")
+        self.rows = data.get("rows", [])
+        self._by_source = {}
+        for r in self.rows:
+            k = r.get("source")
+            if k is None:
+                continue
+            self._by_source[self._norm(k)] = r
+
+    @staticmethod
+    def _norm(k):
+        return str(k).strip().lower()
+
+    def resolve(self, source_key):
+        """Return the full catalog row for ``source_key``, or ``None`` on a miss."""
+        if source_key is None:
+            return None
+        return self._by_source.get(self._norm(source_key))
+
+    def target(self, source_key):
+        """Return just the Sigma target string for ``source_key`` (row['sigma']),
+        or ``None`` on a miss. Convenience for the common case."""
+        row = self.resolve(source_key)
+        return row.get("sigma") if row else None
+
+    def resolve_or_warn(self, source_key, warnings, *, context=""):
+        """Resolve ``source_key``; on a miss append a standardized LOUD warning to
+        ``warnings`` and return ``None``. The caller must then skip/placeholder —
+        this makes the loud fallback mandatory and uniform across classifiers."""
+        row = self.resolve(source_key)
+        if row is not None:
+            return row
+        where = " (%s)" % context if context else ""
+        warnings.append(
+            "⚠ %s: no documented %s mapping for '%s'%s — %s. "
+            "Add a cited row to refs/catalogs/%s if this is a real construct."
+            % (self.dimension, self.source_tool or "source", source_key, where,
+               self.on_unmapped_default, self.filename)
+        )
+        return None
+
+    def sources(self):
+        """All (normalized) source keys the catalog covers."""
+        return list(self._by_source.keys())
+
+    def unverified(self):
+        """Rows whose Sigma target is not yet live-verified
+        (``sigma_verified.status`` != 'y'). Used to gate a PR / stamp progress."""
+        return [r for r in self.rows
+                if (r.get("sigma_verified") or {}).get("status") != "y"]
+
+
+def load(catalog_dir, dimension):
+    """Load ``<catalog_dir>/<dimension>.json``. Fails LOUDLY if absent — a
+    classifier with no catalog must not silently guess."""
+    path = os.path.join(catalog_dir, dimension + ".json")
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            "coverage catalog missing: %s — the classifier requires a "
+            "documentation-grounded catalog for '%s'; refusing to guess."
+            % (path, dimension)
+        )
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return Catalog(data, path)
+
+
+def load_all(catalog_dir):
+    """Load every ``*.json`` catalog in ``catalog_dir``, keyed by dimension name."""
+    if not os.path.isdir(catalog_dir):
+        raise FileNotFoundError("coverage catalog dir missing: %s" % catalog_dir)
+    out = {}
+    for fn in sorted(os.listdir(catalog_dir)):
+        if fn.endswith(".json"):
+            out[fn[:-5]] = load(catalog_dir, fn[:-5])
+    return out
+
+
+def default_catalog_dir(script_file):
+    """Given a builder's ``__file__`` (in scripts/), return its sibling
+    ``refs/catalogs`` dir. Keeps callers from hand-rolling the ``..`` walk."""
+    scripts_dir = os.path.dirname(os.path.abspath(script_file))
+    return os.path.normpath(os.path.join(scripts_dir, "..", "refs", "catalogs"))

--- a/shared/lib/coverage_catalog.py
+++ b/shared/lib/coverage_catalog.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""coverage_catalog.py — load a documentation-grounded mapping catalog and
+resolve source constructs to Sigma targets, LOUDLY on a miss.
+
+The single source of truth for a classifier's mappings is a JSON catalog under
+the skill's ``refs/catalogs/<dimension>.json``. Each catalog is an envelope::
+
+    {
+      "dimension": "number-format",
+      "source_tool": "looker",
+      "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+      "on_unmapped_default": "warn+skip",
+      "rows": [
+        {"source": "usd_0", "sigma": "$,.0f",
+         "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+         "sigma_verified": {"status": "y", "date": "2026-07-13"},
+         "on_unmapped": "warn+skip",
+         "notes": "..."}
+      ]
+    }
+
+Rows are indexed by ``source`` (normalized: trimmed + lowercased — every one of
+the four classifier dimensions keys on lowercase tokens). ``resolve()`` returns
+the row dict or ``None``. The classifier MUST honor a ``None`` by warning +
+skipping/placeholdering — never by emitting a silent wrong default.
+``resolve_or_warn()`` enforces that: it appends a standardized warning to the
+caller's ``warnings`` list and returns ``None`` on a miss.
+
+Stdlib only (json/os); Windows-safe (os.path). Mirrors the beads-sigma-93ps
+design contract: the catalog is language-neutral data; this loader is the thin
+resolver. See refs/<skill>-coverage.md (generated FROM the catalogs) for the
+human-readable, cited coverage matrix.
+"""
+import json
+import os
+
+MISS = None  # sentinel: resolve() returns None when a source key is absent
+
+
+class Catalog:
+    """A single loaded mapping dimension (viz-kind / number-format / aggregation
+    / control), indexed by source construct."""
+
+    def __init__(self, data, path):
+        self.path = path
+        self.filename = os.path.basename(path)
+        self.dimension = data.get("dimension") or os.path.splitext(self.filename)[0]
+        self.source_tool = data.get("source_tool", "")
+        self.authoritative_doc = data.get("authoritative_doc", "")
+        self.on_unmapped_default = data.get("on_unmapped_default", "warn+skip")
+        self.rows = data.get("rows", [])
+        self._by_source = {}
+        for r in self.rows:
+            k = r.get("source")
+            if k is None:
+                continue
+            self._by_source[self._norm(k)] = r
+
+    @staticmethod
+    def _norm(k):
+        return str(k).strip().lower()
+
+    def resolve(self, source_key):
+        """Return the full catalog row for ``source_key``, or ``None`` on a miss."""
+        if source_key is None:
+            return None
+        return self._by_source.get(self._norm(source_key))
+
+    def target(self, source_key):
+        """Return just the Sigma target string for ``source_key`` (row['sigma']),
+        or ``None`` on a miss. Convenience for the common case."""
+        row = self.resolve(source_key)
+        return row.get("sigma") if row else None
+
+    def resolve_or_warn(self, source_key, warnings, *, context=""):
+        """Resolve ``source_key``; on a miss append a standardized LOUD warning to
+        ``warnings`` and return ``None``. The caller must then skip/placeholder —
+        this makes the loud fallback mandatory and uniform across classifiers."""
+        row = self.resolve(source_key)
+        if row is not None:
+            return row
+        where = " (%s)" % context if context else ""
+        warnings.append(
+            "⚠ %s: no documented %s mapping for '%s'%s — %s. "
+            "Add a cited row to refs/catalogs/%s if this is a real construct."
+            % (self.dimension, self.source_tool or "source", source_key, where,
+               self.on_unmapped_default, self.filename)
+        )
+        return None
+
+    def sources(self):
+        """All (normalized) source keys the catalog covers."""
+        return list(self._by_source.keys())
+
+    def unverified(self):
+        """Rows whose Sigma target is not yet live-verified
+        (``sigma_verified.status`` != 'y'). Used to gate a PR / stamp progress."""
+        return [r for r in self.rows
+                if (r.get("sigma_verified") or {}).get("status") != "y"]
+
+
+def load(catalog_dir, dimension):
+    """Load ``<catalog_dir>/<dimension>.json``. Fails LOUDLY if absent — a
+    classifier with no catalog must not silently guess."""
+    path = os.path.join(catalog_dir, dimension + ".json")
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            "coverage catalog missing: %s — the classifier requires a "
+            "documentation-grounded catalog for '%s'; refusing to guess."
+            % (path, dimension)
+        )
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return Catalog(data, path)
+
+
+def load_all(catalog_dir):
+    """Load every ``*.json`` catalog in ``catalog_dir``, keyed by dimension name."""
+    if not os.path.isdir(catalog_dir):
+        raise FileNotFoundError("coverage catalog dir missing: %s" % catalog_dir)
+    out = {}
+    for fn in sorted(os.listdir(catalog_dir)):
+        if fn.endswith(".json"):
+            out[fn[:-5]] = load(catalog_dir, fn[:-5])
+    return out
+
+
+def default_catalog_dir(script_file):
+    """Given a builder's ``__file__`` (in scripts/), return its sibling
+    ``refs/catalogs`` dir. Keeps callers from hand-rolling the ``..`` walk."""
+    scripts_dir = os.path.dirname(os.path.abspath(script_file))
+    return os.path.normpath(os.path.join(scripts_dir, "..", "refs", "catalogs"))

--- a/shared/lib/test_coverage_catalog.py
+++ b/shared/lib/test_coverage_catalog.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unit test for coverage_catalog.py — the shared documentation-grounded mapping
+loader. Stdlib only; run directly:  python3 shared/lib/test_coverage_catalog.py
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import coverage_catalog as cc  # noqa: E402
+
+
+def _write_catalog(d, name, rows, **envelope):
+    payload = {"rows": rows}
+    payload.update(envelope)
+    with open(os.path.join(d, name + ".json"), "w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+
+class CoverageCatalogTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="cc-test-")
+        _write_catalog(
+            self.dir, "number-format",
+            [
+                {"source": "usd_0", "sigma": "$,.0f",
+                 "doc_ref": "https://example/usd_0",
+                 "sigma_verified": {"status": "y", "date": "2026-07-13"},
+                 "on_unmapped": "warn+skip"},
+                {"source": "Percent_1", "sigma": ",.1%",  # mixed case -> normalized
+                 "doc_ref": "https://example/percent_1",
+                 "sigma_verified": {"status": "n"},
+                 "on_unmapped": "warn+skip"},
+            ],
+            dimension="number-format", source_tool="looker",
+            authoritative_doc="https://example/authority",
+            on_unmapped_default="warn+skip",
+        )
+
+    def test_resolve_hit_and_normalization(self):
+        cat = cc.load(self.dir, "number-format")
+        self.assertEqual(cat.target("usd_0"), "$,.0f")
+        # trimmed + case-insensitive
+        self.assertEqual(cat.target("  USD_0 "), "$,.0f")
+        self.assertEqual(cat.target("percent_1"), ",.1%")
+
+    def test_resolve_miss_returns_none(self):
+        cat = cc.load(self.dir, "number-format")
+        self.assertIsNone(cat.resolve("gbp_9"))
+        self.assertIsNone(cat.target("gbp_9"))
+        self.assertIsNone(cat.resolve(None))
+
+    def test_resolve_or_warn_is_loud_on_miss(self):
+        cat = cc.load(self.dir, "number-format")
+        warnings = []
+        self.assertIsNone(cat.resolve_or_warn("gbp_9", warnings, context="tile 'X'"))
+        self.assertEqual(len(warnings), 1)
+        w = warnings[0]
+        self.assertIn("number-format", w)
+        self.assertIn("gbp_9", w)
+        self.assertIn("looker", w)
+        self.assertIn("tile 'X'", w)
+        self.assertIn("number-format.json", w)
+        # a hit adds NO warning
+        self.assertIsNotNone(cat.resolve_or_warn("usd_0", warnings))
+        self.assertEqual(len(warnings), 1)
+
+    def test_metadata_and_unverified(self):
+        cat = cc.load(self.dir, "number-format")
+        self.assertEqual(cat.dimension, "number-format")
+        self.assertEqual(cat.source_tool, "looker")
+        self.assertEqual(cat.authoritative_doc, "https://example/authority")
+        self.assertEqual(sorted(cat.sources()), ["percent_1", "usd_0"])
+        unv = cat.unverified()
+        self.assertEqual([r["source"] for r in unv], ["Percent_1"])
+
+    def test_missing_catalog_fails_loudly(self):
+        with self.assertRaises(FileNotFoundError):
+            cc.load(self.dir, "does-not-exist")
+        with self.assertRaises(FileNotFoundError):
+            cc.load_all(os.path.join(self.dir, "nope"))
+
+    def test_load_all(self):
+        _write_catalog(self.dir, "viz-kind",
+                       [{"source": "looker_bar", "sigma": "bar-chart"}],
+                       dimension="viz-kind", source_tool="looker")
+        cats = cc.load_all(self.dir)
+        self.assertEqual(sorted(cats.keys()), ["number-format", "viz-kind"])
+        self.assertEqual(cats["viz-kind"].target("looker_bar"), "bar-chart")
+
+    def test_default_catalog_dir(self):
+        fake = "/a/b/skills/x/scripts/build.py"
+        got = cc.default_catalog_dir(fake)
+        self.assertTrue(got.endswith(os.path.join("skills", "x", "refs", "catalogs")))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -2,6 +2,20 @@
   "description": "Canonical shared infra files. Edit the canonical copy under shared/, then run tools/sync-shared.rb. CI (tools/check-shared.rb) fails if any target drifts from canonical (exceptions excluded).",
   "shared": [
     {
+      "canonical": "shared/lib/coverage_catalog.py",
+      "targets": [
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/coverage_catalog.py",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/coverage_catalog.py"
+      ]
+    },
+    {
+      "canonical": "shared/scripts/gen-coverage-matrix.py",
+      "targets": [
+        "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/gen-coverage-matrix.py",
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-coverage-matrix.py"
+      ]
+    },
+    {
       "canonical": "shared/lib/sigma_rest.py",
       "targets": [
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/sigma_rest.py"

--- a/shared/scripts/gen-coverage-matrix.py
+++ b/shared/scripts/gen-coverage-matrix.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""gen-coverage-matrix.py — generate refs/<skill>-coverage.md FROM the JSON
+catalogs (refs/catalogs/*.json), so the human-readable coverage matrix can never
+drift from the machine-loaded single source of truth (beads-sigma-kvza).
+
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md --check     # exit 1 if the file is stale
+
+One table per dimension, five columns (the handoff's shape):
+  | construct | doc ref | Sigma target | sigma_verified (y/n·date) | on-unmapped |
+
+Stdlib only; Windows-safe.
+"""
+import argparse
+import json
+import os
+import sys
+
+DIM_ORDER = ["viz-kind", "number-format", "aggregation", "control"]
+DIM_TITLE = {
+    "viz-kind": "Visualization / chart kind",
+    "number-format": "Number format",
+    "aggregation": "Aggregation",
+    "control": "Control / filter",
+}
+
+
+def _md_escape(s):
+    return str(s).replace("|", "\\|").replace("\n", " ")
+
+
+def _verified_cell(r):
+    sv = r.get("sigma_verified") or {}
+    status = sv.get("status", "n")
+    if status == "y":
+        return "✅ y · %s" % sv.get("date", "?")
+    return "🟡 n"
+
+
+def _target_cell(r):
+    sig = r.get("sigma")
+    if sig is None and r.get("sigma_if") is None:
+        return "— (no Sigma equivalent)"
+    parts = []
+    if sig is not None:
+        parts.append("`%s`" % _md_escape(sig))
+    if r.get("sigma_if"):
+        parts.append("if→`%s`" % _md_escape(r["sigma_if"]))
+    return " ".join(parts) if parts else "—"
+
+
+def _doc_cell(r):
+    ref = r.get("doc_ref", "")
+    return "[doc](%s)" % ref if ref.startswith("http") else _md_escape(ref or "—")
+
+
+def render(catalogs, skill):
+    cats = {}
+    for fn in sorted(os.listdir(catalogs)):
+        if fn.endswith(".json"):
+            cats[fn[:-5]] = json.load(open(os.path.join(catalogs, fn)))
+    order = [d for d in DIM_ORDER if d in cats] + [d for d in sorted(cats) if d not in DIM_ORDER]
+
+    out = []
+    out.append("# %s → Sigma — dashboard classifier coverage matrix" % skill.capitalize())
+    out.append("")
+    out.append("> **GENERATED — do not edit by hand.** Regenerate with "
+               "`python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs "
+               "--skill %s --out refs/%s-coverage.md`. The JSON catalogs in "
+               "`refs/catalogs/` are the single source of truth; the classifier "
+               "(`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them "
+               "via `shared/lib/coverage_catalog.py`. A no-drift test asserts this "
+               "file matches the catalogs." % (skill, skill))
+    out.append("")
+    out.append("Every documented source construct maps to a real, current Sigma target "
+               "or a loud fallback — no silent wrong-defaults, no name-substring "
+               "guessing (beads-sigma-kvza).")
+    out.append("")
+    out.append("**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at "
+               "**query time** in a live migration (no `type=error` column) on the date "
+               "shown; 🟡 n = target is documented but not yet query-verified.")
+    out.append("")
+    total = sum(len(c.get("rows", [])) for c in cats.values())
+    ver = sum(1 for c in cats.values() for r in c.get("rows", [])
+              if (r.get("sigma_verified") or {}).get("status") == "y")
+    out.append("**Coverage:** %d documented constructs across %d dimensions; "
+               "%d live-verified." % (total, len(cats), ver))
+    out.append("")
+
+    for dim in order:
+        c = cats[dim]
+        out.append("## %s" % DIM_TITLE.get(dim, dim))
+        out.append("")
+        if c.get("description"):
+            out.append("_%s_" % c["description"])
+            out.append("")
+        if c.get("authoritative_doc"):
+            out.append("Authoritative source: <%s>" % c["authoritative_doc"])
+            out.append("")
+        out.append("| construct | doc ref | Sigma target | sigma_verified | on-unmapped |")
+        out.append("|---|---|---|---|---|")
+        for r in c.get("rows", []):
+            notes = r.get("notes")
+            src = "`%s`" % _md_escape(r["source"])
+            onun = _md_escape(r.get("on_unmapped", c.get("on_unmapped_default", "")))
+            row = "| %s | %s | %s | %s | %s |" % (
+                src, _doc_cell(r), _target_cell(r), _verified_cell(r), onun)
+            out.append(row)
+            if notes:
+                out.append("| | | | | _%s_ |" % _md_escape(notes))
+        out.append("")
+
+    out.append("---")
+    out.append("_Compositional constructs that do not serialize to a flat table "
+               "(Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask "
+               "parsers, count-on-joined-view) stay as cited predicates in the "
+               "classifier; this matrix covers the enumerable maps._")
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--catalogs", required=True)
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if --out is stale vs the catalogs (no write)")
+    a = ap.parse_args()
+    text = render(a.catalogs, a.skill)
+    if a.check:
+        cur = open(a.out).read() if os.path.exists(a.out) else ""
+        if cur != text:
+            sys.stderr.write("STALE: %s does not match refs/catalogs — regenerate.\n" % a.out)
+            sys.exit(1)
+        print("OK: %s matches the catalogs." % a.out)
+        return
+    open(a.out, "w").write(text)
+    print("wrote %s (%d bytes)" % (a.out, len(text)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
The reusable **template** for documentation-grounding migration-skill dashboard classifiers (epic **beads-sigma-kvza**). Replaces hardcoded `case`/`||` judgement with cited, machine-loaded mapping catalogs.

- **`shared/lib/coverage_catalog.py`** — thin loader. `resolve(source)` → a cited row, or a **loud** miss via `resolve_or_warn` (never a silent wrong-default). Fails loudly if a catalog is missing. + unit test (7/7).
- **`shared/scripts/gen-coverage-matrix.py`** — generates `refs/<skill>-coverage.md` **from** the JSON catalogs, with a `--check` no-drift mode so the human matrix can't diverge from code.
- **manifest + sync fan-out** into `looker-to-sigma` and `qlik-to-sigma` `scripts/lib`.

Design mirrors the beads-sigma-93ps contract: catalog = language-neutral data, code = thin resolver/predicates.

## Verification
- `python3 shared/lib/test_coverage_catalog.py` → 7/7.
- `ruby tools/check-shared.rb` → 284 copies match canonical.

## Stacking
Base for the two skill PRs (`kvza-looker`, `kvza-qlik`) — merge this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)