### PR TITLE
kvza.1/.2 (looker): documentation-ground build_workbook.py classifier

### DIFF
--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/catalogs/aggregation.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/catalogs/aggregation.json
@@ -1,0 +1,17 @@
+{
+  "dimension": "aggregation",
+  "source_tool": "looker",
+  "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-measure-types",
+  "sigma_target_doc": "https://help.sigmacomputing.com/docs/aggregate-functions",
+  "on_unmapped_default": "warn+skip (NEVER silently default to Count())",
+  "description": "LookML measure `type` -> Sigma aggregate function. `sigma` is the plain aggregate; `sigma_if` is the filtered variant used when the measure carries a `filters:` sub-block (Looker filtered measures). Compositional measure types (yesno, number/expression, running/period-over-period, percentile, list) are NOT flat-mappable and stay as cited predicates in formula_for(); an unmapped scalar type warns+skips. count / count_distinct are resolved compositionally in formula_for (a plain count on a JOINED view becomes CountDistinct on that view's PK), so their plain `sigma` here documents the canonical target rather than driving the fallback branch.",
+  "rows": [
+    {"source": "sum", "sigma": "Sum", "sigma_if": "SumIf", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-types#sum", "sigma_target_ref": "https://help.sigmacomputing.com/docs/sum", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-parity CSA.TJ (looker skilltest-orders, wb a11ec834); 5/5 strict, no type=error"}, "on_unmapped": "warn+skip"},
+    {"source": "average", "sigma": "Avg", "sigma_if": "AvgIf", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-types#average", "sigma_target_ref": "https://help.sigmacomputing.com/docs/avgif", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "min", "sigma": "Min", "sigma_if": "MinIf", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-types#min", "sigma_target_ref": "https://help.sigmacomputing.com/docs/aggregate-functions", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "max", "sigma": "Max", "sigma_if": "MaxIf", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-types#max", "sigma_target_ref": "https://help.sigmacomputing.com/docs/aggregate-functions", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "median", "sigma": "Median", "sigma_if": null, "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-types#median", "sigma_target_ref": "https://help.sigmacomputing.com/docs/aggregate-functions", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip", "notes": "Sigma has no MedianIf; a filtered median warns (filter dropped)."},
+    {"source": "count", "sigma": "Count()", "sigma_if": "CountIf", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-types#count", "sigma_target_ref": "https://help.sigmacomputing.com/docs/aggregate-functions", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip", "notes": "Resolved in formula_for: a plain count on a JOINED view -> CountDistinct on that view's primary_key (counts entities, not fact rows). Plain `sigma` here is the canonical fact-grain target."},
+    {"source": "count_distinct", "sigma": "CountDistinct", "sigma_if": "CountDistinctIf", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-types#count_distinct", "sigma_target_ref": "https://help.sigmacomputing.com/docs/aggregate-functions", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-parity CSA.TJ (looker skilltest-orders, wb a11ec834); 5/5 strict, no type=error"}, "on_unmapped": "warn+skip"}
+  ]
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/catalogs/control.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/catalogs/control.json
@@ -1,0 +1,13 @@
+{
+  "dimension": "control",
+  "source_tool": "looker",
+  "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#filters",
+  "sigma_target_doc": "refs/control-parity.md",
+  "on_unmapped_default": "list (documented default control kind for a categorical dashboard filter)",
+  "description": "Looker dashboard filter `type` -> Sigma control kind. Only the date case is special (a Sigma `list` control bound to a datetime column is silently dropped on POST, so a date filter MUST become a date-range control). Everything else is a categorical `list` control — the DOCUMENTED default, not a silent guess. An override applies in code: a filter bound to a date/time dimension_group becomes date-range regardless of the Looker filter `type` (compositional, cited).",
+  "rows": [
+    {"source": "date_filter", "sigma": "date-range", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#type_for_filters", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-parity CSA.TJ (looker skilltest-orders, wb a11ec834); 5/5 strict, no type=error"}, "on_unmapped": "n/a", "notes": "A datetime-bound list control comes back with empty filters (dead control) — must be a date control."},
+    {"source": "field_filter", "sigma": "list", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#type_for_filters", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-parity CSA.TJ (looker skilltest-orders, wb a11ec834); 5/5 strict, no type=error"}, "on_unmapped": "n/a", "notes": "Categorical list control (documented default). A field_filter bound to a date dimension_group is overridden to date-range in code."},
+    {"source": "string_filter", "sigma": "list", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#type_for_filters", "sigma_verified": {"status": "n"}, "on_unmapped": "n/a"}
+  ]
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/catalogs/number-format.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/catalogs/number-format.json
@@ -1,0 +1,27 @@
+{
+  "dimension": "number-format",
+  "source_tool": "looker",
+  "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name",
+  "sigma_target_doc": "https://help.sigmacomputing.com/docs/data-types-and-formats",
+  "on_unmapped_default": "warn (keep numeric value, no format) — a custom value_format mask is tried in code before this fallback",
+  "description": "LookML `value_format_name` (built-in named format) -> Sigma column number format (D3 format string in {kind:number, formatString}). Custom `value_format` Excel/TO_CHAR masks are NOT in this table — they are parsed by cited predicates custom_value_format_to_d3() / snowflake_mask_to_format(). An unrecognized named format falls through to the custom-mask parser, then to a loud warn (never a name-substring currency guess).",
+  "rows": [
+    {"source": "usd", "sigma": "$,.2f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-parity CSA.TJ (looker skilltest-orders, wb a11ec834); 5/5 strict, no type=error"}, "on_unmapped": "warn+keep-value", "notes": "USD, 2 decimals, thousands sep."},
+    {"source": "usd_0", "sigma": "$,.0f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value", "notes": "USD, 0 decimals."},
+    {"source": "gbp", "sigma": "£,.2f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "gbp_0", "sigma": "£,.0f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "eur", "sigma": "€,.2f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "eur_0", "sigma": "€,.0f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "percent_0", "sigma": ",.0%", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value", "notes": "LookML percent_N assumes the value is a ratio (0-1); Sigma % format multiplies by 100 the same way."},
+    {"source": "percent_1", "sigma": ",.1%", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "percent_2", "sigma": ",.2%", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "percent_3", "sigma": ",.3%", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "percent_4", "sigma": ",.4%", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "decimal_0", "sigma": ",.0f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "decimal_1", "sigma": ",.1f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "decimal_2", "sigma": ",.2f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "decimal_3", "sigma": ",.3f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "decimal_4", "sigma": ",.4f", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value"},
+    {"source": "id", "sigma": "d", "doc_ref": "https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+keep-value", "notes": "Plain integer, no thousands separator (D3 'd')."}
+  ]
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/catalogs/viz-kind.json
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/catalogs/viz-kind.json
@@ -1,0 +1,19 @@
+{
+  "dimension": "viz-kind",
+  "source_tool": "looker",
+  "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-lookml-dashboard",
+  "on_unmapped_default": "warn+skip",
+  "description": "Looker dashboard element visualization `type` -> Sigma workbook element kind. The single source of truth for build_workbook.py's tile classifier. Unmapped vis types warn+skip (a merged-results tile with no vis type is the one documented exception, defaulted in code with a warning).",
+  "rows": [
+    {"source": "single_value", "sigma": "kpi-chart", "doc_ref": "https://cloud.google.com/looker/docs/single-value", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-parity CSA.TJ (looker skilltest-orders, wb a11ec834); 5/5 strict, no type=error"}, "on_unmapped": "warn+skip", "notes": "Looker single_value tile -> Sigma KPI."},
+    {"source": "looker_column", "sigma": "bar-chart", "doc_ref": "https://cloud.google.com/looker/docs/column-chart-options", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-parity CSA.TJ (looker skilltest-orders, wb a11ec834); 5/5 strict, no type=error"}, "on_unmapped": "warn+skip", "notes": "Vertical bars. Sigma bar-chart with NO orientation key = vertical."},
+    {"source": "looker_bar", "sigma": "bar-chart", "doc_ref": "https://cloud.google.com/looker/docs/bar-chart-options", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip", "notes": "Horizontal bars. build_workbook adds orientation:horizontal downstream (see test_grid_fidelity.py)."},
+    {"source": "looker_area", "sigma": "area-chart", "doc_ref": "https://cloud.google.com/looker/docs/area-chart-options", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "looker_line", "sigma": "line-chart", "doc_ref": "https://cloud.google.com/looker/docs/line-chart-options", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "looker_pie", "sigma": "pie-chart", "doc_ref": "https://cloud.google.com/looker/docs/pie-chart-and-donut-chart-options", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-parity CSA.TJ (looker skilltest-orders, wb a11ec834); 5/5 strict, no type=error"}, "on_unmapped": "warn+skip"},
+    {"source": "looker_donut_multiples", "sigma": "donut-chart", "doc_ref": "https://cloud.google.com/looker/docs/pie-chart-and-donut-chart-options", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip", "notes": "Looker donut small-multiples has no Sigma equivalent -> single donut-chart; build_workbook warns about the lost small-multiples facet."},
+    {"source": "table", "sigma": "table", "doc_ref": "https://cloud.google.com/looker/docs/table-chart-options", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-parity CSA.TJ (looker skilltest-orders, wb a11ec834); 5/5 strict, no type=error"}, "on_unmapped": "warn+skip"},
+    {"source": "looker_grid", "sigma": "table", "doc_ref": "https://cloud.google.com/looker/docs/table-chart-options", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip", "notes": "Looker grid (data table) -> Sigma table."},
+    {"source": "looker_scatter", "sigma": "scatter-chart", "doc_ref": "https://cloud.google.com/looker/docs/scatterplot-options", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"}
+  ]
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/refs/looker-coverage.md
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/refs/looker-coverage.md
@@ -1,0 +1,98 @@
+# Looker → Sigma — dashboard classifier coverage matrix
+
+> **GENERATED — do not edit by hand.** Regenerate with `python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker --out refs/looker-coverage.md`. The JSON catalogs in `refs/catalogs/` are the single source of truth; the classifier (`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them via `shared/lib/coverage_catalog.py`. A no-drift test asserts this file matches the catalogs.
+
+Every documented source construct maps to a real, current Sigma target or a loud fallback — no silent wrong-defaults, no name-substring guessing (beads-sigma-kvza).
+
+**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at **query time** in a live migration (no `type=error` column) on the date shown; 🟡 n = target is documented but not yet query-verified.
+
+**Coverage:** 37 documented constructs across 4 dimensions; 9 live-verified.
+
+## Visualization / chart kind
+
+_Looker dashboard element visualization `type` -> Sigma workbook element kind. The single source of truth for build_workbook.py's tile classifier. Unmapped vis types warn+skip (a merged-results tile with no vis type is the one documented exception, defaulted in code with a warning)._
+
+Authoritative source: <https://cloud.google.com/looker/docs/reference/param-lookml-dashboard>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `single_value` | [doc](https://cloud.google.com/looker/docs/single-value) | `kpi-chart` | ✅ y · 2026-07-13 | warn+skip |
+| | | | | _Looker single_value tile -> Sigma KPI._ |
+| `looker_column` | [doc](https://cloud.google.com/looker/docs/column-chart-options) | `bar-chart` | ✅ y · 2026-07-13 | warn+skip |
+| | | | | _Vertical bars. Sigma bar-chart with NO orientation key = vertical._ |
+| `looker_bar` | [doc](https://cloud.google.com/looker/docs/bar-chart-options) | `bar-chart` | 🟡 n | warn+skip |
+| | | | | _Horizontal bars. build_workbook adds orientation:horizontal downstream (see test_grid_fidelity.py)._ |
+| `looker_area` | [doc](https://cloud.google.com/looker/docs/area-chart-options) | `area-chart` | 🟡 n | warn+skip |
+| `looker_line` | [doc](https://cloud.google.com/looker/docs/line-chart-options) | `line-chart` | 🟡 n | warn+skip |
+| `looker_pie` | [doc](https://cloud.google.com/looker/docs/pie-chart-and-donut-chart-options) | `pie-chart` | ✅ y · 2026-07-13 | warn+skip |
+| `looker_donut_multiples` | [doc](https://cloud.google.com/looker/docs/pie-chart-and-donut-chart-options) | `donut-chart` | 🟡 n | warn+skip |
+| | | | | _Looker donut small-multiples has no Sigma equivalent -> single donut-chart; build_workbook warns about the lost small-multiples facet._ |
+| `table` | [doc](https://cloud.google.com/looker/docs/table-chart-options) | `table` | ✅ y · 2026-07-13 | warn+skip |
+| `looker_grid` | [doc](https://cloud.google.com/looker/docs/table-chart-options) | `table` | 🟡 n | warn+skip |
+| | | | | _Looker grid (data table) -> Sigma table._ |
+| `looker_scatter` | [doc](https://cloud.google.com/looker/docs/scatterplot-options) | `scatter-chart` | 🟡 n | warn+skip |
+
+## Number format
+
+_LookML `value_format_name` (built-in named format) -> Sigma column number format (D3 format string in {kind:number, formatString}). Custom `value_format` Excel/TO_CHAR masks are NOT in this table — they are parsed by cited predicates custom_value_format_to_d3() / snowflake_mask_to_format(). An unrecognized named format falls through to the custom-mask parser, then to a loud warn (never a name-substring currency guess)._
+
+Authoritative source: <https://cloud.google.com/looker/docs/reference/param-field-value-format-name>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `usd` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `$,.2f` | ✅ y · 2026-07-13 | warn+keep-value |
+| | | | | _USD, 2 decimals, thousands sep._ |
+| `usd_0` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `$,.0f` | 🟡 n | warn+keep-value |
+| | | | | _USD, 0 decimals._ |
+| `gbp` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `£,.2f` | 🟡 n | warn+keep-value |
+| `gbp_0` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `£,.0f` | 🟡 n | warn+keep-value |
+| `eur` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `€,.2f` | 🟡 n | warn+keep-value |
+| `eur_0` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `€,.0f` | 🟡 n | warn+keep-value |
+| `percent_0` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `,.0%` | 🟡 n | warn+keep-value |
+| | | | | _LookML percent_N assumes the value is a ratio (0-1); Sigma % format multiplies by 100 the same way._ |
+| `percent_1` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `,.1%` | 🟡 n | warn+keep-value |
+| `percent_2` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `,.2%` | 🟡 n | warn+keep-value |
+| `percent_3` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `,.3%` | 🟡 n | warn+keep-value |
+| `percent_4` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `,.4%` | 🟡 n | warn+keep-value |
+| `decimal_0` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `,.0f` | 🟡 n | warn+keep-value |
+| `decimal_1` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `,.1f` | 🟡 n | warn+keep-value |
+| `decimal_2` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `,.2f` | 🟡 n | warn+keep-value |
+| `decimal_3` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `,.3f` | 🟡 n | warn+keep-value |
+| `decimal_4` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `,.4f` | 🟡 n | warn+keep-value |
+| `id` | [doc](https://cloud.google.com/looker/docs/reference/param-field-value-format-name#default_value_formats) | `d` | 🟡 n | warn+keep-value |
+| | | | | _Plain integer, no thousands separator (D3 'd')._ |
+
+## Aggregation
+
+_LookML measure `type` -> Sigma aggregate function. `sigma` is the plain aggregate; `sigma_if` is the filtered variant used when the measure carries a `filters:` sub-block (Looker filtered measures). Compositional measure types (yesno, number/expression, running/period-over-period, percentile, list) are NOT flat-mappable and stay as cited predicates in formula_for(); an unmapped scalar type warns+skips. count / count_distinct are resolved compositionally in formula_for (a plain count on a JOINED view becomes CountDistinct on that view's PK), so their plain `sigma` here documents the canonical target rather than driving the fallback branch._
+
+Authoritative source: <https://cloud.google.com/looker/docs/reference/param-measure-types>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `sum` | [doc](https://cloud.google.com/looker/docs/reference/param-measure-types#sum) | `Sum` if→`SumIf` | ✅ y · 2026-07-13 | warn+skip |
+| `average` | [doc](https://cloud.google.com/looker/docs/reference/param-measure-types#average) | `Avg` if→`AvgIf` | 🟡 n | warn+skip |
+| `min` | [doc](https://cloud.google.com/looker/docs/reference/param-measure-types#min) | `Min` if→`MinIf` | 🟡 n | warn+skip |
+| `max` | [doc](https://cloud.google.com/looker/docs/reference/param-measure-types#max) | `Max` if→`MaxIf` | 🟡 n | warn+skip |
+| `median` | [doc](https://cloud.google.com/looker/docs/reference/param-measure-types#median) | `Median` | 🟡 n | warn+skip |
+| | | | | _Sigma has no MedianIf; a filtered median warns (filter dropped)._ |
+| `count` | [doc](https://cloud.google.com/looker/docs/reference/param-measure-types#count) | `Count()` if→`CountIf` | 🟡 n | warn+skip |
+| | | | | _Resolved in formula_for: a plain count on a JOINED view -> CountDistinct on that view's primary_key (counts entities, not fact rows). Plain `sigma` here is the canonical fact-grain target._ |
+| `count_distinct` | [doc](https://cloud.google.com/looker/docs/reference/param-measure-types#count_distinct) | `CountDistinct` if→`CountDistinctIf` | ✅ y · 2026-07-13 | warn+skip |
+
+## Control / filter
+
+_Looker dashboard filter `type` -> Sigma control kind. Only the date case is special (a Sigma `list` control bound to a datetime column is silently dropped on POST, so a date filter MUST become a date-range control). Everything else is a categorical `list` control — the DOCUMENTED default, not a silent guess. An override applies in code: a filter bound to a date/time dimension_group becomes date-range regardless of the Looker filter `type` (compositional, cited)._
+
+Authoritative source: <https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#filters>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `date_filter` | [doc](https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#type_for_filters) | `date-range` | ✅ y · 2026-07-13 | n/a |
+| | | | | _A datetime-bound list control comes back with empty filters (dead control) — must be a date control._ |
+| `field_filter` | [doc](https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#type_for_filters) | `list` | ✅ y · 2026-07-13 | n/a |
+| | | | | _Categorical list control (documented default). A field_filter bound to a date dimension_group is overridden to date-range in code._ |
+| `string_filter` | [doc](https://cloud.google.com/looker/docs/reference/param-lookml-dashboard#type_for_filters) | `list` | 🟡 n | n/a |
+
+---
+_Compositional constructs that do not serialize to a flat table (Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask parsers, count-on-joined-view) stay as cited predicates in the classifier; this matrix covers the enumerable maps._

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/build_workbook.py
@@ -32,40 +32,33 @@ TIMEFRAME_SUFFIX = {"raw": "Raw", "time": "Time", "date": "Date", "week": "Week"
                     "month": "Month", "quarter": "Quarter", "year": "Year"}
 DEFAULT_TIMEFRAMES = ["raw", "time", "date", "week", "month", "quarter", "year"]
 
-TILE_KIND = {
-    "single_value": "kpi-chart", "looker_column": "bar-chart", "looker_bar": "bar-chart",
-    "looker_area": "area-chart", "looker_line": "line-chart", "looker_pie": "pie-chart",
-    "looker_donut_multiples": "donut-chart", "table": "table", "looker_grid": "table",
-    "looker_scatter": "scatter-chart",
-}
-AGG = {"average": "Avg", "sum": "Sum", "min": "Min", "max": "Max", "median": "Median"}
+# ── documentation-grounded mapping catalogs (SINGLE SOURCE OF TRUTH) ─────────
+# Every classifier map below is loaded from refs/catalogs/<dimension>.json —
+# cited rows (source doc + Sigma target + sigma_verified), complete coverage,
+# and a loud fallback on anything unmapped. NO inline mapping literal may bypass
+# these catalogs (grep-enforced by tests/test_grounding.py). The human-readable
+# coverage matrix in refs/looker-coverage.md is GENERATED from these files.
+# Loader: shared/lib/coverage_catalog.py (synced to scripts/lib/). Design mirrors
+# the beads-sigma-93ps contract: catalog = data, code = thin resolver/predicates.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import coverage_catalog as _cc  # noqa: E402
+_CAT_DIR = _cc.default_catalog_dir(__file__)
+VIZ_CAT  = _cc.load(_CAT_DIR, "viz-kind")        # Looker vis type   -> Sigma element kind
+FMT_CAT  = _cc.load(_CAT_DIR, "number-format")   # value_format_name -> Sigma number format (D3)
+AGG_CAT  = _cc.load(_CAT_DIR, "aggregation")     # measure type      -> Sigma aggregate fn (+ *If)
+CTRL_CAT = _cc.load(_CAT_DIR, "control")         # dashboard filter  -> Sigma control kind
 
-# ── LookML value_format_name / value_format -> Sigma column format ──────────
-# Sigma columns carry an optional `format` object — for numbers:
-#   {"kind": "number", "formatString": "<d3-format>"}  (see sigma-workbooks
-#   reference/specification/formatting.md). LookML measures declare their display
-#   via a named format (`value_format_name`) or a custom Excel-style mask
-#   (`value_format`). Map the common named formats to d3 format strings; fall
-#   back to a best-effort translation of a custom mask.
-VALUE_FORMAT_NAME_MAP = {
-    "usd":          "$,.2f",
-    "usd_0":        "$,.0f",
-    "gbp":          "£,.2f",
-    "gbp_0":        "£,.0f",
-    "eur":          "€,.2f",
-    "eur_0":        "€,.0f",
-    "percent_0":    ",.0%",
-    "percent_1":    ",.1%",
-    "percent_2":    ",.2%",
-    "percent_3":    ",.3%",
-    "percent_4":    ",.4%",
-    "decimal_0":    ",.0f",
-    "decimal_1":    ",.1f",
-    "decimal_2":    ",.2f",
-    "decimal_3":    ",.3f",
-    "decimal_4":    ",.4f",
-    "id":           "d",            # plain integer, no thousands separator
-}
+# Back-compat dict views derived from the catalogs. These carry the SAME keys and
+# values the old inline literals did (locked by tests/golden/); the loud fallback
+# on a miss lives at each USE site (resolve_or_warn), not here.
+TILE_KIND = {r["source"]: r["sigma"] for r in VIZ_CAT.rows}
+AGG = {r["source"]: r["sigma"] for r in AGG_CAT.rows if r.get("sigma")}
+
+# LookML value_format_name -> Sigma column `format` object ({"kind":"number",
+# "formatString":"<d3>"}, see the Sigma data-types-and-formats ref). Custom
+# `value_format` Excel/TO_CHAR masks are handled by the cited predicates
+# custom_value_format_to_d3() / snowflake_mask_to_format() below.
+VALUE_FORMAT_NAME_MAP = {r["source"]: r["sigma"] for r in FMT_CAT.rows}
 
 def custom_value_format_to_d3(mask):
     """Best-effort translate a LookML custom value_format (Excel-style mask) to a
@@ -206,7 +199,7 @@ def parse_join_aliases(model_files):
     return aliases
 
 
-def build_field_index(view_files, aliases=None):
+def build_field_index(view_files, aliases=None, warnings=None):
     measures = {}   # "view.field" -> (agg_type, base_display_or_None, sql, filters)
     formats = {}    # "view.field" -> Sigma format dict (or None)
     dims = set()    # "view.field"
@@ -283,8 +276,21 @@ def build_field_index(view_files, aliases=None):
             # capture the measure's display format (named or custom mask)
             vfn = re.search(r"value_format_name:\s*(\w+)", block)
             vf = re.search(r'value_format:\s*"([^"]*)"', block)
-            fmt = sigma_format_for(vfn.group(1) if vfn else None, vf.group(1) if vf else None)
-            if fmt: formats[key] = fmt
+            _vfn = vfn.group(1) if vfn else None
+            _vf = vf.group(1) if vf else None
+            fmt = sigma_format_for(_vfn, _vf)
+            if fmt:
+                formats[key] = fmt
+            elif (_vfn or _vf) and warnings is not None:
+                # a display format WAS declared but neither the documented
+                # value_format_name catalog nor the custom-mask parser could map it —
+                # ship the numeric value UNFORMATTED + say so (never a silent None,
+                # never a name-substring currency guess).
+                _decl = ("value_format_name '%s'" % _vfn) if _vfn else ("value_format '%s'" % _vf)
+                warnings.append(
+                    "⚠ number-format: measure '%s' declares %s but it maps to no Sigma "
+                    "format (refs/catalogs/number-format.json) — column shipped UNFORMATTED. "
+                    "Add a cited row if this is a real named format." % (key, _decl))
             # TO_CHAR display-mask measure → numeric aggregate + Sigma format
             # (display-identical to the mask; value stays numeric). Unparseable
             # masks keep mtype=string and stay on the loud-warning path.
@@ -348,9 +354,9 @@ def main():
     model_files = (glob.glob(os.path.join(a.views, "*.model.lkml"))
                    + glob.glob(os.path.join(a.views, "..", "*.model.lkml")))
     aliases = parse_join_aliases(model_files)
-    measures, dims, view_pk, formats, yesno_dims, dim_groups, dim_labels = build_field_index(
-        sorted(glob.glob(os.path.join(a.views, "*.view.lkml"))), aliases)
     warnings = []
+    measures, dims, view_pk, formats, yesno_dims, dim_groups, dim_labels = build_field_index(
+        sorted(glob.glob(os.path.join(a.views, "*.view.lkml"))), aliases, warnings)
 
     # ── per-explore masters ────────────────────────────────────────────────────
     # A Looker dashboard's tiles can hit SEVERAL explores; one master per explore,
@@ -500,8 +506,7 @@ def main():
             return "(" + formula_for(key, explore) + ")" if key in measures else m.group(0)
         e = re.sub(r"\$\{(\w+)\}", sub, measures[f][2])
         return re.sub(r"\bNULLIF\s*\(", "NullIf(", e, flags=re.I).replace("${TABLE}.", "").strip()
-    IF_AGG = {"sum": "SumIf", "count": "CountIf", "count_distinct": "CountDistinctIf",
-              "average": "AvgIf", "max": "MaxIf", "min": "MinIf"}
+    IF_AGG = {r["source"]: r["sigma_if"] for r in AGG_CAT.rows if r.get("sigma_if")}
 
     def measure_filters(f):
         return measures[f][3] if is_measure(f) and len(measures[f]) > 3 else []
@@ -566,10 +571,27 @@ def main():
                 if view != explore:
                     pkd = pk_display(view, explore)
                     if pkd: return f"CountDistinct([{master_of(explore)['name']}/{pkd}])"
+                return "Count()"   # fact-grain row count (documented; aggregation.json 'count')
+            if mtype == "count_distinct":
+                if cd:
+                    return f"CountDistinct([{master_of(explore)['name']}/{cd}])"
+                warnings.append(f"⚠ measure '{f}': count_distinct base column did not resolve to "
+                                f"a master column — emitted Count() (counts ROWS, not distinct "
+                                f"values); parity at risk, add the base column to the explore.")
                 return "Count()"
-            if mtype == "count_distinct": return f"CountDistinct([{master_of(explore)['name']}/{cd}])" if cd else "Count()"
             fn = AGG.get(mtype)
-            return f"{fn}([{master_of(explore)['name']}/{cd}])" if fn and cd else "Count()"
+            if fn and cd:
+                return f"{fn}([{master_of(explore)['name']}/{cd}])"
+            if not fn:
+                # no documented Sigma aggregate for this LookML measure type — DO NOT fake a
+                # number; emit a loud placeholder column (refs/catalogs/aggregation.json).
+                warnings.append(f"⚠ measure '{f}': no documented Sigma aggregate for LookML measure "
+                                f"type '{mtype}' (refs/catalogs/aggregation.json) — emitted a "
+                                f"placeholder column; add a cited row if this is a real type.")
+                return f'"⚠ {leaf(f)}: unmapped measure type {mtype}"'
+            warnings.append(f"⚠ measure '{f}' (type {mtype}): base column did not resolve to a "
+                            f"master column — emitted Count() as a degraded fallback; verify parity.")
+            return "Count()"
         return f"[{master_of(explore)['name']}/{cd}]"
     def _warn_count(f, el):
         if measures.get(f, (None,))[0] == "count":
@@ -1278,7 +1300,12 @@ def main():
         # of the Looker filter `type` (a Looker field_filter on a date renders a
         # list in LookML but must become a date control in Sigma).
         _fld = flt.get("dimension") or flt.get("field") or flt.get("_resolvedField")
-        is_date_field = (flt["type"] == "date_filter"
+        # control kind is documentation-grounded (refs/catalogs/control.json): only
+        # a date_filter maps to date-range; every other type is the documented
+        # `list` default. Compositional override: a filter bound to a date/time
+        # dimension_group must be a date control regardless of the Looker type.
+        _type_is_date = (CTRL_CAT.target(flt["type"]) == "date-range")
+        is_date_field = (_type_is_date
                          or (_fld is not None and dimgroup_display(_fld) is not None))
         ctype = "date-range" if is_date_field else "list"
         cid = flt["name"].lower().replace(" ", "-")

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/tests/golden/skilltest_orders_workbook.canon.txt
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/tests/golden/skilltest_orders_workbook.canon.txt
@@ -1,0 +1,482 @@
+{
+  "folderId": "<FOLDER_ID>",
+  "layout": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"page-dash\">\n<GridContainer elementId=\"band-hdr\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"band-hdrtext\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\"/>\n</GridContainer>\n<GridContainer elementId=\"band-ctl\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"4 / 7\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ID0000\" gridColumn=\"1 / 9\" gridRow=\"1 / 4\"/>\n  <LayoutElement elementId=\"ID0001\" gridColumn=\"9 / 17\" gridRow=\"1 / 4\"/>\n  <LayoutElement elementId=\"ID0002\" gridColumn=\"17 / 25\" gridRow=\"1 / 4\"/>\n</GridContainer>\n<GridContainer elementId=\"band-kpi\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"7 / 13\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ID0003\" gridColumn=\"1 / 9\" gridRow=\"1 / 7\"/>\n  <LayoutElement elementId=\"ID0004\" gridColumn=\"9 / 17\" gridRow=\"1 / 7\"/>\n  <LayoutElement elementId=\"ID0005\" gridColumn=\"17 / 25\" gridRow=\"1 / 7\"/>\n</GridContainer>\n<GridContainer elementId=\"band-row-1\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"13 / 29\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ID0006\" gridColumn=\"1 / 13\" gridRow=\"1 / 17\"/>\n  <LayoutElement elementId=\"ID0007\" gridColumn=\"13 / 25\" gridRow=\"1 / 17\"/>\n</GridContainer>\n<GridContainer elementId=\"band-row-2\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"29 / 41\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ID0008\" gridColumn=\"1 / 25\" gridRow=\"1 / 13\"/>\n</GridContainer>\n</Page>",
+  "name": "SKILLTEST Looker Orders Pulse (from Looker)",
+  "pages": [
+    {
+      "elements": [
+        {
+          "columns": [
+            {
+              "formula": "[Order Fact/Net Revenue]",
+              "id": "ID0009",
+              "name": "Net Revenue"
+            },
+            {
+              "formula": "[Order Fact/Order Id]",
+              "id": "ID0010",
+              "name": "Order Id"
+            },
+            {
+              "formula": "[Order Fact/customer_dim/Region]",
+              "id": "ID0011",
+              "name": "Region (customer_dim)"
+            },
+            {
+              "formula": "[Order Fact/Ship Method]",
+              "id": "ID0012",
+              "name": "Ship Method"
+            },
+            {
+              "formula": "[Order Fact/Order Channel]",
+              "id": "ID0013",
+              "name": "Order Channel"
+            },
+            {
+              "formula": "[Order Fact/Order Status]",
+              "id": "ID0014",
+              "name": "Order Status"
+            },
+            {
+              "formula": "[Order Fact/customer_dim/First Order Date]",
+              "id": "ID0015",
+              "name": "First Order Date (customer_dim)"
+            }
+          ],
+          "id": "m-master",
+          "kind": "table",
+          "name": "Data",
+          "source": {
+            "dataModelId": "dm-x",
+            "elementId": "el-x",
+            "kind": "data-model"
+          }
+        },
+        {
+          "columns": [
+            {
+              "formula": "[Data/Net Revenue]",
+              "id": "ID0016",
+              "name": "Net Revenue"
+            },
+            {
+              "formula": "[Data/Order Id]",
+              "id": "ID0017",
+              "name": "Order Id"
+            },
+            {
+              "formula": "[Data/Region (customer_dim)]",
+              "id": "ID0018",
+              "name": "Region (customer_dim)"
+            },
+            {
+              "formula": "[Data/Ship Method]",
+              "id": "ID0019",
+              "name": "Ship Method"
+            },
+            {
+              "formula": "[Data/Order Channel]",
+              "id": "ID0020",
+              "name": "Order Channel"
+            },
+            {
+              "formula": "[Data/Order Status]",
+              "id": "ID0021",
+              "name": "Order Status"
+            },
+            {
+              "formula": "[Data/First Order Date (customer_dim)]",
+              "id": "ID0022",
+              "name": "First Order Date (customer_dim)"
+            }
+          ],
+          "id": "scope-1",
+          "kind": "table",
+          "name": "Data Scope 1",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          }
+        },
+        {
+          "columns": [
+            {
+              "formula": "[Data/Net Revenue]",
+              "id": "ID0023",
+              "name": "Net Revenue"
+            },
+            {
+              "formula": "[Data/Order Id]",
+              "id": "ID0024",
+              "name": "Order Id"
+            },
+            {
+              "formula": "[Data/Region (customer_dim)]",
+              "id": "ID0025",
+              "name": "Region (customer_dim)"
+            },
+            {
+              "formula": "[Data/Ship Method]",
+              "id": "ID0026",
+              "name": "Ship Method"
+            },
+            {
+              "formula": "[Data/Order Channel]",
+              "id": "ID0027",
+              "name": "Order Channel"
+            },
+            {
+              "formula": "[Data/Order Status]",
+              "id": "ID0028",
+              "name": "Order Status"
+            },
+            {
+              "formula": "[Data/First Order Date (customer_dim)]",
+              "id": "ID0029",
+              "name": "First Order Date (customer_dim)"
+            }
+          ],
+          "id": "scope-2",
+          "kind": "table",
+          "name": "Data Scope 2",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          }
+        }
+      ],
+      "id": "page-data",
+      "name": "Data"
+    },
+    {
+      "elements": [
+        {
+          "columns": [
+            {
+              "format": {
+                "formatString": "$,.2f",
+                "kind": "number"
+              },
+              "formula": "Sum([Data/Net Revenue])",
+              "id": "ID0030",
+              "name": "Total Net Revenue"
+            }
+          ],
+          "id": "ID0003",
+          "kind": "kpi-chart",
+          "name": "Total Net Revenue",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "value": {
+            "columnId": "ID0030"
+          }
+        },
+        {
+          "columns": [
+            {
+              "formula": "CountDistinct([Data/Order Id])",
+              "id": "ID0031",
+              "name": "Order Count"
+            }
+          ],
+          "id": "ID0004",
+          "kind": "kpi-chart",
+          "name": "Order Count",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "value": {
+            "columnId": "ID0031"
+          }
+        },
+        {
+          "columns": [
+            {
+              "format": {
+                "formatString": "$,.2f",
+                "kind": "number"
+              },
+              "formula": "1.0 * (Sum([Data/Net Revenue])) / NullIf((CountDistinct([Data/Order Id])), 0)",
+              "id": "ID0032",
+              "name": "Average Order Value"
+            }
+          ],
+          "id": "ID0005",
+          "kind": "kpi-chart",
+          "name": "Average Order Value",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "value": {
+            "columnId": "ID0032"
+          }
+        },
+        {
+          "columns": [
+            {
+              "formula": "[Data Scope 1/Region (customer_dim)]",
+              "id": "ID0033",
+              "name": "Region (customer_dim)"
+            },
+            {
+              "format": {
+                "formatString": "$,.2f",
+                "kind": "number"
+              },
+              "formula": "Sum([Data Scope 1/Net Revenue])",
+              "id": "ID0034",
+              "name": "Total Net Revenue"
+            }
+          ],
+          "id": "ID0006",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Region",
+          "source": {
+            "elementId": "scope-1",
+            "kind": "table"
+          },
+          "xAxis": {
+            "columnId": "ID0033",
+            "sort": {
+              "by": "ID0034",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "ID0034"
+            ]
+          }
+        },
+        {
+          "color": {
+            "id": "ID0035",
+            "sort": {
+              "by": "ID0036",
+              "direction": "descending"
+            }
+          },
+          "columns": [
+            {
+              "formula": "[Data Scope 2/Ship Method]",
+              "id": "ID0035",
+              "name": "Ship Method"
+            },
+            {
+              "formula": "CountDistinct([Data Scope 2/Order Id])",
+              "id": "ID0036",
+              "name": "Order Count"
+            }
+          ],
+          "id": "ID0007",
+          "kind": "pie-chart",
+          "name": "Orders by Ship Method",
+          "source": {
+            "elementId": "scope-2",
+            "kind": "table"
+          },
+          "value": {
+            "id": "ID0036"
+          }
+        },
+        {
+          "columns": [
+            {
+              "formula": "[Data Scope 2/Order Channel]",
+              "id": "ID0037",
+              "name": "Order Channel"
+            },
+            {
+              "formula": "CountDistinct([Data Scope 2/Order Id])",
+              "id": "ID0038",
+              "name": "Order Count"
+            },
+            {
+              "format": {
+                "formatString": "$,.2f",
+                "kind": "number"
+              },
+              "formula": "Sum([Data Scope 2/Net Revenue])",
+              "id": "ID0039",
+              "name": "Total Net Revenue"
+            },
+            {
+              "format": {
+                "formatString": "$,.2f",
+                "kind": "number"
+              },
+              "formula": "1.0 * (Sum([Data Scope 2/Net Revenue])) / NullIf((CountDistinct([Data Scope 2/Order Id])), 0)",
+              "id": "ID0040",
+              "name": "Average Order Value"
+            },
+            {
+              "formula": "[Data Scope 2/Order Status]",
+              "hidden": true,
+              "id": "ID0041",
+              "name": "Order Status"
+            }
+          ],
+          "filters": [
+            {
+              "columnId": "ID0041",
+              "id": "ID0042",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                "Complete",
+                "Returned"
+              ]
+            }
+          ],
+          "groupings": [
+            {
+              "calculations": [
+                "ID0038",
+                "ID0039",
+                "ID0040"
+              ],
+              "groupBy": [
+                "ID0037"
+              ],
+              "id": "ID0043",
+              "sort": [
+                {
+                  "columnId": "ID0039",
+                  "direction": "descending"
+                }
+              ]
+            }
+          ],
+          "id": "ID0008",
+          "kind": "table",
+          "name": "Channel Summary",
+          "source": {
+            "elementId": "scope-2",
+            "kind": "table"
+          }
+        },
+        {
+          "controlId": "region",
+          "controlType": "list",
+          "filters": [
+            {
+              "columnId": "ID0011",
+              "source": {
+                "elementId": "m-master",
+                "kind": "table"
+              }
+            },
+            {
+              "columnId": "ID0025",
+              "source": {
+                "elementId": "scope-2",
+                "kind": "table"
+              }
+            }
+          ],
+          "id": "ID0000",
+          "kind": "control",
+          "mode": "include",
+          "name": "Region",
+          "selectionMode": "multiple",
+          "source": {
+            "columnId": "ID0011",
+            "kind": "source",
+            "source": {
+              "elementId": "m-master",
+              "kind": "table"
+            }
+          },
+          "values": []
+        },
+        {
+          "controlId": "order-channel",
+          "controlType": "list",
+          "filters": [
+            {
+              "columnId": "ID0013",
+              "source": {
+                "elementId": "m-master",
+                "kind": "table"
+              }
+            },
+            {
+              "columnId": "ID0020",
+              "source": {
+                "elementId": "scope-1",
+                "kind": "table"
+              }
+            }
+          ],
+          "id": "ID0001",
+          "kind": "control",
+          "mode": "include",
+          "name": "Order Channel",
+          "selectionMode": "multiple",
+          "source": {
+            "columnId": "ID0013",
+            "kind": "source",
+            "source": {
+              "elementId": "m-master",
+              "kind": "table"
+            }
+          },
+          "values": []
+        },
+        {
+          "controlId": "first-order-date",
+          "controlType": "date-range",
+          "filters": [
+            {
+              "columnId": "ID0015",
+              "source": {
+                "elementId": "m-master",
+                "kind": "table"
+              }
+            }
+          ],
+          "id": "ID0002",
+          "kind": "control",
+          "mode": "between",
+          "name": "First Order Date"
+        },
+        {
+          "id": "band-hdr",
+          "kind": "container",
+          "style": {
+            "backgroundColor": "#0F172A",
+            "borderRadius": "round"
+          }
+        },
+        {
+          "body": "# <span style=\"color: #FFFFFF\">SKILLTEST Looker Orders Pulse</span>",
+          "id": "band-hdrtext",
+          "kind": "text"
+        },
+        {
+          "id": "band-ctl",
+          "kind": "container"
+        },
+        {
+          "id": "band-kpi",
+          "kind": "container"
+        },
+        {
+          "id": "band-row-1",
+          "kind": "container"
+        },
+        {
+          "id": "band-row-2",
+          "kind": "container"
+        }
+      ],
+      "id": "page-dash",
+      "name": "SKILLTEST Looker Orders Pulse"
+    }
+  ],
+  "schemaVersion": 1
+}

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grounding.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/tests/test_grounding.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Grounding regression for build_workbook.py (beads-sigma-kvza).
+
+Proves the dashboard classifier is documentation-grounded and loud-on-unmapped:
+  1. GOLDEN LOCK   — the fixture builds byte-identical (modulo random ids) to the
+     committed golden, so catalog extraction + loud-fallback edits changed no
+     behavior on a clean dashboard.
+  2. CATALOGS      — all four refs/catalogs/*.json load, have unique cited rows.
+  3. NO INLINE MAP — the viz/format/aggregation maps are LOADED from the catalogs;
+     no residual inline literal bypasses the single source of truth.
+  4. LOUD FALLBACKS — an unknown vis type, an unmapped value_format_name, and an
+     unmapped measure type each WARN (never a silent skip / wrong default).
+
+Run: python3 tests/test_grounding.py   (exit 0 = pass)
+"""
+import json, os, re, shutil, subprocess, sys, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+SCRIPTS = os.path.join(SKILL, "scripts")
+FIX = os.path.join(SKILL, "fixtures", "skilltest-orders")
+VIEWS = os.path.join(FIX, "views")
+DASH = os.path.join(FIX, "skilltest_orders.dashboard.lookml")
+CATDIR = os.path.join(SKILL, "refs", "catalogs")
+GOLDEN = os.path.join(HERE, "golden", "skilltest_orders_workbook.canon.txt")
+sys.path.insert(0, SCRIPTS)
+sys.path.insert(0, os.path.join(SCRIPTS, "lib"))
+
+ID_RE = re.compile(r'[a-z]{1,6}-[a-z0-9]{8}')
+
+def canon(spec):
+    s = json.dumps(spec, indent=2, sort_keys=True)
+    remap = {}
+    def repl(m):
+        t = m.group(0)
+        if t not in remap: remap[t] = "ID%04d" % len(remap)
+        return remap[t]
+    return ID_RE.sub(repl, s)
+
+def build(contract, views=VIEWS):
+    with tempfile.TemporaryDirectory() as d:
+        cpath = os.path.join(d, "c.json"); opath = os.path.join(d, "wb.json")
+        json.dump(contract, open(cpath, "w"))
+        r = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS, "build_workbook.py"), cpath,
+             "--views", views, "--dm-id", "dm-x", "--element-id", "el-x",
+             "--dm-element-name", "Order Fact", "--out", opath],
+            capture_output=True, text=True)
+        assert r.returncode == 0, "build_workbook failed:\n" + r.stderr
+        return json.load(open(opath)), (r.stdout + r.stderr)
+
+
+def test_golden():
+    import parse_lookml_dashboard as offline
+    contract = offline.parse(DASH)[0]
+    spec, _ = build(contract)
+    got = canon(spec)
+    want = open(GOLDEN).read()
+    assert got == want, ("GOLDEN DRIFT — build_workbook output changed on the clean "
+                         "fixture. If intentional, regenerate the golden.\n"
+                         + "\n".join(_first_diff(want, got)))
+    print("[ok] golden: fixture builds byte-identical to committed golden")
+
+def _first_diff(a, b):
+    la, lb = a.splitlines(), b.splitlines()
+    for i, (x, y) in enumerate(zip(la, lb)):
+        if x != y:
+            return ["  first diff @line %d" % i, "  golden: " + x, "  got:    " + y]
+    return ["  (length differs: %d vs %d lines)" % (len(la), len(lb))]
+
+
+def test_catalogs_valid():
+    import coverage_catalog as cc
+    cats = cc.load_all(CATDIR)
+    assert set(cats) == {"viz-kind", "number-format", "aggregation", "control"}, sorted(cats)
+    for name, cat in cats.items():
+        assert cat.rows, name
+        assert cat.source_tool == "looker", (name, cat.source_tool)
+        assert cat.authoritative_doc.startswith("http") or name == "control", name
+        seen = set()
+        for r in cat.rows:
+            key = str(r["source"]).lower()
+            assert key not in seen, ("duplicate source in %s: %s" % (name, key))
+            seen.add(key)
+            assert r.get("doc_ref", "").startswith("http"), (name, r["source"])
+            # every mapped Sigma target present (aggregation count/cd document it too)
+            assert r.get("sigma") is not None or r.get("sigma_if") is not None, (name, r["source"])
+    print("[ok] catalogs: 4 dimensions load, cited, unique sources")
+
+
+def test_no_inline_maps():
+    src = open(os.path.join(SCRIPTS, "build_workbook.py")).read()
+    assert "coverage_catalog" in src and "_cc.load(" in src, "builder does not load catalogs"
+    # the maps must be catalog-derived, not inline literals
+    assert "for r in VIZ_CAT.rows" in src, "TILE_KIND not derived from viz-kind catalog"
+    assert "for r in FMT_CAT.rows" in src, "VALUE_FORMAT_NAME_MAP not derived from catalog"
+    assert "for r in AGG_CAT.rows" in src, "AGG/IF_AGG not derived from aggregation catalog"
+    # the two old silent defaults must be gone
+    assert 'if fn and cd else "Count()"' not in src, "silent AGG else-Count() still present"
+    assert 'if cd else "Count()"' not in src, "silent count_distinct else-Count() still present"
+    print("[ok] no-inline-map: viz/format/agg maps loaded from catalogs; silent Count() removed")
+
+
+def _clone_element(contract, pred):
+    for el in contract["elements"]:
+        if pred(el):
+            return json.loads(json.dumps(el))
+    raise AssertionError("no element matched")
+
+
+def test_loud_unknown_viz():
+    import parse_lookml_dashboard as offline
+    contract = offline.parse(DASH)[0]
+    el = _clone_element(contract, lambda e: e.get("tileType") == "single_value")
+    el["name"] = "Funnel Tile"; el["tileType"] = "looker_funnel"
+    contract["elements"].append(el)
+    spec, out = build(contract)
+    assert "looker_funnel" in out and "no Sigma mapping" in out, out
+    # the funnel tile must NOT have produced an element
+    names = re.findall(r'"name":\s*"([^"]*)"', json.dumps(spec))
+    assert "Funnel Tile" not in names, "unmapped viz was silently emitted"
+    print("[ok] loud viz: unknown vis type 'looker_funnel' warns + skips")
+
+
+def test_loud_unknown_format():
+    import importlib, coverage_catalog  # noqa
+    bw = importlib.import_module("build_workbook")
+    with tempfile.TemporaryDirectory() as d:
+        vpath = os.path.join(d, "t.view.lkml")
+        open(vpath, "w").write(
+            "view: t {\n"
+            "  dimension: pk { primary_key: yes type: number sql: ${TABLE}.ID ;; }\n"
+            "  dimension: amt { hidden: yes type: number sql: ${TABLE}.AMT ;; }\n"
+            "  measure: good { type: sum sql: ${amt} ;; value_format_name: usd }\n"
+            "  measure: bad_fmt { type: sum sql: ${amt} ;; value_format_name: zzz_bogus_fmt }\n"
+            "}\n")
+        w = []
+        bw.build_field_index([vpath], None, w)
+        joined = "\n".join(w)
+        assert "zzz_bogus_fmt" in joined and "UNFORMATTED" in joined, joined
+        # the good one produced NO warning
+        assert "value_format_name 'usd'" not in joined, joined
+    print("[ok] loud format: unmapped value_format_name warns (ships unformatted)")
+
+
+def test_loud_unknown_agg():
+    """A measure of an unmapped LookML type -> loud placeholder, not a silent Count()."""
+    import parse_lookml_dashboard as offline
+    with tempfile.TemporaryDirectory() as d:
+        vdir = os.path.join(d, "views"); shutil.copytree(VIEWS, vdir)
+        of = os.path.join(vdir, "order_fact.view.lkml")
+        txt = open(of).read().rstrip()
+        assert txt.endswith("}"), "unexpected view file shape"
+        txt = txt[:-1] + (
+            "\n  measure: weird_metric {\n"
+            "    type: sum_distinct\n"
+            "    sql: ${net_revenue} ;;\n"
+            "  }\n}\n")
+        open(of, "w").write(txt)
+        contract = offline.parse(DASH)[0]
+        el = _clone_element(contract, lambda e: e.get("tileType") == "single_value")
+        el["name"] = "Weird KPI"; el["fields"] = ["order_fact.weird_metric"]
+        el["listen"] = {}
+        contract["elements"].append(el)
+        spec, out = build(contract, views=vdir)
+        assert "weird_metric" in out and "no documented Sigma aggregate" in out, out
+        assert "unmapped measure type sum_distinct" in json.dumps(spec), \
+            "expected a loud placeholder column formula for the unmapped measure type"
+        assert "Count()" not in json.dumps(spec).split("Weird")[1][:200] if "Weird" in json.dumps(spec) else True
+    print("[ok] loud agg: unmapped measure type -> placeholder + warn (no silent Count())")
+
+
+def test_coverage_matrix_fresh():
+    """refs/looker-coverage.md must be regenerated from the catalogs (no drift)."""
+    r = subprocess.run(
+        [sys.executable, os.path.join(SCRIPTS, "gen-coverage-matrix.py"),
+         "--catalogs", CATDIR, "--skill", "looker",
+         "--out", os.path.join(SKILL, "refs", "looker-coverage.md"), "--check"],
+        capture_output=True, text=True)
+    assert r.returncode == 0, ("coverage matrix is stale — regenerate:\n" + r.stderr)
+    print("[ok] coverage matrix: refs/looker-coverage.md matches the catalogs")
+
+
+if __name__ == "__main__":
+    test_catalogs_valid()
+    test_no_inline_maps()
+    test_coverage_matrix_fresh()
+    test_golden()
+    test_loud_unknown_viz()
+    test_loud_unknown_format()
+    test_loud_unknown_agg()
+    print("ALL PASS")


### PR DESCRIPTION
## What (beads-sigma-kvza.1 + .2, looker)
Replaces the hardcoded viz/format/aggregation maps in `build_workbook.py` with cited JSON catalogs (`refs/catalogs/`) loaded via the shared `coverage_catalog` loader — the single source of truth. `refs/looker-coverage.md` is generated from them.

**De-silenced fallbacks:** `formula_for` no longer silently defaults to `Count()` on an unmapped measure type (loud placeholder) or an unresolved `count_distinct` base column (loud degraded note); an unknown `value_format_name` warns + ships unformatted instead of a silent `None`.

## Verification
- **Behavior-preserving:** the `skilltest-orders` fixture builds **byte-identical** to the committed golden (`tests/test_grounding.py`, 7 checks incl. no-inline-map + no-drift + 3 loud-fallback cases).
- **LIVE E2E vs CSA.TJ:** DM + workbook POST, **33 columns resolve, 0 `type=error`**, parity **5/5 strict** vs warehouse; render verified (3 currency KPIs, bar, pie, grouped table, date-range control).

## Stacking
Based on `kvza-infra` (needs the shared loader). Retarget to `main` after infra merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)