### PR TITLE
Support cross-tenant / guest (B2B) Power BI migrations via --tenant (#347)

### DIFF
--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/fabric-inventory.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/fabric-inventory.py
@@ -28,9 +28,26 @@ import sys, os, json, time, base64, argparse, re, atexit
 import requests
 import msal
 
-CACHE = "/tmp/pbiauth/cache.bin"
+def _tenant_from_argv(argv):
+    """#347: pre-read --tenant BEFORE the module-level MSAL app/cache are built.
+    Accepts a raw tenant GUID or a pasted report URL (ctid=... is extracted)."""
+    for i, a in enumerate(argv):
+        v = a.split("=", 1)[1] if a.startswith("--tenant=") else (
+            argv[i + 1] if a == "--tenant" and i + 1 < len(argv) else None)
+        if v:
+            m = re.search(r"[?&]ctid=([0-9a-fA-F-]{36})", v)
+            return m.group(1) if m else v
+    return None
+
+
+_t = _tenant_from_argv(sys.argv)
+if _t:
+    os.environ["PBI_TENANT"] = _t
+_TENANT = os.environ.get("PBI_TENANT", "organizations")  # default = caller's home tenant
+
+CACHE = os.environ.get("PBI_TOKEN_CACHE") or ("/tmp/pbiauth/cache.bin" if _TENANT == "organizations" else f"/tmp/pbiauth/cache-{_TENANT}.bin")
 CLIENT_ID = "ea0616ba-638b-4df5-95b9-636659ae5121"  # well-known PowerBI Desktop public client
-AUTHORITY = "https://login.microsoftonline.com/organizations"
+AUTHORITY = f"https://login.microsoftonline.com/{_TENANT}"
 FABRIC_SCOPE = ["https://api.fabric.microsoft.com/.default"]
 PBI_SCOPE = ["https://analysis.windows.net/powerbi/api/.default"]
 FABRIC_BASE = "https://api.fabric.microsoft.com/v1"
@@ -333,6 +350,9 @@ def main():
                     help="fail rather than launch a device-code flow (headless / CI)")
     ap.add_argument("--workspaces", default=None, help="comma-sep workspace ids to limit to")
     ap.add_argument("--limit-models", type=int, default=0, help="cap models scanned (0=all)")
+    ap.add_argument("--tenant", default=None,
+                    help="target tenant (guest/B2B) — raw GUID or a report URL with ctid=...; "
+                         "pre-parsed at import (default: home tenant)")
     args = ap.parse_args()
     os.makedirs(args.out, exist_ok=True)
     os.makedirs(os.path.join(args.out, "raw-tmsl"), exist_ok=True)

--- a/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/probe-admin.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-assessment/scripts/probe-admin.py
@@ -24,13 +24,31 @@ Usage:
 """
 
 import truststore; truststore.inject_into_ssl()
-import sys, os, json, time, argparse, atexit
+import sys, os, json, time, argparse, atexit, re
 import requests
 import msal
 
-CACHE = "/tmp/pbiauth/cache.bin"
+
+def _tenant_from_argv(argv):
+    """#347: pre-read --tenant BEFORE the module-level MSAL app/cache are built.
+    Accepts a raw tenant GUID or a pasted report URL (ctid=... is extracted)."""
+    for i, a in enumerate(argv):
+        v = a.split("=", 1)[1] if a.startswith("--tenant=") else (
+            argv[i + 1] if a == "--tenant" and i + 1 < len(argv) else None)
+        if v:
+            m = re.search(r"[?&]ctid=([0-9a-fA-F-]{36})", v)
+            return m.group(1) if m else v
+    return None
+
+
+_t = _tenant_from_argv(sys.argv)
+if _t:
+    os.environ["PBI_TENANT"] = _t
+_TENANT = os.environ.get("PBI_TENANT", "organizations")  # default = caller's home tenant
+
+CACHE = os.environ.get("PBI_TOKEN_CACHE") or ("/tmp/pbiauth/cache.bin" if _TENANT == "organizations" else f"/tmp/pbiauth/cache-{_TENANT}.bin")
 CLIENT_ID = "ea0616ba-638b-4df5-95b9-636659ae5121"
-AUTHORITY = "https://login.microsoftonline.com/organizations"
+AUTHORITY = f"https://login.microsoftonline.com/{_TENANT}"
 PBI_SCOPE = ["https://analysis.windows.net/powerbi/api/.default"]
 PBI_BASE = "https://api.powerbi.com/v1.0/myorg"
 
@@ -66,6 +84,9 @@ def classify(status):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--no-interactive", action="store_true")
+    ap.add_argument("--tenant", default=None,
+                    help="target tenant (guest/B2B) — raw GUID or a report URL with ctid=...; "
+                         "pre-parsed at import (default: home tenant)")
     args = ap.parse_args()
     tok = get_token(interactive=not args.no_interactive)
     if not tok:

--- a/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/scripts/pbi_import_to_snowflake.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-import-to-snowflake/scripts/pbi_import_to_snowflake.py
@@ -48,22 +48,40 @@ _retry = Retry(total=5, connect=5, read=5, backoff_factor=1.5,
 SESS.mount("https://", HTTPAdapter(max_retries=_retry))
 
 CLIENT_ID = "ea0616ba-638b-4df5-95b9-636659ae5121"  # public Power BI Desktop client
-AUTHORITY = "https://login.microsoftonline.com/organizations"
-CACHE = os.environ.get("PBI_TOKEN_CACHE", "/tmp/pbiauth/cache.bin")
 PBI_BASE = "https://api.powerbi.com/v1.0/myorg"
 FABRIC_BASE = "https://api.fabric.microsoft.com/v1"
 BAND_MAX = int(os.environ.get("PBI_BAND_MAX", "45000"))  # under executeQueries' silent truncation ceiling
 
+
 # ---- auth ----------------------------------------------------------------
+# #347: resolve the authority + cache at CALL time so --tenant (set in main()
+# after this module is imported) targets a guest/B2B tenant, with a per-tenant
+# cache file so the guest token doesn't collide with the home token.
+def _tenant():
+    return os.environ.get("PBI_TENANT", "organizations")
+
+
+def _authority():
+    return "https://login.microsoftonline.com/" + _tenant()
+
+
+def _cache_path():
+    if os.environ.get("PBI_TOKEN_CACHE"):
+        return os.environ["PBI_TOKEN_CACHE"]
+    t = _tenant()
+    return "/tmp/pbiauth/cache.bin" if t == "organizations" else f"/tmp/pbiauth/cache-{t}.bin"
+
+
 def _app():
+    path = _cache_path()
     cache = msal.SerializableTokenCache()
-    if os.path.exists(CACHE):
-        cache.deserialize(open(CACHE).read())
-    app = msal.PublicClientApplication(CLIENT_ID, authority=AUTHORITY, token_cache=cache)
-    return app, cache
+    if os.path.exists(path):
+        cache.deserialize(open(path).read())
+    app = msal.PublicClientApplication(CLIENT_ID, authority=_authority(), token_cache=cache)
+    return app, cache, path
 
 def get_tokens():
-    app, cache = _app()
+    app, cache, CACHE = _app()
     accts = app.get_accounts()
     def acq(scope):
         for a in accts:
@@ -344,7 +362,13 @@ def main():
     ap.add_argument("--only", default=None, help="comma-separated PBI table names to include")
     ap.add_argument("--limit-rows", type=int, default=None, help="TOPN per table (cheap testing)")
     ap.add_argument("--dry-run", action="store_true", help="extract + gen SQL, do not execute in Snowflake")
+    ap.add_argument("--tenant", default=None,
+                    help="target tenant when the dataset lives in a DIFFERENT tenant than your home "
+                         "tenant (guest/B2B). A raw tenant GUID, or a report URL with ctid=...")
     args = ap.parse_args()
+    if args.tenant:  # #347: set before get_tokens() — authority/cache resolve at call time
+        m = re.search(r"[?&]ctid=([0-9a-fA-F-]{36})", args.tenant)
+        os.environ["PBI_TENANT"] = m.group(1) if m else args.tenant
 
     only = set(s.strip() for s in args.only.split(",")) if args.only else None
     pbi, fab = get_tokens()

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/connection.md
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/refs/connection.md
@@ -15,15 +15,36 @@ The path that needs **no app and no IT toggle**: device-code login against a Mic
 ```python
 import truststore; truststore.inject_into_ssl()   # MANDATORY — see TLS note
 import msal, requests
+_tenant = os.environ.get("PBI_TENANT", "organizations")  # override for guest/B2B — see below
 app = msal.PublicClientApplication(
     "ea0616ba-638b-4df5-95b9-636659ae5121",          # well-known "Power BI Desktop" public client
-    authority="https://login.microsoftonline.com/organizations",
+    authority=f"https://login.microsoftonline.com/{_tenant}",
     token_cache=<SerializableTokenCache from /tmp/pbiauth/cache.bin>)
 flow = app.initiate_device_flow(scopes=["https://api.fabric.microsoft.com/.default"])
 # print flow["verification_uri"] + flow["user_code"]; user signs in once
 res  = app.acquire_token_by_device_flow(flow)        # token aud=api.fabric.microsoft.com, scp=user_impersonation
 ```
 `scripts/fabric-extract.py` (read) and `scripts/fabric-auth-check.py` (write-capability/capacity probe) implement this with a persistent cache + silent re-auth.
+
+## Cross-tenant / guest (B2B) — `--tenant` (#347)
+The default `organizations` authority always authenticates into the caller's **home**
+tenant. When the report lives in a **different** tenant — the normal consultant/partner
+case where you're a **guest (B2B)** in a client's tenant — a home-tenant token makes every
+Fabric call 404 as `WorkspaceNotFound`, even though you can open the report in a browser.
+
+Target the report's tenant with `--tenant` (or `PBI_TENANT`). It accepts a raw tenant GUID
+**or** a pasted report URL (the `ctid=<guid>` query param is extracted automatically):
+```
+# the tenant GUID is the ctid= in the report URL:  https://app.powerbi.com/.../reports/<id>?ctid=<TENANT>
+python scripts/fabric-extract.py --tenant <TENANT-GUID-or-report-URL> --report "<name>" ...
+# or, driving the whole pipeline:
+ruby scripts/migrate-powerbi.rb --tenant <TENANT> ...   # exported as PBI_TENANT to every PBI child
+```
+The token cache is **namespaced per tenant** (`/tmp/pbiauth/cache-<tenant>.bin`) so a guest
+token never collides with the cached home-tenant token. `--tenant` is available on
+`fabric-extract.py`, `fabric-extract-batch.py`, `migrate-powerbi.rb`,
+`pbi_import_to_snowflake.py`, and the assessment scripts (`probe-admin.py`,
+`fabric-inventory.py`); the orchestrator-invoked helpers inherit `PBI_TENANT` from the env.
 
 ## TLS inspection — the gotcha that bit us
 Corp network MITM-inspects `api.fabric.microsoft.com` → Python raises `CERTIFICATE_VERIFY_FAILED: self-signed certificate in certificate chain`. Fix: **`truststore.inject_into_ssl()` as the first import** (uses the macOS keychain, which trusts the corp root CA). Note `login.microsoftonline.com` is *not* inspected (proxy bypass), so msal auth succeeds even without truststore — only the API calls fail. Always inject.

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/export-pbi-pages.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/export-pbi-pages.py
@@ -17,7 +17,8 @@ import truststore; truststore.inject_into_ssl()
 import argparse, os, sys, time
 import msal, requests
 
-CACHE = os.environ.get("PBI_TOKEN_CACHE", "/tmp/pbiauth/cache.bin")
+_T = os.environ.get("PBI_TENANT", "organizations")  # #347: guest/B2B tenant via PBI_TENANT
+CACHE = os.environ.get("PBI_TOKEN_CACHE") or ("/tmp/pbiauth/cache.bin" if _T == "organizations" else f"/tmp/pbiauth/cache-{_T}.bin")
 CLIENT = "ea0616ba-638b-4df5-95b9-636659ae5121"
 
 
@@ -26,7 +27,7 @@ def token():
     if os.path.exists(CACHE):
         cache.deserialize(open(CACHE).read())
     app = msal.PublicClientApplication(
-        CLIENT, authority="https://login.microsoftonline.com/organizations", token_cache=cache)
+        CLIENT, authority=f"https://login.microsoftonline.com/{_T}", token_cache=cache)
     for a in app.get_accounts():
         r = app.acquire_token_silent(["https://analysis.windows.net/powerbi/api/.default"], account=a)
         if r and "access_token" in r:

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/extract-pbir.py
@@ -32,9 +32,10 @@ Idempotent: re-running overwrites signals.json; a fetch only re-downloads when
 import argparse, base64, json, os, sys, time
 
 CLIENT_ID = "ea0616ba-638b-4df5-95b9-636659ae5121"  # Power BI Desktop public client
-AUTHORITY = "https://login.microsoftonline.com/organizations"
+_TENANT   = os.environ.get("PBI_TENANT", "organizations")  # #347: guest/B2B tenant via PBI_TENANT
+AUTHORITY = f"https://login.microsoftonline.com/{_TENANT}"
 SCOPES    = ["https://api.fabric.microsoft.com/.default"]
-CACHE     = "/tmp/pbiauth/cache.bin"
+CACHE     = os.environ.get("PBI_TOKEN_CACHE") or ("/tmp/pbiauth/cache.bin" if _TENANT == "organizations" else f"/tmp/pbiauth/cache-{_TENANT}.bin")
 FAB_BASE  = "https://api.fabric.microsoft.com/v1"
 
 # PBIR visualType -> Sigma element kind (research/powerbi-visual-layout.md §4e).

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/fabric-auth-check.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/fabric-auth-check.py
@@ -1,13 +1,14 @@
 import truststore; truststore.inject_into_ssl()
 import sys, json, base64, os, atexit, requests, msal
 
-CACHE = "/tmp/pbiauth/cache.bin"
+_T = os.environ.get("PBI_TENANT", "organizations")  # #347: guest/B2B tenant via PBI_TENANT
+CACHE = os.environ.get("PBI_TOKEN_CACHE") or ("/tmp/pbiauth/cache.bin" if _T == "organizations" else f"/tmp/pbiauth/cache-{_T}.bin")
 cache = msal.SerializableTokenCache()
 if os.path.exists(CACHE): cache.deserialize(open(CACHE).read())
 atexit.register(lambda: open(CACHE, "w").write(cache.serialize()) if cache.has_state_changed else None)
 
 CID = "ea0616ba-638b-4df5-95b9-636659ae5121"
-AUTH = "https://login.microsoftonline.com/organizations"
+AUTH = f"https://login.microsoftonline.com/{_T}"
 SCOPES = ["https://api.fabric.microsoft.com/.default"]
 
 app = msal.PublicClientApplication(CID, authority=AUTH, token_cache=cache)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/fabric-extract-batch.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/fabric-extract-batch.py
@@ -44,9 +44,14 @@ ap.add_argument("--out-root", default="/tmp/pbi-batch")
 ap.add_argument("--pool", type=int, default=4,
                 help="concurrent definition fetches (hard cap 4 — Fabric per-principal throttling)")
 ap.add_argument("--no-cache", action="store_true", help="bypass the estate-map session cache")
+ap.add_argument("--tenant", default=None,
+                help="target tenant when reports live in a DIFFERENT tenant than your home tenant "
+                     "(guest/B2B). A raw tenant GUID, or a pasted report URL (ctid=... is extracted).")
 ARGS = ap.parse_args()
 if not ARGS.reports and not ARGS.all:
     ap.error("need --reports or --all")
+if ARGS.tenant:
+    os.environ["PBI_TENANT"] = fab.normalize_tenant(ARGS.tenant)
 
 
 def slug(s):
@@ -63,7 +68,7 @@ def main():
     # ---- estate map (session cache -> live parallel enumeration) -------------
     estate = None if ARGS.no_cache else fab.load_estate_cache()
     if estate:
-        print(f"[estate-cache] using {fab.ESTATE_CACHE}", flush=True)
+        print(f"[estate-cache] using {fab.estate_cache_path()}", flush=True)
     else:
         estate = fab.enumerate_estate(tok, timings=tm)
         fab.save_estate_cache(estate)

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/fabric-extract.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/fabric-extract.py
@@ -53,7 +53,15 @@ ap.add_argument("--report-bundle", default=None,
 ap.add_argument("--pool", type=int, default=2,
                 help="concurrent definition fetches (capped at 4 — Fabric per-principal throttling)")
 ap.add_argument("--no-cache", action="store_true", help="bypass the estate-map session cache")
+ap.add_argument("--tenant", default=None,
+                help="target tenant when the report lives in a DIFFERENT tenant than your home "
+                     "tenant (guest/B2B). A raw tenant GUID, or a pasted report URL (ctid=... is "
+                     "extracted). Default: your home tenant.")
 ARGS = ap.parse_args()
+
+# Set PBI_TENANT before the (call-time) authority/cache are resolved in get_token.
+if ARGS.tenant:
+    os.environ["PBI_TENANT"] = fab.normalize_tenant(ARGS.tenant)
 
 
 def main():

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/migrate-powerbi.rb
@@ -129,6 +129,10 @@ OptionParser.new do |o|
   o.on('--workspace ID')       { |v| opts[:ws] = v }
   o.on('--dataset ID')         { |v| opts[:dataset] = v }
   o.on('--skip-freshness')     {     opts[:skip_fresh] = true }
+  # #347: target a report/model in a DIFFERENT tenant than your HOME tenant
+  # (guest / B2B). A raw tenant GUID, or a pasted report URL (ctid=... parsed).
+  # Threaded to every Power BI child via ENV['PBI_TENANT'] (they inherit env).
+  o.on('--tenant ID')          { |v| opts[:tenant] = v }
   # Phase E (opt-in) — Enhance. NEVER runs without --enhance; with --enhance
   # but no --enhance-accept the run stops at exit 14 with the scan proposals
   # (present them per-item to the human, e.g. AskUserQuestion), then re-run
@@ -143,6 +147,14 @@ OptionParser.new do |o|
   o.on('--reuse-dm ID')        { |v| opts[:reuse_dm] = v }
   o.on('--no-reuse')           {     opts[:no_reuse] = true }
 end.parse!
+
+# #347: publish the target tenant into the env so EVERY Power BI child process
+# (fabric-extract.py, pbi-freshness.py, phase6 harness, …) inherits it and
+# authenticates against the report's tenant instead of the caller's home tenant.
+if opts[:tenant]
+  ctid = opts[:tenant][/[?&]ctid=([0-9a-fA-F-]{36})/, 1]
+  ENV['PBI_TENANT'] = ctid || opts[:tenant]
+end
 
 VENDORED_PBI = File.expand_path('../converter/powerbi.mjs', __dir__)
 if opts[:print_converter]
@@ -159,11 +171,15 @@ end
 CONNECT_HINT = <<~HINT.freeze
   Extract them by CONNECTING to Power BI (device-code login, no Entra app):
       python scripts/fabric-extract.py --report "<report name>" [--workspace "<ws id|name>"] \\
+        [--tenant "<tenant GUID | report URL with ctid=...>"] \\
         --out-dir <WORK> --report-out-dir <WORK> --report-bundle <WORK>/report-bundle.json
   It prints a device code + https://microsoft.com/devicelogin — the USER signs in
   once, then re-run this command with the extracted --tmsl (model.bim) + --pbir
   (report-bundle.json). See refs/connection.md. Do NOT hand-author a workbook spec
   or proceed without the model — if you can't extract it, STOP and tell the user.
+  Cross-tenant (guest/B2B): if the report lives in a client's tenant, pass
+  --tenant <that tenant GUID or the ctid= in the report URL> here AND to
+  fabric-extract.py, or every Fabric call 404s as WorkspaceNotFound.
 HINT
 abort "FATAL: missing --tmsl (the Power BI semantic model, TMSL/model.bim).\n#{CONNECT_HINT}" unless opts[:tmsl]
 abort "FATAL: --tmsl not found: #{opts[:tmsl]}\n#{CONNECT_HINT}" unless File.exist?(opts[:tmsl])

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi-freshness.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi-freshness.py
@@ -44,7 +44,8 @@ import truststore; truststore.inject_into_ssl()  # noqa: E702
 import msal
 import requests
 
-CACHE = "/tmp/pbiauth/cache.bin"
+_T = os.environ.get("PBI_TENANT", "organizations")  # #347: guest/B2B tenant via PBI_TENANT
+CACHE = os.environ.get("PBI_TOKEN_CACHE") or ("/tmp/pbiauth/cache.bin" if _T == "organizations" else f"/tmp/pbiauth/cache-{_T}.bin")
 CLIENT = "ea0616ba-638b-4df5-95b9-636659ae5121"  # well-known PBI public client
 SCOPE = ["https://analysis.windows.net/powerbi/api/.default"]
 CRED_HINTS = ("credential", "expired", "AADSTS", "authentication", "login")
@@ -55,7 +56,7 @@ def token():
     if os.path.exists(CACHE):
         cache.deserialize(open(CACHE).read())
     app = msal.PublicClientApplication(
-        CLIENT, authority="https://login.microsoftonline.com/organizations",
+        CLIENT, authority=f"https://login.microsoftonline.com/{_T}",
         token_cache=cache)
     tok = None
     for a in app.get_accounts():

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_exec.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_exec.py
@@ -1,10 +1,11 @@
 import truststore; truststore.inject_into_ssl()
 import sys, os, json, msal, requests
-CACHE="/tmp/pbiauth/cache.bin"
+_T=os.environ.get("PBI_TENANT","organizations")  # #347: guest/B2B tenant via PBI_TENANT
+CACHE=os.environ.get("PBI_TOKEN_CACHE") or ("/tmp/pbiauth/cache.bin" if _T=="organizations" else f"/tmp/pbiauth/cache-{_T}.bin")
 cache=msal.SerializableTokenCache()
 if os.path.exists(CACHE): cache.deserialize(open(CACHE).read())
 app=msal.PublicClientApplication("ea0616ba-638b-4df5-95b9-636659ae5121",
-    authority="https://login.microsoftonline.com/organizations", token_cache=cache)
+    authority=f"https://login.microsoftonline.com/{_T}", token_cache=cache)
 SCOPE=["https://analysis.windows.net/powerbi/api/.default"]
 tok=None
 for a in app.get_accounts():

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_fabric.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/pbi_fabric.py
@@ -21,6 +21,7 @@ Stdlib + msal/requests/truststore only (same deps as the scripts it serves).
 import base64
 import json
 import os
+import re
 import sys
 import threading
 import time
@@ -30,11 +31,50 @@ import truststore; truststore.inject_into_ssl()  # corp TLS inspection — manda
 import msal
 import requests
 
-CACHE = os.environ.get("PBI_TOKEN_CACHE", "/tmp/pbiauth/cache.bin")
-ESTATE_CACHE = os.environ.get("PBI_ESTATE_CACHE", "/tmp/pbiauth/estate-map.json")
 FAB_BASE = "https://api.fabric.microsoft.com/v1"
 PBI_BASE = "https://api.powerbi.com/v1.0/myorg"
-AUTHORITY = "https://login.microsoftonline.com/organizations"
+
+
+# --- tenant override (#347) -------------------------------------------------
+# The target report may live in a DIFFERENT tenant than the caller's HOME
+# tenant — the normal consultant/partner (guest / B2B) case. The generic
+# `organizations` authority (the default) always authenticates into the home
+# tenant, so a guest report then fails every Fabric call as WorkspaceNotFound.
+# PBI_TENANT (a raw tenant GUID) overrides the authority; entry points expose
+# it as --tenant. Authority AND cache path are resolved at CALL time so a
+# --tenant parsed after this module is imported still takes effect, and the
+# per-tenant cache file keeps a guest token from colliding with the home token.
+def _tenant():
+    return os.environ.get("PBI_TENANT", "organizations")
+
+
+def _authority(tenant=None):
+    return "https://login.microsoftonline.com/" + (tenant or _tenant())
+
+
+def cache_path(tenant=None):
+    if os.environ.get("PBI_TOKEN_CACHE"):
+        return os.environ["PBI_TOKEN_CACHE"]
+    t = tenant or _tenant()
+    return "/tmp/pbiauth/cache.bin" if t == "organizations" else f"/tmp/pbiauth/cache-{t}.bin"
+
+
+def estate_cache_path(tenant=None):
+    if os.environ.get("PBI_ESTATE_CACHE"):
+        return os.environ["PBI_ESTATE_CACHE"]
+    t = tenant or _tenant()
+    return "/tmp/pbiauth/estate-map.json" if t == "organizations" \
+        else f"/tmp/pbiauth/estate-map-{t}.json"
+
+
+def normalize_tenant(value):
+    """Tenant id from a raw GUID, or the `ctid` extracted from a pasted report URL."""
+    if not value:
+        return None
+    m = re.search(r"[?&]ctid=([0-9a-fA-F-]{36})", value)
+    return m.group(1) if m else value
+
+
 FABRIC_SCOPE = ["https://api.fabric.microsoft.com/.default"]
 POWERBI_SCOPE = ["https://analysis.windows.net/powerbi/api/.default"]
 # Well-known public clients — no app registration needed (PBI Desktop first).
@@ -48,27 +88,38 @@ MAX_LRO_POOL = 4
 ENUM_POOL = 8
 
 _cache_lock = threading.Lock()
-_msal_cache = msal.SerializableTokenCache()
-if os.path.exists(CACHE):
-    _msal_cache.deserialize(open(CACHE).read())
+_caches = {}  # cache-file path -> SerializableTokenCache (one per tenant)
 
 
-def _persist_msal():
-    if _msal_cache.has_state_changed:
-        os.makedirs(os.path.dirname(CACHE), exist_ok=True)
+def _load_cache(path):
+    c = _caches.get(path)
+    if c is None:
+        c = msal.SerializableTokenCache()
+        if os.path.exists(path):
+            c.deserialize(open(path).read())
+        _caches[path] = c
+    return c
+
+
+def _persist_msal(cache, path):
+    if cache.has_state_changed:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
         with _cache_lock:
-            open(CACHE, "w").write(_msal_cache.serialize())
+            open(path, "w").write(cache.serialize())
 
 
-def get_token(scopes=None, interactive=True):
-    """Silent token from the shared cache; device-code fallback when allowed."""
+def get_token(scopes=None, interactive=True, tenant=None):
+    """Silent token from the per-tenant cache; device-code fallback when allowed."""
     scopes = scopes or FABRIC_SCOPE
+    authority = _authority(tenant)
+    path = cache_path(tenant)
+    cache = _load_cache(path)
     for cid, cname in CLIENT_CANDIDATES:
-        app = msal.PublicClientApplication(cid, authority=AUTHORITY, token_cache=_msal_cache)
+        app = msal.PublicClientApplication(cid, authority=authority, token_cache=cache)
         for acct in app.get_accounts():
             r = app.acquire_token_silent(scopes, account=acct)
             if r and "access_token" in r:
-                _persist_msal()
+                _persist_msal(cache, path)
                 return r["access_token"]
         if not interactive:
             continue
@@ -76,13 +127,14 @@ def get_token(scopes=None, interactive=True):
         if "user_code" not in flow:
             continue
         print("=" * 60, file=sys.stderr)
-        print(f"CLIENT={cname}  SCOPE={scopes[0]}", file=sys.stderr)
+        print(f"CLIENT={cname}  SCOPE={scopes[0]}  TENANT={_tenant() if tenant is None else tenant}",
+              file=sys.stderr)
         print(f">>> Go to: {flow['verification_uri']}", file=sys.stderr)
         print(f">>> Enter code: {flow['user_code']}", file=sys.stderr)
         print("=" * 60, file=sys.stderr)
         res = app.acquire_token_by_device_flow(flow)
         if "access_token" in res:
-            _persist_msal()
+            _persist_msal(cache, path)
             return res["access_token"]
     return None
 
@@ -267,15 +319,16 @@ def enumerate_estate(tok, pool=ENUM_POOL, timings=None):
 
 def load_estate_cache():
     try:
-        return json.load(open(ESTATE_CACHE))
+        return json.load(open(estate_cache_path()))
     except (OSError, ValueError):
         return None
 
 
 def save_estate_cache(estate):
     try:
-        os.makedirs(os.path.dirname(ESTATE_CACHE), exist_ok=True)
-        json.dump(estate, open(ESTATE_CACHE, "w"), indent=2)
+        path = estate_cache_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        json.dump(estate, open(path, "w"), indent=2)
     except OSError:
         pass  # cache is best-effort
 
@@ -352,7 +405,7 @@ def resolve_targets(tok, model_name=None, workspace=None, report=None,
         if cached:
             hit = search(cached)
             if hit:
-                log(f"[estate-cache] hit ({ESTATE_CACHE}) — skipping enumeration")
+                log(f"[estate-cache] hit ({estate_cache_path()}) — skipping enumeration")
                 return hit
             log("[estate-cache] name miss — invalidating + re-enumerating live")
 

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/phase6-parity-pbi.rb
@@ -108,11 +108,12 @@ HARNESS = File.join(HERE, 'pbi_exec.py')
 HARNESS_SRC = <<~PY
   import truststore; truststore.inject_into_ssl()
   import sys, os, json, msal, requests
-  CACHE="/tmp/pbiauth/cache.bin"
+  _T=os.environ.get("PBI_TENANT","organizations")  # #347: guest/B2B tenant via PBI_TENANT
+  CACHE=os.environ.get("PBI_TOKEN_CACHE") or ("/tmp/pbiauth/cache.bin" if _T=="organizations" else "/tmp/pbiauth/cache-"+_T+".bin")
   cache=msal.SerializableTokenCache()
   if os.path.exists(CACHE): cache.deserialize(open(CACHE).read())
   app=msal.PublicClientApplication("ea0616ba-638b-4df5-95b9-636659ae5121",
-      authority="https://login.microsoftonline.com/organizations", token_cache=cache)
+      authority="https://login.microsoftonline.com/"+_T, token_cache=cache)
   SCOPE=["https://analysis.windows.net/powerbi/api/.default"]
   tok=None
   for a in app.get_accounts():


### PR DESCRIPTION
## Problem (#347)
Every MSAL authority in the powerbi plugin was hardcoded to `https://login.microsoftonline.com/organizations`, which always authenticates into the caller's **home** tenant. When the target report lives in a **different** tenant — the normal consultant/partner case where you're a **guest (B2B)** in a client's tenant — the token is scoped to the wrong tenant and every Fabric call 404s as `WorkspaceNotFound`, even though the report opens in a browser. No flag/env existed to target another tenant. Reported by @R-Crowder.

The literal was duplicated across **10 code sites** in 3 skills (powerbi-to-sigma, powerbi-assessment, powerbi-import-to-snowflake) — not just `pbi_fabric.py`.

## Fix
- **`pbi_fabric.py`** — authority **and** cache path resolved at **call time** from `PBI_TENANT` (default `organizations` = home tenant, behavior unchanged). `get_token(tenant=)` added; **per-tenant cache namespacing** (`cache-<tenant>.bin` / `estate-map-<tenant>.json`) so a guest token can't collide with the cached home token (the collision @R-Crowder worked around). `normalize_tenant()` extracts `ctid=` from a pasted report URL.
- **`--tenant` flag** (raw GUID **or** a report URL) on the user-facing entry points: `fabric-extract.py`, `fabric-extract-batch.py`, `pbi_import_to_snowflake.py`, `probe-admin.py`, `fabric-inventory.py`. The two assessment scripts build their MSAL app at module load, so `--tenant` is pre-parsed from argv before that.
- **`migrate-powerbi.rb`** — `--tenant` sets `ENV['PBI_TENANT']`, inherited by every Power BI child process (freshness / parity / export); `CONNECT_HINT` updated.
- The 6 remaining authority literals (`pbi_exec`, `fabric-auth-check`, `extract-pbir`, `export-pbi-pages`, `pbi-freshness`, the `phase6-parity` Python heredoc) now read `PBI_TENANT`.
- `refs/connection.md` documents the cross-tenant recipe (incl. finding the tenant GUID as the `ctid=` in the report URL).

## Verification (offline E2E)
A stub-MSAL/requests harness runs each script and asserts the constructed authority + cache path resolve to the target tenant — a real guest login can't run headlessly, but the tenant plumbing can:

```
Group 1 pbi_fabric helpers + get_token ...... PASS (authority + cache + ctid parse)
Group 2 --tenant entry points (6) ........... PASS (incl. --tenant as a ctid= URL)
Group 3 env-driven scripts (6) .............. PASS
Group 4 phase6 heredoc ...................... PASS
RESULT: PASS=13 FAIL=0
Default (no --tenant): authority=/organizations, cache=/tmp/pbiauth/cache.bin  ✅ unchanged
```

Fixes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)