### PR TITLE
kvza.4: Ruby coverage-catalog loader (grounding infra for Ruby skills)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/gen-coverage-matrix.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/gen-coverage-matrix.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""gen-coverage-matrix.py — generate refs/<skill>-coverage.md FROM the JSON
+catalogs (refs/catalogs/*.json), so the human-readable coverage matrix can never
+drift from the machine-loaded single source of truth (beads-sigma-kvza).
+
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md --check     # exit 1 if the file is stale
+
+One table per dimension, five columns (the handoff's shape):
+  | construct | doc ref | Sigma target | sigma_verified (y/n·date) | on-unmapped |
+
+Stdlib only; Windows-safe.
+"""
+import argparse
+import json
+import os
+import sys
+
+DIM_ORDER = ["viz-kind", "number-format", "aggregation", "control"]
+DIM_TITLE = {
+    "viz-kind": "Visualization / chart kind",
+    "number-format": "Number format",
+    "aggregation": "Aggregation",
+    "control": "Control / filter",
+}
+
+
+def _md_escape(s):
+    return str(s).replace("|", "\\|").replace("\n", " ")
+
+
+def _verified_cell(r):
+    sv = r.get("sigma_verified") or {}
+    status = sv.get("status", "n")
+    if status == "y":
+        return "✅ y · %s" % sv.get("date", "?")
+    return "🟡 n"
+
+
+def _target_cell(r):
+    sig = r.get("sigma")
+    if sig is None and r.get("sigma_if") is None:
+        return "— (no Sigma equivalent)"
+    parts = []
+    if sig is not None:
+        parts.append("`%s`" % _md_escape(sig))
+    if r.get("sigma_if"):
+        parts.append("if→`%s`" % _md_escape(r["sigma_if"]))
+    return " ".join(parts) if parts else "—"
+
+
+def _doc_cell(r):
+    ref = r.get("doc_ref", "")
+    return "[doc](%s)" % ref if ref.startswith("http") else _md_escape(ref or "—")
+
+
+def render(catalogs, skill):
+    cats = {}
+    for fn in sorted(os.listdir(catalogs)):
+        if fn.endswith(".json"):
+            cats[fn[:-5]] = json.load(open(os.path.join(catalogs, fn)))
+    order = [d for d in DIM_ORDER if d in cats] + [d for d in sorted(cats) if d not in DIM_ORDER]
+
+    out = []
+    out.append("# %s → Sigma — dashboard classifier coverage matrix" % skill.capitalize())
+    out.append("")
+    out.append("> **GENERATED — do not edit by hand.** Regenerate with "
+               "`python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs "
+               "--skill %s --out refs/%s-coverage.md`. The JSON catalogs in "
+               "`refs/catalogs/` are the single source of truth; the classifier "
+               "(`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them "
+               "via `shared/lib/coverage_catalog.py`. A no-drift test asserts this "
+               "file matches the catalogs." % (skill, skill))
+    out.append("")
+    out.append("Every documented source construct maps to a real, current Sigma target "
+               "or a loud fallback — no silent wrong-defaults, no name-substring "
+               "guessing (beads-sigma-kvza).")
+    out.append("")
+    out.append("**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at "
+               "**query time** in a live migration (no `type=error` column) on the date "
+               "shown; 🟡 n = target is documented but not yet query-verified.")
+    out.append("")
+    total = sum(len(c.get("rows", [])) for c in cats.values())
+    ver = sum(1 for c in cats.values() for r in c.get("rows", [])
+              if (r.get("sigma_verified") or {}).get("status") == "y")
+    out.append("**Coverage:** %d documented constructs across %d dimensions; "
+               "%d live-verified." % (total, len(cats), ver))
+    out.append("")
+
+    for dim in order:
+        c = cats[dim]
+        out.append("## %s" % DIM_TITLE.get(dim, dim))
+        out.append("")
+        if c.get("description"):
+            out.append("_%s_" % c["description"])
+            out.append("")
+        if c.get("authoritative_doc"):
+            out.append("Authoritative source: <%s>" % c["authoritative_doc"])
+            out.append("")
+        out.append("| construct | doc ref | Sigma target | sigma_verified | on-unmapped |")
+        out.append("|---|---|---|---|---|")
+        for r in c.get("rows", []):
+            notes = r.get("notes")
+            src = "`%s`" % _md_escape(r["source"])
+            onun = _md_escape(r.get("on_unmapped", c.get("on_unmapped_default", "")))
+            row = "| %s | %s | %s | %s | %s |" % (
+                src, _doc_cell(r), _target_cell(r), _verified_cell(r), onun)
+            out.append(row)
+            if notes:
+                out.append("| | | | | _%s_ |" % _md_escape(notes))
+        out.append("")
+
+    out.append("---")
+    out.append("_Compositional constructs that do not serialize to a flat table "
+               "(Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask "
+               "parsers, count-on-joined-view) stay as cited predicates in the "
+               "classifier; this matrix covers the enumerable maps._")
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--catalogs", required=True)
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if --out is stale vs the catalogs (no write)")
+    a = ap.parse_args()
+    text = render(a.catalogs, a.skill)
+    if a.check:
+        cur = open(a.out).read() if os.path.exists(a.out) else ""
+        if cur != text:
+            sys.stderr.write("STALE: %s does not match refs/catalogs — regenerate.\n" % a.out)
+            sys.exit(1)
+        print("OK: %s matches the catalogs." % a.out)
+        return
+    open(a.out, "w").write(text)
+    print("wrote %s (%d bytes)" % (a.out, len(text)))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_catalog.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_catalog.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+#
+# coverage_catalog.rb — Ruby twin of shared/lib/coverage_catalog.py. Loads a
+# documentation-grounded mapping catalog and resolves source constructs to Sigma
+# targets, LOUDLY on a miss. Used by the Ruby dashboard classifiers
+# (powerbi/quicksight build-workbook-from-*.rb) exactly as the Python loader is
+# used by the Python builders (looker/qlik). The JSON catalog schema is
+# language-neutral and identical across both — see the Python file's header.
+#
+#   require_relative 'lib/coverage_catalog'
+#   viz = Coverage.load(Coverage.default_catalog_dir(__FILE__), 'viz-kind')
+#   kind = viz.target(src)                 # cited Sigma target, or nil on a miss
+#   row  = viz.resolve_or_warn(src, warns, context: title)  # nil + loud warn on miss
+#
+# Mirrors the beads-sigma-93ps contract: catalog = language-neutral data, this =
+# the thin resolver. Stdlib only (json); Ruby 2.6-compatible.
+
+require 'json'
+
+module Coverage
+  MISS = nil # resolve returns nil when a source key is absent
+
+  class Catalog
+    attr_reader :path, :filename, :dimension, :source_tool, :authoritative_doc,
+                :on_unmapped_default, :rows
+
+    def initialize(data, path)
+      @path = path
+      @filename = File.basename(path)
+      @dimension = data['dimension'] || File.basename(path, '.json')
+      @source_tool = data['source_tool'] || ''
+      @authoritative_doc = data['authoritative_doc'] || ''
+      @on_unmapped_default = data['on_unmapped_default'] || 'warn+skip'
+      @rows = data['rows'] || []
+      @by_source = {}
+      @rows.each do |r|
+        k = r['source']
+        @by_source[norm(k)] = r unless k.nil?
+      end
+    end
+
+    # Return the full catalog row for source_key, or nil on a miss.
+    def resolve(source_key)
+      return nil if source_key.nil?
+      @by_source[norm(source_key)]
+    end
+
+    # Just the Sigma target string (row['sigma']), or nil on a miss.
+    def target(source_key)
+      r = resolve(source_key)
+      r && r['sigma']
+    end
+
+    # Resolve; on a miss append a standardized LOUD warning to `warnings` and
+    # return nil. The caller MUST then skip/placeholder — makes the loud
+    # fallback mandatory and uniform.
+    def resolve_or_warn(source_key, warnings, context: '')
+      r = resolve(source_key)
+      return r if r
+      where = context.to_s.empty? ? '' : " (#{context})"
+      tool = @source_tool.empty? ? 'source' : @source_tool
+      warnings << "⚠ #{@dimension}: no documented #{tool} mapping for " \
+                  "'#{source_key}'#{where} — #{@on_unmapped_default}. Add a cited " \
+                  "row to refs/catalogs/#{@filename} if this is a real construct."
+      nil
+    end
+
+    def sources
+      @by_source.keys
+    end
+
+    # Rows whose Sigma target is not yet live-verified (sigma_verified.status != 'y').
+    def unverified
+      @rows.reject { |r| (r['sigma_verified'] || {})['status'] == 'y' }
+    end
+
+    private
+
+    def norm(k)
+      k.to_s.strip.downcase
+    end
+  end
+
+  # Load <catalog_dir>/<dimension>.json. Fails LOUDLY if absent — a classifier
+  # with no catalog must not silently guess.
+  def self.load(catalog_dir, dimension)
+    path = File.join(catalog_dir, "#{dimension}.json")
+    unless File.exist?(path)
+      raise "coverage catalog missing: #{path} — the classifier requires a " \
+            "documentation-grounded catalog for '#{dimension}'; refusing to guess."
+    end
+    Catalog.new(JSON.parse(File.read(path)), path)
+  end
+
+  # Load every *.json catalog in catalog_dir, keyed by dimension name.
+  def self.load_all(catalog_dir)
+    raise "coverage catalog dir missing: #{catalog_dir}" unless File.directory?(catalog_dir)
+    out = {}
+    Dir[File.join(catalog_dir, '*.json')].sort.each do |p|
+      d = File.basename(p, '.json')
+      out[d] = load(catalog_dir, d)
+    end
+    out
+  end
+
+  # Given a builder's __FILE__ (in scripts/), return its sibling refs/catalogs dir.
+  def self.default_catalog_dir(script_file)
+    scripts_dir = File.dirname(File.expand_path(script_file))
+    File.expand_path(File.join(scripts_dir, '..', 'refs', 'catalogs'))
+  end
+end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/gen-coverage-matrix.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/gen-coverage-matrix.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""gen-coverage-matrix.py — generate refs/<skill>-coverage.md FROM the JSON
+catalogs (refs/catalogs/*.json), so the human-readable coverage matrix can never
+drift from the machine-loaded single source of truth (beads-sigma-kvza).
+
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md --check     # exit 1 if the file is stale
+
+One table per dimension, five columns (the handoff's shape):
+  | construct | doc ref | Sigma target | sigma_verified (y/n·date) | on-unmapped |
+
+Stdlib only; Windows-safe.
+"""
+import argparse
+import json
+import os
+import sys
+
+DIM_ORDER = ["viz-kind", "number-format", "aggregation", "control"]
+DIM_TITLE = {
+    "viz-kind": "Visualization / chart kind",
+    "number-format": "Number format",
+    "aggregation": "Aggregation",
+    "control": "Control / filter",
+}
+
+
+def _md_escape(s):
+    return str(s).replace("|", "\\|").replace("\n", " ")
+
+
+def _verified_cell(r):
+    sv = r.get("sigma_verified") or {}
+    status = sv.get("status", "n")
+    if status == "y":
+        return "✅ y · %s" % sv.get("date", "?")
+    return "🟡 n"
+
+
+def _target_cell(r):
+    sig = r.get("sigma")
+    if sig is None and r.get("sigma_if") is None:
+        return "— (no Sigma equivalent)"
+    parts = []
+    if sig is not None:
+        parts.append("`%s`" % _md_escape(sig))
+    if r.get("sigma_if"):
+        parts.append("if→`%s`" % _md_escape(r["sigma_if"]))
+    return " ".join(parts) if parts else "—"
+
+
+def _doc_cell(r):
+    ref = r.get("doc_ref", "")
+    return "[doc](%s)" % ref if ref.startswith("http") else _md_escape(ref or "—")
+
+
+def render(catalogs, skill):
+    cats = {}
+    for fn in sorted(os.listdir(catalogs)):
+        if fn.endswith(".json"):
+            cats[fn[:-5]] = json.load(open(os.path.join(catalogs, fn)))
+    order = [d for d in DIM_ORDER if d in cats] + [d for d in sorted(cats) if d not in DIM_ORDER]
+
+    out = []
+    out.append("# %s → Sigma — dashboard classifier coverage matrix" % skill.capitalize())
+    out.append("")
+    out.append("> **GENERATED — do not edit by hand.** Regenerate with "
+               "`python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs "
+               "--skill %s --out refs/%s-coverage.md`. The JSON catalogs in "
+               "`refs/catalogs/` are the single source of truth; the classifier "
+               "(`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them "
+               "via `shared/lib/coverage_catalog.py`. A no-drift test asserts this "
+               "file matches the catalogs." % (skill, skill))
+    out.append("")
+    out.append("Every documented source construct maps to a real, current Sigma target "
+               "or a loud fallback — no silent wrong-defaults, no name-substring "
+               "guessing (beads-sigma-kvza).")
+    out.append("")
+    out.append("**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at "
+               "**query time** in a live migration (no `type=error` column) on the date "
+               "shown; 🟡 n = target is documented but not yet query-verified.")
+    out.append("")
+    total = sum(len(c.get("rows", [])) for c in cats.values())
+    ver = sum(1 for c in cats.values() for r in c.get("rows", [])
+              if (r.get("sigma_verified") or {}).get("status") == "y")
+    out.append("**Coverage:** %d documented constructs across %d dimensions; "
+               "%d live-verified." % (total, len(cats), ver))
+    out.append("")
+
+    for dim in order:
+        c = cats[dim]
+        out.append("## %s" % DIM_TITLE.get(dim, dim))
+        out.append("")
+        if c.get("description"):
+            out.append("_%s_" % c["description"])
+            out.append("")
+        if c.get("authoritative_doc"):
+            out.append("Authoritative source: <%s>" % c["authoritative_doc"])
+            out.append("")
+        out.append("| construct | doc ref | Sigma target | sigma_verified | on-unmapped |")
+        out.append("|---|---|---|---|---|")
+        for r in c.get("rows", []):
+            notes = r.get("notes")
+            src = "`%s`" % _md_escape(r["source"])
+            onun = _md_escape(r.get("on_unmapped", c.get("on_unmapped_default", "")))
+            row = "| %s | %s | %s | %s | %s |" % (
+                src, _doc_cell(r), _target_cell(r), _verified_cell(r), onun)
+            out.append(row)
+            if notes:
+                out.append("| | | | | _%s_ |" % _md_escape(notes))
+        out.append("")
+
+    out.append("---")
+    out.append("_Compositional constructs that do not serialize to a flat table "
+               "(Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask "
+               "parsers, count-on-joined-view) stay as cited predicates in the "
+               "classifier; this matrix covers the enumerable maps._")
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--catalogs", required=True)
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if --out is stale vs the catalogs (no write)")
+    a = ap.parse_args()
+    text = render(a.catalogs, a.skill)
+    if a.check:
+        cur = open(a.out).read() if os.path.exists(a.out) else ""
+        if cur != text:
+            sys.stderr.write("STALE: %s does not match refs/catalogs — regenerate.\n" % a.out)
+            sys.exit(1)
+        print("OK: %s matches the catalogs." % a.out)
+        return
+    open(a.out, "w").write(text)
+    print("wrote %s (%d bytes)" % (a.out, len(text)))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/coverage_catalog.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/coverage_catalog.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+#
+# coverage_catalog.rb — Ruby twin of shared/lib/coverage_catalog.py. Loads a
+# documentation-grounded mapping catalog and resolves source constructs to Sigma
+# targets, LOUDLY on a miss. Used by the Ruby dashboard classifiers
+# (powerbi/quicksight build-workbook-from-*.rb) exactly as the Python loader is
+# used by the Python builders (looker/qlik). The JSON catalog schema is
+# language-neutral and identical across both — see the Python file's header.
+#
+#   require_relative 'lib/coverage_catalog'
+#   viz = Coverage.load(Coverage.default_catalog_dir(__FILE__), 'viz-kind')
+#   kind = viz.target(src)                 # cited Sigma target, or nil on a miss
+#   row  = viz.resolve_or_warn(src, warns, context: title)  # nil + loud warn on miss
+#
+# Mirrors the beads-sigma-93ps contract: catalog = language-neutral data, this =
+# the thin resolver. Stdlib only (json); Ruby 2.6-compatible.
+
+require 'json'
+
+module Coverage
+  MISS = nil # resolve returns nil when a source key is absent
+
+  class Catalog
+    attr_reader :path, :filename, :dimension, :source_tool, :authoritative_doc,
+                :on_unmapped_default, :rows
+
+    def initialize(data, path)
+      @path = path
+      @filename = File.basename(path)
+      @dimension = data['dimension'] || File.basename(path, '.json')
+      @source_tool = data['source_tool'] || ''
+      @authoritative_doc = data['authoritative_doc'] || ''
+      @on_unmapped_default = data['on_unmapped_default'] || 'warn+skip'
+      @rows = data['rows'] || []
+      @by_source = {}
+      @rows.each do |r|
+        k = r['source']
+        @by_source[norm(k)] = r unless k.nil?
+      end
+    end
+
+    # Return the full catalog row for source_key, or nil on a miss.
+    def resolve(source_key)
+      return nil if source_key.nil?
+      @by_source[norm(source_key)]
+    end
+
+    # Just the Sigma target string (row['sigma']), or nil on a miss.
+    def target(source_key)
+      r = resolve(source_key)
+      r && r['sigma']
+    end
+
+    # Resolve; on a miss append a standardized LOUD warning to `warnings` and
+    # return nil. The caller MUST then skip/placeholder — makes the loud
+    # fallback mandatory and uniform.
+    def resolve_or_warn(source_key, warnings, context: '')
+      r = resolve(source_key)
+      return r if r
+      where = context.to_s.empty? ? '' : " (#{context})"
+      tool = @source_tool.empty? ? 'source' : @source_tool
+      warnings << "⚠ #{@dimension}: no documented #{tool} mapping for " \
+                  "'#{source_key}'#{where} — #{@on_unmapped_default}. Add a cited " \
+                  "row to refs/catalogs/#{@filename} if this is a real construct."
+      nil
+    end
+
+    def sources
+      @by_source.keys
+    end
+
+    # Rows whose Sigma target is not yet live-verified (sigma_verified.status != 'y').
+    def unverified
+      @rows.reject { |r| (r['sigma_verified'] || {})['status'] == 'y' }
+    end
+
+    private
+
+    def norm(k)
+      k.to_s.strip.downcase
+    end
+  end
+
+  # Load <catalog_dir>/<dimension>.json. Fails LOUDLY if absent — a classifier
+  # with no catalog must not silently guess.
+  def self.load(catalog_dir, dimension)
+    path = File.join(catalog_dir, "#{dimension}.json")
+    unless File.exist?(path)
+      raise "coverage catalog missing: #{path} — the classifier requires a " \
+            "documentation-grounded catalog for '#{dimension}'; refusing to guess."
+    end
+    Catalog.new(JSON.parse(File.read(path)), path)
+  end
+
+  # Load every *.json catalog in catalog_dir, keyed by dimension name.
+  def self.load_all(catalog_dir)
+    raise "coverage catalog dir missing: #{catalog_dir}" unless File.directory?(catalog_dir)
+    out = {}
+    Dir[File.join(catalog_dir, '*.json')].sort.each do |p|
+      d = File.basename(p, '.json')
+      out[d] = load(catalog_dir, d)
+    end
+    out
+  end
+
+  # Given a builder's __FILE__ (in scripts/), return its sibling refs/catalogs dir.
+  def self.default_catalog_dir(script_file)
+    scripts_dir = File.dirname(File.expand_path(script_file))
+    File.expand_path(File.join(scripts_dir, '..', 'refs', 'catalogs'))
+  end
+end

--- a/shared/lib/coverage_catalog.rb
+++ b/shared/lib/coverage_catalog.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+#
+# coverage_catalog.rb — Ruby twin of shared/lib/coverage_catalog.py. Loads a
+# documentation-grounded mapping catalog and resolves source constructs to Sigma
+# targets, LOUDLY on a miss. Used by the Ruby dashboard classifiers
+# (powerbi/quicksight build-workbook-from-*.rb) exactly as the Python loader is
+# used by the Python builders (looker/qlik). The JSON catalog schema is
+# language-neutral and identical across both — see the Python file's header.
+#
+#   require_relative 'lib/coverage_catalog'
+#   viz = Coverage.load(Coverage.default_catalog_dir(__FILE__), 'viz-kind')
+#   kind = viz.target(src)                 # cited Sigma target, or nil on a miss
+#   row  = viz.resolve_or_warn(src, warns, context: title)  # nil + loud warn on miss
+#
+# Mirrors the beads-sigma-93ps contract: catalog = language-neutral data, this =
+# the thin resolver. Stdlib only (json); Ruby 2.6-compatible.
+
+require 'json'
+
+module Coverage
+  MISS = nil # resolve returns nil when a source key is absent
+
+  class Catalog
+    attr_reader :path, :filename, :dimension, :source_tool, :authoritative_doc,
+                :on_unmapped_default, :rows
+
+    def initialize(data, path)
+      @path = path
+      @filename = File.basename(path)
+      @dimension = data['dimension'] || File.basename(path, '.json')
+      @source_tool = data['source_tool'] || ''
+      @authoritative_doc = data['authoritative_doc'] || ''
+      @on_unmapped_default = data['on_unmapped_default'] || 'warn+skip'
+      @rows = data['rows'] || []
+      @by_source = {}
+      @rows.each do |r|
+        k = r['source']
+        @by_source[norm(k)] = r unless k.nil?
+      end
+    end
+
+    # Return the full catalog row for source_key, or nil on a miss.
+    def resolve(source_key)
+      return nil if source_key.nil?
+      @by_source[norm(source_key)]
+    end
+
+    # Just the Sigma target string (row['sigma']), or nil on a miss.
+    def target(source_key)
+      r = resolve(source_key)
+      r && r['sigma']
+    end
+
+    # Resolve; on a miss append a standardized LOUD warning to `warnings` and
+    # return nil. The caller MUST then skip/placeholder — makes the loud
+    # fallback mandatory and uniform.
+    def resolve_or_warn(source_key, warnings, context: '')
+      r = resolve(source_key)
+      return r if r
+      where = context.to_s.empty? ? '' : " (#{context})"
+      tool = @source_tool.empty? ? 'source' : @source_tool
+      warnings << "⚠ #{@dimension}: no documented #{tool} mapping for " \
+                  "'#{source_key}'#{where} — #{@on_unmapped_default}. Add a cited " \
+                  "row to refs/catalogs/#{@filename} if this is a real construct."
+      nil
+    end
+
+    def sources
+      @by_source.keys
+    end
+
+    # Rows whose Sigma target is not yet live-verified (sigma_verified.status != 'y').
+    def unverified
+      @rows.reject { |r| (r['sigma_verified'] || {})['status'] == 'y' }
+    end
+
+    private
+
+    def norm(k)
+      k.to_s.strip.downcase
+    end
+  end
+
+  # Load <catalog_dir>/<dimension>.json. Fails LOUDLY if absent — a classifier
+  # with no catalog must not silently guess.
+  def self.load(catalog_dir, dimension)
+    path = File.join(catalog_dir, "#{dimension}.json")
+    unless File.exist?(path)
+      raise "coverage catalog missing: #{path} — the classifier requires a " \
+            "documentation-grounded catalog for '#{dimension}'; refusing to guess."
+    end
+    Catalog.new(JSON.parse(File.read(path)), path)
+  end
+
+  # Load every *.json catalog in catalog_dir, keyed by dimension name.
+  def self.load_all(catalog_dir)
+    raise "coverage catalog dir missing: #{catalog_dir}" unless File.directory?(catalog_dir)
+    out = {}
+    Dir[File.join(catalog_dir, '*.json')].sort.each do |p|
+      d = File.basename(p, '.json')
+      out[d] = load(catalog_dir, d)
+    end
+    out
+  end
+
+  # Given a builder's __FILE__ (in scripts/), return its sibling refs/catalogs dir.
+  def self.default_catalog_dir(script_file)
+    scripts_dir = File.dirname(File.expand_path(script_file))
+    File.expand_path(File.join(scripts_dir, '..', 'refs', 'catalogs'))
+  end
+end

--- a/shared/lib/test_coverage_catalog.rb
+++ b/shared/lib/test_coverage_catalog.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Unit test for coverage_catalog.rb. Run: ruby shared/lib/test_coverage_catalog.rb
+
+require 'json'
+require 'tmpdir'
+require_relative 'coverage_catalog'
+
+$failures = 0
+def check(desc)
+  ok = yield
+  puts(ok ? "  [ok] #{desc}" : "  [FAIL] #{desc}")
+  $failures += 1 unless ok
+end
+
+Dir.mktmpdir('cc-rb-test-') do |dir|
+  File.write(File.join(dir, 'number-format.json'), JSON.dump(
+    'dimension' => 'number-format', 'source_tool' => 'quicksight',
+    'authoritative_doc' => 'https://example/authority', 'on_unmapped_default' => 'warn+skip',
+    'rows' => [
+      { 'source' => 'usd_0', 'sigma' => '$,.0f', 'doc_ref' => 'https://example/usd_0',
+        'sigma_verified' => { 'status' => 'y', 'date' => '2026-07-13' } },
+      { 'source' => 'Percent_1', 'sigma' => ',.1%', 'doc_ref' => 'https://example/pct',
+        'sigma_verified' => { 'status' => 'n' } }
+    ]
+  ))
+  cat = Coverage.load(dir, 'number-format')
+
+  check('resolve hit + case/space normalization') do
+    cat.target('usd_0') == '$,.0f' && cat.target('  USD_0 ') == '$,.0f' && cat.target('percent_1') == ',.1%'
+  end
+  check('resolve miss -> nil') { cat.resolve('gbp_9').nil? && cat.target('gbp_9').nil? && cat.resolve(nil).nil? }
+
+  w = []
+  miss = cat.resolve_or_warn('gbp_9', w, context: "visual 'X'")
+  check('resolve_or_warn loud on miss') do
+    miss.nil? && w.length == 1 && w[0].include?('number-format') && w[0].include?('gbp_9') &&
+      w[0].include?('quicksight') && w[0].include?("visual 'X'") && w[0].include?('number-format.json')
+  end
+  cat.resolve_or_warn('usd_0', w)
+  check('resolve_or_warn silent on hit') { w.length == 1 }
+
+  check('metadata + sources') do
+    cat.dimension == 'number-format' && cat.source_tool == 'quicksight' &&
+      cat.sources.sort == %w[percent_1 usd_0]
+  end
+  check('unverified') { cat.unverified.map { |r| r['source'] } == ['Percent_1'] }
+
+  raised = false
+  begin; Coverage.load(dir, 'nope'); rescue RuntimeError; raised = true; end
+  check('missing catalog fails loudly') { raised }
+
+  File.write(File.join(dir, 'viz-kind.json'), JSON.dump(
+    'dimension' => 'viz-kind', 'source_tool' => 'quicksight',
+    'rows' => [{ 'source' => 'BAR', 'sigma' => 'bar-chart' }]))
+  cats = Coverage.load_all(dir)
+  check('load_all') { cats.keys.sort == %w[number-format viz-kind] && cats['viz-kind'].target('bar') == 'bar-chart' }
+
+  check('default_catalog_dir') do
+    Coverage.default_catalog_dir('/a/b/skills/x/scripts/build.rb').end_with?(File.join('skills', 'x', 'refs', 'catalogs'))
+  end
+end
+
+if $failures.zero?
+  puts 'ALL PASS'
+else
+  puts "#{$failures} FAILURE(S)"; exit 1
+end

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -9,10 +9,19 @@
       ]
     },
     {
+      "canonical": "shared/lib/coverage_catalog.rb",
+      "targets": [
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/coverage_catalog.rb",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/coverage_catalog.rb"
+      ]
+    },
+    {
       "canonical": "shared/scripts/gen-coverage-matrix.py",
       "targets": [
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/gen-coverage-matrix.py",
-        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-coverage-matrix.py"
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-coverage-matrix.py",
+        "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/gen-coverage-matrix.py",
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/gen-coverage-matrix.py"
       ]
     },
     {


### PR DESCRIPTION
The Ruby twin of the `coverage_catalog` loader (#349), so the **Ruby** dashboard classifiers (powerbi + quicksight `build-workbook-from-*.rb`) can load the same language-neutral JSON mapping catalogs the Python builders (looker/qlik) use.

- `shared/lib/coverage_catalog.rb` — same API as the Python loader: `resolve`/`target` + a **loud** `resolve_or_warn` miss; fails loudly on a missing catalog. Ruby 2.6-safe. Unit test 9/9.
- Synced into `powerbi` + `quicksight` `scripts/lib`; the language-neutral `gen-coverage-matrix.py` is synced to both too.

Prereq for the powerbi/quicksight grounding PRs. `ruby tools/check-shared.rb` → 288 copies match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)