### PR TITLE
Fix get-token.sh base64 line-wrapping that corrupts the auth header (#346)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get-token.sh
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get-token.sh
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get-token.sh
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get-token.sh
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get-token.sh
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get-token.sh
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get-token.sh
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get-token.sh
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get-token.sh
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-token.sh
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get-token.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/shared/scripts/get-token.sh
+++ b/shared/scripts/get-token.sh
@@ -30,7 +30,11 @@ if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
   exit 1
 fi
 
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
 
 RESPONSE=$(curl -sf -X POST \
   -H "Authorization: Basic ${CREDENTIALS}" \

--- a/tools/lint-skills.rb
+++ b/tools/lint-skills.rb
@@ -75,22 +75,60 @@ skills.each do |dir|
   ok += 1
 end
 
+# ---------------------------------------------------------------------------
+# Portability content-lint (bead: windows-portability). The rules above check
+# SKILL.md prose; these scan SCRIPT BODIES for the class of "validated only on
+# macOS" footgun that shipped in #346 — a bug that is LATENT on the BSD/macOS
+# dev box and only bites on Windows/Linux. A regression here fails the PR.
+# ---------------------------------------------------------------------------
+port_fails = []  # [path, lineno, msg]
+
+# #346: a shell `base64` ENCODE must strip newlines. GNU coreutils base64 (Git
+# Bash on Windows, Linux CI) wraps at 76 columns, injecting newlines that
+# corrupt a multi-line Authorization header; BSD/macOS base64 does not wrap, so
+# the bug is invisible on the dev box. Require `tr -d '\n'` (portable) or
+# `-w0`/`--wrap=0` (GNU-only) on the same pipeline.
+Dir.glob('**/*.sh').sort.each do |f|
+  File.readlines(f).each_with_index do |line, i|
+    next if line =~ /\A\s*#/                           # skip comments
+    next unless line =~ /\|\s*base64\b/                # pipes INTO base64 (encode)
+    next if line =~ /base64\s+(-d|-D|--decode)\b/       # decode, not encode
+    next if line =~ /tr\s+-d/ || line =~ /base64\s+(-w\s*0|--wrap[= ]?0)/
+    port_fails << [f, i + 1,
+                   "shell base64 encode without newline strip — add `| tr -d '\\n'` " \
+                   '(GNU base64 wraps at 76 cols and corrupts the auth header; see #346)']
+  end
+end
+
 unless warns.empty?
   puts "Tracked baseline gaps (WARN — fix and remove from #{baseline_path}):"
   warns.each { |n, id, desc, r| puts "  ~ #{n}: #{desc}\n      #{r}" }
   puts
 end
 
-if fails.empty?
-  puts "OK: #{ok} converter SKILL.md files document all mandatory gates (#{warns.size} tracked baseline gaps)."
+if fails.empty? && port_fails.empty?
+  puts "OK: #{ok} converter SKILL.md files document all mandatory gates " \
+       "(#{warns.size} tracked baseline gaps); portability content-lint clean."
   exit 0
 end
 
-puts "SKILL CONFORMANCE FAILURE"
-puts "A converter SKILL.md is missing a mandatory gate (docs/phase-schema.md)."
-puts "Fix the skill, or — if genuinely N/A — add it to #{baseline_path} with a reason."
-puts
-fails.each { |n, id, desc| puts "  FAIL  #{n}: missing #{id} — #{desc}" }
-puts
-puts "failures: #{fails.size}"
+unless fails.empty?
+  puts "SKILL CONFORMANCE FAILURE"
+  puts "A converter SKILL.md is missing a mandatory gate (docs/phase-schema.md)."
+  puts "Fix the skill, or — if genuinely N/A — add it to #{baseline_path} with a reason."
+  puts
+  fails.each { |n, id, desc| puts "  FAIL  #{n}: missing #{id} — #{desc}" }
+  puts
+  puts "conformance failures: #{fails.size}"
+  puts
+end
+
+unless port_fails.empty?
+  puts "PORTABILITY LINT FAILURE"
+  puts "A script has a known cross-platform footgun (latent on macOS; breaks on Windows/Linux)."
+  puts
+  port_fails.each { |f, ln, msg| puts "  FAIL  #{f}:#{ln} — #{msg}" }
+  puts
+  puts "portability failures: #{port_fails.size}"
+end
 exit 1


### PR DESCRIPTION
## Problem (#346)
`shared/scripts/get-token.sh` builds the HTTP Basic auth header with `printf ... | base64`, but doesn't disable line-wrapping. On **GNU coreutils** `base64` (Git Bash on Windows, Linux CI) the output wraps at 76 columns, injecting newlines. `$( )` strips only the *trailing* newline; the internal ones survive into `Authorization: Basic ${CREDENTIALS}`, producing a malformed multi-line header that Sigma rejects. The failure message blames the credentials ("check SIGMA_CLIENT_ID/SECRET") even though they're valid — burning debugging time.

**Latent on macOS** because BSD `base64` doesn't wrap by default. Reported by @R-Crowder from a real Windows migration.

## Fix
```diff
-CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
```
`tr -d '\n'` (not `base64 -w0`, which BSD/macOS lacks) keeps it cross-platform.

Edited the **canonical** `shared/scripts/get-token.sh` and ran `ruby tools/sync-shared.rb` to fan out to all **12 vendored copies** (per `CONTRIBUTING.md` shared-infra workflow). `tools/check-shared.rb` confirms all copies match canonical.

## Regression gate
Added a **portability content-lint** to `tools/lint-skills.rb` (already run in CI `corpus-check.yml` + the local governance githook): fails if any `*.sh` pipes into `base64` (encode) without a `tr -d '\n'` / `-w0` strip. Verified it flags a deliberately-reverted copy and passes clean on this branch. This closes the "validated only on macOS" blind spot for this bug class.

## Verification
- `ruby tools/check-shared.rb` → all 296 shared copies match canonical ✅
- `ruby tools/lint-skills.rb` → conformance + portability lint clean ✅
- Simulated GNU 76-col wrap (`base64 | fold -w76`) → 4 lines; `| tr -d '\n'` collapses to a single unbroken token ✅

Fixes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)