### PR TITLE
kvza.1/.2 (qlik): documentation-ground build-sigma-workbook.py classifier

### DIFF
--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/fixtures/retail-orders/denorm.json
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/fixtures/retail-orders/denorm.json
@@ -1,0 +1,394 @@
+{
+  "element": {
+    "id": "HEDI8VP0ys",
+    "kind": "table",
+    "source": {
+      "connectionId": "",
+      "kind": "sql",
+      "statement": "SELECT\n  f.ORDER_ID AS ORDER_ID,\n  f.ORDER_LINE AS ORDER_LINE,\n  f.CUSTOMER_KEY AS CUSTOMER_KEY,\n  f.PRODUCT_KEY AS PRODUCT_KEY,\n  f.PROMO_KEY AS PROMO_KEY,\n  f.ORDER_STORE_KEY AS STORE_KEY,\n  f.ORDER_DATE_KEY AS DATE_KEY,\n  f.ORDER_CHANNEL AS ORDER_CHANNEL,\n  f.SHIP_METHOD AS SHIP_METHOD,\n  f.ORDER_STATUS AS ORDER_STATUS,\n  f.QUANTITY_ORDERED AS QUANTITY_ORDERED,\n  f.QUANTITY_RETURNED AS QUANTITY_RETURNED,\n  f.UNIT_PRICE AS UNIT_PRICE,\n  f.UNIT_COST AS UNIT_COST,\n  f.DISCOUNT_AMOUNT AS DISCOUNT_AMOUNT,\n  f.SHIPPING_AMOUNT AS SHIPPING_AMOUNT,\n  f.TAX_AMOUNT AS TAX_AMOUNT,\n  f.GROSS_REVENUE AS GROSS_REVENUE,\n  f.NET_REVENUE AS NET_REVENUE,\n  f.GROSS_PROFIT AS GROSS_PROFIT,\n  f.NET_PROFIT AS NET_PROFIT,\n  f.IS_FIRST_ORDER AS IS_FIRST_ORDER,\n  f.IS_RETURNED AS IS_RETURNED,\n  f.IS_CANCELLED AS IS_CANCELLED,\n  f.DAYS_TO_SHIP AS DAYS_TO_SHIP,\n  a.CUSTOMER_ID AS CUSTOMER_ID,\n  a.FIRST_NAME AS FIRST_NAME,\n  a.LAST_NAME AS LAST_NAME,\n  a.CITY AS CUSTOMER_CITY,\n  a.STATE AS CUSTOMER_STATE,\n  a.REGION AS CUSTOMER_REGION,\n  a.CUSTOMER_SEGMENT AS CUSTOMER_SEGMENT,\n  a.LOYALTY_TIER AS LOYALTY_TIER,\n  a.ACQUISITION_CHANNEL AS ACQUISITION_CHANNEL,\n  a.LIFETIME_REVENUE AS LIFETIME_REVENUE,\n  b.PRODUCT_ID AS PRODUCT_ID,\n  b.PRODUCT_NAME AS PRODUCT_NAME,\n  b.CATEGORY AS CATEGORY,\n  b.SUBCATEGORY AS SUBCATEGORY,\n  b.BRAND AS BRAND,\n  b.IS_PRIVATE_LABEL AS IS_PRIVATE_LABEL,\n  b.IS_SEASONAL AS IS_SEASONAL,\n  c.STORE_ID AS STORE_ID,\n  c.STORE_NAME AS STORE_NAME,\n  c.STORE_TYPE AS STORE_TYPE,\n  c.CITY AS STORE_CITY,\n  c.STATE AS STORE_STATE,\n  c.REGION AS STORE_REGION,\n  c.DISTRICT AS DISTRICT,\n  c.MANAGER_NAME AS MANAGER_NAME,\n  d.FULL_DATE AS FULL_DATE,\n  d.DAY_OF_WEEK AS DAY_OF_WEEK,\n  d.MONTH_NUMBER AS MONTH_NUMBER,\n  d.MONTH_NAME AS MONTH_NAME,\n  d.QUARTER AS QUARTER,\n  d.YEAR AS YEAR,\n  d.IS_WEEKEND AS IS_WEEKEND,\n  d.IS_HOLIDAY AS IS_HOLIDAY,\n  e.PROMO_NAME AS PROMO_NAME,\n  e.PROMO_TYPE AS PROMO_TYPE,\n  e.CHANNEL AS PROMO_CHANNEL,\n  e.DISCOUNT_PCT AS DISCOUNT_PCT,\n  e.TARGET_SEGMENT AS TARGET_SEGMENT\nFROM CSA.TJ.ORDER_FACT f\nLEFT JOIN CSA.TJ.CUSTOMER_DIM a ON f.CUSTOMER_KEY = a.CUSTOMER_KEY\nLEFT JOIN CSA.TJ.PRODUCT_DIM b ON f.PRODUCT_KEY = b.PRODUCT_KEY\nLEFT JOIN CSA.TJ.STORE_DIM c ON f.ORDER_STORE_KEY = c.STORE_KEY\nLEFT JOIN CSA.TJ.DATE_DIM d ON f.ORDER_DATE_KEY = d.DATE_KEY\nLEFT JOIN CSA.TJ.PROMO_DIM e ON f.PROMO_KEY = e.PROMO_KEY"
+    },
+    "columns": [
+      {
+        "id": "JtcytGxX9l",
+        "name": "Order Id",
+        "formula": "[Custom SQL/ORDER_ID]"
+      },
+      {
+        "id": "qvJTXcUvgI",
+        "name": "Order Line",
+        "formula": "[Custom SQL/ORDER_LINE]"
+      },
+      {
+        "id": "hqS7kSu1D4",
+        "name": "Customer Key",
+        "formula": "[Custom SQL/CUSTOMER_KEY]"
+      },
+      {
+        "id": "nExgz1nZvo",
+        "name": "Product Key",
+        "formula": "[Custom SQL/PRODUCT_KEY]"
+      },
+      {
+        "id": "L9V2MmDcvX",
+        "name": "Promo Key",
+        "formula": "[Custom SQL/PROMO_KEY]"
+      },
+      {
+        "id": "jwdVRViTil",
+        "name": "Store Key",
+        "formula": "[Custom SQL/STORE_KEY]"
+      },
+      {
+        "id": "Rg8Icgyfbv",
+        "name": "Date Key",
+        "formula": "[Custom SQL/DATE_KEY]"
+      },
+      {
+        "id": "xsTq27T3H1",
+        "name": "Order Channel",
+        "formula": "[Custom SQL/ORDER_CHANNEL]"
+      },
+      {
+        "id": "i7u8f9YKew",
+        "name": "Ship Method",
+        "formula": "[Custom SQL/SHIP_METHOD]"
+      },
+      {
+        "id": "4ZcqdNs1cT",
+        "name": "Order Status",
+        "formula": "[Custom SQL/ORDER_STATUS]"
+      },
+      {
+        "id": "0ijrE5m9CJ",
+        "name": "Quantity Ordered",
+        "formula": "[Custom SQL/QUANTITY_ORDERED]"
+      },
+      {
+        "id": "Q3Z47EyhYH",
+        "name": "Quantity Returned",
+        "formula": "[Custom SQL/QUANTITY_RETURNED]"
+      },
+      {
+        "id": "MetuxT5CbV",
+        "name": "Unit Price",
+        "formula": "[Custom SQL/UNIT_PRICE]"
+      },
+      {
+        "id": "NXSIzBf2XR",
+        "name": "Unit Cost",
+        "formula": "[Custom SQL/UNIT_COST]"
+      },
+      {
+        "id": "6UWD2rFOSc",
+        "name": "Discount Amount",
+        "formula": "[Custom SQL/DISCOUNT_AMOUNT]"
+      },
+      {
+        "id": "3JKxPFaorD",
+        "name": "Shipping Amount",
+        "formula": "[Custom SQL/SHIPPING_AMOUNT]"
+      },
+      {
+        "id": "XLpVjFqQjd",
+        "name": "Tax Amount",
+        "formula": "[Custom SQL/TAX_AMOUNT]"
+      },
+      {
+        "id": "WnuywMUlXM",
+        "name": "Gross Revenue",
+        "formula": "[Custom SQL/GROSS_REVENUE]"
+      },
+      {
+        "id": "2koM0wUKpp",
+        "name": "Net Revenue",
+        "formula": "[Custom SQL/NET_REVENUE]"
+      },
+      {
+        "id": "ClwPzfqhmu",
+        "name": "Gross Profit",
+        "formula": "[Custom SQL/GROSS_PROFIT]"
+      },
+      {
+        "id": "PvduXFUAxf",
+        "name": "Net Profit",
+        "formula": "[Custom SQL/NET_PROFIT]"
+      },
+      {
+        "id": "79cU4hYOET",
+        "name": "Is First Order",
+        "formula": "[Custom SQL/IS_FIRST_ORDER]"
+      },
+      {
+        "id": "qB27nOj1w9",
+        "name": "Is Returned",
+        "formula": "[Custom SQL/IS_RETURNED]"
+      },
+      {
+        "id": "TjDLQ4vDxL",
+        "name": "Is Cancelled",
+        "formula": "[Custom SQL/IS_CANCELLED]"
+      },
+      {
+        "id": "JhekwYlnib",
+        "name": "Days to Ship",
+        "formula": "[Custom SQL/DAYS_TO_SHIP]"
+      },
+      {
+        "id": "zW7dKEeIKn",
+        "name": "Customer Id",
+        "formula": "[Custom SQL/CUSTOMER_ID]"
+      },
+      {
+        "id": "ZKnCJ38V8C",
+        "name": "First Name",
+        "formula": "[Custom SQL/FIRST_NAME]"
+      },
+      {
+        "id": "kJbNmClcNP",
+        "name": "Last Name",
+        "formula": "[Custom SQL/LAST_NAME]"
+      },
+      {
+        "id": "nr2kSfwLCN",
+        "name": "Customer City",
+        "formula": "[Custom SQL/CUSTOMER_CITY]"
+      },
+      {
+        "id": "obHVn93esG",
+        "name": "Customer State",
+        "formula": "[Custom SQL/CUSTOMER_STATE]"
+      },
+      {
+        "id": "12I7sa4ghu",
+        "name": "Customer Region",
+        "formula": "[Custom SQL/CUSTOMER_REGION]"
+      },
+      {
+        "id": "829ztyhEHl",
+        "name": "Customer Segment",
+        "formula": "[Custom SQL/CUSTOMER_SEGMENT]"
+      },
+      {
+        "id": "At5KXEnudS",
+        "name": "Loyalty Tier",
+        "formula": "[Custom SQL/LOYALTY_TIER]"
+      },
+      {
+        "id": "sMiwobiuta",
+        "name": "Acquisition Channel",
+        "formula": "[Custom SQL/ACQUISITION_CHANNEL]"
+      },
+      {
+        "id": "B5rDIU5tvS",
+        "name": "Lifetime Revenue",
+        "formula": "[Custom SQL/LIFETIME_REVENUE]"
+      },
+      {
+        "id": "egjAOoqeRX",
+        "name": "Product Id",
+        "formula": "[Custom SQL/PRODUCT_ID]"
+      },
+      {
+        "id": "88gxSZz0KY",
+        "name": "Product Name",
+        "formula": "[Custom SQL/PRODUCT_NAME]"
+      },
+      {
+        "id": "aCV254epzF",
+        "name": "Category",
+        "formula": "[Custom SQL/CATEGORY]"
+      },
+      {
+        "id": "KqOaVWQlBv",
+        "name": "Subcategory",
+        "formula": "[Custom SQL/SUBCATEGORY]"
+      },
+      {
+        "id": "RHHgTKrEov",
+        "name": "Brand",
+        "formula": "[Custom SQL/BRAND]"
+      },
+      {
+        "id": "k5vrKN8R10",
+        "name": "Is Private Label",
+        "formula": "[Custom SQL/IS_PRIVATE_LABEL]"
+      },
+      {
+        "id": "YHyuG5QIO8",
+        "name": "Is Seasonal",
+        "formula": "[Custom SQL/IS_SEASONAL]"
+      },
+      {
+        "id": "FeQFA6ztV8",
+        "name": "Store Id",
+        "formula": "[Custom SQL/STORE_ID]"
+      },
+      {
+        "id": "HQ9kRMWqrc",
+        "name": "Store Name",
+        "formula": "[Custom SQL/STORE_NAME]"
+      },
+      {
+        "id": "H3rK5r5r6S",
+        "name": "Store Type",
+        "formula": "[Custom SQL/STORE_TYPE]"
+      },
+      {
+        "id": "eo7ixYIHm0",
+        "name": "Store City",
+        "formula": "[Custom SQL/STORE_CITY]"
+      },
+      {
+        "id": "An0NLcq9hN",
+        "name": "Store State",
+        "formula": "[Custom SQL/STORE_STATE]"
+      },
+      {
+        "id": "T0z9CVaJrt",
+        "name": "Store Region",
+        "formula": "[Custom SQL/STORE_REGION]"
+      },
+      {
+        "id": "uWhmvXBS5J",
+        "name": "District",
+        "formula": "[Custom SQL/DISTRICT]"
+      },
+      {
+        "id": "y32q4w2OyD",
+        "name": "Manager Name",
+        "formula": "[Custom SQL/MANAGER_NAME]"
+      },
+      {
+        "id": "lXRPS4WMhN",
+        "name": "Full Date",
+        "formula": "[Custom SQL/FULL_DATE]"
+      },
+      {
+        "id": "KG4v6LTkqc",
+        "name": "Day of Week",
+        "formula": "[Custom SQL/DAY_OF_WEEK]"
+      },
+      {
+        "id": "1dubUq7aGZ",
+        "name": "Month Number",
+        "formula": "[Custom SQL/MONTH_NUMBER]"
+      },
+      {
+        "id": "rk2hQsiJcK",
+        "name": "Month Name",
+        "formula": "[Custom SQL/MONTH_NAME]"
+      },
+      {
+        "id": "ozh2b8WhCv",
+        "name": "Quarter",
+        "formula": "[Custom SQL/QUARTER]"
+      },
+      {
+        "id": "zhqIvRXp1M",
+        "name": "Year",
+        "formula": "[Custom SQL/YEAR]"
+      },
+      {
+        "id": "K6Oy2jgESB",
+        "name": "Is Weekend",
+        "formula": "[Custom SQL/IS_WEEKEND]"
+      },
+      {
+        "id": "8ai0yxRjv8",
+        "name": "Is Holiday",
+        "formula": "[Custom SQL/IS_HOLIDAY]"
+      },
+      {
+        "id": "tGPFXGPyV8",
+        "name": "Promo Name",
+        "formula": "[Custom SQL/PROMO_NAME]"
+      },
+      {
+        "id": "x12zPEdS5K",
+        "name": "Promo Type",
+        "formula": "[Custom SQL/PROMO_TYPE]"
+      },
+      {
+        "id": "yIs653XREB",
+        "name": "Promo Channel",
+        "formula": "[Custom SQL/PROMO_CHANNEL]"
+      },
+      {
+        "id": "f94ys3BooC",
+        "name": "Discount Pct",
+        "formula": "[Custom SQL/DISCOUNT_PCT]"
+      },
+      {
+        "id": "VE9E2gJZhf",
+        "name": "Target Segment",
+        "formula": "[Custom SQL/TARGET_SEGMENT]"
+      }
+    ],
+    "order": [
+      "JtcytGxX9l",
+      "qvJTXcUvgI",
+      "hqS7kSu1D4",
+      "nExgz1nZvo",
+      "L9V2MmDcvX",
+      "jwdVRViTil",
+      "Rg8Icgyfbv",
+      "xsTq27T3H1",
+      "i7u8f9YKew",
+      "4ZcqdNs1cT",
+      "0ijrE5m9CJ",
+      "Q3Z47EyhYH",
+      "MetuxT5CbV",
+      "NXSIzBf2XR",
+      "6UWD2rFOSc",
+      "3JKxPFaorD",
+      "XLpVjFqQjd",
+      "WnuywMUlXM",
+      "2koM0wUKpp",
+      "ClwPzfqhmu",
+      "PvduXFUAxf",
+      "79cU4hYOET",
+      "qB27nOj1w9",
+      "TjDLQ4vDxL",
+      "JhekwYlnib",
+      "zW7dKEeIKn",
+      "ZKnCJ38V8C",
+      "kJbNmClcNP",
+      "nr2kSfwLCN",
+      "obHVn93esG",
+      "12I7sa4ghu",
+      "829ztyhEHl",
+      "At5KXEnudS",
+      "sMiwobiuta",
+      "B5rDIU5tvS",
+      "egjAOoqeRX",
+      "88gxSZz0KY",
+      "aCV254epzF",
+      "KqOaVWQlBv",
+      "RHHgTKrEov",
+      "k5vrKN8R10",
+      "YHyuG5QIO8",
+      "FeQFA6ztV8",
+      "HQ9kRMWqrc",
+      "H3rK5r5r6S",
+      "eo7ixYIHm0",
+      "An0NLcq9hN",
+      "T0z9CVaJrt",
+      "uWhmvXBS5J",
+      "y32q4w2OyD",
+      "lXRPS4WMhN",
+      "KG4v6LTkqc",
+      "1dubUq7aGZ",
+      "rk2hQsiJcK",
+      "ozh2b8WhCv",
+      "zhqIvRXp1M",
+      "K6Oy2jgESB",
+      "8ai0yxRjv8",
+      "tGPFXGPyV8",
+      "x12zPEdS5K",
+      "yIs653XREB",
+      "f94ys3BooC",
+      "VE9E2gJZhf"
+    ]
+  },
+  "sql": "SELECT\n  f.ORDER_ID AS ORDER_ID,\n  f.ORDER_LINE AS ORDER_LINE,\n  f.CUSTOMER_KEY AS CUSTOMER_KEY,\n  f.PRODUCT_KEY AS PRODUCT_KEY,\n  f.PROMO_KEY AS PROMO_KEY,\n  f.ORDER_STORE_KEY AS STORE_KEY,\n  f.ORDER_DATE_KEY AS DATE_KEY,\n  f.ORDER_CHANNEL AS ORDER_CHANNEL,\n  f.SHIP_METHOD AS SHIP_METHOD,\n  f.ORDER_STATUS AS ORDER_STATUS,\n  f.QUANTITY_ORDERED AS QUANTITY_ORDERED,\n  f.QUANTITY_RETURNED AS QUANTITY_RETURNED,\n  f.UNIT_PRICE AS UNIT_PRICE,\n  f.UNIT_COST AS UNIT_COST,\n  f.DISCOUNT_AMOUNT AS DISCOUNT_AMOUNT,\n  f.SHIPPING_AMOUNT AS SHIPPING_AMOUNT,\n  f.TAX_AMOUNT AS TAX_AMOUNT,\n  f.GROSS_REVENUE AS GROSS_REVENUE,\n  f.NET_REVENUE AS NET_REVENUE,\n  f.GROSS_PROFIT AS GROSS_PROFIT,\n  f.NET_PROFIT AS NET_PROFIT,\n  f.IS_FIRST_ORDER AS IS_FIRST_ORDER,\n  f.IS_RETURNED AS IS_RETURNED,\n  f.IS_CANCELLED AS IS_CANCELLED,\n  f.DAYS_TO_SHIP AS DAYS_TO_SHIP,\n  a.CUSTOMER_ID AS CUSTOMER_ID,\n  a.FIRST_NAME AS FIRST_NAME,\n  a.LAST_NAME AS LAST_NAME,\n  a.CITY AS CUSTOMER_CITY,\n  a.STATE AS CUSTOMER_STATE,\n  a.REGION AS CUSTOMER_REGION,\n  a.CUSTOMER_SEGMENT AS CUSTOMER_SEGMENT,\n  a.LOYALTY_TIER AS LOYALTY_TIER,\n  a.ACQUISITION_CHANNEL AS ACQUISITION_CHANNEL,\n  a.LIFETIME_REVENUE AS LIFETIME_REVENUE,\n  b.PRODUCT_ID AS PRODUCT_ID,\n  b.PRODUCT_NAME AS PRODUCT_NAME,\n  b.CATEGORY AS CATEGORY,\n  b.SUBCATEGORY AS SUBCATEGORY,\n  b.BRAND AS BRAND,\n  b.IS_PRIVATE_LABEL AS IS_PRIVATE_LABEL,\n  b.IS_SEASONAL AS IS_SEASONAL,\n  c.STORE_ID AS STORE_ID,\n  c.STORE_NAME AS STORE_NAME,\n  c.STORE_TYPE AS STORE_TYPE,\n  c.CITY AS STORE_CITY,\n  c.STATE AS STORE_STATE,\n  c.REGION AS STORE_REGION,\n  c.DISTRICT AS DISTRICT,\n  c.MANAGER_NAME AS MANAGER_NAME,\n  d.FULL_DATE AS FULL_DATE,\n  d.DAY_OF_WEEK AS DAY_OF_WEEK,\n  d.MONTH_NUMBER AS MONTH_NUMBER,\n  d.MONTH_NAME AS MONTH_NAME,\n  d.QUARTER AS QUARTER,\n  d.YEAR AS YEAR,\n  d.IS_WEEKEND AS IS_WEEKEND,\n  d.IS_HOLIDAY AS IS_HOLIDAY,\n  e.PROMO_NAME AS PROMO_NAME,\n  e.PROMO_TYPE AS PROMO_TYPE,\n  e.CHANNEL AS PROMO_CHANNEL,\n  e.DISCOUNT_PCT AS DISCOUNT_PCT,\n  e.TARGET_SEGMENT AS TARGET_SEGMENT\nFROM CSA.TJ.ORDER_FACT f\nLEFT JOIN CSA.TJ.CUSTOMER_DIM a ON f.CUSTOMER_KEY = a.CUSTOMER_KEY\nLEFT JOIN CSA.TJ.PRODUCT_DIM b ON f.PRODUCT_KEY = b.PRODUCT_KEY\nLEFT JOIN CSA.TJ.STORE_DIM c ON f.ORDER_STORE_KEY = c.STORE_KEY\nLEFT JOIN CSA.TJ.DATE_DIM d ON f.ORDER_DATE_KEY = d.DATE_KEY\nLEFT JOIN CSA.TJ.PROMO_DIM e ON f.PROMO_KEY = e.PROMO_KEY"
+}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/catalogs/aggregation.json
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/catalogs/aggregation.json
@@ -1,0 +1,16 @@
+{
+  "dimension": "aggregation",
+  "source_tool": "qlik",
+  "authoritative_doc": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/aggregation-functions.htm",
+  "sigma_target_doc": "https://help.sigmacomputing.com/docs/aggregate-functions",
+  "on_unmapped_default": "return None -> caller warns + skips the chart (NEVER default to Sum)",
+  "description": "Qlik aggregation function -> Sigma aggregate function, used token-wise by translate_measure. `qlik_fn` is matched case-insensitively; `sigma` is the emitted function. Count(DISTINCT X) is a distinct row (Qlik spells distinct as an inline keyword, Sigma as a separate function). Compositional forms are NOT in this table and stay as cited predicates in translate_measure: simple Set Analysis {<F={v}>} -> If(); arithmetic combinations Sum(a)/Sum(b); and (dropped+flagged) Aggr/Rank/Above/Peek/$()-vars/FirstSortedValue.",
+  "rows": [
+    {"source": "sum", "sigma": "Sum", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/BasicAggregationFunctions/Sum.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/sum", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); 142 cols resolve, 0 type=error, parity GREEN"}, "on_unmapped": "warn+skip"},
+    {"source": "avg", "sigma": "Avg", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/BasicAggregationFunctions/Avg.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/aggregate-functions", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); 142 cols resolve, 0 type=error, parity GREEN"}, "on_unmapped": "warn+skip"},
+    {"source": "min", "sigma": "Min", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/BasicAggregationFunctions/Min.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/aggregate-functions", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "max", "sigma": "Max", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/BasicAggregationFunctions/Max.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/aggregate-functions", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "count", "sigma": "Count", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/CounterAggregationFunctions/Count.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/aggregate-functions", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "count_distinct", "sigma": "CountDistinct", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/CounterAggregationFunctions/Count.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/aggregate-functions", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); 142 cols resolve, 0 type=error, parity GREEN"}, "on_unmapped": "warn+skip", "notes": "Qlik Count(DISTINCT X) -> Sigma CountDistinct(X)."}
+  ]
+}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/catalogs/control.json
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/catalogs/control.json
@@ -1,0 +1,12 @@
+{
+  "dimension": "control",
+  "source_tool": "qlik",
+  "authoritative_doc": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/Filterpane/filter-pane.htm",
+  "sigma_target_doc": "refs/control-parity.md",
+  "on_unmapped_default": "list (documented default control kind for a categorical Qlik field)",
+  "description": "Qlik filter/listbox field kind -> Sigma control kind. Only the date case is special: a Sigma `list` control whose target is a datetime column posts fine but Sigma SILENTLY STRIPS the target (dead control) — so date fields become date-range controls. Date detection is COMPOSITIONAL (engine tags $date/$timestamp are authoritative; qNumFormat date pattern + column name are fallbacks) and stays as the cited predicate date_field(). Alternate-state listboxes have no Sigma equivalent -> flagged MANUAL (not emitted); a field not on the denorm element -> skipped+warned.",
+  "rows": [
+    {"source": "date", "sigma": "date-range", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/Filterpane/filter-pane.htm", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); 142 cols resolve, 0 type=error, parity GREEN"}, "on_unmapped": "n/a", "notes": "Field the date_field() predicate tags as date/timestamp — a datetime-bound list control is silently stripped by Sigma."},
+    {"source": "field", "sigma": "list", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/Filterpane/filter-pane.htm", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); 142 cols resolve, 0 type=error, parity GREEN"}, "on_unmapped": "n/a", "notes": "Categorical list control (documented default)."}
+  ]
+}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/catalogs/number-format.json
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/catalogs/number-format.json
@@ -1,0 +1,15 @@
+{
+  "dimension": "number-format",
+  "source_tool": "qlik",
+  "authoritative_doc": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm",
+  "sigma_target_doc": "https://help.sigmacomputing.com/docs/data-types-and-formats",
+  "on_unmapped_default": "no qFmt -> return None (ship the numeric value UNFORMATTED) + loud warn — NEVER a name-substring currency guess, NEVER a silent ,.0f default",
+  "description": "Qlik qNumFormat.qFmt (an Excel-style number mask) -> Sigma column format (D3 formatString). The mapping is COMPOSITIONAL — sigma_fmt() parses the mask: '$' prefix -> currency, '%' -> percent, and the count of 0/# digits after '.' -> decimals. These rows are PINNED PARSER EXAMPLES that a test asserts sigma_fmt() reproduces, grounding the parser against documented qNumFormat semantics. The old name-substring currency guess (revenue|profit|... -> $,.0f) and the silent ,.0f default were REMOVED (beads-sigma-kvza) — an absent qFmt now yields no format + a loud note.",
+  "rows": [
+    {"source": "$#,##0", "sigma": "$,.0f", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); rendered $127,514 via qFmt parser, 0 type=error"}, "on_unmapped": "n/a", "notes": "Currency, no decimals."},
+    {"source": "$#,##0.00", "sigma": "$,.2f", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "n/a", "notes": "Currency, 2 decimals."},
+    {"source": "#,##0", "sigma": ",.0f", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "n/a", "notes": "Thousands-separated integer."},
+    {"source": "#,##0.0%", "sigma": ",.1%", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "n/a", "notes": "Percent, 1 decimal."},
+    {"source": "0.00%", "sigma": ",.2%", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "n/a", "notes": "Percent, 2 decimals."}
+  ]
+}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/catalogs/viz-kind.json
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/catalogs/viz-kind.json
@@ -1,0 +1,18 @@
+{
+  "dimension": "viz-kind",
+  "source_tool": "qlik",
+  "authoritative_doc": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/visualizations.htm",
+  "on_unmapped_default": "warn+skip (no native Sigma kind) — or, when the tile has dims+measures, approximate as bar-chart WITH a warning",
+  "description": "Qlik object vizType -> Sigma workbook element kind. The single source of truth for build-sigma-workbook.py's chart classifier. `auto-chart` is NOT in this table — it is resolved compositionally by shape (no dims -> KPI; >=2 dims -> grouped table; 1 temporal dim -> line; else bar), a cited predicate in build_element.",
+  "rows": [
+    {"source": "barchart", "sigma": "bar-chart", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/BarChart/bar-chart.htm", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); 142 cols resolve, 0 type=error, parity GREEN"}, "on_unmapped": "warn+skip"},
+    {"source": "linechart", "sigma": "line-chart", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/LineChart/line-chart.htm", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); 142 cols resolve, 0 type=error, parity GREEN"}, "on_unmapped": "warn+skip"},
+    {"source": "piechart", "sigma": "pie-chart", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/PieChart/pie-chart.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "combochart", "sigma": "combo-chart", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/ComboChart/combo-chart.htm", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); 142 cols resolve, 0 type=error, parity GREEN"}, "on_unmapped": "warn+skip"},
+    {"source": "scatterplot", "sigma": "scatter-chart", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/ScatterPlot/scatter-plot.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "table", "sigma": "table", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/Table/table.htm", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); 142 cols resolve, 0 type=error, parity GREEN"}, "on_unmapped": "warn+skip"},
+    {"source": "kpi", "sigma": "kpi-chart", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/KPI/KPI.htm", "sigma_verified": {"status": "y", "date": "2026-07-13", "method": "live-verify CSA.TJ (qlik retail-orders, wb 9adb1ae8); 142 cols resolve, 0 type=error, parity GREEN"}, "on_unmapped": "warn+skip"},
+    {"source": "pivot-table", "sigma": "pivot-table", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/PivotTable/pivot-table.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip"},
+    {"source": "map", "sigma": "region-map", "doc_ref": "https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/Map/Map.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+skip", "notes": "build_element refuses to guess a region grain and warns+skips if it cannot resolve one."}
+  ]
+}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/qlik-coverage.md
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/refs/qlik-coverage.md
@@ -1,0 +1,79 @@
+# Qlik → Sigma — dashboard classifier coverage matrix
+
+> **GENERATED — do not edit by hand.** Regenerate with `python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill qlik --out refs/qlik-coverage.md`. The JSON catalogs in `refs/catalogs/` are the single source of truth; the classifier (`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them via `shared/lib/coverage_catalog.py`. A no-drift test asserts this file matches the catalogs.
+
+Every documented source construct maps to a real, current Sigma target or a loud fallback — no silent wrong-defaults, no name-substring guessing (beads-sigma-kvza).
+
+**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at **query time** in a live migration (no `type=error` column) on the date shown; 🟡 n = target is documented but not yet query-verified.
+
+**Coverage:** 22 documented constructs across 4 dimensions; 11 live-verified.
+
+## Visualization / chart kind
+
+_Qlik object vizType -> Sigma workbook element kind. The single source of truth for build-sigma-workbook.py's chart classifier. `auto-chart` is NOT in this table — it is resolved compositionally by shape (no dims -> KPI; >=2 dims -> grouped table; 1 temporal dim -> line; else bar), a cited predicate in build_element._
+
+Authoritative source: <https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/visualizations.htm>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `barchart` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/BarChart/bar-chart.htm) | `bar-chart` | ✅ y · 2026-07-13 | warn+skip |
+| `linechart` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/LineChart/line-chart.htm) | `line-chart` | ✅ y · 2026-07-13 | warn+skip |
+| `piechart` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/PieChart/pie-chart.htm) | `pie-chart` | 🟡 n | warn+skip |
+| `combochart` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/ComboChart/combo-chart.htm) | `combo-chart` | ✅ y · 2026-07-13 | warn+skip |
+| `scatterplot` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/ScatterPlot/scatter-plot.htm) | `scatter-chart` | 🟡 n | warn+skip |
+| `table` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/Table/table.htm) | `table` | ✅ y · 2026-07-13 | warn+skip |
+| `kpi` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/KPI/KPI.htm) | `kpi-chart` | ✅ y · 2026-07-13 | warn+skip |
+| `pivot-table` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/PivotTable/pivot-table.htm) | `pivot-table` | 🟡 n | warn+skip |
+| `map` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/Map/Map.htm) | `region-map` | 🟡 n | warn+skip |
+| | | | | _build_element refuses to guess a region grain and warns+skips if it cannot resolve one._ |
+
+## Number format
+
+_Qlik qNumFormat.qFmt (an Excel-style number mask) -> Sigma column format (D3 formatString). The mapping is COMPOSITIONAL — sigma_fmt() parses the mask: '$' prefix -> currency, '%' -> percent, and the count of 0/# digits after '.' -> decimals. These rows are PINNED PARSER EXAMPLES that a test asserts sigma_fmt() reproduces, grounding the parser against documented qNumFormat semantics. The old name-substring currency guess (revenue|profit|... -> $,.0f) and the silent ,.0f default were REMOVED (beads-sigma-kvza) — an absent qFmt now yields no format + a loud note._
+
+Authoritative source: <https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `$#,##0` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm) | `$,.0f` | ✅ y · 2026-07-13 | n/a |
+| | | | | _Currency, no decimals._ |
+| `$#,##0.00` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm) | `$,.2f` | 🟡 n | n/a |
+| | | | | _Currency, 2 decimals._ |
+| `#,##0` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm) | `,.0f` | 🟡 n | n/a |
+| | | | | _Thousands-separated integer._ |
+| `#,##0.0%` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm) | `,.1%` | 🟡 n | n/a |
+| | | | | _Percent, 1 decimal._ |
+| `0.00%` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Scripting/FormattingFunctions/Num.htm) | `,.2%` | 🟡 n | n/a |
+| | | | | _Percent, 2 decimals._ |
+
+## Aggregation
+
+_Qlik aggregation function -> Sigma aggregate function, used token-wise by translate_measure. `qlik_fn` is matched case-insensitively; `sigma` is the emitted function. Count(DISTINCT X) is a distinct row (Qlik spells distinct as an inline keyword, Sigma as a separate function). Compositional forms are NOT in this table and stay as cited predicates in translate_measure: simple Set Analysis {<F={v}>} -> If(); arithmetic combinations Sum(a)/Sum(b); and (dropped+flagged) Aggr/Rank/Above/Peek/$()-vars/FirstSortedValue._
+
+Authoritative source: <https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/aggregation-functions.htm>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `sum` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/BasicAggregationFunctions/Sum.htm) | `Sum` | ✅ y · 2026-07-13 | warn+skip |
+| `avg` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/BasicAggregationFunctions/Avg.htm) | `Avg` | ✅ y · 2026-07-13 | warn+skip |
+| `min` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/BasicAggregationFunctions/Min.htm) | `Min` | 🟡 n | warn+skip |
+| `max` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/BasicAggregationFunctions/Max.htm) | `Max` | 🟡 n | warn+skip |
+| `count` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/CounterAggregationFunctions/Count.htm) | `Count` | 🟡 n | warn+skip |
+| `count_distinct` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/ChartFunctions/CounterAggregationFunctions/Count.htm) | `CountDistinct` | ✅ y · 2026-07-13 | warn+skip |
+| | | | | _Qlik Count(DISTINCT X) -> Sigma CountDistinct(X)._ |
+
+## Control / filter
+
+_Qlik filter/listbox field kind -> Sigma control kind. Only the date case is special: a Sigma `list` control whose target is a datetime column posts fine but Sigma SILENTLY STRIPS the target (dead control) — so date fields become date-range controls. Date detection is COMPOSITIONAL (engine tags $date/$timestamp are authoritative; qNumFormat date pattern + column name are fallbacks) and stays as the cited predicate date_field(). Alternate-state listboxes have no Sigma equivalent -> flagged MANUAL (not emitted); a field not on the denorm element -> skipped+warned._
+
+Authoritative source: <https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/Filterpane/filter-pane.htm>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `date` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/Filterpane/filter-pane.htm) | `date-range` | ✅ y · 2026-07-13 | n/a |
+| | | | | _Field the date_field() predicate tags as date/timestamp — a datetime-bound list control is silently stripped by Sigma._ |
+| `field` | [doc](https://help.qlik.com/en-US/sense/Subsystems/Hub/Content/Sense_Hub/Visualizations/Filterpane/filter-pane.htm) | `list` | ✅ y · 2026-07-13 | n/a |
+| | | | | _Categorical list control (documented default)._ |
+
+---
+_Compositional constructs that do not serialize to a flat table (Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask parsers, count-on-joined-view) stay as cited predicates in the classifier; this matrix covers the enumerable maps._

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/build-sigma-workbook.py
@@ -50,10 +50,31 @@ KEEP_UNMATCHED = os.environ.get("QLIK_KEEP_UNMATCHED", "") == "1"
 ROW_SCALE = 2          # min row-scale; Qlik rows are ~3x shorter than Sigma's
 KPI_MIN_ROWS = 5       # Sigma kpi-chart clips its title below ~5 grid rows
 TEMPORAL = re.compile(r"DATE|MONTH|YEAR|QUARTER|WEEK|DAY", re.I)
-NATIVE = {"barchart": "bar-chart", "linechart": "line-chart", "piechart": "pie-chart",
-          "combochart": "combo-chart", "scatterplot": "scatter-chart",
-          "table": "table", "kpi": "kpi-chart", "pivot-table": "pivot-table",
-          "map": "region-map"}
+# ── documentation-grounded mapping catalogs (SINGLE SOURCE OF TRUTH) ─────────
+# viz/aggregation/control maps are LOADED from refs/catalogs/<dimension>.json —
+# cited rows, live-verified Sigma targets, loud fallback on anything unmapped.
+# NO inline mapping literal may bypass these (grep-enforced by tests/test_grounding.py).
+# The human-readable matrix in refs/qlik-coverage.md is GENERATED from these files.
+# Loader: shared/lib/coverage_catalog.py (synced to scripts/lib/). Mirrors the
+# beads-sigma-93ps contract: catalog = data, code = thin resolver/predicates.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import coverage_catalog as _cc  # noqa: E402
+_CAT_DIR = _cc.default_catalog_dir(__file__)
+VIZ_CAT  = _cc.load(_CAT_DIR, "viz-kind")       # Qlik vizType     -> Sigma element kind
+AGG_CAT  = _cc.load(_CAT_DIR, "aggregation")    # Qlik agg fn      -> Sigma aggregate fn
+CTRL_CAT = _cc.load(_CAT_DIR, "control")        # Qlik field kind  -> Sigma control kind
+# number-format is COMPOSITIONAL (sigma_fmt parses the qNumFormat mask); its
+# catalog (refs/catalogs/number-format.json) pins the parser to documented
+# examples via tests/test_grounding.py rather than a flat lookup.
+
+# Qlik vizType -> Sigma element kind (auto-chart resolved by shape in build_element).
+NATIVE = {r["source"]: r["sigma"] for r in VIZ_CAT.rows}
+# Qlik aggregation fn -> Sigma aggregate fn (token-wise in translate_measure). The
+# recognized non-distinct fns drive the regex alternation; Count(DISTINCT) is separate.
+_AGG_TO_SIGMA = {r["source"]: r["sigma"] for r in AGG_CAT.rows}
+_AGG_ALT = "|".join(sorted(r["source"] for r in AGG_CAT.rows if r["source"] != "count_distinct"))
+def _agg_sigma(qlik_fn):
+    return _AGG_TO_SIGMA.get(str(qlik_fn).lower(), str(qlik_fn).capitalize())
 
 _ids = {}
 def nid(prefix):
@@ -77,8 +98,15 @@ def api_post(path, body):
                 continue
             print("HTTP", e.code, detail[:800], file=sys.stderr); raise
 
-def sigma_fmt(qfmt, name=""):
-    """Qlik qNumFormat.qFmt -> Sigma formatString. Falls back to a name heuristic."""
+def sigma_fmt(qfmt, name="", warnings=None):
+    """Qlik qNumFormat.qFmt (an Excel-style mask) -> Sigma format object, or None.
+    PARSER ONLY: a leading '$' -> currency, '%' -> percent, and the count of 0/#
+    after '.' -> decimals (qNumFormat grammar:
+    help.qlik.com/.../Scripting/FormattingFunctions/Num.htm; mapping pinned by
+    refs/catalogs/number-format.json + tests/test_grounding.py).
+    An ABSENT qFmt yields None — ship the numeric value UNFORMATTED + a loud note.
+    The old name-substring currency guess (revenue|profit|... -> $,.0f) and the
+    silent ,.0f default were REMOVED (beads-sigma-kvza): no judgement-based guessing."""
     if qfmt:
         dec = 0
         if "." in qfmt:
@@ -86,10 +114,11 @@ def sigma_fmt(qfmt, name=""):
         if "%" in qfmt: return {"kind": "number", "formatString": f",.{dec}%"}
         pre = "$" if qfmt.lstrip().startswith("$") else ""
         return {"kind": "number", "formatString": f"{pre},.{dec}f"}
-    if re.search(r"%|margin|rate", name, re.I): return {"kind": "number", "formatString": ",.1%"}
-    if re.search(r"revenue|profit|amount|value|cost|price", name, re.I):
-        return {"kind": "number", "formatString": "$,.0f"}
-    return {"kind": "number", "formatString": ",.0f"}
+    if warnings is not None and name:
+        warnings.append(f"⚠ number-format: measure '{name}' has no Qlik qNumFormat — shipped "
+                        f"UNFORMATTED (no name-substring currency guess, no silent default). "
+                        f"Apply a Sigma column format if a specific display is needed.")
+    return None
 
 class Resolver:
     """Raw Qlik field name -> master-column display name (via the denorm element)."""
@@ -115,7 +144,7 @@ def translate_measure(expr, resolve):
         if d is None: unresolved.append(f)
         return f"[{MASTER}/{d}]"
     def set_analysis(m):
-        agg, cf, op, vals_raw, xf = (m.group(1).capitalize(), m.group(2),
+        agg, cf, op, vals_raw, xf = (_agg_sigma(m.group(1)), m.group(2),
                                      m.group(3), m.group(4), m.group(5))
         conds = []
         for val in (v.strip() for v in vals_raw.split(",")):
@@ -129,17 +158,20 @@ def translate_measure(expr, resolve):
         cond = (" and " if op == "-=" else " or ").join(conds)
         if len(conds) > 1: cond = f"({cond})"
         inner = f"If({cond}, {ref(xf)})"
-        return f"CountDistinct({inner})" if agg == "Count" and m.group(0).upper().find("DISTINCT") >= 0 \
+        _cd = _AGG_TO_SIGMA.get("count_distinct", "CountDistinct")
+        return f"{_cd}({inner})" if agg == _agg_sigma("count") and m.group(0).upper().find("DISTINCT") >= 0 \
             else f"{agg}({inner})"
+    # aggregation function names + Sigma targets come from refs/catalogs/aggregation.json
+    _cd = _AGG_TO_SIGMA.get("count_distinct", "CountDistinct")
     # 1) simple Set Analysis  Agg({<F={v,...}>} [DISTINCT] X)  (also F-={...} exclusion)
-    e = re.sub(r"\b(Sum|Avg|Min|Max|Count)\s*\(\s*\{\s*<\s*([A-Za-z0-9_]+)\s*(-?=)\s*\{([^}]*)\}\s*>\s*\}\s*(?:DISTINCT\s+)?([A-Za-z0-9_]+)\s*\)",
+    e = re.sub(r"\b(" + _AGG_ALT + r")\s*\(\s*\{\s*<\s*([A-Za-z0-9_]+)\s*(-?=)\s*\{([^}]*)\}\s*>\s*\}\s*(?:DISTINCT\s+)?([A-Za-z0-9_]+)\s*\)",
                set_analysis, e, flags=re.I)
     # 2) Count(DISTINCT X)
     e = re.sub(r"\bCount\s*\(\s*DISTINCT\s+([A-Za-z0-9_]+)\s*\)",
-               lambda m: f"CountDistinct({ref(m.group(1))})", e, flags=re.I)
+               lambda m: f"{_cd}({ref(m.group(1))})", e, flags=re.I)
     # 3) plain Agg(FIELD)
-    e = re.sub(r"\b(Sum|Avg|Min|Max|Count)\s*\(\s*([A-Za-z0-9_]+)\s*\)",
-               lambda m: f"{m.group(1).capitalize()}({ref(m.group(2))})", e, flags=re.I)
+    e = re.sub(r"\b(" + _AGG_ALT + r")\s*\(\s*([A-Za-z0-9_]+)\s*\)",
+               lambda m: f"{_agg_sigma(m.group(1))}({ref(m.group(2))})", e, flags=re.I)
     if unresolved: return None
     # anything left that looks like a bare Qlik field/function = untranslated
     leftovers = re.sub(r'"[^"]*"|\[[^\]]*\]|\b(?:CountDistinct|Sum|Avg|Min|Max|Count|If|and|or)\b', "", e)
@@ -209,15 +241,19 @@ def build_control(lb, resolve, mcol_id, raw_of, warnings, scope, unbound, seen_f
     el = {"id": "el-" + re.sub(r"[^a-z0-9]", "", str(lb["id"]).lower()),
           "kind": "control", "controlId": ctl_id, "name": label or dn,
           "filters": [{"source": {"kind": "table", "elementId": MASTER_ID}, "columnId": cid}]}
-    if date_field(info, raw_of.get(dn)):
+    # control kind is documentation-grounded (refs/catalogs/control.json): a
+    # date-typed field -> date-range, everything else -> the documented `list`
+    # default. date_field() (engine tags/format/name) is the cited predicate.
+    _ctype = CTRL_CAT.target("date") if date_field(info, raw_of.get(dn)) else CTRL_CAT.target("field")
+    if _ctype == "date-range":
         # date-range needs no `source` (the column comes from the filter
         # binding) but DOES require a flat `mode` — without it the POST fails
         # with the misleading "Invalid kind: control" (live-verified 2026-06-12;
         # the widget shape is picked by mode, see sigma-workbooks controls.md).
-        el.update({"controlType": "date-range", "mode": "between",
+        el.update({"controlType": _ctype, "mode": "between",
                    "includeNulls": "when-no-value-is-selected"})
     else:
-        el.update({"controlType": "list", "mode": "include", "selectionMode": "multiple",
+        el.update({"controlType": _ctype, "mode": "include", "selectionMode": "multiple",
                    "values": [],
                    "source": {"kind": "source",
                               "source": {"kind": "table", "elementId": MASTER_ID}, "columnId": cid}})
@@ -348,7 +384,10 @@ def build_element(c, resolve, warnings):
             continue
         mname = mlabels[i] or (title if kind == "kpi-chart" else f"Measure {i+1}")
         cid = nid("y")
-        cols.append({"id": cid, "formula": f, "name": mname, "format": sigma_fmt(mfmts[i], mname)})
+        _mcol = {"id": cid, "formula": f, "name": mname}
+        _fmt = sigma_fmt(mfmts[i], mname, warnings)
+        if _fmt: _mcol["format"] = _fmt
+        cols.append(_mcol)
         mids.append(cid); mnames.append(mname)
     if not mids:
         warnings.append(f"skip '{title}': no translatable measures"); return None

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/golden/retail_orders_workbook.spec.json
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/golden/retail_orders_workbook.spec.json
@@ -1,0 +1,2065 @@
+{
+  "name": "GOLDEN",
+  "schemaVersion": 1,
+  "pages": [
+    {
+      "id": "page-data",
+      "name": "Data",
+      "elements": [
+        {
+          "id": "m-master",
+          "name": "Master",
+          "kind": "table",
+          "source": {
+            "dataModelId": "dm-x",
+            "elementId": "el-x",
+            "kind": "data-model"
+          },
+          "columns": [
+            {
+              "id": "o0",
+              "name": "Order Id",
+              "formula": "[Custom SQL/Order Id]"
+            },
+            {
+              "id": "o1",
+              "name": "Order Line",
+              "formula": "[Custom SQL/Order Line]"
+            },
+            {
+              "id": "o2",
+              "name": "Customer Key",
+              "formula": "[Custom SQL/Customer Key]"
+            },
+            {
+              "id": "o3",
+              "name": "Product Key",
+              "formula": "[Custom SQL/Product Key]"
+            },
+            {
+              "id": "o4",
+              "name": "Promo Key",
+              "formula": "[Custom SQL/Promo Key]"
+            },
+            {
+              "id": "o5",
+              "name": "Store Key",
+              "formula": "[Custom SQL/Store Key]"
+            },
+            {
+              "id": "o6",
+              "name": "Date Key",
+              "formula": "[Custom SQL/Date Key]"
+            },
+            {
+              "id": "o7",
+              "name": "Order Channel",
+              "formula": "[Custom SQL/Order Channel]"
+            },
+            {
+              "id": "o8",
+              "name": "Ship Method",
+              "formula": "[Custom SQL/Ship Method]"
+            },
+            {
+              "id": "o9",
+              "name": "Order Status",
+              "formula": "[Custom SQL/Order Status]"
+            },
+            {
+              "id": "o10",
+              "name": "Quantity Ordered",
+              "formula": "[Custom SQL/Quantity Ordered]"
+            },
+            {
+              "id": "o11",
+              "name": "Quantity Returned",
+              "formula": "[Custom SQL/Quantity Returned]"
+            },
+            {
+              "id": "o12",
+              "name": "Unit Price",
+              "formula": "[Custom SQL/Unit Price]"
+            },
+            {
+              "id": "o13",
+              "name": "Unit Cost",
+              "formula": "[Custom SQL/Unit Cost]"
+            },
+            {
+              "id": "o14",
+              "name": "Discount Amount",
+              "formula": "[Custom SQL/Discount Amount]"
+            },
+            {
+              "id": "o15",
+              "name": "Shipping Amount",
+              "formula": "[Custom SQL/Shipping Amount]"
+            },
+            {
+              "id": "o16",
+              "name": "Tax Amount",
+              "formula": "[Custom SQL/Tax Amount]"
+            },
+            {
+              "id": "o17",
+              "name": "Gross Revenue",
+              "formula": "[Custom SQL/Gross Revenue]"
+            },
+            {
+              "id": "o18",
+              "name": "Net Revenue",
+              "formula": "[Custom SQL/Net Revenue]"
+            },
+            {
+              "id": "o19",
+              "name": "Gross Profit",
+              "formula": "[Custom SQL/Gross Profit]"
+            },
+            {
+              "id": "o20",
+              "name": "Net Profit",
+              "formula": "[Custom SQL/Net Profit]"
+            },
+            {
+              "id": "o21",
+              "name": "Is First Order",
+              "formula": "[Custom SQL/Is First Order]"
+            },
+            {
+              "id": "o22",
+              "name": "Is Returned",
+              "formula": "[Custom SQL/Is Returned]"
+            },
+            {
+              "id": "o23",
+              "name": "Is Cancelled",
+              "formula": "[Custom SQL/Is Cancelled]"
+            },
+            {
+              "id": "o24",
+              "name": "Days to Ship",
+              "formula": "[Custom SQL/Days to Ship]"
+            },
+            {
+              "id": "o25",
+              "name": "Customer Id",
+              "formula": "[Custom SQL/Customer Id]"
+            },
+            {
+              "id": "o26",
+              "name": "First Name",
+              "formula": "[Custom SQL/First Name]"
+            },
+            {
+              "id": "o27",
+              "name": "Last Name",
+              "formula": "[Custom SQL/Last Name]"
+            },
+            {
+              "id": "o28",
+              "name": "Customer City",
+              "formula": "[Custom SQL/Customer City]"
+            },
+            {
+              "id": "o29",
+              "name": "Customer State",
+              "formula": "[Custom SQL/Customer State]"
+            },
+            {
+              "id": "o30",
+              "name": "Customer Region",
+              "formula": "[Custom SQL/Customer Region]"
+            },
+            {
+              "id": "o31",
+              "name": "Customer Segment",
+              "formula": "[Custom SQL/Customer Segment]"
+            },
+            {
+              "id": "o32",
+              "name": "Loyalty Tier",
+              "formula": "[Custom SQL/Loyalty Tier]"
+            },
+            {
+              "id": "o33",
+              "name": "Acquisition Channel",
+              "formula": "[Custom SQL/Acquisition Channel]"
+            },
+            {
+              "id": "o34",
+              "name": "Lifetime Revenue",
+              "formula": "[Custom SQL/Lifetime Revenue]"
+            },
+            {
+              "id": "o35",
+              "name": "Product Id",
+              "formula": "[Custom SQL/Product Id]"
+            },
+            {
+              "id": "o36",
+              "name": "Product Name",
+              "formula": "[Custom SQL/Product Name]"
+            },
+            {
+              "id": "o37",
+              "name": "Category",
+              "formula": "[Custom SQL/Category]"
+            },
+            {
+              "id": "o38",
+              "name": "Subcategory",
+              "formula": "[Custom SQL/Subcategory]"
+            },
+            {
+              "id": "o39",
+              "name": "Brand",
+              "formula": "[Custom SQL/Brand]"
+            },
+            {
+              "id": "o40",
+              "name": "Is Private Label",
+              "formula": "[Custom SQL/Is Private Label]"
+            },
+            {
+              "id": "o41",
+              "name": "Is Seasonal",
+              "formula": "[Custom SQL/Is Seasonal]"
+            },
+            {
+              "id": "o42",
+              "name": "Store Id",
+              "formula": "[Custom SQL/Store Id]"
+            },
+            {
+              "id": "o43",
+              "name": "Store Name",
+              "formula": "[Custom SQL/Store Name]"
+            },
+            {
+              "id": "o44",
+              "name": "Store Type",
+              "formula": "[Custom SQL/Store Type]"
+            },
+            {
+              "id": "o45",
+              "name": "Store City",
+              "formula": "[Custom SQL/Store City]"
+            },
+            {
+              "id": "o46",
+              "name": "Store State",
+              "formula": "[Custom SQL/Store State]"
+            },
+            {
+              "id": "o47",
+              "name": "Store Region",
+              "formula": "[Custom SQL/Store Region]"
+            },
+            {
+              "id": "o48",
+              "name": "District",
+              "formula": "[Custom SQL/District]"
+            },
+            {
+              "id": "o49",
+              "name": "Manager Name",
+              "formula": "[Custom SQL/Manager Name]"
+            },
+            {
+              "id": "o50",
+              "name": "Full Date",
+              "formula": "[Custom SQL/Full Date]"
+            },
+            {
+              "id": "o51",
+              "name": "Day of Week",
+              "formula": "[Custom SQL/Day of Week]"
+            },
+            {
+              "id": "o52",
+              "name": "Month Number",
+              "formula": "[Custom SQL/Month Number]"
+            },
+            {
+              "id": "o53",
+              "name": "Month Name",
+              "formula": "[Custom SQL/Month Name]"
+            },
+            {
+              "id": "o54",
+              "name": "Quarter",
+              "formula": "[Custom SQL/Quarter]"
+            },
+            {
+              "id": "o55",
+              "name": "Year",
+              "formula": "[Custom SQL/Year]"
+            },
+            {
+              "id": "o56",
+              "name": "Is Weekend",
+              "formula": "[Custom SQL/Is Weekend]"
+            },
+            {
+              "id": "o57",
+              "name": "Is Holiday",
+              "formula": "[Custom SQL/Is Holiday]"
+            },
+            {
+              "id": "o58",
+              "name": "Promo Name",
+              "formula": "[Custom SQL/Promo Name]"
+            },
+            {
+              "id": "o59",
+              "name": "Promo Type",
+              "formula": "[Custom SQL/Promo Type]"
+            },
+            {
+              "id": "o60",
+              "name": "Promo Channel",
+              "formula": "[Custom SQL/Promo Channel]"
+            },
+            {
+              "id": "o61",
+              "name": "Discount Pct",
+              "formula": "[Custom SQL/Discount Pct]"
+            },
+            {
+              "id": "o62",
+              "name": "Target Segment",
+              "formula": "[Custom SQL/Target Segment]"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pg-1",
+      "name": "Retail Orders \u2014 Overview",
+      "elements": [
+        {
+          "id": "el-krev",
+          "kind": "kpi-chart",
+          "name": "Net Revenue",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y1",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y1"
+          }
+        },
+        {
+          "id": "el-kord",
+          "kind": "kpi-chart",
+          "name": "Orders",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y2",
+              "formula": "CountDistinct([Master/Order Id])",
+              "name": "Orders",
+              "format": {
+                "kind": "number",
+                "formatString": ",.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y2"
+          }
+        },
+        {
+          "id": "el-kmar",
+          "kind": "kpi-chart",
+          "name": "Net Margin",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y3",
+              "formula": "Sum([Master/Net Profit])/Sum([Master/Net Revenue])",
+              "name": "Net Margin",
+              "format": {
+                "kind": "number",
+                "formatString": ",.1%"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y3"
+          }
+        },
+        {
+          "id": "el-lb6",
+          "kind": "control",
+          "controlId": "FullDateFilter",
+          "name": "Order Date",
+          "filters": [
+            {
+              "source": {
+                "kind": "table",
+                "elementId": "m-master"
+              },
+              "columnId": "o50"
+            }
+          ],
+          "controlType": "date-range",
+          "mode": "between",
+          "includeNulls": "when-no-value-is-selected"
+        },
+        {
+          "id": "el-ccat",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Category",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x1",
+              "formula": "[Master/Category]",
+              "name": "Category"
+            },
+            {
+              "id": "y4",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn1",
+              "formula": "Not(IsNull([Master/Category]))",
+              "name": "Category Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f1",
+              "columnId": "nn1",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x1",
+            "sort": {
+              "by": "y4",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y4"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-cmon",
+          "kind": "line-chart",
+          "name": "Revenue & Profit by Month",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x2",
+              "formula": "[Master/Month Number]",
+              "name": "Month"
+            },
+            {
+              "id": "y5",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "y6",
+              "formula": "Sum([Master/Net Profit])",
+              "name": "Net Profit",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn2",
+              "formula": "Not(IsNull([Master/Month Number]))",
+              "name": "Month Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f2",
+              "columnId": "nn2",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x2"
+          },
+          "yAxis": {
+            "columnIds": [
+              "y5",
+              "y6"
+            ]
+          }
+        },
+        {
+          "id": "el-lb1",
+          "kind": "control",
+          "controlId": "CustomerRegionFilter",
+          "name": "Customer Region",
+          "filters": [
+            {
+              "source": {
+                "kind": "table",
+                "elementId": "m-master"
+              },
+              "columnId": "o30"
+            }
+          ],
+          "controlType": "list",
+          "mode": "include",
+          "selectionMode": "multiple",
+          "values": [],
+          "source": {
+            "kind": "source",
+            "source": {
+              "kind": "table",
+              "elementId": "m-master"
+            },
+            "columnId": "o30"
+          }
+        },
+        {
+          "id": "el-lb4",
+          "kind": "control",
+          "controlId": "CategoryFilter",
+          "name": "Category",
+          "filters": [
+            {
+              "source": {
+                "kind": "table",
+                "elementId": "m-master"
+              },
+              "columnId": "o37"
+            }
+          ],
+          "controlType": "list",
+          "mode": "include",
+          "selectionMode": "multiple",
+          "values": [],
+          "source": {
+            "kind": "source",
+            "source": {
+              "kind": "table",
+              "elementId": "m-master"
+            },
+            "columnId": "o37"
+          }
+        },
+        {
+          "id": "el-cseg",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Customer Segment",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x3",
+              "formula": "[Master/Customer Segment]",
+              "name": "Segment"
+            },
+            {
+              "id": "y7",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn3",
+              "formula": "Not(IsNull([Master/Customer Segment]))",
+              "name": "Segment Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f3",
+              "columnId": "nn3",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x3",
+            "sort": {
+              "by": "y7",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y7"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-ctbl",
+          "kind": "table",
+          "name": "Store Performance",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x4",
+              "formula": "[Master/Store Name]",
+              "name": "Store"
+            },
+            {
+              "id": "x5",
+              "formula": "[Master/Store Region]",
+              "name": "Region"
+            },
+            {
+              "id": "y8",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "y9",
+              "formula": "CountDistinct([Master/Order Id])",
+              "name": "Orders",
+              "format": {
+                "kind": "number",
+                "formatString": ",.0f"
+              }
+            },
+            {
+              "id": "nn4",
+              "formula": "Not(IsNull([Master/Store Name]))",
+              "name": "Store Matched",
+              "hidden": true
+            },
+            {
+              "id": "nn5",
+              "formula": "Not(IsNull([Master/Store Region]))",
+              "name": "Region Matched",
+              "hidden": true
+            }
+          ],
+          "filters": [
+            {
+              "id": "f4",
+              "columnId": "nn4",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            },
+            {
+              "id": "f5",
+              "columnId": "nn5",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "groupings": [
+            {
+              "id": "g1",
+              "groupBy": [
+                "x4",
+                "x5"
+              ],
+              "calculations": [
+                "y8",
+                "y9"
+              ],
+              "sort": [
+                {
+                  "columnId": "y8",
+                  "direction": "descending"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "band-pg-1-hdr",
+          "kind": "container",
+          "style": {
+            "backgroundColor": "#0F172A",
+            "borderRadius": "round"
+          }
+        },
+        {
+          "id": "band-pg-1-hdrtext",
+          "kind": "text",
+          "body": "# <span style=\"color: #FFFFFF\">Retail Orders \u2014 Overview</span>"
+        },
+        {
+          "id": "band-pg-1-1",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-1-2",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-1-3",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-1-4",
+          "kind": "container"
+        }
+      ]
+    },
+    {
+      "id": "pg-2",
+      "name": "Product Performance",
+      "elements": [
+        {
+          "id": "el-pk1",
+          "kind": "kpi-chart",
+          "name": "Net Revenue",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y10",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y10"
+          }
+        },
+        {
+          "id": "el-pk2",
+          "kind": "kpi-chart",
+          "name": "Units Sold",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y11",
+              "formula": "Sum([Master/Quantity Ordered])",
+              "name": "Units Sold",
+              "format": {
+                "kind": "number",
+                "formatString": ",.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y11"
+          }
+        },
+        {
+          "id": "el-pk3",
+          "kind": "kpi-chart",
+          "name": "Return Rate",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y12",
+              "formula": "Sum([Master/Quantity Returned])/Sum([Master/Quantity Ordered])",
+              "name": "Return Rate",
+              "format": {
+                "kind": "number",
+                "formatString": ",.1%"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y12"
+          }
+        },
+        {
+          "id": "el-pc1",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Category",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x6",
+              "formula": "[Master/Category]",
+              "name": "Category"
+            },
+            {
+              "id": "y13",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn6",
+              "formula": "Not(IsNull([Master/Category]))",
+              "name": "Category Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f6",
+              "columnId": "nn6",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x6",
+            "sort": {
+              "by": "y13",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y13"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-pc2",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Subcategory",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x7",
+              "formula": "[Master/Subcategory]",
+              "name": "Subcategory"
+            },
+            {
+              "id": "y14",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn7",
+              "formula": "Not(IsNull([Master/Subcategory]))",
+              "name": "Subcategory Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f7",
+              "columnId": "nn7",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x7",
+            "sort": {
+              "by": "y14",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y14"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-pc3",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Brand",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x8",
+              "formula": "[Master/Brand]",
+              "name": "Brand"
+            },
+            {
+              "id": "y15",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn8",
+              "formula": "Not(IsNull([Master/Brand]))",
+              "name": "Brand Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f8",
+              "columnId": "nn8",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x8",
+            "sort": {
+              "by": "y15",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y15"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-pc4",
+          "kind": "bar-chart",
+          "name": "Units Sold by Category",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x9",
+              "formula": "[Master/Category]",
+              "name": "Category"
+            },
+            {
+              "id": "y16",
+              "formula": "Sum([Master/Quantity Ordered])",
+              "name": "Units",
+              "format": {
+                "kind": "number",
+                "formatString": ",.0f"
+              }
+            },
+            {
+              "id": "nn9",
+              "formula": "Not(IsNull([Master/Category]))",
+              "name": "Category Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f9",
+              "columnId": "nn9",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x9",
+            "sort": {
+              "by": "y16",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y16"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "band-pg-2-hdr",
+          "kind": "container",
+          "style": {
+            "backgroundColor": "#0F172A",
+            "borderRadius": "round"
+          }
+        },
+        {
+          "id": "band-pg-2-hdrtext",
+          "kind": "text",
+          "body": "# <span style=\"color: #FFFFFF\">Product Performance</span>"
+        },
+        {
+          "id": "band-pg-2-1",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-2-2",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-2-3",
+          "kind": "container"
+        }
+      ]
+    },
+    {
+      "id": "pg-3",
+      "name": "Customer Analytics",
+      "elements": [
+        {
+          "id": "el-cuk1",
+          "kind": "kpi-chart",
+          "name": "Net Revenue",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y17",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y17"
+          }
+        },
+        {
+          "id": "el-cuk2",
+          "kind": "kpi-chart",
+          "name": "Orders",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y18",
+              "formula": "CountDistinct([Master/Order Id])",
+              "name": "Orders",
+              "format": {
+                "kind": "number",
+                "formatString": ",.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y18"
+          }
+        },
+        {
+          "id": "el-cuk3",
+          "kind": "kpi-chart",
+          "name": "Avg Order Value",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y19",
+              "formula": "Sum([Master/Net Revenue])/CountDistinct([Master/Order Id])",
+              "name": "Avg Order Value",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y19"
+          }
+        },
+        {
+          "id": "el-cuc1",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Segment",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x10",
+              "formula": "[Master/Customer Segment]",
+              "name": "Segment"
+            },
+            {
+              "id": "y20",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn10",
+              "formula": "Not(IsNull([Master/Customer Segment]))",
+              "name": "Segment Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f10",
+              "columnId": "nn10",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x10",
+            "sort": {
+              "by": "y20",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y20"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-cuc2",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Region",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x11",
+              "formula": "[Master/Customer Region]",
+              "name": "Region"
+            },
+            {
+              "id": "y21",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn11",
+              "formula": "Not(IsNull([Master/Customer Region]))",
+              "name": "Region Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f11",
+              "columnId": "nn11",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x11",
+            "sort": {
+              "by": "y21",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y21"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-cuc3",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Loyalty Tier",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x12",
+              "formula": "[Master/Loyalty Tier]",
+              "name": "Loyalty Tier"
+            },
+            {
+              "id": "y22",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn12",
+              "formula": "Not(IsNull([Master/Loyalty Tier]))",
+              "name": "Loyalty Tier Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f12",
+              "columnId": "nn12",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x12",
+            "sort": {
+              "by": "y22",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y22"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-cuc4",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Acquisition Channel",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x13",
+              "formula": "[Master/Acquisition Channel]",
+              "name": "Channel"
+            },
+            {
+              "id": "y23",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn13",
+              "formula": "Not(IsNull([Master/Acquisition Channel]))",
+              "name": "Channel Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f13",
+              "columnId": "nn13",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x13",
+            "sort": {
+              "by": "y23",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y23"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "band-pg-3-hdr",
+          "kind": "container",
+          "style": {
+            "backgroundColor": "#0F172A",
+            "borderRadius": "round"
+          }
+        },
+        {
+          "id": "band-pg-3-hdrtext",
+          "kind": "text",
+          "body": "# <span style=\"color: #FFFFFF\">Customer Analytics</span>"
+        },
+        {
+          "id": "band-pg-3-1",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-3-2",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-3-3",
+          "kind": "container"
+        }
+      ]
+    },
+    {
+      "id": "pg-4",
+      "name": "Store Operations",
+      "elements": [
+        {
+          "id": "el-sk1",
+          "kind": "kpi-chart",
+          "name": "Net Revenue",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y24",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y24"
+          }
+        },
+        {
+          "id": "el-sk2",
+          "kind": "kpi-chart",
+          "name": "Orders",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y25",
+              "formula": "CountDistinct([Master/Order Id])",
+              "name": "Orders",
+              "format": {
+                "kind": "number",
+                "formatString": ",.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y25"
+          }
+        },
+        {
+          "id": "el-sk3",
+          "kind": "kpi-chart",
+          "name": "Avg Days to Ship",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y26",
+              "formula": "Avg([Master/Days to Ship])",
+              "name": "Avg Days to Ship",
+              "format": {
+                "kind": "number",
+                "formatString": ",.1f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y26"
+          }
+        },
+        {
+          "id": "el-sc1",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Store Region",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x14",
+              "formula": "[Master/Store Region]",
+              "name": "Region"
+            },
+            {
+              "id": "y27",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn14",
+              "formula": "Not(IsNull([Master/Store Region]))",
+              "name": "Region Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f14",
+              "columnId": "nn14",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x14",
+            "sort": {
+              "by": "y27",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y27"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-sc2",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Store",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x15",
+              "formula": "[Master/Store Name]",
+              "name": "Store"
+            },
+            {
+              "id": "y28",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn15",
+              "formula": "Not(IsNull([Master/Store Name]))",
+              "name": "Store Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f15",
+              "columnId": "nn15",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x15",
+            "sort": {
+              "by": "y28",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y28"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-sc3",
+          "kind": "bar-chart",
+          "name": "Net Revenue by District",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x16",
+              "formula": "[Master/District]",
+              "name": "District"
+            },
+            {
+              "id": "y29",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn16",
+              "formula": "Not(IsNull([Master/District]))",
+              "name": "District Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f16",
+              "columnId": "nn16",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x16",
+            "sort": {
+              "by": "y29",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y29"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-sc4",
+          "kind": "bar-chart",
+          "name": "Orders by Store Type",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x17",
+              "formula": "[Master/Store Type]",
+              "name": "Store Type"
+            },
+            {
+              "id": "y30",
+              "formula": "CountDistinct([Master/Order Id])",
+              "name": "Orders",
+              "format": {
+                "kind": "number",
+                "formatString": ",.0f"
+              }
+            },
+            {
+              "id": "nn17",
+              "formula": "Not(IsNull([Master/Store Type]))",
+              "name": "Store Type Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f17",
+              "columnId": "nn17",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x17",
+            "sort": {
+              "by": "y30",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y30"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "band-pg-4-hdr",
+          "kind": "container",
+          "style": {
+            "backgroundColor": "#0F172A",
+            "borderRadius": "round"
+          }
+        },
+        {
+          "id": "band-pg-4-hdrtext",
+          "kind": "text",
+          "body": "# <span style=\"color: #FFFFFF\">Store Operations</span>"
+        },
+        {
+          "id": "band-pg-4-1",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-4-2",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-4-3",
+          "kind": "container"
+        }
+      ]
+    },
+    {
+      "id": "pg-5",
+      "name": "Promotions & Channel",
+      "elements": [
+        {
+          "id": "el-prk1",
+          "kind": "kpi-chart",
+          "name": "Net Revenue",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y31",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y31"
+          }
+        },
+        {
+          "id": "el-prk2",
+          "kind": "kpi-chart",
+          "name": "Discount Amount",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y32",
+              "formula": "Sum([Master/Discount Amount])",
+              "name": "Discount Amount",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y32"
+          }
+        },
+        {
+          "id": "el-prk3",
+          "kind": "kpi-chart",
+          "name": "Holiday Revenue",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "y33",
+              "formula": "Sum(If([Master/Is Holiday] = 1, [Master/Net Revenue]))",
+              "name": "Holiday Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            }
+          ],
+          "value": {
+            "columnId": "y33"
+          }
+        },
+        {
+          "id": "el-prc1",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Promo Type",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x18",
+              "formula": "[Master/Promo Type]",
+              "name": "Promo Type"
+            },
+            {
+              "id": "y34",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn18",
+              "formula": "Not(IsNull([Master/Promo Type]))",
+              "name": "Promo Type Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f18",
+              "columnId": "nn18",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x18",
+            "sort": {
+              "by": "y34",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y34"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-prc2",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Order Channel",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x19",
+              "formula": "[Master/Order Channel]",
+              "name": "Channel"
+            },
+            {
+              "id": "y35",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn19",
+              "formula": "Not(IsNull([Master/Order Channel]))",
+              "name": "Channel Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f19",
+              "columnId": "nn19",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x19",
+            "sort": {
+              "by": "y35",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y35"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-prc3",
+          "kind": "bar-chart",
+          "name": "Net Revenue by Ship Method",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x20",
+              "formula": "[Master/Ship Method]",
+              "name": "Ship Method"
+            },
+            {
+              "id": "y36",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn20",
+              "formula": "Not(IsNull([Master/Ship Method]))",
+              "name": "Ship Method Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f20",
+              "columnId": "nn20",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x20",
+            "sort": {
+              "by": "y36",
+              "direction": "descending"
+            }
+          },
+          "yAxis": {
+            "columnIds": [
+              "y36"
+            ]
+          },
+          "dataLabel": {
+            "labels": "shown"
+          }
+        },
+        {
+          "id": "el-prc4",
+          "kind": "line-chart",
+          "name": "Net Revenue by Month",
+          "source": {
+            "elementId": "m-master",
+            "kind": "table"
+          },
+          "columns": [
+            {
+              "id": "x21",
+              "formula": "[Master/Month Number]",
+              "name": "Month"
+            },
+            {
+              "id": "y37",
+              "formula": "Sum([Master/Net Revenue])",
+              "name": "Net Revenue",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f"
+              }
+            },
+            {
+              "id": "nn21",
+              "formula": "Not(IsNull([Master/Month Number]))",
+              "name": "Month Matched"
+            }
+          ],
+          "filters": [
+            {
+              "id": "f21",
+              "columnId": "nn21",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ],
+          "xAxis": {
+            "columnId": "x21"
+          },
+          "yAxis": {
+            "columnIds": [
+              "y37"
+            ]
+          }
+        },
+        {
+          "id": "band-pg-5-hdr",
+          "kind": "container",
+          "style": {
+            "backgroundColor": "#0F172A",
+            "borderRadius": "round"
+          }
+        },
+        {
+          "id": "band-pg-5-hdrtext",
+          "kind": "text",
+          "body": "# <span style=\"color: #FFFFFF\">Promotions & Channel</span>"
+        },
+        {
+          "id": "band-pg-5-1",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-5-2",
+          "kind": "container"
+        },
+        {
+          "id": "band-pg-5-3",
+          "kind": "container"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_grounding.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/tests/test_grounding.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Grounding regression for build-sigma-workbook.py (beads-sigma-kvza).
+
+  1. GOLDEN LOCK   — the fixture builds byte-identical to the committed golden
+     (build-sigma-workbook.py uses a deterministic id counter, no randomness).
+  2. CATALOGS      — all four refs/catalogs/*.json load, cited, unique rows.
+  3. NO INLINE MAP — viz/aggregation/control maps LOADED from the catalogs; the
+     name-substring currency guess + silent ,.0f default are gone.
+  4. FORMAT PARSER — sigma_fmt() reproduces every pinned qNumFormat example in
+     number-format.json (parser grounded to documented Qlik semantics).
+  5. LOUD FALLBACKS — an unknown vizType warns+skips; an absent qFmt ships the
+     value unformatted + a loud note (no name-substring guess, no silent default).
+  6. NO-DRIFT      — refs/qlik-coverage.md is regenerated from the catalogs.
+
+Run: python3 tests/test_grounding.py   (exit 0 = pass)
+"""
+import importlib.util, json, os, subprocess, sys, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+SCRIPTS = os.path.join(SKILL, "scripts")
+FIX = os.path.join(SKILL, "fixtures", "retail-orders")
+CATDIR = os.path.join(SKILL, "refs", "catalogs")
+GOLDEN = os.path.join(HERE, "golden", "retail_orders_workbook.spec.json")
+BUILDER = os.path.join(SCRIPTS, "build-sigma-workbook.py")
+sys.path.insert(0, os.path.join(SCRIPTS, "lib"))
+
+
+def _load_builder():
+    spec = importlib.util.spec_from_file_location("bsw", BUILDER)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def _build(charts=None, denorm=None):
+    with tempfile.TemporaryDirectory() as d:
+        charts = charts or os.path.join(FIX, "charts.json")
+        denorm = denorm or os.path.join(FIX, "denorm.json")
+        spec_out = os.path.join(d, "spec.json")
+        r = subprocess.run(
+            [sys.executable, BUILDER, "--charts", charts, "--layout", os.path.join(FIX, "layout.json"),
+             "--denorm", denorm, "--dm-id", "dm-x", "--denorm-element-id", "el-x", "--name", "GOLDEN",
+             "--dry-run", "--spec-out", spec_out, "--out", os.path.join(d, "res.json"),
+             "--element-map", os.path.join(d, "emap.json"), "--layout-out", os.path.join(d, "l.xml")],
+            capture_output=True, text=True)
+        assert r.returncode == 0, "builder failed:\n" + r.stderr
+        return json.load(open(spec_out)), (r.stdout + r.stderr)
+
+
+def test_golden():
+    spec, _ = _build()
+    got = json.dumps(spec, indent=2)
+    want = open(GOLDEN).read()
+    assert got == want, "GOLDEN DRIFT — build-sigma-workbook output changed on the fixture."
+    print("[ok] golden: fixture builds byte-identical to committed golden")
+
+
+def test_catalogs_valid():
+    import coverage_catalog as cc
+    cats = cc.load_all(CATDIR)
+    assert set(cats) == {"viz-kind", "number-format", "aggregation", "control"}, sorted(cats)
+    for name, cat in cats.items():
+        assert cat.rows and cat.source_tool == "qlik", name
+        seen = set()
+        for r in cat.rows:
+            k = str(r["source"]).lower()
+            assert k not in seen, ("dup source in %s: %s" % (name, k)); seen.add(k)
+            assert r.get("doc_ref", "").startswith("http"), (name, r["source"])
+    print("[ok] catalogs: 4 dimensions load, cited, unique sources")
+
+
+def test_no_inline_maps():
+    src = open(BUILDER).read()
+    assert "coverage_catalog" in src and "_cc.load(" in src, "builder does not load catalogs"
+    assert "for r in VIZ_CAT.rows" in src, "NATIVE not derived from viz-kind catalog"
+    assert "_AGG_ALT" in src and "AGG_CAT.rows" in src, "aggregation not catalog-derived"
+    assert "CTRL_CAT.target(" in src, "control kind not catalog-derived"
+    # the name-substring currency guess + silent default must be gone
+    assert "revenue|profit|amount|value|cost|price" not in src, "name-substring currency guess still present"
+    assert 'return {"kind": "number", "formatString": ",.0f"}' not in src, "silent ,.0f default still present"
+    print("[ok] no-inline-map: maps catalog-derived; name-guess + silent default removed")
+
+
+def test_format_parser_pinned():
+    m = _load_builder()
+    cat = json.load(open(os.path.join(CATDIR, "number-format.json")))
+    for r in cat["rows"]:
+        got = (m.sigma_fmt(r["source"]) or {}).get("formatString")
+        assert got == r["sigma"], ("qFmt %r -> %r, catalog says %r" % (r["source"], got, r["sigma"]))
+    print("[ok] format parser: reproduces all %d pinned qNumFormat examples" % len(cat["rows"]))
+
+
+def test_loud_no_qfmt_format():
+    m = _load_builder()
+    # a revenue-named measure with NO qFmt used to name-guess $,.0f; now None + warn
+    w = []
+    assert m.sigma_fmt(None, "Net Revenue", w) is None, "absent qFmt must yield no format"
+    assert w and "UNFORMATTED" in w[0], w
+    assert m.sigma_fmt(None, "Total Profit") is None, "no name-substring currency guess allowed"
+    # a real qFmt still parses
+    assert m.sigma_fmt("$#,##0")["formatString"] == "$,.0f"
+    print("[ok] loud format: absent qFmt -> None + warn (no name guess, no silent default)")
+
+
+def test_loud_unknown_viz():
+    # mutate an EXISTING (layout-referenced) chart's vizType to an unmapped one so
+    # it is actually placed + classified — an appended chart absent from layout.json
+    # is never built.
+    charts = json.load(open(os.path.join(FIX, "charts.json")))
+    placed = {"c-cat", "c-seg", "c-mon", "c-tbl"}  # ids referenced by layout.json
+    hit = next(i for i, c in enumerate(charts) if c["id"] in placed)
+    charts[hit] = json.loads(json.dumps(charts[hit]))
+    charts[hit]["vizType"] = "sankey"
+    with tempfile.TemporaryDirectory() as d:
+        cpath = os.path.join(d, "charts.json"); json.dump(charts, open(cpath, "w"))
+        spec, out = _build(charts=cpath)
+    assert "sankey" in out and ("no native Sigma kind" in out or "approximated" in out), out
+    print("[ok] loud viz: unmapped vizType 'sankey' warns (approximated/skipped, not silent)")
+
+
+def test_coverage_matrix_fresh():
+    r = subprocess.run(
+        [sys.executable, os.path.join(SCRIPTS, "gen-coverage-matrix.py"),
+         "--catalogs", CATDIR, "--skill", "qlik",
+         "--out", os.path.join(SKILL, "refs", "qlik-coverage.md"), "--check"],
+        capture_output=True, text=True)
+    assert r.returncode == 0, ("coverage matrix stale — regenerate:\n" + r.stderr)
+    print("[ok] coverage matrix: refs/qlik-coverage.md matches the catalogs")
+
+
+if __name__ == "__main__":
+    test_catalogs_valid()
+    test_no_inline_maps()
+    test_format_parser_pinned()
+    test_loud_no_qfmt_format()
+    test_loud_unknown_viz()
+    test_coverage_matrix_fresh()
+    test_golden()
+    print("ALL PASS")


### PR DESCRIPTION
## What (beads-sigma-kvza.1 + .2, qlik)
Replaces the hardcoded `NATIVE` viz map + `translate_measure` aggregation tokens with cited JSON catalogs (`refs/catalogs/`) loaded via the shared `coverage_catalog` loader; the control-kind decision is catalog-driven too. `refs/qlik-coverage.md` is generated from them.

**Killed the number-format judgement:** `sigma_fmt` no longer name-substring-guesses currency (`revenue|profit|... -> $,.0f`) nor silently defaults to `,.0f`. It is now a **qNumFormat parser only**; an absent qFmt ships the value unformatted + a loud note. The parser is pinned to documented qNumFormat examples in `number-format.json`.

## Verification
- **Behavior-preserving:** the `retail-orders` fixture builds **byte-identical** to the committed golden (deterministic ids; `tests/test_grounding.py`, 7 checks). Adds a frozen `fixtures/retail-orders/denorm.json` for offline builder tests.
- **LIVE E2E vs CSA.TJ:** DM + workbook POST, **142 columns resolve, 0 `type=error`**, parity **GREEN**; render verified (3 KPIs, Category/Segment bars, Revenue&Profit line, Store table, date-range control).

## Stacking
Based on `kvza-infra` (needs the shared loader). Retarget to `main` after infra merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)