### PR TITLE
kvza.4: sync grounding loader+generator into the 4 Python skills

### DIFF
--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/gen-coverage-matrix.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/gen-coverage-matrix.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""gen-coverage-matrix.py — generate refs/<skill>-coverage.md FROM the JSON
+catalogs (refs/catalogs/*.json), so the human-readable coverage matrix can never
+drift from the machine-loaded single source of truth (beads-sigma-kvza).
+
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md --check     # exit 1 if the file is stale
+
+One table per dimension, five columns (the handoff's shape):
+  | construct | doc ref | Sigma target | sigma_verified (y/n·date) | on-unmapped |
+
+Stdlib only; Windows-safe.
+"""
+import argparse
+import json
+import os
+import sys
+
+DIM_ORDER = ["viz-kind", "number-format", "aggregation", "control"]
+DIM_TITLE = {
+    "viz-kind": "Visualization / chart kind",
+    "number-format": "Number format",
+    "aggregation": "Aggregation",
+    "control": "Control / filter",
+}
+
+
+def _md_escape(s):
+    return str(s).replace("|", "\\|").replace("\n", " ")
+
+
+def _verified_cell(r):
+    sv = r.get("sigma_verified") or {}
+    status = sv.get("status", "n")
+    if status == "y":
+        return "✅ y · %s" % sv.get("date", "?")
+    return "🟡 n"
+
+
+def _target_cell(r):
+    sig = r.get("sigma")
+    if sig is None and r.get("sigma_if") is None:
+        return "— (no Sigma equivalent)"
+    parts = []
+    if sig is not None:
+        parts.append("`%s`" % _md_escape(sig))
+    if r.get("sigma_if"):
+        parts.append("if→`%s`" % _md_escape(r["sigma_if"]))
+    return " ".join(parts) if parts else "—"
+
+
+def _doc_cell(r):
+    ref = r.get("doc_ref", "")
+    return "[doc](%s)" % ref if ref.startswith("http") else _md_escape(ref or "—")
+
+
+def render(catalogs, skill):
+    cats = {}
+    for fn in sorted(os.listdir(catalogs)):
+        if fn.endswith(".json"):
+            cats[fn[:-5]] = json.load(open(os.path.join(catalogs, fn)))
+    order = [d for d in DIM_ORDER if d in cats] + [d for d in sorted(cats) if d not in DIM_ORDER]
+
+    out = []
+    out.append("# %s → Sigma — dashboard classifier coverage matrix" % skill.capitalize())
+    out.append("")
+    out.append("> **GENERATED — do not edit by hand.** Regenerate with "
+               "`python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs "
+               "--skill %s --out refs/%s-coverage.md`. The JSON catalogs in "
+               "`refs/catalogs/` are the single source of truth; the classifier "
+               "(`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them "
+               "via `shared/lib/coverage_catalog.py`. A no-drift test asserts this "
+               "file matches the catalogs." % (skill, skill))
+    out.append("")
+    out.append("Every documented source construct maps to a real, current Sigma target "
+               "or a loud fallback — no silent wrong-defaults, no name-substring "
+               "guessing (beads-sigma-kvza).")
+    out.append("")
+    out.append("**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at "
+               "**query time** in a live migration (no `type=error` column) on the date "
+               "shown; 🟡 n = target is documented but not yet query-verified.")
+    out.append("")
+    total = sum(len(c.get("rows", [])) for c in cats.values())
+    ver = sum(1 for c in cats.values() for r in c.get("rows", [])
+              if (r.get("sigma_verified") or {}).get("status") == "y")
+    out.append("**Coverage:** %d documented constructs across %d dimensions; "
+               "%d live-verified." % (total, len(cats), ver))
+    out.append("")
+
+    for dim in order:
+        c = cats[dim]
+        out.append("## %s" % DIM_TITLE.get(dim, dim))
+        out.append("")
+        if c.get("description"):
+            out.append("_%s_" % c["description"])
+            out.append("")
+        if c.get("authoritative_doc"):
+            out.append("Authoritative source: <%s>" % c["authoritative_doc"])
+            out.append("")
+        out.append("| construct | doc ref | Sigma target | sigma_verified | on-unmapped |")
+        out.append("|---|---|---|---|---|")
+        for r in c.get("rows", []):
+            notes = r.get("notes")
+            src = "`%s`" % _md_escape(r["source"])
+            onun = _md_escape(r.get("on_unmapped", c.get("on_unmapped_default", "")))
+            row = "| %s | %s | %s | %s | %s |" % (
+                src, _doc_cell(r), _target_cell(r), _verified_cell(r), onun)
+            out.append(row)
+            if notes:
+                out.append("| | | | | _%s_ |" % _md_escape(notes))
+        out.append("")
+
+    out.append("---")
+    out.append("_Compositional constructs that do not serialize to a flat table "
+               "(Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask "
+               "parsers, count-on-joined-view) stay as cited predicates in the "
+               "classifier; this matrix covers the enumerable maps._")
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--catalogs", required=True)
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if --out is stale vs the catalogs (no write)")
+    a = ap.parse_args()
+    text = render(a.catalogs, a.skill)
+    if a.check:
+        cur = open(a.out).read() if os.path.exists(a.out) else ""
+        if cur != text:
+            sys.stderr.write("STALE: %s does not match refs/catalogs — regenerate.\n" % a.out)
+            sys.exit(1)
+        print("OK: %s matches the catalogs." % a.out)
+        return
+    open(a.out, "w").write(text)
+    print("wrote %s (%d bytes)" % (a.out, len(text)))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/coverage_catalog.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""coverage_catalog.py — load a documentation-grounded mapping catalog and
+resolve source constructs to Sigma targets, LOUDLY on a miss.
+
+The single source of truth for a classifier's mappings is a JSON catalog under
+the skill's ``refs/catalogs/<dimension>.json``. Each catalog is an envelope::
+
+    {
+      "dimension": "number-format",
+      "source_tool": "looker",
+      "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+      "on_unmapped_default": "warn+skip",
+      "rows": [
+        {"source": "usd_0", "sigma": "$,.0f",
+         "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+         "sigma_verified": {"status": "y", "date": "2026-07-13"},
+         "on_unmapped": "warn+skip",
+         "notes": "..."}
+      ]
+    }
+
+Rows are indexed by ``source`` (normalized: trimmed + lowercased — every one of
+the four classifier dimensions keys on lowercase tokens). ``resolve()`` returns
+the row dict or ``None``. The classifier MUST honor a ``None`` by warning +
+skipping/placeholdering — never by emitting a silent wrong default.
+``resolve_or_warn()`` enforces that: it appends a standardized warning to the
+caller's ``warnings`` list and returns ``None`` on a miss.
+
+Stdlib only (json/os); Windows-safe (os.path). Mirrors the beads-sigma-93ps
+design contract: the catalog is language-neutral data; this loader is the thin
+resolver. See refs/<skill>-coverage.md (generated FROM the catalogs) for the
+human-readable, cited coverage matrix.
+"""
+import json
+import os
+
+MISS = None  # sentinel: resolve() returns None when a source key is absent
+
+
+class Catalog:
+    """A single loaded mapping dimension (viz-kind / number-format / aggregation
+    / control), indexed by source construct."""
+
+    def __init__(self, data, path):
+        self.path = path
+        self.filename = os.path.basename(path)
+        self.dimension = data.get("dimension") or os.path.splitext(self.filename)[0]
+        self.source_tool = data.get("source_tool", "")
+        self.authoritative_doc = data.get("authoritative_doc", "")
+        self.on_unmapped_default = data.get("on_unmapped_default", "warn+skip")
+        self.rows = data.get("rows", [])
+        self._by_source = {}
+        for r in self.rows:
+            k = r.get("source")
+            if k is None:
+                continue
+            self._by_source[self._norm(k)] = r
+
+    @staticmethod
+    def _norm(k):
+        return str(k).strip().lower()
+
+    def resolve(self, source_key):
+        """Return the full catalog row for ``source_key``, or ``None`` on a miss."""
+        if source_key is None:
+            return None
+        return self._by_source.get(self._norm(source_key))
+
+    def target(self, source_key):
+        """Return just the Sigma target string for ``source_key`` (row['sigma']),
+        or ``None`` on a miss. Convenience for the common case."""
+        row = self.resolve(source_key)
+        return row.get("sigma") if row else None
+
+    def resolve_or_warn(self, source_key, warnings, *, context=""):
+        """Resolve ``source_key``; on a miss append a standardized LOUD warning to
+        ``warnings`` and return ``None``. The caller must then skip/placeholder —
+        this makes the loud fallback mandatory and uniform across classifiers."""
+        row = self.resolve(source_key)
+        if row is not None:
+            return row
+        where = " (%s)" % context if context else ""
+        warnings.append(
+            "⚠ %s: no documented %s mapping for '%s'%s — %s. "
+            "Add a cited row to refs/catalogs/%s if this is a real construct."
+            % (self.dimension, self.source_tool or "source", source_key, where,
+               self.on_unmapped_default, self.filename)
+        )
+        return None
+
+    def sources(self):
+        """All (normalized) source keys the catalog covers."""
+        return list(self._by_source.keys())
+
+    def unverified(self):
+        """Rows whose Sigma target is not yet live-verified
+        (``sigma_verified.status`` != 'y'). Used to gate a PR / stamp progress."""
+        return [r for r in self.rows
+                if (r.get("sigma_verified") or {}).get("status") != "y"]
+
+
+def load(catalog_dir, dimension):
+    """Load ``<catalog_dir>/<dimension>.json``. Fails LOUDLY if absent — a
+    classifier with no catalog must not silently guess."""
+    path = os.path.join(catalog_dir, dimension + ".json")
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            "coverage catalog missing: %s — the classifier requires a "
+            "documentation-grounded catalog for '%s'; refusing to guess."
+            % (path, dimension)
+        )
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return Catalog(data, path)
+
+
+def load_all(catalog_dir):
+    """Load every ``*.json`` catalog in ``catalog_dir``, keyed by dimension name."""
+    if not os.path.isdir(catalog_dir):
+        raise FileNotFoundError("coverage catalog dir missing: %s" % catalog_dir)
+    out = {}
+    for fn in sorted(os.listdir(catalog_dir)):
+        if fn.endswith(".json"):
+            out[fn[:-5]] = load(catalog_dir, fn[:-5])
+    return out
+
+
+def default_catalog_dir(script_file):
+    """Given a builder's ``__file__`` (in scripts/), return its sibling
+    ``refs/catalogs`` dir. Keeps callers from hand-rolling the ``..`` walk."""
+    scripts_dir = os.path.dirname(os.path.abspath(script_file))
+    return os.path.normpath(os.path.join(scripts_dir, "..", "refs", "catalogs"))

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/gen-coverage-matrix.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/gen-coverage-matrix.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""gen-coverage-matrix.py — generate refs/<skill>-coverage.md FROM the JSON
+catalogs (refs/catalogs/*.json), so the human-readable coverage matrix can never
+drift from the machine-loaded single source of truth (beads-sigma-kvza).
+
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md --check     # exit 1 if the file is stale
+
+One table per dimension, five columns (the handoff's shape):
+  | construct | doc ref | Sigma target | sigma_verified (y/n·date) | on-unmapped |
+
+Stdlib only; Windows-safe.
+"""
+import argparse
+import json
+import os
+import sys
+
+DIM_ORDER = ["viz-kind", "number-format", "aggregation", "control"]
+DIM_TITLE = {
+    "viz-kind": "Visualization / chart kind",
+    "number-format": "Number format",
+    "aggregation": "Aggregation",
+    "control": "Control / filter",
+}
+
+
+def _md_escape(s):
+    return str(s).replace("|", "\\|").replace("\n", " ")
+
+
+def _verified_cell(r):
+    sv = r.get("sigma_verified") or {}
+    status = sv.get("status", "n")
+    if status == "y":
+        return "✅ y · %s" % sv.get("date", "?")
+    return "🟡 n"
+
+
+def _target_cell(r):
+    sig = r.get("sigma")
+    if sig is None and r.get("sigma_if") is None:
+        return "— (no Sigma equivalent)"
+    parts = []
+    if sig is not None:
+        parts.append("`%s`" % _md_escape(sig))
+    if r.get("sigma_if"):
+        parts.append("if→`%s`" % _md_escape(r["sigma_if"]))
+    return " ".join(parts) if parts else "—"
+
+
+def _doc_cell(r):
+    ref = r.get("doc_ref", "")
+    return "[doc](%s)" % ref if ref.startswith("http") else _md_escape(ref or "—")
+
+
+def render(catalogs, skill):
+    cats = {}
+    for fn in sorted(os.listdir(catalogs)):
+        if fn.endswith(".json"):
+            cats[fn[:-5]] = json.load(open(os.path.join(catalogs, fn)))
+    order = [d for d in DIM_ORDER if d in cats] + [d for d in sorted(cats) if d not in DIM_ORDER]
+
+    out = []
+    out.append("# %s → Sigma — dashboard classifier coverage matrix" % skill.capitalize())
+    out.append("")
+    out.append("> **GENERATED — do not edit by hand.** Regenerate with "
+               "`python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs "
+               "--skill %s --out refs/%s-coverage.md`. The JSON catalogs in "
+               "`refs/catalogs/` are the single source of truth; the classifier "
+               "(`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them "
+               "via `shared/lib/coverage_catalog.py`. A no-drift test asserts this "
+               "file matches the catalogs." % (skill, skill))
+    out.append("")
+    out.append("Every documented source construct maps to a real, current Sigma target "
+               "or a loud fallback — no silent wrong-defaults, no name-substring "
+               "guessing (beads-sigma-kvza).")
+    out.append("")
+    out.append("**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at "
+               "**query time** in a live migration (no `type=error` column) on the date "
+               "shown; 🟡 n = target is documented but not yet query-verified.")
+    out.append("")
+    total = sum(len(c.get("rows", [])) for c in cats.values())
+    ver = sum(1 for c in cats.values() for r in c.get("rows", [])
+              if (r.get("sigma_verified") or {}).get("status") == "y")
+    out.append("**Coverage:** %d documented constructs across %d dimensions; "
+               "%d live-verified." % (total, len(cats), ver))
+    out.append("")
+
+    for dim in order:
+        c = cats[dim]
+        out.append("## %s" % DIM_TITLE.get(dim, dim))
+        out.append("")
+        if c.get("description"):
+            out.append("_%s_" % c["description"])
+            out.append("")
+        if c.get("authoritative_doc"):
+            out.append("Authoritative source: <%s>" % c["authoritative_doc"])
+            out.append("")
+        out.append("| construct | doc ref | Sigma target | sigma_verified | on-unmapped |")
+        out.append("|---|---|---|---|---|")
+        for r in c.get("rows", []):
+            notes = r.get("notes")
+            src = "`%s`" % _md_escape(r["source"])
+            onun = _md_escape(r.get("on_unmapped", c.get("on_unmapped_default", "")))
+            row = "| %s | %s | %s | %s | %s |" % (
+                src, _doc_cell(r), _target_cell(r), _verified_cell(r), onun)
+            out.append(row)
+            if notes:
+                out.append("| | | | | _%s_ |" % _md_escape(notes))
+        out.append("")
+
+    out.append("---")
+    out.append("_Compositional constructs that do not serialize to a flat table "
+               "(Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask "
+               "parsers, count-on-joined-view) stay as cited predicates in the "
+               "classifier; this matrix covers the enumerable maps._")
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--catalogs", required=True)
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if --out is stale vs the catalogs (no write)")
+    a = ap.parse_args()
+    text = render(a.catalogs, a.skill)
+    if a.check:
+        cur = open(a.out).read() if os.path.exists(a.out) else ""
+        if cur != text:
+            sys.stderr.write("STALE: %s does not match refs/catalogs — regenerate.\n" % a.out)
+            sys.exit(1)
+        print("OK: %s matches the catalogs." % a.out)
+        return
+    open(a.out, "w").write(text)
+    print("wrote %s (%d bytes)" % (a.out, len(text)))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/coverage_catalog.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""coverage_catalog.py — load a documentation-grounded mapping catalog and
+resolve source constructs to Sigma targets, LOUDLY on a miss.
+
+The single source of truth for a classifier's mappings is a JSON catalog under
+the skill's ``refs/catalogs/<dimension>.json``. Each catalog is an envelope::
+
+    {
+      "dimension": "number-format",
+      "source_tool": "looker",
+      "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+      "on_unmapped_default": "warn+skip",
+      "rows": [
+        {"source": "usd_0", "sigma": "$,.0f",
+         "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+         "sigma_verified": {"status": "y", "date": "2026-07-13"},
+         "on_unmapped": "warn+skip",
+         "notes": "..."}
+      ]
+    }
+
+Rows are indexed by ``source`` (normalized: trimmed + lowercased — every one of
+the four classifier dimensions keys on lowercase tokens). ``resolve()`` returns
+the row dict or ``None``. The classifier MUST honor a ``None`` by warning +
+skipping/placeholdering — never by emitting a silent wrong default.
+``resolve_or_warn()`` enforces that: it appends a standardized warning to the
+caller's ``warnings`` list and returns ``None`` on a miss.
+
+Stdlib only (json/os); Windows-safe (os.path). Mirrors the beads-sigma-93ps
+design contract: the catalog is language-neutral data; this loader is the thin
+resolver. See refs/<skill>-coverage.md (generated FROM the catalogs) for the
+human-readable, cited coverage matrix.
+"""
+import json
+import os
+
+MISS = None  # sentinel: resolve() returns None when a source key is absent
+
+
+class Catalog:
+    """A single loaded mapping dimension (viz-kind / number-format / aggregation
+    / control), indexed by source construct."""
+
+    def __init__(self, data, path):
+        self.path = path
+        self.filename = os.path.basename(path)
+        self.dimension = data.get("dimension") or os.path.splitext(self.filename)[0]
+        self.source_tool = data.get("source_tool", "")
+        self.authoritative_doc = data.get("authoritative_doc", "")
+        self.on_unmapped_default = data.get("on_unmapped_default", "warn+skip")
+        self.rows = data.get("rows", [])
+        self._by_source = {}
+        for r in self.rows:
+            k = r.get("source")
+            if k is None:
+                continue
+            self._by_source[self._norm(k)] = r
+
+    @staticmethod
+    def _norm(k):
+        return str(k).strip().lower()
+
+    def resolve(self, source_key):
+        """Return the full catalog row for ``source_key``, or ``None`` on a miss."""
+        if source_key is None:
+            return None
+        return self._by_source.get(self._norm(source_key))
+
+    def target(self, source_key):
+        """Return just the Sigma target string for ``source_key`` (row['sigma']),
+        or ``None`` on a miss. Convenience for the common case."""
+        row = self.resolve(source_key)
+        return row.get("sigma") if row else None
+
+    def resolve_or_warn(self, source_key, warnings, *, context=""):
+        """Resolve ``source_key``; on a miss append a standardized LOUD warning to
+        ``warnings`` and return ``None``. The caller must then skip/placeholder —
+        this makes the loud fallback mandatory and uniform across classifiers."""
+        row = self.resolve(source_key)
+        if row is not None:
+            return row
+        where = " (%s)" % context if context else ""
+        warnings.append(
+            "⚠ %s: no documented %s mapping for '%s'%s — %s. "
+            "Add a cited row to refs/catalogs/%s if this is a real construct."
+            % (self.dimension, self.source_tool or "source", source_key, where,
+               self.on_unmapped_default, self.filename)
+        )
+        return None
+
+    def sources(self):
+        """All (normalized) source keys the catalog covers."""
+        return list(self._by_source.keys())
+
+    def unverified(self):
+        """Rows whose Sigma target is not yet live-verified
+        (``sigma_verified.status`` != 'y'). Used to gate a PR / stamp progress."""
+        return [r for r in self.rows
+                if (r.get("sigma_verified") or {}).get("status") != "y"]
+
+
+def load(catalog_dir, dimension):
+    """Load ``<catalog_dir>/<dimension>.json``. Fails LOUDLY if absent — a
+    classifier with no catalog must not silently guess."""
+    path = os.path.join(catalog_dir, dimension + ".json")
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            "coverage catalog missing: %s — the classifier requires a "
+            "documentation-grounded catalog for '%s'; refusing to guess."
+            % (path, dimension)
+        )
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return Catalog(data, path)
+
+
+def load_all(catalog_dir):
+    """Load every ``*.json`` catalog in ``catalog_dir``, keyed by dimension name."""
+    if not os.path.isdir(catalog_dir):
+        raise FileNotFoundError("coverage catalog dir missing: %s" % catalog_dir)
+    out = {}
+    for fn in sorted(os.listdir(catalog_dir)):
+        if fn.endswith(".json"):
+            out[fn[:-5]] = load(catalog_dir, fn[:-5])
+    return out
+
+
+def default_catalog_dir(script_file):
+    """Given a builder's ``__file__`` (in scripts/), return its sibling
+    ``refs/catalogs`` dir. Keeps callers from hand-rolling the ``..`` walk."""
+    scripts_dir = os.path.dirname(os.path.abspath(script_file))
+    return os.path.normpath(os.path.join(scripts_dir, "..", "refs", "catalogs"))

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/gen-coverage-matrix.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/gen-coverage-matrix.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""gen-coverage-matrix.py — generate refs/<skill>-coverage.md FROM the JSON
+catalogs (refs/catalogs/*.json), so the human-readable coverage matrix can never
+drift from the machine-loaded single source of truth (beads-sigma-kvza).
+
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md --check     # exit 1 if the file is stale
+
+One table per dimension, five columns (the handoff's shape):
+  | construct | doc ref | Sigma target | sigma_verified (y/n·date) | on-unmapped |
+
+Stdlib only; Windows-safe.
+"""
+import argparse
+import json
+import os
+import sys
+
+DIM_ORDER = ["viz-kind", "number-format", "aggregation", "control"]
+DIM_TITLE = {
+    "viz-kind": "Visualization / chart kind",
+    "number-format": "Number format",
+    "aggregation": "Aggregation",
+    "control": "Control / filter",
+}
+
+
+def _md_escape(s):
+    return str(s).replace("|", "\\|").replace("\n", " ")
+
+
+def _verified_cell(r):
+    sv = r.get("sigma_verified") or {}
+    status = sv.get("status", "n")
+    if status == "y":
+        return "✅ y · %s" % sv.get("date", "?")
+    return "🟡 n"
+
+
+def _target_cell(r):
+    sig = r.get("sigma")
+    if sig is None and r.get("sigma_if") is None:
+        return "— (no Sigma equivalent)"
+    parts = []
+    if sig is not None:
+        parts.append("`%s`" % _md_escape(sig))
+    if r.get("sigma_if"):
+        parts.append("if→`%s`" % _md_escape(r["sigma_if"]))
+    return " ".join(parts) if parts else "—"
+
+
+def _doc_cell(r):
+    ref = r.get("doc_ref", "")
+    return "[doc](%s)" % ref if ref.startswith("http") else _md_escape(ref or "—")
+
+
+def render(catalogs, skill):
+    cats = {}
+    for fn in sorted(os.listdir(catalogs)):
+        if fn.endswith(".json"):
+            cats[fn[:-5]] = json.load(open(os.path.join(catalogs, fn)))
+    order = [d for d in DIM_ORDER if d in cats] + [d for d in sorted(cats) if d not in DIM_ORDER]
+
+    out = []
+    out.append("# %s → Sigma — dashboard classifier coverage matrix" % skill.capitalize())
+    out.append("")
+    out.append("> **GENERATED — do not edit by hand.** Regenerate with "
+               "`python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs "
+               "--skill %s --out refs/%s-coverage.md`. The JSON catalogs in "
+               "`refs/catalogs/` are the single source of truth; the classifier "
+               "(`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them "
+               "via `shared/lib/coverage_catalog.py`. A no-drift test asserts this "
+               "file matches the catalogs." % (skill, skill))
+    out.append("")
+    out.append("Every documented source construct maps to a real, current Sigma target "
+               "or a loud fallback — no silent wrong-defaults, no name-substring "
+               "guessing (beads-sigma-kvza).")
+    out.append("")
+    out.append("**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at "
+               "**query time** in a live migration (no `type=error` column) on the date "
+               "shown; 🟡 n = target is documented but not yet query-verified.")
+    out.append("")
+    total = sum(len(c.get("rows", [])) for c in cats.values())
+    ver = sum(1 for c in cats.values() for r in c.get("rows", [])
+              if (r.get("sigma_verified") or {}).get("status") == "y")
+    out.append("**Coverage:** %d documented constructs across %d dimensions; "
+               "%d live-verified." % (total, len(cats), ver))
+    out.append("")
+
+    for dim in order:
+        c = cats[dim]
+        out.append("## %s" % DIM_TITLE.get(dim, dim))
+        out.append("")
+        if c.get("description"):
+            out.append("_%s_" % c["description"])
+            out.append("")
+        if c.get("authoritative_doc"):
+            out.append("Authoritative source: <%s>" % c["authoritative_doc"])
+            out.append("")
+        out.append("| construct | doc ref | Sigma target | sigma_verified | on-unmapped |")
+        out.append("|---|---|---|---|---|")
+        for r in c.get("rows", []):
+            notes = r.get("notes")
+            src = "`%s`" % _md_escape(r["source"])
+            onun = _md_escape(r.get("on_unmapped", c.get("on_unmapped_default", "")))
+            row = "| %s | %s | %s | %s | %s |" % (
+                src, _doc_cell(r), _target_cell(r), _verified_cell(r), onun)
+            out.append(row)
+            if notes:
+                out.append("| | | | | _%s_ |" % _md_escape(notes))
+        out.append("")
+
+    out.append("---")
+    out.append("_Compositional constructs that do not serialize to a flat table "
+               "(Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask "
+               "parsers, count-on-joined-view) stay as cited predicates in the "
+               "classifier; this matrix covers the enumerable maps._")
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--catalogs", required=True)
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if --out is stale vs the catalogs (no write)")
+    a = ap.parse_args()
+    text = render(a.catalogs, a.skill)
+    if a.check:
+        cur = open(a.out).read() if os.path.exists(a.out) else ""
+        if cur != text:
+            sys.stderr.write("STALE: %s does not match refs/catalogs — regenerate.\n" % a.out)
+            sys.exit(1)
+        print("OK: %s matches the catalogs." % a.out)
+        return
+    open(a.out, "w").write(text)
+    print("wrote %s (%d bytes)" % (a.out, len(text)))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/coverage_catalog.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""coverage_catalog.py — load a documentation-grounded mapping catalog and
+resolve source constructs to Sigma targets, LOUDLY on a miss.
+
+The single source of truth for a classifier's mappings is a JSON catalog under
+the skill's ``refs/catalogs/<dimension>.json``. Each catalog is an envelope::
+
+    {
+      "dimension": "number-format",
+      "source_tool": "looker",
+      "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+      "on_unmapped_default": "warn+skip",
+      "rows": [
+        {"source": "usd_0", "sigma": "$,.0f",
+         "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+         "sigma_verified": {"status": "y", "date": "2026-07-13"},
+         "on_unmapped": "warn+skip",
+         "notes": "..."}
+      ]
+    }
+
+Rows are indexed by ``source`` (normalized: trimmed + lowercased — every one of
+the four classifier dimensions keys on lowercase tokens). ``resolve()`` returns
+the row dict or ``None``. The classifier MUST honor a ``None`` by warning +
+skipping/placeholdering — never by emitting a silent wrong default.
+``resolve_or_warn()`` enforces that: it appends a standardized warning to the
+caller's ``warnings`` list and returns ``None`` on a miss.
+
+Stdlib only (json/os); Windows-safe (os.path). Mirrors the beads-sigma-93ps
+design contract: the catalog is language-neutral data; this loader is the thin
+resolver. See refs/<skill>-coverage.md (generated FROM the catalogs) for the
+human-readable, cited coverage matrix.
+"""
+import json
+import os
+
+MISS = None  # sentinel: resolve() returns None when a source key is absent
+
+
+class Catalog:
+    """A single loaded mapping dimension (viz-kind / number-format / aggregation
+    / control), indexed by source construct."""
+
+    def __init__(self, data, path):
+        self.path = path
+        self.filename = os.path.basename(path)
+        self.dimension = data.get("dimension") or os.path.splitext(self.filename)[0]
+        self.source_tool = data.get("source_tool", "")
+        self.authoritative_doc = data.get("authoritative_doc", "")
+        self.on_unmapped_default = data.get("on_unmapped_default", "warn+skip")
+        self.rows = data.get("rows", [])
+        self._by_source = {}
+        for r in self.rows:
+            k = r.get("source")
+            if k is None:
+                continue
+            self._by_source[self._norm(k)] = r
+
+    @staticmethod
+    def _norm(k):
+        return str(k).strip().lower()
+
+    def resolve(self, source_key):
+        """Return the full catalog row for ``source_key``, or ``None`` on a miss."""
+        if source_key is None:
+            return None
+        return self._by_source.get(self._norm(source_key))
+
+    def target(self, source_key):
+        """Return just the Sigma target string for ``source_key`` (row['sigma']),
+        or ``None`` on a miss. Convenience for the common case."""
+        row = self.resolve(source_key)
+        return row.get("sigma") if row else None
+
+    def resolve_or_warn(self, source_key, warnings, *, context=""):
+        """Resolve ``source_key``; on a miss append a standardized LOUD warning to
+        ``warnings`` and return ``None``. The caller must then skip/placeholder —
+        this makes the loud fallback mandatory and uniform across classifiers."""
+        row = self.resolve(source_key)
+        if row is not None:
+            return row
+        where = " (%s)" % context if context else ""
+        warnings.append(
+            "⚠ %s: no documented %s mapping for '%s'%s — %s. "
+            "Add a cited row to refs/catalogs/%s if this is a real construct."
+            % (self.dimension, self.source_tool or "source", source_key, where,
+               self.on_unmapped_default, self.filename)
+        )
+        return None
+
+    def sources(self):
+        """All (normalized) source keys the catalog covers."""
+        return list(self._by_source.keys())
+
+    def unverified(self):
+        """Rows whose Sigma target is not yet live-verified
+        (``sigma_verified.status`` != 'y'). Used to gate a PR / stamp progress."""
+        return [r for r in self.rows
+                if (r.get("sigma_verified") or {}).get("status") != "y"]
+
+
+def load(catalog_dir, dimension):
+    """Load ``<catalog_dir>/<dimension>.json``. Fails LOUDLY if absent — a
+    classifier with no catalog must not silently guess."""
+    path = os.path.join(catalog_dir, dimension + ".json")
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            "coverage catalog missing: %s — the classifier requires a "
+            "documentation-grounded catalog for '%s'; refusing to guess."
+            % (path, dimension)
+        )
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return Catalog(data, path)
+
+
+def load_all(catalog_dir):
+    """Load every ``*.json`` catalog in ``catalog_dir``, keyed by dimension name."""
+    if not os.path.isdir(catalog_dir):
+        raise FileNotFoundError("coverage catalog dir missing: %s" % catalog_dir)
+    out = {}
+    for fn in sorted(os.listdir(catalog_dir)):
+        if fn.endswith(".json"):
+            out[fn[:-5]] = load(catalog_dir, fn[:-5])
+    return out
+
+
+def default_catalog_dir(script_file):
+    """Given a builder's ``__file__`` (in scripts/), return its sibling
+    ``refs/catalogs`` dir. Keeps callers from hand-rolling the ``..`` walk."""
+    scripts_dir = os.path.dirname(os.path.abspath(script_file))
+    return os.path.normpath(os.path.join(scripts_dir, "..", "refs", "catalogs"))

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/gen-coverage-matrix.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/gen-coverage-matrix.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""gen-coverage-matrix.py — generate refs/<skill>-coverage.md FROM the JSON
+catalogs (refs/catalogs/*.json), so the human-readable coverage matrix can never
+drift from the machine-loaded single source of truth (beads-sigma-kvza).
+
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md
+  python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill looker \
+      --out refs/looker-coverage.md --check     # exit 1 if the file is stale
+
+One table per dimension, five columns (the handoff's shape):
+  | construct | doc ref | Sigma target | sigma_verified (y/n·date) | on-unmapped |
+
+Stdlib only; Windows-safe.
+"""
+import argparse
+import json
+import os
+import sys
+
+DIM_ORDER = ["viz-kind", "number-format", "aggregation", "control"]
+DIM_TITLE = {
+    "viz-kind": "Visualization / chart kind",
+    "number-format": "Number format",
+    "aggregation": "Aggregation",
+    "control": "Control / filter",
+}
+
+
+def _md_escape(s):
+    return str(s).replace("|", "\\|").replace("\n", " ")
+
+
+def _verified_cell(r):
+    sv = r.get("sigma_verified") or {}
+    status = sv.get("status", "n")
+    if status == "y":
+        return "✅ y · %s" % sv.get("date", "?")
+    return "🟡 n"
+
+
+def _target_cell(r):
+    sig = r.get("sigma")
+    if sig is None and r.get("sigma_if") is None:
+        return "— (no Sigma equivalent)"
+    parts = []
+    if sig is not None:
+        parts.append("`%s`" % _md_escape(sig))
+    if r.get("sigma_if"):
+        parts.append("if→`%s`" % _md_escape(r["sigma_if"]))
+    return " ".join(parts) if parts else "—"
+
+
+def _doc_cell(r):
+    ref = r.get("doc_ref", "")
+    return "[doc](%s)" % ref if ref.startswith("http") else _md_escape(ref or "—")
+
+
+def render(catalogs, skill):
+    cats = {}
+    for fn in sorted(os.listdir(catalogs)):
+        if fn.endswith(".json"):
+            cats[fn[:-5]] = json.load(open(os.path.join(catalogs, fn)))
+    order = [d for d in DIM_ORDER if d in cats] + [d for d in sorted(cats) if d not in DIM_ORDER]
+
+    out = []
+    out.append("# %s → Sigma — dashboard classifier coverage matrix" % skill.capitalize())
+    out.append("")
+    out.append("> **GENERATED — do not edit by hand.** Regenerate with "
+               "`python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs "
+               "--skill %s --out refs/%s-coverage.md`. The JSON catalogs in "
+               "`refs/catalogs/` are the single source of truth; the classifier "
+               "(`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them "
+               "via `shared/lib/coverage_catalog.py`. A no-drift test asserts this "
+               "file matches the catalogs." % (skill, skill))
+    out.append("")
+    out.append("Every documented source construct maps to a real, current Sigma target "
+               "or a loud fallback — no silent wrong-defaults, no name-substring "
+               "guessing (beads-sigma-kvza).")
+    out.append("")
+    out.append("**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at "
+               "**query time** in a live migration (no `type=error` column) on the date "
+               "shown; 🟡 n = target is documented but not yet query-verified.")
+    out.append("")
+    total = sum(len(c.get("rows", [])) for c in cats.values())
+    ver = sum(1 for c in cats.values() for r in c.get("rows", [])
+              if (r.get("sigma_verified") or {}).get("status") == "y")
+    out.append("**Coverage:** %d documented constructs across %d dimensions; "
+               "%d live-verified." % (total, len(cats), ver))
+    out.append("")
+
+    for dim in order:
+        c = cats[dim]
+        out.append("## %s" % DIM_TITLE.get(dim, dim))
+        out.append("")
+        if c.get("description"):
+            out.append("_%s_" % c["description"])
+            out.append("")
+        if c.get("authoritative_doc"):
+            out.append("Authoritative source: <%s>" % c["authoritative_doc"])
+            out.append("")
+        out.append("| construct | doc ref | Sigma target | sigma_verified | on-unmapped |")
+        out.append("|---|---|---|---|---|")
+        for r in c.get("rows", []):
+            notes = r.get("notes")
+            src = "`%s`" % _md_escape(r["source"])
+            onun = _md_escape(r.get("on_unmapped", c.get("on_unmapped_default", "")))
+            row = "| %s | %s | %s | %s | %s |" % (
+                src, _doc_cell(r), _target_cell(r), _verified_cell(r), onun)
+            out.append(row)
+            if notes:
+                out.append("| | | | | _%s_ |" % _md_escape(notes))
+        out.append("")
+
+    out.append("---")
+    out.append("_Compositional constructs that do not serialize to a flat table "
+               "(Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask "
+               "parsers, count-on-joined-view) stay as cited predicates in the "
+               "classifier; this matrix covers the enumerable maps._")
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--catalogs", required=True)
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if --out is stale vs the catalogs (no write)")
+    a = ap.parse_args()
+    text = render(a.catalogs, a.skill)
+    if a.check:
+        cur = open(a.out).read() if os.path.exists(a.out) else ""
+        if cur != text:
+            sys.stderr.write("STALE: %s does not match refs/catalogs — regenerate.\n" % a.out)
+            sys.exit(1)
+        print("OK: %s matches the catalogs." % a.out)
+        return
+    open(a.out, "w").write(text)
+    print("wrote %s (%d bytes)" % (a.out, len(text)))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/coverage_catalog.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/coverage_catalog.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""coverage_catalog.py — load a documentation-grounded mapping catalog and
+resolve source constructs to Sigma targets, LOUDLY on a miss.
+
+The single source of truth for a classifier's mappings is a JSON catalog under
+the skill's ``refs/catalogs/<dimension>.json``. Each catalog is an envelope::
+
+    {
+      "dimension": "number-format",
+      "source_tool": "looker",
+      "authoritative_doc": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+      "on_unmapped_default": "warn+skip",
+      "rows": [
+        {"source": "usd_0", "sigma": "$,.0f",
+         "doc_ref": "https://cloud.google.com/looker/docs/reference/param-measure-value-format-name",
+         "sigma_verified": {"status": "y", "date": "2026-07-13"},
+         "on_unmapped": "warn+skip",
+         "notes": "..."}
+      ]
+    }
+
+Rows are indexed by ``source`` (normalized: trimmed + lowercased — every one of
+the four classifier dimensions keys on lowercase tokens). ``resolve()`` returns
+the row dict or ``None``. The classifier MUST honor a ``None`` by warning +
+skipping/placeholdering — never by emitting a silent wrong default.
+``resolve_or_warn()`` enforces that: it appends a standardized warning to the
+caller's ``warnings`` list and returns ``None`` on a miss.
+
+Stdlib only (json/os); Windows-safe (os.path). Mirrors the beads-sigma-93ps
+design contract: the catalog is language-neutral data; this loader is the thin
+resolver. See refs/<skill>-coverage.md (generated FROM the catalogs) for the
+human-readable, cited coverage matrix.
+"""
+import json
+import os
+
+MISS = None  # sentinel: resolve() returns None when a source key is absent
+
+
+class Catalog:
+    """A single loaded mapping dimension (viz-kind / number-format / aggregation
+    / control), indexed by source construct."""
+
+    def __init__(self, data, path):
+        self.path = path
+        self.filename = os.path.basename(path)
+        self.dimension = data.get("dimension") or os.path.splitext(self.filename)[0]
+        self.source_tool = data.get("source_tool", "")
+        self.authoritative_doc = data.get("authoritative_doc", "")
+        self.on_unmapped_default = data.get("on_unmapped_default", "warn+skip")
+        self.rows = data.get("rows", [])
+        self._by_source = {}
+        for r in self.rows:
+            k = r.get("source")
+            if k is None:
+                continue
+            self._by_source[self._norm(k)] = r
+
+    @staticmethod
+    def _norm(k):
+        return str(k).strip().lower()
+
+    def resolve(self, source_key):
+        """Return the full catalog row for ``source_key``, or ``None`` on a miss."""
+        if source_key is None:
+            return None
+        return self._by_source.get(self._norm(source_key))
+
+    def target(self, source_key):
+        """Return just the Sigma target string for ``source_key`` (row['sigma']),
+        or ``None`` on a miss. Convenience for the common case."""
+        row = self.resolve(source_key)
+        return row.get("sigma") if row else None
+
+    def resolve_or_warn(self, source_key, warnings, *, context=""):
+        """Resolve ``source_key``; on a miss append a standardized LOUD warning to
+        ``warnings`` and return ``None``. The caller must then skip/placeholder —
+        this makes the loud fallback mandatory and uniform across classifiers."""
+        row = self.resolve(source_key)
+        if row is not None:
+            return row
+        where = " (%s)" % context if context else ""
+        warnings.append(
+            "⚠ %s: no documented %s mapping for '%s'%s — %s. "
+            "Add a cited row to refs/catalogs/%s if this is a real construct."
+            % (self.dimension, self.source_tool or "source", source_key, where,
+               self.on_unmapped_default, self.filename)
+        )
+        return None
+
+    def sources(self):
+        """All (normalized) source keys the catalog covers."""
+        return list(self._by_source.keys())
+
+    def unverified(self):
+        """Rows whose Sigma target is not yet live-verified
+        (``sigma_verified.status`` != 'y'). Used to gate a PR / stamp progress."""
+        return [r for r in self.rows
+                if (r.get("sigma_verified") or {}).get("status") != "y"]
+
+
+def load(catalog_dir, dimension):
+    """Load ``<catalog_dir>/<dimension>.json``. Fails LOUDLY if absent — a
+    classifier with no catalog must not silently guess."""
+    path = os.path.join(catalog_dir, dimension + ".json")
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            "coverage catalog missing: %s — the classifier requires a "
+            "documentation-grounded catalog for '%s'; refusing to guess."
+            % (path, dimension)
+        )
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return Catalog(data, path)
+
+
+def load_all(catalog_dir):
+    """Load every ``*.json`` catalog in ``catalog_dir``, keyed by dimension name."""
+    if not os.path.isdir(catalog_dir):
+        raise FileNotFoundError("coverage catalog dir missing: %s" % catalog_dir)
+    out = {}
+    for fn in sorted(os.listdir(catalog_dir)):
+        if fn.endswith(".json"):
+            out[fn[:-5]] = load(catalog_dir, fn[:-5])
+    return out
+
+
+def default_catalog_dir(script_file):
+    """Given a builder's ``__file__`` (in scripts/), return its sibling
+    ``refs/catalogs`` dir. Keeps callers from hand-rolling the ``..`` walk."""
+    scripts_dir = os.path.dirname(os.path.abspath(script_file))
+    return os.path.normpath(os.path.join(scripts_dir, "..", "refs", "catalogs"))

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -5,7 +5,11 @@
       "canonical": "shared/lib/coverage_catalog.py",
       "targets": [
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/coverage_catalog.py",
-        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/coverage_catalog.py"
+        "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/coverage_catalog.py",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/coverage_catalog.py",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/coverage_catalog.py",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/coverage_catalog.py",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/coverage_catalog.py"
       ]
     },
     {
@@ -21,7 +25,11 @@
         "plugins/looker-to-sigma/skills/looker-to-sigma/scripts/gen-coverage-matrix.py",
         "plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/gen-coverage-matrix.py",
         "plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/gen-coverage-matrix.py",
-        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/gen-coverage-matrix.py"
+        "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/gen-coverage-matrix.py",
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/gen-coverage-matrix.py",
+        "plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/gen-coverage-matrix.py",
+        "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/gen-coverage-matrix.py",
+        "plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/gen-coverage-matrix.py"
       ]
     },
     {
@@ -485,8 +493,10 @@
         "plugins/sisense-to-sigma/skills/sisense-assessment/refs/environment.md",
         "plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/environment.md",
         "plugins/tableau-to-sigma/skills/tableau-assessment/refs/environment.md",
-        { "path": "plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/environment.md",
-          "exception": "Intentional fork: carries Tableau-specific Windows guidance — in-process Sigma + Tableau PAT token minting by migrate-tableau.rb (#310), the get-tableau-token.py twin, and BOM-tolerant spec reads — that does not apply to the other plugins' orchestrators." },
+        {
+          "path": "plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/environment.md",
+          "exception": "Intentional fork: carries Tableau-specific Windows guidance \u2014 in-process Sigma + Tableau PAT token minting by migrate-tableau.rb (#310), the get-tableau-token.py twin, and BOM-tolerant spec reads \u2014 that does not apply to the other plugins' orchestrators."
+        },
         "plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/refs/environment.md",
         "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/environment.md"
       ]


### PR DESCRIPTION
Vendors the shared `coverage_catalog.py` loader + `gen-coverage-matrix.py` into thoughtspot/gooddata/sisense/microstrategy `scripts/` (manifest + fan-out), ahead of their per-skill grounding PRs. No classifier behavior change. `check-shared` → 296 copies match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)