### PR TITLE
kvza.1/.2 (microstrategy): documentation-ground convert.py classifier

### DIFF
--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/catalogs/aggregation.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/catalogs/aggregation.json
@@ -1,0 +1,15 @@
+{
+  "dimension": "aggregation",
+  "source_tool": "microstrategy",
+  "authoritative_doc": "https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Using_group_value_functions.htm",
+  "sigma_target_doc": "https://help.sigmacomputing.com/docs/aggregate-functions",
+  "on_unmapped_default": "warn + emit UPPER() SQL as a documented degraded passthrough (NEVER silently pass an unknown MicroStrategy function through)",
+  "description": "MicroStrategy metric group-value function (metric expression token) -> Sigma aggregate function (`sigma`, used verbatim by metric_formula) and warehouse SQL aggregate (`sql`, the FN dict used by metric_sql when it emits AE-emulation SQL). The FN dict {source->sql} in convert.py.metric_sql is DERIVED from these rows; an unmapped function no longer silently passes through as fname.upper() — it WARNS loudly first, then emits UPPER() as a documented degraded fallback. Count with a `<Distinct=True>` parameter is COMPOSITIONAL (Count -> CountDistinct) and is resolved in metric_formula() with a cited comment, not as a separate flat row.",
+  "rows": [
+    {"source": "Sum", "sigma": "Sum", "sql": "SUM", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Sum_.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/sum", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+upper"},
+    {"source": "Count", "sigma": "Count", "sql": "COUNT", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Count_.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/count", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+upper", "notes": "Count<Distinct=True> is compositional -> Sigma CountDistinct (handled in metric_formula, not this flat map)."},
+    {"source": "Avg", "sigma": "Avg", "sql": "AVG", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Avg_.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/avg", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+upper"},
+    {"source": "Max", "sigma": "Max", "sql": "MAX", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Max_.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/max", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+upper"},
+    {"source": "Min", "sigma": "Min", "sql": "MIN", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Min_.htm", "sigma_target_ref": "https://help.sigmacomputing.com/docs/min", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+upper"}
+  ]
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/catalogs/control.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/catalogs/control.json
@@ -1,0 +1,13 @@
+{
+  "dimension": "control",
+  "source_tool": "microstrategy",
+  "authoritative_doc": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/intro_add_filters.htm",
+  "sigma_target_doc": "refs/control-parity.md",
+  "on_unmapped_default": "list (documented default control kind for a categorical dossier selector / chapter filter)",
+  "description": "Bound-column data type of a MicroStrategy dossier selector / chapter filter (Bundle.attribute_ctl_type: 'date' | 'number' | 'text', derived from the rendered DESC form's dataType) -> Sigma control kind. convert.py.emit_controls() resolves the control kind through this catalog. Only the date case is special: a Sigma `list` control whose filter target is a DATETIME *or NUMERIC* column posts 200 but Sigma SILENTLY STRIPS the target (reads back filters:null — live-verified on this converter 2026-06-12; datetime is a cross-plugin gotcha, see refs/control-parity.md). Dates become date-range controls; numbers stay `list` but bind through a hidden Text() cast; text is a plain `list`. Unresolvable source attributes / metric-qualification selectors are already recorded LOUDLY in control-scope.json (status: unbound / manual).",
+  "rows": [
+    {"source": "date", "sigma": "date-range", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/getting_started_selector.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "n/a", "notes": "A datetime-bound list control reads back filters:null (dead control) — must be a date-range control with a flat `mode`."},
+    {"source": "number", "sigma": "list", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/getting_started_selector.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "n/a", "notes": "A list-control filter target on a NUMERIC column is silently stripped by Sigma (200 on POST/PUT, filters:null on readback) — numeric selectors bind through a hidden Text() cast column."},
+    {"source": "text", "sigma": "list", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/getting_started_selector.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "n/a", "notes": "Categorical list control (documented default)."}
+  ]
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/catalogs/number-format.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/catalogs/number-format.json
@@ -1,0 +1,15 @@
+{
+  "dimension": "number-format",
+  "source_tool": "microstrategy",
+  "authoritative_doc": "https://www2.microstrategy.com/producthelp/current/MSTRWeb/webhelp/lang_1033/content/Formatting_numeric_values_in_a_visualization.htm",
+  "sigma_target_doc": "https://help.sigmacomputing.com/docs/data-types-and-formats",
+  "on_unmapped_default": "warn + ship UNFORMATTED (None) — NEVER a name/column-substring currency/percent guess",
+  "description": "MicroStrategy metric number-format CATEGORY (Fixed / Currency / Percent / Number / Scientific — the documented Number-format categories) -> Sigma column number format (D3 formatString in {kind:number, formatString}). convert.py.metric_display_format() reads the metric's EXPLICIT MicroStrategy format (metricFormatType / format.values property block) via _mstr_format_category() and resolves the category here. A 'reserved'/'general'/empty format block means 'inherit default' = NO explicit format: the metric ships UNFORMATTED with a LOUD note. This REPLACES the beads-sigma-kvza disease — the old code guessed a $/%/integer format from the metric NAME (pct|percent|margin|ratio|rate) or fact-column NAME (REVENUE|PROFIT|COST|AMOUNT|PRICE, QUANTITY|UNITS|COUNT) with a silent None fallback; that name/column-substring guessing is GONE. Custom (user format-string) masks are not in this flat table — they would be parsed by a cited predicate if MicroStrategy supplied one (the modeling-API bundles seen so far carry empty format blocks).",
+  "rows": [
+    {"source": "currency", "sigma": "$,.2f", "doc_ref": "https://www2.microstrategy.com/producthelp/current/reportdesigner/webhelp/lang_1033/content/formatting_metrics_on_a_report.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+unformatted", "notes": "MSTR Currency category default: currency symbol, thousands separator, 2 decimals."},
+    {"source": "percent", "sigma": ",.2%", "doc_ref": "https://www2.microstrategy.com/producthelp/current/reportdesigner/webhelp/lang_1033/content/formatting_metrics_on_a_report.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+unformatted", "notes": "MSTR Percent: a stored ratio (0.275) renders as 27.50%; Sigma % format multiplies by 100 the same way."},
+    {"source": "fixed", "sigma": ",.2f", "doc_ref": "https://www2.microstrategy.com/producthelp/current/reportdesigner/webhelp/lang_1033/content/formatting_metrics_on_a_report.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+unformatted", "notes": "MSTR Fixed category default: thousands separator, 2 decimal places."},
+    {"source": "number", "sigma": ",.0f", "doc_ref": "https://www2.microstrategy.com/producthelp/current/mstrio-py/mstrio.modeling.metric.metric_format.html", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+unformatted", "notes": "Plain integer with thousands separator."},
+    {"source": "scientific", "sigma": ".2e", "doc_ref": "https://www2.microstrategy.com/producthelp/current/mstrio-py/mstrio.modeling.metric.metric_format.html", "sigma_verified": {"status": "n"}, "on_unmapped": "warn+unformatted", "notes": "MSTR Scientific -> D3 exponential."}
+  ]
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/catalogs/viz-kind.json
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/catalogs/viz-kind.json
@@ -1,0 +1,24 @@
+{
+  "dimension": "viz-kind",
+  "source_tool": "microstrategy",
+  "wired": false,
+  "status": "documentation-only",
+  "authoritative_doc": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm",
+  "sigma_target_doc": "https://help.sigmacomputing.com/docs/add-charts-and-graphs",
+  "on_unmapped_default": "flagged table (data preserved, loud warning) — NEVER silently wrong",
+  "description": "DOCUMENTATION-ONLY — NOT loaded by convert.py. The MicroStrategy dossier converter (scripts/convert.py) currently emits exactly ONE Sigma table element per dossier chapter (viz_chapter); every dossier visual — grid, KPI, chart — collapses to a Sigma table today, so there is NO visualizationType->element-kind code map to ground. This catalog records the ASPIRATIONAL MSTR visualizationType -> Sigma element kind mapping (chart emission is roadmap) drawn from refs/viz-type-mapping.md and kept in sync with the ACTIVE classifier that DOES use it: microstrategy-assessment/scripts/assess.py (VIZ_MAPPED). Only `grid` is on the validated build path (it is what collapses to a Sigma table). Do not wire this into convert.py without real emission code — that would fake coverage the converter does not have.",
+  "rows": [
+    {"source": "grid", "sigma": "table", "build": "validated", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/webhelp/lang_1033/Content/Displaying_a_visual_representation_of_your_data__V.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table", "notes": "Pivot when crossTab:true. The ONLY type on the validated build path — convert.py collapses each chapter to a Sigma table."},
+    {"source": "kpi", "sigma": "kpi-chart", "build": "roadmap", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/Library/en-us/Content/intro_kpi_viz.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table", "notes": "Highest-volume unbuilt type in the demo sweep; currently collapses to a table."},
+    {"source": "bar_chart", "sigma": "bar-chart", "build": "roadmap", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table"},
+    {"source": "line_chart", "sigma": "line-chart", "build": "roadmap", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/AdvancedReportingGuide/WebHelp/Lang_1033/Content/Line.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table"},
+    {"source": "area_chart", "sigma": "area-chart", "build": "roadmap", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table"},
+    {"source": "pie_chart", "sigma": "pie-chart", "build": "roadmap", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MCG-Workstation/en-us/Content/Creating_a_graph_with_pies_or_rings.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table"},
+    {"source": "ring_chart", "sigma": "donut-chart", "build": "roadmap", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MCG-Workstation/en-us/Content/Creating_a_graph_with_pies_or_rings.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table", "notes": "MSTR ring = pie/donut variant."},
+    {"source": "combo_chart", "sigma": "combo-chart", "build": "roadmap", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table"},
+    {"source": "bubble_chart", "sigma": "scatter-chart", "build": "roadmap", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table", "notes": "Size slot -> Sigma scatter."},
+    {"source": "multi_metric_kpi", "sigma": "kpi-chart", "build": "roadmap", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/Library/en-us/Content/intro_kpi_viz.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table", "notes": "One Sigma KPI per metric."},
+    {"source": "compound_grid", "sigma": "table", "build": "roadmap", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/webhelp/lang_1033/Content/Displaying_a_visual_representation_of_your_data__V.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table"},
+    {"source": "heat_map", "sigma": "table", "build": "fallback", "doc_ref": "https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm", "sigma_verified": {"status": "n"}, "on_unmapped": "flagged-table", "notes": "Size+color tile grid has no Sigma analog -> flagged table."}
+  ]
+}

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/microstrategy-coverage.md
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/refs/microstrategy-coverage.md
@@ -1,0 +1,88 @@
+# Microstrategy → Sigma — dashboard classifier coverage matrix
+
+> **GENERATED — do not edit by hand.** Regenerate with `python3 scripts/gen-coverage-matrix.py --catalogs refs/catalogs --skill microstrategy --out refs/microstrategy-coverage.md`. The JSON catalogs in `refs/catalogs/` are the single source of truth; the classifier (`scripts/build_workbook.py` / `build-sigma-workbook.py`) LOADS them via `shared/lib/coverage_catalog.py`. A no-drift test asserts this file matches the catalogs.
+
+Every documented source construct maps to a real, current Sigma target or a loud fallback — no silent wrong-defaults, no name-substring guessing (beads-sigma-kvza).
+
+**`sigma_verified` legend:** ✅ y = the mapped Sigma target resolved at **query time** in a live migration (no `type=error` column) on the date shown; 🟡 n = target is documented but not yet query-verified.
+
+**Coverage:** 25 documented constructs across 4 dimensions; 0 live-verified.
+
+## Visualization / chart kind
+
+_DOCUMENTATION-ONLY — NOT loaded by convert.py. The MicroStrategy dossier converter (scripts/convert.py) currently emits exactly ONE Sigma table element per dossier chapter (viz_chapter); every dossier visual — grid, KPI, chart — collapses to a Sigma table today, so there is NO visualizationType->element-kind code map to ground. This catalog records the ASPIRATIONAL MSTR visualizationType -> Sigma element kind mapping (chart emission is roadmap) drawn from refs/viz-type-mapping.md and kept in sync with the ACTIVE classifier that DOES use it: microstrategy-assessment/scripts/assess.py (VIZ_MAPPED). Only `grid` is on the validated build path (it is what collapses to a Sigma table). Do not wire this into convert.py without real emission code — that would fake coverage the converter does not have._
+
+Authoritative source: <https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `grid` | [doc](https://www2.microstrategy.com/producthelp/Current/MSTRWeb/webhelp/lang_1033/Content/Displaying_a_visual_representation_of_your_data__V.htm) | `table` | 🟡 n | flagged-table |
+| | | | | _Pivot when crossTab:true. The ONLY type on the validated build path — convert.py collapses each chapter to a Sigma table._ |
+| `kpi` | [doc](https://www2.microstrategy.com/producthelp/Current/Library/en-us/Content/intro_kpi_viz.htm) | `kpi-chart` | 🟡 n | flagged-table |
+| | | | | _Highest-volume unbuilt type in the demo sweep; currently collapses to a table._ |
+| `bar_chart` | [doc](https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm) | `bar-chart` | 🟡 n | flagged-table |
+| `line_chart` | [doc](https://www2.microstrategy.com/producthelp/Current/AdvancedReportingGuide/WebHelp/Lang_1033/Content/Line.htm) | `line-chart` | 🟡 n | flagged-table |
+| `area_chart` | [doc](https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm) | `area-chart` | 🟡 n | flagged-table |
+| `pie_chart` | [doc](https://www2.microstrategy.com/producthelp/Current/MCG-Workstation/en-us/Content/Creating_a_graph_with_pies_or_rings.htm) | `pie-chart` | 🟡 n | flagged-table |
+| `ring_chart` | [doc](https://www2.microstrategy.com/producthelp/Current/MCG-Workstation/en-us/Content/Creating_a_graph_with_pies_or_rings.htm) | `donut-chart` | 🟡 n | flagged-table |
+| | | | | _MSTR ring = pie/donut variant._ |
+| `combo_chart` | [doc](https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm) | `combo-chart` | 🟡 n | flagged-table |
+| `bubble_chart` | [doc](https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm) | `scatter-chart` | 🟡 n | flagged-table |
+| | | | | _Size slot -> Sigma scatter._ |
+| `multi_metric_kpi` | [doc](https://www2.microstrategy.com/producthelp/Current/Library/en-us/Content/intro_kpi_viz.htm) | `kpi-chart` | 🟡 n | flagged-table |
+| | | | | _One Sigma KPI per metric._ |
+| `compound_grid` | [doc](https://www2.microstrategy.com/producthelp/Current/MSTRWeb/webhelp/lang_1033/Content/Displaying_a_visual_representation_of_your_data__V.htm) | `table` | 🟡 n | flagged-table |
+| `heat_map` | [doc](https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/viz_gallery.htm) | `table` | 🟡 n | flagged-table |
+| | | | | _Size+color tile grid has no Sigma analog -> flagged table._ |
+
+## Number format
+
+_MicroStrategy metric number-format CATEGORY (Fixed / Currency / Percent / Number / Scientific — the documented Number-format categories) -> Sigma column number format (D3 formatString in {kind:number, formatString}). convert.py.metric_display_format() reads the metric's EXPLICIT MicroStrategy format (metricFormatType / format.values property block) via _mstr_format_category() and resolves the category here. A 'reserved'/'general'/empty format block means 'inherit default' = NO explicit format: the metric ships UNFORMATTED with a LOUD note. This REPLACES the beads-sigma-kvza disease — the old code guessed a $/%/integer format from the metric NAME (pct|percent|margin|ratio|rate) or fact-column NAME (REVENUE|PROFIT|COST|AMOUNT|PRICE, QUANTITY|UNITS|COUNT) with a silent None fallback; that name/column-substring guessing is GONE. Custom (user format-string) masks are not in this flat table — they would be parsed by a cited predicate if MicroStrategy supplied one (the modeling-API bundles seen so far carry empty format blocks)._
+
+Authoritative source: <https://www2.microstrategy.com/producthelp/current/MSTRWeb/webhelp/lang_1033/content/Formatting_numeric_values_in_a_visualization.htm>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `currency` | [doc](https://www2.microstrategy.com/producthelp/current/reportdesigner/webhelp/lang_1033/content/formatting_metrics_on_a_report.htm) | `$,.2f` | 🟡 n | warn+unformatted |
+| | | | | _MSTR Currency category default: currency symbol, thousands separator, 2 decimals._ |
+| `percent` | [doc](https://www2.microstrategy.com/producthelp/current/reportdesigner/webhelp/lang_1033/content/formatting_metrics_on_a_report.htm) | `,.2%` | 🟡 n | warn+unformatted |
+| | | | | _MSTR Percent: a stored ratio (0.275) renders as 27.50%; Sigma % format multiplies by 100 the same way._ |
+| `fixed` | [doc](https://www2.microstrategy.com/producthelp/current/reportdesigner/webhelp/lang_1033/content/formatting_metrics_on_a_report.htm) | `,.2f` | 🟡 n | warn+unformatted |
+| | | | | _MSTR Fixed category default: thousands separator, 2 decimal places._ |
+| `number` | [doc](https://www2.microstrategy.com/producthelp/current/mstrio-py/mstrio.modeling.metric.metric_format.html) | `,.0f` | 🟡 n | warn+unformatted |
+| | | | | _Plain integer with thousands separator._ |
+| `scientific` | [doc](https://www2.microstrategy.com/producthelp/current/mstrio-py/mstrio.modeling.metric.metric_format.html) | `.2e` | 🟡 n | warn+unformatted |
+| | | | | _MSTR Scientific -> D3 exponential._ |
+
+## Aggregation
+
+_MicroStrategy metric group-value function (metric expression token) -> Sigma aggregate function (`sigma`, used verbatim by metric_formula) and warehouse SQL aggregate (`sql`, the FN dict used by metric_sql when it emits AE-emulation SQL). The FN dict {source->sql} in convert.py.metric_sql is DERIVED from these rows; an unmapped function no longer silently passes through as fname.upper() — it WARNS loudly first, then emits UPPER() as a documented degraded fallback. Count with a `<Distinct=True>` parameter is COMPOSITIONAL (Count -> CountDistinct) and is resolved in metric_formula() with a cited comment, not as a separate flat row._
+
+Authoritative source: <https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Using_group_value_functions.htm>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `Sum` | [doc](https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Sum_.htm) | `Sum` | 🟡 n | warn+upper |
+| `Count` | [doc](https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Count_.htm) | `Count` | 🟡 n | warn+upper |
+| | | | | _Count<Distinct=True> is compositional -> Sigma CountDistinct (handled in metric_formula, not this flat map)._ |
+| `Avg` | [doc](https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Avg_.htm) | `Avg` | 🟡 n | warn+upper |
+| `Max` | [doc](https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Max_.htm) | `Max` | 🟡 n | warn+upper |
+| `Min` | [doc](https://www2.microstrategy.com/producthelp/Current/FunctionsRef/Content/FuncRef/Min_.htm) | `Min` | 🟡 n | warn+upper |
+
+## Control / filter
+
+_Bound-column data type of a MicroStrategy dossier selector / chapter filter (Bundle.attribute_ctl_type: 'date' | 'number' | 'text', derived from the rendered DESC form's dataType) -> Sigma control kind. convert.py.emit_controls() resolves the control kind through this catalog. Only the date case is special: a Sigma `list` control whose filter target is a DATETIME *or NUMERIC* column posts 200 but Sigma SILENTLY STRIPS the target (reads back filters:null — live-verified on this converter 2026-06-12; datetime is a cross-plugin gotcha, see refs/control-parity.md). Dates become date-range controls; numbers stay `list` but bind through a hidden Text() cast; text is a plain `list`. Unresolvable source attributes / metric-qualification selectors are already recorded LOUDLY in control-scope.json (status: unbound / manual)._
+
+Authoritative source: <https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/intro_add_filters.htm>
+
+| construct | doc ref | Sigma target | sigma_verified | on-unmapped |
+|---|---|---|---|---|
+| `date` | [doc](https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/getting_started_selector.htm) | `date-range` | 🟡 n | n/a |
+| | | | | _A datetime-bound list control reads back filters:null (dead control) — must be a date-range control with a flat `mode`._ |
+| `number` | [doc](https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/getting_started_selector.htm) | `list` | 🟡 n | n/a |
+| | | | | _A list-control filter target on a NUMERIC column is silently stripped by Sigma (200 on POST/PUT, filters:null on readback) — numeric selectors bind through a hidden Text() cast column._ |
+| `text` | [doc](https://www2.microstrategy.com/producthelp/Current/MSTRWeb/WebHelp/Lang_1033/Content/getting_started_selector.htm) | `list` | 🟡 n | n/a |
+| | | | | _Categorical list control (documented default)._ |
+
+---
+_Compositional constructs that do not serialize to a flat table (Set Analysis, filtered `*If`, ratio measures, TO_CHAR/Excel mask parsers, count-on-joined-view) stay as cited predicates in the classifier; this matrix covers the enumerable maps._

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/convert.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/convert.py
@@ -35,7 +35,37 @@ args are given.
 """
 import argparse
 import json
+import os
 import re
+import sys
+
+# ── documentation-grounded mapping catalogs (SINGLE SOURCE OF TRUTH) ─────────
+# Every enumerable classifier map below is loaded from refs/catalogs/<dim>.json —
+# cited rows (MicroStrategy source doc + Sigma target + sigma_verified), and a
+# LOUD fallback on anything unmapped. NO inline mapping literal may bypass these
+# catalogs (grep-enforced by tests/test_grounding.py). The human-readable
+# coverage matrix in refs/microstrategy-coverage.md is GENERATED from these files.
+# Loader: shared/lib/coverage_catalog.py (synced to scripts/lib/). Design mirrors
+# the beads-sigma-kvza / -93ps contract: catalog = data, code = thin resolver.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import coverage_catalog as _cc  # noqa: E402
+_CAT_DIR = _cc.default_catalog_dir(__file__)
+AGG_CAT = _cc.load(_CAT_DIR, "aggregation")     # MSTR group function -> Sigma/SQL aggregate
+FMT_CAT = _cc.load(_CAT_DIR, "number-format")   # MSTR format category -> Sigma number format
+CTRL_CAT = _cc.load(_CAT_DIR, "control")        # bound-column type    -> Sigma control kind
+# NB: refs/catalogs/viz-kind.json is DOCUMENTATION-ONLY and is deliberately NOT
+# loaded here. convert.py emits exactly one Sigma table per dossier chapter
+# (see Bundle.viz_chapter); there is no visualizationType->element-kind code map
+# to ground yet (chart emission is roadmap — the ACTIVE viz classifier lives in
+# microstrategy-assessment/scripts/assess.py VIZ_MAPPED). Loading it here would
+# fake wiring the converter does not have.
+
+# FN: MSTR metric group function -> warehouse SQL aggregate, DERIVED from the
+# aggregation catalog (formerly an inline dict literal mapping Sum/Count/Avg/
+# Max/Min to their uppercased SQL names). metric_sql() resolves through
+# resolve_or_warn so an unmapped function WARNS loudly (never a silent
+# passthrough), then still emits UPPER() as a documented degraded fallback.
+FN = {r["source"]: r["sql"] for r in AGG_CAT.rows if r.get("sql")}
 
 
 def friendly(col: str) -> str:
@@ -51,6 +81,10 @@ def slug(s: str) -> str:
 class Bundle:
     def __init__(self, raw):
         self.raw = raw
+        # LOUD-fallback sink: catalog resolvers append standardized warnings here
+        # (aggregation / number-format) from deep in the emit recursion; main()
+        # prints the deduped union alongside build_workbook_spec's warnings.
+        self.warnings = []
         self.tables = raw["tables"]          # logical table id -> def
         self.attributes = raw["attributes"]  # attribute id -> def
         self.metrics = raw["metrics"]        # metric id -> def
@@ -179,6 +213,12 @@ class Bundle:
                             distinct = True
                         j += 1
                     i = j  # skip past the parameter block
+                # COMPOSITIONAL (cited: refs/catalogs/aggregation.json Count row) —
+                # MSTR Count<Distinct=True> -> Sigma CountDistinct. Not a flat
+                # catalog row (the Distinct=True is an expression parameter, not a
+                # distinct function token); the plain group functions (Sum/Count/
+                # Avg/Max/Min) share tokens with their Sigma names, so metric_formula
+                # emits the MSTR function name verbatim as the Sigma aggregate.
                 if fname == "Count" and distinct:
                     fname = "CountDistinct"
                 out.append(fname)
@@ -220,8 +260,6 @@ class Bundle:
     def metric_sql(self, mid, fact_alias="ORDER_FACT"):
         m = self.metrics[mid]
         toks = m["expression"]["tokens"]
-        FN = {"Sum": "SUM", "Count": "COUNT", "Avg": "AVG", "Max": "MAX",
-              "Min": "MIN"}
         out = []
         distinct_pending = False
         i = 0
@@ -239,7 +277,18 @@ class Bundle:
                             distinct = True
                         j += 1
                     i = j
-                out.append(FN.get(fname, fname.upper()))
+                # DOCUMENTATION-GROUNDED (refs/catalogs/aggregation.json). An
+                # unmapped MSTR function no longer silently passes through as
+                # fname.upper(): resolve_or_warn appends a LOUD warning, then we
+                # emit UPPER() only as a documented degraded fallback.
+                sql_fn = FN.get(fname)
+                if sql_fn is None:
+                    AGG_CAT.resolve_or_warn(
+                        fname, self.warnings,
+                        context="metric %r AE-emulation SQL"
+                                % m["information"]["name"])
+                    sql_fn = fname.upper()
+                out.append(sql_fn)
                 distinct_pending = distinct
             elif ty == "object_reference":
                 tgt = t.get("target", {})
@@ -357,27 +406,50 @@ class Bundle:
             + f'\nFROM F f\nJOIN F w ON w."{qkey_f}" = f."{qkey_f}"\n  AND ('
             + "\n    OR ".join(conds) + ")")
 
-    # ---- display format for a metric (MSTR bundle format blocks are empty,
-    # so derive from semantics: count/quantity -> integer, ratio/pct -> percent,
-    # money facts -> currency)
-    def metric_display_format(self, mid):
-        m = self.metrics[mid]
-        name = m["information"]["name"]
-        if re.search(r"pct|percent|margin|ratio|rate", name, re.I):
-            return {"kind": "number", "formatString": ",.2%"}
-        toks = m["expression"]["tokens"]
-        funcs = [t["value"] for t in toks if t.get("type") == "function"
-                 and t.get("value") not in ("=",)]
-        fact_cols = [self.fact_col[t["target"]["objectId"]] for t in toks
-                     if t.get("type") == "object_reference"
-                     and t.get("target", {}).get("subType") == "fact"]
-        if any(f.startswith("Count") for f in funcs):
-            return {"kind": "number", "formatString": ",.0f"}
-        if any(re.search(r"REVENUE|PROFIT|COST|AMOUNT|PRICE", c) for c in fact_cols):
-            return {"kind": "number", "formatString": "$,.2f"}
-        if any(re.search(r"QUANTITY|UNITS|COUNT", c) for c in fact_cols):
-            return {"kind": "number", "formatString": ",.0f"}
+    # ---- display format for a metric — DOCUMENTATION-GROUNDED (beads-sigma-kvza)
+    @staticmethod
+    def _mstr_format_category(m):
+        """Return the metric's EXPLICIT MicroStrategy number-format category
+        (lowercased: 'currency' / 'percent' / 'fixed' / 'number' / 'scientific',
+        etc.), or None when the metric carries no explicit format. Compositional
+        cited predicate — the flat category->Sigma-format map lives in
+        refs/catalogs/number-format.json (authoritative_doc). MicroStrategy
+        expresses a metric's format via `metricFormatType` (a named category)
+        and/or a `format.values` property block; a 'reserved'/'general' type with
+        an empty format block means 'inherit the default' = NO explicit format."""
+        ft = str(m.get("metricFormatType") or "").strip().lower()
+        if ft and ft not in ("reserved", "default", "general", "automatic"):
+            return ft
+        fmt = m.get("format") or {}
+        for v in (fmt.get("values") or []):
+            if isinstance(v, dict):
+                c = v.get("category") or v.get("formatCategory") or v.get("name")
+                if c:
+                    return str(c).strip().lower()
         return None
+
+    def metric_display_format(self, mid):
+        """Sigma number format for a metric, GROUNDED in the metric's real
+        MicroStrategy format via refs/catalogs/number-format.json. When there is
+        NO explicit MSTR format we ship the metric UNFORMATTED and record a LOUD
+        note — we do NOT guess a currency/percent/integer format from the metric
+        or fact-column NAME. (The old name/column-substring guessing —
+        pct|percent|margin -> %, REVENUE|PROFIT|COST -> $ — with a silent None
+        fallback was the beads-sigma-kvza disease and is GONE.)"""
+        m = self.metrics[mid]
+        cat = self._mstr_format_category(m)
+        if not cat:
+            self.warnings.append(
+                "⚠ number-format: metric %r has no explicit MicroStrategy number "
+                "format (metricFormatType=%r) — shipping UNFORMATTED; set an "
+                "explicit format in Sigma if needed (no name-substring guess)."
+                % (m["information"]["name"], m.get("metricFormatType")))
+            return None
+        row = FMT_CAT.resolve_or_warn(
+            cat, self.warnings, context="metric %r" % m["information"]["name"])
+        if not row or not row.get("sigma"):
+            return None
+        return {"kind": "number", "formatString": row["sigma"]}
 
     # ---- dossier filter signals (chapter filters + selectors)
     @staticmethod
@@ -607,7 +679,14 @@ def emit_controls(b: "Bundle", pages, page_ctx, warnings):
 
         key_col, desc_col = b.attribute_unit_cols(aid)
         ctl_col = desc_col or key_col   # what MSTR renders in the selector
-        ctl_type = b.attribute_ctl_type(aid)
+        ctl_type = b.attribute_ctl_type(aid)   # 'date' | 'number' | 'text'
+        # DOCUMENTATION-GROUNDED control kind (refs/catalogs/control.json). The
+        # bound-column type resolves to a Sigma control kind; a miss warns loudly
+        # and falls back to the documented default 'list'. The as_text cast below
+        # still keys off ctl_type == 'number' (numeric list targets are silently
+        # stripped by Sigma — see the catalog row note).
+        ctl_kind_row = CTRL_CAT.resolve_or_warn(ctl_type, warnings, context=src)
+        ctl_kind = (ctl_kind_row or {}).get("sigma") or "list"
         filters, wired = [], []
         for ctx in ctxs:
             cid = find_or_add_col(ctx, ctl_col, as_text=(ctl_type == "number"))
@@ -631,7 +710,7 @@ def emit_controls(b: "Bundle", pages, page_ctx, warnings):
                "kind": "control", "controlId": ctl_id_for(label),
                "name": label,
                "filters": filters}
-        if ctl_type == "date":
+        if ctl_kind == "date-range":
             # date-range needs no `source` but DOES require a flat `mode` —
             # without it the POST fails with the misleading "Invalid kind:
             # control" (live-verified cross-plugin; see control-parity.md)
@@ -1152,7 +1231,10 @@ def main():
               f"{[w['elementId'] for w in c['wired']]} scope={c['scope']}")
     for u in control_scope["unbound"]:
         print(f"control UNBOUND [{u['status']}]: {u['sourceName']} — {u['reason']}")
-    for w in warnings:
+    # LOUD fallbacks: the catalog resolvers append to b.warnings (aggregation /
+    # number-format, from build_dm_spec + build_workbook_spec) and to `warnings`
+    # (control, from emit_controls). Print the deduped union.
+    for w in dict.fromkeys(list(b.warnings) + list(warnings)):
         print(f"WARN: {w}")
     print(f"signals: {control_scope['sourceFilterSignals']} filter signal(s), "
           f"{len(control_scope['controls'])} control(s) emitted")

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/tests/test_grounding.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/tests/test_grounding.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Grounding regression for convert.py (beads-sigma-kvza / microstrategy).
+
+Proves the MicroStrategy dossier classifier is documentation-grounded and
+loud-on-unmapped:
+  1. CATALOGS      — the JSON catalogs under refs/catalogs/ load, are cited
+     (real doc URLs), have unique sources, and name microstrategy as the source.
+  2. NO INLINE MAP — the WIRED maps (aggregation FN, number-format, control) are
+     LOADED from the catalogs; no residual inline literal bypasses them, and the
+     two named silent defaults (name/column-substring format guessing; the
+     FN.get(fname, fname.upper()) aggregate passthrough) are GONE.
+  3. LOUD FALLBACKS — an unmapped MSTR aggregate function, a metric with no
+     explicit MSTR number format (and an explicit-but-unmapped one), and an
+     unknown control-bound type each WARN (never a silent wrong default).
+  4. COVERAGE MATRIX — refs/microstrategy-coverage.md is regenerated from the
+     catalogs (no drift).
+
+No byte-golden: convert.py is deterministic but this pass intentionally CHANGES
+format output (the disease cure removes the name-substring guesses), so the
+contract is verbatim extraction of the enumerable map + the loud-fallback units
+above, plus an end-to-end smoke run on the offline fixture bundle.
+
+Run: python3 tests/test_grounding.py   (exit 0 = pass)
+"""
+import json, os, re, subprocess, sys, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+SCRIPTS = os.path.join(SKILL, "scripts")
+CONV = os.path.join(SCRIPTS, "convert.py")
+CATDIR = os.path.join(SKILL, "refs", "catalogs")
+BUNDLE = os.path.join(SKILL, "fixtures", "bundle.json")
+AE_WINNERS = os.path.join(SKILL, "fixtures", "ae_winners.json")
+COVERAGE = os.path.join(SKILL, "refs", "microstrategy-coverage.md")
+sys.path.insert(0, SCRIPTS)
+sys.path.insert(0, os.path.join(SCRIPTS, "lib"))
+
+WIRED_DIMS = {"number-format", "aggregation", "control"}
+
+
+def _new_bundle():
+    """A Bundle with __init__ bypassed — enough state for the unit-level
+    classifier methods (metric_sql / metric_display_format) without a full
+    bundle.json."""
+    import convert
+    b = convert.Bundle.__new__(convert.Bundle)
+    b.warnings = []
+    b.metrics = {}
+    b.fact_col = {}
+    return b
+
+
+def test_catalogs_valid():
+    import coverage_catalog as cc
+    cats = cc.load_all(CATDIR)
+    assert set(cats) == {"viz-kind", "number-format", "aggregation", "control"}, sorted(cats)
+    for name, cat in cats.items():
+        assert cat.rows, name
+        assert cat.source_tool == "microstrategy", (name, cat.source_tool)
+        assert cat.authoritative_doc.startswith("http"), (name, cat.authoritative_doc)
+        seen = set()
+        for r in cat.rows:
+            key = str(r["source"]).lower()
+            assert key not in seen, "duplicate source in %s: %s" % (name, key)
+            seen.add(key)
+            assert r.get("doc_ref", "").startswith("http"), (name, r["source"])
+            assert r.get("sigma") is not None, (name, r["source"])
+            assert (r.get("sigma_verified") or {}).get("status") == "n", \
+                ("this pass defers live query-verification — every row must be "
+                 "status 'n': %s/%s" % (name, r["source"]))
+    # viz-kind is documentation-only and must SAY so (not wired into convert.py)
+    viz = cats["viz-kind"]
+    assert getattr(viz, "rows"), "viz-kind"
+    raw = json.load(open(os.path.join(CATDIR, "viz-kind.json")))
+    assert raw.get("wired") is False and raw.get("status") == "documentation-only", \
+        "viz-kind.json must be flagged documentation-only / wired:false"
+    print("[ok] catalogs: 4 dimensions load, cited, unique sources, all status=n")
+
+
+def test_no_inline_maps():
+    src = open(CONV).read()
+    assert "coverage_catalog" in src and "_cc.load(" in src, "builder does not load catalogs"
+    # WIRED maps must be catalog-derived / catalog-resolved, not inline literals
+    assert "for r in AGG_CAT.rows" in src, "FN not derived from aggregation catalog"
+    assert "AGG_CAT.resolve_or_warn(" in src, "aggregation miss not routed through loud resolver"
+    assert "FMT_CAT.resolve_or_warn(" in src, "number-format not resolved via catalog"
+    assert "CTRL_CAT.resolve_or_warn(" in src, "control kind not resolved via catalog"
+    # viz-kind must NOT be loaded (no fake wiring)
+    assert '_cc.load(_CAT_DIR, "viz-kind")' not in src and \
+           "_cc.load(_CAT_DIR, 'viz-kind')" not in src, \
+        "viz-kind is documentation-only — convert.py must not load it"
+    # the named silent defaults must be GONE (precise code patterns, not prose)
+    assert '"Sum": "SUM"' not in src, "inline FN literal still present"
+    assert "FN.get(fname, fname.upper())" not in src, "silent aggregate passthrough still present"
+    assert 're.search(r"pct' not in src, "name-substring % guess still present"
+    assert 're.search(r"REVENUE' not in src, "column-substring $ guess still present"
+    print("[ok] no-inline-map: agg/format/control catalog-resolved; name/column guesses removed")
+
+
+def test_loud_unknown_agg():
+    """An unmapped MSTR group function WARNS, then still emits UPPER() SQL as a
+    documented degraded fallback (never a silent passthrough)."""
+    b = _new_bundle()
+    b.metrics = {"m1": {"information": {"name": "Weird Metric"},
+                        "expression": {"tokens": [
+                            {"type": "function", "value": "Stddev"},
+                            {"type": "character", "value": "("},
+                            {"type": "object_reference",
+                             "target": {"subType": "fact", "objectId": "f1"}},
+                            {"type": "character", "value": ")"},
+                        ]}}}
+    b.fact_col = {"f1": "SOME_COL"}
+    sql = b.metric_sql("m1", "FACT")
+    assert "STDDEV(FACT.SOME_COL)" in sql, sql
+    assert any("aggregation" in w and "Stddev" in w for w in b.warnings), b.warnings
+    # a MAPPED function does NOT warn
+    b2 = _new_bundle()
+    b2.metrics = {"m2": {"information": {"name": "Total"},
+                         "expression": {"tokens": [
+                             {"type": "function", "value": "Sum"},
+                             {"type": "character", "value": "("},
+                             {"type": "object_reference",
+                              "target": {"subType": "fact", "objectId": "f1"}},
+                             {"type": "character", "value": ")"},
+                         ]}}}
+    b2.fact_col = {"f1": "AMT"}
+    assert b2.metric_sql("m2", "F").startswith("SUM("), b2.metric_sql("m2", "F")
+    assert not b2.warnings, b2.warnings
+    print("[ok] loud agg: unmapped MSTR function -> warn + UPPER() degraded fallback")
+
+
+def test_loud_unknown_format():
+    """No explicit MSTR format -> loud note + None (no name guess). An explicit
+    mapped category -> the catalog format. An explicit UNMAPPED category ->
+    loud note + None."""
+    b = _new_bundle()
+    b.metrics = {
+        "reserved": {"information": {"name": "Order Count"},
+                     "metricFormatType": "reserved",
+                     "format": {"header": [], "values": []}},
+        "pctname": {"information": {"name": "Profit Margin Pct"},
+                    "metricFormatType": "reserved",
+                    "format": {"header": [], "values": []}},
+        "cur": {"information": {"name": "Revenue"},
+                "metricFormatType": "Currency",
+                "format": {"header": [], "values": []}},
+        "frac": {"information": {"name": "Odd Fmt"},
+                 "metricFormatType": "Fraction",
+                 "format": {"header": [], "values": []}},
+    }
+    # reserved (no explicit format) -> loud note, None
+    assert b.metric_display_format("reserved") is None
+    assert any("no explicit MicroStrategy number format" in w
+               and "Order Count" in w for w in b.warnings), b.warnings
+    # a metric NAMED "...Pct" no longer triggers a silent % guess
+    assert b.metric_display_format("pctname") is None, \
+        "name-substring percent guess must be gone"
+    # a REAL MSTR format category maps via the catalog
+    assert b.metric_display_format("cur") == {"kind": "number", "formatString": "$,.2f"}, \
+        b.metric_display_format("cur")
+    # an explicit but UNMAPPED category warns loudly and ships unformatted
+    n_before = len(b.warnings)
+    assert b.metric_display_format("frac") is None
+    assert any("number-format" in w and "fraction" in w.lower()
+               for w in b.warnings[n_before:]), b.warnings[n_before:]
+    print("[ok] loud format: no/unmapped MSTR format -> warn + unformatted; mapped -> catalog format")
+
+
+def test_control_catalog():
+    """Control-bound type resolves to a Sigma control kind via the catalog;
+    an unknown kind warns loudly and falls back to the documented default."""
+    import convert
+    assert convert.CTRL_CAT.target("date") == "date-range"
+    assert convert.CTRL_CAT.target("number") == "list"
+    assert convert.CTRL_CAT.target("text") == "list"
+    warns = []
+    assert convert.CTRL_CAT.resolve_or_warn("weird_kind", warns) is None
+    assert warns and "control" in warns[0], warns
+    print("[ok] control: date->date-range, number/text->list; unknown warns")
+
+
+def test_coverage_matrix_fresh():
+    r = subprocess.run(
+        [sys.executable, os.path.join(SCRIPTS, "gen-coverage-matrix.py"),
+         "--catalogs", CATDIR, "--skill", "microstrategy",
+         "--out", COVERAGE, "--check"],
+        capture_output=True, text=True)
+    assert r.returncode == 0, ("coverage matrix stale — regenerate:\n" + r.stderr)
+    print("[ok] coverage matrix: refs/microstrategy-coverage.md matches the catalogs")
+
+
+def test_e2e_offline_fixture():
+    """End-to-end smoke on the offline fixture bundle: the converter still runs
+    deterministically, every metric now ships UNFORMATTED with a LOUD note (the
+    fixture carries no explicit MSTR format), and NO guessed format survives."""
+    with tempfile.TemporaryDirectory() as d:
+        r = subprocess.run(
+            [sys.executable, CONV, "--bundle", BUNDLE,
+             "--connection-id", "conn-x", "--database", "CSA",
+             "--folder-id", "fld-x", "--ae-winners", AE_WINNERS,
+             "--out-dm", os.path.join(d, "dm.json"),
+             "--out-wb", os.path.join(d, "wb.json"),
+             "--out-layout", os.path.join(d, "layout.xml"),
+             "--control-scope-out", os.path.join(d, "cs.json")],
+            capture_output=True, text=True, cwd=d)
+        assert r.returncode == 0, r.stderr
+        out = r.stdout + r.stderr
+        assert "no explicit MicroStrategy number format" in out, out
+        wb = open(os.path.join(d, "wb.json")).read()
+        dm = open(os.path.join(d, "dm.json")).read()
+        assert "formatString" not in wb and "formatString" not in dm, \
+            "a guessed number format survived the disease cure"
+    print("[ok] e2e: fixture builds; metrics ship unformatted + loud; no guessed format")
+
+
+if __name__ == "__main__":
+    test_catalogs_valid()
+    test_no_inline_maps()
+    test_loud_unknown_agg()
+    test_loud_unknown_format()
+    test_control_catalog()
+    test_coverage_matrix_fresh()
+    test_e2e_offline_fixture()
+    print("ALL PASS")


### PR DESCRIPTION
Grounds MicroStrategy's format/agg/control via the Python `coverage_catalog` loader. **Kills the `metric_display_format` name/column-substring guess** (pct/margin→%, REVENUE/PROFIT→$) → real format or nil + loud note. Grounds the FN agg map + makes an unmapped MSTR group-function a loud warn (was silent `fname.upper()` passthrough). viz-kind is documentation-only (convert.py emits one table per dossier chapter — chart emission is roadmap; noted honestly in coverage.md). refs/microstrategy-coverage.md generated; tests/test_grounding.py passes. `sigma_verified=n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)