### PR TITLE
kvza.3: warn on absent dashboard geometry instead of silent auto-grid (QS/TS/Cognos)

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/apply-layout.mjs
@@ -147,6 +147,10 @@ for (const p of spec.pages || []) {
   if (xml) pageBlocks.push(xml);
 }
 if (!pageBlocks.length) { console.log('no layoutable pages — nothing to lay out'); process.exit(0); }
+// beads-sigma-kvza.3: the band layout is SYNTHESIZED from element order — the Cognos
+// report's pixel geometry is not read — so say so LOUDLY rather than let it read as
+// source-faithful placement.
+console.warn(`⚠ layout: synthesized a banded grid for ${pageBlocks.length} page(s) from element order — Cognos report pixel geometry is not read, so placement is NOT source-faithful; review it.`);
 spec.layout = `<?xml version="1.0" encoding="utf-8"?>\n${pageBlocks.join('\n')}`;
 for (const k of ['workbookId', 'url', 'ownerId', 'createdBy', 'updatedBy', 'createdAt', 'updatedAt', 'latestDocumentVersion', 'documentVersion']) delete spec[k];
 if (a.folder && !spec.folderId) spec.folderId = a.folder;

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
@@ -146,6 +146,11 @@ def layout_sheet(sheet, v2e, eids_for_sheet)
 
   # fallback: 2-per-row flow over this sheet's mapped elements (preserving sheet order)
   if placed.empty?
+    # beads-sigma-kvza.3: no source visual geometry (positions absent) — say so
+    # LOUDLY instead of silently synthesizing a grid that looks source-faithful.
+    warn "⚠ layout: QuickSight sheet '#{sheet['Name'] || sheet['SheetId'] || 'sheet'}' has no " \
+         "source visual geometry (positions absent) — SYNTHESIZED a 2-per-row auto-flow; " \
+         "placement is NOT source-faithful, review it."
     sheet_eids = (sheet['Visuals'] || []).map { |v| _t, inner = v.first; v2e[inner['VisualId']] }
                                           .compact.select { |eid| eids_for_sheet.include?(eid) }
     col = 1; row = 1

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/apply_layouts.py
@@ -216,6 +216,11 @@ def build_layout(spec, tiles=None, controls=None):
         elems = [{"id": e["id"], "kind": e["kind"]} for e in main["elements"]
                  if e.get("kind") not in ("container", "control")
                  and not str(e.get("id", "")).startswith("band-")]
+        # beads-sigma-kvza.3: no source geometry (layout.tiles absent) — say so
+        # LOUDLY instead of silently synthesizing a grid that looks source-faithful.
+        print("⚠ layout: no ThoughtSpot tile geometry (layout.tiles absent) — "
+              "SYNTHESIZED an auto grid; placement is NOT source-faithful, review it.",
+              file=sys.stderr)
         items = auto_items(elems)
     if ctl_items:
         # drop the tiles/charts below the controls band so nothing overlaps it


### PR DESCRIPTION
The QuickSight/ThoughtSpot/Cognos layout builders synthesized an auto-flow/banded grid without saying so, so a synthesized layout read as source-faithful. Each now emits a **loud warning** when source geometry is absent:
- **quicksight** `build-quicksight-layout.rb`: the `placed.empty?` 2-per-row flow fallback
- **thoughtspot** `apply_layouts.py`: the `auto_items` branch (no `layout.tiles`)
- **cognos** `apply-layout.mjs`: banded-grid synthesis (Cognos pixel geometry not read)

Warnings only (STDERR/console) — no spec-output change. Closes **beads-sigma-kvza.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)