### PR TITLE
kvza (cognos): kill silent ||'Sum' aggregate default + coverage matrix

### DIFF
--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.mjs
@@ -25,9 +25,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/util.js
+// converter/node_modules/fast-xml-parser/src/util.js
 var require_util = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/util.js"(exports) {
+  "converter/node_modules/fast-xml-parser/src/util.js"(exports) {
     "use strict";
     var nameStartChar = ":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
     var nameChar = nameStartChar + "\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
@@ -99,9 +99,9 @@ var require_util = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/validator.js
+// converter/node_modules/fast-xml-parser/src/validator.js
 var require_validator = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/validator.js"(exports) {
+  "converter/node_modules/fast-xml-parser/src/validator.js"(exports) {
     "use strict";
     var util = require_util();
     var defaultOptions = {
@@ -411,9 +411,9 @@ var require_validator = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
+// converter/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
 var require_OptionsBuilder = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js"(exports) {
+  "converter/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js"(exports) {
     var { DANGEROUS_PROPERTY_NAMES, criticalProperties } = require_util();
     var defaultOnDangerousProperty = (name) => {
       if (DANGEROUS_PROPERTY_NAMES.includes(name)) {
@@ -537,9 +537,9 @@ var require_OptionsBuilder = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
+// converter/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
 var require_xmlNode = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js"(exports, module) {
+  "converter/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js"(exports, module) {
     "use strict";
     var XmlNode = class {
       constructor(tagname) {
@@ -564,9 +564,9 @@ var require_xmlNode = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
+// converter/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
 var require_DocTypeReader = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js"(exports, module) {
+  "converter/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js"(exports, module) {
     var util = require_util();
     var DocTypeReader = class {
       constructor(options) {
@@ -852,9 +852,9 @@ var require_DocTypeReader = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/strnum/strnum.js
+// converter/node_modules/strnum/strnum.js
 var require_strnum = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/strnum/strnum.js"(exports, module) {
+  "converter/node_modules/strnum/strnum.js"(exports, module) {
     var hexRegex = /^[-+]?0x[a-fA-F0-9]+$/;
     var numRegex = /^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/;
     var consider = {
@@ -940,9 +940,9 @@ var require_strnum = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/ignoreAttributes.js
+// converter/node_modules/fast-xml-parser/src/ignoreAttributes.js
 var require_ignoreAttributes = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/ignoreAttributes.js"(exports, module) {
+  "converter/node_modules/fast-xml-parser/src/ignoreAttributes.js"(exports, module) {
     function getIgnoreAttributesFn(ignoreAttributes) {
       if (typeof ignoreAttributes === "function") {
         return ignoreAttributes;
@@ -965,9 +965,9 @@ var require_ignoreAttributes = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
+// converter/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
 var require_OrderedObjParser = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js"(exports, module) {
+  "converter/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js"(exports, module) {
     "use strict";
     var util = require_util();
     var xmlNode = require_xmlNode();
@@ -1570,9 +1570,9 @@ var require_OrderedObjParser = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/node2json.js
+// converter/node_modules/fast-xml-parser/src/xmlparser/node2json.js
 var require_node2json = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/node2json.js"(exports) {
+  "converter/node_modules/fast-xml-parser/src/xmlparser/node2json.js"(exports) {
     "use strict";
     function prettify(node, options) {
       return compress(node, options);
@@ -1657,9 +1657,9 @@ var require_node2json = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
+// converter/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
 var require_XMLParser = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js"(exports, module) {
+  "converter/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js"(exports, module) {
     var { buildOptions } = require_OptionsBuilder();
     var OrderedObjParser = require_OrderedObjParser();
     var { prettify } = require_node2json();
@@ -1715,9 +1715,9 @@ var require_XMLParser = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js
+// converter/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js
 var require_orderedJs2Xml = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js"(exports, module) {
+  "converter/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js"(exports, module) {
     var EOL = "\n";
     function toXml(jArray, options) {
       let indentation = "";
@@ -1848,9 +1848,9 @@ var require_orderedJs2Xml = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js
+// converter/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js
 var require_json2xml = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js"(exports, module) {
+  "converter/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js"(exports, module) {
     "use strict";
     var buildFromOrderedJs = require_orderedJs2Xml();
     var getIgnoreAttributesFn = require_ignoreAttributes();
@@ -2094,9 +2094,9 @@ var require_json2xml = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/fxp.js
+// converter/node_modules/fast-xml-parser/src/fxp.js
 var require_fxp = __commonJS({
-  "plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/node_modules/fast-xml-parser/src/fxp.js"(exports, module) {
+  "converter/node_modules/fast-xml-parser/src/fxp.js"(exports, module) {
     "use strict";
     var validator = require_validator();
     var XMLParser2 = require_XMLParser();
@@ -2109,12 +2109,12 @@ var require_fxp = __commonJS({
   }
 });
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.ts
+// converter/cli.ts
 import { readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/sigma-ids.ts
+// converter/sigma-ids.ts
 var SIGMA_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 var _usedIds = /* @__PURE__ */ new Set();
 var SIGMA_LOWERCASE_WORDS = /* @__PURE__ */ new Set([
@@ -2291,7 +2291,7 @@ function buildDerivedElements(elements) {
   return derived;
 }
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos.ts
+// converter/cognos.ts
 function applyLearnedRules(expr, rules) {
   let s = expr || "";
   for (const r of rules || []) {
@@ -2655,7 +2655,7 @@ function parseJoinExpr(expr) {
 }
 var trunc = (s, n = 80) => s && s.length > n ? s.slice(0, n) + "\u2026" : s || "";
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
+// converter/cognos-report.ts
 var import_fast_xml_parser = __toESM(require_fxp(), 1);
 var xmlParser = new import_fast_xml_parser.XMLParser({
   ignoreAttributes: false,
@@ -2989,7 +2989,9 @@ function convertCognosReportToSigma(xml2, options = {}) {
       warns.forEach((w) => warnings.push(`"${qName}.${r}": ${w}`));
       const id = sigmaShortId();
       if (grouped && isMeasureItem(di)) {
-        const fn = AGG[di.aggregate.toLowerCase()] || "Sum";
+        const _aggk = di.aggregate.toLowerCase();
+        if (!AGG[_aggk]) warnings.push(`list measure "${di.name}" (query "${qName}"): unmapped Cognos aggregate '${di.aggregate}' \u2014 defaulted to Sum (degraded); verify parity or add the mapping (refs/cognos-coverage.md).`);
+        const fn = AGG[_aggk] || "Sum";
         columns.push({ id, name: sigmaDisplayName(di.name), formula: /^\s*(Sum|Avg|Min|Max|Count|CountDistinct)\s*\(/.test(formula) ? formula : `${fn}(${formula})` });
         measureIds.push(id);
       } else {
@@ -3201,7 +3203,12 @@ function convertCognosReportToSigma(xml2, options = {}) {
       warns.forEach((w) => warnings.push(`"${vizName}.${e.ref}": ${w}`));
       if (categorical && !measure && (di.dataType === "1" || di.dataType === "2")) formula = `Text(${formula})`;
       const id = sigmaShortId();
-      const fn = measure ? ROLLUP_AGG[String(e.rollup || "").toLowerCase()] || "Sum" : "";
+      let fn = "";
+      if (measure) {
+        const _rk = String(e.rollup || "").toLowerCase();
+        if (_rk && !ROLLUP_AGG[_rk]) warnings.push(`chart "${vizName}" measure "${nm}": unmapped Cognos rollup '${e.rollup}' \u2014 defaulted to Sum (degraded); verify parity (refs/cognos-coverage.md).`);
+        fn = ROLLUP_AGG[_rk] || "Sum";
+      }
       const col = { id, name: nm, formula: measure ? `${fn}(${formula})` : formula };
       if (e.format) col.format = e.format;
       cols.push(col);
@@ -3396,7 +3403,7 @@ function convertCognosReportToSigma(xml2, options = {}) {
   };
 }
 
-// plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cli.ts
+// converter/cli.ts
 function loadLearnedRules() {
   try {
     const p = join(homedir(), ".cognos-to-sigma", "learned-rules.json");

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/converter/cognos-report.ts
@@ -424,7 +424,10 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
       warns.forEach((w) => warnings.push(`"${qName}.${r}": ${w}`));
       const id = sigmaShortId();
       if (grouped && isMeasureItem(di)) {
-        const fn = AGG[di.aggregate!.toLowerCase()] || 'Sum';
+        // beads-sigma-kvza: an unmapped Cognos aggregate must be LOUD, not a silent Sum.
+        const _aggk = di.aggregate!.toLowerCase();
+        if (!AGG[_aggk]) warnings.push(`list measure "${di.name}" (query "${qName}"): unmapped Cognos aggregate '${di.aggregate}' — defaulted to Sum (degraded); verify parity or add the mapping (refs/cognos-coverage.md).`);
+        const fn = AGG[_aggk] || 'Sum';
         columns.push({ id, name: sigmaDisplayName(di.name), formula: /^\s*(Sum|Avg|Min|Max|Count|CountDistinct)\s*\(/.test(formula) ? formula : `${fn}(${formula})` });
         measureIds.push(id);
       } else {
@@ -631,7 +634,14 @@ export function convertCognosReportToSigma(xml: string, options: CognosReportOpt
       // renders as a continuous axis in Sigma — cast to Text so it binds categorically.
       if (categorical && !measure && (di.dataType === '1' || di.dataType === '2')) formula = `Text(${formula})`;
       const id = sigmaShortId();
-      const fn = measure ? (ROLLUP_AGG[String(e.rollup || '').toLowerCase()] || 'Sum') : '';
+      // beads-sigma-kvza: warn on an unmapped Cognos rollup (empty rollup -> Sum is the
+      // documented default and is NOT a miss). Degraded Sum stays but is now loud.
+      let fn = '';
+      if (measure) {
+        const _rk = String(e.rollup || '').toLowerCase();
+        if (_rk && !ROLLUP_AGG[_rk]) warnings.push(`chart "${vizName}" measure "${nm}": unmapped Cognos rollup '${e.rollup}' — defaulted to Sum (degraded); verify parity (refs/cognos-coverage.md).`);
+        fn = ROLLUP_AGG[_rk] || 'Sum';
+      }
       const col: WbColumn = { id, name: nm, formula: measure ? `${fn}(${formula})` : formula };
       if (e.format) col.format = e.format;
       cols.push(col);

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/cognos-coverage.md
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/refs/cognos-coverage.md
@@ -1,0 +1,67 @@
+# Cognos → Sigma — dashboard/report classifier coverage matrix
+
+> **Grounding note (beads-sigma-kvza).** Unlike the other migration skills (whose
+> classifiers LOAD JSON catalogs via `coverage_catalog.{py,rb}`), cognos-to-sigma's
+> classifier is **TypeScript bundled to `converter/cli.mjs`** (from `converter/cognos-report.ts`).
+> There is no TS catalog loader, so cognos's maps are grounded as **cited constants in
+> the TS source** with a **loud fallback** on anything unmapped — and documented here.
+> A machine-loaded TS catalog would be the same shape and belongs with the converter
+> (lanq) track. Every mapped Sigma target is a real, current Sigma construct.
+
+Cognos was already the most loud of the classifiers (an unknown visual degrades to a
+**warned table**, never a silent chart; number formats are read from the report's
+`currencyFormat`/`percentFormat`/`numberFormat` nodes, never guessed from a column
+name). This pass closed the one remaining silent default: an **unmapped Cognos
+aggregate / rollup no longer silently becomes `Sum`** — it warns first.
+
+## Visualization / chart kind
+Source: `cognos-report.ts` `VIZ_KIND` (+ `VIZ_NOANALOG`). Cognos `com.ibm.vis.*` → Sigma element kind.
+Authoritative source: <https://www.ibm.com/docs/en/cognos-analytics> (visualization types).
+
+| Cognos vizType | Sigma target | on-unmapped |
+|---|---|---|
+| `com.ibm.vis.clusteredbar` / `stackedbar` / `clusteredcolumn` / `stackedcolumn` | `bar-chart` | — |
+| `com.ibm.vis.line` / `spline` | `line-chart` | — |
+| `com.ibm.vis.area` / `stackedarea` | `area-chart` | — |
+| `com.ibm.vis.pie` | `pie-chart` | — |
+| `com.ibm.vis.donut` | `donut-chart` | — |
+| `com.ibm.vis.clusteredcombination` / `stackedcombination` | `combo-chart` | — |
+| `com.ibm.vis.bubble` / `scatter` | `scatter-chart` | — |
+| _unknown vizType_ | — (no native equivalent) | **loud warn + emit the data as a `table`** (`cognos-report.ts` `if (!kind)`) — never a silent concrete chart |
+
+## Aggregation
+Source: `cognos-report.ts` `AGG` (list footer/dataItem) + `ROLLUP_AGG` (chart rollup). Cognos aggregate/rollup → Sigma aggregate function.
+Authoritative source: IBM Cognos regularAggregate / rollup; Sigma <https://help.sigmacomputing.com/docs/aggregate-functions>.
+
+| Cognos aggregate/rollup | Sigma target | on-unmapped |
+|---|---|---|
+| `total` / `summary` / `aggregate` / `calculated` / `sum` | `Sum` | — |
+| `average` / `avg` | `Avg` | — |
+| `count` | `Count` | — |
+| `countdistinct` | `CountDistinct` | — |
+| `maximum` | `Max` | — |
+| `minimum` | `Min` | — |
+| _unmapped aggregate/rollup_ | `Sum` (degraded) | **loud warn** ("unmapped Cognos aggregate/rollup '…' — defaulted to Sum (degraded); verify parity") — was a silent `\|\| 'Sum'` before this pass |
+
+## Number format
+Source: `cognos-report.ts` `formatFromNode` — reads the report's `currencyFormat` / `percentFormat` / `numberFormat` nodes (decimals from `@_decimalSize`, SI scaling from `@_scale`/`K`/`M`/`B`). Currency `$,.Nf` / `$,.Ns`, percent `,.N%`, number `,.Nf`.
+| Cognos format node | Sigma target | on-unmapped |
+|---|---|---|
+| `currencyFormat` | `$,.<dec>f` (or `$,.<dec>s` scaled) | — |
+| `percentFormat` | `,.<dec>%` | — |
+| `numberFormat` | `,.<dec>f` (or `$,.<dec>s` scaled) | — |
+| _no format node_ | `undefined` (Sigma type default) | benign — **no name-substring currency guessing** (contrast the other tools' disease) |
+
+## Control / filter
+Source: `cognos-report.ts` — Cognos `prompt('p',…)` → Sigma `segmented` control; detail filters → element `filters` (list, include/exclude); a macro measure-swap prompt → control + `Switch(...)`.
+| Cognos construct | Sigma target | on-unmapped |
+|---|---|---|
+| `prompt(...)` parameter | `segmented` control (values from `<selectValue>`) | empty options → **warn** ("no `<selectValue>` options — emitted an empty segmented control; add values in Sigma") |
+| detail filter (`= value`) | element `filters` (kind `list`, mode include/exclude) | — |
+| `?prompt?` comparison | segmented control + boolean match column + list filter on `[true]` | — |
+
+---
+_The Cognos expression translator (`translateCognosExpr`), the crosstab/list grouping
+logic, and the band layout are compositional and stay as cited code — this matrix
+covers the enumerable maps. Re-bundle `converter/cli.mjs` from `converter/cognos-report.ts`
+after any map change (esbuild; see `tools/vendor-converters.sh` cognos case)._


### PR DESCRIPTION
Closes the last silent default in the Cognos classifier: an unmapped Cognos aggregate (list dataItem, `cognos-report.ts:427`) or chart rollup (`:634`) no longer silently becomes `Sum` — it **warns first** (empty rollup still → Sum, a documented default). Re-bundled `converter/cli.mjs` (esbuild), verified via a dry-run conversion of the great-outdoors fixture (maps intact, warning present).

Adds `refs/cognos-coverage.md` (VIZ_KIND / AGG+ROLLUP_AGG / format-node / prompt-control, cited). Cognos is the TS-bundled converter, so its maps are grounded as cited TS constants + loud fallback rather than a machine-loaded catalog (a TS loader belongs with the lanq/converter track). This brings **9/9 non-Tableau skills** to documentation-grounded classifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)